### PR TITLE
Fixes #464, fixes #465, fixes #466

### DIFF
--- a/code/game/gamemodes/vampire/vampire_datum.dm
+++ b/code/game/gamemodes/vampire/vampire_datum.dm
@@ -33,3 +33,10 @@
 
 		if (power.helptext)
 			vampire.current << "<font color='green'>[power.helptext]</font>"
+
+// Proc to safely remove blood, without resulting in negative amounts of blood.
+/datum/vampire/proc/use_blood(var/blood_to_use)
+	if (!blood_to_use || blood_to_use <= 0)
+		return
+
+	blood_usable = max(0, blood_usable - blood_to_use)

--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -165,7 +165,8 @@
 				vampire.last_frenzy_message = world.time
 
 	// Remove one point per every life() tick.
-	vampire.frenzy--
+	if (vampire.frenzy > 0)
+		vampire.frenzy--
 
 /mob/proc/vampire_start_frenzy(var/force_frenzy = 0)
 	var/datum/vampire/vampire = mind.vampire

--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -92,7 +92,7 @@
 
 	if (account_loyalty_implant)
 		for (var/obj/item/weapon/implant/loyalty/I in T)
-			if (T.implanted)
+			if (I.implanted)
 				if (notify)
 					src << "<span class='warning'>You feel [T.name]'s mind unreachable due to forced loyalty.</span>"
 				return 0

--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -64,7 +64,7 @@
 	return vampire
 
 // Checks whether or not the target can be affected by a vampire's abilities.
-/mob/proc/vampire_can_affect_target(var/mob/living/carbon/human/T)
+/mob/proc/vampire_can_affect_target(var/mob/living/carbon/human/T, var/notify = 1, var/account_loyalty_implant = 0)
 	if (!T || !istype(T))
 		return 0
 
@@ -77,15 +77,25 @@
 
 	if (T.mind)
 		if (T.mind.assigned_role == "Chaplain")
-			src << "<span class='warning'>Your connection with the Veil is not strong enough to effect a man as devout as them.</span>"
+			if (notify)
+				src << "<span class='warning'>Your connection with the Veil is not strong enough to effect a man as devout as them.</span>"
 			return 0
 		else if (T.mind.vampire)
-			src << "<span class='warning'>You lack the power required to affect another creature of the Veil.</span>"
+			if (notify)
+				src << "<span class='warning'>You lack the power required to affect another creature of the Veil.</span>"
 			return 0
 
 	if (T.get_species() == "Machine")
-		src << "<span class='warning'>You lack the power interact with mechanical constructs.</span>"
+		if (notify)
+			src << "<span class='warning'>You lack the power interact with mechanical constructs.</span>"
 		return 0
+
+	if (account_loyalty_implant)
+		for (var/obj/item/weapon/implant/loyalty/I in T)
+			if (T.implanted)
+				if (notify)
+					src << "<span class='warning'>You feel [T.name]'s mind unreachable due to forced loyalty.</span>"
+				return 0
 
 	return 1
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -128,7 +128,7 @@
 		if (H == src)
 			continue
 
-		if (!vampire_can_affect_target(H))
+		if (!vampire_can_affect_target(H, 0))
 			continue
 
 		H.Weaken(8)
@@ -310,7 +310,7 @@
 		if (istype(T) && (T:l_ear || T:r_ear) && istype((T:l_ear || T:r_ear), /obj/item/clothing/ears/earmuffs))
 			continue
 
-		if (!vampire_can_affect_target(T))
+		if (!vampire_can_affect_target(T, 0))
 			continue
 
 		T << "<span class='danger'><font size='3'><b>You hear an ear piercing shriek and feel your senses go dull!</b></font></span>"
@@ -605,7 +605,7 @@
 
 	var/mob/living/carbon/human/T = input(src, "Select Victim") as null|mob in victims
 
-	if (!vampire_can_affect_target(T))
+	if (!vampire_can_affect_target(T, 1, 1))
 		return
 
 	if (!(vampire.status & VAMP_FULLPOWER))
@@ -778,7 +778,7 @@
 			if (T == src)
 				continue
 
-			if (!vampire_can_affect_target(T))
+			if (!vampire_can_affect_target(T, 0, 1))
 				continue
 
 			if (!T.client)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -87,7 +87,7 @@
 
 			frenzy_lower_chance = 20
 
-		if (prob(frenzy_lower_chance))
+		if (prob(frenzy_lower_chance) && vampire.frenzy > 0)
 			vampire.frenzy--
 
 		if (blood_total != vampire.blood_total)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -181,7 +181,7 @@
 		T.Stun(20)
 		T.stuttering = 20
 
