### PR TITLE
Cult construct and firelock improvements

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -77,6 +77,20 @@
 		A.all_doors.Remove(src)
 	. = ..()
 
+/obj/machinery/door/firedoor/attack_generic(var/mob/user, var/damage)
+	if(stat & (BROKEN|NOPOWER))
+		if(damage >= 10)
+			if(src.density)
+				visible_message("<span class='danger'>\The [user] forces \the [src] open!</span>")
+				open(1)
+			else
+				visible_message("<span class='danger'>\The [user] forces \the [src] closed!</span>")
+				close(1)
+		else
+			visible_message("<span class='notice'>\The [user] strains fruitlessly to force \the [src] [density ? "open" : "closed"].</span>")
+		return
+	..()
+
 /obj/machinery/door/firedoor/get_material()
 	return get_material_by_name(DEFAULT_WALL_MATERIAL)
 

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -12,7 +12,7 @@
 	a_intent = I_HURT
 	stop_automated_movement = 1
 	status_flags = CANPUSH
-	universal_speak = 0
+	universal_speak = 1
 	universal_understand = 1
 	attack_sound = 'sound/weapons/spiderlunge.ogg'
 	min_oxy = 0

--- a/code/modules/mob/living/simple_animal/hostile/moghesfauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/moghesfauna.dm
@@ -20,6 +20,8 @@
 	harm_intent_damage = 0
 	melee_damage_lower = 30
 	melee_damage_upper = 30
+	mob_size = 30
+	environment_smash = 2
 	attacktext = "chomped"
 	attack_sound = 'sound/misc/monstergrowl.ogg'
 

--- a/code/modules/mob/living/simple_animal/hostile/moghesfauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/moghesfauna.dm
@@ -31,6 +31,6 @@
 	. =..()
 	var/mob/living/L = .
 	if(istype(L))
-		if(prob(15))
+		if(prob(25))
 			L.Weaken(3)
 			L.visible_message("<span class='danger'>\The [src] knocks down \the [L]!</span>")

--- a/html/changelogs/alberyk-PR-807.yml
+++ b/html/changelogs/alberyk-PR-807.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Cult constructs can now properly speak basic once more."
+  - rscadd: "Simple animals, and cult constructs, can force unpowered or broken firedoors now."


### PR DESCRIPTION
Cult constructs can now speak properly to people.
Simple animals, and construct cults, can now open force firelocks after smashing them.
Also, improving plain-tyrants a bit more.