### PR TITLE
Fax Alerts

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -62,6 +62,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	var/lid = 0
 	//End Form Integration
 	var/datum/announcement/announcement = new
+	var/list/obj/item/device/pda/alert_pdas = list() //The PDAs we alert upon a request receipt.
 
 /obj/machinery/requests_console/power_change()
 	..()
@@ -266,6 +267,14 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 				else
 					dat += text("<br>Paper container lid <A href='?src=\ref[src];setLid=1'>CLOSE</A>.")
 
+				dat += "<br><br>PDAs to notify:<br>"
+
+				if (alert_pdas && alert_pdas.len)
+					for (var/obj/item/device/pda/pda in alert_pdas)
+						dat += "[alert_pdas[pda]] - <a href='byond://?src=\ref[src];unlink=\ref[pda]'>Unlink</a><br>"
+
+				dat += "<br><a href='byond://?src=\ref[src];linkpda=1'>Add PDA to Notify</a>"
+
 		user << browse("[dat]", "window=request_console")
 		onclose(user, "req_console")
 	return
@@ -343,6 +352,8 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 										O.show_message(text("\icon[Console] *The Requests Console beeps: 'PRIORITY Alert in [department]'"))
 								Console.messages += "<B><FONT color='red'>High Priority message from <A href='?src=\ref[Console];write=[ckey(department)]'>[department]</A></FONT></B><BR>[sending]"
 
+								Console.do_pda_alerts("Priority alert received from [department]!")
+
 		//					if("3")		//Not implemanted, but will be 		//Removed as it doesn't look like anybody intends on implimenting it ~Carn
 		//						if(Console.newmessagepriority < 3)
 		//							Console.newmessagepriority = 3
@@ -362,6 +373,8 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 									for (var/mob/O in hearers(4, Console.loc))
 										O.show_message(text("\icon[Console] *The Requests Console beeps: 'Message from [department]'"))
 								Console.messages += "<B>Message from <A href='?src=\ref[Console];write=[ckey(department)]'>[department]</A></FONT></B><BR>[message]"
+
+								Console.do_pda_alerts("Message received from [department].")
 
 						screen = 6
 						Console.set_light(2)
@@ -471,6 +484,26 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 		if(null)	//skip
 		if("1")	silent = 1
 		else	silent = 0
+
+	if(href_list["linkpda"])
+		var/obj/item/device/pda/pda = usr.get_active_hand()
+		if (!pda || !istype(pda))
+			usr << "<span class='warning'>You need to be holding a PDA to link it.</span>"
+		else if (pda in alert_pdas)
+			usr << "<span class='notice'>\The [pda] appears to be already linked.</span>"
+			//Update the name real quick.
+			alert_pdas[pda] = pda.name
+		else
+			alert_pdas += pda
+			alert_pdas[pda] = pda.name
+			usr << "<span class='notice'>You link \the [pda] to \the [src]. It will now ping upon the arrival of a fax to this machine.</span>"
+
+	if(href_list["unlink"])
+		var/obj/item/device/pda/pda = locate(href_list["unlink"])
+		if (pda && istype(pda))
+			if (pda in alert_pdas)
+				usr << "<span class='notice'>You unlink [alert_pdas[pda]] from \the [src]. It will no longer be notified of new faxes.</span>"
+				alert_pdas -= pda
 
 	updateUsrDialog()
 	return
@@ -594,3 +627,17 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	announceAuth = 0
 	message = ""
 	announcement.announcer = ""
+
+/obj/machinery/requests_console/proc/do_pda_alerts(var/message)
+	if (!message)
+		message = "New message received."
+
+	if (!alert_pdas || !alert_pdas.len)
+		return
+
+	for (var/obj/item/device/pda/pda in alert_pdas)
+		if (pda.toff || pda.message_silent)
+			continue
+
+		message = "[message] View it at [src.name]."
+		pda.new_info(pda.message_silent, pda.ttone, "\icon[pda] <b>[message]</b>")

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -24,6 +24,8 @@ var/list/sent_faxes = list()	//cache for faxes that have been sent by the admins
 
 	var/destination = "Central Command" // the department we're sending to
 
