### PR TITLE
Cargo Wire, runtime and inflatable fixes

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -190,24 +190,28 @@
 	update_nearby_tiles()
 
 /obj/structure/inflatable/door/proc/Open()
-	isSwitchingStates = 1
-	flick("door_opening",src)
-	sleep(10)
-	density = 0
-	opacity = 0
-	state = 1
-	update_icon()
-	isSwitchingStates = 0
+	spawn()
+		if(isSwitchingStates) return
+		isSwitchingStates = 1
+		flick("door_opening",src)
+		sleep(10)
+		density = 0
+		opacity = 0
+		state = 1
+		update_icon()
+		isSwitchingStates = 0
 
 /obj/structure/inflatable/door/proc/Close()
-	isSwitchingStates = 1
-	flick("door_closing",src)
-	sleep(10)
-	density = 1
-	opacity = 0
-	state = 0
-	update_icon()
-	isSwitchingStates = 0
+	spawn()
+		if(isSwitchingStates) return
+		isSwitchingStates = 1
+		flick("door_closing",src)
+		sleep(10)
+		density = 1
+		opacity = 0
+		state = 0
+		update_icon()
+		isSwitchingStates = 0
 
 /obj/structure/inflatable/door/update_icon()
 	if(state)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -660,9 +660,9 @@
 		src << "<span class='warning'>It won't budge!</span>"
 		return
 
-	var/mob/M = AM
+	var/mob/M = null
 	if(ismob(AM))
-
+		M = AM
 		if(!can_pull_mobs || !can_pull_size)
 			src << "<span class='warning'>It won't budge!</span>"
 			return

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -181,6 +181,8 @@
 //Updating pixelshift, position and direction
 //Gets called on process, when the grab gets upgraded or the assailant moves
 /obj/item/weapon/grab/proc/adjust_position()
+	if (!affecting)
+		return
 	if(affecting.buckled)
 		animate(affecting, pixel_x = 0, pixel_y = 0, 4, 1, LINEAR_EASING)
 		return

--- a/maps/exodus-1.dmm
+++ b/maps/exodus-1.dmm
@@ -3262,7 +3262,7 @@
 "bkL" = (/obj/machinery/door/airlock{name = "Unit 4"},/turf/simulated/floor/tiled/freezer,/area/crew_quarters/locker/locker_toilet)
 "bkM" = (/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/freezer,/area/crew_quarters/locker/locker_toilet)
 "bkN" = (/obj/machinery/button/remote/blast_door{id = "qm_warehouse"; name = "Warehouse Door Control"; pixel_x = -1; pixel_y = -24; req_access = list(31)},/obj/structure/closet/crate,/turf/simulated/floor/tiled,/area/quartermaster/storage)
-"bkO" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/power/apc{dir = 8; name = "west bump"; pixel_x = -24},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/quartermaster/storage)
+"bkO" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/power/apc{dir = 8; name = "west bump"; pixel_x = -24},/obj/effect/decal/cleanable/dirt,/obj/structure/cable,/turf/simulated/floor/tiled,/area/quartermaster/storage)
 "bkP" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/structure/table/steel,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled,/area/quartermaster/storage)
 "bkQ" = (/obj/effect/large_stock_marker,/turf/simulated/floor/tiled,/area/quartermaster/storage)
 "bkR" = (/obj/structure/disposalpipe/sortjunction/untagged{dir = 1},/obj/structure/table/steel,/turf/simulated/floor/tiled,/area/quartermaster/storage)


### PR DESCRIPTION
Fixes the APC in the cargo warehouse being unpowered
Fixes two runtime errors i reported
Fixes inflatable doors being unresponsive due to a sleep. Seperating the opening code off into a spawned child process has made it much more responsive