### PR TITLE
Improve Object Initialization

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -46,13 +46,18 @@ datum/controller/game_controller/proc/setup()
 datum/controller/game_controller/proc/setup_objects()
 	admin_notice("<span class='danger'>Initializing objects</span>", R_DEBUG)
 	sleep(-1)
-	for(var/atom/movable/object in world)
+	objects_initialized = 1
+	for(var/A in objects_init_list)
+		var/atom/movable/object = A
 		if(isnull(object.gcDestroyed))
 			object.initialize()
 
+	objects_init_list.Cut()
+
 	admin_notice("<span class='danger'>Initializing areas</span>", R_DEBUG)
 	sleep(-1)
-	for(var/area/area in all_areas)
+	for(var/A in all_areas)
+		var/area/area = A
 		area.initialize()
 
 	admin_notice("<span class='danger'>Initializing pipe networks</span>", R_DEBUG)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -20,8 +20,11 @@
 
 /atom/movable/New()
 	..()
-	if(auto_init && ticker && ticker.current_state == GAME_STATE_PLAYING)
-		initialize()
+	if (auto_init)
+		if (objects_initialized)
+			initialize()
+		else
+			objects_init_list += src
 
 /atom/movable/Del()
 	if(isnull(gcDestroyed) && loc)
@@ -271,4 +274,3 @@ var/list/accessible_z_levels = list("1" = 5, "3" = 10, "4" = 15, "6" = 60)
 	if(!candidates.len)
 		return null
 	return text2num(pickweight(candidates))
-

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -20,11 +20,11 @@
 
 /atom/movable/New()
 	..()
-	if (auto_init)
-		if (objects_initialized)
+	if (objects_initialized)
+		if (auto_init)
 			initialize()
-		else
-			objects_init_list += src
+	else
+		objects_init_list += src
 
 /atom/movable/Del()
 	if(isnull(gcDestroyed) && loc)

--- a/code/global.dm
+++ b/code/global.dm
@@ -171,7 +171,5 @@ var/global/list/exo_beacons = list()
 
 // Global variables to speed up object initialization.
 // Boolean to indicate whether objects should initialize themselves in their New() or wait for the game ticker to do it.
+// Check world.dm for the object list.
 var/global/objects_initialized = 0
-
-// A list of all objects that were not initialized in world/New() and need to be initialized.
-var/global/list/atom/movable/objects_init_list = list()

--- a/code/global.dm
+++ b/code/global.dm
@@ -168,3 +168,10 @@ var/global/const/TICKS_IN_SECOND = 10
 
 //List of exosuit tracking beacons, to save performance
 var/global/list/exo_beacons = list()
+
+// Global variables to speed up object initialization.
+// Boolean to indicate whether objects should initialize themselves in their New() or wait for the game ticker to do it.
+var/global/objects_initialized = 0
+
+// A list of all objects that were not initialized in world/New() and need to be initialized.
+var/global/list/atom/movable/objects_init_list = list()

--- a/code/world.dm
+++ b/code/world.dm
@@ -11,6 +11,9 @@
 */
 var/global/datum/global_init/init = new ()
 
+// The list of objects that will need to be initialized in ticker creation.
+var/global/list/objects_init_list = list()
+
 /*
 	Pre-map initialization stuff should go here.
 */


### PR DESCRIPTION
Okay. You can read the entire theory over in this issue: #1365 

But basically. All objects to be initialized are now added to a list in their New() proc on world/New(). This is substantially smaller than the entire world. This allows game_controller/setup_objects() to crawl a much larger list, and speeds it up by 6 seconds (from 9.5 to 3.5 seconds). The impact on world/New() is, on average, under 1 second.

Also fixes #1365 and #1363 as a result of reworking the initialization call logic in atoms_movable.dm. initialize() is now more secure, and can handle recursive calls at any point in time.