### PR TITLE
Mousetrap, mouse and spawning fixes

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -166,3 +166,12 @@
 
 #define RESPAWN_ANIMAL 3000
 #define RESPAWN_MINISYNTH 6000
+
+//Flags for the eat_types variable, a bitfield of what can or can't be eaten
+//Note that any given mob can be more than one type
+#define TYPE_ORGANIC	1//Almost any creature under /mob/living/carbon and most simple animals
+#define	TYPE_SYNTHETIC	2//Everything under /mob/living/silicon, plus IPCs, viscerators
+#define TYPE_HUMANOID	4//Humans, skrell, unathi, tajara, vaurca, diona, IPC, vox
+#define TYPE_WIERD		8//Slimes, constructs, demons, and other creatures of a magical or bluespace nature.
+
+

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -200,14 +200,12 @@
 
 /obj/structure/window/attack_generic(var/mob/user, var/damage)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	if(!damage)
-		return
 	if(damage >= 10)
 		visible_message("<span class='danger'>[user] smashes into [src]!</span>")
 		take_damage(damage)
 	else
 		visible_message("<span class='notice'>\The [user] bonks \the [src] harmlessly.</span>")
-		playsound(src.loc, 'sound/effects/Glasshit.ogg', 7, 1, -1)
+		playsound(src.loc, 'sound/effects/Glasshit.ogg', 10, 1, -2)
 	user.do_attack_animation(src)
 	return 1
 

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -20,29 +20,29 @@
 		if(holder)
 			holder.update_icon()
 
-/obj/item/device/assembly/mousetrap/proc/triggered(mob/target as mob, var/type = "feet")
+/obj/item/device/assembly/mousetrap/proc/triggered(var/mob/living/target, var/type = "feet")
 	if(!armed)
 		return
-	var/obj/item/organ/external/affecting = null
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		switch(type)
-			if("feet")
-				if(!H.shoes)
-					affecting = H.get_organ(pick("l_leg", "r_leg"))
-					H.Weaken(3)
-			if("l_hand", "r_hand")
-				if(!H.gloves)
-					affecting = H.get_organ(type)
-					H.Stun(3)
-		if(affecting)
-			if(affecting.take_damage(rand(7,12), 0))
-				H.UpdateDamageIcon()
-			H.updatehealth()
-	else if(ismouse(target))
+	if(ismouse(target))
 		var/mob/living/simple_animal/mouse/M = target
 		visible_message("\red <b>SPLAT!</b>")
 		M.splat()
+	else
+		var/zone = "chest"
+		if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			switch(type)
+				if("feet")
+					zone = pick("l_leg", "r_leg")
+					if(!H.shoes)
+						H.Weaken(3)
+				if("l_hand", "r_hand")
+					zone = type
+					if(!H.gloves)
+						H.Stun(3)
+
+		target.apply_damage(rand(7,15), BRUTE, def_zone = zone, used_weapon = src)
+
 	playsound(target.loc, 'sound/effects/snap.ogg', 50, 1)
 	layer = MOB_LAYER - 0.2
 	armed = 0
@@ -83,14 +83,14 @@
 
 /obj/item/device/assembly/mousetrap/Crossed(AM as mob|obj)
 	if(armed)
-		if(ishuman(AM))
-			var/mob/living/carbon/H = AM
-			if(H.m_intent == "run")
-				triggered(H)
-				H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
-								  "<span class='warning'>You accidentally step on [src]</span>")
 		if(ismouse(AM))
 			triggered(AM)
+		else if(istype(AM, /mob/living))
+			var/mob/living/L = AM
+			triggered(L)
+			L.visible_message("<span class='warning'>[L] accidentally steps on [src].</span>", \
+							  "<span class='warning'>You accidentally step on [src]</span>")
+
 	..()
 
 

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -21,27 +21,30 @@
 			holder.update_icon()
 
 /obj/item/device/assembly/mousetrap/proc/triggered(var/mob/living/target, var/type = "feet")
-	if(!armed)
+	if(!armed || !istype(target))
 		return
+
+	var/types = target.find_type()
 	if(ismouse(target))
 		var/mob/living/simple_animal/mouse/M = target
 		visible_message("\red <b>SPLAT!</b>")
 		M.splat()
 	else
 		var/zone = "chest"
