### PR TITLE
Fixed sleepers and buckle duplication

### DIFF
--- a/Nanako-PR-345.yml
+++ b/Nanako-PR-345.yml
@@ -25,7 +25,7 @@
 author: Nanako
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
-delete-after: False
+delete-after: True
 
 # Any changes you've made.  See valid prefix list above.
 # INDENT WITH TWO SPACES.  NOT TABS.  SPACES.

--- a/Nanako-PR-345.yml
+++ b/Nanako-PR-345.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: False
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Sleepers will no longer eject their dialysis beaker and bug out when you eject a patient"
+  - bugfix: "Fixed a bug with medical machines where a patient could be duplicated"
+  - rscadd: "The dialysis beaker can now be checked and removed while a sleeper has no occupant"
+

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -272,16 +272,22 @@
 			if(M.Victim == O)
 				usr << "[O.name] will not fit into the sleeper because they have a slime latched onto their head."
 				return
-
 		var/mob/living/L = O
-		if (!L.bucklecheck(user))//We must make sure the person is unbuckled before they go in
+		var/bucklestatus = L.bucklecheck(user)
+
+		if (!bucklestatus)//We must make sure the person is unbuckled before they go in
 			return
+
 
 		if(L == user)
 			visible_message("[user] starts climbing into the sleeper.", 3)
 		else
 			visible_message("[user] starts putting [L.name] into the sleeper.", 3)
-		if(do_after(user, 20))
+
+		if (do_mob(user, L, 30, needhand = 0))
+			if (bucklestatus == 2)
+				var/obj/structure/LB = L.buckled
+				LB.user_unbuckle_mob(user)
 			if(src.occupant)
 				user << "\blue <B>The sleeper is already occupied!</B>"
 				return
@@ -297,8 +303,7 @@
 			src.add_fingerprint(user)
 			if(user.pulling == L)
 				user.pulling = null
-			return
-		return
+
 
 	proc/check_occupant_allowed(mob/M)
 		var/correct_type = 0

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -104,6 +104,11 @@
 			dat += "<HR><A href='?src=\ref[src];ejectify=1'>Eject Patient</A>"
 		else
 			dat += "The sleeper is empty."
+			if(src.connected.beaker)
+				dat += "<HR><A href='?src=\ref[src];removebeaker=1'>Remove Beaker</A><BR>"
+				dat += text("Output Beaker has [] units of free space remaining<BR><HR>", src.connected.beaker.reagents.maximum_volume - src.connected.beaker.reagents.total_volume)
+			else
+				dat += "<HR>No Dialysis Output Beaker is present.<BR><HR>"
 	dat += text("<BR><BR><A href='?src=\ref[];mach_close=sleeper'>Close</A>", user)
 	user << browse(dat, "window=sleeper;size=400x500")
 	onclose(user, "sleeper")
@@ -269,6 +274,10 @@
 				return
 
 		var/mob/living/L = O
+		if (L.buckled && istype(L.buckled, /obj/structure))//We must make sure the person is unbuckled before they go in
+			var/obj/structure/LB = L.buckled
+			LB.user_unbuckle_mob(user)
+
 		if(L == user)
 			visible_message("[user] starts climbing into the sleeper.", 3)
 		else
@@ -374,7 +383,8 @@
 		if(!src.occupant)
 			return
 		for(var/obj/O in src) //once again, why wasn't this here?
-			O.loc = src.loc
+			if (O != beaker)
+				O.loc = src.loc
 		if(src.occupant.client)
 			src.occupant.client.eye = src.occupant.client.mob
 			src.occupant.client.perspective = MOB_PERSPECTIVE

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -274,9 +274,8 @@
 				return
 
 		var/mob/living/L = O
-		if (L.buckled && istype(L.buckled, /obj/structure))//We must make sure the person is unbuckled before they go in
-			var/obj/structure/LB = L.buckled
-			LB.user_unbuckle_mob(user)
+		if (!L.bucklecheck(user))//We must make sure the person is unbuckled before they go in
+			return
 
 		if(L == user)
 			visible_message("[user] starts climbing into the sleeper.", 3)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -112,19 +112,30 @@
 		return
 
 	var/mob/living/L = O
-	if (!L.bucklecheck(user))//We must make sure the person is unbuckled before they go in
+	var/bucklestatus = L.bucklecheck(user)
+
+	if (!bucklestatus)//We must make sure the person is unbuckled before they go in
 		return
 
-	if (M.client)
-		M.client.perspective = EYE_PERSPECTIVE
-		M.client.eye = src
-	M.loc = src
-	src.occupant = M
-	update_use_power(2)
-	src.icon_state = "body_scanner_1"
-	for(var/obj/Obj in src)
-		Obj.loc = src.loc
-		//Foreach goto(154)
+	if(L == user)
+		visible_message("[user] starts climbing into the scanner bed.", 3)
+	else
+		visible_message("[user] starts putting [L.name] into the scanner bed.", 3)
+
+	if (do_mob(user, L, 30, needhand = 0))
+		if (bucklestatus == 2)
+			var/obj/structure/LB = L.buckled
+			LB.user_unbuckle_mob(user)
+		if (M.client)
+			M.client.perspective = EYE_PERSPECTIVE
+			M.client.eye = src
+		M.loc = src
+		src.occupant = M
+		update_use_power(2)
+		src.icon_state = "body_scanner_1"
+		for(var/obj/Obj in src)
+			Obj.loc = src.loc
+			//Foreach goto(154)
 	src.add_fingerprint(user)
 	//G = null
 	return

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -111,9 +111,9 @@
 		user << "\blue <B>Subject cannot have abiotic items on.</B>"
 		return
 
