### PR TITLE
Attack Proc fixes

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -15,7 +15,7 @@ mob/attacked_with_item() should then do mob-type specific stuff (like determinin
 
 Item Hit Effects:
 
-item/apply_hit_effect() can be overriden to do whatever you want. However "standard" physical damage based weapons should make use of the target mob's hit_with_weapon() proc to 
+item/apply_hit_effect() can be overriden to do whatever you want. However "standard" physical damage based weapons should make use of the target mob's hit_with_weapon() proc to
 avoid code duplication. This includes items that may sometimes act as a standard weapon in addition to having other effects (e.g. stunbatons on harm intent).
 */
 
@@ -49,11 +49,13 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return
 
 //I would prefer to rename this attack_as_weapon(), but that would involve touching hundreds of files.
-/obj/item/proc/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/proc/attack(mob/living/M, mob/living/user, var/target_zone = "chest")
+
 	if(!force || (flags & NOBLUDGEON))
 		return 0
 	if(M == user && user.a_intent != I_HURT)
 		return 0
+
 
 	/////////////////////////
 	user.lastattacked = M
@@ -69,6 +71,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	user.do_attack_animation(M)
 
 	var/hit_zone = M.resolve_item_attack(src, user, target_zone)
+	world << "[src] hitzone is [hit_zone] and targetzone is [target_zone]"
 	if(hit_zone)
 		apply_hit_effect(M, user, hit_zone)
 
@@ -78,9 +81,10 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /obj/item/proc/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
 	if(hitsound)
 		playsound(loc, hitsound, 50, 1, -1)
-	
+
 	var/power = force
 	if(HULK in user.mutations)
 		power *= 2
+	world << "Hitting with power [power]"
 	return target.hit_with_weapon(src, user, power, hit_zone)
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -71,7 +71,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	user.do_attack_animation(M)
 
 	var/hit_zone = M.resolve_item_attack(src, user, target_zone)
-	world << "[src] hitzone is [hit_zone] and targetzone is [target_zone]"
 	if(hit_zone)
 		apply_hit_effect(M, user, hit_zone)
 
@@ -85,6 +84,5 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	var/power = force
 	if(HULK in user.mutations)
 		power *= 2
-	world << "Hitting with power [power]"
 	return target.hit_with_weapon(src, user, power, hit_zone)
 

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -26,7 +26,7 @@
 /obj/item/weapon/toy/xmas_cracker/New()
 	..()
 
-/obj/item/weapon/toy/xmas_cracker/attack(mob/target, mob/user)
+/obj/item/weapon/toy/xmas_cracker/attack(mob/target, mob/user, var/target_zone)
 	if( !cracked && istype(target,/mob/living/carbon/human) && (target.stat == CONSCIOUS) && !target.get_active_hand() )
 		target.visible_message("<span class='notice'>[user] and [target] pop \an [src]! *pop*</span>", "<span class='notice'>You pull \an [src] with [target]! *pop*</span>", "<span class='notice'>You hear a *pop*.</span>")
 		var/obj/item/weapon/paper/Joke = new /obj/item/weapon/paper(user.loc)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -91,7 +91,7 @@
 					qdel(src)
 	return
 
-/obj/item/weapon/pen/crayon/attack(mob/M as mob, mob/user as mob)
+/obj/item/weapon/pen/crayon/attack(mob/M as mob, mob/user as mob, var/target_zone)
 	if(M == user)
 		user << "You take a bite of the crayon and swallow it."
 		user.nutrition += 1
@@ -102,4 +102,4 @@
 				user << "<span class='warning'>You ate your crayon!</span>"
 				qdel(src)
 	else
-		..()
+		..(M, user, target_zone)

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -10,7 +10,7 @@
 
 	var/mob/living/silicon/ai/carded_ai
 
-/obj/item/device/aicard/attack(mob/living/silicon/decoy/M as mob, mob/user as mob)
+/obj/item/device/aicard/attack(mob/living/silicon/decoy/M as mob, mob/user as mob, var/target_zone)
 	if (!istype (M, /mob/living/silicon/decoy))
 		return ..()
 	else

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -6,12 +6,12 @@
 	icon_state = "tube"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	amount = 10
-	
+
 	var/list/construction_cost = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 7000)
 	var/construction_time = 5
 
 
