### PR TITLE
Sprint and Vehicle fixes

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -141,18 +141,19 @@
 		if(M.lastarea.has_gravity == 0)
 			inertial_drift(M)
 
-		var/mob/living/carbon/human/MOB = M
-		if(istype(MOB) && !MOB.lying && footstep_sound)
-			if(istype(MOB.shoes, /obj/item/clothing/shoes) && !MOB.shoes:silent)
-				if(MOB.m_intent == "run")
-					playsound(MOB, footstep_sound, 70, 1)
-				else //Run and walk footsteps switched, because walk is the normal movement mode now
-					if(MOB.footstep >= 2)
-						MOB.footstep = 0
-					else
-						MOB.footstep++
-					if(MOB.footstep == 0)
-						playsound(MOB, footstep_sound, 40, 1)
+		if (!M.buckled)
+			var/mob/living/carbon/human/MOB = M
+			if(istype(MOB) && !MOB.lying && footstep_sound)
+				if(istype(MOB.shoes, /obj/item/clothing/shoes) && !MOB.shoes:silent)
+					if(MOB.m_intent == "run")
+						playsound(MOB, footstep_sound, 70, 1)
+					else //Run and walk footsteps switched, because walk is the normal movement mode now
+						if(MOB.footstep >= 2)
+							MOB.footstep = 0
+						else
+							MOB.footstep++
+						if(MOB.footstep == 0)
+							playsound(MOB, footstep_sound, 40, 1)
 
 
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -334,12 +334,12 @@
 	else
 		remainder = cost
 
-	H.adjustOxyLoss(remainder*0.3)
+	H.adjustOxyLoss(remainder*0.25)
 	H.adjustHalLoss(remainder*0.25)
 	H.updatehealth()
 	H.update_oxy_overlay()
 
-	if (H.oxyloss >= exhaust_threshold)
+	if (H.oxyloss >= (exhaust_threshold * 0.8))
 		H.m_intent = "walk"
 		H.hud_used.move_intent.update_move_icon(H)
 		H << span("danger", "You're too exhausted to run anymore!")

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -257,8 +257,39 @@
 			src << "\blue You're pinned to a wall by [mob.pinned[1]]!"
 			return 0
 
+
+
 		move_delay = world.time//set move delay
 		mob.last_move_intent = world.time + 10
+
+
+		if (mob.buckled || mob.pulledby)
+			if(istype(mob.buckled, /obj/vehicle))
+				//manually set move_delay for vehicles so we don't inherit any mob movement penalties
+				//specific vehicle move delays are set in code\modules\vehicles\vehicle.dm
+				move_delay = world.time
+				//drunk driving
+				if(mob.confused && prob(20))
+					direct = pick(cardinal)
+				return mob.buckled.relaymove(mob,direct)
+
+			if(istype(mob.loc, /turf/space)) // Wheelchair driving!
+				return // No wheelchair driving in space
+			if(istype(mob.pulledby, /obj/structure/bed/chair/wheelchair))
+				return mob.pulledby.relaymove(mob, direct)
+			else if(istype(mob.buckled, /obj/structure/bed/chair/wheelchair))
+				if(ishuman(mob.buckled))
+					var/mob/living/carbon/human/driver = mob.buckled
+					var/obj/item/organ/external/l_hand = driver.get_organ("l_hand")
+					var/obj/item/organ/external/r_hand = driver.get_organ("r_hand")
+					if((!l_hand || l_hand.is_stump()) && (!r_hand || r_hand.is_stump()))
+						return // No hands to drive your chair? Tough luck!
+				//drunk wheelchair driving
+				if(mob.confused && prob(20))
+					direct = pick(cardinal)
+				move_delay += 2
+				return mob.buckled.relaymove(mob,direct)
+
 		if (ishuman(mob))
 
 			var/mob/living/carbon/human/H = mob
@@ -282,36 +313,12 @@
 			move_delay = move_delay + tickcomp
 
 
-		if(istype(mob.buckled, /obj/vehicle))
-			//manually set move_delay for vehicles so we don't inherit any mob movement penalties
-			//specific vehicle move delays are set in code\modules\vehicles\vehicle.dm
-			move_delay = world.time
-			//drunk driving
-			if(mob.confused && prob(20))
-				direct = pick(cardinal)
-			return mob.buckled.relaymove(mob,direct)
+
 
 		if(istype(mob.machine, /obj/machinery))
 			if(mob.machine.relaymove(mob,direct))
 				return
 
-		if(mob.pulledby || mob.buckled) // Wheelchair driving!
-			if(istype(mob.loc, /turf/space))
-				return // No wheelchair driving in space
-			if(istype(mob.pulledby, /obj/structure/bed/chair/wheelchair))
-				return mob.pulledby.relaymove(mob, direct)
-			else if(istype(mob.buckled, /obj/structure/bed/chair/wheelchair))
-				if(ishuman(mob.buckled))
-					var/mob/living/carbon/human/driver = mob.buckled
-					var/obj/item/organ/external/l_hand = driver.get_organ("l_hand")
-					var/obj/item/organ/external/r_hand = driver.get_organ("r_hand")
-					if((!l_hand || l_hand.is_stump()) && (!r_hand || r_hand.is_stump()))
-						return // No hands to drive your chair? Tough luck!
-				//drunk wheelchair driving
-				if(mob.confused && prob(20))
-					direct = pick(cardinal)
-				move_delay += 2
-				return mob.buckled.relaymove(mob,direct)
 
 		//We are now going to move
 		moving = 1

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -6,7 +6,7 @@
 	on = 0
 	powered = 1
 	locked = 0
