### PR TITLE
Table and Crate interactions

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -253,3 +253,7 @@
 #define PERMABRIG_SENTENCE 90 // Measured in minutes
 //#define PERMAPRISON_SENTENCE 60 // Measured in IC days
 #define FELONY_LEVEL 2.0 // What is the minimum law severity that counts as a felony?
+
+#define LAYER_TABLE	2.8
+#define LAYER_UNDER_TABLE	2.79
+#define LAYER_ABOVE_TABLE	2.81

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -135,8 +135,11 @@
 
 
 
-
-//Table interactions
+/*
+==========================
+	Table interactions
+==========================
+*/
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if (istype(mover, /obj/structure/closet/crate))//Handle interaction with other crates
 		var/obj/structure/closet/crate/C = mover
@@ -199,24 +202,24 @@
 
 
 
-/obj/structure/closet/crate/proc/put_on_table(var/obj/structure/table/table, var/mob/usr)
-	if (!table || !usr || (tablestatus == -1))
+/obj/structure/closet/crate/proc/put_on_table(var/obj/structure/table/table, var/mob/user)
+	if (!table || !user || (tablestatus == -1))
 		return
 
 	//User must be in reach of the crate
-	if (!usr.Adjacent(src))
-		usr << span("warning", "You need to be closer to the crate!")
+	if (!user.Adjacent(src))
+		user << span("warning", "You need to be closer to the crate!")
 		return
 
 	//One of us has to be near the table
-	if (!usr.Adjacent(table) && !Adjacent(table))
-		usr << span("warning", "Take the crate closer to the table!")
+	if (!user.Adjacent(table) && !Adjacent(table))
+		user << span("warning", "Take the crate closer to the table!")
 		return
 
 
 	for (var/obj/structure/closet/crate/C in get_turf(table))
 		if (C.tablestatus != -1)
-			usr << span("warning", "There's already a crate on this table!")
+			user << span("warning", "There's already a crate on this table!")
 			return
 
 	//Crates are heavy, hauling them onto tables is hard.
@@ -239,9 +242,9 @@
 			timeneeded += 3* M.mob_size
 
 	if (timeneeded > 0)
-		usr.visible_message("[usr] starts hoisting [src] onto the [table]", "You start hoisting [src] onto the [table]. This will take about [timeneeded*0.1] seconds")
-		usr.face_atom(src)
-		if (do_after(usr, timeneeded, needhand = 1))
+		user.visible_message("[user] starts hoisting [src] onto the [table]", "You start hoisting [src] onto the [table]. This will take about [timeneeded*0.1] seconds")
+		user.face_atom(src)
+		if (do_after(user, timeneeded, needhand = 1))
 			success = 1
 
 
@@ -257,13 +260,11 @@
 
 
 
-
-
-
-
-
-
-
+/*
+=====================
+	Secure Crates
+=====================
+*/
 
 
 /obj/structure/closet/crate/secure

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -10,9 +10,14 @@
 	climbable = 1
 //	mouse_drag_pointer = MOUSE_ACTIVE_POINTER	//???
 	var/rigged = 0
+	var/tablestatus = 0
+	pass_flags = PASSTABLE
+
 
 /obj/structure/closet/crate/can_open()
-	return 1
+	if (tablestatus != -1)//Can't be opened while under a table
+		return 1
+	return 0
 
 /obj/structure/closet/crate/can_close()
 	return 1
@@ -49,7 +54,7 @@
 
 	icon_state = icon_opened
 	src.opened = 1
-
+	pass_flags = 0
 	return 1
 
 /obj/structure/closet/crate/close()
@@ -74,15 +79,11 @@
 
 	icon_state = icon_closed
 	src.opened = 0
+	pass_flags = PASSTABLE//Crates can only slide under tables when closed
 	return 1
 
 
-/obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(istype(mover,/obj/item/projectile) && prob(50))
-		return 1
-	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
-	return 0
+
 
 /obj/structure/closet/crate/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(opened)
@@ -130,6 +131,141 @@
 				A.ex_act(severity)
 		qdel(src)
 
