### PR TITLE
Bugfixes: hungry shades, IV drips, PDAs, smallbots and laptops

### DIFF
--- a/code/game/machinery/computer3/laptop.dm
+++ b/code/game/machinery/computer3/laptop.dm
@@ -34,7 +34,7 @@
 		set category = "Object"
 		set src in view(1)
 
-		if(usr.stat || usr.restrained() || usr.lying || !istype(usr, /mob/living))
+		if(usr.stat || usr.restrained() || usr.lying || !istype(usr, /mob/living) || !ishuman(usr))
 			usr << "\red You can't do that."
 			return
 
@@ -63,8 +63,7 @@
 
 
 	AltClick()
-		if(Adjacent(usr))
-			open_computer()
+		open_computer()
 
 //Quickfix until Snapshot works out how he wants to redo power. ~Z
 /obj/item/device/laptop/verb/eject_id()
@@ -123,7 +122,7 @@
 		set category = "Object"
 		set src in view(1)
 
-		if(usr.stat || usr.restrained() || usr.lying || !istype(usr, /mob/living))
+		if(usr.stat || usr.restrained() || usr.lying || !istype(usr, /mob/living) || !ishuman(usr))
 			usr << "\red You can't do that."
 			return
 
@@ -187,5 +186,4 @@
 
 
 	AltClick()
-		if(Adjacent(usr))
-			close_computer()
+		close_computer()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -125,6 +125,8 @@
 				update_icon()
 
 /obj/machinery/iv_drip/attack_hand(mob/user as mob)
+	if (isAI(user))
+		return
 	if(src.beaker)
 		src.beaker.loc = get_turf(src)
 		src.beaker = null

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -342,7 +342,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	return id
 
 /obj/item/device/pda/AltClick(var/mob/user)
-	verb_remove_id()
+	if (ismob(src.loc))
+		verb_remove_id()
 
 /obj/item/device/pda/MouseDrop(obj/over_object as obj, src_location, over_location)
 	var/mob/M = usr

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -61,6 +61,14 @@
 	else
 		return 0
 
+/mob/living/bot/proc/has_ui_access(mob/user)
+	if (access_scanner.allowed(user))
+		return 1
+	if (!locked)
+		return 1
+	if (isAI(user))
+		return 1
+	return 0
 
 /mob/living/bot/attackby(var/obj/item/O, var/mob/user)
 	if(O.GetID())

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -247,8 +247,12 @@ var/list/cleanbot_types // Going to use this to generate a list of types once th
 	patrol_path = list()
 
 /mob/living/bot/cleanbot/attack_hand(var/mob/user)
+	if (!has_ui_access(user) && !emagged)
+		user << "<span class='warning'>The unit's interface refuses to unlock!</span>"
+		return
+
 	var/dat
-	dat += "<TT><B>Automatic Station Cleaner v1.0</B></TT><BR><BR>"
+	dat += "<TT><B>Automatic Station Cleaner v1.1</B></TT><BR><BR>"
 	dat += "Status: <A href='?src=\ref[src];operation=start'>[on ? "On" : "Off"]</A><BR>"
 	dat += "Behaviour controls are [locked ? "locked" : "unlocked"]<BR>"
 	dat += "Maintenance panel is [open ? "opened" : "closed"]"
@@ -259,7 +263,7 @@ var/list/cleanbot_types // Going to use this to generate a list of types once th
 		dat += "Odd looking screw twiddled: <A href='?src=\ref[src];operation=screw'>[screwloose ? "Yes" : "No"]</A><BR>"
 		dat += "Weird button pressed: <A href='?src=\ref[src];operation=oddbutton'>[oddbutton ? "Yes" : "No"]</A>"
 
-	user << browse("<HEAD><TITLE>Cleaner v1.0 controls</TITLE></HEAD>[dat]", "window=autocleaner")
+	user << browse("<HEAD><TITLE>Cleaner v1.1 controls</TITLE></HEAD>[dat]", "window=autocleaner")
 	onclose(user, "autocleaner")
 	return
 
@@ -268,6 +272,11 @@ var/list/cleanbot_types // Going to use this to generate a list of types once th
 		return
 	usr.set_machine(src)
 	add_fingerprint(usr)
+
+	if (!has_ui_access(usr) && !emagged)
+		usr << "<span class='warning'>Insufficient permissions.</span>"
+		return
+
 	switch(href_list["operation"])
 		if("start")
 			if(on)

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -38,8 +38,13 @@
 	. = ..()
 	if(.)
 		return
+
+	if (!has_ui_access(user))
+		user << "<span class='warning'>The unit's interface refuses to unlock!</span>"
+		return
+
 	var/dat = ""
-	dat += "<TT><B>Automatic Hyrdoponic Assisting Unit v1.0</B></TT><BR><BR>"
+	dat += "<TT><B>Automatic Hyrdoponic Assisting Unit v1.1</B></TT><BR><BR>"
 	dat += "Status: <A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A><BR>"
 	dat += "Water Tank: "
 	if (tank)