-		if(ishuman(target))
+		if(ishuman(target) && target.mob_size)
 			var/mob/living/carbon/human/H = target
 			switch(type)
 				if("feet")
-					zone = pick("l_leg", "r_leg")
+					zone = pick("l_foot", "r_foot")
 					if(!H.shoes)
-						H.Weaken(3)
+						H.apply_effect(400/(target.mob_size*(target.mob_size*0.25)), AGONY)//Halloss instead of instant knockdown
+						//Mainly for the benefit of giant monsters like vaurca breeders
 				if("l_hand", "r_hand")
 					zone = type
 					if(!H.gloves)
-						H.Stun(3)
-
-		target.apply_damage(rand(7,15), BRUTE, def_zone = zone, used_weapon = src)
+						H.apply_effect(250/(target.mob_size*(target.mob_size*0.25)), AGONY)
+		if (!(types & TYPE_SYNTHETIC))
+			target.apply_damage(rand(6,14), BRUTE, def_zone = zone, used_weapon = src)
 
 	playsound(target.loc, 'sound/effects/snap.ogg', 50, 1)
 	layer = MOB_LAYER - 0.2

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -21,7 +21,7 @@ var/list/ghost_traps
 
 /datum/ghosttrap
 	var/object = "positronic brain"
-	var/minutes_since_death = 0     // If non-zero the ghost must have been dead for this many minutes to be allowed to spawn
+	var/respawn_check = 0//Which respawning test we check against
 	var/list/ban_checks = list("AI","Cyborg")
 	var/pref_check = BE_SYNTH
 	var/ghost_trap_message = "They are occupying a positronic brain now."
@@ -37,7 +37,7 @@ var/list/ghost_traps
 
 // Check for bans, proper atom types, etc.
 /datum/ghosttrap/proc/assess_candidate(var/mob/dead/observer/candidate, var/mob/target)
-	if(!candidate.MayRespawn(1, minutes_since_death))
+	if(!candidate.MayRespawn(1, respawn_check))
 		return 0
 	if(islist(ban_checks))
 		for(var/bantype in ban_checks)
@@ -174,7 +174,7 @@ var/list/ghost_traps
 	list_as_special_role = FALSE
 
 /datum/ghosttrap/drone/New()
-	minutes_since_death = DRONE_SPAWN_DELAY
+	respawn_check = MINISYNTH
 	..()
 
 datum/ghosttrap/drone/assess_candidate(var/mob/dead/observer/candidate, var/mob/target)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -465,12 +465,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(config.disable_player_mice)
 		src << "<span class='warning'>Spawning as a mouse is currently disabled.</span>"
 		return
-		
+
 	if(ticker.current_state < GAME_STATE_PLAYING)
 		src << "<span class='warning'>You can not spawn as a mouse before round start!</span>"
 		return
-		
-	if(!MayRespawn(1, ANIMAL_SPAWN_DELAY))
+
+	if(!MayRespawn(1, ANIMAL))
 		return
 
 	var/turf/T = get_turf(src)
@@ -815,7 +815,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if (ghostimage)
 			client.images -= ghostimage //remove ourself
 
-mob/dead/observer/MayRespawn(var/feedback = 0, var/respawn_time = 0)
+mob/dead/observer/MayRespawn(var/feedback = 0, var/respawn_type = null)
 	if(!client)
 		return 0
 	if(config.antag_hud_restricted && has_enabled_antagHUD == 1)
@@ -823,10 +823,21 @@ mob/dead/observer/MayRespawn(var/feedback = 0, var/respawn_time = 0)
 			src << "<span class='warning'>antagHUD restrictions prevent you from respawning.</span>"
 		return 0
 
