### PR TITLE
Adv. Scanner Tweaks & General Fixes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -165,7 +165,6 @@
 #include "code\datums\mind.dm"
 #include "code\datums\mixed.dm"
 #include "code\datums\modules.dm"
-#include "code\datums\organs.dm"
 #include "code\datums\recipe.dm"
 #include "code\datums\server_greeting.dm"
 #include "code\datums\sun.dm"

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -420,4 +420,5 @@ proc/TextPreview(var/string,var/len=40)
 	t = replacetext(t, "\[logo\]", "<img src = ntlogo.png>")
 	t = replacetext(t, "\[time\]", "[worldtime2text()]")
 	t = replacetext(t, "\[date\]", "[worlddate2text()]")
+	t = replacetext(t, "\[editorbr\]", "<BR>")
 	return t

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -360,7 +360,7 @@
 				data["bruteDmg"] = 0
 
 		if (istype(O, /obj/item/organ/lungs) && H.is_lung_ruptured())
-			wounds += "Shows symptoms of rupture."
+			wounds += "Shows symptoms of structural failure."
 
 		if (istype(O, /obj/item/organ/brain) && H.has_brain_worms())
 			wounds += "Has an abnormal growth."
@@ -407,7 +407,7 @@
 		if (O.status & ORGAN_BLEEDING)
 			wounds += "Bleeding."
 		if (O.status & ORGAN_BROKEN)
-			wounds += "[O.broken_description]."
+			wounds += "Is \a [O.broken_description]."
 		if (O.open)
 			wounds += "Has an open wound."
 		if (O.germ_level)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -203,11 +203,11 @@
 	
 /obj/machinery/bodyscanner/proc/check_species()
 	if (!occupant || !ishuman(occupant))
-		return 0
+		return 1
 	var/mob/living/carbon/human/O = occupant
 	if (!O)
-		return 0
-	return O.get_species() in allowed_species
+		return 1
+	return !(O.get_species() in allowed_species)
 
 /obj/machinery/body_scanconsole/ex_act(severity)
 
@@ -283,7 +283,7 @@
 	if (src.connected)
 		occupant = src.connected.occupant
 	
-	data["noscan"]		= !(src.connected.check_species())
+	data["noscan"]		= src.connected.check_species()
 	data["nocons"]		= !src.connected
 	data["occupied"] 	= occupied
 	data["invalid"]		= src.connected && src.connected.check_species()
@@ -321,7 +321,7 @@
 		data["radStatus"] 		= val2status(occupant.total_radiation)
 		data["cloneDmgStatus"] 	= val2status(occupant.cloneloss, 10, 35)
 		data["bodyparts"]		= get_organ_wound_data(occupant)
-		var/list/missing 			= get_missing_organs(occupant)
+		var/list/missing 		= get_missing_organs(occupant)
 		data["missingparts"]	= missing
 		data["hasmissing"]		= missing.len ? 1 : 0
 		data["hasvirus"]		= occupant.virus2.len || occupant.viruses.len
@@ -360,7 +360,7 @@
 				data["bruteDmg"] = 0
 
 		if (istype(O, /obj/item/organ/lungs) && H.is_lung_ruptured())
-			wounds += "Appears to be ruptured."
+			wounds += "Shows symptoms of rupture."
 
 		if (istype(O, /obj/item/organ/brain) && H.has_brain_worms())
 			wounds += "Has an abnormal growth."
@@ -403,11 +403,11 @@
 		if (O.status & ORGAN_ROBOT)
 			wounds += "Appears to be composed of inorganic material."
 		if (O.status & ORGAN_SPLINTED)
-			wounds += "Appears to be splinted."
+			wounds += "Splinted."
 		if (O.status & ORGAN_BLEEDING)
-			wounds += "Appears to be bleeding."
+			wounds += "Bleeding."
 		if (O.status & ORGAN_BROKEN)
-			wounds += "Appears to have \a [O.broken_description]."
+			wounds += "[O.broken_description]."
 		if (O.open)
 			wounds += "Has an open wound."
 		if (O.germ_level)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -418,7 +418,7 @@
 	switch (level)
 		if (INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + 200)
 			return "mild"
