### PR TITLE
BUGFIX - Vaurca immunity to tasers and batons

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -282,7 +282,7 @@
 	burn_mod = 1.5 //2x was a bit too much. we'll see how this goes.
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
-	siemens_coefficient = 0 //attempting to mimic the old insulation feature.
+	siemens_coefficient = 1 //setting it to 0 would be redundant due to LordLag's snowflake checks, plus batons/tasers use siemens now too.
 	breath_type = "oxygen"
 	poison_type = "null" //a species that breathes plasma shouldn't be poisoned by it.
 	blurb = "Vaurca are a bipedal insectoid species from the first moon of Sedantis I. \

--- a/html/changelogs/example - Copy.yml
+++ b/html/changelogs/example - Copy.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: N3X15
+author: LordFowl
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/example - Copy.yml
+++ b/html/changelogs/example - Copy.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed Vaurca being immune to tasers and stun batons."
+


### PR DESCRIPTION
Fixes Vaurca immunity to stun batons and tasers, caused by a redundant siemens coefficient value,
Fixes #539 