### PR TITLE
Silicon UI check runtime

### DIFF
--- a/code/modules/nano/interaction/base.dm
+++ b/code/modules/nano/interaction/base.dm
@@ -27,7 +27,7 @@
 
 /mob/living/silicon/robot/shared_nano_interaction()
 	. = STATUS_INTERACTIVE
-	if(cell.charge <= 0)
+	if(!cell || (cell && cell.charge <= 0))
 		return STATUS_CLOSE
 	if(lockcharge)
 		. = STATUS_DISABLED


### PR DESCRIPTION
A missing sanity check was causing runtime errors whenever a borg had no cell, and had a nanoUI window open.