### PR TITLE
Explosion changes

### DIFF
--- a/code/controllers/Processes/explosives.dm
+++ b/code/controllers/Processes/explosives.dm
@@ -8,6 +8,20 @@ var/datum/controller/process/explosives/bomb_processor
 	var/list/explosion_turfs
 	var/explosion_in_progress
 	var/powernet_update_pending = 0
+	var/tiles_per_tick = 10
+	// TODO: Move maximum_parallel_explosions and sleep_delay_ticks to config
+	var/maximum_parallel_explosions = 4
+	var/sleep_delay_ticks = 5
+	var/work_index = 0 // which queued explosion we're working on
+	var/last_work_index = 0
+
+/datum/controller/process/explosives/proc/idle()
+	disable()
+	lighting_process.schedule_interval *= 4
+
+/datum/controller/process/explosives/proc/wake()
+	enable()
+	lighting_process.schedule_interval /= 4
 
 /datum/controller/process/explosives/setup()
 	name = "explosives"
@@ -21,177 +35,37 @@ var/datum/controller/process/explosives/bomb_processor
 
 /datum/controller/process/explosives/doWork()
 	if (!work_queue)
-		setup()	// fix for process failing to re-init after termination
+		setup()
 
 	if (!(work_queue.len))
 		ticks_without_work++
-		if (powernet_update_pending && ticks_without_work > 5)
+		if (powernet_update_pending && ticks_without_work > sleep_delay_ticks)
 			makepowernets()
 			powernet_update_pending = 0
 
 			// All explosions handled, powernet rebuilt.
 			// We can sleep now.
-			disable()
+			idle()
 		return
 
-	ticks_without_work = 0
-	powernet_update_pending = 1
+	if (work_index)
+		if (work_queue[work_index].process_many(tiles_per_tick))
+			work_queue[work_index].notify_listeners()
+			work_queue -= work_queue[work_index]
+		last_work_index = work_index
+		work_index = 0
+	else
+		work_index = get_work_index()
+		doWorkNew()
 
-	for (var/A in work_queue)
-		lighting_process.disable()
-		var/datum/explosiondata/data = A
+/datum/controller/process/explosives/proc/get_work_index()
+	if (work_queue.len == 1 || last_work_index == 0)
+		return 1
 
