### PR TITLE
False Alarm Fixes

### DIFF
--- a/code/modules/events/apc_damage.dm
+++ b/code/modules/events/apc_damage.dm
@@ -1,6 +1,6 @@
 /datum/event/apc_damage
 	var/apcSelectionRange	= 25
-
+	no_fake = 1
 /datum/event/apc_damage/start()
 	var/obj/machinery/power/apc/A = acquire_random_apc()
 

--- a/code/modules/events/bear_attack.dm
+++ b/code/modules/events/bear_attack.dm
@@ -5,6 +5,7 @@
 	var/list/possible_turfs = list()
 	var/spawn_type
 	var/spawn_number
+	ic_name = "a dangerous bioweapon"
 
 /datum/event/bear_attack/setup()
 	for(var/areapath in typesof(/area/maintenance))

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -3,7 +3,7 @@
 	endWhen			= 120
 
 	var/obj/effect/blob/core/Blob
-
+	ic_name = "a biohazard"
 
 /datum/event/blob/announce()
 	command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -3,6 +3,7 @@
 	endWhen 		= 900
 
 	var/list/spawned_carp = list()
+	ic_name = "biological entities"
 
 /datum/event/carp_migration/setup()
 	announceWhen = rand(40, 60)
@@ -32,7 +33,7 @@
 			spawn_locations.Add(C.loc)
 	spawn_locations = shuffle(spawn_locations)
 	num_groups = min(num_groups, spawn_locations.len)
-	
+
 	var/i = 1
 	while (i <= num_groups)
 		var/group_size = rand(group_size_min, group_size_max)

--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -1,3 +1,6 @@
+/datum/event/communications_blackout
+	no_fake = 1
+
 /datum/event/communications_blackout/announce()
 	var/alert = pick(	"Ionospheric anomalies detected. Temporary telecommunication failure imminent. Please contact you*%fj00)`5vc-BZZT", \
 						"Ionospheric anomalies detected. Temporary telecommunication failu*3mga;b4;'1v¬-BZZZT", \
@@ -13,6 +16,8 @@
 
 	if(prob(30))	//most of the time, we don't want an announcement, so as to allow AIs to fake blackouts.
 		command_announcement.Announce(alert, new_sound = sound('sound/misc/interference.ogg', volume=25))
+		return
+	return 1
 
 
 /datum/event/communications_blackout/start()

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -1,6 +1,6 @@
 /datum/event/disease_outbreak
 	announceWhen	= 15
-
+	ic_name = "a viral biohazard"
 
 /datum/event/disease_outbreak/announce()
 	command_announcement.Announce("Confirmed outbreak of level 7 viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -1,6 +1,7 @@
 /datum/event/dust
 	startWhen	= 10
 	endWhen		= 30
+	ic_name = "space dust"
 
 /datum/event/dust/announce()
 	command_announcement.Announce("The station is now passing through a belt of space dust.", "Dust Alert")

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -1,7 +1,7 @@
 /datum/event/electrical_storm
 	var/lightsoutAmount	= 1
 	var/lightsoutRange	= 25
-
+	ic_name = "an electrical storm"
 
 /datum/event/electrical_storm/announce()
 	command_announcement.Announce("An electrical storm has been detected in your area, please repair potential electronic overloads.", "Electrical Storm Alert")

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -61,8 +61,14 @@
 	//If set to 1, this event will not be picked for false announcements
 	//This should really only be used for events that have no announcement
 
+	var/ic_name			= null
+	//A lore-suitable name that maintains the mystery, used for faking events
+
+	var/dummy 			=	0
+	//If 1, this event is a dummy instance used for retrieving values, it should not run or add/remove itself from any lists
 
 /datum/event/nothing
+	no_fake = 1
 
 //Called first before processing.
 //Allows you to setup your event, such as randomly
@@ -127,26 +133,32 @@
 	activeFor++
 
 //Called when start(), announce() and end() has all been called.
-/datum/event/proc/kill(var/do_end = 1)
+/datum/event/proc/kill()
 	// If this event was forcefully killed run end() for individual cleanup
 
-	if(do_end && isRunning)
+	if(!dummy && isRunning)
 		end()
 
 	isRunning = 0
 	endedAt = world.time
-	event_manager.active_events -= src
-	event_manager.event_complete(src)
 
-/datum/event/New(var/datum/event_meta/EM)
-	// event needs to be responsible for this, as stuff like APLUs currently make their own events for curious reasons
-	event_manager.active_events += src
+	if(!dummy)
+		event_manager.active_events -= src
+		event_manager.event_complete(src)
 
+
+
+/datum/event/New(var/datum/event_meta/EM = null, var/is_dummy = 0)
+	dummy = is_dummy
 	event_meta = EM
 	severity = event_meta.severity
 	if(severity < EVENT_LEVEL_MUNDANE) severity = EVENT_LEVEL_MUNDANE
 	if(severity > EVENT_LEVEL_MAJOR) severity = EVENT_LEVEL_MAJOR
 
+	if (dummy)
+		return
+	// event needs to be responsible for this, as stuff like APLUs currently make their own events for curious reasons
+	event_manager.active_events += src
 	startedAt = world.time
 
 	setup()

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -164,8 +164,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,	 					50, 	list(ASSIGNMENT_ENGINEER = 7)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		50,	list(ASSIGNMENT_SECURITY = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Viral Infection",			/datum/event/viral_infection, 			0,		list(ASSIGNMENT_MEDICAL = 12), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Major Vermin Infestation",	/datum/event/infestation, 				60,	list(ASSIGNMENT_JANITOR = 15, ASSIGNMENT_SECURITY = 15)),
-
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Major Vermin Infestation",	/datum/event/infestation, 				60,	list(ASSIGNMENT_JANITOR = 15, ASSIGNMENT_SECURITY = 15))
 	)
 
 /datum/event_container/major
@@ -177,8 +176,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		40,	list(ASSIGNMENT_ENGINEER =  10),1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",		/datum/event/spacevine, 		50,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_GARDENER = 20), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Viral Infection",	/datum/event/viral_infection,	20,	list(ASSIGNMENT_MEDICAL =  13), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Bluespace Bears",	/datum/event/bear_attack,		60,	list(ASSIGNMENT_SECURITY =  10), 1),
-
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Bluespace Bears",	/datum/event/bear_attack,		60,	list(ASSIGNMENT_SECURITY =  10), 1)
 	)
 
 //NOTE: Re added nothing option, but with fairly low weight

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -41,8 +41,13 @@
 	// Add the event back to the list of available events
 	var/datum/event_container/EC = event_containers[E.severity]
 	var/datum/event_meta/EM = E.event_meta
