### PR TITLE
Broken APC Welding

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -630,7 +630,26 @@
 				opened = 1
 			update_icon()
 	else
-		if (((stat & BROKEN) || hacker) \
+		if ((stat & BROKEN) \
+				&& !opened \
+				&& istype(W, /obj/item/weapon/weldingtool) )
+			var/obj/item/weapon/weldingtool/WT = W
+			if (WT.get_fuel() <1)
+				user << "<span class='warning'>You need more welding fuel to complete this task.</span>"
+				return
+			playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
+			if(do_after(user, 10))
+				if(!src || !WT.remove_fuel(1, user)) return
+				if ((stat & BROKEN))
+					new /obj/item/stack/material/steel(loc)
+					user.visible_message(\
+						"<span class='warning'>[user.name] cuts the cover off of the broken APC.</span>",\
+						"<span class='notice'>You cut the cover off the broken APC </span>",\
+						"You hear welding.")
+					opened = 2
+					update_icon()
+
+		else if (((stat & BROKEN) || hacker) \
 				&& !opened \
 				&& W.force >= 5 \
 				&& W.w_class >= 3.0 \

--- a/html/changelogs/Nanako-WeldAPC.yml
+++ b/html/changelogs/Nanako-WeldAPC.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "The cover of broken APCs can now be opened with a welding tool"
+  


### PR DESCRIPTION
A quality of life improvement for synthetics mostly - Allows broken APC covers to be removed with a welding tool. Since synthetics generally don't have the luxury of picking up a fire extinguisher to bash it.