### PR TITLE
Small malfunction tweaks

### DIFF
--- a/code/game/gamemodes/malfunction/malf_hardware.dm
+++ b/code/game/gamemodes/malfunction/malf_hardware.dm
@@ -61,7 +61,7 @@
 /datum/malf_hardware/strong_turrets/install()
 	..()
 	for(var/obj/machinery/porta_turret/T in machines)
-		T.maxhealth = round(initial(T.maxhealth) * 1.4)
+		T.maxhealth = round(initial(T.maxhealth) * 2)
 		T.shot_delay = round(initial(T.shot_delay) / 2)
 		T.auto_repair = 1
 		T.active_power_usage = round(initial(T.active_power_usage) * 5)

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
@@ -25,14 +25,14 @@
 
 /datum/malf_research_ability/manipulation/emergency_forcefield
 	ability = new/datum/game_mode/malfunction/verb/emergency_forcefield()
-	price = 3000
+	price = 1750
 	next = new/datum/malf_research_ability/manipulation/machine_overload()
 	name = "Emergency Forcefield"
 
 
 /datum/malf_research_ability/manipulation/machine_overload
 	ability = new/datum/game_mode/malfunction/verb/machine_overload()
-	price = 7500
+	price = 5000
 	name = "Machine Overload"
 
 // END RESEARCH DATUMS

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -15,13 +15,11 @@
 	next = new/datum/malf_research_ability/networking/advanced_hack()
 	name = "Basic Encryption Hack"
 
-
 /datum/malf_research_ability/networking/advanced_hack
 	ability = new/datum/game_mode/malfunction/verb/advanced_encryption_hack()
 	price = 400
 	next = new/datum/malf_research_ability/networking/elite_hack()
 	name = "Advanced Encryption Hack"
-
 
 /datum/malf_research_ability/networking/elite_hack
 	ability = new/datum/game_mode/malfunction/verb/elite_encryption_hack()
@@ -32,7 +30,7 @@
 
 /datum/malf_research_ability/networking/system_override
 	ability = new/datum/game_mode/malfunction/verb/system_override()
-	price = 2750
+	price = 5000
 	name = "System Override"
 
 // END RESEARCH DATUMS
@@ -99,9 +97,9 @@
 		user << "Hack Aborted"
 		return
 
-	if(prob(60) && user.hack_can_fail)
+	if(prob(50) && user.hack_can_fail)
 		user << "Hack Failed."
-		if(prob(10))
+		if(prob(5))
 			user.hack_fails ++
 			announce_hack_failure(user, "quantum message relay")
 		return
@@ -114,7 +112,6 @@
 			P.info = replacetext(text, "\n", "<br/>")
 			P.update_space(P.info)
 			P.update_icon()
-
 
 /datum/game_mode/malfunction/verb/elite_encryption_hack()
 	set category = "Software"
@@ -130,9 +127,9 @@
 		user << "Hack Aborted"
 		return
 
-	if(prob(75) && user.hack_can_fail)
+	if(prob(60) && user.hack_can_fail)
 		user << "Hack Failed."
-		if(prob(20))
+		if(prob(10))
 			user.hack_fails ++
 			announce_hack_failure(user, "alert control system")
 		return

--- a/html/changelogs/Printer16-malfbalance.yml
+++ b/html/changelogs/Printer16-malfbalance.yml
@@ -6,3 +6,4 @@ changes:
   - tweak: "For malfunctioning AI, the system override research now takes longer."
   - tweak: "With the change above, it now takes less time to research forcefields and machine override."
   - tweak: "The turret enhancer hardware is slightly buffed to make it more useful."
+  - tweak: "There is now a slightly smaller fail and critical fail chance for the malfunctioning AI's Advanced and Elite hack."

--- a/html/changelogs/Printer16-malfbalance.yml
+++ b/html/changelogs/Printer16-malfbalance.yml
@@ -1,0 +1,8 @@
+author: Printer16
+
+delete-after: True
+
+changes: 
+  - tweak: "For malfunctioning AI, the system override research now takes longer."
+  - tweak: "With the change above, it now takes less time to research forcefields and machine override."
+  - tweak: "The turret enhancer hardware is slightly buffed to make it more useful."


### PR DESCRIPTION
This basically makes it harder for the AI to go NUKEM and easier to fake things like announcements and code changes. I increased the system override from 2750 to 5000 in terms of research points, and decreased machine override to 5000 as well as reducing the forcefield research costs. The turret hardware has been buffed slightly (More turret health) to make it (possibly) worthwhile. The Elite and Advanced encryption hacks have had their fail chance slightly reduced. I plan on possibly adding some new hardware for malfunction in the future such as EMP resistant electronics or possibly an interception research tree that allows the AI to intercept messages to centcom. This is to get a general feel of what the balance for things should be.