-	EC.available_events += EM
 
+
+	if (!EM.event_type)//This happens if an event is started with the Trigger Event debug command
+		log_debug("Event of '[E.type]' with missing meta-data has completed.")
+		return
+
+	EC.available_events += EM
 	log_debug("Event '[EM.name]' has completed at [worldtime2text()].")
 
 /datum/event_manager/proc/delay_events(var/severity, var/delay)

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -5,17 +5,18 @@
 
 /datum/event/false_alarm
 	announceWhen	= 0
-	endWhen	=	90
+	endWhen	=	2//90
 	var/datum/event_meta/EM
+	var/eventname
 
 
 /datum/event/false_alarm/end()
-	command_announcement.Announce("Error, It appears our previous announcement about a [EM.name] was a sensor glitch. There is no cause for alarm, please return to your stations.", "False Alarm")
+	command_announcement.Announce("Error, It appears our previous announcement about [eventname] was a sensor glitch. There is no cause for alarm, please return to your stations.", "False Alarm")
 
 
 /datum/event/false_alarm/announce()
 	var/datum/event_container/EC
-	if (prob(50))
+	if (prob(40))
 		EC = event_manager.event_containers[EVENT_LEVEL_MODERATE]
 	else
 		EC = event_manager.event_containers[EVENT_LEVEL_MAJOR]
@@ -26,12 +27,18 @@
 	var/fake_allowed = 0
 	while (!fake_allowed)
 		if (E)
-			E.kill(0)
+			E.kill()
+			qdel(E)
+			E = null
 		EM = pick(EC.available_events)
-		E = new EM.event_type(EM)
+		E = new EM.event_type(EM,1)
 		fake_allowed = !E.no_fake
 
-	message_admins("False Alarm: [E]")
-	E.kill(0)
+	if (E.ic_name)
+		eventname = E.ic_name
+	else
+		eventname = EM.name
+
+	E.kill()
 	E.announce()
 

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -14,8 +14,10 @@
 	command_announcement.Announce("Error, It appears our previous announcement about [eventname] was a sensor glitch. There is no cause for alarm, please return to your stations.", "False Alarm")
 	if (E)
 		qdel(E)
+		E = null
 	if (EM)
 		qdel(EM)
+		EM = null
 
 /datum/event/false_alarm/announce()
 	var/datum/event_container/EC

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -12,9 +12,6 @@
 
 /datum/event/false_alarm/end()
 	command_announcement.Announce("Error, It appears our previous announcement about [eventname] was a sensor glitch. There is no cause for alarm, please return to your stations.", "False Alarm")
-	if (E)
-		qdel(E)
-		E = null
 	if (EM)
 		qdel(EM)
 		EM = null

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -12,7 +12,10 @@
 
 /datum/event/false_alarm/end()
 	command_announcement.Announce("Error, It appears our previous announcement about [eventname] was a sensor glitch. There is no cause for alarm, please return to your stations.", "False Alarm")
-
+	if (E)
+		qdel(E)
+	if (EM)
+		qdel(EM)
 
 /datum/event/false_alarm/announce()
 	var/datum/event_container/EC
@@ -41,4 +44,6 @@
 
 	E.kill()
 	E.announce()
+
+
 

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -5,7 +5,7 @@
 
 /datum/event/false_alarm
 	announceWhen	= 0
