### PR TITLE
False Alarm Event

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1024,6 +1024,7 @@
 #include "code\modules\events\event_container.dm"
 #include "code\modules\events\event_dynamic.dm"
 #include "code\modules\events\event_manager.dm"
+#include "code\modules\events\false_alarm.dm"
 #include "code\modules\events\gravity.dm"
 #include "code\modules\events\grid_check.dm"
 #include "code\modules\events\infestation.dm"

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -121,10 +121,11 @@
 //Called when start(), announce() and end() has all been called.
 /datum/event/proc/kill(var/do_end = 1)
 	// If this event was forcefully killed run end() for individual cleanup
+
 	if(do_end && isRunning)
-		isRunning = 0
 		end()
 
+	isRunning = 0
 	endedAt = world.time
 	event_manager.active_events -= src
 	event_manager.event_complete(src)
@@ -142,3 +143,4 @@
 
 	setup()
 	..()
+

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -49,6 +49,11 @@
 	var/endedAt			= 0 //When this event ended.
 	var/datum/event_meta/event_meta = null
 
+	var/no_fake 		= 0
+	//If set to 1, this event will not be picked for false announcements
+	//This should really only be used for events that have no announcement
+
+
 /datum/event/nothing
 
 //Called first before processing.
@@ -114,9 +119,9 @@
 	activeFor++
 
 //Called when start(), announce() and end() has all been called.
-/datum/event/proc/kill()
+/datum/event/proc/kill(var/do_end = 1)
 	// If this event was forcefully killed run end() for individual cleanup
-	if(isRunning)
+	if(do_end && isRunning)
 		isRunning = 0
 		end()
 

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -126,21 +126,22 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 /datum/event_container/mundane
 	severity = EVENT_LEVEL_MUNDANE
 	available_events = list(
-		// Severity level, event name, even type, base weight, role weights, one shot, min weight, max weight. Last two only used if set and non-zero
+		// 					Severity level, 		event name, 		even type, 						base weight, role weights, one shot, min weight, max weight. Last two only used if set and non-zero
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Nothing",			/datum/event/nothing,			100),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "APC Damage",		/datum/event/apc_damage,		20, 	list(ASSIGNMENT_ENGINEER = 10)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Brand Intelligence",/datum/event/brand_intelligence,20, 	list(ASSIGNMENT_JANITOR = 25),	1),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Damage",		/datum/event/camera_damage,		20, 	list(ASSIGNMENT_ENGINEER = 10)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "APC Damage",		/datum/event/apc_damage,		20, 		list(ASSIGNMENT_ENGINEER = 10)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Brand Intelligence",/datum/event/brand_intelligence,20, 		list(ASSIGNMENT_JANITOR = 25),	1),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Damage",		/datum/event/camera_damage,		20, 		list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic News",		/datum/event/economic_event,	300),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Lost Carp",			/datum/event/carp_migration, 	20, 	list(ASSIGNMENT_SECURITY = 10), 1),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Lost Carp",			/datum/event/carp_migration, 	20, 		list(ASSIGNMENT_SECURITY = 10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Hacker",		/datum/event/money_hacker, 		10),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",		/datum/event/money_lotto, 		0, 		list(ASSIGNMENT_ANY = 1), 1, 5, 15),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",		/datum/event/money_lotto, 		0, 			list(ASSIGNMENT_ANY = 1), 1, 5, 15),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News", 		/datum/event/mundane_news, 		300),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "PDA Spam",			/datum/event/pda_spam, 			0, 		list(ASSIGNMENT_ANY = 3), 0, 0, 50),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Space Dust",		/datum/event/dust	, 			30, 	list(ASSIGNMENT_ENGINEER = 5), 0, 0, 50),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "PDA Spam",			/datum/event/pda_spam, 			0, 			list(ASSIGNMENT_ANY = 3), 0, 0, 50),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Space Dust",		/datum/event/dust	, 			30, 		list(ASSIGNMENT_ENGINEER = 5), 0, 0, 50),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Trivial News",		/datum/event/trivial_news, 		400),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		50,	list(ASSIGNMENT_JANITOR = 50)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			75,		list(ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_GARDENER = 20)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		50,			list(ASSIGNMENT_JANITOR = 50)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			75,			list(ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_GARDENER = 20)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "False Alarm",		/datum/event/false_alarm, 		100),
 	)
 
 /datum/event_container/moderate

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -1,0 +1,33 @@
+//False Alarm Event
+//This picks a random moderate or severe event and fakes its announcement
+//without actually running the event
+//After roughly 3 minutes, CC sends another announcement apologising for the false alarm
+
+/datum/event/false_alarm
+	announceWhen	= 0
+	endWhen	=	90
+	var/datum/event_meta/EM
+
+
+/datum/event/false_alarm/end()
+	command_announcement.Announce("Error, It appears our previous announcement about a [EM.name] was a sensor glitch. There is no cause for alarm, please return to your stations.", "False Alarm")
+
+
+/datum/event/false_alarm/announce()
+	var/datum/event_container/EC
+	if (prob(50))
+		EC = event_manager.event_containers[EVENT_LEVEL_MODERATE]
+	else
+		EC = event_manager.event_containers[EVENT_LEVEL_MAJOR]
+
+	//Don't pick events that are excluded from faking.
+	EM = pick(EC.available_events)
+	while (EM.no_fake)
+		EM = pick(EC.available_events)
+
+	var/datum/event/E = new EM.event_type(EM)
+
+	message_admins("False Alarm: [E]")
+	E.kill(0)
+	E.announce()
+

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -22,10 +22,14 @@
 
 	//Don't pick events that are excluded from faking.
 	EM = pick(EC.available_events)
-	while (EM.no_fake)
+	var/datum/event/E = null
+	var/fake_allowed = 0
+	while (!fake_allowed)
+		if (E)
+			E.kill(0)
 		EM = pick(EC.available_events)
-
-	var/datum/event/E = new EM.event_type(EM)
+		E = new EM.event_type(EM)
+		fake_allowed = !E.no_fake
 
 	message_admins("False Alarm: [E]")
 	E.kill(0)

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -1,3 +1,6 @@
+/datum/event/spontaneous_appendicitis
+	no_fake = 1
+
 /datum/event/spontaneous_appendicitis/start()
 	for(var/mob/living/carbon/human/H in shuffle(living_mob_list)) if(H.client && H.stat != DEAD)
 		var/foundAlready = 0	//don't infect someone that already has the virus

--- a/html/changelogs/Nanako-FalseAlarm.yml
+++ b/html/changelogs/Nanako-FalseAlarm.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a very alarming new event."
+
+  
+  


### PR DESCRIPTION
Adds a new mundane event, false alarm.
It picks a random moderate or severe event and fakes its announcement without actually running the event.

Three minutes later, CC sends another announcement apologising for the false alarm

Also added an event var allowing events to exclude themselves from being picked for faking