### PR TITLE
Communication Fixes

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -107,7 +107,17 @@
 	log_ooc("(LOCAL) [mob.name]/[key] : [msg]")
 
 	var/mob/source = src.mob
-	var/list/heard = get_mobs_in_view(7, get_turf(source))
+	var/list/messageturfs = list()//List of turfs we broadcast to.
+	var/list/messagemobs = list()//List of living mobs nearby who can hear it
+
+	for (var/turf in range(world.view, get_turf(source)))
+		messageturfs += turf
+
+	for(var/mob/M in player_list)
+		if (!M.client)
+			continue
+		if(get_turf(M) in messageturfs)
+			messagemobs += M
 
 	var/display_name = source.key
 	if(holder && holder.fakekey)
@@ -130,7 +140,7 @@
 				admin_stuff += "/([source.key])"
 				if(target != source.client)
 					admin_stuff += "(<A HREF='?src=\ref[target.holder];adminplayerobservejump=\ref[mob]'>JMP</A>)"
-			if(target.mob in heard)
+			if(target.mob in messagemobs)
 				prefix = ""
-			if((target.mob in heard) || display_remote)
+			if((target.mob in messagemobs) || display_remote)
 				target << "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>[prefix]</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -63,7 +63,6 @@
 		messageturfs += turf
 
 	for(var/mob/M in player_list)
-		world << "Testing [M] 2"
 		if (!M.client)
 			continue
 		if(get_turf(M) in messageturfs)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -24,30 +24,6 @@
 	if (message)
 		log_emote("[name]/[key] : [message]")
 