-	if (M.buckled && istype(M.buckled, /obj/structure))//We must make sure the person is unbuckled before they go in
-		var/obj/structure/LB = M.buckled
-		LB.user_unbuckle_mob(user)
+	var/mob/living/L = O
+	if (!L.bucklecheck(user))//We must make sure the person is unbuckled before they go in
+		return
 
 	if (M.client)
 		M.client.perspective = EYE_PERSPECTIVE

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -103,13 +103,18 @@
 		return
 	if(!ismob(O))
 		return
-	var/mob/M = O
+	var/mob/living/M = O//Theres no reason this shouldn't be /mob/living
 	if (src.occupant)
 		user << "\blue <B>The scanner is already occupied!</B>"
 		return
 	if (M.abiotic())
 		user << "\blue <B>Subject cannot have abiotic items on.</B>"
 		return
+
+	if (M.buckled && istype(M.buckled, /obj/structure))//We must make sure the person is unbuckled before they go in
+		var/obj/structure/LB = M.buckled
+		LB.user_unbuckle_mob(user)
+
 	if (M.client)
 		M.client.perspective = EYE_PERSPECTIVE
 		M.client.eye = src

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -202,9 +202,8 @@
 			usr << "[L.name] will not fit into the cryo because they have a slime latched onto their head."
 			return
 
-	if (L.buckled && istype(L.buckled, /obj/structure))//We must make sure the person is unbuckled before they go in
-		var/obj/structure/LB = L.buckled
-		LB.user_unbuckle_mob(user)
+	if (!L.bucklecheck(user))//We must make sure the person is unbuckled before they go in
+		return
 
 	if(put_mob(L))
 		if(L == user)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -202,16 +202,26 @@
 			usr << "[L.name] will not fit into the cryo because they have a slime latched onto their head."
 			return
 
-	if (!L.bucklecheck(user))//We must make sure the person is unbuckled before they go in
+	var/bucklestatus = L.bucklecheck(user)
+
+	if (!bucklestatus)//We must make sure the person is unbuckled before they go in
 		return
 
-	if(put_mob(L))
-		if(L == user)
-			visible_message("[user] climbs into the cryo cell.", 3)
-		else
-			visible_message("[user] puts [L.name] into the cryo cell.", 3)
-			if(user.pulling == L)
-				user.pulling = null
+	if(L == user)
+		visible_message("[user] starts climbing into the cryopod.", 3)
+	else
+		visible_message("[user] starts putting [L.name] into the cryopod.", 3)
+	if (do_mob(user, L, 30, needhand = 0))
+		if (bucklestatus == 2)
+			var/obj/structure/LB = L.buckled
+			LB.user_unbuckle_mob(user)
+		if(put_mob(L))
+			if(L == user)
+				visible_message("[user] climbs into the cryo cell.", 3)
+			else
+				visible_message("[user] puts [L.name] into the cryo cell.", 3)
+				if(user.pulling == L)
+					user.pulling = null
 
 /obj/machinery/atmospherics/unary/cryo_cell/update_icon()
 	overlays.Cut()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -201,6 +201,11 @@
 		if(M.Victim == L)
 			usr << "[L.name] will not fit into the cryo because they have a slime latched onto their head."
 			return
+
+	if (L.buckled && istype(L.buckled, /obj/structure))//We must make sure the person is unbuckled before they go in
+		var/obj/structure/LB = L.buckled
+		LB.user_unbuckle_mob(user)
+
 	if(put_mob(L))
 		if(L == user)
 			visible_message("[user] climbs into the cryo cell.", 3)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -680,4 +680,16 @@ proc/is_blind(A)
 		threatcount += 4
 	return threatcount
 
+
+/mob/living/proc/bucklecheck(var/mob/living/user)
+	if (buckled && istype(buckled, /obj/structure))
+		if (istype(user,/mob/living/silicon/robot))
+			var/obj/structure/LB = buckled
+			LB.user_unbuckle_mob(user)
+			return 1
+		else
+			user << "You must unbuckle the subject first"
+			return 0
+	return 1
+
 #undef SAFE_PERP

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -684,9 +684,7 @@ proc/is_blind(A)
 /mob/living/proc/bucklecheck(var/mob/living/user)
 	if (buckled && istype(buckled, /obj/structure))
 		if (istype(user,/mob/living/silicon/robot))
-			var/obj/structure/LB = buckled
-			LB.user_unbuckle_mob(user)
-			return 1
+			return 2
 		else
 			user << "You must unbuckle the subject first"
 			return 0


### PR DESCRIPTION
Fixed a bug where buckled people could be placed into multiple machines
simultaneously

Medical machines will now unbuckle a patient before accepting them.

Fixed dialysis beaker being ejected from sleeper beds when you eject the patient

Dialysis beaker can now be checked and ejected while a sleeper is empty