### PR TITLE
Sprinting and Movedelay fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1729,13 +1729,18 @@
 	if (failed_last_breath || oxyloss > exhaust_threshold)//Can't catch our breath if we're suffocating
 		return
 
+	if (nutrition <= 0)
+		if (prob(1.5))
+			src << span("warning", "You feel hungry and exhausted, eat something to regain your energy!")
+		return
+
 	if (stamina != max_stamina)
 		//Any suffocation damage slows stamina regen.
 		//This includes oxyloss from low blood levels
 		var/regen = stamina_recovery * (1 - min(((oxyloss*2) / exhaust_threshold), 1))
 		if (regen > 0)
 			stamina = min(max_stamina, stamina+regen)
-			nutrition -= stamina_recovery*0.4
+			nutrition = max(0, nutrition - stamina_recovery*0.32)
 			hud_used.move_intent.update_move_icon(src)
 
 /mob/living/carbon/human/proc/update_health_display()

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -114,8 +114,8 @@
 
 	var/stamina	=	100			  	// The maximum stamina this species has. Determines how long it can sprint
 	var/stamina_recovery = 3	  	// Flat amount of stamina species recovers per proc
-	var/sprint_speed_factor = 0.65	// The percentage of bonus speed you get when sprinting. 0.4 = 40%
-	var/sprint_cost_factor = 1.0  	// Multiplier on stamina cost for sprinting
+	var/sprint_speed_factor = 0.7	// The percentage of bonus speed you get when sprinting. 0.4 = 40%
+	var/sprint_cost_factor = 0.9  	// Multiplier on stamina cost for sprinting
 	var/exhaust_threshold = 50	  	// When stamina runs out, the mob takes oxyloss up til this value. Then collapses and drops to walk
 
 	                              // Determines the organs that the species spawns with and

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -15,8 +15,8 @@
 
 	stamina	=	130			  // Humans can sprint for longer than any other species
 	stamina_recovery = 5
-	sprint_speed_factor = 0.8
-	sprint_cost_factor = 0.7
+	sprint_speed_factor = 0.85
+	sprint_cost_factor = 0.6
 
 /datum/species/unathi
 	name = "Unathi"
@@ -35,7 +35,8 @@
 	stamina	=	120			  // Unathi have the shortest but fastest sprint of all
 	sprint_speed_factor = 3
 	stamina_recovery = 5
-	sprint_cost_factor = 1.8
+	sprint_cost_factor = 1.55
+	exhaust_threshold = 65
 	rarity_value = 3
 
 	blurb = "A heavily reptillian species, Unathi (or 'Sinta as they call themselves) hail from the \
@@ -101,8 +102,8 @@
 
 	stamina	=	90			  // Tajarans evolved to maintain a steady pace in the snow, sprinting wastes energy
 	stamina_recovery = 4
-	sprint_speed_factor = 0.55
-	sprint_cost_factor = 1
+	sprint_speed_factor = 0.6
+	sprint_cost_factor = 0.85
 
 
 	blurb = "The Tajaran race is a species of feline-like bipeds hailing from the planet of Ahdomai in the \
@@ -166,7 +167,7 @@
 	ethanol_resistance = 0.5//gets drunk faster
 
 	stamina	=	90
-	sprint_speed_factor = 1.1 //Evolved for rapid escapes from predators
+	sprint_speed_factor = 1.15 //Evolved for rapid escapes from predators
 
 
 /datum/species/diona
@@ -242,8 +243,8 @@
 	reagent_tag = IS_DIONA
 
 	stamina	=	-1			  // Diona sprinting uses energy instead of stamina
-	sprint_speed_factor = 0.4		  //Speed gained is minor
-
+	sprint_speed_factor = 0.45		  //Speed gained is minor
+	sprint_cost_factor = 0.9
 
 /datum/species/diona/handle_sprint_cost(var/mob/living/carbon/human/H, var/cost)
 	var/datum/dionastats/DS = H.get_dionastats()
@@ -251,7 +252,7 @@
 	if (!DS)
 		return 0 //Something is very wrong
 
-	var/remainder = cost
+	var/remainder = cost * sprint_cost_factor
 
 	if (H.radiation)
 		if (H.radiation > (cost*0.5))//Radiation counts as double energy
@@ -338,13 +339,13 @@
 	has_organ = list() //TODO: Positronic brain.
 
 	stamina	= -1		  // Machines use power and generate heat, stamina is not a thing
