### PR TITLE
PAI Candidacy Fix

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -217,7 +217,7 @@
 					</tr>
 				</table>
 				<br>
-				<p>Each time this button is pressed, a request will be sent out to any available personalities. Check back often give plenty of time for personalities to respond. This process could take anywhere from 15 seconds to several minutes, depending on the available personalities' timeliness.</p>
+				<p>Each time this button is pressed, a request will be sent out to any available personalities. Check back often give plenty of time for personalities to respond. This process could take anywhere from 15 seconds to several minutes, depending on the available personalities' timelines.</p>
 			"}
 	user << browse(dat, "window=paicard")
 	onclose(user, "paicard")
@@ -247,8 +247,11 @@
 		if(confirm == "Yes")
 			for(var/mob/M in src)
 				M << "<font color = #ff0000><h2>You feel yourself slipping away from reality.</h2></font>"
+				sleep(30)
 				M << "<font color = #ff4d4d><h3>Byte by byte you lose your sense of self.</h3></font>"
+				sleep(20)
 				M << "<font color = #ff8787><h4>Your mental faculties leave you.</h4></font>"
+				sleep(30)
 				M << "<font color = #ffc4c4><h5>oblivion... </h5></font>"
 				M.death(0)
 			removePersonality()
@@ -339,6 +342,9 @@
 	update_location(slot)
 
 /obj/item/device/paicard/proc/update_location(var/slotnumber = null)
+	if (!pai)
+		return
+
 	if (!slotnumber)
 		if (istype(loc, /mob))
 			slotnumber = get_equip_slot()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -3,6 +3,7 @@
 var/list/preferences_datums = list()
 
 var/global/list/special_roles = list( //keep synced with the defines BE_* in setup.dm --rastaf
+//REALLY keep synced. The ordering of this list is critical, it must match the order of the BE_* defines --Nanako
 //some autodetection here.
 // TODO: Update to new antagonist system.
 	"traitor" = IS_MODE_COMPILED("traitor"),             // 0
@@ -19,8 +20,8 @@ var/global/list/special_roles = list( //keep synced with the defines BE_* in set
 	"raider" = IS_MODE_COMPILED("heist"),                // 11
 	"diona" = 1,                                         // 12
 	"loyalist" = IS_MODE_COMPILED("revolution"),         // 13
-	"vampire" = IS_MODE_COMPILED("vampire"),             // 14
-	"pAI candidate" = 1, // -- TLE                       // 15
+	"personal AI" = 1, // -- TLE                       // 14
+	"vampire" = IS_MODE_COMPILED("vampire"),             // 15
 )
 
 //used for alternate_option

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -70,6 +70,7 @@
 
 	var/translator_on = 0 // keeps track of the translator module
 
+	var/greeted = 0
 	var/current_pda_messaging = null
 
 /mob/living/silicon/pai/New(var/obj/item/device/paicard/newlocation)
@@ -109,8 +110,17 @@
 	..()
 
 /mob/living/silicon/pai/Login()
+	greet()
 	..()
 
+
+/mob/living/silicon/pai/proc/greet()
+
+	if (!greeted)
+		// Basic intro text.
+		src << "<span class='danger'><font size=3>You are a Personal AI!</font></span>"
+		src << "<span class='notice'>You are a small artificial intelligence contained inside a portable tablet, and you are bound to a master. Your primary directive is to serve them and follow their instructions, follow this prime directive above all others. Check your Software interface to spend ram on programs that can help, and unfold your chassis to take a holographic form and move around the world.</span>"
+		greeted = 1
 
 // this function shows the information about being silenced as a pAI in the Status panel
 /mob/living/silicon/pai/proc/show_silenced()

--- a/code/modules/mob/living/silicon/pai/personality.dm
+++ b/code/modules/mob/living/silicon/pai/personality.dm
@@ -27,7 +27,7 @@
 	return 1
 
 // loads the savefile corresponding to the mob's ckey
-// if silent=true, report incompatible savefiles
+// if silent=false, report incompatible savefiles
 // returns 1 if loaded (or file was incompatible)
 // returns 0 if savefile did not exist
 

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -29,6 +29,9 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 	if(href_list["download"])
 		var/datum/paiCandidate/candidate = locate(href_list["candidate"])
 		var/obj/item/device/paicard/card = locate(href_list["device"])
+		if (!candidate in pai_candidates)
+			return
+
 		if(card.pai)
 			return
 		if(istype(card,/obj/item/device/paicard) && istype(candidate,/datum/paiCandidate))

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -107,6 +107,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 		candidate.key = M.key
 		pai_candidates.Add(candidate)
 
+	candidate.savefile_load(M)//Load the pAI config before displaying the window
 	var/dat = ""
 	dat += {"
 			<style type="text/css">

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -794,6 +794,9 @@ proc/is_blind(A)
 	var/preposition= ""
 	var/action = ""
 	var/action3 = ""
+	if (!reportto)
+		return 0
+
 	if (istype(loc, /mob/living/carbon/human))//This function is for finding where we are on a human. not valid otherwise
 		H = loc
 

--- a/html/changelogs/Nanako-pAICandidacy.yml
+++ b/html/changelogs/Nanako-pAICandidacy.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed pAI and vampire candidacy settings not working properly."
+  - bugfix: "Fixed pAI Personality window not populating automatically"
+  - rscadd: "Added a greeting blurb for pAIs"


### PR DESCRIPTION
These really annoying bugs have been around for too long

Vampire and pAI candidacy settings were misordered in the character setup menu, which resulted in their effects being swapped, ticking one qualifies you for the other, etc. this is kind of a big deal

changes: 
  - bugfix: "Fixed pAI and vampire candidacy settings not working properly."
  - bugfix: "Fixed pAI Personality window not populating automatically"
  - rscadd: "Added a greeting blurb for pAIs"

Also fixed a runtime error related to an earlier PR, caused by people picking up pAIs
and fixes a possibility of a duplication issue