### PR TITLE
Event Probabilities Rework

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -122,6 +122,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 	next_event = EM
 	return EM
 
+
 /datum/event_container/mundane
 	severity = EVENT_LEVEL_MUNDANE
 	available_events = list(
@@ -145,20 +146,20 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 /datum/event_container/moderate
 	severity = EVENT_LEVEL_MODERATE
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",					/datum/event/nothing,					1230),
+		//new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",					/datum/event/nothing,					1230),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			100, 	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_SECURITY = 20), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout,	500,	list(ASSIGNMENT_AI = 150, ASSIGNMENT_SECURITY = 120)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			250,	list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_JANITOR = 150)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Gravity Failure",			/datum/event/gravity,	 				75,		list(ASSIGNMENT_ENGINEER = 60)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grid Check",				/datum/event/grid_check, 				200,	list(ASSIGNMENT_SCIENTIST = 10)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grid Check",				/datum/event/grid_check, 				0,	list(ASSIGNMENT_SCIENTIST = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					0,		list(ASSIGNMENT_AI = 50, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_SCIENTIST = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_shower,				0,		list(ASSIGNMENT_ENGINEER = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Prison Break",				/datum/event/prison_break,				0,		list(ASSIGNMENT_SECURITY = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",			/datum/event/radiation_storm, 			0,		list(ASSIGNMENT_MEDICAL = 50), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Random Antagonist",		/datum/event/random_antag,		 		2.5,	list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				20,		list(ASSIGNMENT_SECURITY = 20)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,	 					30, 	list(ASSIGNMENT_ENGINEER = 5)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Random Antagonist",		/datum/event/random_antag,		 		0,	list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				0,		list(ASSIGNMENT_SECURITY = 20)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,	 					50, 	list(ASSIGNMENT_ENGINEER = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		100,	list(ASSIGNMENT_SECURITY = 30), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Viral Infection",			/datum/event/viral_infection, 			0,		list(ASSIGNMENT_MEDICAL = 150), 1),
 	)
@@ -166,13 +167,17 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 /datum/event_container/major
 	severity = EVENT_LEVEL_MAJOR
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",			/datum/event/nothing,			1320),
+		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",			/datum/event/nothing,			1320),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",			/datum/event/blob, 				0,	list(ASSIGNMENT_ENGINEER = 60), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",	/datum/event/carp_migration,	0,	list(ASSIGNMENT_SECURITY =  3), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		0,	list(ASSIGNMENT_ENGINEER =  3),	1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",		/datum/event/spacevine, 		0,	list(ASSIGNMENT_ENGINEER = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Viral Infection",	/datum/event/viral_infection,	0,	list(ASSIGNMENT_MEDICAL =  30), 1),
 	)
