### PR TITLE
Fixing a minor issue with magazines

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -24,6 +24,7 @@
 	//For MAGAZINE guns
 	var/magazine_type = null	//the type of magazine that the gun comes preloaded with
 	var/obj/item/ammo_magazine/ammo_magazine = null //stored magazine
+	var/list/allowed_magazines		//determines list of which magazines will fit in the gun
 	var/auto_eject = 0			//if the magazine should automatically eject itself when empty.
 	var/auto_eject_sound = null
 	//TODO generalize ammo icon states for guns
@@ -96,9 +97,9 @@
 /obj/item/weapon/gun/projectile/proc/load_ammo(var/obj/item/A, mob/user)
 	if(istype(A, /obj/item/ammo_magazine))
 		var/obj/item/ammo_magazine/AM = A
-		if(!(load_method & AM.mag_type) || caliber != AM.caliber)
-			return //incompatible
-
+		if(!(load_method & AM.mag_type) || caliber != AM.caliber || (allowed_magazines && !is_type_in_list(A, allowed_magazines)))
+			user << "<span class='warning'>[AM] won't load into [src]!</span>"
+			return
 		switch(AM.mag_type)
 			if(MAGAZINE)
 				if(ammo_magazine)

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -26,6 +26,7 @@
 	w_class = 3
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/c45uzi
+	allowed_magazines = list(/obj/item/ammo_magazine/c45uzi)
 	max_shells = 16
 	caliber = ".45"
 	origin_tech = "combat=5;materials=2;syndicate=8"
@@ -44,6 +45,7 @@
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/a12mm
+	allowed_magazines = list(/obj/item/ammo_magazine/a12mm)
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 
@@ -68,6 +70,7 @@
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/mc9mmt/rubber
+	allowed_magazines = list(/obj/item/ammo_magazine/mc9mmt)
 
 /obj/item/weapon/gun/projectile/automatic/wt550/update_icon()
 	..()
