### PR TITLE
Diona Space Light Fix

### DIFF
--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -440,7 +440,7 @@ if (flashlight_active)
 //GETTER FUNCTIONS
 
 /mob/living/carbon/proc/get_lightlevel_diona(var/datum/dionastats/DS)
-	var/light_amount = 1.5 //how much light there is in the place, affects receiving nutrition and healing
+	var/light_amount = DIONA_MAX_LIGHT //how much light there is in the place, affects receiving nutrition and healing
 	var/light_factor = 1//used for  if a gestalt's response node is damaged. it will feed more slowly
 
 	if (DS.light_organ)

--- a/code/modules/mob/living/carbon/human/diona_gestalt.dm
+++ b/code/modules/mob/living/carbon/human/diona_gestalt.dm
@@ -119,6 +119,9 @@
 	set category = "Abilities"
 	set name = "Check light level"
 
+	if (!DS.light_organ || DS.light_organ.is_broken() || DS.light_organ.is_bruised())
+		usr << span("danger", "Our response node is damaged or missing, without it we can't tell light from darkness. We can only hope this area is bright enough to let us regenerate it!")
+		return
 	var/light = get_lightlevel_diona(DS)
 
 	if (light <= -0.75)
@@ -142,6 +145,8 @@
 	var/dark_consciousness = 120//How long this diona can stay on its feet and keep moving in darkness after energy is gone.
 	var/dark_survival = 180//How long this diona can survive in darkness after energy is gone, before it dies
 
+
+
 	var/MLS = (1.5 / 2.1)//Maximum (energy) lost per second, in total darkness
 	DS = new/datum/dionastats()
 	DS.max_energy = energy_duration * MLS
@@ -157,6 +162,17 @@
 		if (istype(organ, /obj/item/organ/diona/nutrients))
 			DS.nutrient_organ = organ
 
+//This proc can be called if some dionastats information needs to be refreshed or re-found
+//Currently only used for refreshing organs
+/mob/living/carbon/human/proc/update_dionastats()
+	DS.light_organ = null
+	DS.nutrient_organ = null
+
+	for (var/organ in internal_organs)
+		if (istype(organ, /obj/item/organ/diona/node))
+			DS.light_organ = organ
+		if (istype(organ, /obj/item/organ/diona/nutrients))
+			DS.nutrient_organ = organ
 
 //Splitting functions
 //====================

--- a/code/modules/organs/organ_alien.dm
+++ b/code/modules/organs/organ_alien.dm
@@ -24,6 +24,8 @@
 	dislocated = -1
 	status = ORGAN_PLANT
 
+
+
 /obj/item/organ/external/diona/chest
 	name = "core trunk"
 	limb_name = "chest"
@@ -136,7 +138,11 @@
 	var/mob/living/carbon/human/H = owner
 	..()
 	if(!istype(H) || !H.organs || !H.organs.len)
-		H.death()
+		H.death()//if you somehow remove all of a gestalt's organs, it will dissolve into nymphs
+
+	if (H.is_diona())
+		spawn(1)
+			H.update_dionastats()//This ensures that the dionastats registers the removal of an organ
 
 /obj/item/organ/diona/process()
 
@@ -182,6 +188,17 @@
 	..()
 	if(!istype(H) || !H.organs || !H.organs.len)
 		H.death()
+
+/obj/item/organ/diona/removed()
+	var/mob/living/carbon/human/H = owner
+	..()
+	if(!istype(H) || !H.organs || !H.organs.len)
+		H.death()//if you somehow remove all of a gestalt's organs, it will dissolve into nymphs
+
+	if (H.is_diona())
+		spawn(1)
+			H.update_dionastats()//This ensures that the dionastats registers the removal of an organ
+
 
 // These are different to the standard diona organs as they have a purpose in other
 // species (absorbing radiation and light respectively)
@@ -412,7 +429,7 @@
     icon_state = "tracheae"
 /obj/item/organ/vaurca/tracheae/removed()
 	return */
-	
+
 // Skeleton limbs.
 /obj/item/organ/external/chest/skeleton
 	name = "rib cage"
@@ -420,7 +437,7 @@
 /obj/item/organ/external/groin/skeleton
 	name = "pelvis"
 	vital = 0
-	
+
 /obj/item/organ/external/arm/skeleton
 	dislocated = -1
 


### PR DESCRIPTION
Fixes diona not recieving any light in space - initialises light amount to the max light value, so that is used in tiles where there is no lighting overlay. ie, space

Fixes dionastats organ references not updating when organs are lost or regrown

Fixes some spamming from lightmessages when a diona recovers after almost dying in the dark.

Adds a new light sensing message to the check light verb, if the response node is damaged or missing