### PR TITLE
Aghost alt-click actions

### DIFF
--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -244,13 +244,15 @@
 
 	log_and_message_admins("has [open ? "<font color='red'>OPENED</font>" : "closed"] [name]. (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)", user)
 
-/obj/machinery/atmospherics/valve/AltClick(var/mob/dead/observer/admin)
+/obj/machinery/atmospherics/valve/digital/AltClick(var/mob/dead/observer/admin)
 	if (istype(admin))
 		if (admin.client && admin.client.holder && ((R_MOD|R_ADMIN) & admin.client.holder.rights))
 			if (open)
-				open()
-			else
 				close()
+			else
+				if (alert(admin, "The valve is currently closed. Do you want to open it?", "Open the valve?", "Yes", "No") == "No")
+					return
+				open()
 
 			log_and_message_admins("has [open ? "opened" : "closed"] [name]. (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)", admin)
 

--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -242,6 +242,18 @@
 		return
 	..()
 
+	log_and_message_admins("has [open ? "<font color='red'>OPENED</font>" : "closed"] [name]. (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)", user)
+
+/obj/machinery/atmospherics/valve/AltClick(var/mob/dead/observer/admin)
+	if (istype(admin))
+		if (admin.client && admin.client.holder && ((R_MOD|R_ADMIN) & admin.client.holder.rights))
+			if (open)
+				open()
+			else
+				close()
+
+			log_and_message_admins("has [open ? "opened" : "closed"] [name]. (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)", admin)
+
 /obj/machinery/atmospherics/valve/digital/open
 	open = 1
 	icon_state = "map_valve1"

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -246,6 +246,25 @@ update_flag
 	healthcheck()
 	return
 
+/obj/machinery/portable_atmospherics/canister/AltClick(var/mob/dead/observer/admin)
+	if (istype(admin))
+		if (admin.client && admin.client.holder && ((R_MOD|R_ADMIN) & admin.client.holder.rights))
+			if (valve_open)
+				if (holding)
+					release_log += "Valve was <b>closed</b> by [key_name(admin)] (aghost), stopping the transfer into the [holding]<br>"
+				else
+					release_log += "Valve was <b>closed</b> by [key_name(admin)] (aghost), stopping the transfer into the <font color='red'><b>air</b></font><br>"
+			else
+				if (alert(admin, "The release valve is currently closed. Do you want to open it?", "Open the valve?", "Yes", "No") == "No")
+					return
+
+				if (holding)
+					release_log += "Valve was <b>opened</b> by [key_name(admin)] (aghost), starting the transfer into the [holding]<br>"
+				else
+					release_log += "Valve was <b>opened</b> by [key_name(admin)] (aghost), starting the transfer into the <font color='red'><b>air</b></font><br>"
+					log_open(admin)
+			valve_open = !valve_open
+
 /obj/machinery/portable_atmospherics/canister/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if(!istype(W, /obj/item/weapon/wrench) && !istype(W, /obj/item/weapon/tank) && !istype(W, /obj/item/device/analyzer) && !istype(W, /obj/item/device/pda))
 		visible_message("\red [user] hits the [src] with a [W]!")

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -199,7 +199,7 @@
 		return
 	..()
 
-/obj/machinery/portable_atmospherics/proc/log_open()
+/obj/machinery/portable_atmospherics/proc/log_open(var/mob/user)
 	if(air_contents.gas.len == 0)
 		return
 
@@ -209,5 +209,9 @@
 			gases += ", [gas]"
 		else
 			gases = gas
-	log_admin("[usr] ([usr.ckey]) opened '[src.name]' containing [gases].")
-	message_admins("[usr] ([usr.ckey]) opened '[src.name]' containing [gases]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
+
+	if (!user && usr)
+		user = usr
+
+	log_admin("[user] ([user.ckey]) opened '[src.name]' containing [gases].")
+	message_admins("[user] ([user.ckey]) opened '[src.name]' containing [gases]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1400,6 +1400,9 @@ proc/admin_notice(var/message, var/rights)
 			msg = "has paralyzed [key_name(H)]."
 			H.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <font color='red'>[H] has been winded by a member of staff! Please freeze all roleplay involving their character until the matter is resolved! Adminmhelp if you have further questions.</font>", "<font color='red'><b>You have been winded by a member of staff! Please stand by until they contact you!</b></font>")
 		else
+			if (alert("The player is currently winded. Do you want to unwind him?", "Unwind player?", "Yes", "No") == "No")
+				return
+
 			H.paralysis = 0
 			msg = "has unparalyzed [key_name(H)]."
 			H.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <font color='green'>[H] has been unwinded by a member of staff!</font>", "<font color='red'><b>You have been unwinded by a member of staff!</b></font>")

--- a/html/changelogs/skull132-Admin.yml
+++ b/html/changelogs/skull132-Admin.yml
@@ -1,0 +1,8 @@
+author: Skull132
+
+delete-after: True
+
+changes:
+  - rscadd: "Ghosts with +ADMIN or +MOD can now alt-left-click on canisters and digital valves in order to toggle them open and shut."
+  - rscadd: "Opening of digital valves provides adminlogs once more."
+  - tweak: "Unwinding now requires that a prompt be confirmed. This should stop wind-unwind-wind shenanigans from happening."


### PR DESCRIPTION
Ghosts with +ADMIN or +MOD can now alt-left-click on canisters and digital valves in order to toggle them open and shut.
Opening of digital valves provides adminlogs once more.
Unwinding now requires that a prompt be confirmed. This should stop wind-unwind-wind shenanigans from happening.