### PR TITLE
Update Icons fix and Cloaking Device rework

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -677,6 +677,7 @@
 #include "code\game\objects\items\weapons\cards_ids.dm"
 #include "code\game\objects\items\weapons\cards_ids_syndicate.dm"
 #include "code\game\objects\items\weapons\cigs_lighters.dm"
+#include "code\game\objects\items\weapons\cloaking_device.dm"
 #include "code\game\objects\items\weapons\clown_items.dm"
 #include "code\game\objects\items\weapons\cosmetics.dm"
 #include "code\game\objects\items\weapons\dice.dm"

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -85,6 +85,9 @@ var/global/list/endgame_safespawns = list()
 
 var/global/list/syndicate_access = list(access_maint_tunnels, access_syndicate, access_external_airlocks)
 
+//Cloaking devices
+var/global/list/cloaking_devices = list()
+
 //////////////////////////
 /////Initial Building/////
 //////////////////////////

--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -33,3 +33,9 @@
 	name = "Chameleon-Projector"
 	item_cost = 8
 	path = /obj/item/device/chameleon
+
+/datum/uplink_item/item/stealth_items/cloak
+	name = "Cloaking Device"
+	item_cost = 12
+	path = /obj/item/weapon/cloaking_device
+	desc = "An advanced battery-powered miniature cloaking device that renders the holder invisible. Consumes a lot of power."

--- a/code/game/modifiers/modifiers.dm
+++ b/code/game/modifiers/modifiers.dm
@@ -404,6 +404,7 @@ it should be avoided in favour of manual removal where possible
 		if (MODIFIER_OVERRIDE_NEIGHBOR)
 			processing_modifiers += src
 			target.modifiers += src
+			activate()
 			return src
 		if (MODIFIER_OVERRIDE_REPLACE)
 			existing.stop()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -243,7 +243,6 @@
 // user is mob that equipped it
 // slot uses the slot_X defines found in setup.dm
 // for items that can be placed in multiple slots
-// note this isn't called during the initial dressing of a player
 /obj/item/proc/equipped(var/mob/user, var/slot)
 	layer = 20
 	equip_slot = slot

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -161,7 +161,7 @@
 
 	src.throwing = 0
 	if (src.loc == user)
-		if(!user.unEquip(src))
+		if(!user.prepare_for_slotmove(src))
 			return
 	else
 		if(isliving(src.loc))
@@ -217,7 +217,8 @@
 /obj/item/proc/moved(mob/user as mob, old_loc as turf)
 	return
 
-// apparently called whenever an item is removed from a slot, container, or anything else.
+//Apparently called whenever an item is dropped on the floor, thrown, or placed into a container.
+//It is called after loc is set, so if placed in a container its loc will be that container
 /obj/item/proc/dropped(var/mob/user)
 	..()
 	if(zoom)

--- a/code/game/objects/items/weapons/cloaking_device.dm
+++ b/code/game/objects/items/weapons/cloaking_device.dm
@@ -35,15 +35,19 @@
 	register_owner(user)
 
 
+//Handles dropped or thrown cloakers
 /obj/item/weapon/cloaking_device/dropped(var/mob/user)
 	..()
 	spawn(1)//Things are dropped on the floor briefly when being put into containers or swapping hands
 	//Its dumb. This little hack works around it
 		var/mob/M = get_holding_mob()
-		if(!M)
+		if(!M || M != owner)
 			register_owner(M)
-			//Either placed somewhere or given to someone.
-			//M will be null if we were dropped on the floor, thats fine, the register function will handle it
+		//Either placed somewhere or given to someone.
+		//M will be null if we were dropped on the floor, thats fine, the register function will handle it
+		//If M contains someone other than the owner, then this device was just passed to someone
+
+	//If M contains the owner then the item hasn't actually been dropped, its just the quirk mentioned above
 
 /obj/item/weapon/cloaking_device/attack_self(mob/user as mob)
 	if (istype(loc, /mob) && loc == user)//safety check incase of shenanigans
@@ -112,7 +116,7 @@
 	if(istype(W, /obj/item/weapon/cell))
 		if(!cell)
 			user.drop_item()
-			W.loc = src
+			W.forceMove = src
 			cell = W
 			user << "<span class='notice'>You install a cell in [src].</span>"
 			update_icon()
@@ -122,7 +126,7 @@
 	else if(istype(W, /obj/item/weapon/screwdriver))
 		if(cell)
 			cell.update_icon()
