### PR TITLE
Balancing the Nar'sie summoned creature

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/creature.dm
+++ b/code/modules/mob/living/simple_animal/hostile/creature.dm
@@ -6,14 +6,14 @@
 	icon_state = "otherthing"
 	icon_living = "otherthing"
 	icon_dead = "otherthing-dead"
-	health = 80
-	maxHealth = 80
+	health = 200
+	maxHealth = 200
 	melee_damage_lower = 25
 	melee_damage_upper = 50
 	attacktext = "chomped"
 	attack_sound = 'sound/weapons/bite.ogg'
 	faction = "creature"
-	speed = 4
+	speed = -2
 
 /mob/living/simple_animal/hostile/creature/cult
 	faction = "cult"

--- a/html/changelogs/delta-creature.yml
+++ b/html/changelogs/delta-creature.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: OneOneThreeEight
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Reduces speed of the Nar'sie summoned creature, buffs their maximum health to make them tanky."


### PR DESCRIPTION
* tweak "Reduces speed of the Nar'sie summoned creature, buffs their maximum health to make them tanky."

Getting rushed by large blob-like insanity other-things is very silly, especially when you can't really counter their mobility. Originally, they'd put you into crit almost instantaneously and _break all of your bones_. Due to how mob code works, they can attack you and chase you, because their attacking within the millisecond as they can in range with you is effectively perfect as opposed to how human reaction time and input works.

 Instead, however, their mobility is much less overwhelming with this change, but they're very tanky, so trying to kite them is "easier" but not without its own difficulties. God help you if you get into range of their devastating melee attacks, or if you get swarmed by several of them.

Granted, a cult apocalypse is probably not meant to be survivable, but when you're two tiles away from a closet and that close to getting safety before gettin' ganked by a creature, it's a bit dumb.