### PR TITLE
Nutrition fixes and tweaks

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -1,4 +1,4 @@
-#define HUNGER_FACTOR              0.05 // Factor of how fast mob nutrition decreases
+
 
 #define REM 0.2 // Means 'Reagent Effect Multiplier'. This is how many units of reagent are consumed per tick
 

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -126,6 +126,9 @@
 #define GLUT_SMALLER 2    // Eat anything smaller than we are
 #define GLUT_ANYTHING 3   // Eat anything, ever
 
+#define BASE_MAX_NUTRITION	400
+#define HUNGER_FACTOR		0.05 // Factor of how fast mob nutrition decreases. Moved here from chemistry define
+
 #define TINT_NONE 0
 #define TINT_MODERATE 1
 #define TINT_HEAVY 2

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -33,7 +33,7 @@ Bonus
 				M << "<span class='notice'>[pick("You feel blubbery.", "You feel full.")]</span>"
 			else
 				M.overeatduration = min(M.overeatduration + 100, 600)
-				M.nutrition = min(M.nutrition + 100, 500)
+				M.nutrition = min(M.nutrition + 100, M.max_nutrition * 1.25)
 
 	return
 
@@ -114,6 +114,6 @@ Bonus
 		switch(A.stage)
 			if(4, 5)
 				M.overeatduration = 0
-				M.nutrition = 400
+				M.nutrition = M.max_nutrition
 
 	return

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -236,7 +236,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 
 	T.dna.real_name = T.real_name //Set this again, just to be sure that it's properly set.
 	changeling.absorbed_dna |= T.dna
-	if(src.nutrition < 400) src.nutrition = min((src.nutrition + T.nutrition), 400)
+	if(src.nutrition < max_nutrition) src.nutrition = min((nutrition + T.nutrition), max_nutrition)
 	changeling.chem_charges += 10
 	changeling.geneticpoints += 2
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -105,9 +105,9 @@
 			R.adjustFireLoss(-wire_rate)
 	else if(ishuman(occupant))
 		var/mob/living/carbon/human/H = occupant
-		if(!isnull(H.internal_organs_by_name["cell"]) && H.nutrition < 450)
-			H.nutrition = min(H.nutrition+10, 450)
-			cell.use(7000/450*10)
+		if(!isnull(H.internal_organs_by_name["cell"]) && H.nutrition < H.max_nutrition)
+			H.nutrition = min(H.nutrition+10, H.max_nutrition)
+			cell.use(7000/H.max_nutrition*10)
 
 
 /obj/machinery/recharge_station/examine(mob/user)

--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -6,7 +6,7 @@
 /mob/living/carbon/alien/diona
 	var/datum/reagents/vessel
 	var/list/internal_organs_by_name = list() // so internal organs have less ickiness too
-	var/max_nutrition = 6000
+	max_nutrition = 6000
 	language = null
 	var/energy_duration = 144//The time in seconds that this diona can exist in total darkness before its energy runs out
 	var/dark_consciousness = 144//How long this diona can stay on its feet and keep moving in darkness after energy is gone.

--- a/code/modules/mob/living/carbon/alien/diona/life.dm
+++ b/code/modules/mob/living/carbon/alien/diona/life.dm
@@ -14,7 +14,7 @@
 
 	// nutrition decrease
 	if (nutrition > 0 && stat != 2)
-		nutrition = max (0, nutrition - HUNGER_FACTOR)
+		nutrition = max (0, nutrition - nutrition_loss)
 
 	if (nutrition > max_nutrition)
 		nutrition = max_nutrition

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -36,9 +36,9 @@
 	. = ..()
 	if(.)
 		if(src.nutrition && src.stat != 2)
-			src.nutrition -= HUNGER_FACTOR/10
+			src.nutrition -= nutrition_loss*0.1//Multiplication is faster than division
 			if(src.m_intent == "run")