+	var/list/obj/item/device/pda/alert_pdas = list() //A list of PDAs to alert upon arrival of the fax.
+
 /obj/machinery/photocopier/faxmachine/New()
 	..()
 	allfaxes += src
@@ -78,6 +80,14 @@ var/list/sent_faxes = list()	//cache for faxes that have been sent by the admins
 
 		if(copyitem)
 			dat += "<a href ='byond://?src=\ref[src];remove=1'>Remove Item</a><br>"
+
+	dat += "<br>PDAs to notify:<br>"
+
+	if (alert_pdas && alert_pdas.len)
+		for (var/obj/item/device/pda/pda in alert_pdas)
+			dat += "[alert_pdas[pda]] - <a href='byond://?src=\ref[src];unlink=\ref[pda]'>Unlink</a><br>"
+
+	dat += "<br><a href='byond://?src=\ref[src];linkpda=1'>Add PDA to Notify</a>"
 
 	user << browse(dat, "window=copier")
 	onclose(user, "copier")
@@ -137,6 +147,26 @@ var/list/sent_faxes = list()	//cache for faxes that have been sent by the admins
 	if(href_list["logout"])
 		authenticated = 0
 
+	if(href_list["linkpda"])
+		var/obj/item/device/pda/pda = usr.get_active_hand()
+		if (!pda || !istype(pda))
+			usr << "<span class='warning'>You need to be holding a PDA to link it.</span>"
+		else if (pda in alert_pdas)
+			usr << "<span class='notice'>\The [pda] appears to be already linked.</span>"
+			//Update the name real quick.
+			alert_pdas[pda] = pda.name
+		else
+			alert_pdas += pda
+			alert_pdas[pda] = pda.name
+			usr << "<span class='notice'>You link \the [pda] to \the [src]. It will now ping upon the arrival of a fax to this machine.</span>"
+
+	if(href_list["unlink"])
+		var/obj/item/device/pda/pda = locate(href_list["unlink"])
+		if (pda && istype(pda))
+			if (pda in alert_pdas)
+				usr << "<span class='notice'>You unlink [alert_pdas[pda]] from \the [src]. It will no longer be notified of new faxes.</span>"
+				alert_pdas -= pda
+
 	updateUsrDialog()
 
 /obj/machinery/photocopier/faxmachine/proc/sendfax(var/destination)
@@ -177,6 +207,8 @@ var/list/sent_faxes = list()	//cache for faxes that have been sent by the admins
 		bundlecopy(incoming)
 	else
 		return 0
+
+	do_pda_alerts()
 
 	use_power(active_power_usage)
 	return 1
@@ -222,3 +254,14 @@ var/list/sent_faxes = list()	//cache for faxes that have been sent by the admins
 			C << msg
 
 	send_to_cciaa_discord("New fax arrived! [faxname]: \"[sent.name]\" by [sender].")
+
+/obj/machinery/photocopier/faxmachine/proc/do_pda_alerts()
+	if (!alert_pdas || !alert_pdas.len)
+		return
+
+	for (var/obj/item/device/pda/pda in alert_pdas)
+		if (pda.toff || pda.message_silent)
+			continue
+
+		var/message = "New fax has arrived at [src.department] fax machine."
+		pda.new_info(pda.message_silent, pda.ttone, "\icon[pda] <b>[message]</b>")

--- a/html/changelogs/skull132-fax_alerts.yml
+++ b/html/changelogs/skull132-fax_alerts.yml
@@ -1,0 +1,12 @@
+author: Skul132
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Fax machines and Request Consoles can now be linked with PDAs to alert the PDA upon message arrival. These options are available in the machine's UI."


### PR DESCRIPTION
Makes fax machines and request consoles ping a set of linked PDAs upon the receipt of a message. You can link your PDA with any of these machines through the UI.