+
+
+
+
+
+//Table interactions
+/obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if (istype(mover, /obj/structure/closet/crate))//Handle interaction with other crates
+		var/obj/structure/closet/crate/C = mover
+		if (tablestatus == 1 && C.tablestatus != 1 && !C.opened)//Allow the crate to slide under us if we're ontop of a table
+			return 1
+		else if (tablestatus == -1 && C.tablestatus == 1)//Allow it to slide over us if we're underneath a table
+			return 1
+		else//Otherwise, block it. Don't allow two crates on the same level of a tile
+			return 0
+	if(istype(mover,/obj/item/projectile))
+		if (tablestatus == 1)//They always block shots on a table
+			return 0
+		else if (!tablestatus && prob(15))//Usually will not block shots when lying on the floor
+			return 0
+		else return 1
+	else if(istype(mover) && mover.checkpass(PASSTABLE))
+		return 1
+	return 0
+
+/obj/structure/closet/crate/Move(var/turf/destination, dir)
+	if(..())
+		if (locate(/obj/structure/table) in destination)
+			if (tablestatus != 1)
+				set_tablestatus(-1)//Slide under the table
+		else
+			set_tablestatus(0)
+
+
+/obj/structure/closet/crate/toggle(var/mob/user)
+	if (!opened && tablestatus == -1)
+		user << span("warning", "You can't open that while it's under the table")
+		return 0
+	else
+		..()
+
+/obj/structure/closet/crate/proc/set_tablestatus(var/target)
+	if (tablestatus != target)
+		tablestatus = target
+
+	spawn(3)//Short spawn prevents things popping up where they shouldnt
+		switch (target)
+			if (1)
+				layer = LAYER_ABOVE_TABLE
+				pixel_y = 8
+			if (0)
+				layer = initial(layer)
+				pixel_y = 0
+			if (-1)
+				layer = LAYER_UNDER_TABLE
+				pixel_y = -4
+
+
+//For putting on tables
+/obj/structure/closet/crate/MouseDrop(atom/over_object)
+	if (istype(over_object, /obj/structure/table))
+		put_on_table(over_object, usr)
+		return 1
+	else
+		return ..()
+
+
+
+/obj/structure/closet/crate/proc/put_on_table(var/obj/structure/table/table, var/mob/usr)
+	if (!table || !usr || (tablestatus == -1))
+		return
+
+	//User must be in reach of the crate
+	if (!usr.Adjacent(src))
+		usr << span("warning", "You need to be closer to the crate!")
+		return
+
+	//One of us has to be near the table
+	if (!usr.Adjacent(table) && !Adjacent(table))
+		usr << span("warning", "Take the crate closer to the table!")
+		return
+
+
+	for (var/obj/structure/closet/crate/C in get_turf(table))
+		if (C.tablestatus != -1)
+			usr << span("warning", "There's already a crate on this table!")
+			return
+
+	//Crates are heavy, hauling them onto tables is hard.
+	//The more stuff thats in it, the longer it takes
+	//Good place to factor in Strength in future
+	var/timeneeded = 20
+	var/success = 0
+
+
+
+	if (tablestatus == 1 && Adjacent(table))
+		//Sliding along a tabletop we're already on. Instant and silent
+		timeneeded = 0
+		success = 1
+	else
+		//Add time based on mass of contents
+		for (var/obj/O in contents)
+			timeneeded += 3* O.w_class
+		for (var/mob/M in contents)
+			timeneeded += 3* M.mob_size
+
+	if (timeneeded > 0)
+		usr.visible_message("[usr] starts hoisting [src] onto the [table]", "You start hoisting [src] onto the [table]. This will take about [timeneeded*0.1] seconds")
+		usr.face_atom(src)
+		if (do_after(usr, timeneeded, needhand = 1))
+			success = 1
+
+
+	if (success == 1)
+		forceMove(get_turf(table))
+		set_tablestatus(1)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 /obj/structure/closet/crate/secure
 	desc = "A secure crate."
 	name = "Secure crate"
@@ -154,7 +290,8 @@
 		overlays += greenlight
 
 /obj/structure/closet/crate/secure/can_open()
-	return !locked
+	if (..())
+		return !locked
 
 /obj/structure/closet/crate/secure/proc/togglelock(mob/user as mob)
 	if(src.opened)

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -6,7 +6,7 @@
 	density = 1
 	anchored = 1
 	climbable = 1
-	layer = 2.8
+	layer = LAYER_TABLE
 	throwpass = 1
 	var/flipped = 0
 	var/maxhealth = 10
@@ -65,7 +65,7 @@
 
 /obj/structure/table/initialize()
 	..()
-	
+
 	// One table per turf.
 	for(var/obj/structure/table/T in loc)
 		if(T != src)

--- a/html/changelogs/Nanako-tablecrates.yml
+++ b/html/changelogs/Nanako-tablecrates.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Crates can now be hoisted ontop of tables, takes time depending on how heavy it is. Crates on tables will always block projectiles, making them easier to shoot with emitters and good cover"
+  - rscadd: "Crates can now be slid under tables. They must be closed to do this, and cannot be opened while under a table. Combined with the above, this allows stacking of up to two crates on one tile."


### PR DESCRIPTION
Inspired partially by complaints about my changes to crates that made them hard to shoot open. This PR adds two main features which interact:

1. Crates can now be slid under tables, making them easier to stow away. A crate only fits under a table while closed, and can't be opened while under there.

2. Crates can now be hoisted up ontop of a table, this takes time depending on the mass of the crate. A crate ontop of a table works as normal, and it will also always block shots, making a table the ideal platform for firing an emitter at one.

A table can have a crate both under and ontop of it, allowing two crates to be stored on one tile, at some cost of convenience and effort. The crates have their pixel offsets modified so that both of them can be seen at once.