### PR TITLE
Bee Fixes

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1228,7 +1228,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 					/obj/item/apiary,
 					/obj/item/queen_bee)
 	cost = 40
-	contraband = 1
+	//contraband = 1
 	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "Beekeeping crate"
 	access = access_hydroponics
@@ -1560,8 +1560,8 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	containertype = /obj/structure/largecrate
 	containername = "jukebox Crate"
 	group = "Hospitality"
-	
-//voidsuit crates 
+
+//voidsuit crates
 
 /datum/supply_packs/voidsuitcrate_eng
 	name = "Engineering Voidsuit Crate"
@@ -1602,7 +1602,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	containername = "atmospherics voidsuit kit"
 	access = access_atmospherics
 	group = "Atmospherics"
-	
+
 /datum/supply_packs/voidsuitcrate_minin
 	name = "Mining Voidsuit Crate"
 	contains = list(/obj/item/clothing/head/helmet/space/void/mining,
@@ -1612,7 +1612,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	containername = "mining voidsuit kit"
 	access = access_mining
 	group = "Supply"
-	
+
 //maglocks crates
 
 /datum/supply_packs/maglocks_engineering

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -131,6 +131,11 @@
 				if(G.assailant == M)
 					M << "<span class='notice'>You already grabbed [src].</span>"
 					return
+
+			if (!attempt_grab(M))
+				return
+
+
 			if(w_uniform)
 				w_uniform.add_fingerprint(M)
 

--- a/code/modules/mob/living/simple_animal/bees.dm
+++ b/code/modules/mob/living/simple_animal/bees.dm
@@ -39,6 +39,7 @@
 		if (prob(35))//probability to reduce spam
 			src.visible_message("\red The bee swarm completely dissipates.")
 		qdel(src)
+		return
 	else
 		health = maxHealth
 		if (prob(35))//probability to reduce spam
@@ -54,7 +55,7 @@
 		var/mob/living/carbon/human/M = target_mob
 		var/sting_prob = 40 // Bees will always try to sting.
 		var/prob_mult = 1
-		if(M in view(src,1)) // Can I see my target?
+		if(M && M in view(src,1)) // Can I see my target?
 			var/obj/item/clothing/worn_suit = M.wear_suit
 			var/obj/item/clothing/worn_helmet = M.head
 			if(worn_suit) // Are you wearing clothes?
@@ -220,7 +221,6 @@
 
 //No more grabbing bee swarms
 /mob/living/simple_animal/bee/attempt_grab(var/mob/living/grabber)
-	world  << "Calling bee attemptgrab!"
 	if (prob(strength*5))//if the swarm is big you might grab a few bees, you won't make a serious dent
 		grabber << "<span class = 'warning'>You attempt to grab the swarm, but only manage to snatch a scant handful of crushed bees.</span>"
 		adjustBruteLoss(strength*0.5)

--- a/code/modules/mob/living/simple_animal/bees.dm
+++ b/code/modules/mob/living/simple_animal/bees.dm
@@ -4,9 +4,10 @@
 	icon = 'icons/obj/apiary_bees_etc.dmi'
 	icon_state = "bees1"
 	icon_dead = "bees1"
-	mob_size = 1
+	mob_size = 0.5
 	unsuitable_atoms_damage = 2.5
 	maxHealth = 20
+	density = 0
 	var/strength = 1
 	var/feral = 0
 	var/mut = 0
@@ -54,31 +55,28 @@
 		var/sting_prob = 40 // Bees will always try to sting.
 		var/prob_mult = 1
 		if(M in view(src,1)) // Can I see my target?
-			if(prob(max(feral * 10, 0)))	// Am I mad enough to want to sting? And yes, when I initially appear, I AM mad enough
-				var/obj/item/clothing/worn_suit = M.wear_suit
-				var/obj/item/clothing/worn_helmet = M.head
-				if(worn_suit) // Are you wearing clothes?
-					if ((worn_suit.flags & THICKMATERIAL))
-						prob_mult -= 0.7
-					else
-						prob_mult -= 0.01 * (min(worn_suit.armor["bio"],70)) // Is it sealed? I can't get to 70% of your body.
-				if(worn_helmet)
-					if ((worn_suit.flags & THICKMATERIAL))
-						prob_mult -= 0.3
-					else
-						prob_mult -= 0.01 *(min(worn_helmet.armor["bio"],30))// Is your helmet sealed? I can't get to 30% of your body.
-				if( prob(sting_prob*prob_mult) && (M.stat == CONSCIOUS || (M.stat == UNCONSCIOUS && prob(25*prob_mult))) ) // Try to sting! If you're not moving, think about stinging.
-					M.apply_damage(min(strength,2)+mut, BURN, sharp=1) // Stinging. The more mutated I am, the harder I sting.
-					M.apply_damage((round(feral/10,1)*(max((round(strength/20,1)),1)))+toxic, TOX) // Bee venom based on how angry I am and how many there are of me!
-					M << "\red You have been stung!"
-					M.flash_pain()
+			var/obj/item/clothing/worn_suit = M.wear_suit
+			var/obj/item/clothing/worn_helmet = M.head
+			if(worn_suit) // Are you wearing clothes?
+				if ((worn_suit.flags & THICKMATERIAL))
+					prob_mult -= 0.7
+				else
+					prob_mult -= 0.01 * (min(worn_suit.armor["bio"],70)) // Is it sealed? I can't get to 70% of your body.
+			if(worn_helmet)
+				if ((worn_helmet.flags & THICKMATERIAL))
+					prob_mult -= 0.3
+				else
+					prob_mult -= 0.01 *(min(worn_helmet.armor["bio"],30))// Is your helmet sealed? I can't get to 30% of your body.
+			if( prob(sting_prob*prob_mult) && (M.stat == CONSCIOUS || (M.stat == UNCONSCIOUS && prob(25*prob_mult))) ) // Try to sting! If you're not moving, think about stinging.
+				M.apply_damage(min(strength,2)+mut, BURN, sharp=1) // Stinging. The more mutated I am, the harder I sting.
+				M.apply_damage(max(strength*2,(round(feral/10,1)*(max((round(strength/20,1)),1)))+toxic), TOX) // Bee venom based on how angry I am and how many there are of me!
+				M << "\red You have been stung!"
+				M.flash_pain()
 
-		//if we're chasing someone, get a little bit angry
-		if(target_mob && prob(5))
-			feral++
+
 
 		//calm down a little bit
-		if(feral > 0)
+		if(feral > 0 && !target_mob)
 			if(prob(feral * 20))
 				feral -= 1
 		else
@@ -91,7 +89,7 @@
 				target_turf = null
 			if(strength > 5)
 				//calm down and spread out a little
-				var/mob/living/simple_animal/bee/B = new(get_turf(pick(orange(src,1))))
+				var/mob/living/simple_animal/bee/B = new(get_turf(src))
 				B.strength = rand(1,5)
 				src.strength -= B.strength
 				update_icons()
@@ -101,7 +99,7 @@
 					src.parent.owned_bee_swarms.Add(B)
 
 		//make some noise
-		if(prob(0.5))
+		if(prob(5))
 			src.visible_message("\blue [pick("Buzzzz.","Hmmmmm.","Bzzz.")]")
 
 		//smoke, water and steam calms us down
@@ -154,20 +152,30 @@
 					density = 0
 				break
 
-		if(target_mob)
-			if(target_mob in view(src,7))
-				target_turf = get_turf(target_mob)
-				wander = 0
 
-			else // My target's gone! But I might still be pissed! You there. You look like a good stinging target!
-				for(var/mob/living/carbon/G in view(src,7))
-					target_mob = G
-					break
+		if(target_mob)//If we have a target
+			if(target_mob in view(src,7))//Check that we can still see them
+				target_turf = get_turf(target_mob)//If so, update the location
+				wander = 0
+			else//Otherwise, if our target is out of view, we clear them so we can pick a new one in the next step
+				target_mob = null
+				target_turf = null
+				wander = 1
+
+		//If we're angry but have no target, lets search for one
+		if (!target_mob && feral)
+			for(var/mob/living/carbon/G in view(src,7))
+				target_mob = G
+				break
+
+		//if we're chasing someone, get a little bit angry
+		if(target_mob && prob(5))
+			feral++
 
 		if(target_turf)
 			if (!(DirBlocked(get_step(src, get_dir(src,target_turf)),get_dir(src,target_turf)))) // Check for windows and doors!
 				Move(get_step(src, get_dir(src,target_turf)))
-				if (prob(0.1))
+				if (prob(10))
 					src.visible_message("\blue The bees swarm after [target_mob]!")
 			if(src.loc == target_turf)
 				target_turf = null
@@ -190,7 +198,7 @@
 		pixel_x = rand(-12,12)
 		pixel_y = rand(-12,12)
 
-	if(!parent && prob(10))
+	if(!parent && prob(8-strength))
 		strength -= 1
 		if(strength <= 0)
 			death()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -236,9 +236,7 @@
 		fire_alert = 0
 
 	if(!atmos_suitable)
-
 		adjustBruteLoss(unsuitable_atoms_damage)
-		if (istype(src, /mob/living/simple_animal/bee))
 	return 1
 
 /mob/living/simple_animal/proc/handle_supernatural()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -99,9 +99,6 @@
 		src.client.screen = null
 	..()
 
-/mob/living/simple_animal/updatehealth()
-	return
-
 /mob/living/simple_animal/examine(mob/user)
 	..()
 
@@ -239,7 +236,10 @@
 		fire_alert = 0
 
 	if(!atmos_suitable)
+
 		adjustBruteLoss(unsuitable_atoms_damage)
+		if (istype(src, /mob/living/simple_animal/bee))
+			world << "Bee taking depressurisation damage. Health is now [health]"
 	return 1
 
 /mob/living/simple_animal/proc/handle_supernatural()
@@ -325,6 +325,9 @@
 			if (!(status_flags & CANPUSH))
 				return
 
+			if (!attempt_grab(M))
+				return
+
 			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
 
 			M.put_in_active_hand(G)
@@ -382,7 +385,9 @@
 		if(supernatural && istype(O,/obj/item/weapon/nullrod))
 			damage *= 2
 			purge = 3
-		adjustBruteLoss(damage)
+
+		apply_damage(damage, O.damtype)
+		//adjustBruteLoss(damage)
 	else
 		usr << "<span class='danger>This weapon is ineffective, it does no damage.</span>"
 
@@ -408,6 +413,11 @@
 
 	if(statpanel("Status") && show_stat_health)
 		stat(null, "Health: [round((health / maxHealth) * 100)]%")
+
+/mob/living/updatehealth()
+	..()
+	if (health <= 0)
+		death()
 
 /mob/living/simple_animal/death(gibbed, deathmessage = "dies!")
 	icon_state = icon_dead

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -239,7 +239,6 @@
 
 		adjustBruteLoss(unsuitable_atoms_damage)
 		if (istype(src, /mob/living/simple_animal/bee))
-			world << "Bee taking depressurisation damage. Health is now [health]"
 	return 1
 
 /mob/living/simple_animal/proc/handle_supernatural()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -605,8 +605,12 @@
 		usr << "<span class='notice'>It won't budge!</span>"
 		return
 
-	var/mob/M = AM
-	if(ismob(AM))
+	var/mob/living/M
+	if(istype(AM, /mob/living))
+		M = AM
+		if (!M.attempt_pull(src))
+			return
+
 		if(!iscarbon(src))
 			M.LAssailant = null
 		else
@@ -631,7 +635,7 @@
 			src << "\red <B>Pulling \the [H] in their current condition would probably be a bad idea.</B>"
 
 	//Attempted fix for people flying away through space when cuffed and dragged.
-	if(ismob(AM))
+	if(M)
 		var/mob/pulled = AM
 		pulled.inertia_dir = 0
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -1,6 +1,19 @@
 #define UPGRADE_COOLDOWN	40
 #define UPGRADE_KILL_TIMER	100
 
+
+//This is called from human_attackhand.dm before grabbing happens.
+//IT is called when grabber tries to grab this mob
+//Override this for special grab behaviour.
+//Returning 0 will make grab fail, returning 1 will suceed
+/mob/living/proc/attempt_grab(var/mob/living/grabber)
+	return 1
+
+//As above, but called when someone tries to pull this mob
+/mob/living/proc/attempt_pull(var/mob/living/grabber)
+	return 1
+
+
 ///Process_Grab()
 ///Called by client/Move()
 ///Checks to see if you are grabbing anything and if moving will affect your grab.
@@ -124,7 +137,7 @@
 
 		if(iscarbon(affecting))
 			handle_eye_mouth_covering(affecting, assailant, assailant.zone_sel.selecting)
-		
+
 		if(force_down)
 			if(affecting.loc != assailant.loc)
 				force_down = 0
@@ -148,7 +161,7 @@
 /obj/item/weapon/grab/proc/handle_eye_mouth_covering(mob/living/carbon/target, mob/user, var/target_zone)
 	var/announce = (target_zone != last_hit_zone) //only display messages when switching between different target zones
 	last_hit_zone = target_zone
-	
+
 	switch(target_zone)
 		if("mouth")
 			if(announce)
@@ -232,7 +245,7 @@
 		else
 			assailant.visible_message("<span class='warning'>[assailant] pins [affecting] down to the ground (now hands)!</span>")
 			apply_pinning(affecting, assailant)
-		
+
 		state = GRAB_AGGRESSIVE
 		icon_state = "grabbed1"
 		hud.icon_state = "reinforce1"
@@ -284,10 +297,10 @@
 		return
 	if(world.time < (last_action + 20))
 		return
-	
+
 	last_action = world.time
 	reset_kill_state() //using special grab moves will interrupt choking them
-	
+
 	//clicking on the victim while grabbing them
 	if(M == affecting)
 		if(ishuman(affecting))
@@ -300,10 +313,10 @@
 						force_down = 0
 						return
 					inspect_organ(affecting, assailant, hit_zone)
-				
+
 				if(I_GRAB)
 					jointlock(affecting, assailant, hit_zone)
-				
+
 				if(I_HURT)
 					if(hit_zone == "eyes")
 						attack_eye(affecting, assailant)
@@ -311,10 +324,10 @@
 						headbut(affecting, assailant)
 					else
 						dislocate(affecting, assailant, hit_zone)
-				
+
 				if(I_DISARM)
 					pin_down(affecting, assailant)
-	
+
 	//clicking on yourself while grabbing them
 	if(M == assailant && state >= GRAB_AGGRESSIVE)
 		devour(affecting, assailant)
@@ -325,7 +338,7 @@
 		qdel(src)
 
 /obj/item/weapon/grab/proc/reset_kill_state()
-	if(state == GRAB_KILL) 
+	if(state == GRAB_KILL)
 		assailant.visible_message("<span class='warning'>[assailant] lost \his tight grip on [affecting]'s neck!</span>")
 		hud.icon_state = "kill"
 		state = GRAB_NECK

--- a/html/changelogs/Nanako-Bees.yml
+++ b/html/changelogs/Nanako-Bees.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Attempting to grab or pull bee swarms no longer works"
+  - bugfix: "Fixed bee swarms still flying around when dead and appearing to be unkillable."
+  - tweak: "Bees now take double damage from fire."
+  - tweak: "Thick material clothing now protects against beestings."
+  - tweak: "Beekeeping crate is no longer contraband in cargo."


### PR DESCRIPTION
Fixes some screwy behaviour with bees, including their seeming-immortality, some AI/targeting issues, and grabbing. strangling a bee swarm was dumb

This PR also fixes the issue of animals not caching damagetype loss vars properly

changes: 
  - bugfix: "Attempting to grab or pull bee swarms no longer works"
  - bugfix: "Fixed bee swarms still flying around when dead and appearing to be unkillable."
  - tweak: "Bees now take double damage from fire."
  - tweak: "Thick material clothing now protects against beestings."
  - tweak: "Beekeeping crate is no longer contraband in cargo."