### PR TITLE
Random antag tweaking

### DIFF
--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -8,6 +8,7 @@ var/datum/antagonist/ninja/ninjas
 	bantype = "ninja"
 	landmark_id = "ninjastart"
 	welcome_text = "You are an elite mercenary assassin of the Spider Clan. You have a variety of abilities at your disposal, thanks to your nano-enhanced cyber armor.</span>"
+	restricted_species = list("Diona")
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_RANDSPAWN | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE
 	antaghud_indicator = "hudninja"
 

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -21,7 +21,7 @@ var/datum/antagonist/cultist/cult
 	loss_text = "The staff managed to stop the cult!"
 	victory_feedback_tag = "win - cult win"
 	loss_feedback_tag = "loss - staff stopped the cult"
-	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
+	flags = ANTAG_SUSPICIOUS | ANTAG_VOTABLE
 	hard_cap = 5
 	hard_cap_round = 6
 	initial_spawn_req = 4

--- a/code/game/antagonist/station/highlander.dm
+++ b/code/game/antagonist/station/highlander.dm
@@ -5,7 +5,7 @@ var/datum/antagonist/highlander/highlanders
 	role_text_plural = "Highlanders"
 	welcome_text = "There can be only one."
 	id = MODE_HIGHLANDER
-	flags = ANTAG_SUSPICIOUS | ANTAG_IMPLANT_IMMUNE //| ANTAG_RANDSPAWN | ANTAG_VOTABLE // Someday...
+	flags = ANTAG_SUSPICIOUS | ANTAG_IMPLANT_IMMUNE
 
 	hard_cap = 5
 	hard_cap_round = 7

--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -5,7 +5,7 @@ var/datum/antagonist/renegade/renegades
 	role_text_plural = "Renegades"
 	welcome_text = "Your own safety matters above all else, trust no one and kill anyone who gets in your way. However, armed as you are, now would be the perfect time to settle that score or grab that pair of yellow gloves you've been eyeing..."
 	id = MODE_RENEGADE
-	flags = ANTAG_SUSPICIOUS | ANTAG_IMPLANT_IMMUNE | ANTAG_RANDSPAWN | ANTAG_VOTABLE
+	flags = ANTAG_SUSPICIOUS | ANTAG_IMPLANT_IMMUNE | ANTAG_VOTABLE
 	hard_cap = 5
 	hard_cap_round = 7
 

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -7,9 +7,10 @@
 	var/severity 	= 0 // The current severity of this event
 	var/one_shot	= 0	//If true, then the event will not be re-added to the list of available events
 	var/list/role_weights = list()
+	var/list/excluded_gamemodes = list()	// A list of gamemodes during which this event won't fire.
 	var/datum/event/event_type
 
-/datum/event_meta/New(var/event_severity, var/event_name, var/datum/event/type, var/event_weight, var/list/job_weights, var/is_one_shot = 0, var/min_event_weight = 0, var/max_event_weight = 0)
+/datum/event_meta/New(var/event_severity, var/event_name, var/datum/event/type, var/event_weight, var/list/job_weights, var/is_one_shot = 0, var/min_event_weight = 0, var/max_event_weight = 0, var/list/excluded_roundtypes)
 	name = event_name
 	severity = event_severity
 	event_type = type
@@ -19,9 +20,16 @@
 	max_weight = max_event_weight
 	if(job_weights)
 		role_weights = job_weights
+	if(excluded_roundtypes)
+		excluded_roundtypes = excluded_gamemodes
 
 /datum/event_meta/proc/get_weight(var/list/active_with_role)
 	if(!enabled)
+		return 0
+
+	if(excluded_gamemodes.len && (ticker.mode in excluded_gamemodes))
+		// There's no way it'll be run this round anyways.
+		enabled = 0
 		return 0
 
 	var/job_weight = 0
@@ -143,4 +151,3 @@
 
 	setup()
 	..()
-

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -21,7 +21,7 @@
 	if(job_weights)
 		role_weights = job_weights
 	if(excluded_roundtypes)
