### PR TITLE
Bot Access

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -17,6 +17,7 @@
 	var/obj/access_scanner = null
 	var/list/req_access = list()
 	var/list/req_one_access = list()
+	var/master_access = access_robotics
 
 /mob/living/bot/New()
 	..()
@@ -53,12 +54,19 @@
 /mob/living/bot/death()
 	explode()
 
+/mob/living/bot/proc/has_master_access(var/obj/item/I)
+	var/list/L = I.GetAccess()
+	if (master_access in L)
+		return 1
+	else
+		return 0
+
+
 /mob/living/bot/attackby(var/obj/item/O, var/mob/user)
 	if(O.GetID())
-		if(access_scanner.allowed(user) && !open && !emagged)
+		if((has_master_access(O) || access_scanner.allowed(user)) && !open && !emagged)
 			locked = !locked
 			user << "<span class='notice'>Controls are now [locked ? "locked." : "unlocked."]</span>"
-			attack_hand(user)
 		else
 			if(emagged)
 				user << "<span class='warning'>ERROR</span>"

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -317,6 +317,7 @@
 		user << "<span class='notice'>You add the robot arm to the bucket and sensor assembly. Beep boop!</span>"
 		user.drop_from_inventory(src)
 		qdel(src)
+		return 1
 
 	else if(istype(O, /obj/item/weapon/pen))
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -105,6 +105,7 @@
 				else
 					item_state = "ed209_legs"
 					icon_state = "ed209_legs"
+				return 1
 
 		if(2)
 			if(istype(W, /obj/item/clothing/suit/storage/vest))
@@ -115,6 +116,7 @@
 				name = "vest/legs/frame assembly"
 				item_state = "ed209_shell"
 				icon_state = "ed209_shell"
+				return 1
 
 		if(3)
 			if(istype(W, /obj/item/weapon/weldingtool))
@@ -123,6 +125,7 @@
 					build_step++
 					name = "shielded frame assembly"
 					user << "<span class='notice'>You welded the vest to [src].</span>"
+					return 1
 		if(4)
 			if(istype(W, /obj/item/clothing/head/helmet))
 				user.drop_item()
@@ -132,6 +135,7 @@
 				name = "covered and shielded frame assembly"
 				item_state = "ed209_hat"
 				icon_state = "ed209_hat"
+				return 1
 
 		if(5)
 			if(isprox(W))
@@ -142,6 +146,7 @@
 				name = "covered, shielded and sensored frame assembly"
 				item_state = "ed209_prox"
 				icon_state = "ed209_prox"
+				return 1
 
 		if(6)
 			if(istype(W, /obj/item/stack/cable_coil))
@@ -166,6 +171,7 @@
 				icon_state = "ed209_taser"
 				user.drop_item()
 				qdel(W)
+				return 1
 
 		if(8)
 			if(istype(W, /obj/item/weapon/screwdriver))
@@ -188,3 +194,4 @@
 				qdel(W)
 				user.drop_from_inventory(src)
 				qdel(src)
+				return 1

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -319,6 +319,7 @@
 		name = "farmbot assembly"
 		user.remove_from_mob(W)
 		qdel(W)
+		return 1
 
 	else if((istype(W, /obj/item/weapon/reagent_containers/glass/bucket)) && (build_step == 1))
 		build_step++
@@ -326,6 +327,7 @@
 		name = "farmbot assembly with bucket"
 		user.remove_from_mob(W)
 		qdel(W)
+		return 1//Prevents the object's afterattack from executing and causing runtime errors
 
 	else if((istype(W, /obj/item/weapon/material/minihoe)) && (build_step == 2))
 		build_step++
@@ -333,6 +335,7 @@
 		name = "farmbot assembly with bucket and minihoe"
 		user.remove_from_mob(W)
 		qdel(W)
+		return 1
 
 	else if((isprox(W)) && (build_step == 3))
 		build_step++
@@ -345,6 +348,7 @@
 		user.remove_from_mob(W)
 		qdel(W)
 		qdel(src)
+		return 1
 
 	else if(istype(W, /obj/item/weapon/pen))
 		var/t = input(user, "Enter new robot name", name, created_name) as text

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -327,6 +327,7 @@
 		user << "<span class='notice'>You add the sensor to the toolbox and tiles!</span>"
 		user.drop_from_inventory(src)
 		qdel(src)
+		return 1
 	else if (istype(W, /obj/item/weapon/pen))
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)
 		if(!t)
@@ -357,6 +358,7 @@
 		user << "<span class='notice'>You add the robot arm to the odd looking toolbox assembly! Boop beep!</span>"
 		user.drop_from_inventory(src)
 		qdel(src)
+		return 1
 	else if(istype(W, /obj/item/weapon/pen))
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)
 		if(!t)

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -169,7 +169,7 @@
 		O.loc = src
 		reagent_glass = O
 		user << "<span class='notice'>You insert [O].</span>"
-		return
+		return 1
 	else
 		..()
 
@@ -350,6 +350,7 @@
 					user << "<span class='notice'>You add the health sensor to [src].</span>"
 					name = "First aid/robot arm/health analyzer assembly"
 					overlays += image('icons/obj/aibots.dmi', "na_scanner")
+					return 1
 
 			if(1)
 				if(isprox(W))
@@ -362,3 +363,4 @@
 					S.name = created_name
 					user.drop_from_inventory(src)
 					qdel(src)
+					return 1

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -488,6 +488,7 @@
 		user << "You add the signaler to the helmet."
 		user.drop_from_inventory(src)
 		qdel(src)
+		return 1
 	else
 		return
 
@@ -508,6 +509,7 @@
 			build_step = 1
 			overlays += image('icons/obj/aibots.dmi', "hs_hole")
 			user << "You weld a hole in \the [src]."
+			return 1
 
 	else if(isprox(O) && (build_step == 1))
 		user.drop_item()
@@ -516,6 +518,7 @@
 		overlays += image('icons/obj/aibots.dmi', "hs_eye")
 		name = "helmet/signaler/prox sensor assembly"
 		qdel(O)
+		return 1
 
 	else if((istype(O, /obj/item/robot_parts/l_arm) || istype(O, /obj/item/robot_parts/r_arm)) && build_step == 2)
 		user.drop_item()
@@ -524,6 +527,7 @@
 		name = "helmet/signaler/prox sensor/robot arm assembly"
 		overlays += image('icons/obj/aibots.dmi', "hs_arm")
 		qdel(O)
+		return 1
 
 	else if(istype(O, /obj/item/weapon/melee/baton) && build_step == 3)
 		user.drop_item()
@@ -532,6 +536,7 @@
 		S.name = created_name
 		qdel(O)
 		qdel(src)
+		return 1
 
 	else if(istype(O, /obj/item/weapon/pen))
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)

--- a/html/changelogs/Nanako-BotAccess.yml
+++ b/html/changelogs/Nanako-BotAccess.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Roboticists now have master-access to all bots"
+  


### PR DESCRIPTION
Added Master access to bot control panels for roboticists and research directors

Also added a return 1 to all bot construction steps, to prevent calling afterattack for the items used on the bot. This fixes a couple runtime errors and prevents more in future. Not included in changelog as this is irrelevant to end-users since they cant see runtime errors