-	sprint_speed_factor = 0.85	  // About as capable of speed as a human
+	sprint_speed_factor = 0.9	  // About as capable of speed as a human
 
 
 /datum/species/machine/handle_sprint_cost(var/mob/living/carbon/human/H, var/cost)
 	if (H.stat == CONSCIOUS)
-		H.bodytemperature += cost*1.35
-		H.nutrition -= cost*0.9
+		H.bodytemperature += cost*1.25
+		H.nutrition -= cost*0.75
 		if (H.nutrition > 0)
 			return 1
 		else
@@ -407,8 +408,8 @@
 	base_color = "#575757"
 
 	stamina	=	100			  // Long period of sprinting, but relatively low speed gain
-	sprint_speed_factor = 0.5
-	sprint_cost_factor = 0.27
+	sprint_speed_factor = 0.55
+	sprint_cost_factor = 0.23
 	stamina_recovery = 1//slow recovery
 
 

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -59,7 +59,7 @@
 	else
 		newspeed = text2num(response)
 
-	if (!newspeed || newspeed >= speed || newspeed <= 0)
+	if (!newspeed || newspeed >= speed || newspeed <= 0.2)
 		src << "Error, invalid value entered. Walk speed has not been changed"
 		return
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -181,7 +181,19 @@
 
 	if(moving) return 0
 
-	if(world.time < move_delay)	return
+	if(world.time < move_delay)
+		return
+
+
+//This compensates for the inaccuracy of move ticks
+//Whenever world.time overshoots the movedelay, due to it only ticking once per decisecond
+//The overshoot value is subtracted from our next delay, farther down where move delay is set.
+//This doesn't entirely remove the problem, but it keeps travel times accurate to within 0.1 seconds
+//Over an infinite distance, and prevents the inaccuracy from compounding. Thus making it basically a non-issue
+	var/leftover = world.time - move_delay
+	if (leftover > 1)
+		leftover = 0
+
 
 	if(locate(/obj/effect/stop/, mob.loc))
 		for(var/obj/effect/stop/S in mob.loc)
@@ -259,7 +271,7 @@
 
 
 
-		move_delay = world.time//set move delay
+		move_delay = world.time - leftover//set move delay
 		mob.last_move_intent = world.time + 10
 
 

--- a/html/changelogs/Nanako_Sprintfixes.yml
+++ b/html/changelogs/Nanako_Sprintfixes.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed a significant issue that caused many people to sprint slower than they should have."
+  - bugfix: "Fixed being able to regenerate stamina while hungry and drive nutrition into infinite negative."
+  - bugfix: "Fixed being able to set your walk speed so low you paralyse yourself almost forever."
+  - tweak: "Adjusted many values related to sprinting and stamina"


### PR DESCRIPTION
A package of small fixes and tweaks to sprinting, but more importantly, a very major fix

Client/Move only fires off once per decisecond (roughly every 0.9 deciseconds actually, it seems) and it checks then for if world.time is greater than movedelay.

This can result in it overshooting the delay by almost 0.9 deciseconds, which doesn't seem like much but it adds up over time, and creates a significant - and inconsistent slowdown, which affects fast moving player mobs. Sprinting has revealed this weakness. In one test, a journey that should have taken 7 seconds, was taking 9 seconds instead. 

The inaccuracy issue was causing everyone, every step, to be slowed down by a value equal to their movedelay delta % 0.9
Which meant it applied consistently to any single actor, but not consistently across mobs, and in a way that had no relation to a mob's speed, only how close it was to a multiple of 0.9
tajaran walk speed for example, at 4.5 dc delay, was entirely unaffected. Most other species were slowed down by 0.4-0.8 dc per step

My solution; I've implemented compensation for this issue. Whenever world.time overshoots the movedelay, the remainder is subtracted from the next movedelay. This keeps movement speed consistent and actually smooths things out a bit. It doesn't completely solve the problem, but it keeps travel times accurate to within 1 decisecond and prevents it from growing and compounding over long distances.

As a result of this fix, most player controlled mobs will be a bit faster, and it may be worth considering increasing the human delay a little to compensate. Most importantly though, this means that everyone is exactly as fast as they should be and not slowed down by a bug.

As for the other factors:
Sprint speeds slightly increased for most species
Sprinting costs lowered by 15% for everyone
Nutrition costs of regenerating stamina lowered by 20%
Fixes being able to paralyse yourself with low walk speed, and being able to rack up infinite negative nutrition by constantly sprinting.