### PR TITLE
Nymph draining fix

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/diona_powers.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_powers.dm
@@ -241,6 +241,7 @@
 			var/remove_amount = (total_blood - 280) * 0.3
 			if (remove_amount > 0)
 				vessel.remove_reagent("blood", remove_amount, 1)//85 units of blood is enough to affect a human and make them woozy
+				nutrition += remove_amount*0.5
 			var/list/data = vessel.get_data("blood")
 			newDNA = data["blood_DNA"]
 
@@ -250,7 +251,7 @@
 			donor.adjustBruteLoss(4)
 			src.visible_message("<span class='notice'>[src] sucks some blood from [donor.name]</span>", "<span class='notice'>You extract a delicious mouthful of blood from [donor.name]!</span>")
 
-			nutrition += remove_amount*0.5
+
 
 
 			if (newDNA in sampled_DNA)

--- a/code/modules/mob/living/carbon/alien/diona/diona_powers.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_powers.dm
@@ -250,7 +250,7 @@
 			donor.adjustBruteLoss(4)
 			src.visible_message("<span class='notice'>[src] sucks some blood from [donor.name]</span>", "<span class='notice'>You extract a delicious mouthful of blood from [donor.name]!</span>")
 
-			nutrition += 40
+			nutrition += remove_amount*0.5
 
 
 			if (newDNA in sampled_DNA)

--- a/code/modules/mob/living/carbon/alien/diona/diona_powers.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_powers.dm
@@ -229,14 +229,18 @@
 
 		src.visible_message("<span class='danger'>[src] is trying to bite [donor.name]</span>", "\red You start biting [donor.name], you and them must stay still!")
 		face_atom(get_turf(donor))
-		if (do_mob(src, donor, 30, needhand = 0))
+		if (do_mob(src, donor, 40, needhand = 0))
 
 			//Attempt to find the blood vessel, but don't create a fake one if its not there.
 			//If the target doesn't have a vessel its probably due to someone not implementing it properly, like xenos
 			//We'll still allow it
 			var/datum/reagents/vessel = donor.get_vessel(1)
 			var/newDNA
-			vessel.remove_reagent("blood", 85, 1)//85 units of blood is enough to affect a human and make them woozy
+			var/datum/reagent/blood/B = vessel.get_master_reagent()
+			var/total_blood = B.volume
+			var/remove_amount = (total_blood - 280) * 0.3
+			if (remove_amount > 0)
+				vessel.remove_reagent("blood", remove_amount, 1)//85 units of blood is enough to affect a human and make them woozy
 			var/list/data = vessel.get_data("blood")
 			newDNA = data["blood_DNA"]
 

--- a/html/changelogs/Nanako-Nymphblood.yml
+++ b/html/changelogs/Nanako-Nymphblood.yml
@@ -1,0 +1,7 @@
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - tweak: "Fixed nymphs being able to kill people by repeated DNA sampling."


### PR DESCRIPTION
Fixes nymphs being able to kill people by repeated blood sampling.
The amount drained will gradually drop off and never bring blood below half