-		if (data.is_rec)
-			explosion_rec(data.epicenter, data.rec_pow)
-		else
-			explosion(data)
-
-		SCHECK
-
-		work_queue -= data
-		lighting_process.enable()
-
-// Handle a non-recusrive explosion.
-/datum/controller/process/explosives/proc/explosion(var/datum/explosiondata/data)
-	var/turf/epicenter = data.epicenter
-	var/devastation_range = data.devastation_range
-	var/heavy_impact_range = data.heavy_impact_range
-	var/light_impact_range = data.light_impact_range
-	var/flash_range = data.flash_range
-	var/adminlog = data.adminlog
-	var/z_transfer = data.z_transfer
-	var/power = data.rec_pow
-
-	if(config.use_recursive_explosions)
-		explosion_rec(epicenter, power)
-		return
-
-	var/start = world.timeofday
-	epicenter = get_turf(epicenter)
-	if(!epicenter) return
-
-	// Handles recursive propagation of explosions.
-	if(devastation_range > 2 || heavy_impact_range > 2)
-		if(HasAbove(epicenter.z) && z_transfer & UP)
-			explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, UP)
-		if(HasBelow(epicenter.z) && z_transfer & DOWN)
-			explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, DOWN)
-
-	var/max_range = max(devastation_range, heavy_impact_range, light_impact_range, flash_range)
-
-	// Play sounds; we want sounds to be different depending on distance so we will manually do it ourselves.
-	// Stereo users will also hear the direction of the explosion!
-	// Calculate far explosion sound range. Only allow the sound effect for heavy/devastating explosions.
-	// 3/7/14 will calculate to 80 + 35
-	var/far_dist = 0
-	far_dist += heavy_impact_range * 5
-	far_dist += devastation_range * 20
-	// Play sounds; we want sounds to be different depending on distance so we will manually do it ourselves.
-
-	// Stereo users will also hear the direction of the explosion!
-
-	// Calculate far explosion sound range. Only allow the sound effect for heavy/devastating explosions.
-
-	// 3/7/14 will calculate to 80 + 35
-	var/volume = 10 + (power * 20)
-
-	var/frequency = get_rand_frequency()
-	var/closedist = round(max_range + world.view - 2, 1)
-
-	//Whether or not this explosion causes enough vibration to send sound or shockwaves through the station
-	var/vibration = 1
-	if (istype(epicenter,/turf/space))
-		vibration = 0
-		for (var/turf/T in range(src, max_range))
-			if (!istype(T,/turf/space))
-		//If there is a nonspace tile within the explosion radius
-		//Then we can reverberate shockwaves through that, and allow it to be felt in a vacuum
-				vibration = 1
-
-	if (vibration)
-		for(var/mob/M in player_list)
-			SCHECK
-			// Double check for client
-			var/reception = 2//Whether the person can be shaken or hear sound
-			//2 = BOTH
-			//1 = shockwaves only
-			//0 = no effect
-			if(M && M.client)
-				var/turf/M_turf = get_turf(M)
-
-
-
-				if(M_turf && M_turf.z == epicenter.z)
-					if (istype(M_turf,/turf/space))
-					//If the person is standing in space, they wont hear
-						//But they may still feel the shaking
-						reception = 0
-						for (var/turf/T in range(M, 1))
-							if (!istype(T,/turf/space))
-							//If theyre touching the hull or on some extruding part of the station
-								reception = 1//They will get screenshake
-								break
-
-					if (!reception)
-						continue
-
-					var/dist = get_dist(M_turf, epicenter)
-					if (reception == 2 && (M.ear_deaf <= 0 || !M.ear_deaf))//Dont play sounds to deaf people
-						// If inside the blast radius + world.view - 2
-						if(dist <= closedist)
-							M.playsound_local(epicenter, get_sfx("explosion"), min(100, volume), 1, frequency, falloff = 5) // get_sfx() is so that everyone gets the same sound
-							//You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
-
-						else
-							volume = M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', volume, 1, frequency, usepressure = 0, falloff = 1000)
-							//Playsound local will return the final volume the sound is actually played at
-							//It will return 0 if the sound volume falls to 0 due to falloff or pressure
-							//Also return zero if sound playing failed for some other reason
-
-					//Deaf people will feel vibrations though
-					if (volume > 0)//Only shake camera if someone was close enough to hear it
-						shake_camera(M, min(60,max(2,(power*18) / dist)), min(3.5,((power*3) / dist)),0.05)
-						//Maximum duration is 6 seconds, and max strength is 3.5
-						//Becuse values higher than those just get really silly
-
-	if(adminlog)
-		message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
-		log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ")
-
-	if(heavy_impact_range > 1)
-		var/datum/effect/system/explosion/E = new/datum/effect/system/explosion()
-		E.set_up(epicenter)
-		E.start()
-
-	var/x0 = epicenter.x
-	var/y0 = epicenter.y
-	var/z0 = epicenter.z
-
-	for(var/turf/T in trange(max_range, epicenter))
-		var/dist = sqrt((T.x - x0)**2 + (T.y - y0)**2)
-
-		if(dist < devastation_range)		dist = 1
-		else if(dist < heavy_impact_range)	dist = 2
-		else if(dist < light_impact_range)	dist = 3
-		else								continue
-
-		T.ex_act(dist)
-		SCHECK
-		if(T)
-			for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
-				var/atom/movable/AM = atom_movable
-				if(AM && AM.simulated)	AM.ex_act(dist)
-				SCHECK
-
-	var/took = (world.timeofday-start)/10
-	//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare
-	if(Debug2)	world.log << "## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds."
-
-	//Machines which report explosions.
-	for(var/i,i<=doppler_arrays.len,i++)
-		var/obj/machinery/doppler_array/Array = doppler_arrays[i]
-		if(Array)
-			Array.sense_explosion(x0,y0,z0,devastation_range,heavy_impact_range,light_impact_range,took)
+	if (last_work_index < maximum_parallel_explosions)
+		return last_work_index + 1
+	else
+		return 1
 
 // Handle a recursive explosion.
 /datum/controller/process/explosives/proc/explosion_rec(turf/epicenter, power)
@@ -266,11 +140,12 @@ var/datum/controller/process/explosives/bomb_processor
 	if (!data || !istype(data))
 		return
 
+	data.prepare()	// pre-calculate some stuff that only needs to be calculated once
 	work_queue += data
 
 	// Wake it up from sleeping if necessary.
 	if (disabled)
-		enable()
+		wake()
 
 /datum/controller/process/explosives/statProcess()
 	..()
@@ -287,3 +162,120 @@ var/datum/controller/process/explosives/bomb_processor
 	var/z_transfer
 	var/is_rec
 	var/rec_pow
