### PR TITLE
Better spam prevention placing

### DIFF
--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -18,8 +18,6 @@
 				if (client.prefs.muted & MUTE_IC)
 					src << "\red You cannot send IC messages (muted)."
 					return
-				if (src.client.handle_spam_prevention(message,MUTE_IC))
-					return
 			if (stat)
 				return
 			if(!(message))

--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -19,8 +19,6 @@
 				if (client.prefs.muted & MUTE_IC)
 					src << "\red You cannot send IC messages (muted)."
 					return
-				if (src.client.handle_spam_prevention(message,MUTE_IC))
-					return
 			if (stat)
 				return
 			if(!(message))

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -74,8 +74,6 @@
 				if (client.prefs.muted & MUTE_IC)
 					src << "\red You cannot send IC messages (muted)."
 					return
-				if (src.client.handle_spam_prevention(message,MUTE_IC))
-					return
 			if (stat)
 				return
 			if(!(message))

--- a/code/modules/mob/living/carbon/metroid/emote.dm
+++ b/code/modules/mob/living/carbon/metroid/emote.dm
@@ -18,8 +18,6 @@
 				if (client.prefs.muted & MUTE_IC)
 					src << "\red You cannot send IC messages (muted)."
 					return
-				if (src.client.handle_spam_prevention(message,MUTE_IC))
-					return
 				if (stat)
 					return
 				if(!(message))

--- a/code/modules/mob/living/parasite/meme_captive.dm
+++ b/code/modules/mob/living/parasite/meme_captive.dm
@@ -9,8 +9,6 @@
 		if(client.prefs.muted & MUTE_IC)
 			src << "\red You cannot speak in IC (muted)."
 			return
-		if (src.client.handle_spam_prevention(message,MUTE_IC))
-			return
 
 	if(istype(src.loc,/mob/living/parasite/meme))
 

--- a/code/modules/mob/living/silicon/pai/emote.dm
+++ b/code/modules/mob/living/silicon/pai/emote.dm
@@ -13,8 +13,6 @@
 				if(client.prefs.muted & MUTE_IC)
 					src << "You cannot send IC messages (muted)."
 					return
-				if (src.client.handle_spam_prevention(message,MUTE_IC))
-					return
 			if (stat)
 				return
 			if(!(message))

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -4,8 +4,6 @@
 			if(client.prefs.muted & MUTE_IC)
 				src << "You cannot send IC messages (muted)."
 				return 0
-			if (src.client.handle_spam_prevention(message,MUTE_IC))
-				return 0
 
 		message = sanitize(message)
 

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -14,8 +14,6 @@
 				if(client.prefs.muted & MUTE_IC)
 					src << "You cannot send IC messages (muted)."
 					return
-				if (src.client.handle_spam_prevention(message,MUTE_IC))
-					return
 			if (stat)
 				return
 			if(!(message))

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -9,8 +9,6 @@
 		if(client.prefs.muted & MUTE_IC)
 			src << "\red You cannot speak in IC (muted)."
 			return
-		if (src.client.handle_spam_prevention(message,MUTE_IC))
-			return
 
 	if(istype(src.loc,/mob/living/simple_animal/borer))
 
@@ -53,7 +51,7 @@
 			verbs -= /mob/living/carbon/proc/release_control
 			verbs -= /mob/living/carbon/proc/punish_host
 			verbs -= /mob/living/carbon/proc/spawn_larvae
-		
+
 		return
-	
+
 	..()

--- a/code/modules/mob/living/simple_animal/borer/say.dm
+++ b/code/modules/mob/living/simple_animal/borer/say.dm
@@ -16,8 +16,6 @@
 		if(client.prefs.muted & MUTE_IC)
 			src << "\red You cannot speak in IC (muted)."
 			return
-		if (src.client.handle_spam_prevention(message,MUTE_IC))
-			return
 
 	if (copytext(message, 1, 2) == "*")
 		return emote(copytext(message, 2))

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -26,6 +26,10 @@
 	*/
 
 	set_typing_indicator(0)
+
+	if (src.client.handle_spam_prevention(message, MUTE_IC))
+		return
+
 	usr.say(message)
 
 /mob/verb/me_verb(message as text)
@@ -39,6 +43,10 @@
 	message = sanitize(message)
 
 	set_typing_indicator(0)
+
+	if (src.client.handle_spam_prevention(message, MUTE_IC))
+		return
+
 	if(use_me)
 		usr.emote("me",usr.emote_type,message)
 	else

--- a/html/changelogs/skull132-SpamPrevention.yml
+++ b/html/changelogs/skull132-SpamPrevention.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Skull132
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Spam prevention is no longer activated by automated emotes."


### PR DESCRIPTION
Removes the spam prevention procs from all background procs, and ensures that they're only placed on procs that the user can initiate.

This will remove the chance of having spam prevention trigger from automated emotes.

Fixes #613