### PR TITLE
Gripper, Nymph and Mob size fixes

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -115,10 +115,10 @@
 
 
 // Defines mob sizes, used by lockers and to determine what is considered a small sized mob, etc.
-#define MOB_LARGE  		40
-#define MOB_MEDIUM 		20
-#define MOB_SMALL 		10
-#define MOB_TINY 		5
+#define MOB_LARGE  		16
+#define MOB_MEDIUM 		9
+#define MOB_SMALL 		6
+#define MOB_TINY 		4
 #define MOB_MINISCULE	1
 
 // Gluttony levels.

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -127,7 +127,7 @@
 		if (!grippersafety(G))return
 		if(!resolved && A && W)
 			W.afterattack(A,src,1,params)
-			if (!grippersafety(G))return
+		if (!grippersafety(G))return
 		W.force = G.force_holder
 		return
 	if(!isturf(loc))
@@ -141,7 +141,7 @@
 			if (!grippersafety(G))return
 			if(!resolved && A && W)
 				W.afterattack(A, src, 1, params)
-				if (!grippersafety(G))return
+			if (!grippersafety(G))return
 			W.force = G.force_holder
 			return
 		//No non-adjacent clicks. Can't fire guns

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -39,7 +39,7 @@
 	close_sound = 'sound/items/zip.ogg'
 	var/item_path = /obj/item/bodybag
 	density = 0
-	storage_capacity = (MOB_MEDIUM * 2) - 1
+	storage_capacity = 30
 	var/contains_body = 0
 
 /obj/structure/closet/body_bag/attackby(W as obj, mob/user as mob)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -12,7 +12,8 @@
 	var/wall_mounted = 0 //never solid (You can always pass over it)
 	var/health = 100
 	var/breakout = 0 //if someone is currently breaking out. mutex
-	var/storage_capacity = 2 * MOB_MEDIUM //This is so that someone can't pack hundreds of items in a locker/crate
+	var/storage_capacity = 40 //Tying this to mob sizes was dumb
+	//This is so that someone can't pack hundreds of items in a locker/crate
 							  //then open it in a populated area to crash clients.
 	var/open_sound = 'sound/machines/click.ogg'
 	var/close_sound = 'sound/machines/click.ogg'

--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -31,6 +31,15 @@
 	var/list/language_progress
 	var/obj/item/clothing/head/hat
 	maxHealth = 85
+	pass_flags = PASSTABLE
+
+/mob/living/carbon/alien/diona/movement_delay()
+	. = ..()
+	switch(m_intent)
+		if ("walk")
+			. += 3
+		if ("run")
+			species.handle_sprint_cost(src,.+config.walk_speed)
 
 /mob/living/carbon/alien/diona/ex_act(severity)
 	if (life_tick < 4)
@@ -50,6 +59,7 @@
 	update_verbs()
 	sampled_DNA = list()
 	language_progress = list()
+
 
 /mob/living/carbon/alien/diona/verb/check_light()
 	set category = "Abilities"

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -15,7 +15,7 @@
 	num_alternate_languages = 2
 	secondary_langs = list("Sol Common")
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
-
+	mob_size = 9
 	spawn_flags = CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR | HAS_SOCKS
 
@@ -50,6 +50,7 @@
 	exhaust_threshold = 65
 	rarity_value = 3
 	breakcuffs = list(MALE)
+	mob_size = 10
 
 	blurb = "A heavily reptillian species, Unathi (or 'Sinta as they call themselves) hail from the Uuosa-Eso \
 	system, which roughly translates to 'burning mother'. A relatively recent addition to the galactic stage, they \
@@ -217,7 +218,7 @@
 	num_alternate_languages = 1
 	name_language = "Rootsong"
 	ethanol_resistance = -1//Can't get drunk
-
+	mob_size = 12//Worker gestalts are 150kg
 	blurb = "Commonly referred to (erroneously) as 'plant people', the Dionaea are a strange space-dwelling collective \
 	species hailing from Epsilon Ursae Minoris. Each 'diona' is a cluster of numerous cat-sized organisms called nymphs; \
 	there is no effective upper limit to the number that can fuse in gestalt, and reports exist	of the Epsilon Ursae \
@@ -277,7 +278,7 @@
 	sprint_speed_factor = 0.5		  //Speed gained is minor
 	sprint_cost_factor = 0.8
 
-/datum/species/diona/handle_sprint_cost(var/mob/living/carbon/human/H, var/cost)
+/datum/species/diona/handle_sprint_cost(var/mob/living/carbon/H, var/cost)
 	var/datum/dionastats/DS = H.get_dionastats()
 
 	if (!DS)
@@ -326,7 +327,11 @@
 
 /datum/species/diona/handle_post_spawn(var/mob/living/carbon/human/H)
 	H.gender = NEUTER
-	return ..()
+	if (ishuman(H))
+		return ..()
+	else//Most of the stuff in the parent function doesnt apply to nymphs
+		add_inherent_verbs(H)
+
 
 /datum/species/diona/handle_death(var/mob/living/carbon/human/H, var/gibbed = 0)
 	if (!gibbed)

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -115,11 +115,8 @@
 	drop(get_turf(src))
 
 /obj/item/weapon/gripper/proc/drop(var/atom/target)
-	if(wrapped.loc != src)
-		wrapped = null
-		return
-
-	wrapped.forceMove(target)
+	if(wrapped && wrapped.loc == src)
+		wrapped.forceMove(target)
 	wrapped = null
 	update_icon()
 	return 1

--- a/code/modules/mob/living/simple_animal/friendly/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mushroom.dm
@@ -6,7 +6,7 @@
 	icon_state = "mushroom"
 	icon_living = "mushroom"
 	icon_dead = "mushroom_dead"
-	mob_size = MOB_SMALL
+	mob_size = MOB_TINY
 	speak_chance = 0
 	turns_per_move = 1
 	maxHealth = 5
@@ -22,7 +22,7 @@
 	density = 0
 	holder_type = /obj/item/weapon/holder/mushroom
 	mob_size = 2
-	
+
 /mob/living/simple_animal/mushroom/New()
 	..()
 	harvest_time = world.time

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -33,7 +33,7 @@
 	icon_living = "parrot_fly"
 	icon_dead = "parrot_dead"
 	pass_flags = PASSTABLE
-	mob_size = MOB_SMALL
+	mob_size = MOB_TINY
 
 	speak = list("Hi","Hello!","Cracker?","BAWWWWK george mellons griffing me")
 	speak_emote = list("squawks","says","yells")

--- a/html/changelogs/Nanako-Nymphgripper.yml
+++ b/html/changelogs/Nanako-Nymphgripper.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: N3X15
+author: Nanako
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/Nanako-Nymphgripper.yml
+++ b/html/changelogs/Nanako-Nymphgripper.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed diona nymphs being unable to pass over tables and furniture."
+  - rscadd: "Diona nymph walking speed greatly reduced. Nymphs can now sprint"


### PR DESCRIPTION
Fixes gripper runtime errors. two safety checks were indented a level more than they should have been.

Fixes nymphs not being able to pass under tables. Turns out pass flags and mob sizes are now set by the species,. Added an exception for nymphs in the diona override because they dont really qualify as a subspecies. 

In the process of doing that, also added mob sizes for diona and unathi. Other species can have them when their loredevs give me some values

Corrected various mob sizes that baystation screwed up, reverting them back to values compatible with our standard (mob size = square root of mass in kg)

Nerfed diona nymph walking speed, and added sprinting for nymphs (which is the same speed their walk was, but with energy costs)