### PR TITLE
Alcohol Tweaks

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1223,6 +1223,7 @@
 #include "code\modules\mob\living\carbon\human\human_organs.dm"
 #include "code\modules\mob\living\carbon\human\human_powers.dm"
 #include "code\modules\mob\living\carbon\human\human_species.dm"
+#include "code\modules\mob\living\carbon\human\intoxication.dm"
 #include "code\modules\mob\living\carbon\human\inventory.dm"
 #include "code\modules\mob\living\carbon\human\life.dm"
 #include "code\modules\mob\living\carbon\human\login.dm"

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -18,6 +18,7 @@
 	//Active emote/pose
 	var/pose = null
 	var/list/chem_effects = list()
+	var/intoxication = 0//Units of alcohol in their system
 	var/datum/reagents/metabolism/bloodstr = null
 	var/datum/reagents/metabolism/ingested = null
 	var/datum/reagents/metabolism/touching = null

--- a/code/modules/mob/living/carbon/human/intoxication.dm
+++ b/code/modules/mob/living/carbon/human/intoxication.dm
@@ -1,7 +1,7 @@
 #define		AE_DIZZY 		5
-#define		AE_CLUMSY		10
 #define 	AE_SLURRING 	15
-#define 	AE_CONFUSION 	20
+#define 	AE_CONFUSION 	18
+#define		AE_CLUMSY		22
 #define 	AE_BLURRING 	25
 #define		AE_VOMIT		40
 #define 	AE_DROWSY 		55
@@ -25,25 +25,31 @@ var/mob/living/carbon/human/alcohol_clumsy = 0
 		return
 
 	if(intoxication > AE_DIZZY*SR) // Early warning
+		if (dizziness == 0)
+			src << "<span class='notice'>The room starts spinning!</span>"
 		var/target_dizziness = min(1000,(BASE_DIZZY + ((intoxication - AE_DIZZY*SR)*10)/SR))
 		make_dizzy(target_dizziness - dizziness) // We will repeatedly set our target dizziness to a desired value based on intoxication level
-
-	//Make the drinker temporarily clumsy if intoxication is high enough
-	//We use a var to track if alcohol caused it, we won't add nor remove it if the drinker was already clumsy from some other source
-	if(intoxication > AE_CLUMSY*SR)
-		if (!alcohol_clumsy && !(CLUMSY in mutations))
-			mutations.Add(CLUMSY)
-			alcohol_clumsy = 1
-	else //Remove it if intoxication drops too low. We'll also have another check to remove it in life.dm
-		if (alcohol_clumsy)
-			mutations.Remove(CLUMSY)
-			alcohol_clumsy = 0
 
 	if(intoxication > AE_SLURRING*SR) // Slurring
 		slurring = max(slurring, 30)
 
 	if(intoxication > AE_CONFUSION*SR) // Confusion - walking in random directions
+		if (confused == 0)
+			src << "<span class='notice'>You feel unsteady on your feet!</span>"
 		confused = max(confused, 20)
+
+	//Make the drinker temporarily clumsy if intoxication is high enough
+	//We use a var to track if alcohol caused it, we won't add nor remove it if the drinker was already clumsy from some other source
+	if(intoxication > AE_CLUMSY*SR)
+		if (!alcohol_clumsy && !(CLUMSY in mutations))
+			src << "<span class='notice'>You feel a bit clumsy and uncoordinated.</span>"
+			mutations.Add(CLUMSY)
+			alcohol_clumsy = 1
+	else //Remove it if intoxication drops too low. We'll also have another check to remove it in life.dm
+		if (alcohol_clumsy)
+			src << "<span class='notice'>You feel more sober and steady</span>"
+			mutations.Remove(CLUMSY)
+			alcohol_clumsy = 0
 
 	if(intoxication > AE_BLURRING*SR) // Blurry vision
 		if (prob(10))//blurry vision effect is annoying, so nerfing it

--- a/code/modules/mob/living/carbon/human/intoxication.dm
+++ b/code/modules/mob/living/carbon/human/intoxication.dm
@@ -1,0 +1,42 @@
+#define		AE_DIZZY 		5
+#define 	AE_SLURRING 	10
+#define 	AE_CONFUSION 	18
+#define 	AE_BLURRING 	30
+#define 	AE_DROWSY 		55
+#define 	AE_OVERDOSE 	80
+#define 	AE_BLACKOUT		90
+
+#define		BASE_DIZZY		100
+
+#define 	ALCOHOL_FILTRATION_RATE		0.02//The base rate at which intoxication decreases per proc. this is actually multiplied by 3 most of the time if the liver is healthy
+
+//This proc handles the effects of being intoxicated. Removal of intoxication is done elswhere: By the liver, in organ_internal.dm
+/mob/living/carbon/human/proc/handle_intoxication()
+	var/SR = species.ethanol_resistance
+	if (SR == -1)
+		//This species can't get drunk, how did we even get here?
+		intoxication = 0
+		return
+
+	if(intoxication > AE_DIZZY*SR) // Early warning
+		var/target_dizziness = min(1000,(BASE_DIZZY + ((intoxication - AE_DIZZY*SR)*20)/SR))
+		make_dizzy(target_dizziness - dizziness) // We will repeatedly set our target dizziness to a desired value based on intoxication level
+
+	if(intoxication > AE_SLURRING*SR) // Slurring
+		slurring = max(slurring, 30)
+
+	if(intoxication > AE_CONFUSION*SR) // Confusion - walking in random directions
+		confused = max(confused, 20)
+
+	if(intoxication > AE_BLURRING*SR) // Blurry vision
+		eye_blurry = max(eye_blurry, 10)
+
+	if(intoxication > AE_DROWSY*SR) // Drowsyness - periodically falling asleep
+		drowsyness = max(drowsyness, 20)
+
+	if(intoxication > AE_OVERDOSE*SR) // Toxic dose
+		add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
+
+	if(intoxication > AE_BLACKOUT*SR) // Pass out
+		paralysis = max(paralysis, 20)
+		sleeping  = max(sleeping, 30)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -903,6 +903,9 @@
 					total_phoronloss += vsc.plc.CONTAMINATION_LOSS
 			if(!(status_flags & GODMODE)) adjustToxLoss(total_phoronloss)
 
+			if (intoxication)
+				handle_intoxication()
+
 		if(status_flags & GODMODE)	return 0	//godmode
 
 		var/obj/item/organ/diona/node/light_organ = locate() in internal_organs

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -905,6 +905,9 @@
 
 			if (intoxication)
 				handle_intoxication()
