### PR TITLE
Rubber and Beanbag rounds rebalancing

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -78,6 +78,11 @@
 	if(!isliving(target))	return 0
 	if(isanimal(target))	return 0
 	var/mob/living/L = target
+	if (agony && ishuman(target))
+		var/mob/living/carbon/human/H = target
+		var/obj/item/organ/external/organ = H.get_organ(def_zone)
+		var/armor = H.getarmor_organ(organ, check_armour)
+		agony = max(0, agony - armor)
 	L.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, incinerate, blocked) // add in AGONY!
 	return 1
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -11,8 +11,8 @@
 
 	muzzle_type = /obj/effect/projectile/bullet/muzzle
 
-/obj/item/projectile/bullet/on_hit(var/atom/target, var/blocked = 0)
-	if (..(target, blocked))
+/obj/item/projectile/bullet/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
+	if (..(target, blocked, def_zone))
 		var/mob/living/L = target
 		shake_camera(L, 3, 2)
 
@@ -111,7 +111,7 @@
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
 	check_armour = "melee"
-	damage = 10
+	damage = 5
 	agony = 40
 	embed = 0
 	sharp = 0
@@ -125,7 +125,7 @@
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
 	check_armour = "melee"
-	damage = 20
+	damage = 10
 	agony = 60
 	embed = 0
 	sharp = 0

--- a/html/changelogs/Nanako-Nonlethal.yml
+++ b/html/changelogs/Nanako-Nonlethal.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Lethal damage of rubber bullets and beanbag shells reduced. They will be far less likely to cause broken bones and internal damage now."
+  - tweak: "Halloss (Pain) from rubber and beanbag rounds is now blocked by armour."


### PR DESCRIPTION
Halves the brute damage of these two round types, to reduce their serious injury rate to more believable levels.
In addition, armor blocks the halloss, making them largely ineffective against an armoured target.


changes: 
  - tweak: "Lethal damage of rubber bullets and beanbag shells reduced. They will be far less likely to cause broken bones and internal damage now."
  - tweak: "Halloss (Pain) from rubber and beanbag rounds is now blocked by armour."