### PR TITLE
Recharger and Deathscream fix

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -255,3 +255,23 @@
 	set src in oview(1)
 
 	go_in(usr)
+
+
+/obj/machinery/recharge_station/MouseDrop_T(var/atom/movable/C, mob/usr)
+	if (istype(C, /mob/living/silicon/robot))
+		var/mob/living/silicon/robot/R = C
+		if (!usr.Adjacent(R) || !Adjacent(usr))
+			usr << span("danger", "You need to get closer if you want to put [C] into that charger!")
+			return
+
+		usr.visible_message(span("danger","[usr] starts hauling [C] into the recharging unit!"), span("danger","You start hauling and pushing [C] into the recharger. This might take a while..."), "You hear heaving and straining")
+		if (do_mob(usr, R, R.mob_size*10, needhand = 1))
+			if (go_in(R))
+				usr.visible_message(span("notice","After a great effort, [usr] manages to get [C] into the recharging unit!"))
+				return 1
+			else
+				usr << span("danger","Failed loading [C] into the charger. Please ensure that [C] has a power cell and is not buckled down, and that the charger is functioning.")
+		else
+			usr << span("danger","Cancelled loading [C] into the charger. You and [C] must stay still!")
+		return
+	return ..()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -38,7 +38,7 @@
 	update_icon()
 
 /obj/machinery/recharge_station/proc/has_cell_power()
-	return cell && cell.percent() > 0
+	return cell && cell.percent() > 3
 
 /obj/machinery/recharge_station/process()
 	if(stat & (BROKEN))
@@ -53,7 +53,7 @@
 		return
 
 	//First, draw from the internal power cell to recharge/repair/etc the occupant
-	if(occupant)
+	if(occupant && has_cell_power())
 		process_occupant()
 
 	//Then, if external power is available, recharge the internal cell
@@ -104,6 +104,9 @@
 		if(wire_rate && R.getFireLoss() && cell.checked_use(wire_power_use * wire_rate * CELLRATE))
 			R.adjustFireLoss(-wire_rate)
 
+		if (!has_cell_power())
+			visible_message(span("danger", "The recharger bleeps and announces a vocal warning: \" ERROR: Recharger internal capacitor depleted. Charging efficiency will be negatively affected. \""))
+
 /obj/machinery/recharge_station/examine(mob/user)
 	..(user)
 	user << "The charge meter reads: [round(chargepercentage())]%"
@@ -151,9 +154,9 @@
 	cell = locate(/obj/item/weapon/cell) in component_parts
 
 	charging_efficiency = 0.85 + 0.015 * cap_rating
-	charging_power = 30000 + 12000 * cap_rating
-	restore_power_active = 10000 + 10000 * cap_rating
-	restore_power_passive = 5000 + 1000 * cap_rating
+	charging_power = 30000 + 16000 * cap_rating
+	restore_power_active = 10000 + 12000 * cap_rating
+	restore_power_passive = 5000 + 6000 * cap_rating
 	weld_rate = max(0, man_rating - 3)
 	wire_rate = max(0, man_rating - 5)
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -257,21 +257,21 @@
 	go_in(usr)
 
 
-/obj/machinery/recharge_station/MouseDrop_T(var/atom/movable/C, mob/usr)
+/obj/machinery/recharge_station/MouseDrop_T(var/atom/movable/C, mob/user)
 	if (istype(C, /mob/living/silicon/robot))
 		var/mob/living/silicon/robot/R = C
-		if (!usr.Adjacent(R) || !Adjacent(usr))
-			usr << span("danger", "You need to get closer if you want to put [C] into that charger!")
+		if (!user.Adjacent(R) || !Adjacent(user))
+			user << span("danger", "You need to get closer if you want to put [C] into that charger!")
 			return
 
-		usr.visible_message(span("danger","[usr] starts hauling [C] into the recharging unit!"), span("danger","You start hauling and pushing [C] into the recharger. This might take a while..."), "You hear heaving and straining")
-		if (do_mob(usr, R, R.mob_size*10, needhand = 1))
+		user.visible_message(span("danger","[user] starts hauling [C] into the recharging unit!"), span("danger","You start hauling and pushing [C] into the recharger. This might take a while..."), "You hear heaving and straining")
+		if (do_mob(user, R, R.mob_size*10, needhand = 1))
 			if (go_in(R))