-		vampire.blood_usable -= 10
+		vampire.use_blood(10)
 		admin_attack_log(src, T, "used hypnotise to stun [key_name(T)]", "was stunned by [key_name(src)] using hypnotise", "used hypnotise on")
 
 		verbs -= /mob/living/carbon/human/proc/vampire_hypnotise
@@ -237,7 +237,7 @@
 
 	log_and_message_admins("activated veil step.")
 
-	vampire.blood_usable -= 20
+	vampire.use_blood(20)
 	verbs -= /mob/living/carbon/human/proc/vampire_veilstep
 	spawn(300)
 		verbs += /mob/living/carbon/human/proc/vampire_veilstep
@@ -284,7 +284,7 @@
 
 	log_and_message_admins("summoned bats.")
 
-	vampire.blood_usable -= 60
+	vampire.use_blood(60)
 	verbs -= /mob/living/carbon/human/proc/vampire_bats
 	spawn (1200)
 		verbs += /mob/living/carbon/human/proc/vampire_bats
@@ -328,7 +328,7 @@
 		L.broken()
 
 	playsound(src.loc, 'sound/effects/creepyshriek.ogg', 100, 1)
-	vampire.blood_usable -= 90
+	vampire.use_blood(90)
 
 	if (victims.len)
 		admin_attacker_log_many_victims(src, victims, "used chriopteran screech to stun", "was stunned by [key_name(src)] using chriopteran screech", "used chiropteran screech to stun")
@@ -361,7 +361,7 @@
 
 		log_and_message_admins("activated veil walk.")
 
-		vampire.blood_usable -= 80
+		vampire.use_blood(80)
 
 // Veilwalk's dummy holder
 /obj/effect/dummy/veil_walk
@@ -426,7 +426,7 @@
 			return
 
 	if (owner_vampire.blood_usable >= 5)
-		owner_vampire.blood_usable -= 5
+		owner_vampire.use_blood(5)
 
 		switch (warning_level)
 			if (0)
@@ -631,7 +631,7 @@
 	src << "<span class='notice'>You command [T.name], and they will obey.</span>"
 	emote("me", 1, "whispers.")
 
-	vampire.blood_usable -= 25
+	vampire.use_blood(25)
 	verbs -= /mob/living/carbon/human/proc/vampire_dominate
 	spawn(1800)
 		verbs += /mob/living/carbon/human/proc/vampire_dominate
@@ -684,7 +684,7 @@
 
 	admin_attack_log(src, T, "enthralled [key_name(T)]", "was enthralled by [key_name(src)]", "successfully enthralled")
 
-	vampire.blood_usable -= 150
+	vampire.use_blood(150)
 	verbs -= /mob/living/carbon/human/proc/vampire_enthrall
 	spawn(2800)
 		verbs += /mob/living/carbon/human/proc/vampire_enthrall
@@ -728,7 +728,7 @@
 
 	admin_attack_log(src, T, "used diseased touch on [key_name(T)]", "was given a lethal disease by [key_name(src)]", "used diseased touch (<a href='?src=\ref[lethal];info=1'>virus info</a>) on")
 
-	vampire.blood_usable -= 200
+	vampire.use_blood(200)
 	verbs -= /mob/living/carbon/human/proc/vampire_diseasedtouch
 	spawn(1800)
 		verbs += /mob/living/carbon/human/proc/vampire_diseasedtouch
@@ -761,7 +761,7 @@
 							"[src.name] has your best interests at heart, you can feel it.",
 							"A quiet voice tells you that [src.name] should be considered a friend.")
 
-	vampire.blood_usable -= 10
+	vampire.use_blood(10)
 
 	log_and_message_admins("activated presence.")
 
@@ -792,7 +792,7 @@
 			if (prob(probability))
 				T << "<font color='green'><i>[pick(emotes)]</i></font>"
 
-		vampire.blood_usable -= 5
+		vampire.use_blood(5)
 
 		if (vampire.blood_usable < 5)
 			vampire.status &= ~VAMP_PRESENCE

--- a/html/changelogs/skull132-pull_499.yml
+++ b/html/changelogs/skull132-pull_499.yml
@@ -1,0 +1,13 @@
+author: Skull132
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Vampires can no longer have negative amounts of blood or frenzy. This also means that frenzy from low levels of blood is acheivable again."
+  - bugfix: "Dominate and presence no longer affect loyalty implanted personnel, unless the casting vampire has attained full power."


### PR DESCRIPTION
LIs restrict social abilities (presence and dominate).
Also adds a notify parameter to vampire_can_effect_target. This way, the vamp doesn't get notifications in passive loops, such as Presence.
No more negative frenzy or usable blood.