-		if (INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 200)
+		if (INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
 			return "worsening mild"
 		if (INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
 			return "borderline acute"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -245,10 +245,6 @@
 /obj/machinery/body_scanconsole/attack_hand(user as mob)
 	if(..())
 		return
-
-	var/mob/living/carbon/human/O = connected.occupant
-	if (O && O.species.flags & NO_SCAN)
-		state("Unable to scan: No diagnostics profile for this species installed.")
 		
 	ui_interact(user)
 
@@ -265,12 +261,14 @@
 /obj/machinery/body_scanconsole/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
 	var/list/data = list()
 	var/occupied = (src.connected && src.connected.occupant)
-	var/mob/living/carbon/human/occupant = src.connected.occupant
+	var/mob/living/carbon/human/occupant
+	if (src.connected)
+		occupant = src.connected.occupant
 	
-	data["noscan"]		= !occupant || occupant.species.flags & NO_SCAN
+	data["noscan"]		= !occupant || !ishuman(occupant) || occupant.species.flags & NO_SCAN
 	data["nocons"]		= !src.connected
 	data["occupied"] 	= occupied
-	data["invalid"]		= data["noscan"] || data["nocons"] || !data["occupied"]
+	data["invalid"]		= data["noscan"] || data["nocons"] || !data["occupied"] || !occupant
 	if (!data["invalid"])
 		var/datum/reagents/R = occupant.bloodstr
 		var/datum/reagents/B = occupant.vessel

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -578,7 +578,7 @@
 		if (infection == "")
 			infection = "None"
 		if(e.rejecting)
-			infected += "(being rejected)"
+			infected += " (being rejected)"
 
 		if (e.implants.len)
 			var/unknown_body = 0

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -305,7 +305,9 @@
 		var/list/missing 			= get_missing_organs(occupant)
 		data["missingparts"]	= missing
 		data["hasmissing"]		= missing.len ? 1 : 0
-		data["hasvirus"]		= occupant.virus2.len
+		data["hasvirus"]		= occupant.virus2.len || occupant.viruses.len
+		data["hastgvirus"]		= occupant.viruses.len
+		data["tgvirus"]			= occupant.viruses
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -286,7 +286,7 @@
 	data["noscan"]		= !(src.connected.check_species())
 	data["nocons"]		= !src.connected
 	data["occupied"] 	= occupied
-	data["invalid"]		= src.connected && src.connected.check_occupant_validity()
+	data["invalid"]		= src.connected && src.connected.check_species()
 	data["ipc"]			= src.connected && occupant && isipc(occupant)
 	if (!data["invalid"])
 		var/datum/reagents/R = occupant.bloodstr

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -4,6 +4,7 @@
 /obj/machinery/bodyscanner
 	var/mob/living/carbon/occupant
 	var/locked
+	var/obj/machinery/body_scanconsole/connected
 	name = "Body Scanner"
 	desc = "A state-of-the-art medical diagnostics machine. Guaranteed detection of all your bodily ailments or your money back!"
 	icon = 'icons/obj/Cryogenic2.dmi'
@@ -14,6 +15,11 @@
 	use_power = 1
 	idle_power_usage = 60
 	active_power_usage = 10000	//10 kW. It's a big all-body scanner.
+
+/obj/machinery/bodyscanner/Destroy()
+	// So the GC can qdel this.
+	src.connected.connected = null
+	return ..()
 
 /obj/machinery/bodyscanner/relaymove(mob/user as mob)
 	if (user.stat)
@@ -200,6 +206,10 @@
 		else
 	return
 
+/obj/machinery/body_scanconsole/Destroy()
+	src.connected.connected = null
+	return ..()
+
 /obj/machinery/body_scanconsole/power_change()
 	..()
 	if(stat & BROKEN)
@@ -225,6 +235,7 @@
 	..()
 	spawn(5)
 		src.connected = locate(/obj/machinery/bodyscanner, get_step(src, WEST))
+		src.connected.connected = src
 		return
 	return
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -5,6 +5,16 @@
 	var/mob/living/carbon/occupant
 	var/locked
 	var/obj/machinery/body_scanconsole/connected
+	var/list/allowed_species = list(
+		"Human",
+		"Skrell",
+		"Unathi",
+		"Tajara",
+		"M'sai Tajara",
+		"Zhan-Khazan Tajara",
+		"Vaurca Worker",
+		"Vaurca Warrior"
+	)
 	name = "Body Scanner"
 	desc = "A state-of-the-art medical diagnostics machine. Guaranteed detection of all your bodily ailments or your money back!"
 	icon = 'icons/obj/Cryogenic2.dmi'
@@ -190,6 +200,14 @@
 				return
 		else
 	return
+	
+/obj/machinery/bodyscanner/proc/check_species()
+	if (!occupant || !ishuman(occupant))
+		return 0
+	var/mob/living/carbon/human/O = occupant
+	if (!O)
+		return 0
+	return O.get_species() in allowed_species
 
 /obj/machinery/body_scanconsole/ex_act(severity)
 
@@ -265,16 +283,17 @@
 	if (src.connected)
 		occupant = src.connected.occupant
 	
-	data["noscan"]		= !occupant || !ishuman(occupant) || occupant.species.flags & NO_SCAN
+	data["noscan"]		= !(src.connected.check_species())
 	data["nocons"]		= !src.connected
 	data["occupied"] 	= occupied
-	data["invalid"]		= data["noscan"] || data["nocons"] || !data["occupied"] || !occupant
+	data["invalid"]		= src.connected && src.connected.check_occupant_validity()
+	data["ipc"]			= src.connected && occupant && isipc(occupant)
 	if (!data["invalid"])
 		var/datum/reagents/R = occupant.bloodstr
 		var/datum/reagents/B = occupant.vessel
 		data["stat"]			= occupant.stat
 		data["name"]			= occupant.name
-		data["species"]			= occupant.species.name	// mostly for fluff. 
+		data["species"]			= occupant.get_species()	// mostly for fluff. 
 		data["health"]			= occupant.health
 		data["maxHealth"]		= occupant.maxHealth
 		data["minHealth"]		= config.health_threshold_dead

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -5,6 +5,7 @@
 	var/mob/living/carbon/occupant
 	var/locked
 	name = "Body Scanner"
+	desc = "A state-of-the-art medical diagnostics machine. Guaranteed detection of all your bodily ailments or your money back!"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "body_scanner_0"
 	density = 1
@@ -216,6 +217,7 @@
 	var/delete
 	var/temphtml
 	name = "Body Scanner Console"
+	desc = "A control panel for some kind of medical device."
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "body_scannerconsole"
 	density = 0
@@ -256,6 +258,8 @@
 	return src.attack_hand(user)
 
 /obj/machinery/body_scanconsole/attack_hand(user as mob)
+	ui_interact(user)	// TODO: CHECK STATE BEFORE RUNNING THIS
+	return
 	if(..())
 		return
 	if(stat & (NOPOWER|BROKEN))
@@ -263,10 +267,13 @@
 	if(!connected || (connected.stat & (NOPOWER|BROKEN)))
 		user << "<span class='warning'>This console is not connected to a functioning body scanner.</span>"
 		return
+	if (!connected.occupant)
+		user << span("warning", "The body scanner is empty.")
+		return
 	if(!ishuman(connected.occupant))
 		user << "<span class='warning'>This device can only scan compatible lifeforms.</span>"
 		return
-
+		
 	var/dat
 	if (src.delete && src.temphtml) //Window in buffer but its just simple message, so nothing
 		src.delete = src.delete
@@ -285,23 +292,217 @@
 
 
 /obj/machinery/body_scanconsole/Topic(href, href_list)
-	if (..())
-		return
+	..()
 
 	if (href_list["print"])
 		if (!src.connected)
 			usr << "\icon[src]<span class='warning'>Error: No body scanner connected.</span>"
 			return
 		var/mob/living/carbon/human/occupant = src.connected.occupant
-		if (!src.connected.occupant)
+		if (!occupant)
 			usr << "\icon[src]<span class='warning'>The body scanner is empty.</span>"
 			return
-		if (!istype(occupant,/mob/living/carbon/human))
+		if (!ishuman(occupant))
 			usr << "\icon[src]<span class='warning'>The body scanner cannot scan that lifeform.</span>"
 			return
+
+		world.log << "## DEBUG: Diag. scanner [src] at [src.loc] is printing a report."
+
 		var/obj/item/weapon/paper/R = new(src.loc)
 		R.set_content_unsafe("Scan ([occupant])", format_occupant_data(src.connected.get_occupant_data()))
 
+		print(R, "[src] beeps, printing [R.name] after a moment.")
+
+
+/obj/machinery/body_scanconsole/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+	var/list/data = list()
+	var/occupied = (src.connected && src.connected.occupant)
+	
+	data["occupied"] = occupied
+	if (occupied)
+		var/mob/living/carbon/human/occupant = src.connected.occupant
+		var/datum/reagents/R = occupant.bloodstr
+		var/datum/reagents/B = occupant.vessel
+		data["stat"]			= occupant.stat
+		data["name"]			= occupant.name
+		data["health"]			= occupant.health
+		data["maxHealth"]		= occupant.maxHealth
+		data["minHealth"]		= config.health_threshold_dead
+		data["bruteLoss"]		= occupant.getBruteLoss()
+		data["oxyLoss"]			= occupant.getOxyLoss()
+		data["toxLoss"]			= occupant.getToxLoss()
+		data["fireLoss"]		= occupant.getFireLoss()
+		data["rads"]			= occupant.total_radiation
+		data["cloneloss"]		= occupant.getCloneLoss()
+		data["brainloss"]		= occupant.getBrainLoss()
+		data["paralysis"]		= occupant.paralysis
+		data["bodytemp"]		= occupant.bodytemperature
+		data["occupant"] 		= occupant
+		data["bloodAmt"] 		= B.get_reagent_amount("blood")
+		data["bloodMax"] 		= 560	// You'd think this'd be defined somewhere.
+		data["bloodPerc"]		= (data["bloodAmt"] / data["bloodMax"]) * 100
+		data["bloodStatus"]		= val2status(data["bloodAmt"], B.total_volume * 0.9, B.total_volume * 0.8, inverse = 1)
+		data["inaprovAmt"] 		= R.get_reagent_amount("inaprovaline")
+		data["soporAmt"] 		= R.get_reagent_amount("stoxin")
+		data["bicardAmt"] 		= R.get_reagent_amount("bicaridine")
+		data["dexAmt"] 			= R.get_reagent_amount("dexalin")
+		data["dermAmt"]			= R.get_reagent_amount("dermaline")
+		data["otherAmt"]		= R.total_volume - (data["soporAmt"] + data["dexAmt"] + data["bicardAmt"] + data["inaprovAmt"] + data["dermAmt"])
+		data["brainDmgStatus"] 	= val2status(occupant.brainloss, 20, 50)
+		data["radStatus"] 		= val2status(occupant.total_radiation)
+		data["cloneDmgStatus"] 	= val2status(occupant.cloneloss, 10, 35)
+		var/org 				= get_organ_wound_data(occupant)
+		data["organData"]		= generate_organ_panes(org)
+
+	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if (!ui)
+		ui = new(user, src, ui_key, "med_diagnostics.tmpl", "Medical Diagnostics", 800, 500, state = state)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
+
+// It's ugly, but directly using NanoUI for this doesn't seem to work.
+/obj/machinery/body_scanconsole/proc/generate_organ_panes(var/list/data)
+	var/output = ""
+	for (var/item in data)
+		var/temp = "<div><div class='line'>"
+		temp += "<b>[item["name"]]</b></div>"
+		temp += "<div class='line'><div class='statusLabel'=&gt; Burn Dmg:</div>"
+		temp += "<div class='statusValue'>[item["burnDmg"]]</div></div>"
+		temp += "<div class='line'><div class='statusLabel'=&gt; Brute Dmg:</div>"
+		temp += "<div class='statusValue'>[item["bruteDmg"]]</div></div>"
+		if (item["hasWounds"])
+			temp += "<ul>[item["wounds"]]</ul>"
+		
+		temp += "</div>"
+		output += temp
+
+	return output
+
+/obj/machinery/body_scanconsole/proc/get_missing_organs(var/mob/living/carbon/human/H)
+	var/list/missingOrgans = list()
+	var/list/species_organs = H.species.has_organ
+	for (var/organ_name in H.species.has_organ)
+		if (!locate(species_organs[organ_name]) in H.internal_organs)
+			missingOrgans += organ_name
+	return missingOrgans
+
+/obj/machinery/body_scanconsole/proc/get_organ_wound_data(var/mob/living/carbon/human/H)
+	var/list/organs = list()
+	
+	// Internal Organs. (Duh.)
+	for (var/obj/item/organ/O in H.internal_organs)
+		var/list/data = list()
+		data["name"] = O.name
+		var/wounds = ""
+		switch (O.damtype)
+			if ("brute")
+				data["bruteDmg"] = O.damage
+				data["burnDmg"] = 0
+			if ("burn")
+				data["burnDmg"] = O.damage
+				data["bruteDmg"] = 0
+
+		if (istype(O, /obj/item/organ/lungs) && H.is_lung_ruptured())
+			wounds += "<li>Appears to be ruptured.</li>"
+
+		if (istype(O, /obj/item/organ/brain) && H.has_brain_worms())
+			wounds += "<li>Has an abnormal growth.</li>"
+
+		if (istype(O, H.species.vision_organ))
+			if (H.sdisabilities & BLIND)
+				wounds += "<li>Appears to have cataracts.</li>"
+			else if (H.disabilities & NEARSIGHTED)
+				wounds += "<li>Appears to have misaligned retinas.</li>"
+
+		if (O.germ_level)
+			wounds += get_infection_level(O.germ_level)
+		
+		if (O.rejecting)
+			wounds += "<li>Shows symptoms of organ rejection.</li>"
+
+		data["hasWounds"] = length(wounds) ? 1 : 0
+		data["wounds"] = wounds
+		organs += data
+		world.log << "## DEBUG: Int. Organ [O.name]: hasWounds=[length(wounds) ? 1 : 0],damtype=[O.damtype],damage=[O.damage]"
+
+	// Limbs.
+	for (var/obj/item/organ/external/O in H.organs)
+		var/list/data = list()
+		data["burnDmg"] = O.burn_dam
+		data["bruteDmg"] = O.brute_dam
+		
+		var/list/wounds = list()
+		//var/broken
+		var/num_IB = 0
+		for (var/datum/wound/W in O.wounds)
+			if (W.internal)
+				num_IB++
+
+		if (num_IB)
+			if (num_IB > 1)
+				wounds += "<li>Shows signs of severe internal bleeding.</li>"
+			else
+				wounds += "<li>Shows signs of internal bleeding.</li>"
+
+		if (O.status & ORGAN_ROBOT)
+			wounds += "<li>Appears to be prosthetic.</li>"
+		if (O.status & ORGAN_SPLINTED)
+			wounds += "<li>Appears to be splinted.</li>"
+		if (O.status & ORGAN_BLEEDING)
+			wounds += "<li>Appears to be bleeding.</li>"
+		if (O.status & ORGAN_BROKEN)
+			wounds += "<li>[O.broken_description]</li>"
+		if (O.open)
+			wounds += "<li>Has an open wound.</li>"
+		if (O.germ_level)
+			wounds += get_infection_level(O.germ_level)
+		if (O.rejecting)
+			wounds += "<li>Shows symptoms indicating limb rejection.</li>"
+
+		if (O.implants.len)
+			var/unk = 0
+			for (var/I in O.implants)
+				if (is_type_in_list(I, known_implants))
+					wounds += "[I] implanted."
+				else
+					unk++
+			if (unk)
+				wounds += "<li>Has an abnormal mass of tissue present.</li>"
+	
+		data["hasWounds"] = length(wounds) ? 1 : 0
+		data["wounds"] = wounds
+		organs += data
+		world.log << "## DEBUG: Ext. Organ [O.name]: hasWounds=[length(wounds) ? 1 : 0],num_IB=[num_IB],brute_dam=[O.brute_dam],burn_dam=[O.burn_dam]."
+
+	return organs
+
+/obj/machinery/body_scanconsole/proc/get_infection_level(var/level)
+	var/output = ""
+	switch (level)
+		if (INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + 200)
+			output = "mild"
+		if (INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 200)
+			output = "worsening mild"
+		if (INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
+			output = "borderline acute"
+		if (INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + 200)
+			output = "acute"
+		if (INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
+			output = "worsening acute"
+		if (INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 400)
+			output = "borderline septic"
+		if (INFECTION_LEVEL_THREE to INFINITY)
+			output = "septic"
+	
+	return "<li>Shows symptoms of \a [output] infection.</li>"
+
+/obj/machinery/body_scanconsole/proc/val2status(var/val, var/warn_threshold = 10, var/danger_threshold = 50, var/inverse = 0)
+	if (val < warn_threshold)
+		return inverse ? "bad" : "good"
+	if (val < danger_threshold)
+		return "average"
+	return inverse ? "good" : "bad"
 
 /obj/machinery/bodyscanner/proc/get_occupant_data()
 	if (!occupant || !istype(occupant, /mob/living/carbon/human))

--- a/code/global.dm
+++ b/code/global.dm
@@ -40,7 +40,7 @@ var/const/company_name  = "NanoTrasen"
 var/const/company_short = "NT"
 var/game_version        = "Baystation12"
 var/changelog_hash      = ""
-var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 544)
+var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 442)
 
 var/round_progressing = 1
 var/master_mode       = "extended" // "extended"

--- a/html/changelogs/lohikar-advscan.yml
+++ b/html/changelogs/lohikar-advscan.yml
@@ -28,6 +28,6 @@ changes:
   - rscadd: "Added a fancy new UI to the medical advanced scanner."
   - bugfix: "The medical advanced scanner can print once more."
   - tweak: "Tweaked how the advanced scanner describes injuries and infections."
-  - rscdel: "You can no longer scan Dionae, Vox, and IPCs with the adv. scanner."
+  - rscdel: "You can no longer scan Dionae and IPCs with the adv. scanner."
   - bugfix: "The in-game year should be lore-accurate again."
   - bugfix: "Text-editors on consoles should no longer show [editorbr]."

--- a/html/changelogs/lohikar-advscan.yml
+++ b/html/changelogs/lohikar-advscan.yml
@@ -1,0 +1,33 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Lohikar
+delete-after: True
+changes: 
+  - rscadd: "Added a fancy new UI to the medical advanced scanner."
+  - bugfix: "The medical advanced scanner can print once more."
+  - tweak: "Tweaked how the advanced scanner describes injuries and infections."
+  - rscdel: "You can no longer scan Dionae, Vox, and IPCs with the adv. scanner."
+  - bugfix: "The in-game year should be lore-accurate again."
+  - bugfix: "Text-editors on consoles should no longer show [editorbr]."

--- a/maps/exodus-2.dmm
+++ b/maps/exodus-2.dmm
@@ -1404,7 +1404,7 @@
 "AZ" = (/turf/unsimulated/wall,/area/syndicate_mothership{name = "\improper Raider Base"})
 "Ba" = (/obj/machinery/vending/cola{name = "Robust Softdrinks"; prices = list()},/turf/unsimulated/floor{icon_state = "dark"},/area/centcom/specops)
 "Bb" = (/obj/structure/table/reinforced,/turf/unsimulated/floor{tag = "icon-cult"; name = "plating"; icon_state = "cult"},/area/centcom/holding)
-"Bc" = (/obj/machinery/bodyscanner{dir = 8; icon_state = "body_scanner_0"; tag = "icon-body_scanner_0 (EAST)"},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/skipjack_station/start)
+"Bc" = (/obj/machinery/bodyscanner{allowed_species = list("Human","Skrell","Unathi","Tajara","M'sai Tajara","Zhan-Khazan Tajara","Vaurca Worker","Vaurca Warrior","Vox"); dir = 8; icon_state = "body_scanner_0"; tag = "icon-body_scanner_0 (EAST)"},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/skipjack_station/start)
 "Bd" = (/turf/simulated/shuttle/wall{tag = "icon-swall_straight (WEST)"; icon_state = "swall_straight"; dir = 8},/area/shuttle/escape/centcom)
 "Be" = (/turf/simulated/shuttle/wall{tag = "icon-swall_t"; icon_state = "swall_t"},/area/shuttle/escape/centcom)
 "Bf" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/vending/cola{name = "hacked Robust Softdrinks"; prices = list()},/turf/unsimulated/floor{dir = 8; icon_state = "wood"},/area/syndicate_mothership{name = "\improper Raider Base"})

--- a/nano/templates/med_diagnostics.tmpl
+++ b/nano/templates/med_diagnostics.tmpl
@@ -164,7 +164,7 @@
 			</div>
 			{{if value.hasWounds}}
 				<div class="line">
-					<div class="statusLabel">=&gt; Wounds:</div>
+					<div class="statusLabel">=&gt; Information:</div>
 					<div class="statusValue">
 						<ul>
 						{{for value.wounds :wound:woundi}}

--- a/nano/templates/med_diagnostics.tmpl
+++ b/nano/templates/med_diagnostics.tmpl
@@ -5,6 +5,8 @@
 		<div class="line bad">Error: No scanner bed detected!</div>
 	{{else !data.occupied}}
 		<div class="line">No occupant detected.</div>
+	{{else data.ipc}}
+		<div class="line">Error: Object in scanner bed interfering with sensor array.</div>
 	{{else data.noscan}}
 		<div class="line bad">Error: No diagnostics profile installed for this species.</div>
 	{{/if}}	

--- a/nano/templates/med_diagnostics.tmpl
+++ b/nano/templates/med_diagnostics.tmpl
@@ -75,11 +75,31 @@
 	</div>
 	<div class='line'>
 		<div class='statusLabel'>Est. Paralysis Lvl:</div>
-		<div class='statusValue'>{{:data.paralysis}}%</div>
+		<div class='statusValue'>{{:data.paralysis}}%{{if data.paralysis}}({{:helper.round(data.paralysis / 4)}} seconds left){{/if}}</div>
 	</div>
 	<div class='line'>
 		<div class='statusLabel'>Body Temperature:</div>
 		<div class='statusValue'>{{:data.bodytemp}} K (~{{:helper.round(data.bodytemp - 273.15)}} C)</div>
+	</div>
+	<div class="line">
+		<div class="statusLabel">Viral Status:</div>
+		{{if data.hasvirus}}
+			<div class="statusValue bad">Present</div>
+		{{else data.hastgvirus}}
+				{{for data.tgvirus}}
+					<div class="statusValue bad">{{:value.form}} Detected</div>
+					<div class="statusLabel">=&gt; Name</div>
+					<div class="statusValue">{{:value.name}}</div>
+					<div class="statusLabel">=&gt; Type</div>
+					<div class="statusValue">{{:value.spread}}</div>
+					<div class="statusLabel">=&gt; Stage</div>
+					<div class="statusValue">{{:value.stage}} of {{:value.max_stages}}</div>
+					<div class="statusLabel">=&gt; Possible Cure</div>
+					<div class="statusValue">{{:value.cure}}</div>
+				{{/for}}
+		{{else}}
+			<div class="statusValue good">Not Detected</div>
+		{{/if}}
 	</div>
 	</div>
 	<h3>Blood Status</h3>

--- a/nano/templates/med_diagnostics.tmpl
+++ b/nano/templates/med_diagnostics.tmpl
@@ -1,7 +1,13 @@
 <h3>Overall Health</h3>
 <div class='statusDisplay'>
-{{if !data.occupied}}
-	<div class='line'>No occupant detected.</div>
+{{if data.invalid}}
+	{{if data.nocons}}
+		<div class="line bad">Error: No scanner bed detected!</div>
+	{{else !data.occupied}}
+		<div class="line">No occupant detected.</div>
+	{{else data.noscan}}
+		<div class="line bad">Error: No diagnostics profile installed for this species.</div>
+	{{/if}}	
 {{else}}
 	<div class="line">
 		{{:data.name}}&nbsp;=>&nbsp;
@@ -12,6 +18,10 @@
 		{{else}}
 			<span class="bad">DEAD</span>
 		{{/if}}
+	</div>
+	<div class="line">
+		<div class="statusLabel">Species:</div>
+		<div class="statusValue">{{:data.species}}</div>
 	</div>
 	{{if data.stat < 2}}
 		<div class="line">
@@ -69,7 +79,7 @@
 	</div>
 	<div class='line'>
 		<div class='statusLabel'>Body Temperature:</div>
-		<div class='statusValue'>{{:data.bodytemp}}K</div>
+		<div class='statusValue'>{{:data.bodytemp}} K (~{{:helper.round(data.bodytemp - 273.15)}} C)</div>
 	</div>
 	</div>
 	<h3>Blood Status</h3>
@@ -77,7 +87,7 @@
 	<div class="line">
 		<div class="statusLabel">Blood Level:</div>
 			{{:helper.displayBar(data.bloodAmt, 0, data.bloodMax, data.bloodStatus)}}
-		<div class="statusValue">{{:helper.round(data.bloodPerc)}}%</div>
+		<div class="statusValue">{{:helper.round(data.bloodPerc)}}% ({{:helper.round(data.bloodAmt)}}u)</div>
 	</div>
 	<div class="line">
 		<div class="statusLabel">=&gt; Inaprovaline:</div>
@@ -105,9 +115,46 @@
 	</div>
 	</div>
 	<h3>Body Status</h3>
+	{{if data.hasmissing}}
 	<div class='statusDisplay'>
-	<!-- Generated server-side. -->
-	{{:data.organData}}
+		<span class="bad">Unable to locate the following organ(s).</span>
+		<ul>
+			{{for data.missingparts}}
+				<li>{{:value}}</li>
+			{{/for}}
+		</ul>
+	</div>
+	{{/if}}
+	<div class='statusDisplay'>
+	{{for data.bodyparts}}
+		<div><!-- container -->
+			<div class="line">
+				<b>{{:value.name}}</b>
+			</div>
+			<div class="line">
+				<div class="statusLabel">=&gt; Burn Dmg:</div>
+				<div class="statusValue">{{:helper.round(value.burnDmg)}}</div>
+			</div>
+
+			<div class="line">
+				<div class="statusLabel">=&gt; Brute Dmg:</div>
+				<div class="statusValue">{{:helper.round(value.bruteDmg)}}</div>
+			</div>
+			{{if value.hasWounds}}
+				<div class="line">
+					<div class="statusLabel">=&gt; Wounds:</div>
+					<div class="statusValue">
+						<ul>
+						{{for value.wounds :wound:woundi}}
+							<li>{{:wound}}</li>
+						{{/for}}
+						</ul>
+					</div>
+				</div>
+			{{/if}}
+		</div>
+		<hr>
+	{{/for}}
 </div>
 	<h3>Actions</h3>
 	{{:helper.link('Print Report', '', {'print' : 1})}}

--- a/nano/templates/med_diagnostics.tmpl
+++ b/nano/templates/med_diagnostics.tmpl
@@ -1,0 +1,114 @@
+<h3>Overall Health</h3>
+<div class='statusDisplay'>
+{{if !data.occupied}}
+	<div class='line'>No occupant detected.</div>
+{{else}}
+	<div class="line">
+		{{:data.name}}&nbsp;=>&nbsp;
+		{{if data.stat == 0}}
+			<span class="good">Conscious</span>
+		{{else data.stat == 1}}
+			<span class="average">Unconscious</span>
+		{{else}}
+			<span class="bad">DEAD</span>
+		{{/if}}
+	</div>
+	{{if data.stat < 2}}
+		<div class="line">
+			<div class="statusLabel">Health:</div>
+			{{if data.health >= 0}}
+				{{:helper.displayBar(data.health, 0, data.maxHealth, 'good')}}
+			{{else}}
+				{{:helper.displayBar(data.health, 0, data.minHealth, 'average alignRight')}}
+			{{/if}}
+			<div class="statusValue">{{:helper.round(data.health)}}</div>
+		</div>
+		<div class="line">
+			<div class="statusLabel">=&gt; Brute Damage:</div>
+			{{:helper.displayBar(data.bruteLoss, 0, data.maxHealth, 'bad')}}
+			<div class="statusValue">{{:helper.round(data.bruteLoss)}}</div>
+		</div>
+		<div class="line">
+			<div class="statusLabel">=&gt; Resp. Damage:</div>
+			{{:helper.displayBar(data.oxyLoss, 0, data.maxHealth, 'bad')}}
+			<div class="statusValue">{{:helper.round(data.oxyLoss)}}</div>
+		</div>
+		<div class="line">
+			<div class="statusLabel">=&gt; Toxin Damage:</div>
+			{{:helper.displayBar(data.toxLoss, 0, data.maxHealth, 'bad')}}
+			<div class="statusValue">{{:helper.round(data.toxLoss)}}</div>
+		</div>
+		<div class="line">
+			<div class="statusLabel">=&gt; Burn Severity:</div>
+			{{:helper.displayBar(data.fireLoss, 0, data.maxHealth, 'bad')}}
+			<div class="statusValue">{{:helper.round(data.fireLoss)}}</div>
+		</div>
+	{{/if}}
+	<hr>
+	<div class='line'>
+		<div class='statusLabel'>Radiation Lvl:</div>
+		<div class='statusValue'>
+			<span class='{{:data.radStatus}}'>{{:data.rads}} rads</span>
+		</div>
+	</div>
+	<div class='line'>
+		<div class='statusLabel'>Genetic Dmg:</div>
+		<div class='statusValue'>
+			<span class='{{:data.cloneDmgStatus}}'>{{:data.cloneloss}}%</span>
+		</div>
+	</div>
+	<div class='line'>
+		<div class='statusLabel'>Est. Brain Dmg:</div>
+		<div class='statusValue'>
+			<span class='{{:data.brainDmgStatus}}'>{{:data.brainloss}}%</span>
+		</div>
+	</div>
+	<div class='line'>
+		<div class='statusLabel'>Est. Paralysis Lvl:</div>
+		<div class='statusValue'>{{:data.paralysis}}%</div>
+	</div>
+	<div class='line'>
+		<div class='statusLabel'>Body Temperature:</div>
+		<div class='statusValue'>{{:data.bodytemp}}K</div>
+	</div>
+	</div>
+	<h3>Blood Status</h3>
+	<div class='statusDisplay'>
+	<div class="line">
+		<div class="statusLabel">Blood Level:</div>
+			{{:helper.displayBar(data.bloodAmt, 0, data.bloodMax, data.bloodStatus)}}
+		<div class="statusValue">{{:helper.round(data.bloodPerc)}}%</div>
+	</div>
+	<div class="line">
+		<div class="statusLabel">=&gt; Inaprovaline:</div>
+		<div class="statusValue">{{:helper.round(data.inaprovAmt)}} unit(s)</div>
+	</div>
+	<div class="line">
+		<div class="statusLabel">=&gt; Soporific:</div>
+		<div class="statusValue">{{:helper.round(data.soporAmt)}} unit(s)</div>
+	</div>
+	<div class="line">
+		<div class="statusLabel">=&gt; Bicaridine:</div>
+		<div class="statusValue">{{:helper.round(data.bicardAmt)}} unit(s)</div>
+	</div>
+	<div class="line">
+		<div class="statusLabel">=&gt; Dermaline:</div>
+		<div class="statusValue">{{:helper.round(data.dermAmt)}} unit(s)</div>
+	</div>
+	<div class="line">
+		<div class="statusLabel">=&gt; Dexalin:</div>
+		<div class="statusValue">{{:helper.round(data.dexAmt)}} unit(s)</div>
+	</div>
+	<div class="line">
+		<div class="statusLabel">=&gt; Other:</div>
+		<div class="statusValue">{{:helper.round(data.otherAmt)}} unit(s)</div>
+	</div>
+	</div>
+	<h3>Body Status</h3>
+	<div class='statusDisplay'>
+	<!-- Generated server-side. -->
+	{{:data.organData}}
+</div>
+	<h3>Actions</h3>
+	{{:helper.link('Print Report', '', {'print' : 1})}}
+{{/if}}

--- a/nano/templates/med_diagnostics.tmpl
+++ b/nano/templates/med_diagnostics.tmpl
@@ -75,7 +75,7 @@
 	</div>
 	<div class='line'>
 		<div class='statusLabel'>Est. Paralysis Lvl:</div>
-		<div class='statusValue'>{{:data.paralysis}}%{{if data.paralysis}}({{:helper.round(data.paralysis / 4)}} seconds left){{/if}}</div>
+		<div class='statusValue'>{{:data.paralysis}}%{{if data.paralysis}} ({{:helper.round(data.paralysis / 4)}} seconds left){{/if}}</div>
 	</div>
 	<div class='line'>
 		<div class='statusLabel'>Body Temperature:</div>


### PR DESCRIPTION
changelog:
  - rscadd: "Added a fancy new UI to the medical advanced scanner."
  - bugfix: "The medical advanced scanner can print once more."
  - tweak: "Tweaked how the advanced scanner describes injuries and infections."
  - rscdel: "You can no longer scan Dionae, Vox, and IPCs with the adv. scanner."
  - bugfix: "The in-game year should be lore-accurate again."
  - bugfix: "Text-editors on consoles should no longer show [editorbr]."

Fixes #1419.
Fixes #1551.
Fixes #1516.
Adv. Scanners now obey `NO_SCAN` species flags.
Adv. Scanners now use NanoUI.
Fixed a runtime from adv. scanners' consoles being deleted.