### PR TITLE
Immortal AI Fix

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -36,7 +36,7 @@ REAGENT SCANNER
 
 	for(var/turf/T in range(1, src.loc) )
 
-		if(!T.intact)
+		if(!T || !T.intact)
 			continue
 
 		for(var/obj/O in T.contents)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -11,7 +11,7 @@
 
 		src.updatehealth()
 
-		if (!hardware_integrity() || !backup_capacitor())
+		if (hardware_integrity() <= 0 || !backup_capacitor() <= 0)
 			death()
 			return
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -11,7 +11,7 @@
 
 		src.updatehealth()
 
-		if (hardware_integrity() <= 0 || !backup_capacitor() <= 0)
+		if (hardware_integrity() <= 0 || backup_capacitor() <= 0)
 			death()
 			return
 


### PR DESCRIPTION
We've run into a bug lately where an AI wouldn't die when it had taken a ton of damage.

I've not figured out how to reproduce the conditions that caused it, but i see some bad checks in the life() proc that could lead to it - checking specifically for a false output from a function that returns a number.This fix should ensure that if the bug does happen again somehow, it should be handled by the regular checks, i changed the checks to be true if the returned value <=0

Also includes a tiny safety check in the Tray scanner to fix a runtime error that i ran into, while trying to asplode an AI