-			cell.loc = get_turf(src.loc)
+			cell.forceMove = get_turf(src.loc)
 			cell = null
 			user << "<span class='notice'>You remove the cell from the [src].</span>"
 			deactivate()

--- a/code/game/objects/items/weapons/cloaking_device.dm
+++ b/code/game/objects/items/weapons/cloaking_device.dm
@@ -1,0 +1,176 @@
+/obj/item/weapon/cloaking_device
+	name = "cloaking device"
+	desc = "Use this to become invisible to the human eye."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "shield0"
+	var/active = 0.0
+	flags = CONDUCT
+	item_state = "electronic"
+	throwforce = 10.0
+	throw_speed = 2
+	throw_range = 10
+	w_class = 2.0
+	origin_tech = list(TECH_MAGNET = 3, TECH_ILLEGAL = 4)
+
+	var/power_usage = 35000//A high powered cell allows 5 minutes of continuous usage
+	//Note it can be toggled on and off easily. You can make it last an hour if you only use it when
+	//people are nearby to see. Carry spare/better cells for extended cloaking.
+	var/obj/item/weapon/cell/cell = null
+	var/mob/living/owner = null
+	var/datum/modifier/cloaking_device/modifier = null
+
+/obj/item/weapon/cloaking_device/New()
+	..()
+	cloaking_devices += src
+	cell = new /obj/item/weapon/cell/high(src)
+
+/obj/item/weapon/cloaking_device/Destroy()
+	..()
+	cloaking_devices -= src
+
+
+/obj/item/weapon/cloaking_device/equipped(var/mob/user, var/slot)
+	..()
+	//Picked up or switched hands or worn
+	register_owner(user)
+
+
+/obj/item/weapon/cloaking_device/dropped(var/mob/user)
+	..()
+	spawn(1)//Things are dropped on the floor briefly when being put into containers or swapping hands
+	//Its dumb. This little hack works around it
+		var/mob/M = get_holding_mob()
+		if(!M)
+			register_owner(M)
+			//Either placed somewhere or given to someone.
+			//M will be null if we were dropped on the floor, thats fine, the register function will handle it
+
+/obj/item/weapon/cloaking_device/attack_self(mob/user as mob)
+	if (istype(loc, /mob) && loc == user)//safety check incase of shenanigans
+		register_owner(user)
+		if (active)
+			deactivate()
+		else
+			activate()
+		src.add_fingerprint(user)
+		return
+
+/obj/item/weapon/cloaking_device/proc/activate()
+	if (active)
+		return
+
+	if (!cell || !cell.checked_use(power_usage*5*CELLRATE))//Costs a small burst to enter cloak
+		if (owner)
+			owner << "The [src] clicks uselessly, it has no power left."
+		return
+
+	processing_objects.Add(src)
+	active = 1
+	src.icon_state = "shield1"
+	stop_modifier()
+	playsound(src, 'sound/effects/phasein.ogg', 10, 1, -2)//Cloaking is quieter than uncloaking
+	if (owner)
+		owner << "<span class='notice'>\The [src] is now active.</span>"
+		start_modifier()
+
+/obj/item/weapon/cloaking_device/proc/deactivate()
+	if (!active)
+		return
+	active = 0
+	src.icon_state = "shield0"
+	if (owner)
+		owner << "<span class='notice'>\The [src] is now inactive.</span>"
+
+	playsound(src, 'sound/effects/phasein.ogg', 50, 1)
+	stop_modifier()
+	processing_objects.Remove(src)
+
+/obj/item/weapon/cloaking_device/emp_act(severity)
+	deactivate()
+	..()
+
+
+/obj/item/weapon/cloaking_device/proc/register_owner(var/mob/user)
+	if (!owner || owner != user)
+		stop_modifier()
+		owner = user
+		if (active)
+			start_modifier()
+
+
+/obj/item/weapon/cloaking_device/proc/start_modifier()
+	if (owner)
+		modifier = owner.add_modifier(/datum/modifier/cloaking_device, MODIFIER_ITEM, src, override = MODIFIER_OVERRIDE_NEIGHBOR)
+
+/obj/item/weapon/cloaking_device/proc/stop_modifier()
+	if (modifier)
+		modifier.stop(1)
+		modifier = null
+
+
+/obj/item/weapon/cloaking_device/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/cell))
+		if(!cell)
+			user.drop_item()
+			W.loc = src
+			cell = W
+			user << "<span class='notice'>You install a cell in [src].</span>"
+			update_icon()
+		else
+			user << "<span class='notice'>[src] already has a cell.</span>"
+
+	else if(istype(W, /obj/item/weapon/screwdriver))
+		if(cell)
+			cell.update_icon()
+			cell.loc = get_turf(src.loc)
+			cell = null
+			user << "<span class='notice'>You remove the cell from the [src].</span>"
+			deactivate()
+			return
+	..()
+
+
+/obj/item/weapon/cloaking_device/examine(mob/user)
+	..()
+	if (!cell)
+		user << "It needs a power cell to function."
+	else
+		user << "It has [cell.percent()]% power remaining"
+
+/obj/item/weapon/cloaking_device/process()
+	if (!cell || !cell.checked_use(power_usage*CELLRATE))
+		deactivate()
+		return
+
+
+/*
+	Modifier
+*/
+/datum/modifier/cloaking_device/activate()
+	..()
+	var/mob/living/L = target
+	L.cloaked = 1
+	L.mouse_opacity = 0
+	L.update_icons()
+
+
+/datum/modifier/cloaking_device/deactivate()
+	..()
+	for (var/a in cloaking_devices)//Check for any other cloaks
+		if (a != source)
+			var/obj/item/weapon/cloaking_device/CD = a
+			if (CD.get_holding_mob() == target)
+				if (CD.active)//If target is holding another active cloak then we wont remove their stealth
+					return
+	var/mob/living/L = target
+	L.cloaked = 0
+	L.mouse_opacity = 1
+	L.update_icons()
+
+
+/datum/modifier/cloaking_device/check_validity()
+	.=..()
+	if (. == 1)
+		var/obj/item/weapon/cloaking_device/C = source
+		if (!C.active)
+			return validity_fail("Cloak is inactive!")

