### PR TITLE
Bugfixes: Welding tool, Constructs, Runes

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -362,30 +362,3 @@ Class Procs:
 		I.loc = loc
 	qdel(src)
 	return 1
-
-/obj/machinery/attack_generic(var/mob/user, var/damage, var/attack_verb, var/wallbreaker)
-	if (istype(user, /mob/living/simple_animal/construct/armoured))
-		// Juggernaut: smash machines up
-		if(damage == 0 || !wallbreaker)
-			return 0
-		visible_message("<span class='danger'>[user] [attack_verb] the [src] apart!</span>")
-		user.do_attack_animation(src)
-
-		// Add sparks
-		var/obj/effect/overlay/sparks = PoolOrNew(/obj/effect/overlay, src.loc)
-		sparks.icon = 'icons/effects/effects.dmi'
-		sparks.icon_state = "empdisable"
-		sparks.name = "emp sparks"
-		sparks.anchored = 1
-		sparks.set_dir(pick(cardinal))
-
-		spawn(1)
-			// leave some melted remains
-			new/obj/effect/decal/cleanable/molten_item(src.loc)
-			// delete the machine obj
-			qdel(src)
-		spawn(10) qdel(sparks)
-
-		return 1
-	else
-		..()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -362,3 +362,30 @@ Class Procs:
 		I.loc = loc
 	qdel(src)
 	return 1
+
+/obj/machinery/attack_generic(var/mob/user, var/damage, var/attack_verb, var/wallbreaker)
+	if (istype(user, /mob/living/simple_animal/construct/armoured))
+		// Juggernaut: smash machines up
+		if(damage == 0 || !wallbreaker)
+			return 0
+		visible_message("<span class='danger'>[user] [attack_verb] the [src] apart!</span>")
+		user.do_attack_animation(src)
+
+		// Add sparks
+		var/obj/effect/overlay/sparks = PoolOrNew(/obj/effect/overlay, src.loc)
+		sparks.icon = 'icons/effects/effects.dmi'
+		sparks.icon_state = "empdisable"
+		sparks.name = "emp sparks"
+		sparks.anchored = 1
+		sparks.set_dir(pick(cardinal))
+
+		spawn(1)
+			// leave some melted remains
+			new/obj/effect/decal/cleanable/molten_item(src.loc)
+			// delete the machine obj
+			qdel(src)
+		spawn(10) qdel(sparks)
+
+		return 1
+	else
+		..()

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -306,15 +306,24 @@
 			var/mob/living/carbon/human/H = M
 			if(H.species.flags & IS_SYNTHETIC)
 				if(M == user)
-					user << "\red You can't repair damage to your own body - it's against OH&S."
+					user << "<span class='warning'>You can't repair damage to your own body - it's against OH&S.</span>"
 					return
-
-		if(S.brute_dam)
-			S.heal_damage(15,0,0,1)
-			user.visible_message("\red \The [user] patches some dents on \the [M]'s [S.name] with \the [src].")
+		if(S.brute_dam == 0)
+			// Organ undamaged
+			user << "Nothing to fix here!"
 			return
+		if (!src.welding)
+			// Welder is switched off!
+			user << "<span class='warning'>You need to light the welding tool, first!</span>"
+			return
+		if (src.remove_fuel(0))
+			// Use a bit of fuel and repair
+			S.heal_damage(15,0,0,1)
+			user.visible_message("<span class='warning'>\The [user] patches some dents on \the [M]'s [S.name] with \the [src].</span>")
 		else
-			user << "Nothing to fix!"
+			// Welding tool is out of fuel
+			user << "Need more welding fuel!"
+		return
 
 	else
 		return ..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -425,7 +425,10 @@
 			if(istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
 				qdel(O)
 			if(istype(O,/obj/effect/rune))
-				user << "<span class='warning'>\red No matter how well you wash, the bloody symbols remain!</span>"
+				var/obj/effect/rune/R = O
+				// Only show message for visible runes
+				if (R.visibility)
+					user << "<span class='warning'>No matter how well you wash, the bloody symbols remain!</span>"
 	else
 		user << "<span class='warning'>\The [source] is too dry to wash that.</span>"
 	source.reagents.trans_to_turf(src, 1, 10)	//10 is the multiplier for the reaction effect. probably needed to wet the floor properly.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -456,16 +456,20 @@
 			user << "<span class='warning'>You lack the reach to be able to repair yourself.</span>"
 			return
 
-		if (!getBruteLoss())
+		if (getBruteLoss() == 0)
 			user << "Nothing to fix here!"
 			return
 		var/obj/item/weapon/weldingtool/WT = W
+		if (!WT.welding)
+			// Welding tool is switched off
+			user << "<span class='warning'>You need to light the welding tool, first!</span>"
+			return
 		if (WT.remove_fuel(0))
 			adjustBruteLoss(-30)
 			updatehealth()
 			add_fingerprint(user)
 			for(var/mob/O in viewers(user, null))
-				O.show_message(text("\red [user] has fixed some of the dents on [src]!"), 1)
+				O.show_message(text("<span class='warning'>[user] has fixed some of the dents on [src]!</span>"), 1)
 		else
 			user << "Need more welding fuel!"
 			return

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -134,6 +134,16 @@
 
 	return (..(P))
 
+/mob/living/simple_animal/construct/armoured/UnarmedAttack(var/atom/A, var/proximity)
+	if(istype(A, /obj/machinery))
+		// Destroy machines instead of opening their UI
+		var/obj/machinery/M = A
+		do_attack_animation(M)
+		playsound(loc, attack_sound, 50, 1, 1)
+		M.ex_act(3.0)
+	else
+		..()
+
 
 
 ////////////////////////Wraith/////////////////////////////////////////////

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -57,11 +57,14 @@
 
 /mob/living/simple_animal/construct/attack_generic(var/mob/user)
 	if(istype(user, /mob/living/simple_animal/construct/builder))
-		if(health < maxHealth)
+		if(getBruteLoss() > 0)
 			adjustBruteLoss(-5)
 			user.visible_message("<span class='notice'>\The [user]</b> mends some of \the [src]'s wounds.</span>")
 		else
-			user << "<span class='notice'>\The [src] is undamaged.</span>"
+			if (health < maxHealth)
+				user << "<span class='notice'>Healing \the [src] any further is beyond your abilities.</span>"
+			else
+				user << "<span class='notice'>\The [src] is undamaged.</span>"
 		return
 	return ..()
 

--- a/html/changelogs/inselc-PR-1072.yml
+++ b/html/changelogs/inselc-PR-1072.yml
@@ -1,0 +1,10 @@
+author: inselc
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed welding tool not using fuel when repairing IPCs, and repairing IPCs in switched-off state."
+  - bugfix: "Fixed Artificers healing other constructs."
+  - bugfix: "Fixed invisible runes triggering message when trying to clean the tile they're on."
+  - rscadd: "Added Juggernaut ability to smash machines."
+


### PR DESCRIPTION
This PR contains patches for #1066, #1065 and #1053.

For #1053, the ability for Juggernauts to smash `/obj/machinery` was added. ~~This one could possibly use a few new sprites for "machinery debris".~~

(Bugfixes get merged directly into master, from what I've gathered?)