### PR TITLE
Runtime error from feeding borgs

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -112,7 +112,7 @@
 		feed_sound(user)
 		return 1
 	else
-		if(istype(user, /mob/living/carbon/human))
+		if(istype(target, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = target
 			if(H.species.flags & IS_SYNTHETIC)
 				H << "<span class='notice'>They have a monitor for a head, where do you think you're going to put that?</span>"


### PR DESCRIPTION
Feeding borgs used to generate runtime errors, as it was trying to access an invalid set of vars.