-				src.nutrition -= HUNGER_FACTOR/10
+				src.nutrition -= nutrition_loss*0.1
 		if((FAT in src.mutations) && src.m_intent == "run" && src.bodytemperature <= 360)
 			src.bodytemperature += 2
 

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -92,8 +92,8 @@ var/list/diona_banned_languages = list(
 		if(DS.nutrient_organ.is_bruised())
 			plus *= 0.5
 	nutrition += plus
-	if (nutrition > 400)
-		nutrition = 400
+	if (nutrition > max_nutrition)
+		nutrition = max_nutrition
 
 /mob/living/carbon/proc/diona_handle_temperature(var/datum/dionastats/DS)
 	if (bodytemperature < TEMP_REGEN_STOP)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1159,7 +1159,12 @@
 	sprint_speed_factor = species.sprint_speed_factor
 	sprint_cost_factor = species.sprint_cost_factor
 	stamina_recovery = species.stamina_recovery
+
 	exhaust_threshold = species.exhaust_threshold
+	max_nutrition = BASE_MAX_NUTRITION * species.max_nutrition_factor
+	nutrition = (rand(25,100)*0.01)*max_nutrition//Starting nutrition is randomised between 25-100% of max
+
+	nutrition_loss = HUNGER_FACTOR * species.nutrition_loss_factor
 	if(species)
 		return 1
 	else

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -17,8 +17,12 @@
 	if (!(species && (species.flags & NO_PAIN)))
 		if(halloss >= 10) tally += (halloss / 10) //halloss shouldn't slow you down if you can't even feel it
 
-	var/hungry = (500 - nutrition)/5 // So overeat would be 100 and default level would be 80
-	if (hungry >= 70) tally += hungry/50
+
+//Simpler hunger slowdown calculations, this should be a little faster due to no division, and more scaleable
+	if (nutrition < (max_nutrition * 0.4))
+		tally++
+		if (nutrition < (max_nutrition * 0.1))
+			tally++
 
 	if(wear_suit)
 		tally += wear_suit.slowdown

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -122,7 +122,6 @@
 	var/primitive_form            // Lesser form, if any (ie. monkey for humans)
 	var/greater_form              // Greater form, if any, ie. human for monkeys.
 	var/holder_type
-	var/gluttonous                // Can eat some mobs. Values can be GLUT_TINY, GLUT_SMALLER, GLUT_ANYTHING.
 	var/rarity_value = 1          // Relative rarity/collector value for this species.
 	var/ethanol_resistance = 1	  // How well the mob resists alcohol, lower values get drunk faster, higher values need to drink more
 
@@ -131,6 +130,10 @@
 	var/sprint_speed_factor = 0.7	// The percentage of bonus speed you get when sprinting. 0.4 = 40%
 	var/sprint_cost_factor = 0.9  	// Multiplier on stamina cost for sprinting
 	var/exhaust_threshold = 50	  	// When stamina runs out, the mob takes oxyloss up til this value. Then collapses and drops to walk
+
+	var/gluttonous                // Can eat some mobs. Values can be GLUT_TINY, GLUT_SMALLER, GLUT_ANYTHING.
+	var/max_nutrition_factor = 1	//Multiplier on maximum nutrition
+	var/nutrition_loss_factor = 1	//Multiplier on passive nutrition losses
 
 	                              // Determines the organs that the species spawns with and
 	var/list/has_organ = list(    // which required-organ checks are conducted.

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -71,7 +71,7 @@
 
 	//Hunger/feeding vars
 	var/hunger_enabled = 1//If set to 0, a creature ignores hunger
-	var/max_nutrition = 50
+	max_nutrition = 50
 	var/metabolic_factor = 1//A multiplier on how fast nutrition is lost. used to tweak the rates on a per-animal basis
 	var/nutrition_step = 0.2 //nutrition lost per tick and per step, calculated from mob_size, 0.2 is a fallback
 	var/bite_factor = 0.4

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -108,6 +108,8 @@
 	var/drowsyness = 0.0//Carbon
 	var/charges = 0.0
 	var/nutrition = 400.0//Carbon
+	var/nutrition_loss = HUNGER_FACTOR//How much hunger is lost per tick. This is modified by species
+	var/max_nutrition = 400
 
 	var/overeatduration = 0		// How long this guy is overeating //Carbon
 	var/paralysis = 0.0

--- a/html/changelogs/Nanako-Nutrition.yml
+++ b/html/changelogs/Nanako-Nutrition.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Nutrition is now randomised on spawning"


### PR DESCRIPTION
Fixes nutrition displays not updating.

Adds code support for species-variable levels of max nutrition storage, and nutrition loss. No actual variations are yet implemented, awaiting input from lore team.

Fixes all relevant static isntances of numeric literals with the max_nutrition variable

And a feature tweak: Players will now spawn with randomised nutrition levels when they join