### PR TITLE
Bug fixes (#1214, #1219, #1174, #1185, #1202, #1170)

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -107,6 +107,14 @@
 		return
 
 	command_announcement.Announce(text, title, new_sound = 'sound/AI/commandreport.ogg')
+	for (var/obj/machinery/computer/communications/C in machines)
+		if(! (C.stat & (BROKEN|NOPOWER) ) )
+			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( C.loc )
+			P.name = "[command_name()] Update"
+			P.info = replacetext(text, "\n", "<br/>")
+			P.update_space(P.info)
+			P.update_icon()
+
 
 /datum/game_mode/malfunction/verb/elite_encryption_hack()
 	set category = "Software"

--- a/code/game/objects/effects/decals/posters/bs12.dm
+++ b/code/game/objects/effects/decals/posters/bs12.dm
@@ -288,42 +288,42 @@
 	icon_state="bsposter58"
 	name = "space bear information poster"
 	desc = "This poster displays a picture of a legendary space bear."
-	
+
 /datum/poster/bay_59
 	icon_state = "bsposter59"
 	name = "ATLAS poster"
 	desc = "ATLAS: For all of Humanity."
-	
+
 /datum/poster/bay_60
 	icon_state = "bsposter60"
 	name = "N.S.S. Aurora"
 	desc = "This poster is a picture of the old, now defunct, N.S.S. Aurora. Commissioned in 2454 and decommissioned in the early days of 2458."
-	
+
 /datum/poster/bay_61
 	icon_state = "bsposter61"
 	name = "Xenobiology Safety Protocols"
 	desc = "This posters warms the crew about the dangers of xenobiology outbreaks."
-	
+
 /datum/poster/bay_62
 	icon_state = "bsposter62"
 	name = "Xenobiology Division"
 	desc = "This one depicts a green skrell research director doing autopsy on an alien lifeform."
-	
+
 /datum/poster/bay_63
 	icon_state = "bsposter63"
 	name = "Suit Sensors"
 	desc = "This particular one depicts a female doctor tending to an injured crewmember. It says; \"Remember to enable your suit sensors!\"."
-	
+
 /datum/poster/bay_64
 	icon_state = "bsposter64"
 	name = "Maintenance Drones"
-	desc = "This particular one depicts a maintenance drone. It reminders the crew to don't disturb them when they are doing repairs."
-	
+	desc = "This particular one depicts a maintenance drone. It reminds the crew to don't disturb them when they are doing repairs."
+
 /datum/poster/bay_65
 	icon_state = "bsposter65"
 	name = "Importance of Plasma"
 	desc = "A corporate morale poster showing three forms of plasma. Teaching the very basics of this really important substance."
-	
+
 /datum/poster/bay_66
 	icon_state = "bsposter66"
 	name = "BFG 9000"

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1005,10 +1005,13 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			var/who = src.owner
 			if(prob(50))
 				who = P.owner
+
 			for(var/mob/living/silicon/ai/ai in mob_list)
-				// Allows other AIs to intercept the message but the AI won't intercept their own message.
 				if(ai.aiPDA != P && ai.aiPDA != src)
-					ai.show_message("<i>Intercepted message from <b>[who]</b>: [t]</i>")
+					if(who != P.owner)
+						ai.show_message("<i>Intercepted message to <b>[who]</b>: [t]</i>")
+					else
+						ai.show_message("<i>Intercepted message from <b>[who]</b>: [t]</i>")
 
 		P.new_message_from_pda(src, t)
 		nanomanager.update_user_uis(U, src) // Update the sending user's PDA UI so that they can see the new message

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -12,7 +12,6 @@
 	var/on = 0.0
 	var/stabilization_on = 0
 	var/warned = 0
-	var/warnednogas
 	var/volume_rate = 500              //Needed for borg jetpack transfer
 	action_button_name = "Toggle Jetpack"
 
@@ -66,11 +65,13 @@
 		src.ion_trail.stop()
 		return 0
 
-	if((num < 5))
-		if(src.air_contents.total_moles <num && warned != 1)
-			warned = 1
-			playsound(user, 'sound/effects/alert.ogg', 50, 1)
-			user << "<span class='danger'>The meter on \the [src] indicates you are almost out of gas and beeps loudly!</span>"
+	if (src.air_contents.total_moles < 3 && !warned)
+		warned = 1
+		playsound(user, 'sound/effects/alert.ogg', 50, 1)
+		user << "<span class='danger'>The meter on \the [src] indicates you are almost out of gas and beeps loudly!</span>"
+		spawn(600)
+			warned = 0
+
 
 
 	var/datum/gas_mixture/G = src.air_contents.remove(num)

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -27,7 +27,6 @@
 	. = ..()
 	if(air_contents.total_moles < 5)
 		user << "<span class='danger'>The meter on \the [src] indicates you are almost out of gas!</span>"
-		playsound(user, 'sound/effects/alert.ogg', 50, 1)
 
 /obj/item/weapon/tank/jetpack/verb/toggle_rockets()
 	set name = "Toggle Jetpack Stabilization"

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -11,6 +11,8 @@
 	var/datum/effect/effect/system/ion_trail_follow/ion_trail
 	var/on = 0.0
 	var/stabilization_on = 0
+	var/warned = 0
+	var/warnednogas
 	var/volume_rate = 500              //Needed for borg jetpack transfer
 	action_button_name = "Toggle Jetpack"
 
@@ -63,6 +65,12 @@
 	if((num < 0.005 || src.air_contents.total_moles < num))
 		src.ion_trail.stop()
 		return 0
+
+	if((num < 5))
+		if(src.air_contents.total_moles <num && warned != 1)
+			warned = 1
+			playsound(user, 'sound/effects/alert.ogg', 50, 1)
+			user << "<span class='danger'>The meter on \the [src] indicates you are almost out of gas and beeps loudly!</span>"
 
 
 	var/datum/gas_mixture/G = src.air_contents.remove(num)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -465,7 +465,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(config.disable_player_mice)
 		src << "<span class='warning'>Spawning as a mouse is currently disabled.</span>"
 		return
-
+	if(ticker.current_state < GAME_STATE_PLAYING)
+		src << "<span class='warning'>You can not spawn as a mouse before round start!</span>"
+		return
 	if(!MayRespawn(1, ANIMAL_SPAWN_DELAY))
 		return
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -465,9 +465,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(config.disable_player_mice)
 		src << "<span class='warning'>Spawning as a mouse is currently disabled.</span>"
 		return
+		
 	if(ticker.current_state < GAME_STATE_PLAYING)
 		src << "<span class='warning'>You can not spawn as a mouse before round start!</span>"
 		return
+		
 	if(!MayRespawn(1, ANIMAL_SPAWN_DELAY))
 		return
 

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -75,7 +75,6 @@ var/list/cleanbot_types // Going to use this to generate a list of types once th
 	if(!path.len)
 		path = AStar(loc, target.loc, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id = botcard)
 		if(!path)
-			custom_emote(2, "can't reach \the [target.name] and is giving up for now.")
 			log_debug("[src] can't reach [target.name] ([target.x], [target.y])")
 			ignorelist |= target
 			target.clean_marked = null

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -75,7 +75,7 @@ var/list/cleanbot_types // Going to use this to generate a list of types once th
 	if(!path.len)
 		path = AStar(loc, target.loc, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id = botcard)
 		if(!path)
-			log_debug("[src] can't reach [target.name] ([target.x], [target.y])")
+			//log_debug("[src] can't reach [target.name] ([target.x], [target.y])")
 			ignorelist |= target
 			target.clean_marked = null
 			target = null
@@ -198,7 +198,6 @@ var/list/cleanbot_types // Going to use this to generate a list of types once th
 		return
 
 	cleaning = 1
-	custom_emote(2, "begins to clean up \the [D]")
 	target.being_cleaned = 1
 	update_icons()
 	var/cleantime = istype(D, /obj/effect/decal/cleanable/dirt) ? 10 : 50

--- a/html/changelogs/Printer16-Bugfixes.yml
+++ b/html/changelogs/Printer16-Bugfixes.yml
@@ -13,6 +13,6 @@ changes:
   - rscdel: "Removed empty jetpacks playing a sound."
   - bugfix: "A malfunctioning AI's advanced encyrption hack now prints a paper at the communications console."
   - bugfix: "Intercepted messages now say 'to' depending if it intercepted the message sender."
-  - bugfix: "Cleanbots no longer make emotes when they are unable to find their path (How would you know anyways?)"
+  - bugfix: "Cleanbots no longer make emotes when they are unable to find their path (How would you know anyways?) They are also a lot more quite."
   - bugfix: "You can no longer join as a mouse before roundstart."
   - bugfix: "The maintenance drone poster no longer has a typo."

--- a/html/changelogs/Printer16-Bugfixes.yml
+++ b/html/changelogs/Printer16-Bugfixes.yml
@@ -1,0 +1,17 @@
+# Your name.  
+author: Printer16
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removed empty jetpacks playing a sound."
+  - bugfix: "A malfunctioning AI's advanced encyrption hack now prints a paper at the communications console."
+  - bugfix: "Intercepted messages now say 'to' depending if it intercepted the message sender."
+  - bugfix: "Cleanbots no longer make emotes when they are unable to find their path (How would you know anyways?)"
+  - bugfix: "You can no longer join as a mouse before roundstart."

--- a/html/changelogs/Printer16-Bugfixes.yml
+++ b/html/changelogs/Printer16-Bugfixes.yml
@@ -15,3 +15,4 @@ changes:
   - bugfix: "Intercepted messages now say 'to' depending if it intercepted the message sender."
   - bugfix: "Cleanbots no longer make emotes when they are unable to find their path (How would you know anyways?)"
   - bugfix: "You can no longer join as a mouse before roundstart."
+  - bugfix: "The maintenance drone poster no longer has a typo."


### PR DESCRIPTION
Jetpack sounds #1214 -Removed the sound entirely. No point in it. Still says if its close to being out of gas, however.
AI malf paper #1219 
Typo in drone poster #1174
Intercepted messages show 'from' when they should show 'to' #1185
Cleanbots will spam emotes if they can't reach dirt  #1202 -How would bystanders know anyways?
Player controlled mice issues #1170 -Fixed this up by just saying nope to people trying to join as a mouse before roundstart.

