### PR TITLE
Joinmenu, slimes, and runtime error fixes

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -404,8 +404,9 @@
 			if(job && IsJobAvailable(job.title))
 				var/active = 0
 				// Only players with the job assigned and AFK for less than 10 minutes count as active
-				for(var/mob/M in player_list) if(M.mind && M.client && M.mind.assigned_role == job.title && M.client.inactivity <= 10 * 60 * 10)
-					active++
+				for(var/mob/M in player_list) //Added isliving check here, so it won't check ghosts and qualify them as active
+					if(isliving(M) && M.mind && M.client && M.mind.assigned_role == job.title && M.client.inactivity <= 10 * 60 * 10)
+						active++
 				dat += "<a href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title] ([job.current_positions]) (Active: [active])</a><br>"
 
 		dat += "</center>"

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -313,8 +313,10 @@
 //No animations will be performed by this proc.
 /proc/electrocute_mob(mob/living/carbon/M as mob, var/power_source, var/obj/source, var/siemens_coeff = 1.0)
 	if(istype(M.loc,/obj/mecha))	return 0	//feckin mechs are dumb
-	var/mob/living/carbon/human/H = M //20/1/16 Insulation (vaurca)
-	if(H.species.name == "Vaurca")	return 0
+	var/mob/living/carbon/human/H = null
+	if (ishuman(M))
+		H = M //20/1/16 Insulation (vaurca)
+		if(H.species.name == "Vaurca")	return 0
 	var/area/source_area
 	if(istype(power_source,/area))
 		source_area = power_source
@@ -344,8 +346,7 @@
 	//If following checks determine user is protected we won't alarm for long.
 	if(PN)
 		PN.trigger_warning(5)
-	if(istype(M,/mob/living/carbon/human))
-		//var/mob/living/carbon/human/H = M
+	if(H)
 		if(H.species.siemens_coefficient == 0)
 			return
 		if(H.gloves)

--- a/html/changelogs/Nanako-slimespray.yml
+++ b/html/changelogs/Nanako-slimespray.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Spraying water will now wet all mobs in the tile, dividing reagents amongst them. This fixes some issues where slimes would be unsprayable."
+
+  


### PR DESCRIPTION
Fixes an issue with recently ghosted players still showing active in the join menu
Fixes a runtime error with electrified grilles. Thanks LF :package: 
Also changes water spraying to fix a couple of bugs. Water sprays will now wet all mobs in tiles they hit, instead of only one. Reagents are divided amongst mobs hit.