### PR TITLE
Nutrition Rearranging, Skrell and Unathi diets

### DIFF
--- a/Nanako-PR-331.yml
+++ b/Nanako-PR-331.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Proteins now restore blood twice as effectively"
+  - rscadd: "Unathi will no longer digest nutriment, only proteins"
+  - rscadd: "Added seafood protein, For fish"
+  - rscadd: "Skrell are able to safely digest seafood protein"
+  - rscadd: "Space-carp fillets, and all recipes made with them, now contain seafood protein instead of animal protein"
+  - tweak: "Unathi are now immune to Carpotoxin"

--- a/Nanako-PR-331.yml
+++ b/Nanako-PR-331.yml
@@ -35,7 +35,6 @@ delete-after: True
 changes: 
   - tweak: "Proteins now restore blood twice as effectively"
   - rscadd: "Unathi will no longer digest nutriment, only proteins"
-  - rscadd: "Added seafood protein, For fish"
+  - rscadd: "Added seafood protein. Space-carp fillets, and all recipes made with them, now contain seafood protein instead of animal protein"
   - rscadd: "Skrell are able to safely digest seafood protein"
-  - rscadd: "Space-carp fillets, and all recipes made with them, now contain seafood protein instead of animal protein"
   - tweak: "Unathi are now immune to Carpotoxin"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -37,6 +37,11 @@
 	color = "#003333"
 	strength = 10
 
+/datum/reagent/toxin/carpotoxin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien && alien == IS_SKRELL)
+		return
+	..()
+
 /datum/reagent/toxin/phoron
 	name = "Phoron"
 	id = "phoron"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -38,7 +38,7 @@
 	strength = 10
 
 /datum/reagent/toxin/carpotoxin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien && alien == IS_SKRELL)
+	if(alien && alien == IS_UNATHI)
 		return
 	..()
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -614,7 +614,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("protein", 3)
+		reagents.add_reagent("seafood", 3)
 		reagents.add_reagent("carpotoxin", 3)
 		src.bitesize = 6
 
@@ -626,7 +626,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("protein", 4)
+		reagents.add_reagent("seafood", 4)
 		reagents.add_reagent("carpotoxin", 3)
 		bitesize = 3
 
@@ -813,7 +813,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("protein", 6)
+		reagents.add_reagent("seafood", 6)
 		reagents.add_reagent("carpotoxin", 3)
 		bitesize = 3
 
@@ -1114,7 +1114,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("protein", 3)
+		reagents.add_reagent("seafood", 3)
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("carpotoxin", 3)
 		reagents.add_reagent("capsaicin", 3)
@@ -1708,7 +1708,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("protein", 3)
+		reagents.add_reagent("seafood", 3)
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("carpotoxin", 3)
 		bitesize = 3


### PR DESCRIPTION
This PR replaces Akrilla's previous one about unathi nutrition, with his permission. Please merge this instead of the other one.

*Rearranged nutrition code a little - Added a Digest proc and put the
three stat changing lines in there (blood, nutrition, healing) to
standardise it. and reduce code duplication. Digest is called from other places instead of pasting those three lines around repeatedly
*Added blood_factor and regen_factor variables to nutriment, to easily
set how much bloodrestore or healing an inherited food will do. This
reduces numeric literals in code
*protein now has a blood factor of 12 instead of 6 (iron is absorbed better from meat)
*Unathi now cannot digest nutriment, it will do nothing. (not harmful)
*Added seafood protein as a descendant of protein.
*Skrell can safely eat seafood protein (By Senpai Jackboot's request)
*Space Carp, and all recipes made with carp fillets, now contain seafood
protein instead of animal protein, and thus are safe for skrell to eat if prepared properly. (the carpotoxin can still poison them)
*Unathi are now immune to carpotoxin