### PR TITLE
Species preview image fix

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -605,8 +605,9 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	dat += "<td width = 400>[current_species.blurb]</td>"
 	dat += "<td width = 200 align='center'>"
 	if("preview" in icon_states(current_species.icobase))
-		usr << browse_rsc(icon(current_species.icobase,"preview"), "species_preview_[current_species.name].png")
-		dat += "<img src='species_preview_[current_species.name].png' width='64px' height='64px'><br/><br/>"
+		var/curr_name = html_encode(current_species.name)
+		usr << browse_rsc(icon(current_species.icobase,"preview"), "species_preview_[curr_name].png")
+		dat += "<img src='species_preview_[curr_name].png' width='64px' height='64px'><br/><br/>"
 	dat += "<b>Language:</b> [current_species.language]<br/>"
 	dat += "<small>"
 	if(current_species.spawn_flags & CAN_JOIN)


### PR DESCRIPTION
This should fix image previews for any species that has HTML-illegal chars in their name.

Fixes #1396.