-		var/list/seeing_obj = list() //For objs that need to see emotes.  You can use see_emote(), which is based off of hear_talk()
-
- //Hearing gasp and such every five seconds is not good emotes were not global for a reason.
- // Maybe some people are okay with that.
-
-		for(var/mob/M in player_list)
-			if (!M.client)
-				continue //skip monkeys and leavers
-			if (istype(M, /mob/new_player))
-				continue
-			if(findtext(message," snores.")) //Because we have so many sleeping people.
-				break
-			if(M.stat == 2 && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
-				M.show_message(message)
-
-		for(var/I in view(world.view, get_turf(usr))) //get_turf is needed to stop weirdness with x-ray.
-			if(istype(I, /mob/))
-				var/mob/M = I
-				for(var/obj/O in M.contents)
-					seeing_obj |= O
-			else if(istype(I, /obj/))
-				var/obj/O = I
-				seeing_obj |= O
-
 		send_emote(message, m_type)
 
 
@@ -86,7 +62,8 @@
 	for (var/turf in view(world.view, get_turf(src)))
 		messageturfs += turf
 
-	for(var/mob/living/M in player_list)
+	for(var/mob/M in player_list)
+		world << "Testing [M] 2"
 		if (!M.client)
 			continue
 		if(get_turf(M) in messageturfs)
@@ -95,9 +72,10 @@
 				continue
 			else if (istype(M, /mob/living) && !(type == 2 && (sdisabilities & DEAF || ear_deaf)))
 				messagemobs += M
-		else if(M.stat == DEAD && (M.client.prefs.toggles & CHAT_GHOSTEARS))
-			messagemobs += M
-			continue
+		else if(src.client)
+			if  (M.stat == DEAD && (M.client.prefs.toggles & CHAT_GHOSTSIGHT))
+				messagemobs += M
+				continue
 
 	for (var/mob/N in messagemobs)
 		N.show_message(message, type)

--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -117,12 +117,5 @@
 			src << text("Invalid Emote: []", act)
 	if ((message && src.stat == 0))
 		log_emote("[name]/[key] : [message]")
-		if (m_type & 1)
-			for(var/mob/O in viewers(src, null))
-				O.show_message(message, m_type)
-				//Foreach goto(703)
-		else
-			for(var/mob/O in hearers(src, null))
-				O.show_message(message, m_type)
-				//Foreach goto(746)
+		send_emote(message, m_type)
 	return

--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -65,16 +65,4 @@
 	if (message)
 		log_emote("[name]/[key] : [message]")
 
-		for(var/mob/M in dead_mob_list)
-			if (!M.client || istype(M, /mob/new_player))
-				continue //skip monkeys, leavers, and new_players
-			if(M.stat == DEAD && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
-				M.show_message(message)
-
-
-		if (m_type & 1)
-			for (var/mob/O in viewers(src, null))
-				O.show_message(message, m_type)
-		else if (m_type & 2)
-			for (var/mob/O in hearers(src.loc, null))
-				O.show_message(message, m_type)
+		send_emote(message, m_type)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -571,19 +571,7 @@ wink, yawn, swish, sway/wag, fastsway/qwag, stopsway/swag"}
  //Hearing gasp and such every five seconds is not good emotes were not global for a reason.
  // Maybe some people are okay with that.
 
-		for(var/mob/M in dead_mob_list)
-			if(!M.client || istype(M, /mob/new_player))
-				continue //skip monkeys, leavers and new players
-			if(M.stat == DEAD && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
-				M.show_message(message)
-
-
-		if (m_type & 1)
-			for (var/mob/O in get_mobs_in_view(world.view,src))
-				O.show_message(message, m_type)
-		else if (m_type & 2)
-			for (var/mob/O in (hearers(src.loc, null) | get_mobs_in_view(world.view,src)))
-				O.show_message(message, m_type)
+		send_emote(message, m_type)
 
 
 /mob/living/carbon/human/verb/pose()

--- a/code/modules/mob/living/carbon/metroid/emote.dm
+++ b/code/modules/mob/living/carbon/metroid/emote.dm
@@ -88,12 +88,7 @@
 		else
 			src << "\blue Unusable emote '[act]'. Say *help for a list."
 	if ((message && src.stat == 0))
-		if (m_type & 1)
-			for(var/mob/O in viewers(src, null))
-				O.show_message(message, m_type)
-		else
-			for(var/mob/O in hearers(src, null))
-				O.show_message(message, m_type)
+		send_emote(message, m_type)
 	if(updateicon)
 		regenerate_icons()
 	return

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -262,7 +262,7 @@ proc/get_radio_key_from_channel(var/channel)
 
 
 		for(var/mob/M in player_list)
-			if(M.stat == DEAD && M.client && (M.client.prefs.toggles & CHAT_GHOSTEARS))
+			if(src.client && M.stat == DEAD && M.client && (M.client.prefs.toggles & CHAT_GHOSTEARS))
 				listening |= M
 				continue
 			if(M.loc && M.locs[1] in hearturfs)

--- a/code/modules/mob/living/silicon/pai/emote.dm
+++ b/code/modules/mob/living/silicon/pai/emote.dm
@@ -91,10 +91,5 @@
 			src << "\blue Unusable emote '[act]'. Say *help for a list."
 
 	if ((message && src.stat == 0))
-		if (m_type & 1)
-			for(var/mob/O in viewers(src, null))
-				O.show_message(message, m_type)
-		else
-			for(var/mob/O in hearers(src, null))
-				O.show_message(message, m_type)
+		send_emote(message, m_type)
 	return

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -209,10 +209,5 @@
 			src << "\blue Unusable emote '[act]'. Say *help for a list."
 
 	if ((message && src.stat == 0))
-		if (m_type & 1)
-			for(var/mob/O in viewers(src, null))
-				O.show_message(message, m_type)
-		else
-			for(var/mob/O in hearers(src, null))
-				O.show_message(message, m_type)
+		send_emote(message, m_type)
 	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -97,7 +97,18 @@
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 
 /mob/visible_message(var/message, var/self_message, var/blind_message)
-	for(var/mob/M in viewers(src))
+	var/list/messageturfs = list()//List of turfs we broadcast to.
+	var/list/messagemobs = list()//List of living mobs nearby who can hear it, and distant ghosts who've chosen to hear it
+	for (var/turf in view(world.view, get_turf(src)))
+		messageturfs += turf
+
+	for(var/mob/M in player_list)
+		if (!M.client)
+			continue
+		if(get_turf(M) in messageturfs)
+			messagemobs += M
+
+	for(var/mob/M in messagemobs)
 		if(self_message && M==src)
 			M.show_message(self_message, 1, blind_message, 2)
 		else if(M.see_invisible < invisibility)  // Cannot view the invisible, but you can hear it.
@@ -113,6 +124,7 @@
 // message is the message output to anyone who can see e.g. "[src] does something!"
 // self_message (optional) is what the src mob sees  e.g. "You do something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
+//This is obsolete now
 /mob/proc/contained_visible_message(var/atom/broadcaster, var/message, var/self_message, var/blind_message)
 	var/self_served = 0
 	for(var/mob/M in viewers(broadcaster))
@@ -129,13 +141,27 @@
 		src.show_message(self_message, 1, blind_message, 2)
 
 
+
+
 // Show a message to all mobs in sight of this atom
 // Use for objects performing visible actions
 // message is output to anyone who can see, e.g. "The [src] does something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 /atom/proc/visible_message(var/message, var/blind_message)
-	for(var/mob/M in viewers(src))
+	var/list/messageturfs = list()//List of turfs we broadcast to.
+	var/list/messagemobs = list()//List of living mobs nearby who can hear it, and distant ghosts who've chosen to hear it
+	for (var/turf in view(world.view, get_turf(src)))
+		messageturfs += turf
+
+	for(var/mob/M in player_list)
+		if (!M.client)
+			continue
+		if(get_turf(M) in messageturfs)
+			messagemobs += M
+
+	for(var/mob/M in messagemobs)
 		M.show_message( message, 1, blind_message, 2)
+
 
 // Returns an amount of power drawn from the object (-1 if it's not viable).
 // If drain_check is set it will not actually drain power, just return a value.

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -19,7 +19,7 @@ em						{font-style: normal;font-weight: bold;}
 .ooc img.text_tag		{width: 32px; height: 10px;}
 
 .ooc .everyone			{color: #002eb8;}
-.ooc .looc				{color: #3A9696;}
+.ooc .looc				{color: #6699CC;}
 .ooc .elevated			{color: #2e78d9;}
 .ooc .moderator			{color: #184880;}
 .ooc .developer			{color: #1b521f;}

--- a/html/changelogs/Nanako-ContainedMessages.yml
+++ b/html/changelogs/Nanako-ContainedMessages.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "LOOC, visible messages and visible emotes now work properly for contained mobs, including PAIs in card form, and any kind of held anima/nymph/drone"
+  - tweak: "LOOC Colour changed to an older one."
+  

--- a/html/changelogs/Nanako-ContainedMessages.yml
+++ b/html/changelogs/Nanako-ContainedMessages.yml
@@ -34,5 +34,6 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - bugfix: "LOOC, visible messages and visible emotes now work properly for contained mobs, including PAIs in card form, and any kind of held anima/nymph/drone"
+  - bugfix: "MAJOR USABILITY FIX: Distant ghosts no longer see emotes from NPC mobs, like squeaking mice and clacking crabs. Ghost sight will now only show emotes from distant players, turning it on is now useful."
   - tweak: "LOOC Colour changed to an older one."
   


### PR DESCRIPTION
Fixes LOOOC, visible messages and visible emotes not working properly for contained mobs. This fixes quite a few bugs, which ill mark later

Also changes the LOOC colour at tainavaa's request, to an older color that is less noticeable and easier to filter out

And a VERY important fix that everyone will love. Clientless mobs' emotes are no longer shown to ghosts with ghost sight enabled. This feature was utterly useless due to the emote spam you recieve from mice, wizard experiments, station pets, and that damned crab. now it is useful

changes: 
  - bugfix: "LOOC, visible messages and visible emotes now work properly for contained mobs, including PAIs in card form, and any kind of held anima/nymph/drone"
  - bugfix: "MAJOR USABILITY FIX: Distant ghosts no longer see emotes from NPC mobs, like squeaking mice and clacking crabs. Ghost sight will now only show emotes from distant players, turning it on is now useful."
  - tweak: "LOOC Colour changed to an older one."