### PR TITLE
Pepperspray fix for #403

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -16,10 +16,17 @@
 	var/spray_size = 3
 	var/list/spray_sizes = list(1,3)
 	volume = 250
+	var/safety = 0
 
 /obj/item/weapon/reagent_containers/spray/New()
 	..()
 	src.verbs -= /obj/item/weapon/reagent_containers/verb/set_APTFT
+
+/obj/item/weapon/reagent_containers/spray/AltClick()
+	safety = !safety
+	playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
+	usr << "<span class = 'notice'>You twist the locking cap on the end of the nozzle, the spraybottle is now [safety ? "locked" : "unlocked"].</span>"
+
 
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
 	if(istype(A, /obj/item/weapon/storage) || istype(A, /obj/structure/table) || istype(A, /obj/structure/closet) || istype(A, /obj/item/weapon/reagent_containers) || istype(A, /obj/structure/sink) || istype(A, /obj/structure/janitorialcart))
@@ -34,6 +41,11 @@
 
 	if(reagents.total_volume < amount_per_transfer_from_this)
 		user << "<span class='notice'>\The [src] is empty!</span>"
+		return
+
+	if(safety)
+		playsound(src.loc, 'sound/weapons/empty.ogg', 25, 1)
+		user << "<span class='notice'>The safety is on!</span>"
 		return
 
 	Spray_at(A, user, proximity)
@@ -121,7 +133,8 @@
 	item_state = "pepperspray"
 	possible_transfer_amounts = null
 	volume = 40
-	var/safety = 1
+	safety = 1
+
 
 /obj/item/weapon/reagent_containers/spray/pepper/New()
 	..()
@@ -131,9 +144,13 @@
 	if(..(user, 1))
 		user << "The safety is [safety ? "on" : "off"]."
 
+/obj/item/weapon/reagent_containers/spray/pepper/AltClick()
+	return //No altclick functionality for pepper spray
+
 /obj/item/weapon/reagent_containers/spray/pepper/attack_self(var/mob/user)
 	safety = !safety
 	usr << "<span class = 'notice'>You switch the safety [safety ? "on" : "off"].</span>"
+	playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
 
 /obj/item/weapon/reagent_containers/spray/pepper/Spray_at(atom/A as mob|obj)
 	if(safety)

--- a/html/changelogs/Nanako-PR-412.yml
+++ b/html/changelogs/Nanako-PR-412.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Pepperspray will no longer make a spraying sound if used while the safety is on"
+  - rscadd: "Spray bottles can now be locked by alt-clicking"


### PR DESCRIPTION
- bugfix: "Pepperspray will no longer make a spraying sound if used while the safety is on"
  - rscadd: "Spray bottles can now be locked by alt-clicking"