### PR TITLE
Cyborg beakers and grippers

### DIFF
--- a/Nanako-PR-338.yml
+++ b/Nanako-PR-338.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: False
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a new Chemistry Gripper for cyborgs. It holds beakers, bottles, pills, pillbottles, spraybottles, labellers, and phoron sheets"
+  - bugfix: "Removed Large Beaker from crisis and research cyborgs, replaced with chemistry gripper"
+  - bugfix: "Cyborgs can now interact with reagent grinders"
+  - rscadd: "Cyborgs can now place objects in their gripper, on a table"
+  - rscadd: "Cyborgs can now place objects from their gripper into a disposal bin"
+  - rscadd: "Cyborgs can now use a gripper to take valid objects out of cardboard boxes"
+  - tweak: "Cyborgs can now use their other tools, on things held in their gripper"
+  - tweak: "Using an empty gripper on a machine now interacts with it"

--- a/Nanako-PR-338.yml
+++ b/Nanako-PR-338.yml
@@ -25,7 +25,7 @@
 author: Nanako
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
-delete-after: False
+delete-after: True
 
 # Any changes you've made.  See valid prefix list above.
 # INDENT WITH TWO SPACES.  NOT TABS.  SPACES.

--- a/Nanako-PR-338.yml
+++ b/Nanako-PR-338.yml
@@ -42,3 +42,4 @@ changes:
   - rscadd: "Cyborgs can now use a gripper to take valid objects out of cardboard boxes"
   - tweak: "Cyborgs can now use their other tools, on things held in their gripper"
   - tweak: "Using an empty gripper on a machine now interacts with it"
+  - tweak: "Cyborgs can now use items held in their gripper on rechargers"

--- a/Nanako-PR-338.yml
+++ b/Nanako-PR-338.yml
@@ -35,6 +35,7 @@ delete-after: False
 changes: 
   - rscadd: "Added a new Chemistry Gripper for cyborgs. It holds beakers, bottles, pills, pillbottles, spraybottles, labellers, and phoron sheets"
   - bugfix: "Removed Large Beaker from crisis and research cyborgs, replaced with chemistry gripper"
+  - rscadd: "Surgical Cyborgs now also have a chemistry gripper"
   - bugfix: "Cyborgs can now interact with reagent grinders"
   - rscadd: "Cyborgs can now place objects in their gripper, on a table"
   - rscadd: "Cyborgs can now place objects from their gripper into a disposal bin"

--- a/Nanako-PR-338.yml
+++ b/Nanako-PR-338.yml
@@ -35,7 +35,6 @@ delete-after: False
 changes: 
   - rscadd: "Added a new Chemistry Gripper for cyborgs. It holds beakers, bottles, pills, pillbottles, spraybottles, labellers, and phoron sheets"
   - bugfix: "Removed Large Beaker from crisis and research cyborgs, replaced with chemistry gripper"
-  - rscadd: "Surgical Cyborgs now also have a chemistry gripper"
   - bugfix: "Cyborgs can now interact with reagent grinders"
   - rscadd: "Cyborgs can now place objects in their gripper, on a table"
   - rscadd: "Cyborgs can now place objects from their gripper into a disposal bin"

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -17,6 +17,21 @@ obj/machinery/recharger
 
 obj/machinery/recharger/attackby(obj/item/weapon/G as obj, mob/user as mob)
 	if(istype(user,/mob/living/silicon))
+		if (istype(G, /obj/item/weapon/gripper))//Code for allowing cyborgs to use rechargers
+			var/obj/item/weapon/gripper/Gri = G
+			if (charging)//If there's something in the charger
+				if (Gri.grip_item(charging, user))//we attempt to grab it
+					charging = null
+					update_icon()
+
+			else if (Gri.wrapped)//If we're not charging anything, and the gripper is holding something
+				var/obj/item/I = Gri.wrapped
+				for (var/allowed_type in allowed_devices)
+					if (istype(I, allowed_type))//If the thing in the gripper is valid for this charger
+						I.loc = src//we put it inside
+						Gri.wrapped = null
+						charging = I
+						update_icon()
 		return
 
 	var/allowed = 0

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -241,6 +241,8 @@
 
 				user.visible_message("<span class='danger'>[user] removes the power cell from [A]!</span>", "You remove the power cell.")
 
+	else
+		target.attack_ai(user)
 //TODO: Matter decompiler.
 /obj/item/weapon/matter_decompiler
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -24,6 +24,8 @@
 		/obj/item/weapon/smes_coil
 		)
 
+	//var/list/after_items = list( //This is a list of items for which we have to trigger afterattack instead of attack, in order for them to work properly from within a gripper
+
 	var/obj/item/wrapped = null // Item currently being held.
 
 	var/force_holder = null //

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -27,6 +27,7 @@
 	var/obj/item/wrapped = null // Item currently being held.
 
 	var/force_holder = null //
+	var/justdropped = 0//When set to 1, the gripper has just dropped its item, and should not attempt to trigger anything
 
 // VEEEEERY limited version for mining borgs. Basically only for swapping cells and upgrading the drills.
 /obj/item/weapon/gripper/miner
