### PR TITLE
Silicon language fix

### DIFF
--- a/code/modules/mob/living/devour.dm
+++ b/code/modules/mob/living/devour.dm
@@ -29,12 +29,17 @@
 
 
 /mob/living/proc/attempt_devour(var/mob/living/victim, var/eat_types, var/mouth_size = null)
-	face_atom(victim)
+
 
 	//This function will attempt to eat the victim,
 	//either by swallowing them if they're small enough, or starting to devour them otherwise
 		//If a mouth_size is passed in, it will be used instead of this mob's size, for determining whether the victim is small enough to swallow
 	//This function is the main gateway to devouring, and will have all the safety checks
+	if (!victim)
+		return 0
+
+	face_atom(victim)
+
 	if (victim == src)
 		src << "\red You can't eat yourself!"
 		return 0

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -33,6 +33,8 @@
 	silicon_mob_list |= src
 	..()
 	add_language("Ceti Basic")
+	var/datum/language/L = locate(/datum/language/common) in languages
+	default_language = L
 	init_subsystems()
 
 /mob/living/silicon/Destroy()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1090,7 +1090,7 @@ var/list/wierd_mobs_inclusive = list( /mob/living/simple_animal/construct,
 		mobtypes |= TYPE_SYNTHETIC
 	else
 		var/datum/species/S = src.get_species(1)
-		if (S.flags & IS_SYNTHETIC)
+		if (S && (S.flags & IS_SYNTHETIC))
 			mobtypes |= TYPE_SYNTHETIC
 
 	if (mob_listed(src, wierd_mobs_specific,1))


### PR DESCRIPTION
Fixes synthetics speaking in a null language, by initialising their default language to basic. This should fix nymphs being unable to understand them.

Also fixes three runtime errors with finding types and devouring