### PR TITLE
Borg Gripper and Module Tweaks

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -21,7 +21,8 @@
 		/obj/item/weapon/camera_assembly,
 		/obj/item/weapon/tank,
 		/obj/item/weapon/circuitboard,
-		/obj/item/weapon/smes_coil
+		/obj/item/weapon/smes_coil,
+		/obj/item/device/assembly//Primarily for making improved cameras, but opens many possibilities
 		)
 
 	var/obj/item/wrapped = null // Item currently being held.
@@ -82,8 +83,12 @@
 		/obj/item/weapon/circuitboard,
 		/obj/item/slime_extract,
 		/obj/item/weapon/reagent_containers/glass,
-		/obj/item/weapon/reagent_containers/food/snacks/monkeycube
-
+		/obj/item/weapon/reagent_containers/food/snacks/monkeycube,
+		/obj/item/device/assembly,//For building bots and similar complex R&D devices
+		/obj/item/device/healthanalyzer,//For building medibots
+		/obj/item/weapon/disk,
+		/obj/item/device/analyzer/plant_analyzer,//For farmbot construction
+		/obj/item/weapon/material/minihoe//Farmbots and xenoflora
 		)
 
 /obj/item/weapon/gripper/chemistry //A gripper designed for chemistry, to allow borgs to work efficiently in the lab
@@ -129,6 +134,11 @@
 /obj/item/weapon/gripper/attack_self(mob/user as mob)
 	if(wrapped)
 		return wrapped.attack_self(user)
+	return ..()
+
+/obj/item/weapon/gripper/AltClick(mob/user as mob)
+	if(wrapped)
+		return wrapped.AltClick(user)
 	return ..()
 
 /obj/item/weapon/gripper/verb/drop_item()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -516,6 +516,8 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/analyzer/plant_analyzer(src)
 	src.modules += new /obj/item/weapon/storage/bag/plants(src)
 	src.modules += new /obj/item/weapon/robot_harvester(src)
+	src.modules += new /obj/item/weapon/material/kitchen/rollingpin(src)
+	src.modules += new /obj/item/weapon/material/knife(src)
 
 	var/obj/item/weapon/rsf/M = new /obj/item/weapon/rsf(src)
 	M.stored_matter = 30
@@ -617,7 +619,11 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/weapon/gripper/chemistry(src)
+	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
+	src.modules += new /obj/item/device/reagent_scanner/adv(src)
 	src.modules += new /obj/item/weapon/extinguisher(src)
+	src.modules += new /obj/item/weapon/storage/bag/plants(src)
+	src.modules += new /obj/item/weapon/pen/robopen(src)
 	src.emag = new /obj/item/weapon/hand_tele(src)
 
 	var/datum/matter_synth/nanite = new /datum/matter_synth/nanite(10000)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -71,6 +71,9 @@
 			flags |= OPENCONTAINER
 		update_icon()
 
+	AltClick(var/mob/user)
+		set_APTFT()
+
 	afterattack(var/obj/target, var/mob/user, var/flag)
 
 		if(!is_open_container() || !flag)

--- a/html/changelogs/Nanako-Borgfixes.yml
+++ b/html/changelogs/Nanako-Borgfixes.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added several new items to research and engineering grippers, allows research borgs to build some bots and work in xenoflora. Engineering units can make motion sensing cameras. Also added some small items to research module to assist in robotics/xenoflora, and a rollingpin+knife to the service borg for kitchen work."
+  - bugfix: "Fixed borgs being unable to set transfer amount on beakers. Beakers can now be alt-clicked to set the transfer amount, including when held in a gripper."


### PR DESCRIPTION
Fills in some strange holes in cyborg functionality, fixing several borgs that were not quite fit at doing their jobs:

-Adds rolling pin and knife to service borgs; should allow them to cook a full range of foods. I've been getting regular nagging about this one from the community
-Adds the ability to pick up assemblies for engineering/research borgs, allowing them to construct some complex devices, notably bots and motionsensing cameras.
-Several items added to research borg: Dropper and reagent scanner, for chemistry, pen for renaming bots and writing research notes, and a plant bag for working in xenoflora
-Added altclick functionality for setting transfer rates on beakers. Essential for chemistry and cooking, since borgs can't use rightclick verbs on gripped items.