--- a/code/game/objects/items/weapons/cloaking_device.dm
+++ b/code/game/objects/items/weapons/cloaking_device.dm
@@ -116,7 +116,7 @@
 	if(istype(W, /obj/item/weapon/cell))
 		if(!cell)
 			user.drop_item()
-			W.forceMove = src
+			W.forceMove(src)
 			cell = W
 			user << "<span class='notice'>You install a cell in [src].</span>"
 			update_icon()
@@ -126,7 +126,7 @@
 	else if(istype(W, /obj/item/weapon/screwdriver))
 		if(cell)
 			cell.update_icon()
-			cell.forceMove = get_turf(src.loc)
+			cell.forceMove(get_turf(src.loc))
 			cell = null
 			user << "<span class='notice'>You remove the cell from the [src].</span>"
 			deactivate()

--- a/code/game/objects/items/weapons/cloaking_device.dm
+++ b/code/game/objects/items/weapons/cloaking_device.dm
@@ -41,7 +41,7 @@
 	spawn(1)//Things are dropped on the floor briefly when being put into containers or swapping hands
 	//Its dumb. This little hack works around it
 		var/mob/M = get_holding_mob()
-		if(!M || M != owner)
+		if(!M)
 			register_owner(M)
 		//Either placed somewhere or given to someone.
 		//M will be null if we were dropped on the floor, thats fine, the register function will handle it

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -156,7 +156,7 @@
 		set_light(1.5, 1.5, "#006AFF")
 	else
 		set_light(0)
-		
+
 // tact
 /obj/item/weapon/shield/riot/tact
 	name = "tactical shield"
@@ -209,37 +209,4 @@
 
 	add_fingerprint(user)
 	return
-
-/obj/item/weapon/cloaking_device
-	name = "cloaking device"
-	desc = "Use this to become invisible to the human eye."
-	icon = 'icons/obj/device.dmi'
-	icon_state = "shield0"
-	var/active = 0.0
-	flags = CONDUCT
-	item_state = "electronic"
-	throwforce = 10.0
-	throw_speed = 2
-	throw_range = 10
-	w_class = 2.0
-	origin_tech = list(TECH_MAGNET = 3, TECH_ILLEGAL = 4)
-
-
-/obj/item/weapon/cloaking_device/attack_self(mob/user as mob)
-	src.active = !( src.active )
-	if (src.active)
-		user << "<span class='notice'>\The [src] is now active.</span>"
-		src.icon_state = "shield1"
-	else
-		user << "<span class='notice'>\The [src] is now inactive.</span>"
-		src.icon_state = "shield0"
-	src.add_fingerprint(user)
-	return
-
-/obj/item/weapon/cloaking_device/emp_act(severity)
-	active = 0
-	icon_state = "shield0"
-	if(ismob(loc))
-		loc:update_icons()
-	..()
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -351,9 +351,9 @@
 /obj/item/weapon/storage/proc/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
 	if(!istype(W)) return 0
 	if(usr)
