### PR TITLE
Fixed incorrect creation order of tables

### DIFF
--- a/SQL/Aurora_SQL_Schema.sql
+++ b/SQL/Aurora_SQL_Schema.sql
@@ -56,6 +56,20 @@ CREATE TABLE `ss13_ban_mirrors` (
   PRIMARY KEY (`ban_mirror_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+CREATE TABLE `ss13_player` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `ckey` varchar(32) CHARACTER SET latin1 NOT NULL,
+  `firstseen` datetime NOT NULL,
+  `lastseen` datetime NOT NULL,
+  `ip` varchar(18) CHARACTER SET latin1 NOT NULL,
+  `computerid` varchar(32) CHARACTER SET latin1 NOT NULL,
+  `lastadminrank` varchar(32) CHARACTER SET latin1 NOT NULL DEFAULT 'Player',
+  `whitelist_status` int(11) unsigned NOT NULL DEFAULT '0',
+  `migration_status` tinyint(1) DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `ckey` (`ckey`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 CREATE TABLE `ss13_characters` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `ckey` varchar(32) NOT NULL,
@@ -235,20 +249,6 @@ CREATE TABLE `ss13_notes` (
   `lasteditor` varchar(32) CHARACTER SET latin1 DEFAULT NULL,
   `lasteditdate` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE TABLE `ss13_player` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `ckey` varchar(32) CHARACTER SET latin1 NOT NULL,
-  `firstseen` datetime NOT NULL,
-  `lastseen` datetime NOT NULL,
-  `ip` varchar(18) CHARACTER SET latin1 NOT NULL,
-  `computerid` varchar(32) CHARACTER SET latin1 NOT NULL,
-  `lastadminrank` varchar(32) CHARACTER SET latin1 NOT NULL DEFAULT 'Player',
-  `whitelist_status` int(11) unsigned NOT NULL DEFAULT '0',
-  `migration_status` tinyint(1) DEFAULT '0',
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `ckey` (`ckey`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `ss13_player_linking` (


### PR DESCRIPTION
Two tables queries were throwing errors on execution because their primary key constraint was dependent on a table that was not yet defined.

Just simply moved the 'ss13_players' table to be executed before the constraint reliant queries execute.