### PR TITLE
Explosion and other tweaks

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -86,7 +86,7 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 
 						//Deaf people will feel vibrations though
 						if (volume > 0)//Only shake camera if someone was close enough to hear it
-							shake_camera(M, min(60,max(2,(power*28) / dist)), min(3.5,((power*6) / dist)),0.05)
+							shake_camera(M, min(60,max(2,(power*18) / dist)), min(3.5,((power*3) / dist)),0.05)
 							//Maximum duration is 6 seconds, and max strength is 3.5
 							//Becuse values higher than those just get really silly
 

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -141,7 +141,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Trivial News",		/datum/event/trivial_news, 		400),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		60,	list(ASSIGNMENT_JANITOR = 20, ASSIGNMENT_SECURITY = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			75,		list(ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_GARDENER = 20)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Clogged Vents",		/datum/event/vent_clog, 		100),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Clogged Vents",		/datum/event/vent_clog, 		85),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "False Alarm",		/datum/event/false_alarm, 		100),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Supply Drop",		/datum/event/supply_drop, 		80),
 
@@ -172,13 +172,13 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 /datum/event_container/major
 	severity = EVENT_LEVEL_MAJOR
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",			/datum/event/nothing,			80),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",			/datum/event/nothing,			90),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",			/datum/event/blob, 				50,	list(ASSIGNMENT_ENGINEER = 5,ASSIGNMENT_SECURITY =  5), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",	/datum/event/carp_migration,	60,	list(ASSIGNMENT_SECURITY =  10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		40,	list(ASSIGNMENT_ENGINEER =  10),1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",		/datum/event/spacevine, 		50,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_GARDENER = 20), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",		/datum/event/spacevine, 		60,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_GARDENER = 20), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Viral Infection",	/datum/event/viral_infection,	20,	list(ASSIGNMENT_MEDICAL =  13), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Bluespace Bears",	/datum/event/bear_attack,		60,	list(ASSIGNMENT_SECURITY =  10), 1)
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Bluespace Bears",	/datum/event/bear_attack,		50,	list(ASSIGNMENT_SECURITY =  10), 1)
 	)
 
 //NOTE: Re added nothing option, but with fairly low weight

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -1,7 +1,7 @@
 /var/global/spacevines_spawned = 0
 
 /datum/event/spacevine
-	announceWhen	= 10
+	announceWhen	= 30
 	ic_name = "a biohazard"
 
 /datum/event/spacevine/start()

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -73,6 +73,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 				t = input("Enter any OOC comments", "pAI OOC Comments", candidate.comments) as message
 				if(t)
 					candidate.comments = sanitize(t)
+
 			if("save")
 				candidate.savefile_save(usr)
 			if("load")
@@ -95,7 +96,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 							p.alertUpdate()
 				usr << browse(null, "window=paiRecruit")
 				return
-
+		candidate.savefile_save(usr)
 		recruitWindow(usr, href_list["allow_submit"] != "0")
 
 /datum/paiController/proc/recruitWindow(var/mob/M as mob, allowSubmit = 1)
@@ -206,18 +207,9 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 			</tr>
 		</table>
 		<br>
-		<table>
-			<tr>
-				<td class="button">
-					<a href='byond://?src=\ref[src];option=save;new=1;allow_submit=[allowSubmit];candidate=\ref[candidate]' class="button">Save Personality</a>
-				</td>
-			</tr>
-			<tr>
-				<td class="button">
-					<a href='byond://?src=\ref[src];option=load;new=1;allow_submit=[allowSubmit];candidate=\ref[candidate]' class="button">Load Personality</a>
-				</td>
-			</tr>
-		</table><br>
+		/*
+
+		*/
 	"}
 	if(allowSubmit)
 		dat += {"

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -207,9 +207,6 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 			</tr>
 		</table>
 		<br>
-		/*
-
-		*/
 	"}
 	if(allowSubmit)
 		dat += {"

--- a/html/changelogs/Nanako_PaiEventTweaks.yml
+++ b/html/changelogs/Nanako_PaiEventTweaks.yml
@@ -1,0 +1,8 @@
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed being unable to save pAI information. It now autosaves whenever anything is entered. Save and load buttons are obsolete and removed."
+  - tweak: "Altered some event probabilities. And the announcement for space vines is now delayed significantly longer"


### PR DESCRIPTION
A package of assorted stuff i wanted to get done

Reduces screenshaking from explosions by about 50%, as per testing yesterday.
Reduces probabilities of bluespace bears and clogged scrubber events. as per skull's recommendation
Slightly increases the Nothing weight for severe events, just to make them a tiny bit rarer

Slightly increases the probability of space vines, and significantly increases the warning delay on it: Its one of the least common major events, and also trivialised because of the rapid warning, this should help a bit.



Fixes a bug with being unable to save pAI settings. This was caused by another bugfix i implemented - auto loading the pAI settings whenever the window is displayed. The solution i've implemented is to auto-save the form whenever information is entered.

The save and load buttons were largely redundant before, since you can only have one saved personality. With this change they are now entirely redundant and obsolete, thus they have been removed.