@@ -47,7 +52,7 @@
 	else
 		dat += "Error: Watertank not found"
 	dat += "<br>Behaviour controls are [locked ? "locked" : "unlocked"]<hr>"
-	if(!locked)
+	if(!locked || issilicon(usr))
 		dat += "<TT>Watering controls:<br>"
 		dat += "Water plants : <A href='?src=\ref[src];water=1'>[waters_trays ? "Yes" : "No"]</A><BR>"
 		dat += "Refill watertank : <A href='?src=\ref[src];refill=1'>[refills_water ? "Yes" : "No"]</A><BR>"
@@ -60,7 +65,7 @@
 		dat += "Remove dead plants: <A href='?src=\ref[src];removedead=1'>[removes_dead ? "Yes" : "No"]</A><BR>"
 		dat += "</TT>"
 
-	user << browse("<HEAD><TITLE>Farmbot v1.0 controls</TITLE></HEAD>[dat]", "window=autofarm")
+	user << browse("<HEAD><TITLE>Farmbot v1.1 controls</TITLE></HEAD>[dat]", "window=autofarm")
 	onclose(user, "autofarm")
 	return
 
@@ -77,13 +82,18 @@
 		return
 	usr.machine = src
 	add_fingerprint(usr)
-	if((href_list["power"]) && (access_scanner.allowed(usr)))
+
+	if (!has_ui_access(usr))
+		usr << "<span class='warning'>Insufficient permissions.</span>"
+		return
+
+	if(href_list["power"])
 		if(on)
 			turn_off()
 		else
 			turn_on()
 
-	if(locked)
+	if(locked && !issilicon(usr))
 		return
 
 	if(href_list["water"])

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -25,9 +25,13 @@
 		icon_state = "floorbot[on]e"
 
 /mob/living/bot/floorbot/attack_hand(var/mob/user)
+	if (!has_ui_access(user))
+		user << "<span class='warning'>The unit's interface refuses to unlock!</span>"
+		return
+
 	user.set_machine(src)
 	var/dat
-	dat += "<TT><B>Automatic Station Floor Repairer v1.0</B></TT><BR><BR>"
+	dat += "<TT><B>Automatic Station Floor Repairer v1.1</B></TT><BR><BR>"
 	dat += "Status: <A href='?src=\ref[src];operation=start'>[src.on ? "On" : "Off"]</A><BR>"
 	dat += "Maintenance panel is [open ? "opened" : "closed"]<BR>"
 	//dat += "Tiles left: [amount]<BR>"
@@ -43,7 +47,7 @@
 			bmode = "Disabled"
 		dat += "<BR><BR>Bridge Mode : <A href='?src=\ref[src];operation=bridgemode'>[bmode]</A><BR>"
 
-	user << browse("<HEAD><TITLE>Repairbot v1.0 controls</TITLE></HEAD>[dat]", "window=autorepair")
+	user << browse("<HEAD><TITLE>Repairbot v1.1 controls</TITLE></HEAD>[dat]", "window=autorepair")
 	onclose(user, "autorepair")
 	return
 
@@ -58,6 +62,11 @@
 		return
 	usr.set_machine(src)
 	add_fingerprint(usr)
+
+	if (!has_ui_access(usr))
+		usr << "<span class='warning'>Insufficient permissions.</span>"
+		return
+
 	switch(href_list["operation"])
 		if("start")
 			if (on)

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -120,8 +120,12 @@
 		icon_state = "medibot[on]"
 
 /mob/living/bot/medbot/attack_hand(var/mob/user)
+	if (!has_ui_access(user))
+		user << "<span class='warning'>The unit's interface refuses to unlock!</span>"
+		return
+
 	var/dat
-	dat += "<TT><B>Automatic Medical Unit v1.0</B></TT><BR><BR>"
+	dat += "<TT><B>Automatic Medical Unit v1.1</B></TT><BR><BR>"
 	dat += "Status: <A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A><BR>"
 	dat += "Maintenance panel is [open ? "opened" : "closed"]<BR>"
 	dat += "Beaker: "
@@ -152,7 +156,7 @@
 
 		dat += "The speaker switch is [vocal ? "on" : "off"]. <a href='?src=\ref[src];togglevoice=[1]'>Toggle</a><br>"
 
-	user << browse("<HEAD><TITLE>Medibot v1.0 controls</TITLE></HEAD>[dat]", "window=automed")
+	user << browse("<HEAD><TITLE>Medibot v1.1 controls</TITLE></HEAD>[dat]", "window=automed")
 	onclose(user, "automed")
 	return
 
@@ -178,13 +182,18 @@
 		return
 	usr.set_machine(src)
 	add_fingerprint(usr)
