### PR TITLE
Tip of the Round

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -30,6 +30,8 @@ var/global/datum/controller/gameticker/ticker
 	var/delay_end = 0	//if set to nonzero, the round will not restart on it's own
 
 	var/triai = 0//Global holder for Triumvirate
+	var/tipped = 0							//Did we broadcast the tip of the day yet?
+	var/selected_tip						// What will be the tip of the day?
 
 	var/round_end_announced = 0 // Spam Prevention. Announce round end only once.
 
@@ -60,6 +62,9 @@ var/global/datum/controller/gameticker/ticker
 						for(var/i=0, i<10, i++)
 							sleep(1)
 							vote.process()
+			if(pregame_timeleft <= 10 && !tipped)
+				send_tip_of_the_round()
+				tipped = 1
 			if(pregame_timeleft <= 0)
 				current_state = GAME_STATE_SETTING_UP
 	while (!setup())
@@ -447,3 +452,16 @@ var/global/datum/controller/gameticker/ticker
 		log_game("[i]s[total_antagonists[i]].")
 
 	return 1
+
+/datum/controller/gameticker/proc/send_tip_of_the_round()
+	var/m
+	if(selected_tip)
+		m = selected_tip
+	else
+		var/list/randomtips = file2list("config/tips.txt")
+		if(randomtips.len)
+			m = pick(randomtips)
+
+	if(m)
+		world << "<font color='purple'><b>Tip of the round: \
+			</b>[html_encode(m)]</font>"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -127,7 +127,9 @@ var/list/admin_verbs_fun = list(
 	/client/proc/roll_dices,
 	/datum/admins/proc/create_admin_fax,
 	/datum/admins/proc/call_supply_drop,
-	/datum/admins/proc/call_drop_pod
+	/datum/admins/proc/call_drop_pod,
+	/client/proc/show_tip,
+	/client/proc/fab_tip
 	)
 
 var/list/admin_verbs_spawn = list(
@@ -1032,10 +1034,10 @@ var/list/admin_verbs_cciaa = list(
 
 	if (alert("Are you sure you want to wipe [target.name]? They will be ghosted and their job slot freed.", "Confirm AI Termination", "No", "No", "Yes") != "Yes")
 		return
-	
+
 	log_and_message_admins("admin-wiped [key_name_admin(target)]'s core.")
 	target.do_wipe_core()
-	
+
 /client/proc/restart_sql()
 	set category = "Debug"
 	set name = "Reconnect SQL"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -949,3 +949,50 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		usr << "Random events disabled"
 		message_admins("Admin [key_name_admin(usr)] has disabled random events.", 1)
 	feedback_add_details("admin_verb","TRE") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/fab_tip()
+	set category = "Admin"
+	set name = "Fabricate Tip"
+	set desc = "Sends a tip (that you specify) to all players. After all \
+		you're the experienced player here."
+
+	if(!holder)
+		return
+
+	var/input = input(usr, "Please specify your tip that you want to send to the players.", "Tip", "") as message|null
+	if(!input)
+		return
+
+	if(!ticker)
+		return
+
+	ticker.selected_tip = input
+
+	// If we've already tipped, then send it straight away.
+	if(ticker.tipped)
+		ticker.send_tip_of_the_round()
+		ticker.selected_tip = initial(ticker.selected_tip)
+
+
+	message_admins("[key_name_admin(usr)] sent a tip of the round.")
+	log_admin("[key_name(usr)] sent \"[input]\" as the Tip of the Round.")
+	feedback_add_details("admin_verb","TIP")
+
+/client/proc/show_tip()
+	set category = "Debug"
+	set name = "Show Tip"
+	set desc = "Sends a tip (that the config specifies) to all players. After all \
+		you're not the experienced player here."
+
+	if(!holder)
+		return
+
+	if(!ticker)
+		return
+
+	ticker.send_tip_of_the_round()
+
+
+	message_admins("[key_name_admin(usr)] sent a pregenerated tip of the round.")
+	log_admin("[key_name(usr)] sent a pregenerated Tip of the Round.")
+	feedback_add_details("admin_verb","FAP")

--- a/config/example/tips.txt
+++ b/config/example/tips.txt
@@ -1,0 +1,171 @@
+You can catch thrown items by toggling on your throw mode with an empty hand active.
+To crack the safe in the vault, use a stethoscope on it.
+You can climb onto a table by dragging yourself onto one.
+You can drag other players onto yourself to open the strip menu, letting you remove their equipment or force them to wear something.
+Clicking on a windoor rather then bumping into it will keep it open, you can click it again to close it.
+You can spray a fire extinguisher or fire a gun while floating through space to change your direction. Simply fire opposite to where you want to go.
+You can change the control scheme by pressing tab. One is WASD, the other is the arrow keys. Keep in mind that hotkeys are also changed with this.
+All vending machines can be hacked to obtain some contraband items from them, and some can be fed with coins to gain access to premium items.
+Glass shards can be welded to make glass, and metal rods can be welded to make metal.
+If you need to drag multiple people either to safety or to space, bring a locker over and stuff them all in before hauling them off.
+You can grab someone by clicking on them with the grab intent, then upgrade the grab by clicking on the grab button in your active hand. An aggressive grab will allow you to place someone on a table by clicking on it, or throw them by toggling on throwing.
+Holding alt and left clicking a tile will allow you to see its contents in the top right window pane, which is much faster than right clicking.
+The resist button will allow you to resist out of handcuffs, being buckled to a chair or bed, out of locked lockers and more. Whenever you're stuck, try resisting!
+You can move an item out of the way by dragging it and then clicking on an adjacent tile with an empty hand.
+Maintenance is full of equipment that is randomized every round. Look around and see if anything is worth using.There are many places around the station to hide contraband. A few for starters: linen boxes, toilet cisterns, body bags. Experiment to find more!
+As the Captain, you are one of the highest priority targets on the station. Everything from revolutions, to nuclear operatives, to traitors that need to rob you of your unique lasgun or your life are things to worry about.
+As the Captain, you have absolute access and control over the station, but this does not mean that being a horrible person won't result in mutiny and a ban.
+As the Chief Medical Officer, your hypospray is like an instant injection syringe that can hold 30 units as opposed to the standard 15.
+As the Chief Medical Officer, coordinate and communicate with your doctors, chemists, and EMTs during a nuclear emergency, blob infestation, or some other crisis to keep people alive and fighting.
+As a Medical Doctor, you can attempt to drain blood from a husk with a syringe to determine the cause. If you can extract blood, it was caused by extreme temperatures or lasers, if there is no blood to extract, it was caused by something unnatural.
+As a Medical Doctor, you can surgically implant or extract things from people's chests. This can range from putting in a bomb to pulling out an alien larva.
+As a Medical Doctor, you must target the correct limb and be on help intent when trying to perform surgery on someone.
+As a Chemist, there are dozens of chemicals that can heal, and even more that can cause harm. Experiment!
+As the Virologist, you only require small amounts of vaccine to heal a sick patient. Work with the Chemist to distribute your cures more efficiently.
+As the Research Director, you can take AIs out of their cores by loading them into an intelliCard, and then from there into an AI system integrity restorer computer to revive and/or repair them.
+As the Research Director, you can lock down cyborgs instead of blowing them up. Then you can have their laws reset or if that doesn't work, safely dismantled.
+As a Xenoscientist, you can inject yourself with the mutation toxin extracted from green slimes to become a slime person, who will never be attacked by slimes!
+As a Xenoscientist, you can maximize the number of uses you get out of a slime by feeding it slime steroid, created from purple slimes, while alive. You can then apply extract enhancer, created from cerulean slimes, on each extract.
+As a Scientist, researchable machine parts can seriously improve the efficiency and speed of machines around the station. In some cases, it can even unlock new functions.
+As a Scientist, the teleporter in Misc research can be set-up to teleport across the whole station! All you need to do is crack the formula.
+As a Roboticist, you can repair your cyborgs with a welding tool. If they have taken burn damage from lasers, you can remove their battery, expose the wiring with a screwdriver and replace their wires with a cable coil.
+As the AI, you can click on people's names to look at them. This only works if there are cameras that can see them.
+As the AI, you can quickly open and close doors by holding shift while clicking them, bolt them when holding ctrl, and even shock them while holding alt.
+As the AI, you can take pictures with your camera and upload them to newscasters.
+As a Cyborg, choose your module carefully, as only a roboticist can let you repick it. Remember that you don't need to choose immediately after you spawn!
+As a Cyborg, you are immune to most forms of stunning, and excel at almost everything far better than humans. However, flashes can easily stunlock you and you cannot do any precision work as you lack hands.
+As a Cyborg, you are impervious to fires and heat. If you are rogue, you can release plasma fires everywhere and walk through them without a care in the world!
+As a Cyborg, you are extremely vulnerable to EMPs as EMPs both stun you and damage you. The ion rifle in the armory or a traitor with an EMP kit can kill you in seconds.
+As the Chief Engineer, you can rename areas or create entirely new ones using your station blueprints.
+As the Research Director, you can spy on and even forge PDA communications with the message monitor console! The key is in your office.
+As an Engineer, the supermatter shard is an extremely dangerous piece of equipment: touching it will disintegrate you.
+As an Engineer, you can electrify grilles by placing wire "nodes" beneath them: the big seemingly unconnected bulges from a half completed wiring job.
+As an Engineer, you can power the station solely with the solar arrays. While uninteresting, it is a much safer alternative to most other engines.
+As an Engineer, you can repair windows by using a welding tool on them while on any intent other than harm.
+As an Engineer, you can lock emitters using your ID card to prevent others from disabling them.
+As an Atmospheric Technician, you can't unwrench a pipe if the pressure within is too high.
+As the Head of Security, you are expected to coordinate your security force to handle any threat that comes to the station. Sometimes it means making use of the armory to handle a blob, sometimes it means being ruthless during a revolution or cult.
+As the Head of Security, you can call for forced cyborgization, but may require the Captain's approval.
+As the Head of Security, don't let the power go to your head. You may have high access, great equipment, and a miniature army at your side, but being a terrible person without a good reason is grounds for banning.
+As the Warden, your duty is to be the watchdog of the brig and handler of prisoners when little is happening, and to hand out equipment and weapons to the security officers when a crisis strikes.
+As the Warden, keep a close eye on the armory at all times, as it is a favored strike point of nuclear operatives and cocky traitors.
+As the Warden, if a prisoner's crimes are heinous enough you can put them in permabrig. Make sure to check on them once in a while!
+As the Warden, you can implant criminals you suspect might re-offend with devices that will track their location and allow you to remotely inject them with disabling chemicals. 
+As the Warden, you can use handcuffs on orange prisoner shoes to turn them into cuffed shoes, forcing prisoners to walk and potentially thwarting an escape.
+As a Security Officer, communicate and coordinate with your fellow officers using the security channel (:s) to avoid confusion.
+As a Security Officer, your sechuds or HUDsunglasses can not only see crewmates' job assignments and criminal status, but also if they are loyalty implanted. Use this to your advantage in a revolution to definitively tell who is on your side!
+As a Security Officer, examining someone while wearing sechuds or HUDsunglasses will let you set their arrest level, which will cause Beepsky and other security bots to chase after them.
+As the Detective, people leave fingerprints everywhere and on everything. With the exception of white latex, gloves will hide them. All is not lost, however, as gloves leave fibers specific to their kind such as black or nitrile, pointing to a general department.
+As the Head of Personnel, you are just as large a target as the Captain because of the potential power your ID and computer can hand out.
+As the Chaplain, your null rod has a lot of functions: it can convert water into holy water, which if spread on the ground prevents wizards from jaunting away, can destroy cultist runes by hitting them, and is a very powerful weapon to boot!
+As the Chaplain, your bible is also a container that can store small items. Depending on your god, your starting bible may come with a surprise!
+As the Chaplain, you are much more likely to get a response by praying to the gods than most people. To boost your chances, make altars with colorful crayon runes, lit candles, and wire art.
+As a Botanist, you can hack the MegaSeed Vendor to get access to more exotic seeds. These seeds can alternatively be ordered from cargo.
+As a Botanist, you can mutate the plants growing in your hydroponics trays with unstable mutagen or, as an alternative, crude radioactives from chemistry to get special variations.
+As a Botanist, you should look into increasing the potency of your plants. This increases the size, amount of chemicals, points gained from grinding them in the biogenerator, and lets people know you are a proficient botanist.
+As a Cook, any food you make will be much healthier than the junk food found in vendors. Having the crew routinely eating from you will provide minor buffs.
+As the Bartender, the drinks you start with only give you the basics. If you want more advanced mixtures, look into working with chemistry, hydroponics, or even mining for things to grind up and throw in!
+As the Bartender, you can use a circular saw on your shotgun to make it easier to store.
+As a Janitor, if someone steals your janicart, you can instead use your space cleaner spray, grenades, water sprayer or order another from Cargo.
+As a Janitor, mousetraps can be used to create bombs or booby-trap containers.
+As the Librarian, be sure to keep the shelves stocked and the library clean for crew.
+As a Cargo Technician, you can hack MULEbots to make them faster, run over people in their way, and even let you ride them!
+As a Cargo Technician, you can order contraband items from the supply shuttle console by de-constructing it and using a multitool on the circuit board, the re-assembling it.
+As a Cargo Technician, you can earn more cargo points by shipping back crates from maintenance, liquid containers, plasma sheets, rare seeds from hydroponics, and more!
+As the Quartermaster, be sure to check the manifests on crates you receive to make sure all the info is correct. If there's a mistake, stamp the manifest DENIED and send it back in a crate with the items untouched for a refund!
+As a Shaft Miner, always have a GPS on you, so a fellow miner or cyborg can come to save you if you die.
+As a Traitor, the cryptographic sequencer (emag) can not only open doors, but also lockers, crates, APCs and more. It can hack cyborgs, and even cause bots to go berserk. Use it on the right machines, and you can even order more traitor gear or contact the Syndicate. Experiment!
+As a Traitor, subverting the AI to serve you can make it an extremely powerful ally. However, be careful of the wording in the laws you give it, as it may use your poorly written laws against you!
+As a Traitor, the Captain and the Head of Security are two of the most difficult to kill targets on the station. Plan carefully if either are present.
+As a Traitor, you can manufacture and recycle revolver bullets at a hacked autolathe, making the revolver an extremely powerful tool.
+As a Traitor, you may sometimes hunt other traitors, and in turn be hunted by them.
+As a Traitor, the syndicate encryption key is very useful for coordinating plans with your fellow traitors -- or, of course, betraying them.
+As a Nuclear Operative, communication is key! Use your radio to speak to your fellow operatives and coordinate an attack plan.
+As a Nuclear Operative, you should look into purchasing a syndicate cyborg, as they can provide heavy fire support, are immune to conventional stuns, and can easily take down the AI.
+As a Nuclear Operative, stick together! While your equipment is robust, your fellow operatives are much better at saving your life: they can drag you away from danger while stunned and provide cover fire.
+As a Nuclear Operative, you might end up in a situation where the AI has bolted you into a room. Having some spare C4 in your pocket can save your life.
+As a Monkey, you can crawl through air or scrubber vents by alt+left clicking them. You must drop everything you are wearing and holding to do this, however.
+As a Monkey, you can still wear a few human items, such as backpacks, gas masks and hats, and still have two free hands.
+As the Malfunctioning AI, you should either order your cyborgs to dismantle the robotics console or blow it up yourself in order to protect them. Make sure to hunt down all those laptops too!
+As an Alien, your melee prowess is unmatched, but your ranged abilities are sorely lacking. Make use of corners to force a melee confrontation!
+As an Alien, you take additional damage from all burn attacks, such as lasers, welding tools, and fires. Furthermore, fire can destroy your resin and eggs. Expose areas to space to starve away any flamethrower fires before they can do damage!
+As an Alien, resin floors not only regenerate your plasma supply, but also passively heal you. Fight on resin floors to gain a home turf advantage!
+As an Alien, the facehugger is by far your most powerful weapon because of its ability to instantly win a fight. Remember however that certain helmets, such as biohoods or space helmets will completely block facehugger attacks.
+As an Alien, you are unable to use many human items and machines. Instead, you should focus on sabotaging APCs, computers, cameras and either stowing, spacing, or melting any weapons you find.
+As a Revolutionary, you cannot convert a head of staff or someone who has a loyalty implant. Implants can however be surgically removed, and do not carry over with cloning. Take control of medbay to keep control of conversions!
+As a Revolutionary, cargo can be your best friend or your worst nightmare. In the best case scenario you will be able to order a limitless amount of guns and armor, in the worst case scenario security will take control and order a limitless number of loyalty implants to turn your fellow revolutionaries against you.
+As a Revolutionary, your main power comes from how quickly you spread. Convert people as fast as you can and overwhelm the heads of staff before security can arm up.
+As a Changeling, the Extract DNA sting grants you more people to change into, but does not let you choose more powers.
+As a Changeling, you can absorb someone by strangling them and using the Absorb verb; this gives you the ability to choose more powers, the DNA of whoever you absorbed, and the memory of the absorbed.
+As a Cultist, invest in taking over xenobio, an adamantine golem army can quickly be converted into cultists and constructs.
+As a Cultist, your team starts off very weak, but if necessary can quickly convert everything they have into raw power. Make sure you have the numbers and equipment to support going loud, or the cult will fall flat on its face.
+As a Cultist, the Blood Boil rune will deal massive amounts of brute damage to non-cultists and some damage to fellow cultists of Nar-Sie nearby.
+As a Cultist, you can create an army of manifested goons using a combination of the Manifest rune, which creates homunculi from ghosts, and the Blood Drain rune, which drains life from anyone standing on any blood drain rune.
+As a Wizard, the fireball spell performs very poorly at close range, as it can easily catch you in the blast. It is best used as a form of artillery down long hallways.
+As a Wizard, most spells become unusable if you are not wearing your robe, hat, and sandals.
+As a Ghost, you can double click on people, bots, or the singularity to follow them.
+Occasionally the tip of the round might lie to you. Don't panic, this is normal.
+To defeat your enemy, shoot at them until they die.
+Sometimes you won't be able to avoid dying no matter how good you are at the game. Try not to stress too much about it.
+When a round ends nearly everything about it is lost forever, leave your salt behind with it.
+Killing the entire station isn't fun except when it is.
+You can win a pulse rifle from the arcade machine. Honest.
+Just like real life the entropy of the game can only increase with time. If things aren't on fire yet, just wait.
+Completing your objectives is good practice, but the best antagonists will strive to do more than the bare minimum to really leave an impression.
+The more obscure and underused a game mechanic is, the less likely your victims are to be able to deal with it.
+Cleanbot.
+Some antagonists are supposed to be extremely strong in one on one combat, stop getting mad about it.
+Sometimes a round will just be a bust. C'est la vie.
+This is a game that is constantly being developed for. Expect things to be added, removed, fixed, and broken on a daily basis.
+It's fun to try and predict the round type from the tip of the round message.
+The quartermaster is not a head of staff and will never be one.
+Your sprite represents your hitbox, so that floor length braid makes you easier to kill. The sacrifices we make for snowflake points.
+Spacemen can't move diagonally but most animals can. Blame the slow decline of the numpad.
+Sometimes admins will just do stuff. Roll with it.
+The remake will never come out.
+Plenty of things that aren't traditionally considered weapons can still be used to slowly brutalize someone to death, get creative!
+DEATH IS IMMINENT!
+This game is older than many of the people playing it.
+Do not go gentle into that good night.
+Just the tip?
+Some people are unable to read text on a game where half of it is based on text.
+Phoron check.
+Remember the cheesy line!
+Toolboxes do more damage if they are full of things, but their contents will spill when you use them as a weapon.
+Heads of Staff will be more willing to help you if you bring paperwork that's already filled out.
+See no evil, hear no evil, speak no evil.
+Auto-Hiss, despite the name, can be used for Unathi, Tajara, and Vaurca.
+Service borgs can use the special maidborg sprite if they pray hard enough.
+Chainswords and energy weapons can slice walls and people.
+If you see this message something has gone seriously wrong.
+If you're having trouble as an antagonist, consider a Dionaea whitelist.
+As a Medical Doctor, you can attach limbs from one species to the torso of another species. You too can make your own Frankenstein monster!
+The second antag contest is still running, you know.
+Killing mice on sight is not and never will be gank, no matter how much people complain.
+As an Unathi, you are the only species capable of wearing the rare Breacher hardsuits.
+As an Unathi, you can devour small mobs after some time.
+As a Tajaran, you move pretty fast. Zoom zoom, kitty.
+As a Tajaran, your resistance to cold probably doesn't actually help you in space. Feel free to try, though.
+As a Skrell you can look pretty and...uhh...not slip?
+As a Skrell you have free reign to validhunt synthetics. (Not really, please don't do this oh God what have I done).
+As a Human you are the best. Why do you care about your mechanics?
+As a Human you are really very great.
+As an IPC you are immune to most chemicals and gasses.
+As an IPC you can survive longer than most species in space, despite your supposed "weakness".
+As a Dionaea you can survive pretty much anything except a tiny little bottle of weedkiller.
+As a Dionaea you will die in darkness. Find the light at the end of the tunnel, and quick.
+As a Vaurca you can remotely speak to any other Vaurca on board. Not that there are any.
+As a Vaurca you can wade freely through phoron gas. Avoid phoron fires though. Somehow a species that breathes phoron gas is really weak to fire.
+As an ERT trooper, your most powerful weapons are your team mates. Your second most powerful weapon is your bigass gun.
+As an ERT trooper you're still expected to roleplay and progress the round.
+As a Ninja, you should learn the difference between invisibility and invulnerability.
+As a Ninja, you have a pretty badass sword. Use it.
+As a Cortical Borer, you a limp feather can kill you if you're outside of a host.
+As a NanoTrasen Actor you can't do anything. Thank Bay.
+As a Syndicate Commando you are a Nuke Operative with bigger and better guns. Use them.
+As a Death Commando you have only one course of action: RIP AND TEAR.
+As a Highlander, there can be only one.
+As a Loyalist, remember that you are an antagonist too!
+As a Renegade, consider playing a better gamemode.
+As a Vampire, you can create new vampires out of willing and less than willing crew. Mind that new vampires may decide to turn their powers against you.
+As a Vampire, if you start going hungry for blood don't expect to stay hidden for long.

--- a/html/changelogs/lordfowl - 1885.yml
+++ b/html/changelogs/lordfowl - 1885.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: LordFowl
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added 'Tip of the round' to the lobby. Based off of /tg/'s, it comes with its own Aurora tips too."


### PR DESCRIPTION
Pretty simple. 10 seconds before the round begins, the game will choose a tip and display it.
Tips are handled in the config.
Admins also have a command to display their own customized tip, and also a command to display a pregenerated tip.
Both commands can be ran at any point in the run to good effect. The customized tip will replace the default, Tip of the round that procs 10 seconds before round-start tip, if it is run during the lobby.
