### PR TITLE
Mushroom Limit

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mushroom.dm
@@ -26,7 +26,7 @@
 	..()
 	harvest_time = world.time
 	var/count = 0
-	for (var/mob/living/simple_animal/mushroom in world)
+	for (var/mob/living/simple_animal/mushroom in living_mob_list)
 		count++
 
 	if (count > GLOBAL_MUSHROOM_LIMIT)

--- a/code/modules/mob/living/simple_animal/friendly/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mushroom.dm
@@ -32,6 +32,8 @@
 	if (count > GLOBAL_MUSHROOM_LIMIT)
 		qdel(src)
 
+
+
 /mob/living/simple_animal/mushroom/attack_hand(mob/living/carbon/human/M as mob)
 	if (src.stat == DEAD)//If the creature is dead, we don't pet it, we just pickup the corpse on click
 		get_scooped(M)
@@ -81,3 +83,5 @@
 	seed.thrown_at(src,get_turf(src),1)
 	if(src)
 		gib()
+
+#undef GLOBAL_MUSHROOM_LIMIT

--- a/code/modules/mob/living/simple_animal/friendly/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mushroom.dm
@@ -1,3 +1,5 @@
+#define GLOBAL_MUSHROOM_LIMIT	80
+
 /mob/living/simple_animal/mushroom
 	name = "walking mushroom"
 	desc = "It's a massive mushroom... with legs?"
@@ -23,6 +25,12 @@
 /mob/living/simple_animal/mushroom/New()
 	..()
 	harvest_time = world.time
+	var/count = 0
+	for (var/mob/living/simple_animal/mushroom in world)
+		count++
+
+	if (count > GLOBAL_MUSHROOM_LIMIT)
+		qdel(src)
 
 /mob/living/simple_animal/mushroom/attack_hand(mob/living/carbon/human/M as mob)
 	if (src.stat == DEAD)//If the creature is dead, we don't pet it, we just pickup the corpse on click


### PR DESCRIPTION
Adds a very liberal limit to mushroom spawning. Those spawned over the limit will just qdel themselves.

This isn't designed to prevent mushroom spamming - making lots of them and needing to use large AOE solutions is a fun ocurrence. 

It's only designed to prevent their numbers getting high enough to break the server, as happened recently This limit should allow them to be an IC problem without being an OOC problem

No changelog intentionally, this isn't worth a bulletpoint. When it actually  kicks in, the area will be so spammed with mushrooms anyway that nobody will notice spawning has stopped.