### PR TITLE
Flash Fix

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -326,6 +326,7 @@
 	mymob.flash.name = "flash"
 	mymob.flash.screen_loc = "1,1 to 15,15"
 	mymob.flash.layer = 17
+	mymob.flash.mouse_opacity = 0
 	hud_elements |= mymob.flash
 
 	mymob.pain = new /obj/screen( null )


### PR DESCRIPTION
Prevents developers, and those with certain other admin perms, from seeing the 'flash' object whenever they rightclick anywhere. This is a constant annoyance

No changelog since it doesn't concern the general playerbase