### PR TITLE
Fixes to RnD

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -150,7 +150,7 @@
 	w_class = 3
 	force = 10
 	projectile_type = /obj/item/projectile/energy/blaster
-	max_shots = 30
+	max_shots = 15
 
 	firemodes = list(
 		list(name="single shot", burst=1, burst_delay = 1, fire_delay = 0),

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -127,11 +127,11 @@
 	name = "blaster bolt"
 	icon_state = "laser"
 	check_armour = "laser"
-	damage = 10
+	damage = 15
 	damage_type = BURN
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	embed = 0
-	incinerate = 5
+	incinerate = 2
 
 /*/obj/item/projectile/energy/flamer
 	name = "promethium"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1421,7 +1421,7 @@ datum/design/item/weapon/gatlinglaser
 	id = "gatlinglaser"
 	name = "gatling laser"
 	desc = "A higly sophisticated rapid-fire laser weapon."
-	req_tech = list("combat" = 6, "phorontech" = 6, "materials" = 4, "powerstorage" = 3)
+	req_tech = list("combat" = 6, "phorontech" = 5, "materials" = 6, "powerstorage" = 3)
 	materials = list("$metal" = 18750, "$glass" = 7500, "$phoron" = 7500, "$silver" = 7500, "$diamond" = 3000)
 	build_path = /obj/item/weapon/gun/energy/vaurca/gatlinglaser
 
@@ -1429,7 +1429,7 @@ datum/design/item/weapon/railgun
 	id = "railgun"
 	name = "railgun"
 	desc = "An advanced rifle that magnetically propels hyperdense rods at breakneck speeds to devastating effect."
-	req_tech = list("combat" = 8, "phorontech" = 2, "materials" = 8, "magnets" = 4, "powerstorage" = 5, "syndicate" = 3)
+	req_tech = list("combat" = 8, "phorontech" = 2, "materials" = 7, "magnets" = 4, "powerstorage" = 5, "syndicate" = 3)
 	materials = list("$metal" = 75000, "$glass" = 18750, "$phoron" = 11250, "$gold" = 7500, "$silver" = 7500)
 	build_path = /obj/item/weapon/gun/projectile/automatic/railgun
 
@@ -1442,12 +1442,13 @@ datum/design/item/weapon/zorablaster
 	build_path = /obj/item/weapon/gun/energy/vaurca/blaster
 
 datum/design/item/weapon/lawgiver
+	name = "Lawgiver"
 	desc = "A highly advanced firearm for the modern police force. It has multiple voice-activated firing modes."
 	id = "lawgiver"
 	req_tech = list("combat" = 6, "phorontech" = 4, "bluespace" = 5, "materials" = 7)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 6000, "$glass" = 1000, "$uranium" = 1000, "$phoron" = 1000, "$diamond" = 3000)
-	build_path = "/obj/item/weapon/gun/energy/lawgiver"
+	build_path = /obj/item/weapon/gun/energy/lawgiver
 
 /*This is all the station gets for producable force gloves. It's a high-risk item and thus considered contraband
 outside of RnD without paperwork with the RD's stamp on it. */

--- a/html/changelogs/example - Copy.yml
+++ b/html/changelogs/example - Copy.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: LordFowl
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed certain items being unable to acquire via RnD due to impossibly high research requirements."
+  - bugfix: "Fixed lawgiver not displaying a name for its entry in the protolathe."
+  - tweak: "Halved the effectiveness of the Zo'ra blaster."


### PR DESCRIPTION
+  - bugfix: "Fixed certain items being unable to acquire via RnD due to impossibly high research requirements."
+  - bugfix: "Fixed lawgiver not displaying a name for its entry in the protolathe."
+  - tweak: "Halved the effectiveness of the Zo'ra blaster."