-/obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob, var/target_zone)
 	if (!istype(M) || !istype(user))
 		return 0
 	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs
@@ -29,7 +29,7 @@
 
 	if (istype(M,/mob/living/carbon/human))		//Repairing robolimbs
 		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/S = H.get_organ(user.zone_sel.selecting)
+		var/obj/item/organ/external/S = H.get_organ(target_zone)
 
 		if(S.open == 1)
 			if (S && (S.status & ORGAN_ROBOT))

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -26,12 +26,12 @@
 		src.icon_state = "implanter0"
 	return
 
-/obj/item/weapon/implanter/attack(mob/M as mob, mob/user as mob)
+/obj/item/weapon/implanter/attack(mob/M as mob, mob/user as mob, var/target_zone)
 	if (!istype(M, /mob/living/carbon))
 		return
 	if (user && src.imp)
 		M.visible_message("<span class='warning'>[user] is attemping to implant [M].</span>")
-		
+
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 		user.do_attack_animation(M)
 
@@ -48,7 +48,7 @@
 					src.imp.implanted = 1
 					if (ishuman(M))
 						var/mob/living/carbon/human/H = M
-						var/obj/item/organ/external/affected = H.get_organ(user.zone_sel.selecting)
+						var/obj/item/organ/external/affected = H.get_organ(target_zone)
 						affected.implants += src.imp
 						imp.part = affected
 

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -23,12 +23,12 @@
 	create_reagents(5)
 	return
 
-/obj/item/weapon/material/kitchen/utensil/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/material/kitchen/utensil/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
 	if(!istype(M))
 		return ..()
 
 	if(user.a_intent != I_HELP)
-		if(user.zone_sel.selecting == "head" || user.zone_sel.selecting == "eyes")
+		if(target_zone == "head" || target_zone == "eyes")
 			if((CLUMSY in user.mutations) && prob(50))
 				M = user
 			return eyestab(M,user)
@@ -93,7 +93,7 @@
 	applies_material_colour = 0
 	unbreakable = 1
 
-/obj/item/weapon/material/kitchen/utensil/knife/attack(target as mob, mob/living/user as mob)
+/obj/item/weapon/material/kitchen/utensil/knife/attack(target as mob, mob/living/user as mob, var/target_zone)
 	if ((CLUMSY in user.mutations) && prob(50))
 		user << "<span class='warning'>You accidentally cut yourself with \the [src].</span>"
 		user.take_organ_damage(20)
@@ -116,7 +116,7 @@
 	force_divisor = 0.7 // 10 when wielded with weight 15 (wood)
 	thrown_force_divisor = 1 // as above
 
-/obj/item/weapon/material/kitchen/rollingpin/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/weapon/material/kitchen/rollingpin/attack(mob/living/M as mob, mob/living/user as mob, var/target_zone)
 	if ((CLUMSY in user.mutations) && prob(50))
 		user << "<span class='warning'>\The [src] slips out of your hand and hits your head.</span>"
 		user.drop_from_inventory(src)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -154,11 +154,11 @@
 		reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
 		..()
 
-/obj/item/weapon/storage/fancy/cigarettes/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/storage/fancy/cigarettes/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob,var/target_zone)
 	if(!istype(M, /mob))
 		return
 
-	if(M == user && user.zone_sel.selecting == "mouth" && contents.len > 0 && !user.wear_mask)
+	if(M == user && target_zone == "mouth" && contents.len > 0 && !user.wear_mask)
 		var/obj/item/clothing/mask/smokable/cigarette/W = new /obj/item/clothing/mask/smokable/cigarette(user)
 		reagents.trans_to_obj(W, (reagents.total_volume/contents.len))
 		user.equip_to_slot_if_possible(W, slot_wear_mask)
@@ -215,11 +215,11 @@
 		reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
 		..()
 
-/obj/item/weapon/storage/fancy/cigar/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/storage/fancy/cigar/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
 	if(!istype(M, /mob))
 		return
 