+	var/fast_process = 0
+	var/list/processing_turfs
+	var/epi_x
+	var/epi_y
+	var/epi_z
+	var/start_time
+
+/datum/explosiondata/proc/prepare()
+	epicenter = get_turf(epicenter)
+	if (!epicenter)
+		return 0
+
+	if(devastation_range > 2 || heavy_impact_range > 2)
+		if(HasAbove(epicenter.z) && z_transfer & UP)
+			explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, UP)
+		if(HasBelow(epicenter.z) && z_transfer & DOWN)
+			explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, DOWN)
+
+	max_range = max(devastation_range, heavy_impact_range, light_impact_range, flash_range)
+	start_time = world.timeofday
+
+	if (!fast_process)
+		handle_shake()
+
+// processes()s multiple times
+/datum/explosiondata/proc/process_many(var/ticks)
+	for (var/i = 0, i < ticks, i++)
+		if (process())
+			return 1
+
+// Processes ONE turf - returns true when done processing all turfs
+/datum/explosiondata/proc/process()
+	if (!processing_turfs)
+		return 0
+
+	if (!(processing_turfs.len))
+		return 1
+
+	var/turf/T = processing_turfs[1]
+	processing_turfs -= T
+	var/dist = sqrt((T.x - epi_x)**2 + (T.y - epi_y)**2)
+
+	if(dist < devastation_range)		dist = 1
+	else if(dist < heavy_impact_range)	dist = 2
+	else if(dist < light_impact_range)	dist = 3
+	else								continue
+
+	T.ex_act(dist)
+
+	if(T)
+		for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
+			var/atom/movable/AM = atom_movable
+			if(AM && AM.simulated)	AM.ex_act(dist)
+
+/datum/explosiondata/proc/notify_listeners()
+	var/took = (world.timeofday - start_time) / 10
+	if(Debug2)
+		world.log << "## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds."
+
+	for (var/array in doppler_arrays)
+		var/obj/machinery/doppler_array/A = Array
+		if (A)
+			A.sense_explosion(epi_x, epi_y, epi_z, devastation_range, heavy_impact_range, light_impact_range, took)
+
+/datum/explosiondata/proc/handle_shake(var/max_duration = 60)
+	//Whether or not this explosion causes enough vibration to send sound or shockwaves through the station
+	var/vibration = 1
+	if (istype(epicenter,/turf/space))
+		vibration = 0
+		for (var/turf/T in range(src, max_range))
+			if (!istype(T,/turf/space))
+		//If there is a nonspace tile within the explosion radius
+		//Then we can reverberate shockwaves through that, and allow it to be felt in a vacuum
+				vibration = 1
+
+	if (vibration)
+		for(var/mob/M in player_list)
+			// Double check for client
+			var/reception = 2//Whether the person can be shaken or hear sound
+			//2 = BOTH
+			//1 = shockwaves only
+			//0 = no effect
+			if(M && M.client)
+				var/turf/M_turf = get_turf(M)
+
+				if(M_turf && M_turf.z == epicenter.z)
+					if (istype(M_turf,/turf/space))
+					//If the person is standing in space, they wont hear
+						//But they may still feel the shaking
+						reception = 0
+						for (var/turf/T in range(M, 1))
+							if (!istype(T,/turf/space))
+							//If theyre touching the hull or on some extruding part of the station
+								reception = 1//They will get screenshake
+								break
+
+					if (!reception)
+						continue
+
+					var/dist = get_dist(M_turf, epicenter)
+					if (reception == 2 && (M.ear_deaf <= 0 || !M.ear_deaf))//Dont play sounds to deaf people
+						// If inside the blast radius + world.view - 2
+						if(dist <= closedist)
+							M.playsound_local(epicenter, get_sfx("explosion"), min(100, volume), 1, frequency, falloff = 5) // get_sfx() is so that everyone gets the same sound
+							//You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
+
+						else
+							volume = M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', volume, 1, frequency, usepressure = 0, falloff = 1000)
+							//Playsound local will return the final volume the sound is actually played at
+							//It will return 0 if the sound volume falls to 0 due to falloff or pressure
+							//Also return zero if sound playing failed for some other reason
+
+					//Deaf people will feel vibrations though
+					if (volume > 0)//Only shake camera if someone was close enough to hear it
+						shake_camera(M, min(max_duration, max(2,(power*18) / dist)), min(3.5,((power*3) / dist)),0.05)
+						//Maximum duration is 6 seconds, and max strength is 3.5
+						//Becuse values higher than those just get really silly

--- a/code/controllers/Processes/explosives.dm
+++ b/code/controllers/Processes/explosives.dm
@@ -53,6 +53,8 @@ var/datum/controller/process/explosives/bomb_processor
 		if (E.process_many(tiles_per_tick))
 			E.notify_listeners()
 			work_queue -= E
+		else
+			work_queue[work_index] = E
 		last_work_index = work_index
 		work_index = 0
 	else


### PR DESCRIPTION
Changes the explosion processor to process up to 4 explosions simultaneously.
Should no longer crash when given explosions that take longer than 90 seconds to process.

Known issues:
- Explosions don't process.