### PR TITLE
Medical/Cyborg Tweaks

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -210,8 +210,8 @@ var/list/cheartstopper = list("potassium_chloride")                       // Thi
 
 // Used by robots and robot preferences.
 var/list/robot_module_types = list(
-	"Standard", "Engineering", "Construction", "Surgeon",  "Crisis",
-	"Miner",    "Janitor",     "Service",      "Clerical", "Security",
+	"Standard", "Engineering", "Construction", "Medical",  "Rescue",
+	"Miner",    "Custodial",     "Service",      "Clerical", "Security",
 	"Research"
 )
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -199,11 +199,11 @@
 			wrapped = null
 			return
 
-	else if (istype(target, /obj/item/weapon/storage/box))
+	else if (istype(target, /obj/item/weapon/storage) && !istype(target, /obj/item/weapon/storage/secure))
 		for (var/obj/item/C in target.contents)
 			for(var/typepath in can_hold)
 				if(istype(C,typepath))
-					user << "You grab the [C] from inside the box."
+					user << "You grab the [C] from inside the [target.name]."
 					C.loc = src
 					return
 		user << "There is nothing inside the box that your gripper can collect"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -181,7 +181,7 @@ var/global/list/robot_modules = list(
 	can_be_pushed = 0
 
 /obj/item/weapon/robot_module/medical/surgeon
-	name = "surgeon robot module"
+	name = "medical robot module"
 	sprites = list(
 					"Basic" = "Medbot",
 					"Standard" = "surgeon",
@@ -205,6 +205,9 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/circular_saw(src)
 	src.modules += new /obj/item/weapon/surgicaldrill(src)
 	src.modules += new /obj/item/weapon/gripper/chemistry(src)
+	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
+	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
+	src.modules += new /obj/item/device/reagent_scanner/adv(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("pacid", 250)
 	src.emag.name = "Polyacid spray"
@@ -232,7 +235,7 @@ var/global/list/robot_modules = list(
 	..()
 
 /obj/item/weapon/robot_module/medical/crisis
-	name = "crisis robot module"
+	name = "rescue robot module"
 	sprites = list(
 					"Basic" = "Medbot",
 					"Standard" = "surgeon",
@@ -249,11 +252,13 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/borg/sight/hud/med(src)
 	src.modules += new /obj/item/device/healthanalyzer(src)
 	src.modules += new /obj/item/device/reagent_scanner/adv(src)
+	src.modules += new /obj/item/weapon/crowbar(src)
 	src.modules += new /obj/item/roller_holder(src)
 	src.modules += new /obj/item/weapon/reagent_containers/borghypo/crisis(src)
 	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
+	src.modules += new /obj/item/borg/sight/meson(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("pacid", 250)
 	src.emag.name = "Polyacid spray"
@@ -612,6 +617,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/weapon/gripper/chemistry(src)
+	src.modules += new /obj/item/weapon/extinguisher(src)
 	src.emag = new /obj/item/weapon/hand_tele(src)
 
 	var/datum/matter_synth/nanite = new /datum/matter_synth/nanite(10000)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -4,13 +4,13 @@ var/global/list/robot_modules = list(
 	"Clerical" 		= /obj/item/weapon/robot_module/clerical/general,
 	"Research" 		= /obj/item/weapon/robot_module/research,
 	"Miner" 		= /obj/item/weapon/robot_module/miner,
-	"Crisis" 		= /obj/item/weapon/robot_module/medical/crisis,
-	"Surgeon" 		= /obj/item/weapon/robot_module/medical/surgeon,
+	"Rescue" 		= /obj/item/weapon/robot_module/medical/rescue,
+	"Medical" 		= /obj/item/weapon/robot_module/medical/general,
 	"Security" 		= /obj/item/weapon/robot_module/security/general,
 	"Combat" 		= /obj/item/weapon/robot_module/combat,
 	"Engineering"	= /obj/item/weapon/robot_module/engineering/general,
 	"Construction"	= /obj/item/weapon/robot_module/engineering/construction,
-	"Janitor" 		= /obj/item/weapon/robot_module/janitor
+	"Custodial" 	= /obj/item/weapon/robot_module/janitor
 	)
 
 /obj/item/weapon/robot_module
@@ -173,14 +173,14 @@ var/global/list/robot_modules = list(
 	src.emag = new /obj/item/weapon/melee/energy/sword(src)
 	return
 
-/obj/item/weapon/robot_module/medical
+/obj/item/weapon/robot_module/general
 	name = "medical robot module"
 	channels = list("Medical" = 1)
 	networks = list(NETWORK_MEDICAL)
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
 	can_be_pushed = 0
 
-/obj/item/weapon/robot_module/medical/surgeon
+/obj/item/weapon/robot_module/medical/general
 	name = "medical robot module"
 	sprites = list(
 					"Basic" = "Medbot",
@@ -190,11 +190,11 @@ var/global/list/robot_modules = list(
 					"Drone" = "drone-surgery"
 					)
 
-/obj/item/weapon/robot_module/medical/surgeon/New()
+/obj/item/weapon/robot_module/medical/general/New()
 	..()
 	src.modules += new /obj/item/device/flash(src)
 	src.modules += new /obj/item/device/healthanalyzer(src)
-	src.modules += new /obj/item/weapon/reagent_containers/borghypo/surgeon(src)
+	src.modules += new /obj/item/weapon/reagent_containers/borghypo/medical(src)
 	src.modules += new /obj/item/weapon/scalpel(src)
 	src.modules += new /obj/item/weapon/hemostat(src)
 	src.modules += new /obj/item/weapon/retractor(src)
@@ -228,13 +228,13 @@ var/global/list/robot_modules = list(
 
 	return
 
-/obj/item/weapon/robot_module/medical/surgeon/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
+/obj/item/weapon/robot_module/medical/general/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	if(src.emag)
 		var/obj/item/weapon/reagent_containers/spray/PS = src.emag
 		PS.reagents.add_reagent("pacid", 2 * amount)
 	..()
 
-/obj/item/weapon/robot_module/medical/crisis
+/obj/item/weapon/robot_module/medical/rescue
 	name = "rescue robot module"
 	sprites = list(
 					"Basic" = "Medbot",
@@ -246,7 +246,7 @@ var/global/list/robot_modules = list(
 					)
 	supported_upgrades = list(/obj/item/robot_parts/robot_component/jetpack)
 
-/obj/item/weapon/robot_module/medical/crisis/New()
+/obj/item/weapon/robot_module/medical/rescue/New()
 	..()
 	src.modules += new /obj/item/device/flash(src)
 	src.modules += new /obj/item/borg/sight/hud/med(src)
@@ -254,7 +254,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/reagent_scanner/adv(src)
 	src.modules += new /obj/item/weapon/crowbar(src)
 	src.modules += new /obj/item/roller_holder(src)
-	src.modules += new /obj/item/weapon/reagent_containers/borghypo/crisis(src)
+	src.modules += new /obj/item/weapon/reagent_containers/borghypo/rescue(src)
 	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
@@ -284,7 +284,7 @@ var/global/list/robot_modules = list(
 
 	return
 
-/obj/item/weapon/robot_module/medical/crisis/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
+/obj/item/weapon/robot_module/medical/rescue/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/weapon/reagent_containers/syringe/S = locate() in src.modules
 	if(S.mode == 2)
 		S.reagents.clear_reagents()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -173,7 +173,7 @@ var/global/list/robot_modules = list(
 	src.emag = new /obj/item/weapon/melee/energy/sword(src)
 	return
 
-/obj/item/weapon/robot_module/general
+/obj/item/weapon/robot_module/medical
 	name = "medical robot module"
 	channels = list("Medical" = 1)
 	networks = list(NETWORK_MEDICAL)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -17,11 +17,11 @@
 	var/list/reagent_volumes = list()
 	var/list/reagent_names = list()
 
-/obj/item/weapon/reagent_containers/borghypo/surgeon
-	reagent_ids = list("bicaridine", "inaprovaline", "dexalin", "stoxin")
+/obj/item/weapon/reagent_containers/borghypo/medical
+	reagent_ids = list("bicaridine", "inaprovaline", "dexalin", "stoxin", "spaceacillin", "anti_toxin")
 
-/obj/item/weapon/reagent_containers/borghypo/crisis
-	reagent_ids = list("tricordrazine", "inaprovaline", "tramadol")
+/obj/item/weapon/reagent_containers/borghypo/rescue
+	reagent_ids = list("tricordrazine", "inaprovaline", "tramadol", "hyperzine")
 
 /obj/item/weapon/reagent_containers/borghypo/New()
 	..()

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -21,7 +21,7 @@
 	reagent_ids = list("bicaridine", "inaprovaline", "dexalin", "stoxin", "spaceacillin", "anti_toxin")
 
 /obj/item/weapon/reagent_containers/borghypo/rescue
-	reagent_ids = list("tricordrazine", "inaprovaline", "tramadol", "hyperzine")
+	reagent_ids = list("tricordrazine", "inaprovaline", "tramadol")
 
 /obj/item/weapon/reagent_containers/borghypo/New()
 	..()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -61,7 +61,6 @@
 			user << "<span class='notice'>Airtight lid seals it completely.</span>"
 
 	attack_self()
-		world << "Calling bottle attackself"
 		..()
 		if(is_open_container())
 			usr << "<span class = 'notice'>You put the lid on \the [src].</span>"

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -61,6 +61,7 @@
 			user << "<span class='notice'>Airtight lid seals it completely.</span>"
 
 	attack_self()
+		world << "Calling bottle attackself"
 		..()
 		if(is_open_container())
 			usr << "<span class = 'notice'>You put the lid on \the [src].</span>"

--- a/html/changelogs/Nanako-MediborgTweaks.yml
+++ b/html/changelogs/Nanako-MediborgTweaks.yml
@@ -33,12 +33,7 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Surgeon and Crisis cyborg modules renamed to Medical and Rescue."
-  - tweak: "Janitor cyborg module renamed to Custodial."
-  - tweak: "Rescue module now has a crowbar and meson vision."
-  - tweak: "Rescue module hypospray now has Hyperzine."
-  - tweak: "Medical module hypospray now has spaceacillin and dylovene."
-  - tweak: "Medical module now has a reagent scanner, syringe and dropper."
-  - tweak: "Research cyborg module now has a fire extinguisher."
+  - tweak: "Surgeon and Crisis cyborg modules renamed to Medical and Rescue, Janitor cyborg module renamed to Custodial."
+  - tweak: "Tweaked equipment of cyborg modules."
   - rscadd: "Grippers can now grab valid items inside any unsecure container"
   

--- a/html/changelogs/Nanako-MediborgTweaks.yml
+++ b/html/changelogs/Nanako-MediborgTweaks.yml
@@ -34,7 +34,11 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - tweak: "Surgeon and Crisis cyborg modules renamed to Medical and Rescue."
+  - tweak: "Janitor cyborg module renamed to Custodial."
   - tweak: "Rescue module now has a crowbar and meson vision."
+  - tweak: "Rescue module hypospray now has Hyperzine."
+  - tweak: "Medical module hypospray now has spaceacillin and dylovene."
   - tweak: "Medical module now has a reagent scanner, syringe and dropper."
   - tweak: "Research cyborg module now has a fire extinguisher."
+  - rscadd: "Grippers can now grab valid items inside any unsecure container"
   

--- a/html/changelogs/Nanako-MediborgTweaks.yml
+++ b/html/changelogs/Nanako-MediborgTweaks.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Surgeon and Crisis cyborg modules renamed to Medical and Rescue."
+  - tweak: "Rescue module now has a crowbar and meson vision."
+  - tweak: "Medical module now has a reagent scanner, syringe and dropper."
+  - tweak: "Research cyborg module now has a fire extinguisher."
+  


### PR DESCRIPTION
A package of interesting and perhaps controversial adjustments to several cyborg modules

changes: 
  - tweak: "Surgeon and Crisis cyborg modules renamed to Medical and Rescue, Janitor cyborg module renamed to Custodial."
  - tweak: "Tweaked equipment of cyborg modules."
  - rscadd: "Grippers can now grab valid items inside any unsecure container"

Renaming of surgeon and crisis follows on from previous discussions. Surgeon fills the role of general medical borg which belongs in medical. 

Custodial is just more professional and formal than janitor.

Crowbar seemed like a bizarre omission from the rescue module, adding that is a no brainer. Meson vision is a bit unusual, but it supplements their rescue role well by allowing them to see topology of the station, more easily find their way around maintenance tunnels, and to see breaches to ascertain the danger of a situation before entering.

Addition of hyperzine aids in getting patients on their feet, making it more plausible to recover multiple patients at once from a dangerous situation. It would also be useful for teamwork alongside an organic paramedic in a voidsuit

Spaceacillin and dylovene for the medical borg are largely convenience. They are widely available in functionally infinite quantities within medbay already.

Reagent scanner, syringe and dropper are vital chemistry tools i missed previously. Several players have complained about the lack of a dropper

Fire extinguisher for the research borg allows it to assist in xenobiology, its an important slime control tool.

And the gripper adjustment just generalises the check a bit to work on any weapon/storage, aside from secure briefcases to prevent exploits. As always its still limited to things the gripper can hold, and grabs the first valid item.

