### PR TITLE
Bugfix/blood bag desc

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -68,7 +68,7 @@
 /obj/item/weapon/reagent_containers/blood/examine(mob/user, distance = 2)
 	..()
 	if (vampire_marks)
-		user << "<span='notice'>There are teeth marks on it.</span>"
+		user << "<span class='warning'>There are teeth marks on it.</span>"
 	return
 
 /obj/item/weapon/reagent_containers/blood/attackby(obj/item/weapon/P as obj, mob/user as mob)

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -66,8 +66,7 @@
 		..()
 
 /obj/item/weapon/reagent_containers/blood/examine(mob/user, distance = 2)
-	..()
-	if (vampire_marks)
+	if (..() && vampire_marks)
 		user << "<span class='warning'>There are teeth marks on it.</span>"
 	return
 

--- a/html/changelogs/Bedshaped-PR-1166.yml
+++ b/html/changelogs/Bedshaped-PR-1166.yml
@@ -1,0 +1,6 @@
+author: Bedshaped
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed bitten blood bag message displaying incorrectly."


### PR DESCRIPTION
`..()` returns `distance == -1 || (get_dist(src, user) <= distance)`

changes: 
   - bugfix: "Fixed bitten blood bag message displaying incorrectly."