### PR TITLE
Fix fax machines

### DIFF
--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -290,7 +290,7 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 
 	var/obj/item/rcvdcopy
 	if (istype(copyitem, /obj/item/weapon/paper))
-		rcvdcopy = copy(copyitem)
+		rcvdcopy = copy(copyitem, 0)
 	else if (istype(copyitem, /obj/item/weapon/photo))
 		rcvdcopy = photocopy(copyitem)
 	else if (istype(copyitem, /obj/item/weapon/paper_bundle))

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -256,7 +256,7 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 	// give the sprite some time to flick
 	spawn(20)
 		if (istype(incoming, /obj/item/weapon/paper))
-			copy(incoming)
+			copy(incoming, 1, 0, 0)
 		else if (istype(incoming, /obj/item/weapon/photo))
 			photocopy(incoming)
 		else if (istype(incoming, /obj/item/weapon/paper_bundle))

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -146,7 +146,7 @@
 					toner = 0
 	return
 
-/obj/machinery/photocopier/proc/copy(var/obj/item/weapon/paper/copy)
+/obj/machinery/photocopier/proc/copy(var/obj/item/weapon/paper/copy, var/print = 1)
 	var/obj/item/weapon/paper/c = new /obj/item/weapon/paper()
 	var/info
 	var/pname
@@ -185,8 +185,9 @@
 		return
 	
 	c.set_content_unsafe(pname, info)
-	print(c, 1, 'sound/items/poster_being_created.ogg', 20)
-
+	if (print)
+		src.print(c, 1, 'sound/items/poster_being_created.ogg', 20)
+	return c
 
 /obj/machinery/photocopier/proc/photocopy(var/obj/item/weapon/photo/photocopy)
 	var/obj/item/weapon/photo/p = photocopy.copy()

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -146,7 +146,7 @@
 					toner = 0
 	return
 
-/obj/machinery/photocopier/proc/copy(var/obj/item/weapon/paper/copy, var/print = 1)
+/obj/machinery/photocopier/proc/copy(var/obj/item/weapon/paper/copy, var/print = 1, var/use_sound = 1, var/delay = 20)
 	var/obj/item/weapon/paper/c = new /obj/item/weapon/paper()
 	var/info
 	var/pname
@@ -186,7 +186,7 @@
 	
 	c.set_content_unsafe(pname, info)
 	if (print)
-		src.print(c, 1, 'sound/items/poster_being_created.ogg', 20)
+		src.print(c, use_sound, 'sound/items/poster_being_created.ogg', delay)
 	return c
 
 /obj/machinery/photocopier/proc/photocopy(var/obj/item/weapon/photo/photocopy)


### PR DESCRIPTION
A change with photocopiers cascaded into an issue with fax machines, this fixes it.
changes:
- Faxes to CCIA work again.
- Faxes no longer make two different sounds when printing a fax.