### PR TITLE
Badshaped Bad Badfixes 4

### DIFF
--- a/code/game/objects/items/devices/magnetic_lock.dm
+++ b/code/game/objects/items/devices/magnetic_lock.dm
@@ -121,7 +121,7 @@
 				if (loc == user)
 					powercell.forceMove(user.loc)
 				else
-					powercell.loc = loc
+					powercell.forceMove(loc)
 				powercell = null
 				return
 			if (istype(I, /obj/item/weapon/weldingtool))

--- a/code/game/objects/items/devices/magnetic_lock.dm
+++ b/code/game/objects/items/devices/magnetic_lock.dm
@@ -114,8 +114,14 @@
 				powercell = I
 				return
 			if (istype(I, /obj/item/weapon/crowbar))
+				if (isnull(powercell))
+					user << "<span class='notice'>There is no powercell in \the [src].</span>"
+					return
 				user << "<span class='notice'>You remove \the [powercell] from \the [src].</span>"
-				powercell.loc = loc
+				if (loc == user)
+					powercell.loc = user.loc
+				else
+					powercell.loc = loc
 				powercell = null
 				return
 			if (istype(I, /obj/item/weapon/weldingtool))

--- a/code/game/objects/items/devices/magnetic_lock.dm
+++ b/code/game/objects/items/devices/magnetic_lock.dm
@@ -119,7 +119,7 @@
 					return
 				user << "<span class='notice'>You remove \the [powercell] from \the [src].</span>"
 				if (loc == user)
-					powercell.loc = user.loc
+					powercell.forceMove(user.loc)
 				else
 					powercell.loc = loc
 				powercell = null

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -104,8 +104,9 @@ var/last_chew = 0
 	var/obj/item/organ/external/O = H.organs_by_name[H.hand?"l_hand":"r_hand"]
 	if (!O) return
 
-	var/s = "\red [H.name] chews on \his [O.name]!"
+	var/s = "\red [H.name] chews on [H.get_pronoun(1)] [O.name]!"
 	H.visible_message(s, "\red You chew on your [O.name]!")
+	message_admins("[key_name_admin(H)] is chewing on [H.get_pronoun(1)] restrained hand - (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[H.x];Y=[H.y];Z=[H.z]'>JMP</a>)")
 	H.attack_log += text("\[[time_stamp()]\] <font color='red'>[s] ([H.ckey])</font>")
 	log_attack("[s] ([H.ckey])")
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -404,7 +404,7 @@
 					usr << "<span class='warning'>\The [RG] is already empty.</span>"
 					return
 
-				RG.reagents.remove_any(RG.amount_per_transfer_from_this)
+				RG.reagents.clear_reagents()
 				oviewers(3, usr) << "<span class='notice'>[usr] empties \the [RG] into \the [src].</span>"
 				usr << "<span class='notice'>You empty \the [RG] into \the [src].</span>"
 		return

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -120,6 +120,14 @@
 	log_and_message_admins("emagged [src]")
 	return
 
+/mob/living/bot/emp_act(severity)
+	switch(severity)
+		if(1)
+			death()
+		if(2)
+			turn_off()
+	..()
+
 /mob/living/bot/proc/turn_on()
 	if(stat)
 		return 0

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -124,7 +124,7 @@
 	switch(severity)
 		if(1)
 			death()
-		if(2)
+		else
 			turn_off()
 	..()
 

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -34,10 +34,8 @@ var/list/ventcrawl_machinery = list(
 	return 1
 
 /mob/living/proc/is_allowed_vent_crawl_item(var/obj/item/carried_item)
-	for(var/type in can_enter_vent_with)
-		if(is_type_in_list(carried_item, can_enter_vent_with))
-			return get_inventory_slot(carried_item) == null
-	return 0
+	if(is_type_in_list(carried_item, can_enter_vent_with))
+		return !get_inventory_slot(carried_item)
 
 /mob/living/carbon/is_allowed_vent_crawl_item(var/obj/item/carried_item)
 	if(carried_item in internal_organs)

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -35,8 +35,8 @@ var/list/ventcrawl_machinery = list(
 
 /mob/living/proc/is_allowed_vent_crawl_item(var/obj/item/carried_item)
 	for(var/type in can_enter_vent_with)
-		if(istype(carried_item, can_enter_vent_with))
-			return get_inventory_slot(carried_item) == 0
+		if(is_type_in_list(carried_item, can_enter_vent_with))
+			return get_inventory_slot(carried_item) == null
 	return 0
 
 /mob/living/carbon/is_allowed_vent_crawl_item(var/obj/item/carried_item)

--- a/html/changelogs/Bedshaped-PR-1021.yml
+++ b/html/changelogs/Bedshaped-PR-1021.yml
@@ -1,0 +1,11 @@
+author: Bedshaped
+
+delete-after: True
+
+changes: 
+  - bugfix: "Beepsky and other bots now affected by EMPs."
+  - bugfix: "Fixed power cells disappearing when removed from held mag locks."
+  - spellcheck: "Fixed missing pronoun when chewing your hand."
+  - rscadd: "Added admin notices when someone chews their hand off."
+  - bugfix: "Emptying a container into a sink correctly 'empties' it."
+  - bugfix: "Fixed Spider-bots not being able to ventcrawl."


### PR DESCRIPTION
changes: 
  - bugfix: "Beepsky and other bots now affected by EMPs."
  - bugfix: "Fixed power cells disappearing when removed from held mag locks."
  - spellcheck: "Fixed missing pronoun when chewing your hand."
  - rscadd: "Added admin notices when someone chews their hand off."
  - bugfix: "Emptying a container into a sink correctly 'empties' it."
  - bugfix: "Fixed Spider-bots not being able to ventcrawl."