+
+//NOTE: Removed "Nothing" option from moderate and severe events.
+//They are already made rare and varied enough by the time delay mechanics,
+//forcing a random failure to pick an event sucks, and lack of stuff happening causes lots of SSDs
 
 
 #undef ASSIGNMENT_ANY

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -133,46 +133,45 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Damage",		/datum/event/camera_damage,		20, 	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic News",		/datum/event/economic_event,	300),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Lost Carp",			/datum/event/carp_migration, 	20, 	list(ASSIGNMENT_SECURITY = 10), 1),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Hacker",		/datum/event/money_hacker, 		0, 		list(ASSIGNMENT_ANY = 4), 1, 10, 25),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Hacker",		/datum/event/money_hacker, 		10),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",		/datum/event/money_lotto, 		0, 		list(ASSIGNMENT_ANY = 1), 1, 5, 15),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News", 		/datum/event/mundane_news, 		300),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "PDA Spam",			/datum/event/pda_spam, 			0, 		list(ASSIGNMENT_ANY = 4), 0, 25, 50),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "PDA Spam",			/datum/event/pda_spam, 			0, 		list(ASSIGNMENT_ANY = 3), 0, 0, 50),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Space Dust",		/datum/event/dust	, 			30, 	list(ASSIGNMENT_ENGINEER = 5), 0, 0, 50),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Trivial News",		/datum/event/trivial_news, 		400),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		100,	list(ASSIGNMENT_JANITOR = 100)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		50,	list(ASSIGNMENT_JANITOR = 50)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			75,		list(ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_GARDENER = 20)),
 	)
 
 /datum/event_container/moderate
 	severity = EVENT_LEVEL_MODERATE
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",					/datum/event/nothing,					200),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 10), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			100, 	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_SECURITY = 20), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout,	500,	list(ASSIGNMENT_AI = 150, ASSIGNMENT_SECURITY = 120)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			250,	list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_JANITOR = 150)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",					/datum/event/nothing,					150),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 25)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			50, 	list(ASSIGNMENT_SECURITY = 25)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout,	60),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			60,	list(ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_JANITOR = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Gravity Failure",			/datum/event/gravity,	 				75,		list(ASSIGNMENT_ENGINEER = 60)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grid Check",				/datum/event/grid_check, 				0,	list(ASSIGNMENT_SCIENTIST = 10)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					0,		list(ASSIGNMENT_AI = 50, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_SCIENTIST = 5)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_shower,				0,		list(ASSIGNMENT_ENGINEER = 20)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Prison Break",				/datum/event/prison_break,				0,		list(ASSIGNMENT_SECURITY = 100)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",			/datum/event/radiation_storm, 			0,		list(ASSIGNMENT_MEDICAL = 50), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Random Antagonist",		/datum/event/random_antag,		 		0,	list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				0,		list(ASSIGNMENT_SECURITY = 20)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grid Check",				/datum/event/grid_check, 				100),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					0,		list(ASSIGNMENT_AI = 35, ASSIGNMENT_CYBORG = 20, ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_SCIENTIST = 5)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_shower,				50,		list(ASSIGNMENT_ENGINEER = 25)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Prison Break",				/datum/event/prison_break,				0,		list(ASSIGNMENT_SECURITY = 15, ASSIGNMENT_CYBORG = 20),1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",			/datum/event/radiation_storm, 			100),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Random Antagonist",		/datum/event/random_antag,		 		0,	list(ASSIGNMENT_ANY = 2, ASSIGNMENT_SECURITY = 1)0,10,200),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				50,		list(ASSIGNMENT_SECURITY = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,	 					50, 	list(ASSIGNMENT_ENGINEER = 5)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		100,	list(ASSIGNMENT_SECURITY = 30), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Viral Infection",			/datum/event/viral_infection, 			0,		list(ASSIGNMENT_MEDICAL = 150), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		50,	list(ASSIGNMENT_SECURITY = 25)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Viral Infection",			/datum/event/viral_infection, 			0,		list(ASSIGNMENT_MEDICAL = 10), 1),
 	)
 
 /datum/event_container/major
 	severity = EVENT_LEVEL_MAJOR
 	available_events = list(
-		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",			/datum/event/nothing,			1320),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",			/datum/event/blob, 				0,	list(ASSIGNMENT_ENGINEER = 60), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",	/datum/event/carp_migration,	0,	list(ASSIGNMENT_SECURITY =  3), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		0,	list(ASSIGNMENT_ENGINEER =  3),	1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",		/datum/event/spacevine, 		0,	list(ASSIGNMENT_ENGINEER = 15), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Viral Infection",	/datum/event/viral_infection,	0,	list(ASSIGNMENT_MEDICAL =  30), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",			/datum/event/blob, 				40,	list(ASSIGNMENT_ENGINEER = 5,ASSIGNMENT_SECURITY =  5), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",	/datum/event/carp_migration,	60,	list(ASSIGNMENT_SECURITY =  10), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		50,	list(ASSIGNMENT_ENGINEER =  15),1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",		/datum/event/spacevine, 		50,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_GARDENER = 20), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Viral Infection",	/datum/event/viral_infection,	20,	list(ASSIGNMENT_MEDICAL =  15), 1),
 	)
 
 //NOTE: Removed "Nothing" option from moderate and severe events.

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -151,13 +151,13 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			50, 	list(ASSIGNMENT_SECURITY = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout,	60),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			60,	list(ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_JANITOR = 20)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Gravity Failure",			/datum/event/gravity,	 				75,		list(ASSIGNMENT_ENGINEER = 60)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Gravity Failure",			/datum/event/gravity,	 				100),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grid Check",				/datum/event/grid_check, 				100),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					0,		list(ASSIGNMENT_AI = 35, ASSIGNMENT_CYBORG = 20, ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_SCIENTIST = 5)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					0,		list(ASSIGNMENT_AI = 40, ASSIGNMENT_CYBORG = 20, ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_SCIENTIST = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_shower,				50,		list(ASSIGNMENT_ENGINEER = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Prison Break",				/datum/event/prison_break,				0,		list(ASSIGNMENT_SECURITY = 15, ASSIGNMENT_CYBORG = 20),1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",			/datum/event/radiation_storm, 			100),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Random Antagonist",		/datum/event/random_antag,		 		0,	list(ASSIGNMENT_ANY = 2, ASSIGNMENT_SECURITY = 1)0,10,200),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Random Antagonist",		/datum/event/random_antag,		 		0,	list(ASSIGNMENT_ANY = 2, ASSIGNMENT_SECURITY = 1),0,10,150),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				50,		list(ASSIGNMENT_SECURITY = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,	 					50, 	list(ASSIGNMENT_ENGINEER = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		50,	list(ASSIGNMENT_SECURITY = 25)),
@@ -171,7 +171,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",	/datum/event/carp_migration,	60,	list(ASSIGNMENT_SECURITY =  10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		50,	list(ASSIGNMENT_ENGINEER =  15),1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",		/datum/event/spacevine, 		50,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_GARDENER = 20), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Viral Infection",	/datum/event/viral_infection,	20,	list(ASSIGNMENT_MEDICAL =  15), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Viral Infection",	/datum/event/viral_infection,	20,	list(ASSIGNMENT_MEDICAL =  10), 1),
 	)
 
 //NOTE: Removed "Nothing" option from moderate and severe events.

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -146,7 +146,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 /datum/event_container/moderate
 	severity = EVENT_LEVEL_MODERATE
 	available_events = list(
-		//new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",					/datum/event/nothing,					1230),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",					/datum/event/nothing,					200),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			100, 	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_SECURITY = 20), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout,	500,	list(ASSIGNMENT_AI = 150, ASSIGNMENT_SECURITY = 120)),

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -86,7 +86,7 @@ var/list/event_last_fired = list()
 	possibleEvents[/datum/event/spider_infestation] = 50 + 25 * active_with_role["Security"]
 	possibleEvents[/datum/event/carp_migration] = 50 + 25 * active_with_role["Security"]
 
-	possibleEvents[/datum/event/communications_blackout] = 40//Comms blackout is too common and annoying
+	possibleEvents[/datum/event/communications_blackout] = 60//Comms blackout is too common and annoying
 
 	//Ion laws are fun!
 	possibleEvents[/datum/event/ionstorm] = active_with_role["AI"] * 35 + active_with_role["Cyborg"] * 20 + active_with_role["Engineer"] * 5 + active_with_role["Scientist"] * 5

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -1,3 +1,8 @@
+// WARNING
+//-- Added 2016-08-02 by Nanako
+//This file is deprecated. The lists in event_container.dm handle event probabilities
+//Do not use this file
+
 
 /*
 /proc/start_events()
@@ -45,128 +50,45 @@ var/list/event_last_fired = list()
 	// Code/WorkInProgress/Cael_Aislinn/Economy/Economy_Events.dm
 	// Code/WorkInProgress/Cael_Aislinn/Economy/Economy_Events_Mundane.dm
 
-
-	//Rework by Nanako
-	//Based upon the standard listed above - aim for 100 weight for average.
-	//Assuming a crew containing four people in the primary roles of each department (sec, engineering, science, medical)
-	//Weights with that crew compliment are adapted to be more or less common, by being either side of 100,
-		//based on my idea of which ones are fun
-		//More people in those departments will increase the likelihood of those events. Especially combat oriented ones with lots of sec
-
-
-	//Mundane Events
-	//=====================================
 	possibleEvents[/datum/event/economic_event] = 300
 	possibleEvents[/datum/event/trivial_news] = 400
 	possibleEvents[/datum/event/mundane_news] = 300
+
 	possibleEvents[/datum/event/pda_spam] = max(min(25, player_list.len) * 4, 200)
-	possibleEvents[/datum/event/money_lotto] = 10
-	possibleEvents[/datum/event/brand_intelligence] = 10 + 10 * active_with_role["Janitor"] +  5 * active_with_role["Engineer"]
+	possibleEvents[/datum/event/money_lotto] = max(min(5, player_list.len), 50)
 	if(account_hack_attempted)
-		//Made account hack far rarer, reasoning provided in a forum thread on 2016-06-28
-		//In short, its meaningless, annoying, and it trains people to ignore request consoles
-		//Consider restoring it to commonality when economy is fleshed out and currency becomes meaningful
-		possibleEvents[/datum/event/money_hacker] = 10
-
-	possibleEvents[/datum/event/infestation] = 50 + 50 * active_with_role["Janitor"]
-
-	//Wallrot made much less engineer-dependant, but more gardener-dependant.
-	possibleEvents[/datum/event/wallrot] = 75 + 5 * active_with_role["Engineer"] + 20 * active_with_role["Gardener"]
+		possibleEvents[/datum/event/money_hacker] = max(min(25, player_list.len) * 4, 200)
 
 
+	possibleEvents[/datum/event/carp_migration] = 20 + 10 * active_with_role["Engineer"]
+	possibleEvents[/datum/event/brand_intelligence] = 20 + 25 * active_with_role["Janitor"]
 
+	possibleEvents[/datum/event/rogue_drone] = 5 + 25 * active_with_role["Engineer"] + 25 * active_with_role["Security"]
+	possibleEvents[/datum/event/infestation] = 100 + 100 * active_with_role["Janitor"]
 
-
-
-	//Moderate Events
-	//================================================
-
-		//Combat oriented events, more heavily weighted to number of sec officers
-	possibleEvents[/datum/event/rogue_drone] = 50 + 25 * active_with_role["Security"]
-	possibleEvents[/datum/event/spider_infestation] = 50 + 25 * active_with_role["Security"]
-	possibleEvents[/datum/event/carp_migration] = 50 + 25 * active_with_role["Security"]
-
-	possibleEvents[/datum/event/communications_blackout] = 60//Comms blackout is too common and annoying
-
-	//Ion laws are fun!
-	possibleEvents[/datum/event/ionstorm] = active_with_role["AI"] * 35 + active_with_role["Cyborg"] * 20 + active_with_role["Engineer"] * 5 + active_with_role["Scientist"] * 5
-
-	possibleEvents[/datum/event/grid_check] = 100
-
-	//Janitor has a big weight because they usually fix the lights
-	possibleEvents[/datum/event/electrical_storm] = 60 + 20 * active_with_role["Janitor"] + 5 * active_with_role["Engineer"]
-
-	//Rad storms no longer medical-dependant. If there's no medical you can drink tea and vodka
-	possibleEvents[/datum/event/radiation_storm] = 100
-
-
-	possibleEvents[/datum/event/meteor_shower] = 50 + 25 * active_with_role["Engineer"]//Quite dependant on engineers
-
-	if(active_with_role["Medical"] > 0)
-		//These two are just pointless without medical, so no base chance
-		possibleEvents[/datum/event/spontaneous_appendicitis] = active_with_role["Medical"] * 25
-		possibleEvents[/datum/event/viral_infection] = active_with_role["Medical"] * 10
-
-	if (minutes_passed > 60)
-		//No point in a prison break when no antags have been arrested yet
-		possibleEvents[/datum/event/prison_break] = active_with_role["Security"] * 15 + active_with_role["Cyborg"] * 20
-
-		//Give the previous antag a chance to tell their story before spawning another
-		//This is generally less common but scales with playercount
-		possibleEvents[/datum/event/random_antag] = min(30, player_list.len) + active_with_role["Security"]*8
-
-
-
-
-
-
-
-
-
-
-
-
-	//Severe Events
-	//=================================================
-	//Note, carp migration and viral infection have different behaviour depending whether they're called as moderate or severe
-	//So they exist in both categories
-	possibleEvents[/datum/event/carp_migration] = 60 + 10 * active_with_role["Security"]
-	possibleEvents[/datum/event/viral_infection] = active_with_role["Medical"] * 25
-
-	//More heavily weighted towards engineering, meteor storms are punishing without shields
-	possibleEvents[/datum/event/meteor_wave] = 50 + 15 * active_with_role["Engineer"]
-	possibleEvents[/datum/event/blob] = 40 + 5 * active_with_role["Engineer"] + 5 * active_with_role["Security"]
-
+	possibleEvents[/datum/event/communications_blackout] = 50 + 25 * active_with_role["AI"] + active_with_role["Scientist"] * 25
+	possibleEvents[/datum/event/ionstorm] = active_with_role["AI"] * 25 + active_with_role["Cyborg"] * 25 + active_with_role["Engineer"] * 10 + active_with_role["Scientist"] * 5
+	possibleEvents[/datum/event/grid_check] = 25 + 10 * active_with_role["Engineer"]
+	possibleEvents[/datum/event/electrical_storm] = 15 * active_with_role["Janitor"] + 5 * active_with_role["Engineer"]
+	possibleEvents[/datum/event/wallrot] = 30 * active_with_role["Engineer"] + 50 * active_with_role["Gardener"]
 
 	if(!spacevines_spawned)
-		possibleEvents[/datum/event/spacevine] = 50 + 10 * active_with_role["Engineer"] + 20 * active_with_role["Gardener"]
+		possibleEvents[/datum/event/spacevine] = 10 + 5 * active_with_role["Engineer"]
+	if(minutes_passed >= 30) // Give engineers time to set up engine
+		possibleEvents[/datum/event/meteor_wave] = 10 * active_with_role["Engineer"]
+		possibleEvents[/datum/event/meteor_shower] = 20 * active_with_role["Engineer"]
+		possibleEvents[/datum/event/blob] = 10 * active_with_role["Engineer"]
 
+	if(active_with_role["Medical"] > 0)
+		possibleEvents[/datum/event/radiation_storm] = active_with_role["Medical"] * 10
+		possibleEvents[/datum/event/spontaneous_appendicitis] = active_with_role["Medical"] * 10
+		possibleEvents[/datum/event/viral_infection] = active_with_role["Medical"] * 10
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+	possibleEvents[/datum/event/prison_break] = active_with_role["Security"] * 50
+	if(active_with_role["Security"] > 0)
+		if(!sent_spiders_to_station)
+			possibleEvents[/datum/event/spider_infestation] = max(active_with_role["Security"], 5) + 5
+		possibleEvents[/datum/event/random_antag] = max(active_with_role["Security"], 5) + 2.5
 
 	for(var/event_type in event_last_fired) if(possibleEvents[event_type])
 		var/time_passed = world.time - event_last_fired[event_type]

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -45,45 +45,128 @@ var/list/event_last_fired = list()
 	// Code/WorkInProgress/Cael_Aislinn/Economy/Economy_Events.dm
 	// Code/WorkInProgress/Cael_Aislinn/Economy/Economy_Events_Mundane.dm
 
+
+	//Rework by Nanako
+	//Based upon the standard listed above - aim for 100 weight for average.
+	//Assuming a crew containing four people in the primary roles of each department (sec, engineering, science, medical)
+	//Weights with that crew compliment are adapted to be more or less common, by being either side of 100,
+		//based on my idea of which ones are fun
+		//More people in those departments will increase the likelihood of those events. Especially combat oriented ones with lots of sec
+
+
+	//Mundane Events
+	//=====================================
 	possibleEvents[/datum/event/economic_event] = 300
 	possibleEvents[/datum/event/trivial_news] = 400
 	possibleEvents[/datum/event/mundane_news] = 300
-
 	possibleEvents[/datum/event/pda_spam] = max(min(25, player_list.len) * 4, 200)
-	possibleEvents[/datum/event/money_lotto] = max(min(5, player_list.len), 50)
+	possibleEvents[/datum/event/money_lotto] = 10
+	possibleEvents[/datum/event/brand_intelligence] = 10 + 10 * active_with_role["Janitor"] +  5 * active_with_role["Engineer"]
 	if(account_hack_attempted)
-		possibleEvents[/datum/event/money_hacker] = max(min(25, player_list.len) * 4, 200)
+		//Made account hack far rarer, reasoning provided in a forum thread on 2016-06-28
+		//In short, its meaningless, annoying, and it trains people to ignore request consoles
+		//Consider restoring it to commonality when economy is fleshed out and currency becomes meaningful
+		possibleEvents[/datum/event/money_hacker] = 10
+
+	possibleEvents[/datum/event/infestation] = 50 + 50 * active_with_role["Janitor"]
+
+	//Wallrot made much less engineer-dependant, but more gardener-dependant.
+	possibleEvents[/datum/event/wallrot] = 75 + 5 * active_with_role["Engineer"] + 20 * active_with_role["Gardener"]
 
 
-	possibleEvents[/datum/event/carp_migration] = 20 + 10 * active_with_role["Engineer"]
-	possibleEvents[/datum/event/brand_intelligence] = 20 + 25 * active_with_role["Janitor"]
 
-	possibleEvents[/datum/event/rogue_drone] = 5 + 25 * active_with_role["Engineer"] + 25 * active_with_role["Security"]
-	possibleEvents[/datum/event/infestation] = 100 + 100 * active_with_role["Janitor"]
 
-	possibleEvents[/datum/event/communications_blackout] = 50 + 25 * active_with_role["AI"] + active_with_role["Scientist"] * 25
-	possibleEvents[/datum/event/ionstorm] = active_with_role["AI"] * 25 + active_with_role["Cyborg"] * 25 + active_with_role["Engineer"] * 10 + active_with_role["Scientist"] * 5
-	possibleEvents[/datum/event/grid_check] = 25 + 10 * active_with_role["Engineer"]
-	possibleEvents[/datum/event/electrical_storm] = 15 * active_with_role["Janitor"] + 5 * active_with_role["Engineer"]
-	possibleEvents[/datum/event/wallrot] = 30 * active_with_role["Engineer"] + 50 * active_with_role["Gardener"]
 
-	if(!spacevines_spawned)
-		possibleEvents[/datum/event/spacevine] = 10 + 5 * active_with_role["Engineer"]
-	if(minutes_passed >= 30) // Give engineers time to set up engine
-		possibleEvents[/datum/event/meteor_wave] = 10 * active_with_role["Engineer"]
-		possibleEvents[/datum/event/meteor_shower] = 20 * active_with_role["Engineer"]
-		possibleEvents[/datum/event/blob] = 10 * active_with_role["Engineer"]
+
+	//Moderate Events
+	//================================================
+
+		//Combat oriented events, more heavily weighted to number of sec officers
+	possibleEvents[/datum/event/rogue_drone] = 50 + 25 * active_with_role["Security"]
+	possibleEvents[/datum/event/spider_infestation] = 50 + 25 * active_with_role["Security"]
+	possibleEvents[/datum/event/carp_migration] = 50 + 25 * active_with_role["Security"]
+
+	possibleEvents[/datum/event/communications_blackout] = 40//Comms blackout is too common and annoying
+
+	//Ion laws are fun!
+	possibleEvents[/datum/event/ionstorm] = active_with_role["AI"] * 35 + active_with_role["Cyborg"] * 20 + active_with_role["Engineer"] * 5 + active_with_role["Scientist"] * 5
+
+	possibleEvents[/datum/event/grid_check] = 100
+
+	//Janitor has a big weight because they usually fix the lights
+	possibleEvents[/datum/event/electrical_storm] = 60 + 20 * active_with_role["Janitor"] + 5 * active_with_role["Engineer"]
+
+	//Rad storms no longer medical-dependant. If there's no medical you can drink tea and vodka
+	possibleEvents[/datum/event/radiation_storm] = 100
+
+
+	possibleEvents[/datum/event/meteor_shower] = 50 + 25 * active_with_role["Engineer"]//Quite dependant on engineers
 
 	if(active_with_role["Medical"] > 0)
-		possibleEvents[/datum/event/radiation_storm] = active_with_role["Medical"] * 10
-		possibleEvents[/datum/event/spontaneous_appendicitis] = active_with_role["Medical"] * 10
+		//These two are just pointless without medical, so no base chance
+		possibleEvents[/datum/event/spontaneous_appendicitis] = active_with_role["Medical"] * 25
 		possibleEvents[/datum/event/viral_infection] = active_with_role["Medical"] * 10
 
-	possibleEvents[/datum/event/prison_break] = active_with_role["Security"] * 50
-	if(active_with_role["Security"] > 0)
-		if(!sent_spiders_to_station)
-			possibleEvents[/datum/event/spider_infestation] = max(active_with_role["Security"], 5) + 5
-		possibleEvents[/datum/event/random_antag] = max(active_with_role["Security"], 5) + 2.5
+	if (minutes_passed > 60)
+		//No point in a prison break when no antags have been arrested yet
+		possibleEvents[/datum/event/prison_break] = active_with_role["Security"] * 15 + active_with_role["Cyborg"] * 20
+
+		//Give the previous antag a chance to tell their story before spawning another
+		//This is generally less common but scales with playercount
+		possibleEvents[/datum/event/random_antag] = min(30, player_list.len) + active_with_role["Security"]*8
+
+
+
+
+
+
+
+
+
+
+
+
+	//Severe Events
+	//=================================================
+	//Note, carp migration and viral infection have different behaviour depending whether they're called as moderate or severe
+	//So they exist in both categories
+	possibleEvents[/datum/event/carp_migration] = 60 + 10 * active_with_role["Security"]
+	possibleEvents[/datum/event/viral_infection] = active_with_role["Medical"] * 25
+
+	//More heavily weighted towards engineering, meteor storms are punishing without shields
+	possibleEvents[/datum/event/meteor_wave] = 50 + 15 * active_with_role["Engineer"]
+	possibleEvents[/datum/event/blob] = 40 + 5 * active_with_role["Engineer"] + 5 * active_with_role["Security"]
+
+
+	if(!spacevines_spawned)
+		possibleEvents[/datum/event/spacevine] = 50 + 10 * active_with_role["Engineer"] + 20 * active_with_role["Gardener"]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 	for(var/event_type in event_last_fired) if(possibleEvents[event_type])
 		var/time_passed = world.time - event_last_fired[event_type]

--- a/html/changelogs/Nanako-Events.yml
+++ b/html/changelogs/Nanako-Events.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "All event probabilities reworked for a more varied and interesting event system."


### PR DESCRIPTION
All event triggering weights re-evaluated, standardised, and set according to some semblance of logic.
For exact changes, look at the code, most decisions are explained in comments

Changelog will be added later once i decide exactly how much to put in it, but leaning towards leaving things vague and mysterious

This was done with three design goals in mind:
1. Making 'interesting' events more common, especially those that have a decent chance to affect the dynamic of a round, as well as making annoying/boring things a bit less common.
2. Giving people stuff to do when a department is overstaffed. All the combat things are more weighted towards security staff, and destructive things more weighted towards engineering. Many other events have had staff requirements removed or reduced
3. Evening out event selections, preventing certain things (like blobs and comms blackout) from being too common, and other things (like spiders, drones and meteors) from being so rare. Severe events especially should have a much more varied selection.