-	if(M == user && user.zone_sel.selecting == "mouth" && contents.len > 0 && !user.wear_mask)
+	if(M == user && target_zone == "mouth" && contents.len > 0 && !user.wear_mask)
 		var/obj/item/clothing/mask/smokable/cigarette/cigar/W = new /obj/item/clothing/mask/smokable/cigarette/cigar(user)
 		reagents.trans_to_obj(W, (reagents.total_volume/contents.len))
 		user.equip_to_slot_if_possible(W, slot_wear_mask)

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -90,18 +90,19 @@
 	force = initial(force)
 	for (var/obj/item/I in contents)
 		force += I.w_class*1.5
+	world << "Update force called"
 
 /obj/item/weapon/storage/toolbox/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
 	if (..(W, prevent_warning))
 		update_force()
 
 
-/obj/item/weapon/storage/toolbox/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/weapon/storage/toolbox/attack(mob/living/M as mob, mob/user as mob, var/target_zone)
 	update_force()
-	..(M, user)
-	if (contents.len)
-		spill(3, get_turf(M))
-		playsound(M, 'sound/items/trayhit2.ogg', 100, 1)  //sound playin' again
-		update_force()
-		user.visible_message(span("danger", "[user] smashes the [src] into [M], causing it to break open and strew its contents across the area"))
+	if (..())
+		if (contents.len)
+			spill(3, get_turf(M))
+			playsound(M, 'sound/items/trayhit2.ogg', 100, 1)  //sound playin' again
+			update_force()
+			user.visible_message(span("danger", "[user] smashes the [src] into [M], causing it to break open and strew its contents across the area"))
 

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -90,7 +90,6 @@
 	force = initial(force)
 	for (var/obj/item/I in contents)
 		force += I.w_class*1.5
-	world << "Update force called"
 
 /obj/item/weapon/storage/toolbox/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
 	if (..(W, prevent_warning))

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -24,7 +24,7 @@
 	slot_flags = SLOT_BELT
 	force = 10
 
-/obj/item/weapon/melee/classic_baton/attack(mob/M as mob, mob/living/user as mob)
+/obj/item/weapon/melee/classic_baton/attack(mob/M as mob, mob/living/user as mob, var/target_zone)
 	if ((CLUMSY in user.mutations) && prob(50))
 		user << "<span class='warning'>You club yourself over the head.</span>"
 		user.Weaken(3 * force)
@@ -90,7 +90,7 @@
 
 	return
 
-/obj/item/weapon/melee/telebaton/attack(mob/target as mob, mob/living/user as mob)
+/obj/item/weapon/melee/telebaton/attack(mob/target as mob, mob/living/user as mob, var/target_zone)
 	if(on)
 		if ((CLUMSY in user.mutations) && prob(50))
 			user << "<span class='warning'>You club yourself over the head.</span>"
@@ -103,7 +103,7 @@
 			return
 		if(..() == 1)
 			playsound(src.loc, "swing_hit", 50, 1, -1)
-			if(user.zone_sel.selecting == "r_leg" || user.zone_sel.selecting == "l_leg")
+			if(target_zone == "r_leg" || target_zone == "l_leg")
 				target.Weaken(5) //nerfed, because yes.
 			return
 	else

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -5,9 +5,9 @@
 	icon_state = "taperoll"
 	w_class = 1
 
-/obj/item/weapon/tape_roll/attack(var/mob/living/carbon/human/H, var/mob/user)
+/obj/item/weapon/tape_roll/attack(var/mob/living/carbon/human/H, var/mob/user, var/target_zone)
 	if(istype(H))
-		if(user.zone_sel.selecting == "eyes")
+		if(target_zone == "eyes")
 
 			if(!H.organs_by_name["head"])
 				user << "<span class='warning'>\The [H] doesn't have a head.</span>"
@@ -33,7 +33,7 @@
 			user.visible_message("<span class='danger'>\The [user] has taped up \the [H]'s eyes!</span>")
 			H.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses/blindfold/tape(H), slot_glasses)
 
