### PR TITLE
Golden slimes fix and simple mob alien death loop fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -89,12 +89,12 @@
 /obj/item/projectile/neurotox
 	damage = 30
 	icon_state = "toxin"
-
+/*
 /mob/living/simple_animal/hostile/alien/death()
 	..()
 	visible_message("[src] lets out a waning guttural screech, green blood bubbling from its maw...")
 	playsound(src, 'sound/voice/hiss6.ogg', 100, 1)
-
+*/
 // Xenoarch aliens.
 /mob/living/simple_animal/hostile/samak
 	name = "samak"

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -89,12 +89,12 @@
 /obj/item/projectile/neurotox
 	damage = 30
 	icon_state = "toxin"
-/*
+
 /mob/living/simple_animal/hostile/alien/death()
 	..()
 	visible_message("[src] lets out a waning guttural screech, green blood bubbling from its maw...")
 	playsound(src, 'sound/voice/hiss6.ogg', 100, 1)
-*/
+
 // Xenoarch aliens.
 /mob/living/simple_animal/hostile/samak
 	name = "samak"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -990,6 +990,7 @@
 		if(prob(50))
 			for(var/j = 1, j <= rand(1, 3), j++)
 				step(C, pick(NORTH,SOUTH,EAST,WEST))
+	..()
 
 //Silver
 /datum/chemical_reaction/slime/bork


### PR DESCRIPTION
Fix #1193
And removes the broken death proc from common xeno mobs.

This may help to fix #1015