### PR TITLE
Fixes for some verbs that use command_announcement.Announce

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -106,7 +106,7 @@
 			announce_hack_failure(user, "quantum message relay")
 		return
 
-	command_announcement.Announce(text, title)
+	command_announcement.Announce(text, title, new_sound = 'sound/AI/commandreport.ogg')
 
 /datum/game_mode/malfunction/verb/elite_encryption_hack()
 	set category = "Software"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -513,7 +513,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 	var/reporttitle
 	var/reportbody
-	var/reporter
+	var/reporter = null
 	var/reporttype = input(usr, "Choose whether to use a template or custom report.", "Create Command Report") in list("Template", "Custom", "Cancel")
 	switch(reporttype)
 		if("Template")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -558,11 +558,14 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			C.messagetitle.Add("[command_name()] Update")
 			C.messagetext.Add(P.info)
 
-	reporter = sanitizeSafe(input(usr, "Please enter your name.", "Name") as text|null)
+	if (reporttype == "Template")
+		reporter = sanitizeSafe(input(usr, "Please enter your CCIA name. (blank for no sender)", "Name") as text|null)
+		if (reporter)
+			reportbody += "\n\n- [reporter], Central Command Internal Affairs Agent, [commstation_name()]"
 
 	switch(alert("Should this be announced to the general population?",,"Yes","No"))
 		if("Yes")
-			command_announcement.Announce("[reportbody]\n\n- [reporter], Central Command Internal Affairs Agent, [commstation_name()]", reporttitle, new_sound = 'sound/AI/commandreport.ogg', msg_sanitized = 1);
+			command_announcement.Announce("[reportbody]", reporttitle, new_sound = 'sound/AI/commandreport.ogg', msg_sanitized = 1);
 		if("No")
 			world << "\red New NanoTrasen Update available at all communication consoles."
 			world << sound('sound/AI/commandreport.ogg')

--- a/html/changelogs/bedshaped-PR-623.yml
+++ b/html/changelogs/bedshaped-PR-623.yml
@@ -1,0 +1,7 @@
+author: Bedshaped
+
+delete-after: True
+
+changes: 
+  - tweak: "Command reports now only ask for a name if you used a template"
+  - bugfix: "MalfAI's fake command report plays the regular report sound so the Malf can't be metaguessed"


### PR DESCRIPTION
Fixes:

- "Eldritch Horror, Central Command Internal Affairs Agent, NMSS Odin"
- Someone earlier said it was annoying that the fake CentComm messages sent by MalfAI don't have the same sound as regular CentComm messages, making it easy to tell when it's malf