### PR TITLE
Downloader Program Improvements

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -135,7 +135,6 @@
 /datum/nano_module/program/computer_ntnetdownload
 	name = "Network Downloader"
 	var/obj/item/modular_computer/my_computer = null
-	var/obj/item/weapon/computer_hardware/hard_drive/drive = null
 
 /datum/nano_module/program/computer_ntnetdownload/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	if(program)

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -138,7 +138,6 @@
 	var/obj/item/weapon/computer_hardware/hard_drive/drive = null
 
 /datum/nano_module/program/computer_ntnetdownload/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
-	world << "UI interact"
 	if(program)
 		my_computer = program.computer
 
@@ -189,10 +188,8 @@
 	var/list/data = list()
 	for(var/datum/computer_file/program/P in ntnet_global.available_station_software)
 		var/installed = 0
-		world << "Checking [P]"
 		for(var/datum/computer_file/program/Q in program.holder.stored_files)
 			if (istype(P, Q.type))
-				world << "Already installed"
 				installed = 1
 				break
 
@@ -230,7 +227,6 @@
 
 	for (var/i = 1,i < all_entries.len, i++)
 		var/list/a = all_entries[i]
-		world << a["filename"]
 	data["downloadable_programs"] = all_entries
 	return data
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -224,8 +224,7 @@
 				)))
 				data["hacked_programs"] = hacked_programs
 
-	for (var/i = 1,i < all_entries.len, i++)
-		var/list/a = all_entries[i]
+
 	data["downloadable_programs"] = all_entries
 	return data
 

--- a/nano/templates/ntnet_downloader.tmpl
+++ b/nano/templates/ntnet_downloader.tmpl
@@ -85,10 +85,11 @@
 			</div>
 		</div>
 	{{empty}}
+		<hr><br>
 		{{if data.locked}}
-			<div class="itemContent"><b>ERROR: This terminal is locked, users are disallowed from downloading software. Please contact your system administrator.</b></div>
+			<div class="itemContent" style="color: red; text-align: center; width: 100%;"><b>ERROR: This terminal is locked, users are disallowed from downloading software. Please contact your system administrator.</b></div>
 		{{else}}
-			<div class="itemContent"><b>There are no available programs at this time.</b></div>
+			<div class="itemContent" style="text-align: center; width: 100%;"><b>There are no available programs for your clearance level at this time.</b></div>
 		{{/if}}
 		<br>
 	{{/for}}
@@ -126,4 +127,6 @@
 	{{/if}}
 
 {{/if}}
-<br><br><hr><i>NTOS v2.0.5 Copyright NanoTrasen 2450 - 2458</i>
+<br><br>
+
+<div style="position: fixed; bottom: 5px;"><hr><i>NTOS v2.0.6 Copyright NanoTrasen 2450 - 2458</i></div>

--- a/nano/templates/ntnet_downloader.tmpl
+++ b/nano/templates/ntnet_downloader.tmpl
@@ -84,6 +84,13 @@
 				{{:helper.link("Download", null, {'PRG_downloadfile' : value.filename})}}
 			</div>
 		</div>
+	{{empty}}
+		{{if data.locked}}
+			<div class="itemContent"><b>ERROR: This terminal is locked, users are disallowed from downloading software. Please contact your system administrator.</b></div>
+		{{else}}
+			<div class="itemContent"><b>There are no available programs at this time.</b></div>
+		{{/if}}
+		<br>
 	{{/for}}
 	{{if data.hackedavailable}}
 		<h2>*UNKNOWN* software repository</h2>


### PR DESCRIPTION
The downloader program will no longer show things you already have installed. Clears up some needless clutter, since theres never any reason to download something twice - you can make local copies on the hard drive.

Software lock now works. It didn't before. For the record i still dislike this feature but i fixed it anyway.
Added some information/error messages for when the download list is empty, to explain why
The footer with the version number is now fixed to the bottom of the window instead of floating up
Optimisation: Auto update is now disabled on the software selection menu and enabled when you're downloading something. Saves on needless processing.

Version number incremented