### PR TITLE
crew monitoring font colors

### DIFF
--- a/html/changelogs/Bedshaped-PR-1058.yml
+++ b/html/changelogs/Bedshaped-PR-1058.yml
@@ -1,0 +1,6 @@
+author: Bedshaped
+
+delete-after: True
+
+changes: 
+  - tweak: "Crew monitoring computer: Lightened the font colors of suff and tox."

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -578,11 +578,11 @@ th.misc {
 }
 
 .toxin {
-    color: #9dc65f;
+    color: #8ac44c;
 }
 
 .oxyloss {
-    color: #7ec0ee;
+    color: #00baee;
 }
 
 /* 75px width used in power monitoring console buttons */

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -578,11 +578,11 @@ th.misc {
 }
 
 .toxin {
-    color: green;
+    color: #9dc65f;
 }
 
 .oxyloss {
-    color: blue;
+    color: #7ec0ee;
 }
 
 /* 75px width used in power monitoring console buttons */


### PR DESCRIPTION
changes: 
  - tweak: "Crew monitoring computer: Lightened the font colors of suff and tox."

requested by: @SierraKomodo and Jackboot
Before:
![http://i.imgur.com/6XzyUL2.png](http://i.imgur.com/6XzyUL2.png)
After:
![https://puu.sh/rL9L7/4e544a78a6.png](https://puu.sh/rL9L7/4e544a78a6.png)