### PR TITLE
Maintenance Hatch Expansion and ID/Silicon Tweaks

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -92,9 +92,14 @@
 	//check if it doesn't require any access at all
 	if(src.check_access(null))
 		return 1
+
 	if(istype(M, /mob/living/silicon))
-		//AI can do whatever he wants
-		return 1
+		if(ispAI(M))
+			var/mob/living/silicon/pai/P = M
+			if(P.ID && src.check_access(P.ID))
+				return 1
+		else//AI can do whatever he wants
+			return 1
 	else if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		//if they are holding or wearing a card that has access, that works

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -105,8 +105,8 @@
 		playsound(src.loc, hatch_open_sound, 40, 1, -1)
 	hatchclosetime = world.time + 29
 
-	if (istype(mover, /mob/living/silicon))
-		var/mob/living/silicon/S = mover
+	if (istype(mover, /mob/living))
+		var/mob/living/S = mover
 		S.under_door()
 
 
@@ -190,8 +190,14 @@
 		if(mover.checkpass(PASSGLASS))
 			return !opacity
 		if(density && hashatch && mover.checkpass(PASSDOORHATCH))
-			open_hatch(mover)
-			return 1//If this door is closed, but it has hatches, and this creature can go through hatches. Then we let it through without opening
+			if (istype(mover, /mob/living/silicon/pai))
+				var/mob/living/silicon/pai/P = mover
+				if (allowed(P))
+					open_hatch(mover)
+					return 1
+			else
+				open_hatch(mover)
+				return 1//If this door is closed, but it has hatches, and this creature can go through hatches. Then we let it through without opening
 	return !density
 
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -128,7 +128,7 @@
 	desc = "A card used to provide ID and determine access across the station."
 	icon_state = "id"
 	item_state = "card-id"
-	var/access = list()
+	var/list/access = list()
 	var/registered_name = "Unknown" // The name registered_name on the card
 	slot_flags = SLOT_ID
 
@@ -147,16 +147,29 @@
 /obj/item/weapon/card/id/New()
 	..()
 	spawn(30)
