### PR TITLE
Cargo Stock Fixes 4

### DIFF
--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -216,7 +216,7 @@ var/list/global/random_stock_rare = list(
 	"cloak" = 0.75,
 	"sword" = 0.75,
 	"ims" = 1.5,
-	"exogear" = 1.5,//!!!!!
+	"exogear" = 1.5,
 	"teleporter" = 1,
 	"voice" = 1.5,
 	"nothing" = 0)
@@ -661,7 +661,8 @@ var/list/global/random_stock_large = list(
 		if ("gloves")
 			var/list/allgloves = typesof(/obj/item/clothing/gloves)
 
-			var/list/exclusion = list(/obj/item/clothing/gloves/fluff,\
+			var/list/exclusion = list(/obj/item/clothing/gloves,
+			/obj/item/clothing/gloves/fluff,
 			/obj/item/clothing/gloves/swat/bst)
 			exclusion += typesof(/obj/item/clothing/gloves/rig)
 			exclusion += typesof(/obj/item/clothing/gloves/lightrig)

--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -32,6 +32,10 @@ more variety, and keeps the odds of any one specific item to be about the same
 
 */
 
+
+
+//Debugging verbs. Uncomment this block for some useful cargo debug commands
+/*
 var/global/stockname = ""
 
 /client/verb/set_stock_name()
@@ -51,7 +55,7 @@ var/global/stockname = ""
 	while (num > 0)
 		spawn_stock(stockname, get_turf(mob))
 		num--
-
+*/
 
 var/list/global/random_stock_common = list(
 	"toolbox" = 4,

--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -32,6 +32,27 @@ more variety, and keeps the odds of any one specific item to be about the same
 
 */
 
+var/global/stockname = ""
+
+/client/verb/set_stock_name()
+	stockname = input(usr, "Enter name", "Select stock by name") as text
+
+/client/verb/spawn_1()
+	spawn_stock(stockname, get_turf(mob))
+
+/client/verb/spawn_10()
+	var/num = 10
+	while (num > 0)
+		spawn_stock(stockname, get_turf(mob))
+		num--
+
+/client/verb/spawn_100()
+	var/num = 100
+	while (num > 0)
+		spawn_stock(stockname, get_turf(mob))
+		num--
+
+
 var/list/global/random_stock_common = list(
 	"toolbox" = 4,
 	"meds" = 5,
@@ -90,15 +111,16 @@ var/list/global/random_stock_common = list(
 	"cosmetic" = 2.2,
 	"suitcooler" = 1.2,
 	"officechair" = 1.2,
-	"booze" = 3,
+	"booze" = 3.5,
 	"plant" = 3.5,
 	"bag" = 2,
 	"extinguish" = 2.2,
 	"hailer" = 1.1,
 	"target" = 2,
-	"snacks" = 3.5,
-	"oxytank" = 2.5,
+	"snacks" = 4,
+	"oxytank" = 2.5,//
 	"signs" = 4,
+	"posters" = 3,
 	"parts" = 6,
 	"cane" = 2,
 	"warning" = 2.2,
@@ -120,7 +142,7 @@ var/list/global/random_stock_uncommon = list(
 	"flare" = 2,
 	"deathalarm" = 2,
 	"trackimp" = 1,
-	"flashbang" = 1,
+	"flashbang" = 0.75,
 	"cuffs" = 1,
 	"monkey" = 2,
 	"specialcrayon" = 1.5,
@@ -136,8 +158,8 @@ var/list/global/random_stock_uncommon = list(
 	"bible" = 1,
 	"advwelder" = 2,
 	"sord" = 1,
-	"policebaton" = 2,
-	"stunbaton" = 1,//batons spawn with no powercell
+	"policebaton" = 1.5,
+	"stunbaton" = 0.75,//batons spawn with no powercell
 	"watches" = 3,
 	"MMI" = 1.5,
 	"voidsuit" = 2,
@@ -154,21 +176,21 @@ var/list/global/random_stock_uncommon = list(
 	"linenbin" = 1,
 	"coatrack" = 1,
 	"riotshield" = 2,
-	"fireaxe" = 1.5,
+	"fireaxe" = 1,
 	"service" = 2,
 	"robot" = 2,
-	"latexb" = 1.2,
+	"latexb" = 0.5,
 	"taperoll" = 1,
 	"headset" = 2,
 	"bat" = 1.2,
-	"scythe" = 1,
+	"scythe" = 0.75,
 	"manual" = 2,
 	"jammer" = 2,
 	"rped" = 2,
 	"briefcase" = 2,
-	"blade" = 1.5,
+	"blade" = 1.2,
 	"exoquip" = 2,
-	"laserscalpel" = 1.5,
+	"laserscalpel" = 1.3,
 	"electropack" = 1,
 	"nothing" = 0)
 
@@ -176,23 +198,23 @@ var/list/global/random_stock_rare = list(
 	"gold" = 2.5,
 	"diamond" = 1.5,
 	"uranium" = 3,
-	"EMP" = 1,
+	"EMP" = 0.75,
 	"hypercell" = 3,
 	"combatmeds" = 3,
-	"batterer" = 1,
+	"batterer" = 0.75,
 	"posibrain" = 3,
 	"augmentvision" = 1.6,
-	"thermals" = 2,
+	"thermals" = 1.5,
 	"bsbeaker" = 3,
-	"energyshield" = 3,
+	"energyshield" = 2,
 	"hardsuit" = 0.75,
 	"cluster" = 2.0,
-	"cloak" = 1,
-	"sword" = 1,
+	"cloak" = 0.75,
+	"sword" = 0.75,
 	"ims" = 1.5,
-	"exogear" = 1.5,
+	"exogear" = 1.5,//!!!!!
 	"teleporter" = 1,
-	"voice" = 2,
+	"voice" = 1.5,
 	"nothing" = 0)
 
 var/list/global/random_stock_large = list(
@@ -573,8 +595,12 @@ var/list/global/random_stock_large = list(
 		if("circuitboard")
 			//Spawns a random circuitboard
 			//Allboards being a global list might be faster, but it didnt seem worth the extra memory
-			var/list/allboards = typesof(/obj/item/weapon/circuitboard)
-			allboards -= typesof(/obj/item/weapon/circuitboard/mecha)
+			var/list/allboards = subtypesof(/obj/item/weapon/circuitboard)
+			var/list/exclusion = list(/obj/item/weapon/circuitboard/unary_atmos, \
+				/obj/item/weapon/circuitboard/telecomms, )
+			exclusion += typesof(/obj/item/weapon/circuitboard/mecha)
+
+			allboards -= exclusion
 			var/type = pick(allboards)
 			new type(L)
 
@@ -630,14 +656,17 @@ var/list/global/random_stock_large = list(
 			new /obj/item/weapon/grenade/chem_grenade/metalfoam(L)
 		if ("gloves")
 			var/list/allgloves = typesof(/obj/item/clothing/gloves)
+
+			var/list/exclusion = list(/obj/item/clothing/gloves/fluff,\
+			/obj/item/clothing/gloves/swat/bst)
+			exclusion += typesof(/obj/item/clothing/gloves/rig)
+			exclusion += typesof(/obj/item/clothing/gloves/lightrig)
+			allgloves -= exclusion
 			var/number = rand(1,5)
 			while (number > 0)
 				var/gtype = pick(allgloves)
-				var/thing = new gtype(L)
-				if (!istype(thing, /obj/item/clothing/gloves/rig))//Rig gloves would be buggy
-					number--
-				else
-					qdel(thing)
+				new gtype(L)
+				number--
 		if ("insulated")
 			new /obj/item/clothing/gloves/yellow(L)
 			new /obj/item/clothing/gloves/yellow(L)
@@ -651,7 +680,6 @@ var/list/global/random_stock_large = list(
 			"/obj/item/device/slime_scanner" = 1,
 			"/obj/item/weapon/autopsy_scanner" = 1,
 			"/obj/item/device/robotanalyzer" = 4,
-			"/obj/machinery/disease2/diseaseanalyser" = 0.5,
 			"/obj/item/weapon/mining_scanner" = 1,
 			"/obj/item/device/ano_scanner" = 1,
 			"/obj/item/device/reagent_scanner" = 2,
@@ -757,7 +785,7 @@ var/list/global/random_stock_large = list(
 				new /obj/structure/reagent_dispensers/beerkeg(T)
 			else
 				var/list/drinks = typesof(/obj/item/weapon/reagent_containers/food/drinks/bottle)
-
+				drinks -= /obj/item/weapon/reagent_containers/food/drinks/bottle
 				var/number = rand(1,3)
 				while (number > 0)
 					var/type = pick(drinks)
@@ -885,8 +913,6 @@ var/list/global/random_stock_large = list(
 				new /obj/item/weapon/cane/concealed(L)
 			else if (prob(20))
 				new /obj/item/weapon/staff/broom(L)
-			else if (prob(30))
-				new /obj/item/weapon/staff/stick(L)
 			else
 				new /obj/item/weapon/cane(L)
 
@@ -906,7 +932,6 @@ var/list/global/random_stock_large = list(
 			"/obj/item/clothing/mask/gas/mime" = 0.5,
 			"/obj/item/clothing/mask/gas/monkeymask" = 0.5,
 			"/obj/item/clothing/mask/gas/sexymime" = 0.5,
-			"/obj/item/clothing/mask/gas/death_commando" = 2,
 			"/obj/item/clothing/mask/gas/cyborg" = 1,
 			"/obj/item/clothing/mask/gas/owl_mask" = 1
 			)
@@ -934,6 +959,8 @@ var/list/global/random_stock_large = list(
 				new /obj/item/device/flashlight/lantern(L)
 			if (prob(50))
 				new /obj/item/weapon/mining_scanner(L)
+			if (prob(25))
+				new /obj/item/weapon/storage/box/excavation(L)
 
 		if ("paicard")
 			new /obj/item/device/paicard(L)
@@ -1096,8 +1123,13 @@ var/list/global/random_stock_large = list(
 
 		//Spawns several random circuitboards
 		if("circuitboards")
-			var/list/allboards = typesof(/obj/item/weapon/circuitboard)
-			allboards -= typesof(/obj/item/weapon/circuitboard/mecha)
+			var/list/allboards = subtypesof(/obj/item/weapon/circuitboard)
+			var/list/exclusion = list(/obj/item/weapon/circuitboard/unary_atmos, \
+				/obj/item/weapon/circuitboard/telecomms, )
+			exclusion += typesof(/obj/item/weapon/circuitboard/mecha)
+
+			allboards -= exclusion
+
 			var/number = rand(2,5)
 			while (number > 0)
 				var/type = pick(allboards)
@@ -1139,8 +1171,10 @@ var/list/global/random_stock_large = list(
 			new /obj/random/voidsuit(L,1)
 
 		if ("signs")
-			var/list/allsigns = typesof(/obj/structure/sign)
+			var/list/allsigns = subtypesof(/obj/structure/sign)
 			allsigns -= typesof(/obj/structure/sign/double)
+			allsigns -= typesof(/obj/structure/sign/poster)
+			allsigns -= /obj/structure/sign/directions
 			var/number = rand(1,5)
 
 			while (number > 0)
@@ -1149,6 +1183,12 @@ var/list/global/random_stock_large = list(
 					var/obj/structure/sign/S = new newsign(L)
 					S.unfasten()
 					number--
+		if ("posters")
+			new /obj/item/weapon/contraband/poster(L)
+			if (prob(50))
+				new /obj/item/weapon/contraband/poster(L)
+			if (prob(50))
+				new /obj/item/weapon/contraband/poster(L)
 
 		if ("violin")
 			new /obj/item/device/violin(L)
@@ -1215,9 +1255,10 @@ var/list/global/random_stock_large = list(
 							L = U
 							break
 			var/mob/living/bot/newbot = new type(L)
-			newbot.on = 0//Deactivated
+
 			if (prob(10))
 				newbot.Emag(null)
+			newbot.turn_off()
 		if ("latexb")
 			new /obj/item/latexballon(L)
 
@@ -1509,6 +1550,7 @@ var/list/global/random_stock_large = list(
 			while (number > 0)
 				var/type = pickweight(equips)
 				new type(L)
+				number--
 
 		if ("teleporter")
 			new /obj/item/weapon/hand_tele(L)


### PR DESCRIPTION
Blacklists a lot of iconless things and base classes
Fixes a pretty critical infinite loop with cargo spawning that was crashing the server
Moves posters out of the signs spawn and into their own, spawns them properly in the item form.
Removes disease analyser from scanners
Reduces weights on various weapons and traitor items
Some other minor tweaks to weights