### PR TITLE
API Command Report Fix

### DIFF
--- a/code/datums/api.dm
+++ b/code/datums/api.dm
@@ -879,9 +879,9 @@ proc/api_update_command_database()
 	//Set the report footer for CCIA Announcements
 	if (reporttype == "ccia")
 		if (reportsender)
-			reportbody += "<br/><br/>- [reportsender], Central Command Internal Affairs Agent, [commstation_name()]"
+			reportbody += "<br><br>- [reportsender], Central Command Internal Affairs Agent, [commstation_name()]"
 		else
-			reportbody += "<br/><br/>- CCIAAMS, [commstation_name()]"
+			reportbody += "<br><br>- CCIAAMS, [commstation_name()]"
 
 	if(reportannounce == 1)
 		command_announcement.Announce(reportbody, reporttitle, new_sound = 'sound/AI/commandreport.ogg', do_newscast = 1, msg_sanitized = 1);

--- a/code/datums/api.dm
+++ b/code/datums/api.dm
@@ -853,7 +853,7 @@ proc/api_update_command_database()
 /datum/topic_command/send_commandreport/run_command(queryparams)
 	var/senderkey = sanitize(queryparams["senderkey"]) //Identifier of the sender (Ckey / Userid / ...)
 	var/reporttitle = sanitizeSafe(queryparams["title"]) //Title of the report
-	var/reportbody = sanitizeSafe(queryparams["body"]) //Body of the report
+	var/reportbody = nl2br(sanitize(queryparams["body"],encode=0,extra=0)) //Body of the report
 	var/reporttype = queryparams["type"] //Type of the report: freeform / ccia / admin
 	var/reportsender = sanitizeSafe(queryparams["sendername"]) //Name of the sender
 	var/reportannounce = queryparams["announce"] //Announce the contents report to the public: 1 / 0
@@ -870,7 +870,7 @@ proc/api_update_command_database()
 		if(! (C.stat & (BROKEN|NOPOWER) ) )
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( C.loc )
 			P.name = "[command_name()] Update"
-			P.info = replacetext(reportbody, "\n", "<br/>")
+			P.info = reportbody
 			P.update_space(P.info)
 			P.update_icon()
 			C.messagetitle.Add("[command_name()] Update")


### PR DESCRIPTION
Fixes the > in the ccia command reports sent from the WI.
Fixes multilines in multiline messages not showing up.