-				usr.visible_message(span("notice","After a great effort, [usr] manages to get [C] into the recharging unit!"))
+				user.visible_message(span("notice","After a great effort, [user] manages to get [C] into the recharging unit!"))
 				return 1
 			else
-				usr << span("danger","Failed loading [C] into the charger. Please ensure that [C] has a power cell and is not buckled down, and that the charger is functioning.")
+				user << span("danger","Failed loading [C] into the charger. Please ensure that [C] has a power cell and is not buckled down, and that the charger is functioning.")
 		else
-			usr << span("danger","Cancelled loading [C] into the charger. You and [C] must stay still!")
+			user << span("danger","Cancelled loading [C] into the charger. You and [C] must stay still!")
 		return
 	return ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1072,22 +1072,5 @@
 		notify_ai(ROBOT_NOTIFICATION_NEW_UNIT)
 		sync()
 
-//For picking up small animals
-/mob/living/silicon/robot/MouseDrop(atom/over_object)
-	if (istype(over_object, /obj/machinery/recharge_station))
-		if (!usr.Adjacent(over_object) || !Adjacent(usr))
-			usr << span("danger", "You need to get closer if you want to put [src] into that charger!")
-			return
 
-		var/obj/machinery/recharge_station/station = over_object
-		usr.visible_message(span("danger","[usr] starts hauling [src] into the recharging unit!"), span("danger","You start hauling and pushing [src] into the recharger. This might take a while..."), "You hear heaving and straining")
-		if (do_mob(usr, src, mob_size*10, needhand = 1))
-			if (station.go_in(src))
-				usr.visible_message(span("notice","After a great effort, [usr] manages to get [src] into the recharging unit!"))
-				return 1
-			else
-				usr << span("danger","Failed loading [src] into the charger. Please ensure that [src] has a power cell and is not buckled down, and that the charger is functioning.")
-		else
-			usr << span("danger","Cancelled loading [src] into the charger. You and [src] must stay still!")
-		return
-	return ..()
+

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1071,3 +1071,19 @@
 		connected_ai.connected_robots |= src
 		notify_ai(ROBOT_NOTIFICATION_NEW_UNIT)
 		sync()
+
+//For picking up small animals
+/mob/living/silicon/robot/MouseDrop(atom/over_object)
+	if (istype(over_object, /obj/machinery/recharge_station))
+		if (!usr.Adjacent(over_object) || !Adjacent(usr))
+			usr << span("danger", "You need to get closer if you want to put [src] into that charger!")
+			return
+
+		var/obj/machinery/recharge_station/station = over_object
+		usr.visible_message(span("danger","[usr] starts hauling [src] into the recharging unit!"), span("danger","You start hauling and pushing [src] into the recharger. This might take a while..."), "You hear heaving and straining")
+		if (do_mob(usr, src, mob_size*10, needhand = 1))
+			if (station.go_in(src))
+				usr.visible_message(span("notice","After a great effort, [usr] manages to get [src] into the recharging unit!"))
+				return 1
+		return
+	return ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1085,5 +1085,9 @@
 			if (station.go_in(src))
 				usr.visible_message(span("notice","After a great effort, [usr] manages to get [src] into the recharging unit!"))
 				return 1
+			else
+				usr << span("danger","Failed loading [src] into the charger. Please ensure that [src] has a power cell and is not buckled down, and that the charger is functioning.")
+		else
+			usr << span("danger","Cancelled loading [src] into the charger. You and [src] must stay still!")
 		return
 	return ..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -145,12 +145,14 @@
 
 /mob/living/simple_animal/Life()
 	..()
-	life_tick++
-	//Health
-	updatehealth()
 
+	life_tick++
 	if(stat == DEAD)
 		return 0
+
+
+	//Health
+	updatehealth()
 
 	if(health > maxHealth)
 		health = maxHealth

--- a/html/changelogs/Nanako-Recharger.yml
+++ b/html/changelogs/Nanako-Recharger.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "You can now place a cyborg into a charger, drag and drop it onto the charger."
+  - tweak: "Tweaked recharger power values a little."
+  - bugfix: "Fixed aliens screaming endlessly when dead."


### PR DESCRIPTION
Adds a small feature - allows dragging cyborgs into recharging units.
Tweaks recharger power values a little, makes upgrading them a bit more useful
Fixes the endless deathscream for aliens

I'm aware this is kind of stretching the definition of a hotfix, i'll try not to make a habit of it.

Just doing some final testing, don't merge yet