-	var/timedifference = world.time - timeofdeath
-	if(respawn_time && timeofdeath && timedifference < respawn_time MINUTES)
-		var/timedifference_text = time2text(respawn_time MINUTES - timedifference,"mm:ss")
-		src << "<span class='warning'>You must have been dead for [respawn_time] minute\s to respawn. You have [timedifference_text] left.</span>"
+	if (respawn_type)
+		var/timedifference = world.time- get_death_time(respawn_type)
+		var/respawn_time = 0
+		if (respawn_type == CREW)
+			respawn_time = config.respawn_delay *600
+		else if (respawn_type == ANIMAL)
+			respawn_time = RESPAWN_ANIMAL
+		else if (respawn_type == MINISYNTH)
+			respawn_time = RESPAWN_MINISYNTH
+
+		if (respawn_time && timedifference >= respawn_time)
+			return 1
+		else if (feedback)
+			var/timedifference_text = time2text(respawn_time - timedifference,"mm:ss")
+			src << "<span class='warning'>You must have been dead for [respawn_time/600] minute\s to respawn. You have [timedifference_text] left.</span>"
 		return 0
 
 	return 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -752,7 +752,7 @@ default behaviour is:
 	if(jobban_isbanned(possessor, "Animal"))
 		possessor << "<span class='warning'>You are banned from animal roles.</span>"
 		return 0
-	if(!possessor.MayRespawn(1,ANIMAL_SPAWN_DELAY))
+	if(!possessor.MayRespawn(1,ANIMAL))
 		return 0
 	return 1
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -70,7 +70,7 @@ var/list/mob_hat_cache = list()
 	if(jobban_isbanned(possessor,"Cyborg"))
 		usr << "<span class='danger'>You are banned from playing synthetics and cannot spawn as a drone.</span>"
 		return 0
-	if(!possessor.MayRespawn(1,DRONE_SPAWN_DELAY))
+	if(!possessor.MayRespawn(1,MINISYNTH))
 		return 0
 	return 1
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -105,7 +105,7 @@
 		user << "<span class='danger'>You are banned from playing synthetics and cannot spawn as a drone.</span>"
 		return
 
-	if(!user.MayRespawn(1, DRONE_SPAWN_DELAY))
+	if(!user.MayRespawn(1, MINISYNTH))
 		return
 
 	if(!fabricator)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -55,9 +55,11 @@
 	if(..())
 
 		if(client)
+			walk_to(src,0)
+
 			//Player-animals don't do random speech normally, so this is here
 			//Player-controlled mice will still squeak, but less often than NPC mice
-			if (stat == CONSCIOUS && prob(speak_chance*0.1))
+			if (stat == CONSCIOUS && prob(speak_chance*0.05))
 				squeak_soft(0)
 
 			if(is_ventcrawling == 0)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -439,7 +439,7 @@
 	if (ticker.mode.deny_respawn) //BS12 EDIT
 		usr << "<span class='notice'>Respawn is disabled for this roundtype.</span>"
 		return
-	else if(!MayRespawn(1, config.respawn_delay))
+	else if(!MayRespawn(1, CREW))
 		return
 
 	usr << "You can respawn now, enjoy your new life!"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -949,13 +949,6 @@ proc/is_blind(A)
 //See Devour.dm for more info in how these are used
 
 
-//Flags for the eat_types variable, a bitfield of what can or can't be eaten
-//Note that any given mob can be more than one type
-#define TYPE_ORGANIC	1//Almost any creature under /mob/living/carbon and most simple animals
-#define	TYPE_SYNTHETIC	2//Everything under /mob/living/silicon, plus IPCs, viscerators
-#define TYPE_HUMANOID	4//Humans, skrell, unathi, tajara, vaurca, diona, IPC, vox
-#define TYPE_WIERD		8//Slimes, constructs, demons, and other creatures of a magical or bluespace nature.
-
 
 //Blacklists of mobs that can be excluded from eating by flags in the bitfield
 

--- a/html/changelogs/Nanako-MiceSpawn.yml
+++ b/html/changelogs/Nanako-MiceSpawn.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Mousetraps will now trigger when walked on. Also nerfed the instastun for shoeless mobs stepping on them."
+  - bugfix: "Fixed several mouse related bugs."
+  - bugfix: "Fixed the individual respawn times not working. Respawning should now work as before"


### PR DESCRIPTION
Adjusts mousetraps a bit. So they'll be triggered by all mobs instead of only humans, and trigger when walked on. Also nerfs the instastun that comes from stepping on them without shoes, because that's pretty broken against giant monsters like vaurca breeders. applies halloss instead based on mob size.  Smaller things get hurt more

Linking of issues to follow