### PR TITLE
Powercell and Charging tweaks

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -263,6 +263,7 @@
 
 		//Create the desired item.
 		var/obj/item/I = new making.path(get_step(loc, get_dir(src,usr)))
+		I.Created()
 		if(multiplier > 1 && istype(I, /obj/item/stack))
 			var/obj/item/stack/S = I
 			S.amount = multiplier

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -6,8 +6,9 @@
 	anchored = 1
 	use_power = 1
 	idle_power_usage = 5
-	active_power_usage = 40000	//40 kW. (this the power drawn when charging)
+	active_power_usage = 90000	//90 kW. (this the power drawn when charging)
 	power_channel = EQUIP
+	var/charging_efficiency = 0.92
 	var/obj/item/weapon/cell/charging = null
 	var/chargelevel = -1
 
@@ -105,7 +106,7 @@
 		return
 
 	if (charging && !charging.fully_charged())
-		charging.give(active_power_usage*CELLRATE)
+		charging.give(active_power_usage*CELLRATE*charging_efficiency)
 		update_use_power(2)
 
 		update_icon()

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -7,7 +7,9 @@ obj/machinery/recharger
 	anchored = 1
 	use_power = 1
 	idle_power_usage = 4
-	active_power_usage = 15000	//15 kW
+	active_power_usage = 30000	//15 kW
+	var/charging_efficiency = 0.85
+	//Entropy. The charge put into the cell is multiplied by this
 	var/obj/item/charging = null
 	var/list/allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/melee/baton, /obj/item/device/laptop, /obj/item/weapon/cell)
 	var/icon_state_charged = "recharger2"
@@ -94,7 +96,7 @@ obj/machinery/recharger/process()
 			var/obj/item/weapon/gun/energy/E = charging
 			if(!E.power_supply.fully_charged())
 				icon_state = icon_state_charging
-				E.power_supply.give(active_power_usage*CELLRATE)
+				E.power_supply.give(active_power_usage*CELLRATE*charging_efficiency)
 				update_use_power(2)
 			else
 				icon_state = icon_state_charged
@@ -106,7 +108,7 @@ obj/machinery/recharger/process()
 			if(B.bcell)
 				if(!B.bcell.fully_charged())
 					icon_state = icon_state_charging
-					B.bcell.give(active_power_usage*CELLRATE)
+					B.bcell.give(active_power_usage*CELLRATE*charging_efficiency)
 					update_use_power(2)
 				else
 					icon_state = icon_state_charged
@@ -120,7 +122,7 @@ obj/machinery/recharger/process()
 			var/obj/item/device/laptop/L = charging
 			if(!L.stored_computer.battery.fully_charged())
 				icon_state = icon_state_charging
-				L.stored_computer.battery.give(active_power_usage*CELLRATE)
+				L.stored_computer.battery.give(active_power_usage*CELLRATE*charging_efficiency)
 				update_use_power(2)
 			else
 				icon_state = icon_state_charged
@@ -131,7 +133,7 @@ obj/machinery/recharger/process()
 			var/obj/item/weapon/cell/C = charging
 			if(!C.fully_charged())
 				icon_state = icon_state_charging
-				C.give(active_power_usage*CELLRATE)
+				C.give(active_power_usage*CELLRATE*charging_efficiency)
 				update_use_power(2)
 			else
 				icon_state = icon_state_charged
@@ -165,9 +167,10 @@ obj/machinery/recharger/wallcharger
 	name = "wall recharger"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "wrecharger0"
-	active_power_usage = 25000	//25 kW , It's more specialized than the standalone recharger (guns and batons only) so make it more powerful
+	active_power_usage = 45000	//40 kW , It's more specialized than the standalone recharger (guns and batons only) so make it more powerful
 	allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/melee/baton)
 	icon_state_charged = "wrecharger2"
 	icon_state_charging = "wrecharger1"
 	icon_state_idle = "wrecharger0"
 	portable = 0
+	charging_efficiency = 0.8

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -384,6 +384,7 @@
 	if(being_built)
 		src.being_built.Move(get_step(src,output_dir))
 		src.visible_message("\icon[src] <b>[src]</b> beeps, \"The following has been completed: [src.being_built] is built\".")
+		being_built.Created()
 		src.being_built = null
 	src.updateUsrDialog()
 	return 1

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -184,3 +184,13 @@
 				icon_species_tag = wearer.species.short_name
 				return 1
 	return 0
+
+
+//This function should be called on an item when it is:
+//Built, autolathed, protolathed, crafted or constructed. At runtime, by players or machines
+
+//It should NOT be called on things that:
+//spawn at roundstart, are adminspawned, arrive on shuttles, spawned from vendors, removed from fridges and containers, etc
+//This is useful for setting special behaviour for built items that shouldn't apply to those spawned at roundstart
+/obj/proc/Created()
+	return

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -5,9 +5,15 @@
 /obj/item/weapon/cell/New()
 	..()
 	charge = maxcharge
+	update_icon()
 
 /obj/item/weapon/cell/initialize()
 	..()
+	update_icon()
+
+/obj/item/weapon/cell/Created()
+	//Newly built cells spawn with no charge to prevent power exploits
+	charge = 0
 	update_icon()
 
 /obj/item/weapon/cell/drain_power(var/drain_check, var/surge, var/power = 0)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -383,6 +383,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							linked_lathe.busy = 0
 							screen = 3.1
 							errored = 0
+							new_item.Created()
 						updateUsrDialog()
 
 	else if(href_list["imprint"]) //Causes the Circuit Imprinter to build something.

--- a/html/changelogs/Nanako-Powercells.yml
+++ b/html/changelogs/Nanako-Powercells.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Newly protolathed/fabricated power cells now spawn with no charge."
+  - rscdel: "Added entropy to all cell-charging operations."
+  - tweak: "Most chargers are now faster. Cyborg charging stations are significantly slower."
+  - bugfix: "Fixed newly spawned cells showing the incorrect charge state."


### PR DESCRIPTION
A small package of alterations to fix exploits and tweak useability a little

Cyborg charging stations are much slower, this is intended to make cyborg charging a little more meaningful. Many cyborgs run out of materials long before tunning out of charge, and will spend significant time sitting in the charger with a full cell anyway.

The heavy duty charger, which is the only charging device that connects with a cell directly, is now the fastest charger by default. although with upgrading a cyborg station can overtake it

Zero charge on new cells fixes exploits of fabricating cells, and then sticking them in the APC that runs the fabricator. They must now be charged, which drains power appropriately.

In addition, added entropy to cell charging. The cell being charged recieves some percentage less power than is used by the charger. Efficiency values are somewhat higher than real battery chargers. Efficiency of cyborg charging stations increases with upgrades

changes: 
  - bugfix: "Newly protolathed/fabricated power cells now spawn with no charge."
  - rscdel: "Added entropy to all cell-charging operations."
  - tweak: "Most chargers are now faster. Cyborg charging stations are significantly slower."
  - bugfix: "Fixed newly spawned cells showing the incorrect charge state."