-		excluded_roundtypes = excluded_gamemodes
+		excluded_gamemodes = excluded_roundtypes
 
 /datum/event_meta/proc/get_weight(var/list/active_with_role)
 	if(!enabled)

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -159,7 +159,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_shower,				40,		list(ASSIGNMENT_ENGINEER = 13)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Prison Break",				/datum/event/prison_break,				0,		list(ASSIGNMENT_SECURITY = 15, ASSIGNMENT_CYBORG = 20),1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",			/datum/event/radiation_storm, 			100),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Random Antagonist",		/datum/event/random_antag,		 		0,	list(ASSIGNMENT_ANY = 1, ASSIGNMENT_SECURITY = 1),0,10,125),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Random Antagonist",		/datum/event/random_antag,		 		0,	list(ASSIGNMENT_ANY = 1, ASSIGNMENT_SECURITY = 1),0,10,125, list("Extended")),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				50,		list(ASSIGNMENT_SECURITY = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,	 					50, 	list(ASSIGNMENT_ENGINEER = 7)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		50,	list(ASSIGNMENT_SECURITY = 25)),

--- a/code/modules/events/random_antagonist.dm
+++ b/code/modules/events/random_antagonist.dm
@@ -1,7 +1,4 @@
 // The random spawn proc on the antag datum will handle announcing the spawn and whatnot.
-/datum/event/random_antag
-	var/list/valid_antag_ids = list(MODE_TRAITOR, MODE_VAMPIRE, MODE_CHANGELING, MODE_REVOLUTIONARY)
-
 /datum/event/random_antag/announce()
 	return
 
@@ -9,7 +6,7 @@
 	var/list/valid_types = list()
 	for(var/antag_type  in all_antag_types)
 		var/datum/antagonist/antag = all_antag_types[antag_type]
-		if((antag.id in valid_antag_ids) && (antag.flags & ANTAG_RANDSPAWN))
+		if(antag.flags & ANTAG_RANDSPAWN)
 			valid_types |= antag
 	if(valid_types.len)
 		var/datum/antagonist/antag = pick(valid_types)

--- a/code/modules/events/random_antagonist.dm
+++ b/code/modules/events/random_antagonist.dm
@@ -1,4 +1,7 @@
 // The random spawn proc on the antag datum will handle announcing the spawn and whatnot.
+/datum/event/random_antag
+	var/list/valid_antag_ids = list(MODE_TRAITOR, MODE_VAMPIRE, MODE_CHANGELING, MODE_REVOLUTIONARY)
+
 /datum/event/random_antag/announce()
 	return
 
@@ -6,7 +9,7 @@
 	var/list/valid_types = list()
 	for(var/antag_type  in all_antag_types)
 		var/datum/antagonist/antag = all_antag_types[antag_type]
-		if(antag.flags & ANTAG_RANDSPAWN)
+		if((antag.id in valid_antag_ids) && (antag.flags & ANTAG_RANDSPAWN))
 			valid_types |= antag
 	if(valid_types.len)
 		var/datum/antagonist/antag = pick(valid_types)

--- a/html/changelogs/skull132-Random_antag.yml
+++ b/html/changelogs/skull132-Random_antag.yml
@@ -3,4 +3,5 @@ author: Skull132
 delete-after: True
 
 changes:
+  - tweak: "Diona can no longer be ninjas, due to the restrictions on what they can wear."
   - tweak: "Random antag event will no longer be ran during extended. It also has a narrower selection of antags: namely, all antags with a long start-up time have been excluded (such as cult)."

--- a/html/changelogs/skull132-Random_antag.yml
+++ b/html/changelogs/skull132-Random_antag.yml
@@ -1,0 +1,6 @@
+author: Skull132
+
+delete-after: True
+
+changes:
+  - tweak: "Random antag event will no longer be ran during extended. It also has a narrower selection of antags: namely, all antags with a long start-up time have been excluded (such as cult)."


### PR DESCRIPTION
Random antag now spawns specific antag templates only: namely, ones which will not have major trouble being integrated into the round and rolling with it. Ones with a long start-up time, ala cult, have been excluded.

Also added a game mode blacklist to the event_meta datum. If the current game mode's name is in that blacklist, the event will be disabled and will no longer be run that round.