### PR TITLE
Add db-reconnect adminverb

### DIFF
--- a/code/defines/procs/dbcore.dm
+++ b/code/defines/procs/dbcore.dm
@@ -126,7 +126,7 @@ DBQuery/proc/Execute(var/list/argument_list = null, var/pass_not_found = 0, sql_
 
 	var/result = _dm_db_execute(_db_query, sql_query, db_connection._db_con, cursor_handler, null)
 
-	var error = ErrorMsg()
+	var/error = ErrorMsg()
 	if (error)
 		error("SQL Error: '[error]'")
 		// This is hacky and should probably be changed

--- a/code/defines/procs/dbcore.dm
+++ b/code/defines/procs/dbcore.dm
@@ -70,6 +70,10 @@ DBConnection/proc/Connect(dbi_handler = con_dbi, user_handler = con_user, passwo
 DBConnection/proc/Disconnect()
 	return _dm_db_close(_db_con)
 
+DBConnection/proc/Reconnect()
+	Disconnect()
+	Connect()
+
 DBConnection/proc/IsConnected()
 	if(!config.sql_enabled)
 		return 0
@@ -122,8 +126,13 @@ DBQuery/proc/Execute(var/list/argument_list = null, var/pass_not_found = 0, sql_
 
 	var/result = _dm_db_execute(_db_query, sql_query, db_connection._db_con, cursor_handler, null)
 
-	if (ErrorMsg())
-		error("SQL Error: '[ErrorMsg()]'")
+	var error = ErrorMsg()
+	if (error)
+		error("SQL Error: '[error]'")
+		// This is hacky and should probably be changed
+		if (error == "MySQL server has gone away")
+			log_and_message_admins("is attempting to reconnect the server to MySQL. (Connection Failure)")
+			dbcon.Reconnect()
 
 	return result
 

--- a/code/defines/procs/dbcore.dm
+++ b/code/defines/procs/dbcore.dm
@@ -133,6 +133,8 @@ DBQuery/proc/Execute(var/list/argument_list = null, var/pass_not_found = 0, sql_
 		if (error == "MySQL server has gone away")
 			log_and_message_admins("is attempting to reconnect the server to MySQL. (Connection Failure)")
 			dbcon.Reconnect()
+			if (db_connection.IsConnected())
+				src.Execute(argument_list)
 
 	return result
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -199,7 +199,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/jumptomob,
 	/client/proc/jumptocoord,
 	/client/proc/dsay,
-	/client/proc/toggle_recursive_explosions
+	/client/proc/toggle_recursive_explosions,
+	/client/proc/restart_sql
 	)
 
 var/list/admin_verbs_paranoid_debug = list(
@@ -1035,3 +1036,17 @@ var/list/admin_verbs_cciaa = list(
 	log_and_message_admins("admin-wiped [key_name_admin(target)]'s core.")
 	target.do_wipe_core()
 	
+/client/proc/restart_sql()
+	set category = "Debug"
+	set name = "Reconnect SQL"
+	set desc = "Causes the server to re-establish its connection to the MySQL server."
+
+	if (!check_rights(R_DEBUG))
+		return
+
+	if (alert("Reconnect to SQL?", "SQL Reconnection", "No", "No", "Yes") != "Yes")
+		return
+
+	log_and_message_admins("is attempting to reconnect the server to MySQL.")
+
+	dbcon.Reconnect()


### PR DESCRIPTION
Adds a `Reconnect-SQL` verb to admins with permission flag `R_DEBUG`, as well as making the server attempt to automatically reconnect to SQL on connection drop.