-		else if(user.zone_sel.selecting == "mouth" || user.zone_sel.selecting == "head")
+		else if(target_zone == "mouth" || target_zone == "head")
 			if(!H.organs_by_name["head"])
 				user << "<span class='warning'>\The [H] doesn't have a head.</span>"
 				return
@@ -58,7 +58,7 @@
 			user.visible_message("<span class='danger'>\The [user] has taped up \the [H]'s mouth!</span>")
 			H.equip_to_slot_or_del(new /obj/item/clothing/mask/muzzle/tape(H), slot_wear_mask)
 
-		else if(user.zone_sel.selecting == "r_hand" || user.zone_sel.selecting == "l_hand")
+		else if(target_zone == "r_hand" || target_zone == "l_hand")
 			var/obj/item/weapon/handcuffs/cable/tape/T = new(user)
 			if(!T.place_handcuffs(H, user))
 				user.unEquip(T)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -75,10 +75,10 @@
 		src.pixel_y = rand(0, 16)
 	..()
 
-/obj/item/weapon/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
 	if(!istype(M) || user.a_intent == "help")
 		return ..()
-	if(user.zone_sel.selecting != "eyes" && user.zone_sel.selecting != "head")
+	if(target_zone != "eyes" && target_zone != "head")
 		return ..()
 	if((CLUMSY in user.mutations) && prob(50))
 		M = user
@@ -110,7 +110,7 @@
 		item_state = "cutters_yellow"
 	..()
 
-/obj/item/weapon/wirecutters/attack(mob/living/carbon/C as mob, mob/user as mob)
+/obj/item/weapon/wirecutters/attack(mob/living/carbon/C as mob, mob/user as mob, var/target_zone)
 	if(user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/weapon/handcuffs/cable)))
 		usr.visible_message("\The [usr] cuts \the [C]'s restraints with \the [src]!",\
 		"You cut \the [C]'s restraints with \the [src]!",\
@@ -289,11 +289,11 @@
 	if (istype(location, /turf))
 		location.hotspot_expose(700, 5)
 
-/obj/item/weapon/weldingtool/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/weapon/weldingtool/attack(mob/living/M as mob, mob/user as mob, var/target_zone)
 
 	if(hasorgans(M))
 
-		var/obj/item/organ/external/S = M:organs_by_name[user.zone_sel.selecting]
+		var/obj/item/organ/external/S = M:organs_by_name[target_zone]
 
 		if (!S) return
 		if(!(S.status & ORGAN_ROBOT) || user.a_intent != I_HELP)

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -31,7 +31,7 @@
 		/obj/item/weapon/flame/match,
 		/obj/item/weapon/material/ashtray)
 
-/obj/item/weapon/tray/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/tray/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
 
 	// Drop all the things. All of them.
 	spill(user, M.loc)
@@ -53,7 +53,7 @@
 	var/mob/living/carbon/human/H = M      ///////////////////////////////////// /Let's have this ready for later.
 
 
-	if(!(user.zone_sel.selecting == ("eyes" || "head"))) //////////////hitting anything else other than the eyes
+	if(!(target_zone == ("eyes" || "head"))) //////////////hitting anything else other than the eyes
 		if(prob(33) && !issilicon(M))//robots dont bleed
 			src.add_blood(H)
 			var/turf/location = H.loc
@@ -87,7 +87,7 @@
 		if(istype(protection) && (protection.body_parts_covered & FACE))
 			protected = 1
 			break
-	
+
 	if(protected)
 		M << "<span class='warning'>You get slammed in the face with the tray, against your mask!</span>"
 		if(prob(33) && !issilicon(M))

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -95,10 +95,10 @@
 	desc = "An outdated medical apparatus for listening to the sounds of the human body. It also makes you look like you know what you're doing."
 	icon_state = "stethoscope"
 
-/obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
+/obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user, var/target_zone)
 	if(ishuman(M) && isliving(user))
 		if(user.a_intent == I_HELP)
-			var/body_part = parse_zone(user.zone_sel.selecting)
+			var/body_part = parse_zone(target_zone)
 			if(body_part)
 				var/their = "their"
 				switch(M.gender)

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -328,7 +328,7 @@ All custom items with worn sprites must follow the contained sprite system: http
 
 	return
 
