### PR TITLE
Visible message fix

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -468,21 +468,19 @@ its easier to just keep the beam vertical.
 // message is output to anyone who can see, e.g. "The [src] does something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 /atom/proc/visible_message(var/message, var/blind_message)
+	var/list/messageturfs = list()//List of turfs we broadcast to.
+	var/list/messagemobs = list()//List of living mobs nearby who can hear it, and distant ghosts who've chosen to hear it
+	for (var/turf in view(world.view, get_turf(src)))
+		messageturfs += turf
 
-	var/list/see = get_mobs_or_objects_in_view(world.view,src) | viewers(get_turf(src), null)
+	for(var/mob/M in player_list)
+		if (!M.client || istype(M, /mob/new_player))
+			continue
+		if(get_turf(M) in messageturfs)
+			messagemobs += M
 
-	for(var/I in see)
-		if(isobj(I))
-			spawn(0)
-				if(I) //It's possible that it could be deleted in the meantime.
-					var/obj/O = I
-					O.show_message( message, 1, blind_message, 2)
-		else if(ismob(I))
-			var/mob/M = I
-			if(M.see_invisible >= invisibility) // Cannot view the invisible
-				M.show_message( message, 1, blind_message, 2)
-			else if (blind_message)
-				M.show_message(blind_message, 2)
+	for(var/mob/M in messagemobs)
+		M.show_message(message, 1, blind_message, 2)
 
 // Show a message to all mobs and objects in earshot of this atom
 // Use for objects performing audible actions

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -473,13 +473,15 @@ its easier to just keep the beam vertical.
 	for (var/turf in view(world.view, get_turf(src)))
 		messageturfs += turf
 
-	for(var/mob/M in player_list)
+	for(var/A in player_list)
+		var/mob/M = A
 		if (!M.client || istype(M, /mob/new_player))
 			continue
 		if(get_turf(M) in messageturfs)
 			messagemobs += M
 
-	for(var/mob/M in messagemobs)
+	for(var/A in messagemobs)
+		var/mob/M = A
 		M.show_message(message, 1, blind_message, 2)
 
 // Show a message to all mobs and objects in earshot of this atom

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -101,13 +101,15 @@
 	for (var/turf in view(world.view, get_turf(src)))
 		messageturfs += turf
 
-	for(var/mob/M in player_list)
+	for(var/A in player_list)
+		var/mob/M = A
 		if (!M.client || istype(M, /mob/new_player))
 			continue
 		if(get_turf(M) in messageturfs)
 			messagemobs += M
 
-	for(var/mob/M in messagemobs)
+	for(var/A in messagemobs)
+		var/mob/M = A
 		if(self_message && M==src)
 			M.show_message(self_message, 1, blind_message, 2)
 		else if(M.see_invisible < invisibility)  // Cannot view the invisible, but you can hear it.
@@ -662,9 +664,9 @@
 		src << "<span class='warning'>It won't budge!</span>"
 		return
 
-	var/mob/M = AM
+	var/mob/M = null
 	if(ismob(AM))
-
+		M = AM
 		if(!can_pull_mobs || !can_pull_size)
 			src << "<span class='warning'>It won't budge!</span>"
 			return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -113,6 +113,8 @@
 		else if(M.see_invisible < invisibility)  // Cannot view the invisible, but you can hear it.
 			if(blind_message)
 				M.show_message(blind_message, 2)
+		else
+			M.show_message(message, 1, blind_message, 2)
 
 // Designed for mobs contained inside things, where a normal visible message wont actually be visible
 // Useful for visible actions by pAIs, and held mobs


### PR DESCRIPTION
Undoes baymerge's changes to visible messages and fixes our previous implementation that i wrote. 
Ours is much better all around. 

With the changes baymerge made, they added an additional view call, and some 700 show_message calls to objects, for every single message, its absurdly wasteful.

As far as i'm aware there is no current use case for showing visible messages to objects. If there ever is a need we can implement an efficient solution with a global list of listeners