### PR TITLE
Bugfix/hidejumpsuit fix

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -95,7 +95,6 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	slowdown = 1
 	armor = list(melee = 80, bullet = 20, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
-	flags_inv = HIDEJUMPSUIT
 	siemens_coefficient = 0.5
 	pocket_slots = 4//Fullbody suit, so more slots
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -85,10 +85,15 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(!W)	return 0
 
 	if (W == wear_suit)
+		var/update_uniform = 0
+		if (wear_suit.flags_inv & HIDEJUMPSUIT)
+			update_uniform = 1
 		if(s_store)
 			drop_from_inventory(s_store)
 		wear_suit = null
 		update_inv_wear_suit()
+		if (update_uniform)
+			update_inv_w_uniform(0)
 	else if (W == w_uniform)
 		if (r_store)
 			drop_from_inventory(r_store)


### PR DESCRIPTION
Includes a fix and also riot suits shouldn't have that flag since you can see skin through them. Only when suits completely cover the nude torso layer should they be used.