-/obj/item/weapon/implanter/fluff/attack(mob/M as mob, mob/user as mob)
+/obj/item/weapon/implanter/fluff/attack(mob/M as mob, mob/user as mob, var/target_zone)
 	if (!M.ckey || M.ckey != allowed_ckey)
 		return
 

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -76,7 +76,7 @@
 	name = "[initial(name)] (\the [H])"
 	icon_state = "fingerprint1"
 
-/obj/item/weapon/sample/print/attack(var/mob/living/M, var/mob/user)
+/obj/item/weapon/sample/print/attack(var/mob/living/M, var/mob/user, var/target_zone)
 
 	if(!ishuman(M))
 		return ..()
@@ -94,7 +94,7 @@
 		user.visible_message("<span class='danger'>\The [user] tries to take prints from \the [H], but they move away.</span>")
 		return 1
 
-	if(user.zone_sel.selecting == "r_hand" || user.zone_sel.selecting == "l_hand")
+	if(target_zone == "r_hand" || target_zone == "l_hand")
 		var/has_hand
 		var/obj/item/organ/external/O = H.organs_by_name["r_hand"]
 		if(istype(O) && !O.is_stump())

--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -9,7 +9,7 @@
 /obj/item/weapon/forensics/swab/proc/is_used()
 	return used
 
-/obj/item/weapon/forensics/swab/attack(var/mob/living/M, var/mob/user)
+/obj/item/weapon/forensics/swab/attack(var/mob/living/M, var/mob/user, var/target_zone)
 
 	if(!ishuman(M))
 		return ..()
@@ -32,7 +32,7 @@
 		user.visible_message("<span class='danger'>\The [user] tries to take a swab sample from \the [H], but they move away.</span>")
 		return
 
-	if(user.zone_sel.selecting == "mouth")
+	if(target_zone == "mouth")
 		if(!H.organs_by_name["head"])
 			user << "<span class='warning'>They don't have a head.</span>"
 			return
@@ -43,7 +43,7 @@
 		dna = list(H.dna.unique_enzymes)
 		sample_type = "DNA"
 
-	else if(user.zone_sel.selecting == "r_hand" || user.zone_sel.selecting == "l_hand")
+	else if(target_zone == "r_hand" || target_zone == "l_hand")
 		var/has_hand
 		var/obj/item/organ/external/O = H.organs_by_name["r_hand"]
 		if(istype(O) && !O.is_stump())

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -251,8 +251,8 @@
 	else
 		..()
 
-/obj/item/weapon/book/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(user.zone_sel.selecting == "eyes")
+/obj/item/weapon/book/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
+	if(target_zone == "eyes")
 		user.visible_message("<span class='notice'>You open up the book and show it to [M]. </span>", \
 			"<span class='notice'> [user] opens up a book and shows it to [M]. </span>")
 		M << browse("<TT><I>Penned by [author].</I></TT> <BR>" + "[dat]", "window=book")

--- a/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
@@ -36,3 +36,4 @@
 		wear_hat(W)
 		user.visible_message("<span class='notice'>\The [user] puts \the [W] on \the [src].</span>")
 		return
+	..(W, user)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -152,9 +152,11 @@ emp_act
 
 /mob/living/carbon/human/resolve_item_attack(obj/item/I, mob/living/user, var/target_zone)
 	if(check_attack_throat(I, user))
+		world << "Attack throat is true?"
 		return null
 
 	if(user == src) // Attacking yourself can't miss
+		world << "Returning target zone"
 		return target_zone
 
 	var/hit_zone = get_zone_with_miss_chance(target_zone, src)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -152,11 +152,9 @@ emp_act
 
 /mob/living/carbon/human/resolve_item_attack(obj/item/I, mob/living/user, var/target_zone)
 	if(check_attack_throat(I, user))
-		world << "Attack throat is true?"
 		return null
 
 	if(user == src) // Attacking yourself can't miss
-		world << "Returning target zone"
 		return target_zone
 
 	var/hit_zone = get_zone_with_miss_chance(target_zone, src)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -292,7 +292,7 @@
 
 	return 1
 