@@ -185,7 +186,7 @@
 			wrapped = null
 			return
 
-	else if(istype(target,/obj/item)) //Check that we're not pocketing a mob.
+	else if(istype(target,/obj/item) && !justdropped) //Check that we're not pocketing a mob.
 
 		//...and that the item is not in a container.
 		if(!isturf(target.loc))
@@ -209,7 +210,7 @@
 		else
 			user << "<span class='danger'>Your gripper cannot hold \the [target].</span>"
 
-	else if(istype(target,/obj/machinery/power/apc))
+	else if(istype(target,/obj/machinery/power/apc) && !justdropped)
 		var/obj/machinery/power/apc/A = target
 		if(A.opened)
 			if(A.cell)
@@ -226,7 +227,7 @@
 
 				user.visible_message("<span class='danger'>[user] removes the power cell from [A]!</span>", "You remove the power cell.")
 
-	else if(istype(target,/mob/living/silicon/robot))
+	else if(istype(target,/mob/living/silicon/robot) && !justdropped)
 		var/mob/living/silicon/robot/A = target
 		if(A.opened)
 			if(A.cell)
@@ -241,8 +242,10 @@
 
 				user.visible_message("<span class='danger'>[user] removes the power cell from [A]!</span>", "You remove the power cell.")
 
-	else
+	else if (!justdropped)
 		target.attack_ai(user)
+
+	justdropped = 0
 //TODO: Matter decompiler.
 /obj/item/weapon/matter_decompiler
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -29,6 +29,18 @@
 	var/force_holder = null //
 	var/justdropped = 0//When set to 1, the gripper has just dropped its item, and should not attempt to trigger anything
 
+/obj/item/weapon/gripper/proc/grip_item(obj/item/I as obj, mob/user as mob)
+	//This function returns 1 if we successfully took the item, or 0 if it was invalid. This information is useful to the caller
+	if (!wrapped)
+		for(var/typepath in can_hold)
+			if(istype(I,typepath))
+				user << "You collect \the [I]."
+				I.loc = src
+				wrapped = I
+				return 1
+	return 0
+
+
 // VEEEEERY limited version for mining borgs. Basically only for swapping cells and upgrading the drills.
 /obj/item/weapon/gripper/miner
 	name = "drill maintenance gripper"

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -24,8 +24,6 @@
 		/obj/item/weapon/smes_coil
 		)
 
-	//var/list/after_items = list( //This is a list of items for which we have to trigger afterattack instead of attack, in order for them to work properly from within a gripper
-
 	var/obj/item/wrapped = null // Item currently being held.
 
 	var/force_holder = null //
@@ -149,6 +147,13 @@
 			wrapped = null
 		return 1
 	return 0
+
+/obj/item/weapon/gripper/attackby(var/obj/item/O as obj, var/mob/user as mob)
+	if (wrapped)
+		var/resolved = wrapped.attackby(O,user)
+		if(!resolved && wrapped && O)
+			O.afterattack(wrapped,user,1)//We pass along things targeting the gripper, to objects inside the gripper. So that we can draw chemicals from held beakers for instance
+	return
 
 /obj/item/weapon/gripper/afterattack(var/atom/target, var/mob/living/user, proximity, params)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -186,6 +186,16 @@
 			wrapped = null
 			return
 
+	else if (istype(target, /obj/item/weapon/storage/box))
+		for (var/obj/item/C in target.contents)
+			for(var/typepath in can_hold)
+				if(istype(C,typepath))
+					user << "You grab the [C] from inside the box."
+					C.loc = src
+					return
+		user << "There is nothing inside the box that your gripper can collect"
+		return
+
 	else if(istype(target,/obj/item) && !justdropped) //Check that we're not pocketing a mob.
 
 		//...and that the item is not in a container.
@@ -241,6 +251,7 @@
 				A.cell = null
 
 				user.visible_message("<span class='danger'>[user] removes the power cell from [A]!</span>", "You remove the power cell.")
+
 
 	else if (!justdropped)
 		target.attack_ai(user)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -73,6 +73,19 @@
 
 		)
 