-
+	move_speed = 3
 	load_item_visible = 1
 	load_offset_x = 0
 	mob_offset_y = 7
@@ -29,7 +29,7 @@
 	anchored = 0
 	passenger_allowed = 0
 	locked = 0
-
+	//move_speed = 3
 	load_item_visible = 1
 	load_offset_x = 0
 	load_offset_y = 4
@@ -352,15 +352,12 @@
 /obj/vehicle/train/cargo/engine/update_car(var/train_length, var/active_engines)
 	src.train_length = train_length
 	src.active_engines = active_engines
-
+	move_speed = initial(move_speed)		//so that engines that have been turned off don't lag behind
 	//Update move delay
-	if(!is_train_head() || !on)
-		move_delay = initial(move_delay)		//so that engines that have been turned off don't lag behind
-	else
-		move_delay = max(0, (-car_limit * active_engines) + train_length - active_engines)	//limits base overweight so you cant overspeed trains
-		move_delay *= (1 / max(1, active_engines)) * 2 										//overweight penalty (scaled by the number of engines)
-		move_delay += config.run_speed 														//base reference speed
-		move_delay *= 1.1																	//makes cargo trains 10% slower than running when not overweight
+	if(is_train_head() && on)
+		var/remainder = (car_limit * active_engines) - (train_length - active_engines)
+		if (remainder)
+			move_speed -= 0.25 * remainder															//makes cargo trains 10% slower than running when not overweight
 
 /obj/vehicle/train/cargo/trolley/update_car(var/train_length, var/active_engines)
 	src.train_length = train_length

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -2,7 +2,6 @@
 	name = "train"
 	dir = 4
 
-	move_delay = 1
 
 	health = 100
 	maxhealth = 100
@@ -29,12 +28,18 @@
 	var/old_loc = get_turf(src)
 	if(..())
 		if(tow)
-			tow.Move(old_loc)
+			tow.forceMove(old_loc)
 		return 1
 	else
 		if(lead)
 			unattach()
 		return 0
+
+obj/vehicle/train/forceMove()
+	var/old_loc = get_turf(src)
+	..()
+	if(tow)
+		tow.forceMove(old_loc)
 
 /obj/vehicle/train/Bump(atom/Obstacle)
 	if(!istype(Obstacle, /atom/movable))
@@ -51,7 +56,7 @@
 			var/mob/living/M = A
 			visible_message("\red [src] knocks over [M]!")
 			M.apply_effects(5, 5)				//knock people down if you hit them
-			M.apply_damages(22 / move_delay)	// and do damage according to how fast the train is going
+			M.apply_damages(10 * move_speed)	// and do damage according to how fast the train is going
 			if(istype(load, /mob/living/carbon/human))
 				var/mob/living/D = load
 				D << "\red You hit [M]!"

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -28,7 +28,10 @@
 	var/stat = 0
 	var/emagged = 0
 	var/powered = 0		//set if vehicle is powered and should use fuel when moving
-	var/move_delay = 1	//set this to limit the speed of the vehicle
+
+	move_speed = 2//Expressed in tiles per second. This is used to control how fast the vehicle moves
+
+	var/move_delay//DO NOT MANUALLY SET THIS. For internal use only
 
 	var/obj/item/weapon/cell/cell
 	var/charge_use = 5	//set this to adjust the amount of power the vehicle uses per move
@@ -45,8 +48,22 @@
 /obj/vehicle/New()
 	..()
 	//spawn the cell you want in each vehicle
+	calc_delay()
+
+/obj/vehicle/proc/calc_delay()
+	if (!move_speed || move_speed < 0)//Shouldn't happen
+		move_speed = 0
+		move_delay = 999999999
+		return 0
+
+	move_delay = (1 / move_speed) * 10
+	return 1
+
 
 /obj/vehicle/Move()
+	if (!move_speed)
+		return 0
+
 	if(world.time > l_move_time + move_delay)
 		var/old_loc = get_turf(src)
 		if(on && powered && cell.charge < charge_use)
@@ -180,6 +197,7 @@
 // Vehicle procs
 //-------------------------------------------
 /obj/vehicle/proc/turn_on()
+	calc_delay()
 	if(stat)
 		return 0
 	if(powered && cell.charge < charge_use)
@@ -308,6 +326,7 @@
 	if(ismob(C))
 		buckle_mob(C)
 
+	calc_delay()
 	return 1
 
 /obj/vehicle/user_unbuckle_mob(var/mob/user)
@@ -355,7 +374,7 @@
 		unbuckle_mob(load)
 
 	load = null
-
+	calc_delay()
 	return 1
 
 


### PR DESCRIPTION
A number of bugfixes and under-the-hood tweaks. Nothing here needs changelog, and shouldn't really be noticed by players:

Fixes vehicles using stamina or moving faster when in sprint mode.
Fixes getting footstep sounds when driving a vehicle.
Changes cargo trains to use forceMove instead of move, for towing cars behind them. This fixes an issue where the train would become disconnected if the engine moved too fast.
Completely divorces vehicles from using mob speed vars at all, speed is defined on a per-vehicle basis.
Removes knockdown from sprinting exhaustion. Characters will now stop sprinting before they collapse.