### PR TITLE
Gun Accuracy Enhancements Fix #138

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -279,6 +279,8 @@
 			else if(grabstate >= GRAB_AGGRESSIVE)
 				damage_mult = 1.5
 	P.damage *= damage_mult
+	//you can't miss at point blank..
+	P.can_miss = 1
 
 /obj/item/weapon/gun/proc/process_accuracy(obj/projectile, mob/user, atom/target, acc_mod, dispersion)
 	var/obj/item/projectile/P = projectile
@@ -288,6 +290,9 @@
 	//Accuracy modifiers
 	P.accuracy = accuracy + acc_mod
 	P.dispersion = dispersion
+
+	//Increasing accuracy across the board, ever so slightly
+	P.accuracy += 1
 
 	//accuracy bonus from aiming
 	if (aim_targets && (target in aim_targets))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -36,6 +36,9 @@
 	var/accuracy = 0
 	var/dispersion = 0.0
 
+	//used for shooting at blank range, you shouldn't be able to miss
+	var/can_miss = 0
+
 	var/damage = 10
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE, HALLOSS are the only things that should be in here
 	var/nodamage = 0 //Determines if the projectile will skip any damage inflictions
@@ -172,7 +175,7 @@
 		def_zone = hit_zone //set def_zone, so if the projectile ends up hitting someone else later (to be implemented), it is more likely to hit the same part
 		result = target_mob.bullet_act(src, def_zone)
 
-	if(result == PROJECTILE_FORCE_MISS)
+	if(result == PROJECTILE_FORCE_MISS && (can_miss == 0)) //if you're shooting at point blank you can't miss.
 		visible_message("<span class='notice'>\The [src] misses [target_mob] narrowly!</span>")
 		return 0
 

--- a/html/changelogs/Ryan784-development2.yml
+++ b/html/changelogs/Ryan784-development2.yml
@@ -1,0 +1,7 @@
+author: Ryan784
+
+delete-after: True
+
+changes:
+  - rscadd: "Shooting a gun at blank range will no longer have a chance to miss."
+  - tweak: "Gun accuracy across the board slightly increased."


### PR DESCRIPTION
Shooting at blank range no longer has a chance to miss.
Also slightly increases the accuracy of guns by +1 (an extra tile, we can
tweak this later).