+			else if (alcohol_clumsy)//This var is defined in intoxication.dm, its set true when alcohol has caused clumsiness
+				mutations.Remove(CLUMSY)
+				alcohol_clumsy = 0
 
 		if(status_flags & GODMODE)	return 0	//godmode
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -108,6 +108,8 @@
 	var/holder_type
 	var/gluttonous                // Can eat some mobs. 1 for mice, 2 for monkeys, 3 for people.
 	var/rarity_value = 1          // Relative rarity/collector value for this species.
+	var/ethanol_resistance = 1	  // How well the mob resists alcohol, lower values get drunk faster, higher values need to drink more
+
 	                              // Determines the organs that the species spawns with and
 	var/list/has_organ = list(    // which required-organ checks are conducted.
 		"heart" =    /obj/item/organ/heart,

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -24,6 +24,7 @@
 	primitive_form = "Stok"
 	darksight = 3
 	gluttonous = 1
+	ethanol_resistance = 1.5
 
 	blurb = "A heavily reptillian species, Unathi (or 'Sinta as they call themselves) hail from the \
 	Uuosa-Eso system, which roughly translates to 'burning mother'.<br/><br/>Coming from a harsh, radioactive \
@@ -76,6 +77,7 @@
 	darksight = 8
 	slowdown = -1
 	brute_mod = 1.2
+	ethanol_resistance = 0.8//Gets drunk a little faster
 
 	blurb = "The Tajaran race is a species of feline-like bipeds hailing from the planet of Ahdomai in the \
 	S'randarr system. They have been brought up into the space age by the Humans and Skrell, and have been \
@@ -132,6 +134,7 @@
 	base_color = "#006666"
 
 	reagent_tag = IS_SKRELL
+	ethanol_resistance = 0.5//gets drunk faster
 
 /datum/species/diona
 	name = "Diona"
@@ -147,6 +150,7 @@
 	siemens_coefficient = 0.3
 	eyes = "blank_eyes"
 	show_ssd = "completely quiescent"
+	ethanol_resistance = -1//Can't get drunk
 
 
 	blurb = "Commonly referred to (erroneously) as 'plant people', the Dionaea are a strange space-dwelling collective \
@@ -232,6 +236,7 @@
 	language = "Tradeband"
 	unarmed_types = list(/datum/unarmed_attack/punch)
 	rarity_value = 2
+	ethanol_resistance = -1//Can't get drunk
 
 	eyes = "blank_eyes"
 	brute_mod = 0.5
@@ -283,6 +288,7 @@
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
 	siemens_coefficient = 0 //attempting to mimic the old insulation feature.
+	ethanol_resistance = 2
 	breath_type = "oxygen"
 	poison_type = "null" //a species that breathes plasma shouldn't be poisoned by it.
 	blurb = "Vaurca are a bipedal insectoid species from the first moon of Sedantis I. \

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -711,6 +711,9 @@ proc/is_blind(A)
 			location.add_vomit_floor(src, 1)
 
 		nutrition -= 40
+		if (intoxication)//The pain and system shock of vomiting, sobers you up a little
+			intoxication *= 0.8
+
 		if (istype(src, /mob/living/carbon/human))
 			ingested.trans_to_turf(location,30)//Vomiting empties the stomach, transferring 30u reagents to the floor where you vomited
 	else

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -277,7 +277,7 @@
 			//specific vehicle move delays are set in code\modules\vehicles\vehicle.dm
 			move_delay = world.time + tickcomp
 			//drunk driving
-			if(mob.confused)
+			if(mob.confused && prob(20))
 				direct = pick(cardinal)
 			return mob.buckled.relaymove(mob,direct)
 
@@ -298,7 +298,7 @@
 					if((!l_hand || l_hand.is_stump()) && (!r_hand || r_hand.is_stump()))
 						return // No hands to drive your chair? Tough luck!
 				//drunk wheelchair driving
-				if(mob.confused)
+				if(mob.confused && prob(20))
 					direct = pick(cardinal)
 				move_delay += 2
 				return mob.buckled.relaymove(mob,direct)
@@ -338,7 +338,7 @@
 							M.animate_movement = 2
 							return
 
-		else if(mob.confused)
+		else if(mob.confused && prob(20))
 			step(mob, pick(cardinal))
 		else
 			. = mob.SelfMove(n, direct)

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -141,6 +141,11 @@
 		if(is_broken())
 			filter_effect -= 2
 
+		if (owner.intoxication)
+			//ALCOHOL_FILTRATION_RATE is defined in intoxication.dm
+			owner.intoxication -= ALCOHOL_FILTRATION_RATE*filter_effect*PROCESS_ACCURACY//A weakened liver filters out alcohol more slowly
+			owner.intoxication = max(owner.intoxication, 0)
+
 		// Do some reagent processing.
 		if(owner.chem_effects[CE_ALCOHOL_TOXIC])
 			if(filter_effect < 3)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -79,10 +79,11 @@
 	return
 
 /datum/reagent/ethanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	if(M.get_species() == "Vaurca")
+	if(M.get_species() == "Vaurca")//Vaurca are damaged instead of getting nutrients, but they can still get drunk
 		M.adjustToxLoss(1.5 * removed * (strength / 100))
 	else
 		M.nutrition += nutriment_factor * removed
+
 	if(alien == IS_DIONA)
 		return //Diona can gain nutrients, but don't get drunk or suffer other effects
 
@@ -101,6 +102,7 @@
 
 	if(halluci)
 		M.hallucination = max(M.hallucination, halluci)
+
 
 /datum/reagent/ethanol/touch_obj(var/obj/O)
 	if(istype(O, /obj/item/weapon/paper))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -57,9 +57,9 @@
 	description = "A well-known alcohol with a variety of applications."
 	reagent_state = LIQUID
 	color = "#404030"
-	var/nutriment_factor = 0
-	var/strength = 10 // This is, essentially, units between stages - the lower, the stronger. Less fine tuning, more clarity.
-	var/toxicity = 1
+	ingest_met = 0.5
+	var/nutriment_factor = 0.5
+	var/strength = 100 // This is the Alcohol By Volume of the drink, value is in the range 0-100 unless you wanted to create some bizarre bluespace alcohol with <100
 
 	var/druggy = 0
 	var/adj_temp = 0
@@ -71,39 +71,25 @@
 	glass_desc = "A well-known alcohol with a variety of applications."
 
 /datum/reagent/ethanol/touch_mob(var/mob/living/L, var/amount)
-	if(istype(L))
-		L.adjust_fire_stacks(amount / 15)
+	if(istype(L) && strength > 40)
+		L.adjust_fire_stacks((amount / 10) * (strength / 100))
 
 /datum/reagent/ethanol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.adjustToxLoss(removed * 2 * toxicity)
+	M.adjustToxLoss(removed * 2)
 	return
 
 /datum/reagent/ethanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	M.nutrition += nutriment_factor * removed
-
-	var/strength_mod = 1
-	if(alien == IS_SKRELL)
-		strength_mod *= 5
+	if(M.get_species() == "Vaurca")
+		M.adjustToxLoss(1.5 * removed * (strength / 100))
+	else
+		M.nutrition += nutriment_factor * removed
 	if(alien == IS_DIONA)
-		strength_mod = 0
+		return //Diona can gain nutrients, but don't get drunk or suffer other effects
 
-	M.add_chemical_effect(CE_ALCOHOL, 1)
 
-	if(dose * strength_mod >= strength) // Early warning
-		M.make_dizzy(6) // It is decreased at the speed of 3 per tick
-	if(dose * strength_mod >= strength * 2) // Slurring
-		M.slurring = max(M.slurring, 30)
-	if(dose * strength_mod >= strength * 3) // Confusion - walking in random directions
-		M.confused = max(M.confused, 20)
-	if(dose * strength_mod >= strength * 4) // Blurry vision
-		M.eye_blurry = max(M.eye_blurry, 10)
-	if(dose * strength_mod >= strength * 5) // Drowsyness - periodically falling asleep
-		M.drowsyness = max(M.drowsyness, 20)
-	if(dose * strength_mod >= strength * 6) // Toxic dose
-		M.add_chemical_effect(CE_ALCOHOL_TOXIC, toxicity)
-	if(dose * strength_mod >= strength * 7) // Pass out
-		M.paralysis = max(M.paralysis, 20)
-		M.sleeping  = max(M.sleeping, 30)
+	var/quantity = (strength / 100) * removed
+	M.intoxication += quantity
+
 
 	if(druggy != 0)
 		M.druggy = max(M.druggy, druggy)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -938,7 +938,7 @@
 	id = "absinthe"
 	description = "Watch out that the Green Fairy doesn't come for you!"
 	color = "#33EE00"
-	strength = 12
+	strength = 75
 
 	glass_icon_state = "absintheglass"
 	glass_name = "glass of absinthe"
@@ -950,7 +950,7 @@
 	id = "ale"
 	description = "A dark alchoholic beverage made by malted barley and yeast."
 	color = "#664300"
-	strength = 50
+	strength = 6
 
 	glass_icon_state = "aleglass"
 	glass_name = "glass of ale"
@@ -962,7 +962,7 @@
 	id = "beer"
 	description = "An alcoholic beverage made from malted grains, hops, yeast, and water."
 	color = "#664300"
-	strength = 50
+	strength = 5
 	nutriment_factor = 1
 
 	glass_icon_state = "beerglass"
@@ -981,7 +981,7 @@
 	id = "bluecuracao"
 	description = "Exotically blue, fruity drink, distilled from oranges."
 	color = "#0000CD"
-	strength = 15
+	strength = 25
 
 	glass_icon_state = "curacaoglass"
 	glass_name = "glass of blue curacao"
@@ -993,7 +993,7 @@
 	id = "cognac"
 	description = "A sweet and strongly alchoholic drink, made after numerous distillations and years of maturing. Classy as fornication."
 	color = "#AB3C05"
-	strength = 15
+	strength = 40
 
 	glass_icon_state = "cognacglass"
 	glass_name = "glass of cognac"
@@ -1023,7 +1023,7 @@
 	id = "gin"
 	description = "It's gin. In space. I say, good sir."
 	color = "#664300"
-	strength = 50
+	strength = 40
 
 	glass_icon_state = "ginvodkaglass"
 	glass_name = "glass of gin"
@@ -1035,7 +1035,7 @@
 	id = "kahlua"
 	description = "A widely known, Mexican coffee-flavoured liqueur. In production since 1936!"
 	color = "#664300"
-	strength = 15
+	strength = 20
 
 	glass_icon_state = "kahluaglass"
 	glass_name = "glass of RR coffee liquor"
@@ -1058,7 +1058,7 @@
 	id = "melonliquor"
 	description = "A relatively sweet and fruity 46 proof liquor."
 	color = "#138808" // rgb: 19, 136, 8
-	strength = 50
+	strength = 23
 
 	glass_icon_state = "emeraldglass"
 	glass_name = "glass of melon liquor"
@@ -1070,7 +1070,7 @@
 	id = "rum"
 	description = "Yohoho and all that."
 	color = "#664300"
-	strength = 15
+	strength = 40
 
 	glass_icon_state = "rumglass"
 	glass_name = "glass of rum"
@@ -1082,7 +1082,7 @@
 	id = "sake"
 	description = "Anime's favorite drink."
 	color = "#664300"
-	strength = 25
+	strength = 20
 
 	glass_icon_state = "ginvodkaglass"
 	glass_name = "glass of sake"
@@ -1094,7 +1094,7 @@
 	id = "tequilla"
 	description = "A strong and mildly flavoured, mexican produced spirit. Feeling thirsty hombre?"
 	color = "#FFFF91"
-	strength = 25
+	strength = 40
 
 	glass_icon_state = "tequillaglass"
 	glass_name = "glass of Tequilla"
@@ -1106,7 +1106,7 @@
 	id = "thirteenloko"
 	description = "A potent mixture of caffeine and alcohol."
 	color = "#102000"
-	strength = 25
+	strength = 10
 	nutriment_factor = 1
 
 	glass_icon_state = "thirteen_loko_glass"
@@ -1127,7 +1127,7 @@
 	id = "vermouth"
 	description = "You suddenly feel a craving for a martini..."
 	color = "#91FF91" // rgb: 145, 255, 145
-	strength = 15
+	strength = 17
 
 	glass_icon_state = "vermouthglass"
 	glass_name = "glass of vermouth"
@@ -1139,7 +1139,7 @@
 	id = "vodka"
 	description = "Number one drink AND fueling choice for Russians worldwide."
 	color = "#0064C8" // rgb: 0, 100, 200
-	strength = 15
+	strength = 50
 
 	glass_icon_state = "ginvodkaglass"
 	glass_name = "glass of vodka"
@@ -1155,7 +1155,7 @@
 	id = "whiskey"
 	description = "A superb and well-aged single-malt whiskey. Damn."
 	color = "#664300"
-	strength = 25
+	strength = 40
 
 	glass_icon_state = "whiskeyglass"
 	glass_name = "glass of whiskey"
@@ -1182,7 +1182,7 @@
 	description = "A drink for the daring, can be deadly if incorrectly prepared!"
 	reagent_state = LIQUID
 	color = "#365000"
-	strength = 30
+	strength = 10
 
 	glass_icon_state = "acidspitglass"
 	glass_name = "glass of Acid Spit"
@@ -1231,7 +1231,7 @@
 	id = "andalusia"
 	description = "A nice, strangely named drink."
 	color = "#664300"
-	strength = 15
+	strength = 35
 
 	glass_icon_state = "andalusia"
 	glass_name = "glass of Andalusia"
@@ -1243,7 +1243,7 @@
 	id = "antifreeze"
 	description = "Ultimate refreshment."
 	color = "#664300"
-	strength = 12
+	strength = 20
 	adj_temp = 20
 	targ_temp = 330
 
@@ -1258,7 +1258,7 @@
 	description = "Nuclear proliferation never tasted so good."
 	reagent_state = LIQUID
 	color = "#666300"
-	strength = 10
+	strength = 50
 	druggy = 50
 
 	glass_icon_state = "atomicbombglass"
@@ -1271,7 +1271,7 @@
 	id = "b52"
 	description = "Coffee, Irish Cream, and cognac. You will get bombed."
 	color = "#664300"
-	strength = 12
+	strength = 35
 
 	glass_icon_state = "b52glass"
 	glass_name = "glass of B-52"
@@ -1282,7 +1282,7 @@
 	id = "bahama_mama"
 	description = "Tropical cocktail."
 	color = "#FF7F3B"
-	strength = 25
+	strength = 15
 
 	glass_icon_state = "bahama_mama"
 	glass_name = "glass of Bahama Mama"
@@ -1295,7 +1295,7 @@
 	description = "A drink from Clown Heaven."
 	nutriment_factor = 1
 	color = "#FFFF91"
-	strength = 12
+	strength = 15
 
 	glass_icon_state = "bananahonkglass"
 	glass_name = "glass of Banana Honk"
@@ -1307,7 +1307,7 @@
 	id = "barefoot"
 	description = "Barefoot and pregnant"
 	color = "#664300"
-	strength = 30
+	strength = 15
 
 	glass_icon_state = "b&p"
 	glass_name = "glass of Barefoot"
@@ -1320,7 +1320,7 @@
 	description = "Deny drinking this and prepare for THE LAW."
 	reagent_state = LIQUID
 	color = "#664300"
-	strength = 12
+	strength = 35
 
 	glass_icon_state = "beepskysmashglass"
 	glass_name = "Beepsky Smash"
@@ -1336,7 +1336,7 @@
 	id = "bilk"
 	description = "This appears to be beer mixed with milk. Disgusting."
 	color = "#895C4C"
-	strength = 50
+	strength = 4
 	nutriment_factor = 2
 
 	glass_icon_state = "glass_brown"
@@ -1348,7 +1348,7 @@
 	id = "blackrussian"
 	description = "For the lactose-intolerant. Still as classy as a White Russian."
 	color = "#360000"
-	strength = 15
+	strength = 20
 
 	glass_icon_state = "blackrussianglass"
 	glass_name = "glass of Black Russian"
@@ -1360,7 +1360,7 @@
 	id = "bloodymary"
 	description = "A strange yet pleasurable mixture made of vodka, tomato and lime juice. Or at least you THINK the red stuff is tomato juice."
 	color = "#664300"
-	strength = 15
+	strength = 20
 
 	glass_icon_state = "bloodymaryglass"
 	glass_name = "glass of Bloody Mary"
@@ -1371,7 +1371,7 @@
 	id = "booger"
 	description = "Ewww..."
 	color = "#8CFF8C"
-	strength = 30
+	strength = 20
 
 	glass_icon_state = "booger"
 	glass_name = "glass of Booger"
@@ -1382,7 +1382,7 @@
 	id = "bravebull"
 	description = "It's just as effective as Dutch-Courage!"
 	color = "#664300"
-	strength = 15
+	strength = 30
 
 	glass_icon_state = "bravebullglass"
 	glass_name = "glass of Brave Bull"
@@ -1394,7 +1394,7 @@
 	id = "changelingsting"
 	description = "You take a tiny sip and feel a burning sensation..."
 	color = "#2E6671"
-	strength = 10
+	strength = 40
 
 	glass_icon_state = "changelingsting"
 	glass_name = "glass of Changeling Sting"
@@ -1417,7 +1417,7 @@
 	id = "cubalibre"
 	description = "Rum, mixed with cola. Viva la revolucion."
 	color = "#3E1B00"
-	strength = 30
+	strength = 10
 
 	glass_icon_state = "cubalibreglass"
 	glass_name = "glass of Cuba Libre"
@@ -1454,7 +1454,7 @@
 	description = "Only for the experienced. You think you see sand floating in the glass."
 	nutriment_factor = 1
 	color = "#2E6671"
-	strength = 12
+	strength = 20
 
 	glass_icon_state = "driestmartiniglass"
 	glass_name = "glass of Driest Martini"
@@ -1466,7 +1466,7 @@
 	id = "ginfizz"
 	description = "Refreshingly lemony, deliciously dry."
 	color = "#664300"
-	strength = 30
+	strength = 20
 
 	glass_icon_state = "ginfizzglass"
 	glass_name = "glass of gin fizz"
@@ -1479,7 +1479,7 @@
 	description = "Watered down rum, NanoTrasen approves!"
 	reagent_state = LIQUID
 	color = "#664300"
-	strength = 100
+	strength = 10
 
 	glass_icon_state = "grogglass"
 	glass_name = "glass of grog"
@@ -1503,7 +1503,7 @@
 	description = "Whoah, this stuff looks volatile!"
 	reagent_state = LIQUID
 	color = "#664300"
-	strength = 10
+	strength = 50
 
 	glass_icon_state = "gargleblasterglass"
 	glass_name = "glass of Pan-Galactic Gargle Blaster"
@@ -1515,7 +1515,7 @@
 	id = "gintonic"
 	description = "An all time classic, mild cocktail."
 	color = "#664300"
-	strength = 50
+	strength = 12
 
 	glass_icon_state = "gintonicglass"
 	glass_name = "glass of gin and tonic"
@@ -1527,7 +1527,7 @@
 	id = "goldschlager"
 	description = "100 proof cinnamon schnapps, made for alcoholic teen girls on spring break."
 	color = "#664300"
-	strength = 15
+	strength = 50
 
 	glass_icon_state = "ginvodkaglass"
 	glass_name = "glass of Goldschlager"
@@ -1553,8 +1553,7 @@
 	id = "hooch"
 	description = "Either someone's failure at cocktail making or attempt in alchohol production. In any case, do you really want to drink that?"
 	color = "#664300"
-	strength = 25
-	toxicity = 2
+	strength = 65
 
 	glass_icon_state = "glass_brown2"
 	glass_name = "glass of Hooch"
@@ -1565,7 +1564,7 @@
 	id = "iced_beer"
 	description = "A beer which is so cold the air around it freezes."
 	color = "#664300"
-	strength = 50
+	strength = 5
 	adj_temp = -20
 	targ_temp = 270
 
@@ -1603,7 +1602,7 @@
 	id = "irishcream"
 	description = "Whiskey-imbued cream, what else would you expect from the Irish."
 	color = "#664300"
-	strength = 25
+	strength = 15
 
 	glass_icon_state = "irishcreamglass"
 	glass_name = "glass of Irish cream"
@@ -1615,7 +1614,7 @@
 	id = "longislandicedtea"
 	description = "The liquor cabinet, brought together in a delicious mix. Intended for middle-aged alcoholic women only."
 	color = "#664300"
-	strength = 12
+	strength = 30
 
 	glass_icon_state = "longislandicedteaglass"
 	glass_name = "glass of Long Island iced tea"
@@ -1627,7 +1626,7 @@
 	id = "manhattan"
 	description = "The Detective's undercover drink of choice. He never could stomach gin..."
 	color = "#664300"
-	strength = 15
+	strength = 20
 
 	glass_icon_state = "manhattanglass"
 	glass_name = "glass of Manhattan"
@@ -1639,7 +1638,7 @@
 	id = "manhattan_proj"
 	description = "A scientist's drink of choice, for pondering ways to blow up the station."
 	color = "#664300"
-	strength = 10
+	strength = 30
 	druggy = 30
 
 	glass_icon_state = "proj_manhattanglass"
@@ -1652,7 +1651,7 @@
 	id = "manlydorf"
 	description = "Beer and Ale, brought together in a delicious mix. Intended for true men only."
 	color = "#664300"
-	strength = 25
+	strength = 10
 
 	glass_icon_state = "manlydorfglass"
 	glass_name = "glass of The Manly Dorf"
@@ -1676,7 +1675,7 @@
 	description = "A Viking's drink, though a cheap one."
 	reagent_state = LIQUID
 	color = "#664300"
-	strength = 30
+	strength = 20
 	nutriment_factor = 1
 
 	glass_icon_state = "meadglass"
@@ -1689,7 +1688,7 @@
 	id = "moonshine"
 	description = "You've really hit rock bottom now... your liver packed its bags and left last night."
 	color = "#664300"
-	strength = 12
+	strength = 65
 
 	glass_icon_state = "glass_clear"
 	glass_name = "glass of moonshine"
@@ -1701,7 +1700,7 @@
 	description = "A strong neurotoxin that puts the subject into a death-like state."
 	reagent_state = LIQUID
 	color = "#2E2E61"
-	strength = 10
+	strength = 50
 
 	glass_icon_state = "neurotoxinglass"
 	glass_name = "glass of Neurotoxin"
@@ -1717,7 +1716,7 @@
 	id = "patron"
 	description = "Tequila with silver in it, a favorite of alcoholic women in the club scene."
 	color = "#585840"
-	strength = 30
+	strength = 20
 
 	glass_icon_state = "patronglass"
 	glass_name = "glass of Patron"
@@ -1729,7 +1728,7 @@
 	id = "pwine"
 	description = "Is this even wine? Toxic! Hallucinogenic! Probably consumed in boatloads by your superiors!"
 	color = "#000000"
-	strength = 10
+	strength = 15
 	druggy = 50
 	halluci = 10
 
@@ -1756,7 +1755,7 @@
 	id = "red_mead"
 	description = "The true Viking's drink! Even though it has a strange red color."
 	color = "#C73C00"
-	strength = 30
+	strength = 21
 
 	glass_icon_state = "red_meadglass"
 	glass_name = "glass of red mead"
@@ -1768,7 +1767,7 @@
 	id = "sbiten"
 	description = "A spicy Vodka! Might be a little hot for the little guys!"
 	color = "#664300"
-	strength = 15
+	strength = 40
 	adj_temp = 50
 	targ_temp = 360
 
@@ -1795,7 +1794,7 @@
 	description = "A drink from Mime Heaven."
 	nutriment_factor = 1
 	color = "#664300"
-	strength = 12
+	strength = 18
 
 	glass_icon_state = "silencerglass"
 	glass_name = "glass of Silencer"
@@ -1807,7 +1806,7 @@
 	id = "singulo"
 	description = "A blue-space beverage!"
 	color = "#2E6671"
-	strength = 10
+	strength = 20
 
 	glass_icon_state = "singulo"
 	glass_name = "glass of Singulo"
@@ -1819,7 +1818,7 @@
 	id = "snowwhite"
 	description = "A cold refreshment"
 	color = "#FFFFFF"
-	strength = 30
+	strength = 7
 
 	glass_icon_state = "snowwhite"
 	glass_name = "glass of Snow White"
@@ -1831,7 +1830,7 @@
 	id = "suidream"
 	description = "Comprised of: White soda, blue curacao, melon liquor."
 	color = "#00A86B"
-	strength = 100
+	strength = 5
 
 	glass_icon_state = "sdreamglass"
 	glass_name = "glass of Sui Dream"
@@ -1855,7 +1854,7 @@
 	id = "tequillasunrise"
 	description = "Tequila and orange juice. Much like a Screwdriver, only Mexican~"
 	color = "#FFE48C"
-	strength = 25
+	strength = 15
 
 	glass_icon_state = "tequillasunriseglass"
 	glass_name = "glass of Tequilla Sunrise"
@@ -1866,7 +1865,7 @@
 	id = "threemileisland"
 	description = "Made for a woman, strong enough for a man."
 	color = "#666340"
-	strength = 10
+	strength = 60
 	druggy = 50
 
 	glass_icon_state = "threemileislandglass"
@@ -1880,7 +1879,7 @@
 	description = "This thing is ON FIRE! CALL THE DAMN SHUTTLE!"
 	reagent_state = LIQUID
 	color = "#664300"
-	strength = 10
+	strength = 40
 	adj_temp = 15
 	targ_temp = 330
 
@@ -1893,7 +1892,7 @@
 	id = "vodkamartini"
 	description = "Vodka with Gin. Not quite how 007 enjoyed it, but still delicious."
 	color = "#664300"
-	strength = 12
+	strength = 32
 
 	glass_icon_state = "martiniglass"
 	glass_name = "glass of vodka martini"
@@ -1905,7 +1904,7 @@
 	id = "vodkatonic"
 	description = "For when a gin and tonic isn't russian enough."
 	color = "#0064C8" // rgb: 0, 100, 200
-	strength = 15
+	strength = 13
 
 	glass_icon_state = "vodkatonicglass"
 	glass_name = "glass of vodka and tonic"
@@ -1917,7 +1916,7 @@
 	id = "whiterussian"
 	description = "That's just, like, your opinion, man..."
 	color = "#A68340"
-	strength = 15
+	strength = 24
 
 	glass_icon_state = "whiterussianglass"
 	glass_name = "glass of White Russian"
@@ -1929,7 +1928,7 @@
 	id = "whiskeycola"
 	description = "Whiskey, mixed with cola. Surprisingly refreshing."
 	color = "#3E1B00"
-	strength = 25
+	strength = 15
 
 	glass_icon_state = "whiskeycolaglass"
 	glass_name = "glass of whiskey cola"
@@ -1953,7 +1952,7 @@
 	id = "specialwhiskey"
 	description = "Just when you thought regular station whiskey was good... This silky, amber goodness has to come along and ruin everything."
 	color = "#664300"
-	strength = 25
+	strength = 45
 
 	glass_icon_state = "whiskeyglass"
 	glass_name = "glass of special blend whiskey"
@@ -2015,7 +2014,7 @@
 /datum/reagent/drink/cafe_melange/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.reagents.add_reagent("kelotane", removed * 0.2)
-	
+
 //aurora unique drinks
 
 /datum/reagent/ethanol/daiquiri
@@ -2023,89 +2022,89 @@
 	id = "daiquiri"
 	description = "Exotically blue, fruity drink, distilled from oranges."
 	color = "#664300"
-	strength = 25
+	strength = 15
 
 	glass_icon_state = "daiquiri"
 	glass_name = "glass of Daiquiri"
 	glass_desc = "A splendid looking cocktail."
-	
+
 /datum/reagent/ethanol/icepick
 	name = "Ice Pick"
 	id = "icepick"
 	description = "Big. And red. Hmm...."
 	color = "#664300"
-	strength = 50
+	strength = 10
 
 	glass_icon_state = "icepick"
 	glass_name = "glass of Ice Pick"
-	glass_desc = "Big. And red. Hmm..."	
-	
+	glass_desc = "Big. And red. Hmm..."
+
 /datum/reagent/ethanol/poussecafe
 	name = "Pousse-Cafe"
 	id = "poussecafe"
 	description = "Smells of French and liquore."
 	color = "#664300"
-	strength = 25
+	strength = 15
 
 	glass_icon_state = "pousseecafe"
 	glass_name = "glass of Pousse-Cafe"
-	glass_desc = "Smells of French and liquore."	
-	
+	glass_desc = "Smells of French and liquore."
+
 /datum/reagent/ethanol/mintjulep
 	name = "Mint Julep"
 	id = "mintjulep"
 	description = "As old as time itself, but how does it taste?"
 	color = "#664300"
-	strength = 50
+	strength = 25
 
 	glass_icon_state = "mintjulep"
 	glass_name = "glass of Mint Julep"
-	glass_desc = "As old as time itself, but how does it taste?"	
-	
+	glass_desc = "As old as time itself, but how does it taste?"
+
 /datum/reagent/ethanol/johncollins
 	name = "John Collins"
 	id = "johncollins"
 	description = "Crystal clear, yellow, and smells of gin. How could this go wrong?"
 	color = "#664300"
-	strength = 15
+	strength = 25
 
 	glass_icon_state = "johnscollins"
 	glass_name = "glass of John Collins"
-	glass_desc = "Named after a man, perhaps?"	
-	
+	glass_desc = "Named after a man, perhaps?"
+
 /datum/reagent/ethanol/gimlet
 	name = "Gimlet"
 	id = "gimlet"
 	description = "Small, elegant, and kicks."
 	color = "#664300"
-	strength = 15
+	strength = 13
 
 	glass_icon_state = "gimlet"
 	glass_name = "glass of Gimlet"
-	glass_desc = "Small, elegant, and packs a punch."	
-	
+	glass_desc = "Small, elegant, and packs a punch."
+
 /datum/reagent/ethanol/starsandstripes
 	name = "Stars and Stripes"
 	id = "starsandstripes"
 	description = "Someone, somewhere, is saluting."
 	color = "#664300"
-	strength = 50
+	strength = 10
 
 	glass_icon_state = "starsandstripes"
 	glass_name = "glass of Stars and Stripes"
-	glass_desc = "Someone, somewhere, is saluting."	
-	
+	glass_desc = "Someone, somewhere, is saluting."
+
 /datum/reagent/ethanol/metropolitan
 	name = "Metropolitan"
 	id = "metropolitan"
 	description = "What more could you ask for?"
 	color = "#664300"
-	strength = 25
+	strength = 27
 
 	glass_icon_state = "metropolitan"
 	glass_name = "glass of Metropolitan"
-	glass_desc = "What more could you ask for?"	
-	
+	glass_desc = "What more could you ask for?"
+
 /datum/reagent/ethanol/caruso
 	name = "Caruso"
 	id = "caruso"
@@ -2115,8 +2114,8 @@
 
 	glass_icon_state = "caruso"
 	glass_name = "glass of Caruso"
-	glass_desc = "Green, almost alien."	
-	
+	glass_desc = "Green, almost alien."
+
 /datum/reagent/ethanol/aprilshower
 	name = "April Shower"
 	id = "aprilshower"
@@ -2126,8 +2125,8 @@
 
 	glass_icon_state = "aprilshower"
 	glass_name = "glass of April Shower"
-	glass_desc = "Smells of brandy."	
-	
+	glass_desc = "Smells of brandy."
+
 /datum/reagent/ethanol/carthusiansazerac
 	name = "Carthusian Sazerac"
 	id = "carthusiansazerac"
@@ -2137,8 +2136,8 @@
 
 	glass_icon_state = "carthusiansazerac"
 	glass_name = "glass of Carthusian Sazerac"
-	glass_desc = "Whiskey and... Syrup?"	
-	
+	glass_desc = "Whiskey and... Syrup?"
+
 /datum/reagent/ethanol/deweycocktail
 	name = "Dewey Cocktail"
 	id = "deweycocktail"
@@ -2148,124 +2147,124 @@
 
 	glass_icon_state = "deweycocktail"
 	glass_name = "glass of Dewey Cocktail"
-	glass_desc = "Colours, look at all the colours!"	
-	
+	glass_desc = "Colours, look at all the colours!"
+
 /datum/reagent/ethanol/chartreusegreen
 	name = "Green Chartreuse"
 	id = "chartreusegreen"
 	description = "A green, strong liqueur."
 	color = "#664300"
-	strength = 10
+	strength = 40
 
 	glass_icon_state = "greenchartreuseglass"
 	glass_name = "glass of Green Chartreuse"
-	glass_desc = "A green, strong liqueur."	
-	
+	glass_desc = "A green, strong liqueur."
+
 /datum/reagent/ethanol/chartreuseyellow
 	name = "Yellow Chartreuse"
 	id = "chartreuseyellow"
 	description = "A yellow, strong liqueur."
 	color = "#664300"
-	strength = 10
+	strength = 40
 
 	glass_icon_state = "chartreuseyellowglass"
 	glass_name = "glass of Yellow Chartreuse"
-	glass_desc = "A yellow, strong liqueur."	
-	
+	glass_desc = "A yellow, strong liqueur."
+
 /datum/reagent/ethanol/cremewhite
 	name = "White Creme de Menthe"
 	id = "cremewhite"
 	description = "Mint-flavoured alcohol, in a bottle."
 	color = "#664300"
-	strength = 25
+	strength = 20
 
 	glass_icon_state = "whitecremeglass"
 	glass_name = "glass of White Creme de Menthe"
-	glass_desc = "Mint-flavoured alcohol."	
-	
+	glass_desc = "Mint-flavoured alcohol."
+
 /datum/reagent/ethanol/cremeyvette
 	name = "Creme de Yvette"
 	id = "cremeyvette"
 	description = "Berry-flavoured alcohol, in a bottle."
 	color = "#664300"
-	strength = 25
+	strength = 20
 
 	glass_icon_state = "cremedeyvetteglass"
 	glass_name = "glass of Creme de Yvette"
-	glass_desc = "Berry-flavoured alcohol."	
-	
+	glass_desc = "Berry-flavoured alcohol."
+
 /datum/reagent/ethanol/brandy
 	name = "Brandy"
 	id = "brandy"
 	description = "Cheap knock off for cognac."
 	color = "#664300"
-	strength = 25
+	strength = 40
 
 	glass_icon_state = "brandyglass"
 	glass_name = "glass of Brandy"
-	glass_desc = "Cheap knock off for cognac."	
-	
+	glass_desc = "Cheap knock off for cognac."
+
 /datum/reagent/ethanol/guinnes
 	name = "Guinness"
 	id = "guinnes"
 	description = "Special Guinnes drink."
 	color = "#2E6671"
-	strength = 15
+	strength = 8
 
 	glass_icon_state = "guinnes_glass"
 	glass_name = "glass of Guinness"
-	glass_desc = "A glass of Guinness."	
-	
+	glass_desc = "A glass of Guinness."
+
 /datum/reagent/ethanol/drambuie
 	name = "Drambuie"
 	id = "drambuie"
 	description = "A drink that smells like whiskey but tastes different."
 	color = "#2E6671"
-	strength = 12
+	strength = 40
 
 	glass_icon_state = "drambuieglass"
 	glass_name = "glass of Drambuie"
-	glass_desc = "A drink that smells like whiskey but tastes different."	
-	
+	glass_desc = "A drink that smells like whiskey but tastes different."
+
 /datum/reagent/ethanol/oldfashioned
 	name = "Old Fashioned"
 	id = "oldfashioned"
 	description = "That looks like from sixties."
 	color = "#2E6671"
-	strength = 15
+	strength = 20
 
 	glass_icon_state = "oldfashioned"
 	glass_name = "glass of Old Fashioned"
-	glass_desc = "That looks like from sixties."	
-	
+	glass_desc = "That looks like from sixties."
+
 /datum/reagent/ethanol/blindrussian
 	name = "Blind Russian"
 	id = "blindrussian"
 	description = "You can't see?"
 	color = "#2E6671"
-	strength = 10
+	strength = 40
 
 	glass_icon_state = "blindrussian"
 	glass_name = "glass of Blind Russian"
 	glass_desc = "You can't see?"
-	
+
 /datum/reagent/ethanol/rustynail
 	name = "Old Fashioned"
 	id = "rustynail"
 	description = "That looks like from sixties."
 	color = "#2E6671"
-	strength = 12
+	strength = 25
 
 	glass_icon_state = "rustynail"
 	glass_name = "glass of Old Fashioned"
 	glass_desc = "That looks like from sixties."
-	
+
 /datum/reagent/ethanol/tallrussian
 	name = "Tall Black Russian"
 	id = "tallrussian"
 	description = "Just like black russian but taller."
 	color = "#2E6671"
-	strength = 10
+	strength = 25
 
 	glass_icon_state = "tallrussian"
 	glass_name = "glass of Tall Black Russian"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -599,6 +599,14 @@
 	if(adj_temp > 0)
 		holder.remove_reagent("frostoil", 10 * removed)
 
+	M.dizziness = max(0, M.dizziness - 5)
+	M.drowsyness = max(0, M.drowsyness - 3)
+	M.sleeping = max(0, M.sleeping - 2)
+	M.intoxication = max(0, (M.intoxication - (removed*0.25)))
+	if(M.bodytemperature > 310)
+		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
+
+
 /datum/reagent/drink/coffee/overdose(var/mob/living/carbon/M, var/alien)
 	if(alien == IS_DIONA)
 		return

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -371,7 +371,9 @@
 /datum/reagent/cryptobiolin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
+	M.dizziness = max(150, M.dizziness)//Setting dizziness directly works as long as the make_dizzy proc is called after to spawn the process
 	M.make_dizzy(4)
+
 	M.confused = max(M.confused, 20)
 
 /datum/reagent/impedrezene
@@ -421,12 +423,14 @@
 	M.druggy = max(M.druggy, 30)
 	if(dose < 1)
 		M.stuttering = max(M.stuttering, 3)
+		M.dizziness = max(150, M.dizziness)
 		M.make_dizzy(5)
 		if(prob(5))
 			M.emote(pick("twitch", "giggle"))
 	else if(dose < 2)
 		M.stuttering = max(M.stuttering, 3)
 		M.make_jittery(5)
+		M.dizziness = max(150, M.dizziness)
 		M.make_dizzy(5)
 		M.druggy = max(M.druggy, 35)
 		if(prob(10))
@@ -434,6 +438,7 @@
 	else
 		M.stuttering = max(M.stuttering, 3)
 		M.make_jittery(10)
+		M.dizziness = max(150, M.dizziness)
 		M.make_dizzy(10)
 		M.druggy = max(M.druggy, 40)
 		if(prob(15))

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -3,7 +3,7 @@
 //Bottles now weaken and break when smashed on people's heads. - Giacom
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle
-	amount_per_transfer_from_this = 10
+	amount_per_transfer_from_this = 5//Smaller sip size for more BaRP and less guzzling a litre of vodka before you realise it
 	volume = 120
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	var/const/duration = 13 //Directly relates to the 'weaken' duration. Lowered by armor (i.e. helmets)

--- a/html/changelogs/Nanako-Alcohol.txt
+++ b/html/changelogs/Nanako-Alcohol.txt
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed dizziness effects on alcohol, psilocybin, and cryptobiolin taking a long to start up and sometimes never starting for low doses"
+  - tweak: "Sip size from alcohol bottles is now the same as for glasses, which is half what it was"
+  - tweak: "Rebalanced all alcoholic drinks with more believable alcohol values, and adjusted alcohol metabolism. Generally drinks are stronger but metabolise more slowly, pace yourself!"
+  - rscadd: "Different species now have varying susceptibility to alcohol. Tajarans get drunk slightly faster, skrell are twice as fast as humans, unathi can drink more, and vaurca get drunk very slowly, but alcohol poisons them"
+  - bugfix: "Dousing people in alcohol and setting them on fire, now only works with spirits and liqeurs stronger than 40% ABV, and the heat of the resulting fire is based on the strength"

--- a/html/changelogs/Nanako-Alcohol.yml
+++ b/html/changelogs/Nanako-Alcohol.yml
@@ -34,6 +34,7 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - bugfix: "Fixed dizziness effects on alcohol, psilocybin, and cryptobiolin taking a long to start up and sometimes never starting for low doses."
+  - tweak: "Reduced the strength of the confusion effect"
   - tweak: "Sip size from alcohol bottles is now the same as for glasses, which is half what it was."
   - tweak: "Rebalanced all alcoholic drinks with more believable alcohol values, and adjusted alcohol metabolism. Generally drinks are stronger but metabolise more slowly, pace yourself!"
   - tweak: "Drinking now causes temporary clumsiness until you sober up. Please don't drink and operate heavy machinery."

--- a/html/changelogs/Nanako-Alcohol.yml
+++ b/html/changelogs/Nanako-Alcohol.yml
@@ -33,8 +33,13 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - bugfix: "Fixed dizziness effects on alcohol, psilocybin, and cryptobiolin taking a long to start up and sometimes never starting for low doses"
-  - tweak: "Sip size from alcohol bottles is now the same as for glasses, which is half what it was"
+  - bugfix: "Fixed dizziness effects on alcohol, psilocybin, and cryptobiolin taking a long to start up and sometimes never starting for low doses."
+  - tweak: "Sip size from alcohol bottles is now the same as for glasses, which is half what it was."
   - tweak: "Rebalanced all alcoholic drinks with more believable alcohol values, and adjusted alcohol metabolism. Generally drinks are stronger but metabolise more slowly, pace yourself!"
-  - rscadd: "Different species now have varying susceptibility to alcohol. Tajarans get drunk slightly faster, skrell are twice as fast as humans, unathi can drink more, and vaurca get drunk very slowly, but alcohol poisons them"
-  - bugfix: "Dousing people in alcohol and setting them on fire, now only works with spirits and liqeurs stronger than 40% ABV, and the heat of the resulting fire is based on the strength"
+  - tweak: "Drinking now causes temporary clumsiness until you sober up. Please don't drink and operate heavy machinery."
+  - tweak: "Excessive drinking now has a chance to cause vomiting."
+  - rscadd: "Different species now have varying susceptibility to alcohol. Tajarans get drunk slightly faster, skrell are twice as fast as humans, unathi can drink more, and vaurca get drunk very slowly, but alcohol poisons them."
+  - bugfix: "Dousing people in alcohol and setting them on fire, now only works with spirits and liqeurs stronger than 40% ABV, and the heat of the resulting fire is based on the strength."
+  - tweak: "Ethylredoxrazine now removes alcohol from the patient's blood and stomach, and decreases their intoxication. A large enough dose will make them completely sober."
+  - tweak: "Ethylredoxrazine now metabolises and does its effects much more slowly."
+  - tweak: "Coffee now sobers up drunk people a little."


### PR DESCRIPTION
changes: 
  - bugfix: "Fixed dizziness effects on alcohol, psilocybin, and cryptobiolin taking a long to start up and sometimes never starting for low doses."
  - tweak: "Sip size from alcohol bottles is now the same as for glasses, which is half what it was."
  - tweak: "Rebalanced all alcoholic drinks with more believable alcohol values, and adjusted alcohol metabolism. Generally drinks are stronger but metabolise more slowly, pace yourself!"
  - tweak: "Drinking now causes temporary clumsiness until you sober up. Please don't drink and operate heavy machinery."
  - tweak: "Excessive drinking now has a chance to cause vomiting."
  - rscadd: "Different species now have varying susceptibility to alcohol. Tajarans get drunk slightly faster, skrell are twice as fast as humans, unathi can drink more, and vaurca get drunk very slowly, but alcohol poisons them."
  - bugfix: "Dousing people in alcohol and setting them on fire, now only works with spirits and liqeurs stronger than 40% ABV, and the heat of the resulting fire is based on the strength."
  - tweak: "Ethylredoxrazine now removes alcohol from the patient's blood and stomach, and decreases their intoxication. A large enough dose will make them completely sober."
  - tweak: "Ethylredoxrazine now metabolises and does its effects much more slowly."
  - tweak: "Coffee now sobers up drunk people a little."