-		usr.remove_from_mob(W)
+		usr.prepare_for_slotmove(W)
 		usr.update_icons()	//update our overlays
-	W.loc = src
+	W.forceMove(src)
 	W.on_enter_storage(src)
 	if(usr)
 		if (usr.client && usr.s_active != src)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -219,6 +219,24 @@ var/list/slot_equipment_priority = list( \
 	drop_from_inventory(I)
 	return 1
 
+
+//This function is an unsafe proc used to prepare an item for being moved to a slot, or from a mob to a container
+//It should be equipped to a new slot or forcemoved somewhere immediately after this is called
+/mob/proc/prepare_for_slotmove(obj/item/I)
+
+
+	if(!canUnEquip(I))
+		return 0
+
+	src.u_equip(I)
+	if (src.client)
+		src.client.screen -= I
+	I.layer = initial(I.layer)
+	I.screen_loc = null
+
+	return 1
+
+
 //Attemps to remove an object on a mob.
 /mob/proc/remove_from_mob(var/obj/O)
 	src.u_equip(O)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -313,60 +313,7 @@
 			H.germ_level = 0
 	update_icons()	//apply the now updated overlays to the mob
 
-//Throwing stuff
-/mob/proc/throw_item(atom/target)
-	return
 
-/mob/living/carbon/throw_item(atom/target)
-	src.throw_mode_off()
-	if(usr.stat || !target)
-		return
-	if(target.type == /obj/screen) return
-
-	var/atom/movable/item = src.get_active_hand()
-
-	if(!item) return
-
-	if (istype(item, /obj/item/weapon/grab))
-		var/obj/item/weapon/grab/G = item
-		item = G.throw_held() //throw the person instead of the grab
-		if(ismob(item))
-			var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
-			var/turf/end_T = get_turf(target)
-			if(start_T && end_T)
-				var/mob/M = item
-				var/start_T_descriptor = "<font color='#6b5d00'>tile at [start_T.x], [start_T.y], [start_T.z] in area [get_area(start_T)]</font>"
-				var/end_T_descriptor = "<font color='#6b4400'>tile at [end_T.x], [end_T.y], [end_T.z] in area [get_area(end_T)]</font>"
-
-				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been thrown by [usr.name] ([usr.ckey]) from [start_T_descriptor] with the target [end_T_descriptor]</font>")
-				usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Has thrown [M.name] ([M.ckey]) from [start_T_descriptor] with the target [end_T_descriptor]</font>")
-				msg_admin_attack("[usr.name] ([usr.ckey]) has thrown [M.name] ([M.ckey]) from [start_T_descriptor] with the target [end_T_descriptor] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>)")
-
-	if(!item) return //Grab processing has a chance of returning null
-
-
-	src.remove_from_mob(item)
-	item.loc = src.loc
-
-	//actually throw it!
-	if (item)
-		src.visible_message("\red [src] has thrown [item].")
-
-		if(!src.lastarea)
-			src.lastarea = get_area(src.loc)
-		if((istype(src.loc, /turf/space)) || (src.lastarea.has_gravity == 0))
-			src.inertia_dir = get_dir(target, src)
-			step(src, inertia_dir)
-
-
-/*
-		if(istype(src.loc, /turf/space) || (src.flags & NOGRAV)) //they're in space, move em one space in the opposite direction
-			src.inertia_dir = get_dir(target, src)
-			step(src, inertia_dir)
-*/
-
-
-		item.throw_at(target, item.throw_range, item.throw_speed, src)
 
 /mob/living/carbon/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -542,6 +542,9 @@
 		if("swish")
 			src.animate_tail_once()
 
+		if("idle")
+			src.animate_tail_reset()
+
 		if("wag", "sway")
 			src.animate_tail_start()
 
@@ -554,7 +557,7 @@
 		if("beep")
 			if (!isipc(src))
 				src << span("notice", "You're not a machine!")
-			else 
+			else
 				var/M = null
 				if(param)
 					for (var/mob/A in view(null, null))
@@ -574,7 +577,7 @@
 		if("ping")
 			if (!isipc(src))
 				src << span("notice", "You're not a machine!")
-			else 
+			else
 				var/M = null
 				if(param)
 					for (var/mob/A in view(null, null))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1434,49 +1434,7 @@
 		return
 	return ..()
 
-//Puts the item into our active hand if possible. returns 1 on success.
-/mob/living/carbon/human/put_in_active_hand(var/obj/item/W)
-	return (hand ? put_in_l_hand(W) : put_in_r_hand(W))
 
-//Puts the item into our inactive hand if possible. returns 1 on success.
-/mob/living/carbon/human/put_in_inactive_hand(var/obj/item/W)
-	return (hand ? put_in_r_hand(W) : put_in_l_hand(W))
-
-/mob/living/carbon/human/put_in_hands(var/obj/item/W)
-	if(!W)
-		return 0
-	if(put_in_active_hand(W))
-		update_inv_l_hand()
-		update_inv_r_hand()
-		return 1
-	else if(put_in_inactive_hand(W))
-		update_inv_l_hand()
-		update_inv_r_hand()
-		return 1
-	else
-		return ..()
-
-/mob/living/carbon/human/put_in_l_hand(var/obj/item/W)
-	if(!..() || l_hand)
-		return 0
-
-	W.forceMove(src)
-	l_hand = W
-	W.equipped(src,slot_l_hand)
-	W.add_fingerprint(src)
-	update_inv_l_hand()
-	return 1
-
-/mob/living/carbon/human/put_in_r_hand(var/obj/item/W)
-	if(!..() || r_hand)
-		return 0
-
-	W.forceMove(src)
-	r_hand = W
-	W.equipped(src,slot_r_hand)
-	W.add_fingerprint(src)
-	update_inv_r_hand()
-	return 1
 
 /mob/living/carbon/human/AltClickOn(var/atom/A)
 	var/doClickAction = 1

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -381,3 +381,48 @@ This saves us from having to call add_fingerprint() any time something is put in
 		if(slot_s_store)    items += s_store
 
 	return items
+
+
+//Puts the item into our active hand if possible. returns 1 on success.
+/mob/living/carbon/human/put_in_active_hand(var/obj/item/W)
+	return (hand ? put_in_l_hand(W) : put_in_r_hand(W))
+
+//Puts the item into our inactive hand if possible. returns 1 on success.
+/mob/living/carbon/human/put_in_inactive_hand(var/obj/item/W)
+	return (hand ? put_in_r_hand(W) : put_in_l_hand(W))
+
+/mob/living/carbon/human/put_in_hands(var/obj/item/W)
+	if(!W)
+		return 0
+	if(put_in_active_hand(W))
+		update_inv_l_hand()
+		update_inv_r_hand()
+		return 1
+	else if(put_in_inactive_hand(W))
+		update_inv_l_hand()
+		update_inv_r_hand()
+		return 1
+	else
+		return ..()
+
+/mob/living/carbon/human/put_in_l_hand(var/obj/item/W)
+	if(!..() || l_hand)
+		return 0
+
+	W.forceMove(src)
+	l_hand = W
+	W.equipped(src,slot_l_hand)
+	W.add_fingerprint(src)
+	update_inv_l_hand()
+	return 1
+
+/mob/living/carbon/human/put_in_r_hand(var/obj/item/W)
+	if(!..() || r_hand)
+		return 0
+
+	W.forceMove(src)
+	r_hand = W
+	W.equipped(src,slot_r_hand)
+	W.add_fingerprint(src)
+	update_inv_r_hand()
+	return 1

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -994,8 +994,10 @@
 		if(paralysis || sleeping)
 			blinded = 1
 			stat = UNCONSCIOUS
-			animate_tail_reset()
+
 			adjustHalLoss(-3)
+			if (species.tail)
+				animate_tail_reset()
 
 		if(paralysis)
 			AdjustParalysis(-1)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -179,8 +179,6 @@ Please contact me on #coderbus IRC. ~Carn x
 			src.transform = M
 
 	lying_prev = lying
-	if (type == /mob/living/carbon/human && !client && lying && life_tick > 20)
-		CRASH()
 
 var/global/list/damage_icon_parts = list()
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -144,8 +144,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	var/previous_damage_appearance // store what the body last looked like, so we only have to update it if something changed
 
 //UPDATES OVERLAYS FROM OVERLAYS_LYING/OVERLAYS_STANDING
-//this proc is messy as I was forced to include some old laggy cloaking code to it so that I don't break cloakers
-//I'll work on removing that stuff by rewriting some of the cloaking stuff at a later date.
+//Fixed by Nanako
 /mob/living/carbon/human/update_icons()
 		//so we don't update overlays for lying/standing unless our stance changes again
 	update_hud()		//TODO: remove the need for this

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -69,3 +69,4 @@
 	var/move_delay_mod = 0//Added to move delay, used for calculating movement speeds. Provides a centralised value for modifiers to alter
 
 	var/total_radiation	// DON'T MODIFY THIS DIRECTLY. USE apply_radiation()!
+	var/cloaked = 0//Set to 1 by cloaking devices, optimises update_icons

--- a/html/changelogs/nanako-updatecloak.yml
+++ b/html/changelogs/nanako-updatecloak.yml
@@ -35,5 +35,6 @@ delete-after: True
 changes: 
   - tweak: "Cloaking devices now use power, the cell can be removed for charging or replacement with a screwdriver."
   - tweak: "Cloaking devices now hide the user from rightclick menus, and in general make them harder to hit."
+  - rscadd: "Cloaking device is now available in traitor uplinks. Costs 14 TC, its very powerful."
   - rscadd: "Added an *idle emote for people with tails to reset their tail wagging to the default speeds."
   - bugfix: "Fixed a bug where dead or SSD crewmembers would constantly try to stop wagging their tail (even if they don't have one) causing some lag."

--- a/html/changelogs/nanako-updatecloak.yml
+++ b/html/changelogs/nanako-updatecloak.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Cloaking devices now use power, the cell can be removed for charging or replacement with a screwdriver."
+  - tweak: "Cloaking devices now hide the user from rightclick menus, and in general make them harder to hit."
+  - rscadd: "Added an *idle emote for people with tails to reset their tail wagging to the default speeds."
+  - bugfix: "Fixed a bug where dead or SSD crewmembers would constantly try to stop wagging their tail (even if they don't have one) causing some lag."


### PR DESCRIPTION
I started today by firing up the profiler and spawning a couple hundred naked humans to test with, hoping to find something significant to fix for performance gains. This experiment was quite a success, as i found that human/update_icons was using a disproportionate amount of CPU time.

On investigation i discovered three issues:

1. A pretty significant bug where all dead or SSD human mobs were attempting to update their tail every life proc (even if they dont have one) which resulted in a call to update icons too. I've optimised this so that update icons will only be called if the tail state is changed, and the tail code won't even run for species which don't have tails.

2. Cloaking device code stuck in where it shouldn't be. Hence i decided this was a good opportunity to rework them. I moved their code out into their own file. I removed the special case code from update icons, and instead ported them to the modifier system i wrote a couple months back, its designed for just this sort of thing. Also rebalanced them a little: Cloaking devices now have limited power, roughly 5 minutes of sustained use (this works out to a lot more actual usage if you use it wisely), Cell can be removed/recharged/replaced added the cloaking sound effect, and added mouse_opacity 0 for cloaked mobs. This results in them being un-rightclickable and not seeable in the altclick menu either, making the cloaking generally more robust for hiding. Cloaking devices also added to traitor uplink. 14 TC cost, pretty expensive

3. The optimisation for lying states was written but not implemented for some reason. I fixed it so the icon won't be transformed unless it needs to be: When someone changes between lying/standing, or if they have a nonstandard scaling factor. Scaling factor is fully supported, although currently unused. I intend to make use of it in upcoming genetics work.


With these changes, update_icons is now mostly a nonissue, and thus a great deal of load caused by SSD players is cleaned up

In addition, i've reworked the Dropped proc due to the problems its caused, and lack of valid use cases for its more esoteric behaviour.

Moving an item between your hands, or placing it into a container, now uses a custom proc to remove the item instead of the default unequip one. Which does most of the same stuff but does not call Dropped. 

As a result, dropped now only fires in three situations
1. When an item is actually dropped
2. When an item is thrown
3. When an item is placed into a container:
Note that before this change, placing an object into a container called dropped twice. Once on the floor, and then once in the container. My change removes the first one. The second dropped call still happens, and it happens AFTER the object is inside the container, allowing it to check its location

In short, dropped has been redefined from its old usage of "left an inventory slot" to now mean "left a mob's direct contents" which is a far more useful definition programatically.