### PR TITLE
Alt-attack and trays

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -124,7 +124,15 @@
 	A.BorgCtrlClick(src)
 
 /mob/living/silicon/robot/AltClickOn(var/atom/A)
-	A.BorgAltClick(src)
+	var/doClickAction = 1
+	if (istype(module_active, /obj/item/weapon))
+		var/obj/item/weapon/W = module_active
+		doClickAction = W.alt_attack(A,src)
+
+	if (doClickAction)
+		A.BorgAltClick(src)
+
+
 
 /atom/proc/BorgCtrlShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
 	CtrlShiftClick(user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -346,16 +346,10 @@
 
 	if(istype(W, /obj/item/weapon/tray))
 		var/obj/item/weapon/tray/T = W
-		if(T.calc_carry() > 0)
-			if(prob(85))
-				user << "\red The tray won't fit in [src]."
-				return
-			else
-				W.loc = user.loc
-				if ((user.client && user.s_active != src))
-					user.client.screen -= W
-				W.dropped(user)
-				user << "\red God damnit!"
+		if(T.current_weight > 0)
+			T.spill(user)
+			user << "\red Trying to place a loaded tray into [src] was a bad idea."
+			return
 
 	W.add_fingerprint(user)
 	return handle_item_insertion(W)

--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -7,3 +7,10 @@
 	spawn(0)
 		..()
 	return
+
+//Called when the user alt-clicks on something with this item in their active hand
+//this function is designed to be overridden by individual weapons
+/obj/item/weapon/proc/alt_attack(var/atom/target, var/mob/user)
+	return 1
+	//A return value of 1 continues on to do the normal alt-click action.
+	//A return value of 0 does not continue, and will not do the alt-click

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1454,3 +1454,13 @@
 		return 0
 
 	return 1
+
+/mob/living/carbon/human/AltClickOn(var/atom/A)
+	var/doClickAction = 1
+	if (istype(get_active_hand(), /obj/item/weapon))
+		var/obj/item/weapon/W = get_active_hand()
+		doClickAction = W.alt_attack(A,src)
+
+	if (doClickAction)
+		..()
+

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -139,54 +139,14 @@
 		user << "Harvesting \a [target] is not the purpose of this tool.  The [src] is for plants being grown."
 
 // A special tray for the service droid. Allow droid to pick up and drop items as if they were using the tray normally
-// Click on table to unload, click on item to load. Otherwise works identically to a tray.
-// Unlike the base item "tray", robotrays ONLY pick up food, drinks and condiments.
+// Click on table to unload, click on item to load. Alt+click to load everything on tile
 
 /obj/item/weapon/tray/robotray
 	name = "RoboTray"
 	desc = "An autoloading tray specialized for carrying refreshments."
 
 /obj/item/weapon/tray/robotray/afterattack(atom/target, mob/user as mob, proximity)
-	if(!proximity)
-		return
-	if ( !target )
-		return
-	// pick up items, mostly copied from base tray pickup proc
-	// see code\game\objects\items\weapons\kitchen.dm line 241
-	if ( istype(target,/obj/item))
-		if ( !isturf(target.loc) ) // Don't load up stuff if it's inside a container or mob!
-			return
-		var turf/pickup = target.loc
-
-		var addedSomething = 0
-
-		for(var/obj/item/weapon/reagent_containers/food/I in pickup)
-
-
-			if( I != src && !I.anchored && !istype(I, /obj/item/clothing/under) && !istype(I, /obj/item/clothing/suit) && !istype(I, /obj/item/projectile) )
-				var/add = 0
-				if(I.w_class == 1.0)
-					add = 1
-				else if(I.w_class == 2.0)
-					add = 3
-				else
-					add = 5
-				if(calc_carry() + add >= max_carry)
-					break
-
-				I.loc = src
-				carrying.Add(I)
-				overlays += image("icon" = I.icon, "icon_state" = I.icon_state, "layer" = 30 + I.layer)
-				addedSomething = 1
-		if ( addedSomething )
-			user.visible_message("\blue [user] load some items onto their service tray.")
-
-		return
-
-	// Unloads the tray, copied from base item's proc dropped() and altered
-	// see code\game\objects\items\weapons\kitchen.dm line 263
-
-	if ( isturf(target) || istype(target,/obj/structure/table) )
+	if (isturf(target) || istype(target,/obj/structure/table) )
 		var foundtable = istype(target,/obj/structure/table/)
 		if ( !foundtable ) //it must be a turf!
 			for(var/obj/structure/table/T in target)
@@ -201,27 +161,12 @@
 		else					// they clicked on a table
 			dropspot = target.loc
 
+		if (foundtable)
+			unload_at_loc(dropspot, src)
+		else
+			spill(user,dropspot)
 
-		overlays = null
-
-		var droppedSomething = 0
-
-		for(var/obj/item/I in carrying)
-			I.loc = dropspot
-			carrying.Remove(I)
-			droppedSomething = 1
-			if(!foundtable && isturf(dropspot))
-				// if no table, presume that the person just shittily dropped the tray on the ground and made a mess everywhere!
-				spawn()
-					for(var/i = 1, i <= rand(1,2), i++)
-						if(I)
-							step(I, pick(NORTH,SOUTH,EAST,WEST))
-							sleep(rand(2,4))
-		if ( droppedSomething )
-			if ( foundtable )
-				user.visible_message("\blue [user] unloads their service tray.")
-			else
-				user.visible_message("\blue [user] drops all the items on their tray.")
+		current_weight = 0
 
 	return ..()
 

--- a/html/changelogs/Nanako-PR-394.yml
+++ b/html/changelogs/Nanako-PR-394.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Fixed trays. Trays can now be unloaded by placing them down on a table, then either alt+clicking themn, or rightclicking and selecting Unload Tray"
+  - rscadd: "Trays can now load individual items by using it on them, or using the item on the tray, or alt+click to attempt to load everything on the tile"
+  - rscadd: "Trays will now spill their contents when dropped, thrown, or when you try to place it into a container"
+  - tweak: "Trays now only hold specific things: Food/drinks, reagent containers, utensils, and smoking supplies"
+  - tweak: "Tray capacity increased"


### PR DESCRIPTION
Added alt-attack function to held items/weapons, triggered by holding
alt while clicking. Opens a lot of future possibilities. Works for
cyborgs too. Only trays use it right now.

Overhauled trays to be useful and not-broken. See changelog for
specifics