### PR TITLE
Bugfixes: Fax machines, CentCom turrets, Robo-limb emag. New feature for monkey cubes

### DIFF
--- a/code/modules/cciaa/cciaa.dm
+++ b/code/modules/cciaa/cciaa.dm
@@ -154,9 +154,8 @@
 
 			M.implant_loyalty(M, 1)
 
-			var/obj/item/weapon/card/id/W = new(M)
+			var/obj/item/weapon/card/id/centcom/W = new(M)
 			W.name = "[M.real_name]'s ID Card"
-			W.icon_state = "centcom"
 			W.item_state = "id_inv"
 			W.access = get_all_accesses() + get_centcom_access("CCIA Agent")
 			W.assignment = "Central Command Internal Affairs Agent"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -224,7 +224,7 @@ emp_act
 	if(istype(I,/obj/item/weapon/card/emag))
 		if(!(affecting.status & ORGAN_ROBOT))
 			user << "\red That limb isn't robotic."
-			return
+			return 0
 		if(affecting.sabotaged)
 			user << "\red [src]'s [affecting.name] is already sabotaged!"
 		else
@@ -232,7 +232,7 @@ emp_act
 			var/obj/item/weapon/card/emag/emag = I
 			emag.uses--
 			affecting.sabotaged = 1
-		return 1
+		return 0
 
 	if(I.attack_verb.len)
 		visible_message("\red <B>[src] has been [pick(I.attack_verb)] in the [hit_area] with [I.name] by [user]!</B>")

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1596,7 +1596,7 @@
 
 	afterattack(obj/O as obj, var/mob/living/carbon/human/user as mob, proximity)
 		if(!proximity) return
-		if(istype(O,/obj/structure/sink) && !wrapped)
+		if(( istype(O, /obj/structure/reagent_dispensers/watertank) || istype(O,/obj/structure/sink) ) && !wrapped)
 			user << "You place \the [name] under a stream of water..."
 			if(istype(user))
 				user.unEquip(src)

--- a/html/changelogs/inselc-PR-1116.yml
+++ b/html/changelogs/inselc-PR-1116.yml
@@ -1,0 +1,10 @@
+author: inselc
+
+delete-after: True
+
+changes: 
+  - bugfix: "Removed animation on emagging robotic limbs."
+  - bugfix: "Fixed CCIAA turret whitelist."
+  - bugfix: "Fixed fax machine cooldown."
+  - rscadd: "Added ability to expand monkey cubes at water tanks."
+  - rscadd: "Added stationwide fax broadcast."


### PR DESCRIPTION
This PR contains bugfixes for:
- Fax machine cooldown
- CCIAA turret whitelist (possibly also fixes related access issues)
- Animation playing while "sneakily" emagging robotic limbs

While at it, added feature to broadcast fax to all on-station fax machines.

Added ability to expand monkey cubes using water tanks, since that one was a single-line-mod. Is it alright to include that one in this PR (since it's not really a bugfix)?