### PR TITLE
APC Description fix

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -218,7 +218,6 @@
 
 /obj/machinery/power/apc/examine(mob/user)
 	if(..(user, 1))
-		user << "A control terminal for the area electrical systems."
 		if(stat & BROKEN)
 			user << "Looks broken."
 			return
@@ -226,11 +225,11 @@
 			if(has_electronics && terminal)
 				user << "The cover is [opened==2?"removed":"open"] and the power cell is [ cell ? "installed" : "missing"]."
 			else if (!has_electronics && terminal)
-				user << "There are some wires but no any electronics."
+				user << "There are some wires but not any electronics."
 			else if (has_electronics && !terminal)
-				user << "Electronics installed but not wired."
+				user << "Electronics are installed but not wired."
 			else /* if (!has_electronics && !terminal) */
-				user << "There is no electronics nor connected wires."
+				user << "There are no electronics nor connected wires."
 
 		else
 			if (stat & MAINT)

--- a/html/changelogs/Nanako-APCDesc.yml
+++ b/html/changelogs/Nanako-APCDesc.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed a bug where examining an APC at close range would show its description twice"


### PR DESCRIPTION
Fixes a tiny bug where the description of an APC is duplicated if you examine at close range. Also a few typos and grammatical errors