### PR TITLE
Buckle Tweak

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -61,16 +61,16 @@
 	if(istype(M, /mob/living/carbon/slime))
 		user << "<span class='warning'>The [M] is too squishy to buckle in.</span>"
 		return
+	if (buckled_mob)
+		user << "<span class='warning'>[buckled_mob.name] is already there, unbuckle them first!.</span>"
+		return
 
 	add_fingerprint(user)
-	unbuckle_mob()
+	unbuckle_mob()//this is now just for safety, buckling someone into an occupied chair will fail, instead of removing the occupant
 
 	if(buckle_mob(M))
 		if(M == user)
-			M.visible_message(\
-				"<span class='notice'>[M.name] buckles themselves to [src].</span>",\
-				"<span class='notice'>You buckle yourself to [src].</span>",\
-				"<span class='notice'>You hear metal clanking.</span>")
+			M << "<span class='notice'>You buckle yourself to [src].</span>"
 		else
 			M.visible_message(\
 				"<span class='danger'>[M.name] is buckled to [src] by [user.name]!</span>",\

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -70,7 +70,10 @@
 
 	if(buckle_mob(M))
 		if(M == user)
-			M << "<span class='notice'>You buckle yourself to [src].</span>"
+			M.visible_message(\
+				"<span class='notice'>[M.name] buckles themselves to [src].</span>",\
+				"<span class='notice'>You buckle yourself to [src].</span>",\
+				"<span class='notice'>You hear metal clanking.</span>")
 		else
 			M.visible_message(\
 				"<span class='danger'>[M.name] is buckled to [src] by [user.name]!</span>",\

--- a/html/changelogs/Nanako-Buckle.yml
+++ b/html/changelogs/Nanako-Buckle.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "You can no longer buckle people into a chair/bed/etc which is already occupied."
+  - tweak: "Buckling yourself into something is no longer a visible action, only you will see the message."
+  


### PR DESCRIPTION
changes:
  - bugfix: "You can no longer buckle people into a chair/bed/etc which is already occupied."
  - tweak: "Buckling yourself into something is no longer a visible action, only you will see the message."

The former change, while working as intended, is causing undesireable behaviour, and i think this way makes better sense.

The last one is a brief idea i had to reduce noise in the chatlog. If anyone wants to see if you're buckled in, they can examine you. A message in the chatlog is needless noise and not relevant information to most people. It's most noticeable on the transfer shuttle where the large number of people buckling can impede communication

People buckling others in or unbuckling is still visible