### PR TITLE
Air alarm cleanup + Object Descriptions

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -2,6 +2,7 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "gsensor1"
 	name = "Gas Sensor"
+	desc = "Measures the gas content of the atmosphere around the sensor."
 
 	anchored = 1
 	var/state = 0
@@ -520,7 +521,3 @@ Rate: [volume_rate] L/sec<BR>"}
 		)
 
 		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
-
-
-
-

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -1,5 +1,6 @@
 /obj/machinery/portable_atmospherics/canister
 	name = "canister"
+	desc = "Holds gas. Has a built-in valve to allow for filling portable tanks."
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "yellow"
 	density = 1

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -1,5 +1,6 @@
 /obj/machinery/portable_atmospherics/powered/pump
 	name = "portable air pump"
+	desc = "Used to fill or drain rooms without differentiating between gasses."
 
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "psiphon:0"

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -1,5 +1,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber
 	name = "Portable Air Scrubber"
+	desc = "Scrubs contaminants from the local atmosphere or the connected portable tank."
 
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "pscrubber:0"

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -181,6 +181,7 @@
 
 /obj/structure/AIcore/deactivated
 	name = "inactive AI"
+	desc = "An empty AI core."
 	icon = 'icons/mob/AI.dmi'
 	icon_state = "ai-empty"
 	anchored = 1

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -42,6 +42,7 @@
 
 /obj/machinery/computer/guestpass
 	name = "guest pass terminal"
+	desc = "Allows issuing temporary access to an area."
 	icon_state = "guest"
 
 	icon_screen = "pass"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -4,6 +4,7 @@
 
 /obj/machinery/constructable_frame //Made into a seperate type to make future revisions easier.
 	name = "machine frame"
+	desc = "An empty frame for some kind of machine."
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "box_0"
 	density = 1
@@ -106,26 +107,26 @@
 						if(component_check)
 							playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 							var/obj/machinery/new_machine = new src.circuit.build_path(src.loc, src.dir)
-							
+
 							if(new_machine.component_parts)
 								new_machine.component_parts.Cut()
 							else
 								new_machine.component_parts = list()
-							
+
 							src.circuit.construct(new_machine)
-							
+
 							for(var/obj/O in src)
 								if(circuit.contain_parts) // things like disposal don't want their parts in them
 									O.loc = new_machine
 								else
 									O.loc = null
 								new_machine.component_parts += O
-							
+
 							if(circuit.contain_parts)
 								circuit.loc = new_machine
 							else
 								circuit.loc = null
-							
+
 							new_machine.RefreshParts()
 							qdel(src)
 					else

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -2,6 +2,7 @@
 
 obj/machinery/recharger
 	name = "recharger"
+	desc = "Useful for recharging electronic devices."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "recharger0"
 	anchored = 1

--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -6,6 +6,7 @@
 
 /obj/item/weapon/circuitboard
 	name = "circuit board"
+	desc = "Looks like a circuit. Probably is."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "id_mod"
 	item_state = "electronic"

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -34,24 +34,24 @@
 /obj/machinery/power/breakerbox/examine(mob/user)
 	user << "Large machine with heavy duty switching circuits used for advanced grid control"
 	if(on)
-		user << "\green It seems to be online."
+		user << "<span class='good'>It seems to be online.</span>"
 	else
-		user << "\red It seems to be offline"
+		user << "<span class='bad'>It seems to be offline.</span>"
 
 /obj/machinery/power/breakerbox/attack_ai(mob/user)
 	if(update_locked)
-		user << "\red System locked. Please try again later."
+		user << "<span class='bad'>System locked. Please try again later.</span>"
 		return
 
 	if(busy)
-		user << "\red System is busy. Please wait until current operation is finished before changing power settings."
+		user << "<span class='bad'>System is busy. Please wait until current operation is finished before changing power settings.</span>"
 		return
 
 	busy = 1
-	user << "\green Updating power settings.."
+	user << "<span class='good'>Updating power settings..</span>"
 	if(do_after(user, 50))
 		set_state(!on)
-		user << "\green Update Completed. New setting:[on ? "on": "off"]"
+		user << "<span class='good'>Update Completed. New setting:[on ? "on": "off"]</span>"
 		update_locked = 1
 		spawn(600)
 			update_locked = 0
@@ -60,16 +60,16 @@
 
 /obj/machinery/power/breakerbox/attack_hand(mob/user)
 	if(update_locked)
-		user << "\red System locked. Please try again later."
+		user << "<span class='bad'>System locked. Please try again later.</span>"
 		return
 
 	if(busy)
-		user << "\red System is busy. Please wait until current operation is finished before changing power settings."
+		user << "<span class='bad'>System is busy. Please wait until current operation is finished before changing power settings.</span>"
 		return
 
 	busy = 1
 	for(var/mob/O in viewers(user))
-		O.show_message(text("\red [user] started reprogramming [src]!"), 1)
+		O.show_message(text("<span class='warning'>[user] started reprogramming [src]!</span>"), 1)
 
 	if(do_after(user, 50))
 		set_state(!on)
@@ -87,10 +87,6 @@
 		if(newtag)
 			RCon_tag = newtag
 			user << "<span class='notice'>You changed the RCON tag to: [newtag]</span>"
-
-
-
-
 
 /obj/machinery/power/breakerbox/proc/set_state(var/state)
 	on = state

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -5,7 +5,8 @@
 // Used for advanced grid control (read: Substations)
 
 /obj/machinery/power/breakerbox
-	name = "Breaker Box"
+	name = "breaker box"
+	desc = "A large machine with heavy duty switching circuits used for advanced grid control."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "bbox_off"
 	//directwired = 0
@@ -32,7 +33,7 @@
 	set_state(1)
 
 /obj/machinery/power/breakerbox/examine(mob/user)
-	user << "Large machine with heavy duty switching circuits used for advanced grid control"
+	..()
 	if(on)
 		user << "<span class='good'>It seems to be online.</span>"
 	else

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -67,7 +67,7 @@
 //Dispensers
 /obj/structure/reagent_dispensers/watertank
 	name = "watertank"
-	desc = "A watertank"
+	desc = "A tank filled with water."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "watertank"
 	amount_per_transfer_from_this = 10
@@ -76,8 +76,8 @@
 		reagents.add_reagent("water",1000)
 
 /obj/structure/reagent_dispensers/fueltank
-	name = "fueltank"
-	desc = "A fueltank"
+	name = "fuel tank"
+	desc = "A tank filled with welding fuel."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "weldtank"
 	amount_per_transfer_from_this = 10


### PR DESCRIPTION
- Changes air alarms to use a bit less snowflake code per alarm type.
- Fixes atmos/engineering/RD being unable to unlock the Server Room air alarm.
- Minor air alarm message changes.
- Adds descriptions to a few objects that lacked them.
- Breaker boxes now use `<span>` tags instead of text macros.
- Breaker boxes' description now works correctly.