-	endWhen	=	2//90
+	endWhen	=	90
 	var/datum/event_meta/EM
 	var/eventname
 
@@ -16,7 +16,7 @@
 
 /datum/event/false_alarm/announce()
 	var/datum/event_container/EC
-	if (prob(40))
+	if (prob(60))
 		EC = event_manager.event_containers[EVENT_LEVEL_MODERATE]
 	else
 		EC = event_manager.event_containers[EVENT_LEVEL_MAJOR]

--- a/code/modules/events/gravity.dm
+++ b/code/modules/events/gravity.dm
@@ -1,5 +1,6 @@
 /datum/event/gravity
 	announceWhen = 5
+	ic_name = "a gravity failure"
 
 /datum/event/gravity/setup()
 	endWhen = rand(15, 60)

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -1,5 +1,6 @@
 /datum/event/grid_check	//NOTE: Times are measured in master controller ticks!
 	announceWhen		= 5
+	no_fake = 1
 
 /datum/event/grid_check/setup()
 	endWhen = rand(30,120)

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -36,11 +36,12 @@
 	endWhen = 11
 	var/location
 	var/numlocs = 0
-	var/list/locstrings
+	var/list/locstrings = list()
 	var/vermin
 	var/vermstring
 	var/spawn_area_type
 	var/list/turf/simulated/floor/turfs
+	no_fake = 1
 
 /datum/event/infestation/start()
 	locstrings = new/list(2)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -3,7 +3,7 @@
 /datum/event/ionstorm
 	var/botEmagChance = 0.5
 	var/list/players = list()
-
+	no_fake = 1
 /datum/event/ionstorm/announce()
 	endWhen = rand(500, 1500)
 //		command_alert("The station has entered an ion storm.  Monitor all electronic equipment for malfunctions", "Anomaly Alert")

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -13,6 +13,7 @@
 
 	var/waves		= 8
 	var/next_wave 	= 86
+	ic_name = "a meteor storm"
 
 /datum/event/meteor_wave/setup()
 	startWhen += rand(-15,15)//slightly randomised start time
@@ -56,6 +57,7 @@
 
 	var/waves		= 4//this is randomised
 	var/next_wave 	= 86
+	ic_name = "a meteor shower"
 
 /datum/event/meteor_shower/setup()
 	startWhen += rand(-15,15)//slightly randomised start time

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -3,8 +3,8 @@
 
 	var/releaseWhen = 25
 	var/list/area/prisonAreas = list()
-
-
+	ic_name = "an imprisonment system virus"
+	no_fake = 1//Complicated to announce because of prison areas thing
 /datum/event/prison_break/setup()
 	announceWhen = rand(50, 60)
 	releaseWhen = rand(20, 30)

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -6,6 +6,7 @@
 	announceWhen			= 1
 	endWhen					= revokeAccess
 	var/postStartTicks 		= 0
+	ic_name = "radiation"
 
 /datum/event/radiation_storm/announce()
 	command_announcement.Announce("High levels of radiation detected near the station. Please evacuate into one of the shielded maintenance tunnels.", "Anomaly Alert", new_sound = 'sound/AI/radiation.ogg')

--- a/code/modules/events/random_antagonist.dm
+++ b/code/modules/events/random_antagonist.dm
@@ -1,4 +1,7 @@
 // The random spawn proc on the antag datum will handle announcing the spawn and whatnot.
+/datum/event/random_antag
+	no_fake = 1
+
 /datum/event/random_antag/announce()
 	return
 

--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -1,6 +1,7 @@
 /datum/event/rogue_drone
 	endWhen = 1000
 	var/list/drones_list = list()
+	ic_name = "combat drones"
 
 /datum/event/rogue_drone/start()
 	//spawn them at the same place as carp

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -2,6 +2,7 @@
 
 /datum/event/spacevine
 	announceWhen	= 10
+	ic_name = "a biohazard"
 
 /datum/event/spacevine/start()
 	spacevine_infestation()

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -3,7 +3,7 @@
 /datum/event/spider_infestation
 	announceWhen	= 90
 	var/spawncount = 1
-
+	ic_name = "unidentified lifesigns"
 
 /datum/event/spider_infestation/setup()
 	announceWhen = rand(announceWhen, announceWhen + 60)

--- a/code/modules/events/viral_infection.dm
+++ b/code/modules/events/viral_infection.dm
@@ -2,6 +2,8 @@
 
 datum/event/viral_infection
 	var/list/viruses = list()
+	ic_name = "a biohazard"
+	no_fake = 1//Probability in announce complicates it
 
 datum/event/viral_infection/setup()
 	announceWhen = rand(0, 3000)


### PR DESCRIPTION
-Makes a lot of unsuitable events excluded from faking. Some of them could do with reworking to make them function, like the infestation and prison breaks, but for now i just had to exclude them
-Adds an In-character/descriptive name, used for the announcement apologising for the mistake
-Fixes an issue where using debug Trigger Event verb would fill the events list with empty severe events and cause runtime errors

Fixed quite a lot of other events that threw runtimes when attempting to fake them