### PR TITLE
Recharger fix + Janicart info

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -259,3 +259,23 @@
 	if(!usr.incapacitated())
 		return
 	go_in(usr)
+
+
+/obj/machinery/recharge_station/MouseDrop_T(var/atom/movable/C, mob/user)
+	if (istype(C, /mob/living/silicon/robot))
+		var/mob/living/silicon/robot/R = C
+		if (!user.Adjacent(R) || !Adjacent(user))
+			user << span("danger", "You need to get closer if you want to put [C] into that charger!")
+			return
+		user.face_atom(src)
+		user.visible_message(span("danger","[user] starts hauling [C] into the recharging unit!"), span("danger","You start hauling and pushing [C] into the recharger. This might take a while..."), "You hear heaving and straining")
+		if (do_mob(user, R, R.mob_size*10, needhand = 1))
+			if (go_in(R))
+				user.visible_message(span("notice","After a great effort, [user] manages to get [C] into the recharging unit!"))
+				return 1
+			else
+				user << span("danger","Failed loading [C] into the charger. Please ensure that [C] has a power cell and is not buckled down, and that the charger is functioning.")
+		else
+			user << span("danger","Cancelled loading [C] into the charger. You and [C] must stay still!")
+		return
+	return ..()

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -1,6 +1,10 @@
 /obj/structure/janitorialcart
 	name = "janitorial cart"
 	desc = "The ultimate in janitorial carts! Has space for water, mops, signs, trash bags, and more!"
+	description_info  = "Click and drag a mop bucket onto the cart to mount it\
+	</br>Alt+Click with a mop to put it away, a normal click will wet it in the bucket.\
+	</br>Alt+Click with a container, such as a bucket, to pour its contents into the mounted bucket. A normal click will toss it into the trash\
+	</br>You can also use a lightreplacer, spraybottle (of spacecleaner) and four wet-floor signs on the cart to store them"
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "cart"
 	anchored = 0
@@ -214,13 +218,15 @@
 		ui.open()
 
 /obj/structure/janitorialcart/Topic(href, href_list)
+	world << "Janicart Topic"
 	if(!in_range(src, usr))
 		return
 	if(!isliving(usr))
 		return
 	var/mob/living/user = usr
-
+	world << "JC Topic 2"
 	if(href_list["take"])
+		world << "JC Topic 2: [href_list["take"]]"
 		switch(href_list["take"])
 			if("garbage")
 				if(mybag)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -218,15 +218,12 @@
 		ui.open()
 
 /obj/structure/janitorialcart/Topic(href, href_list)
-	world << "Janicart Topic"
 	if(!in_range(src, usr))
 		return
 	if(!isliving(usr))
 		return
 	var/mob/living/user = usr
-	world << "JC Topic 2"
 	if(href_list["take"])
-		world << "JC Topic 2: [href_list["take"]]"
 		switch(href_list["take"])
 			if("garbage")
 				if(mybag)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -1,6 +1,6 @@
 /obj/structure/mopbucket
 	name = "mop bucket"
-	desc = "Fill it with water, but don't forget a mop!"
+	desc = "Fits onto a standard janitorial cart. Fill it with water, but don't forget a mop!"
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "mopbucket"
 	density = 1


### PR DESCRIPTION
Fixes not being able to drag cyborgs into rechargers. looks like the code got lost in baymerge.

Adds some description_info to janicarts to hopefully allieviate user confusion issues. This only shows in the examine tab. Ieve had a lot of complaints about being unable to do things because people didnt know how