### PR TITLE
Fixed Sterilizine not sterilising wounds. Also tweaked spraybottle message visibility

### DIFF
--- a/Nanako-PR-330.txt
+++ b/Nanako-PR-330.txt
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Sterilizine will now clean wounds, to reduce and prevent infection"
+  - tweak: "Spraybottles now display a message when sprayed on any mob"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -385,6 +385,13 @@
 	for(var/obj/item/I in M.contents)
 		I.was_bloodied = null
 	M.was_bloodied = null
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		for (var/obj/item/organ/external/E in H.organs)//For each external bodypart
+			for (var/datum/wound/W in E.wounds)//We check each wound on that bodypart
+				W.germ_level -= min(removed*20, W.germ_level)//Clean the wound a bit. Note we only clean wounds on the part, not the part itself.
+				if (W.germ_level <= 0)
+					W.disinfected = 1//The wound becomes disinfected if fully cleaned
 
 /datum/reagent/sterilizine/touch_obj(var/obj/O)
 	O.germ_level -= min(volume*20, O.germ_level)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -52,7 +52,7 @@
 	return
 
 /obj/item/weapon/reagent_containers/spray/proc/Spray_at(atom/A as mob|obj, mob/user as mob, proximity)
-	if (A.density && proximity)
+	if ((A.density || istype(A, /mob/living)) && proximity)//isHuman check allows the visible message to proc when spraying lying-down people and
 		A.visible_message("[usr] sprays [A] with [src].")
 		reagents.splash(A, amount_per_transfer_from_this)
 	else


### PR DESCRIPTION
```
*Sterilizine will now reduce the germ level of all wounds on the mob on
contact, proportional to the quantity sprayed
*Sterilizine will now mark wounds as disinfected if it reduces their germ level to zero
*Spraybottles will now display the "<Person> sprays <otherperson> with
the <spraybottle>" message when spraying on any mob
```