### PR TITLE
Re-order world.reboot operations

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -228,7 +228,7 @@ var/list/world_api_rate_limit = list()
 		var/exit_code = shell(command)
 		if (exit_code)
 			log_debug("RuntimeCondenser.exe exited with error code [exit_code].")
-		admin_notice("<span class='danger'>Runtime condensing finished.</span>")
+		admin_notice("<span class='danger'>Runtime condensing finished.</span>", R_DEBUG)
 
 		// Sleep until the next tick before proceeding.
 		sleep(1)

--- a/code/world.dm
+++ b/code/world.dm
@@ -214,12 +214,9 @@ var/list/world_api_rate_limit = list()
 
 	processScheduler.stop()
 
-	for(var/client/C in clients)
-		if(config.server)	//if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
-			C << link("byond://[config.server]")
-
 	// Handle runtime condensing here
 	if (config.log_runtime)
+		admin_notice("<span class='danger'>Starting to condense runtimes.</span>", R_DEBUG)
 		var/input_file = "data/logs/_runtime/[diary_date_string]-runtime.log"
 		var/output_file = "data/logs/_runtime/[diary_date_string]-runtime-condensed.log"
 
@@ -231,6 +228,14 @@ var/list/world_api_rate_limit = list()
 		var/exit_code = shell(command)
 		if (exit_code)
 			log_debug("RuntimeCondenser.exe exited with error code [exit_code].")
+		admin_notice("<span class='danger'>Runtime condensing finished.</span>")
+
+		// Sleep until the next tick before proceeding.
+		sleep(1)
+
+	if(config.server)	//if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
+		for(var/client/C in clients)
+			C << link("byond://[config.server]")
 
 	..(reason)
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -216,7 +216,8 @@ var/list/world_api_rate_limit = list()
 
 	// Handle runtime condensing here
 	if (config.log_runtime)
-		admin_notice("<span class='danger'>Starting to condense runtimes.</span>", R_DEBUG)
+		// 0x20 = R_DEBUG. world.dm is compiled at the very start, so the macros aren't declared here yet.
+		admin_notice("<span class='danger'>Starting to condense runtimes.</span>", 0x20)
 		var/input_file = "data/logs/_runtime/[diary_date_string]-runtime.log"
 		var/output_file = "data/logs/_runtime/[diary_date_string]-runtime-condensed.log"
 
@@ -228,7 +229,7 @@ var/list/world_api_rate_limit = list()
 		var/exit_code = shell(command)
 		if (exit_code)
 			log_debug("RuntimeCondenser.exe exited with error code [exit_code].")
-		admin_notice("<span class='danger'>Runtime condensing finished.</span>", R_DEBUG)
+		admin_notice("<span class='danger'>Runtime condensing finished.</span>", 0x20)
 
 		// Sleep until the next tick before proceeding.
 		sleep(1)


### PR DESCRIPTION
Runtimes are now condensed first, then we sleep for a bit, and then issue the reconnect directive.

This should make the reconnect directive work again properly.