+/obj/item/weapon/gripper/chemistry //A gripper designed for chemistry, to allow borgs to work efficiently in the lab
+	name = "chemistry gripper"
+	icon_state = "gripper-sci"
+	desc = "A specialised grasping tool designed for working in chemistry and pharmaceutical labs"
+
+	can_hold = list(
+		/obj/item/weapon/reagent_containers/glass,
+		/obj/item/weapon/reagent_containers/pill,
+		/obj/item/weapon/storage/pill_bottle,
+		/obj/item/weapon/hand_labeler,
+		/obj/item/stack/material/phoron
+		)
+
 /obj/item/weapon/gripper/service //Used to handle food, drinks, and seeds.
 	name = "service gripper"
 	icon_state = "gripper"

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -82,6 +82,7 @@
 	can_hold = list(
 		/obj/item/weapon/reagent_containers/glass,
 		/obj/item/weapon/reagent_containers/pill,
+		/obj/item/weapon/reagent_containers/spray,
 		/obj/item/weapon/storage/pill_bottle,
 		/obj/item/weapon/hand_labeler,
 		/obj/item/stack/material/phoron

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -250,7 +250,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/reagent_scanner/adv(src)
 	src.modules += new /obj/item/roller_holder(src)
 	src.modules += new /obj/item/weapon/reagent_containers/borghypo/crisis(src)
-	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
+	src.modules += new /obj/item/weapon/gripper/chemistry(src)
 	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
@@ -608,7 +608,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/circular_saw(src)
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
-	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
+	src.modules += new /obj/item/weapon/gripper/chemistry(src)
 	src.emag = new /obj/item/weapon/hand_tele(src)
 
 	var/datum/matter_synth/nanite = new /datum/matter_synth/nanite(10000)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -204,6 +204,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/bonesetter(src)
 	src.modules += new /obj/item/weapon/circular_saw(src)
 	src.modules += new /obj/item/weapon/surgicaldrill(src)
+	src.modules += new /obj/item/weapon/gripper/chemistry(src)
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("pacid", 250)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -204,7 +204,6 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/bonesetter(src)
 	src.modules += new /obj/item/weapon/circular_saw(src)
 	src.modules += new /obj/item/weapon/surgicaldrill(src)
-	src.modules += new /obj/item/weapon/gripper/chemistry(src)
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("pacid", 250)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -598,7 +598,6 @@
 	if (istype(O,/obj/item/weapon/reagent_containers/glass) || \
 		istype(O,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass) || \
 		istype(O,/obj/item/weapon/reagent_containers/food/drinks/shaker))
-
 		if (beaker)
 			return 1
 		else
@@ -642,7 +641,7 @@
 
 	if(!sheet_reagents[O.type] && (!O.reagents || !O.reagents.total_volume))
 		user << "\The [O] is not suitable for blending."
-		return 1
+		return 0
 
 	user.remove_from_mob(O)
 	O.loc = src
@@ -651,7 +650,7 @@
 	return 0
 
 /obj/machinery/reagentgrinder/attack_ai(mob/user as mob)
-	return 0
+	interact(user)
 
 /obj/machinery/reagentgrinder/attack_hand(mob/user as mob)
 	interact(user)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -92,7 +92,6 @@
 			else
 				user << "You need more welding fuel to complete this task."
 				return
-
 	if(istype(I, /obj/item/weapon/melee/energy/blade))
 		user << "You can't place that item inside the disposal unit."
 		return
@@ -124,8 +123,19 @@
 				GM.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been placed in disposals by [usr.name] ([usr.ckey])</font>")
 				msg_admin_attack("[usr] ([usr.ckey]) placed [GM] ([GM.ckey]) in a disposals unit. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>)")
 		return
-
 	if(isrobot(user))
+		if (istype(I, /obj/item/weapon/gripper))
+			var/obj/item/weapon/gripper/Gri = I
+			if (Gri.wrapped)
+				Gri.wrapped.loc = (src)
+				user << "You place \the [Gri.wrapped] into the [src]."
+				for(var/mob/M in viewers(src))
+					if(M == user)
+						continue
+					M.show_message("[user.name] places \the [Gri.wrapped] into the [src].", 3)
+				Gri.wrapped = null
+				Gri.justdropped = 1
+				update()
 		return
 	if(!I)
 		return
@@ -133,7 +143,6 @@
 	user.drop_item()
 	if(I)
 		I.loc = src
-
 	user << "You place \the [I] into the [src]."
 	for(var/mob/M in viewers(src))
 		if(M == user)

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -117,6 +117,7 @@
 			if (G.wrapped)
 				G.wrapped.loc = (src.loc)
 				G.wrapped = null
+				G.justdropped = 1
 		return
 
 	if(W.loc != user) // This should stop mounted modules ending up outside the module.

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -112,6 +112,11 @@
 
 	// Handle dismantling or placing things on the table from here on.
 	if(isrobot(user))
+		if (istype(W, /obj/item/weapon/gripper))
+			var/obj/item/weapon/gripper/G = W
+			if (G.wrapped)
+				G.wrapped.loc = (src.loc)
+				G.wrapped = null
 		return
 
 	if(W.loc != user) // This should stop mounted modules ending up outside the module.


### PR DESCRIPTION
Removed large beakers from crisis and research borgs, and replaced with a new Chemistry Gripper

Plus a couple of little tweaks, fixes and QoL improvements for cyborg grippers. 

changes: 
"Added a new Chemistry Gripper for cyborgs. It holds beakers, bottles, pills, pillbottles, spraybottles, labellers, and phoron sheets"
"Removed Large Beaker from crisis and research cyborgs, replaced with chemistry gripper"
 "Cyborgs can now interact with reagent grinders"
 "Cyborgs can now place objects in their gripper, on a table"
"Cyborgs can now place objects from their gripper into a disposal bin"
"Cyborgs can now use a gripper to take valid objects out of cardboard boxes"
"Cyborgs can now use their other tools, on things held in their gripper"
"Using an empty gripper on a machine now interacts with it"