-	if(istype(loc, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = loc
-		blood_type = H.dna.b_type
-		dna_hash = H.dna.unique_enzymes
-		fingerprint_hash = md5(H.dna.uni_identity)
-		citizenship = H.citizenship
-		religion = H.religion
-		age = H.age
+		if(istype(loc, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = loc
+			blood_type = H.dna.b_type
+			dna_hash = H.dna.unique_enzymes
+			fingerprint_hash = md5(H.dna.uni_identity)
+			citizenship = H.citizenship
+			religion = H.religion
+			age = H.age
 
 /obj/item/weapon/card/id/attack_self(mob/user as mob)
+	if (dna_hash == "\[UNSET\]" && ishuman(user))
+		var/response = alert(user, "This ID card has not been imprinted with biometric data. Would you like to imprint yours now?", "Biometric Imprinting", "Yes", "No")
+		if (response == "Yes")
+			var/mob/living/carbon/human/H = user
+			blood_type = H.dna.b_type
+			dna_hash = H.dna.unique_enzymes
+			fingerprint_hash = md5(H.dna.uni_identity)
+			citizenship = H.citizenship
+			religion = H.religion
+			age = H.age
+			user << "<span class='notice'>Biometric Imprinting Successful!.</span>"
+			return
+
 	for(var/mob/O in viewers(user, null))
 		O.show_message(text("[] shows you: \icon[] []: assignment: []", user, src, src.name, src.assignment), 1)
 

--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -49,9 +49,17 @@
 			src << "You whistle."
 			message = "<B>[src]</B> whistles."
 			m_type = 2
-		if ("beep")
-			src << "You beep."
+		if("beep")
 			message = "<B>[src]</B> beeps."
+			playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 0)
+			m_type = 2
+		if("ping")
+			message = "<B>[src]</B> pings."
+			playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
+			m_type = 2
+		if("buzz")
+			message = "<B>[src]</B> buzzes."
+			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 			m_type = 2
 		if ("boop")
 			src << "You boop."

--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -28,15 +28,12 @@
 		if ("custom")
 			return custom_emote(m_type, message)
 		if ("alarm")
-			src << "You sound an alarm."
 			message = "<B>[src]</B> sounds an alarm."
 			m_type = 2
 		if ("alert")
-			src << "You let out a distressed noise."
 			message = "<B>[src]</B> lets out a distressed noise."
 			m_type = 2
 		if ("notice")
-			src << "You play a loud tone."
 			message = "<B>[src]</B> plays a loud tone."
 			m_type = 2
 		if ("flash")
@@ -46,7 +43,6 @@
 			message = "<B>[src]</B> blinks."
 			m_type = 1
 		if ("whistle")
-			src << "You whistle."
 			message = "<B>[src]</B> whistles."
 			m_type = 2
 		if("beep")
@@ -62,7 +58,6 @@
 			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 			m_type = 2
 		if ("boop")
-			src << "You boop."
 			message = "<B>[src]</B> boops."
 			m_type = 2
 		if ("help")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -676,6 +676,12 @@ default behaviour is:
 /mob/living/proc/slip(var/slipped_on,stun_duration=8)
 	return 0
 
+/mob/living/proc/under_door()
+	//This function puts a silicon on a layer that makes it draw under doors, then periodically checks if its still standing on a door
+	if (layer > UNDERDOOR)//Don't toggle it if we're hiding
+		layer = UNDERDOOR
+		underdoor = 1
+
 /mob/living/carbon/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
 	if(W in internal_organs)
 		return

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -46,3 +46,4 @@
 	var/mouth_size = 2//how large of a creature it can swallow at once, and how big of a bite it can take out of larger things
 	var/eat_types = 0//This is a bitfield which must be initialised in New(). The valid values for it are in devour.dm
 	var/datum/reagents/metabolism/ingested = null
+	var/underdoor //Used for mobs that can walk through maintenance hatches - drones, pais, and spiderbots

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -5,8 +5,9 @@
 
 	emote_type = 2		// pAIs emotes are heard, not seen, so they can be seen through a container (eg. person)
 	small = 1
-	pass_flags = 1
+	pass_flags = PASSTABLE | PASSDOORHATCH
 	density = 0
+	mob_size = 1//As a holographic projection, a pAI is massless except for its card device
 
 	mob_size = 1
 
@@ -14,7 +15,6 @@
 
 	var/network = "SS13"
 	var/obj/machinery/camera/current = null
-
 	var/ram = 100	// Used as currency to purchase different abilities
 	var/list/software = list()
 	var/userDNA		// The DNA string of our assigned user
@@ -34,10 +34,12 @@
 		"Natural" = list("says","yells","asks"),
 		"Beep" = list("beeps","beeps loudly","boops"),
 		"Chirp" = list("chirps","chirrups","cheeps"),
-		"Feline" = list("purrs","yowls","meows")
+		"Feline" = list("purrs","yowls","meows"),
+		"Rodent" = list("squeaks","squeals","squeeks")
 		)
 
 	var/obj/item/weapon/pai_cable/cable		// The cable we produce and use when door or camera jacking
+	var/obj/item/weapon/card/id/ID = null	//Internal ID used to store copied owner access, and to check access for airlocks
 
 	var/master				// Name of the one who commands us
 	var/master_dna			// DNA string for owner verification
@@ -106,6 +108,8 @@
 
 	//PDA
 	pda = new(src)
+	ID = new(src)
+	ID.registered_name = ""
 	spawn(5)
 		pda.ownjob = "Personal Assistant"
 		pda.owner = text("[]", src)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -24,7 +24,7 @@
 
 	var/next_alarm_notice
 	var/list/datum/alarm/queued_alarms = new()
-	var/underdoor
+
 
 	#define SEC_HUD 1 //Security HUD mode
 	#define MED_HUD 2 //Medical HUD mode
@@ -370,10 +370,4 @@
 				spawn(3)//A slight delay to let us finish walking out from under the door
 					layer = initial(layer)
 
-/mob/living/silicon/proc/under_door()
-	//This function puts a silicon on a layer that makes it draw under doors, then periodically checks if its still standing on a door
-	if (layer > UNDERDOOR)//Don't toggle it if we're hiding
-		layer = UNDERDOOR
-		underdoor = 1
 
-/mob/living/silicon/proc/not_under_door()

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -23,7 +23,7 @@
 	icon_dead = "spiderbot-smashed"
 
 	wander = 0
-
+	density = 0
 	health = 25
 	maxHealth = 25
 	hunger_enabled = 0
@@ -39,7 +39,7 @@
 	var/emagged = 0
 	var/obj/item/held_item = null //Storage for single item they can hold.
 	speed = -1                    //Spiderbots gotta go fast.
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSDOORHATCH
 	small = 1
 	speak_emote = list("beeps","clicks","chirps")
 
@@ -298,3 +298,17 @@
 
 /mob/living/simple_animal/spiderbot/binarycheck()
 	return positronic
+
+/mob/living/simple_animal/spiderbot/Move(newloc, direct)
+	..(newloc,direct)
+	if (underdoor)
+		underdoor = 0
+		if ((layer == UNDERDOOR))//if this is false, then we must have used hide, or had our layer changed by something else. We wont do anymore checks for this move proc
+			for (var/obj/machinery/door/D in loc)
+				if (D.hashatch)
+					underdoor = 1
+					break
+
+			if (!underdoor)
+				spawn(3)//A slight delay to let us finish walking out from under the door
+					layer = initial(layer)

--- a/html/changelogs/Nanako-PAIhatch.yml
+++ b/html/changelogs/Nanako-PAIhatch.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Spiderbots no longer block movement."
+  - tweak: "Spiderbots can now use airlock maintenance hatches."
+  - rscadd: "PAIs can now have the owner's ID card scanned onto them to share access."
+  - tweak: "PAIs can now use airlock maintenance hatches, but only on airlocks they have access to. Requires a scanned ID"
+  - tweak: "Added new rodent speech verbs for PAIs"
+  - tweak: "Positronic brains and MMIs outside of a chassis can now use ping/beep/buzz audio emotes."
+  


### PR DESCRIPTION
Registering ID on pAIs and allowing them to use hatches is the main thing here, been meaning to do that for a while.

The biometric data imprinting I added because pAIs depend on comparing the card's DNA to the master before allowing registration. And also because there was no way to imprint your DNA/bloodtype/fingerprint/age/etc onto a newly made ID card, even though the ID you spawn with has these things. And also because bluespace techs don't spawn with the data on their card and it was getting in the way of my testing.

I had to move the underdoor function down a level to mob/living because spiderbots aren't silicon. 

Marked as large risk because of alteration to access.dm

changes: 
  - tweak: "Spiderbots no longer block movement."
  - tweak: "Spiderbots can now use airlock maintenance hatches."
  - rscadd: "PAIs can now have the owner's ID card scanned onto them to share access."
  - tweak: "PAIs can now use airlock maintenance hatches, but only on airlocks they have access to. Requires a scanned ID"
  - tweak: "Added new rodent speech verbs for PAIs"
  - tweak: "Positronic brains and MMIs outside of a chassis can now use ping/beep/buzz audio emotes."
  - tweak: "You can now click an ID in your hand to imprint your biometric data on it, if it's not present. This is only useful if you lose the ID you spawn with and get a new one made up."