-/obj/item/weapon/grab/attack(mob/M, mob/living/user)
+/obj/item/weapon/grab/attack(mob/M, mob/living/user, var/target_zone)
 	if(!affecting)
 		return
 	if(world.time < (last_action + 20))
@@ -304,7 +304,7 @@
 	//clicking on the victim while grabbing them
 	if(M == affecting)
 		if(ishuman(affecting))
-			var/hit_zone = assailant.zone_sel.selecting
+			var/hit_zone = target_zone
 			flick(hud.icon_state, hud)
 			switch(assailant.a_intent)
 				if(I_HELP)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -139,13 +139,13 @@
 		onclose(usr, "[name]")
 	return
 
-/obj/item/weapon/paper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(user.zone_sel.selecting == "eyes")
+/obj/item/weapon/paper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
+	if(target_zone == "eyes")
 		user.visible_message("<span class='notice'>You show the paper to [M]. </span>", \
 			"<span class='notice'> [user] holds up a paper and shows it to [M]. </span>")
 		M.examinate(src)
 
-	else if(user.zone_sel.selecting == "mouth") // lipstick wiping
+	else if(target_zone == "mouth") // lipstick wiping
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H == user)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -58,7 +58,7 @@
 	colour = "white"
 
 
-/obj/item/weapon/pen/attack(mob/M as mob, mob/user as mob)
+/obj/item/weapon/pen/attack(mob/M as mob, mob/user as mob, var/target_zone)
 	if(!ismob(M))
 		return
 	user << "<span class='warning'>You stab [M] with the pen.</span>"

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -39,7 +39,7 @@
 			if(10 to 50) 		icon_state = "half"
 			if(51 to INFINITY)	icon_state = "full"
 
-/obj/item/weapon/reagent_containers/blood/attack(mob/living/carbon/human/M as mob, mob/living/carbon/human/user as mob)
+/obj/item/weapon/reagent_containers/blood/attack(mob/living/carbon/human/M as mob, mob/living/carbon/human/user as mob, var/target_zone)
 	if (user == M && (user.mind.vampire))
 		if (reagents.get_reagent_amount("blood"))
 			user.visible_message("<span class='warning'>[user] raises \the [src] up to \his[user] mouth and bites into it.</span>", "<span class='notice'>You raise \the [src] up to your mouth and bite into it, starting to drain its contents.<br>You need to stand still.</span>")

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -119,17 +119,17 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
 	var/blocked = ..()
-	
+
 	if(user.a_intent != I_HURT)
 		return
 	if(!smash_check(1))
 		return //won't always break on the first hit
-	
+
 	// You are going to knock someone out for longer if they are not wearing a helmet.
 	var/weaken_duration = 0
 	if(blocked < 2)
 		weaken_duration = smash_duration + min(0, force - target.getarmor(hit_zone, "melee") + 10)
-	
+
 	var/mob/living/carbon/human/H = target
 	if(istype(H) && H.headcheck(hit_zone))
 		var/obj/item/organ/affecting = H.get_organ(hit_zone) //headcheck should ensure that affecting is not null
@@ -165,7 +165,7 @@
 	edge = 0
 	var/icon/broken_outline = icon('icons/obj/drinks.dmi', "broken")
 
-/obj/item/weapon/broken_bottle/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/broken_bottle/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
 	return ..()
 


### PR DESCRIPTION
Baymerge changed the attack proc, i think by removing a default value, and a lot of things broke because they weren't using the function correctly.

This proc does three main things.

1. Adds a default to /obj/item/proc/attack to target the chest when no target zone is supplied.

2. Fixes the lack of a target zone in many attack procs, properly defining it so it'll get passed to the parent, and ensure that bodypart-specific targeting works.

3. Removes most instances of code to retrieve the user's selected zone, and instead to use the zone passed into the attack function. saves duplication of effort

This fixes toolboxes not doing damage (they weren't passing a target zone)


Also vaguely related, also fixes nymphs being immortal, they were lacking a call to parent in their attackby proc

There's nothing controversial here, but it should be reviewed carefully for typos or mistakes due to the large volume of things changed