### PR TITLE
Reported issue fixes

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -92,7 +92,7 @@
 	var/power = 2
 	var/power_step = 0.75
 	var/dest
-	var/shieldsoundrange = 200 // The maximum number of tiles away the sound can be heard, falls off over distance, so it will be quiet near the limit
+	var/shieldsoundrange = 220 // The maximum number of tiles away the sound can be heard, falls off over distance, so it will be quiet near the limit
 	pass_flags = PASSTABLE
 	var/done = 0//This is set to 1 when the meteor is done colliding, and is used to ignore additional bumps while waiting for deletion
 
@@ -105,7 +105,7 @@
 	power_step = 0.5
 	hits = 2
 	detonation_chance = 30
-	shieldsoundrange = 100
+	shieldsoundrange = 120
 
 
 /obj/effect/meteor/Destroy()
@@ -131,6 +131,7 @@
 
 				if (T)//We have a double safety check on T to prevent runtime errors
 					meteor_shield_impact_sound(T, shieldsoundrange)
+				msg_admin_attack("Meteor impacted energy field at coords <[x],[y],[z]>")
 				spawn()//Delaying the Qdel a frame provides a little more safety
 					qdel(src)
 
@@ -142,6 +143,9 @@
 					!istype(A,/obj/machinery/field_generator) && \
 					prob(detonation_chance))
 					explosion(loc, power, power + power_step, power + power_step * 2, power + power_step * 3, 0)
+					msg_admin_attack("Meteor exploded at coords <[x],[y],[z]>")
+				else
+					msg_admin_attack("Meteor dissipated without exploding at coords <[x],[y],[z]>")
 				spawn()
 					qdel(src)
 
@@ -160,7 +164,7 @@
 	power = 4
 	power_step = 1
 	detonation_chance = 60
-	shieldsoundrange = 300//This can be set larger than the dimensions of the map, to allow it to remain louder at extreme distance
+	shieldsoundrange = 310//This can be set larger than the dimensions of the map, to allow it to remain louder at extreme distance
 
 	ex_act(severity)
 		return
@@ -192,6 +196,7 @@
 					if (T)
 						meteor_shield_impact_sound(T, shieldsoundrange)
 					explosion(loc, power, power + power_step, power + power_step * 2, power + power_step * 3, 0)
+					msg_admin_attack("Large Meteor impacted energy field and then exploded at coords <[x],[y],[z]>")
 					spawn()//Have to delay the qdel a little, or the playsound will throw a runtime
 						qdel(src)
 
@@ -208,7 +213,11 @@
 					done = 1
 					if(prob(detonation_chance) && !istype(A, /obj/structure/grille))
 						explosion(loc, power, power + power_step, power + power_step * 2, power + power_step * 3, 0)
-					qdel(src)
+						msg_admin_attack("Large Meteor exploded at coords <[x],[y],[z]>")
+					else
+						msg_admin_attack("Large Meteor dissipated without a final explosion at coords <[x],[y],[z]>")
+					spawn()
+						qdel(src)
 
 
 /obj/effect/meteor/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -131,7 +131,7 @@
 
 				if (T)//We have a double safety check on T to prevent runtime errors
 					meteor_shield_impact_sound(T, shieldsoundrange)
-				msg_admin_attack("Meteor impacted energy field at coords <[x],[y],[z]>")
+				msg_admin_attack("Meteor impacted energy field at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
 				spawn()//Delaying the Qdel a frame provides a little more safety
 					qdel(src)
 
@@ -143,9 +143,9 @@
 					!istype(A,/obj/machinery/field_generator) && \
 					prob(detonation_chance))
 					explosion(loc, power, power + power_step, power + power_step * 2, power + power_step * 3, 0)