-	if ((href_list["power"]) && access_scanner.allowed(usr))
+
+	if (!has_ui_access(usr))
+		usr << "<span class='warning'>Insufficient permissions.</span>"
+		return
+
+	if (href_list["power"])
 		if (on)
 			turn_off()
 		else
 			turn_on()
 
-	else if((href_list["adj_threshold"]) && (!locked || issilicon(usr)))
+	else if(href_list["adj_threshold"] && (!locked || issilicon(usr)))
 		var/adjust_num = text2num(href_list["adj_threshold"])
 		heal_threshold += adjust_num
 		if(heal_threshold < 5)
@@ -192,7 +201,7 @@
 		if(heal_threshold > 75)
 			heal_threshold = 75
 
-	else if((href_list["adj_inject"]) && (!locked || issilicon(usr)))
+	else if(href_list["adj_inject"] && (!locked || issilicon(usr)))
 		var/adjust_num = text2num(href_list["adj_inject"])
 		injection_amount += adjust_num
 		if(injection_amount < 5)
@@ -200,7 +209,7 @@
 		if(injection_amount > 15)
 			injection_amount = 15
 
-	else if((href_list["use_beaker"]) && (!locked || issilicon(usr)))
+	else if(href_list["use_beaker"] && (!locked || issilicon(usr)))
 		use_beaker = !use_beaker
 
 	else if (href_list["eject"] && (!isnull(reagent_glass)))
@@ -210,10 +219,10 @@
 		else
 			usr << "<span class='notice'>You cannot eject the beaker because the panel is locked.</span>"
 
-	else if ((href_list["togglevoice"]) && (!locked || issilicon(usr)))
+	else if (href_list["togglevoice"] && (!locked || issilicon(usr)))
 		vocal = !vocal
 
-	else if ((href_list["declaretreatment"]) && (!locked || issilicon(usr)))
+	else if (href_list["declaretreatment"] && (!locked || issilicon(usr)))
 		declare_treatment = !declare_treatment
 
 	attack_hand(usr)

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -254,6 +254,12 @@
 	qdel(src)
 	return
 
+/mob/living/bot/medbot/turn_off()
+	patient = null
+	frustration = 0
+	currently_healing = 0
+	..()
+
 /mob/living/bot/medbot/proc/valid_healing_target(var/mob/living/carbon/human/H)
 	if(H.stat == DEAD) // He's dead, Jim
 		return null

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -39,7 +39,7 @@
 	var/next_destination = "__nearest__"	// This is the next beacon's ID
 	var/nearest_beacon				// Tag of the beakon that we assume to be the closest one
 
-	var/bot_version = 1.3
+	var/bot_version = 1.4
 	var/list/threat_found_sounds = new('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg')
 	var/list/preparing_arrest_sounds = new('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/binsult.ogg', 'sound/voice/bcreep.ogg')
 
@@ -71,6 +71,9 @@
 		icon_state = "secbot[on]"
 
 /mob/living/bot/secbot/attack_hand(var/mob/user)
+	if (!has_ui_access(user))
+		user << "<span class='warning'>The unit's interface refuses to unlock!</span>"
+		return
 	user.set_machine(src)
 	var/dat
 	dat += "<TT><B>Automatic Security Unit v[bot_version]</B></TT><BR><BR>"
@@ -95,11 +98,18 @@
 	usr.set_machine(src)
 	add_fingerprint(usr)
 
-	if((href_list["power"]) && (access_scanner.allowed(usr)))
+	if (!has_ui_access(usr))
+		usr << "<span class='warning'>Insufficient permissions.</span>"
+		return
+
+	if(href_list["power"])
 		if(on)
 			turn_off()
 		else
 			turn_on()
+		attack_hand(usr)
+
+	if (locked && !issilicon(usr))
 		return
 
 	switch(href_list["operation"])

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -27,6 +27,7 @@
 	status_flags = 0
 	faction = "cult"
 	status_flags = CANPUSH
+	hunger_enabled = 0
 
 /mob/living/simple_animal/shade/cultify()
 	return

--- a/html/changelogs/inselc-PR-1088.yml
+++ b/html/changelogs/inselc-PR-1088.yml
@@ -1,0 +1,10 @@
+author: inselc
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed hungry Shades."
+  - bugfix: "Fixed AI being able to interact with IV drips."
+  - bugfix: "Fixed Alt-Clicking PDA on ground displaying wrong message."
+  - bugfix: "Fixed smallbot controls access."
+  - bugfix: "Fixed mice being able to open and close laptop computers."


### PR DESCRIPTION
This PR contains patches for:
- Shades displaying hunger status on examine()
- AI being able to eject blood bags from IV drips
- PDAs displaying misleading message when alt-clicking them while on the ground
- small-bot (medbot, floorbot, beepsky, ...) UI/controls access
- Mice being able to open and close laptop computers

The smallbot-fix will allow everyone with master_access + AI to use the bot's controls (Roboticists will need to unlock the bot by swiping their ID, first). Need some more opinions about this potentially being OP.