@@ -91,6 +94,7 @@
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/c762
+	allowed_magazines = list(/obj/item/ammo_magazine/c762)
 
 	firemodes = list(
 		list(name="semiauto", burst=1, fire_delay=0),
@@ -150,6 +154,7 @@
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/a556
+	allowed_magazines = list(/obj/item/ammo_magazine/a556)
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 
@@ -217,6 +222,7 @@
 	origin_tech = "combat=6;materials=1;syndicate=2"
 	slot_flags = SLOT_BACK
 	ammo_type = "/obj/item/ammo_casing/a762"
+	allowed_magazines = list(/obj/item/ammo_casing/a762)
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/a762
@@ -265,7 +271,7 @@
 		user << "<span class='warning'>You need to open the cover to unload [src].</span>"
 		return
 	..()
-	
+
 /obj/item/weapon/gun/projectile/automatic/tommygun
 	name = "\improper Tommygun"
 	desc = "A classic among criminals. Uses .45 rounds."
@@ -278,6 +284,7 @@
 	ammo_type = /obj/item/ammo_casing/c45
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/tommymag
+	allowed_magazines = list(/obj/item/ammo_magazine/tommymag, /obj/item/ammo_magazine/tommydrum)
 
 /obj/item/weapon/gun/projectile/automatic/tommygun/update_icon()
 	..()
@@ -288,7 +295,7 @@
 	desc = "An advanced rifle that magnetically propels hyperdense rods at breakneck speeds to devastating effect."
 	icon_state = "railgun"
 	item_state = "arifle"
-	w_class = 3
+	w_class = 4
 	force = 10
 	caliber = "trod"
 	origin_tech = "combat=5;materials=2"
@@ -296,6 +303,7 @@
 	fire_sound = 'sound/effects/Explosion2.ogg'
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/trodpack
+	allowed_magazines = list(/obj/item/ammo_magazine/trodpack)
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 

--- a/code/modules/projectiles/guns/projectile/improvised.dm
+++ b/code/modules/projectiles/guns/projectile/improvised.dm
@@ -17,7 +17,7 @@
 	origin_tech = "combat=2;materials=2"
 	handle_casings = CYCLE_CASINGS
 	load_method = SINGLE_CASING
-	
+
 /obj/item/weapon/gun/projectile/shotgun/improvised/special_check(var/mob/living/carbon/human/M)
 	if(prob(60 - (loaded.len * 10)))
 		M.visible_message("<span class='danger'>[M]'s weapon blows up, shattering into pieces!</span>","<span class='danger'>[src] blows up in your face!</span>", "You hear a loud bang!")
@@ -67,7 +67,7 @@
 	icon = 'icons/obj/improvised.dmi'
 	icon_state = "riflestock"
 	var/buildstate = 0
-	
+
 /obj/item/weapon/receivergun
 	name = "receiver"
 	desc = "A receiver and trigger assembly for a firearm."
@@ -135,10 +135,11 @@
 	icon_state = "ipistol"
 	item_state = "gun"
 	caliber = ".45"
+	allowed_magazines = list(/obj/item/ammo_magazine/c45m)
 	origin_tech = "combat=2;materials=2"
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'
 	load_method = MAGAZINE
-	
+
 /obj/item/weapon/stock/update_icon()
 	icon_state = "ipistol[buildstate]"
 

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -2,6 +2,7 @@
 	name = "\improper Colt M1911"
 	desc = "A cheap Martian knock-off of a Colt M1911."
 	magazine_type = /obj/item/ammo_magazine/c45m
+	allowed_magazines = list(/obj/item/ammo_magazine/c45m)
 	icon_state = "colt"
 	caliber = ".45"
 	origin_tech = "combat=2;materials=2"
@@ -35,6 +36,7 @@
 	name = "\improper NT Mk58"
 	icon_state = "secguncomp"
 	magazine_type = /obj/item/ammo_magazine/c45m/rubber
+	allowed_magazines = list(/obj/item/ammo_magazine/c45m)
 	caliber = ".45"
 	origin_tech = "combat=2;materials=2"
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'
@@ -59,6 +61,7 @@
 	origin_tech = "combat=2;materials=2;syndicate=8"
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/c45m
+	allowed_magazines = list(/obj/item/ammo_magazine/c45m)
 
 /obj/item/weapon/gun/projectile/deagle
 	name = "desert eagle"
@@ -69,6 +72,7 @@
 	caliber = ".50"
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/a50
+	allowed_magazines = list(/obj/item/ammo_magazine/a50)
 	auto_eject = 1
 
 /obj/item/weapon/gun/projectile/deagle/gold
@@ -82,8 +86,6 @@
 	item_state = "deagleg"
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 
-
-
 /obj/item/weapon/gun/projectile/gyropistol
 	name = "gyrojet pistol"
 	desc = "A bulky pistol designed to fire self propelled rounds"
@@ -95,6 +97,7 @@
 	ammo_type = "/obj/item/ammo_casing/a75"
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/a75
+	allowed_magazines = list(/obj/item/ammo_magazine/a75)
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 
@@ -117,6 +120,7 @@
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/mc9mm
+	allowed_magazines = list(/obj/item/ammo_magazine/mc9mm)
 
 /obj/item/weapon/gun/projectile/pistol/flash
 	name = "\improper Stechtkin signal pistol"
@@ -173,7 +177,7 @@
 	handle_casings = CYCLE_CASINGS //player has to take the old casing out manually before reloading
 	load_method = SINGLE_CASING
 	max_shells = 1 //literally just a barrel
-	
+
 	var/global/list/ammo_types = list(
 		/obj/item/ammo_casing/a357              = ".357",
 		/obj/item/ammo_casing/a12mm             = "12mm",
@@ -190,7 +194,7 @@
 /obj/item/weapon/gun/projectile/pirate/New()
 	ammo_type = pick(ammo_types)
 	desc += " Uses [ammo_types[ammo_type]] rounds."
-	
+
 	var/obj/item/ammo_casing/ammo = ammo_type
 	caliber = initial(ammo.caliber)
 	..()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -47,8 +47,10 @@
 /obj/item/weapon/gun/projectile/revolver/deckard
 	name = "Deckard .44"
 	desc = "A custom-built revolver, based off the semi-popular Detective Special model."
+	max_shells = 6
 	icon_state = "deckard-empty"
-	ammo_type = /obj/item/ammo_magazine/c38/rubber
+	caliber = "38"
+	ammo_type = /obj/item/ammo_casing/c38
 
 /obj/item/weapon/gun/projectile/revolver/deckard/update_icon()
 	..()


### PR DESCRIPTION
Adding a new var: allowed_magazines.

Pretty much it defines what magazines you can load into a gun, it will stop people from loading submachine guns into pistols and etc. Also, fixing the Deckard revolver.