-					msg_admin_attack("Meteor exploded at coords <[x],[y],[z]>")
+					msg_admin_attack("Meteor exploded at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
 				else
-					msg_admin_attack("Meteor dissipated without exploding at coords <[x],[y],[z]>")
+					msg_admin_attack("Meteor dissipated without exploding at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
 				spawn()
 					qdel(src)
 
@@ -196,7 +196,7 @@
 					if (T)
 						meteor_shield_impact_sound(T, shieldsoundrange)
 					explosion(loc, power, power + power_step, power + power_step * 2, power + power_step * 3, 0)
-					msg_admin_attack("Large Meteor impacted energy field and then exploded at coords <[x],[y],[z]>")
+					msg_admin_attack("Large Meteor impacted energy field and then exploded at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
 					spawn()//Have to delay the qdel a little, or the playsound will throw a runtime
 						qdel(src)
 
@@ -213,9 +213,9 @@
 					done = 1
 					if(prob(detonation_chance) && !istype(A, /obj/structure/grille))
 						explosion(loc, power, power + power_step, power + power_step * 2, power + power_step * 3, 0)
-						msg_admin_attack("Large Meteor exploded at coords <[x],[y],[z]>")
+						msg_admin_attack("Large Meteor exploded at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
 					else
-						msg_admin_attack("Large Meteor dissipated without a final explosion at coords <[x],[y],[z]>")
+						msg_admin_attack("Large Meteor dissipated without a final explosion at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
 					spawn()
 						qdel(src)
 

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -131,7 +131,7 @@
 
 				if (T)//We have a double safety check on T to prevent runtime errors
 					meteor_shield_impact_sound(T, shieldsoundrange)
-				msg_admin_attack("Meteor impacted energy field at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
+				msg_admin_attack("Meteor impacted energy field at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 				spawn()//Delaying the Qdel a frame provides a little more safety
 					qdel(src)
 
@@ -143,9 +143,9 @@
 					!istype(A,/obj/machinery/field_generator) && \
 					prob(detonation_chance))
 					explosion(loc, power, power + power_step, power + power_step * 2, power + power_step * 3, 0)
-					msg_admin_attack("Meteor exploded at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
+					msg_admin_attack("Meteor exploded at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 				else
-					msg_admin_attack("Meteor dissipated without exploding at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
+					msg_admin_attack("Meteor dissipated without exploding at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 				spawn()
 					qdel(src)
 
@@ -196,7 +196,7 @@
 					if (T)
 						meteor_shield_impact_sound(T, shieldsoundrange)
 					explosion(loc, power, power + power_step, power + power_step * 2, power + power_step * 3, 0)
-					msg_admin_attack("Large Meteor impacted energy field and then exploded at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
+					msg_admin_attack("Large Meteor impacted energy field and then exploded at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 					spawn()//Have to delay the qdel a little, or the playsound will throw a runtime
 						qdel(src)
 
@@ -213,9 +213,9 @@
 					done = 1
 					if(prob(detonation_chance) && !istype(A, /obj/structure/grille))
 						explosion(loc, power, power + power_step, power + power_step * 2, power + power_step * 3, 0)
-						msg_admin_attack("Large Meteor exploded at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
+						msg_admin_attack("Large Meteor exploded at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 					else
-						msg_admin_attack("Large Meteor dissipated without a final explosion at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'><[x],[y],[z]>JUMPTO</a>)")
+						msg_admin_attack("Large Meteor dissipated without a final explosion at coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 					spawn()
 						qdel(src)
 

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -19,7 +19,7 @@
 	var/icon_state_closed = null
 	var/icon_state_closing = null
 
-	closed_layer = 3.3 // Above airlocks when closed
+	closed_layer = 3.4 // Above airlocks when closed
 	var/id = 1.0
 	dir = 1
 	explosion_resistance = 25
@@ -144,7 +144,7 @@
 	if(stat & BROKEN)
 		stat &= ~BROKEN
 
-		
+
 /obj/machinery/door/blast/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group) return 1
 	return ..()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -209,14 +209,14 @@
 
 	if(density && istype(C, /obj/item/weapon/screwdriver))
 		hatch_open = !hatch_open
-		user.visible_message("<span class='danger'>[user] has [hatch_open ? "opened" : "closed"] \the [src] maintenance hatch.</span>",
-									"You have [hatch_open ? "opened" : "closed"] the [src] maintenance hatch.")
+		user.visible_message("<span class='danger'>[user] has [hatch_open ? "opened" : "closed"] \the [src] maintenance panel.</span>",
+									"You have [hatch_open ? "opened" : "closed"] the [src] maintenance panel.")
 		update_icon()
 		return
 
 	if(blocked && istype(C, /obj/item/weapon/crowbar) && !repairing)
 		if(!hatch_open)
-			user << "<span class='danger'>You must open the maintenance hatch first!</span>"
+			user << "<span class='danger'>You must open the maintenance panel first!</span>"
 		else
 			user.visible_message("<span class='danger'>[user] is removing the electronics from \the [src].</span>",
 									"You start to remove the electronics from [src].")
@@ -340,13 +340,15 @@
 	return
 
 /obj/machinery/door/firedoor/close()
+	overlays.Cut()
 	latetoggle()
 	return ..()
 
 /obj/machinery/door/firedoor/open(var/forced = 0)
+	overlays.Cut()
 	if(hatch_open)
 		hatch_open = 0
-		visible_message("The maintenance hatch of \the [src] closes.")
+		visible_message("The maintenance panel of \the [src] closes.")
 		update_icon()
 
 	if(!forced)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -77,7 +77,7 @@
 		return
 	if (src.operating)
 		return
-	if (src.density && !M.small && src.allowed(AM))
+	if (src.density && src.allowed(AM))
 		open()
 		if(src.check_access(null))
 			sleep(50)

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -80,7 +80,7 @@
 		else
 			endWhen = next_wave + wave_delay
 
-/datum/event/meteor_wave/start()
+/datum/event/meteor_shower/start()
 	command_announcement.Announce("Meteors have reached the station. Please stay away from outer areas until the shower has passed.", "Meteor Alert")
 
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -19,7 +19,7 @@
 	mob_size = 2
 	small = 1
 
-	//mob_bump_flag = SIMPLE_ANIMAL
+	mob_bump_flag = SIMPLE_ANIMAL
 	//mob_swap_flags = SIMPLE_ANIMAL
 	//mob_push_flags = SIMPLE_ANIMAL
 	//mob_always_swap = 1


### PR DESCRIPTION
Fixed hatch overlay not being cut when a firedoor opens
Fixed firedoor hatches drawing ontop of office/blast shutters when both are on the same tile
Drones can now bump open windoors
added attack logs for meteor impacts
slightly increased volume of meteor shield impact sound
fixed meteor event end announcements