### PR TITLE
Fixes to Rnd MkII

### DIFF
--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -69,7 +69,7 @@
 /datum/language/bug
 	name = "Hivenet"
 	desc = "Complex Vaurcesian language comprised of rapid mandible-clicking, \"It's a bugs life.\""
-	speech_verb = "broadcasts"
+	speech_verb = " broadcasts"
 	colour = "vaurca"
 	key = "9"
 	native = 1

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -110,7 +110,7 @@
 	icon_state = "bfg"
 	item_state = "bfg"
 	charge_meter = 0
-	w_class = 3
+	w_class = 4
 	fire_sound = 'sound/magic/LightningShock.ogg'
 	force = 30
 	projectile_type = /obj/item/projectile/energy/sonic
@@ -130,7 +130,7 @@
 	origin_tech = "combat=5;materials=2"
 	charge_meter = 0
 	slot_flags = SLOT_BACK
-	w_class = 3
+	w_class = 4
 	force = 10
 	projectile_type = /obj/item/projectile/beam/gatlinglaser
 	max_shots = 80
@@ -146,7 +146,7 @@
 	icon_state = "blaster"
 	item_state = "blaster"
 	fire_sound = 'sound/weapons/Laser.ogg'
-	slot_flags = SLOT_BACK
+	slot_flags = SLOT_BACK | SLOT_HOLSTER | SLOT_BELT
 	w_class = 3
 	force = 10
 	projectile_type = /obj/item/projectile/energy/blaster

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -265,7 +265,7 @@
 		user << "<span class='warning'>You need to open the cover to unload [src].</span>"
 		return
 	..()
-	
+
 /obj/item/weapon/gun/projectile/automatic/tommygun
 	name = "\improper Tommygun"
 	desc = "A classic among criminals. Uses .45 rounds."
@@ -288,7 +288,7 @@
 	desc = "An advanced rifle that magnetically propels hyperdense rods at breakneck speeds to devastating effect."
 	icon_state = "railgun"
 	item_state = "arifle"
-	w_class = 3
+	w_class = 4
 	force = 10
 	caliber = "trod"
 	origin_tech = "combat=5;materials=2"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -114,16 +114,16 @@
 	weaken = 5
 	stun = 5
 
-	on_impact(var/atom/A)
-		if(isturf(A))
-			target.ex_act(0)
-		if(ismob(A))
-			var/mob/M = A
-			explosion(target, -1, 0, 2)
-			M.gib()
-		if(!(isturf(A)) & !(ismob(A)))
-			explosion(A, -1, 0, 2)
-		..()
+/obj/item/projectile/energy/sonic/on_impact(var/atom/A)
+	if(isturf(A))
+		target.ex_act(0)
+	if(ismob(A))
+		var/mob/M = A
+		explosion(target, -1, 0, 2)
+		M.gib()
+	if(!(isturf(A)) & !(ismob(A)))
+		explosion(A, -1, 0, 2)
+	..()
 
 /obj/item/projectile/energy/blaster
 	name = "blaster bolt"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -114,14 +114,16 @@
 	weaken = 5
 	stun = 5
 
-/obj/item/projectile/energy/sonic/on_hit(var/atom/target, var/blocked = 0)
-	var/mob/M = target
-	if(isturf(target))
-		target.ex_act(0)
-	if(ismob(target))
-		explosion(target, -1, 0, 2)
-		M.gib()
-	..()
+	on_impact(var/atom/A)
+		if(isturf(A))
+			target.ex_act(0)
+		if(ismob(A))
+			var/mob/M = A
+			explosion(target, -1, 0, 2)
+			M.gib()
+		if(!(isturf(A)) & !(ismob(A)))
+			explosion(A, -1, 0, 2)
+		..()
 
 /obj/item/projectile/energy/blaster
 	name = "blaster bolt"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -20,9 +20,9 @@
 	sharp = 1
 	edge = 1
 
-	on_hit(var/atom/target, var/blocked = 0)
-		explosion(target, -1, 0, 2)
-		return 1
+	on_impact(var/atom/A)
+		explosion(A, -1, 0, 2)
+		..()
 
 /obj/item/projectile/bullet/gyro/law
 	name ="high-ex round"
@@ -159,6 +159,6 @@
 	sharp = 1
 	edge = 1
 
-	on_hit(var/atom/target, var/blocked = 0)
-		explosion(target, 0, 0, 4)
-		return 1
+	on_impact(var/atom/A)
+		explosion(A, 0, 0, 4)
+		..()

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1328,7 +1328,7 @@ datum/design/item/weapon/lasercannon
 datum/design/item/weapon/decloner
 	id = "decloner"
 	req_tech = list("combat" = 8, "materials" = 7, "biotech" = 5, "powerstorage" = 6)
-	materials = list("$gold" = 5000,"$uranium" = 10000, "mutagen" = 40)
+	materials = list("$gold" = 5000,"$uranium" = 10000)
 	build_path = /obj/item/weapon/gun/energy/decloner
 	locked = 1
 

--- a/html/changelogs/LordFowl Fixies.yml
+++ b/html/changelogs/LordFowl Fixies.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: LordFowl
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "The demoleculariser is now constructable via RnD."
+  - bugfix: "Fixed Gatling Lasers and Railguns fitting into bags."
+  - bugfix: "Fixed railguns projectiles not exploding if they missed their target, and generally improved their target criteria."
+  - tweak: "Zo'ra blasters now fit on the belt-slot and into holsters."


### PR DESCRIPTION
  - bugfix: "The demoleculariser is now constructable via RnD."
  - bugfix: "Fixed Gatling Lasers and Railguns fitting into bags."
  - bugfix: "Fixed railguns projectiles not exploding if they missed their target, and generally improved their target criteria."
  - tweak: "Zo'ra blasters now fit on the belt-slot and into holsters."

Not listed:
Updated BFG to make it less laggy and more awesome.

fixes #648 