### PR TITLE
Disable attempt to re-run queries after reconnect

### DIFF
--- a/code/defines/procs/dbcore.dm
+++ b/code/defines/procs/dbcore.dm
@@ -133,7 +133,7 @@ DBQuery/proc/Execute(var/list/argument_list = null, var/pass_not_found = 0, sql_
 		if (error == "MySQL server has gone away")
 			log_game("MySQL connection drop detected, attempting to reconnect.")
 			message_admins("MySQL connection drop detected, attempting to reconnect.")
-			dbcon.Reconnect()
+			db_connection.Reconnect()
 
 	return result
 

--- a/code/defines/procs/dbcore.dm
+++ b/code/defines/procs/dbcore.dm
@@ -131,10 +131,9 @@ DBQuery/proc/Execute(var/list/argument_list = null, var/pass_not_found = 0, sql_
 		error("SQL Error: '[error]'")
 		// This is hacky and should probably be changed
 		if (error == "MySQL server has gone away")
-			log_and_message_admins("is attempting to reconnect the server to MySQL. (Connection Failure)")
+			log_game("MySQL connection drop detected, attempting to reconnect.")
+			message_admins("MySQL connection drop detected, attempting to reconnect.")
 			dbcon.Reconnect()
-			if (db_connection.IsConnected())
-				src.Execute(argument_list)
 
 	return result
 


### PR DESCRIPTION
Reverts the automatic re-execution of queries after the db connection is reestablished, added in 36a084fbbcf4a4e5ece0f0800848af023637ea1f.

It was causing infinite recursion and generally breaking the server, dropping a single query on reconnect is still better than the old behavior of dropping _all_ queries.