### PR TITLE
Fixes spectrometer not accepting coolant

### DIFF
--- a/baystation12.int
+++ b/baystation12.int
@@ -1,6 +1,9 @@
 // BEGIN_INTERNALS
 /*
-MAP_ICON_TYPE: 0
+DIR: code code\modules code\modules\reagents code\modules\reagents\reagent_containers code\modules\research code\modules\research\xenoarchaeology code\modules\research\xenoarchaeology\machinery 
 AUTO_FILE_DIR: OFF
+MAP_ICON_TYPE: 0
+WINDOW: code\modules\research\xenoarchaeology\geosample.dm;code\modules\research\xenoarchaeology\machinery\geosample_scanner.dm
+FILE: code\modules\research\xenoarchaeology\machinery\geosample_scanner.dm
 */
 // END_INTERNALS

--- a/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
+++ b/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
@@ -4,6 +4,7 @@
 	desc = "A specialised, complex scanner for gleaning information on all manner of small things."
 	anchored = 1
 	density = 1
+	flags = OPENCONTAINER
 	icon = 'icons/obj/virology.dmi'
 	icon_state = "analyser"
 
@@ -148,15 +149,15 @@
 	data["radiation"] = round(radiation)
 	data["t_left_radspike"] = round(t_left_radspike)
 	data["rad_shield_on"] = rad_shield
-	
+
 	// update the ui if it exists, returns null if no ui is passed/found
-	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)	
+	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
 		// the ui does not exist, so we'll create a new() one
         // for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
 		ui = new(user, src, ui_key, "geoscanner.tmpl", "High Res Radiocarbon Spectrometer", 900, 825)
 		// when the ui is first opened this is the data it will use
-		ui.set_initial_data(data)		
+		ui.set_initial_data(data)
 		// open the new ui window
 		ui.open()
 		// auto update every Master Controller tick


### PR DESCRIPTION
Basically, xenoarcheologist can't use the radiocarbon spectrometer to date their artifacts they find, and that's depressing. 