### PR TITLE
Fix general antagonist bans

### DIFF
--- a/code/game/gamemodes/antagspawner.dm
+++ b/code/game/gamemodes/antagspawner.dm
@@ -32,11 +32,11 @@
 	for(var/mob/dead/observer/O in player_list)
 		if(!O.MayRespawn())
 			continue
-		if(jobban_isbanned(O, "Syndicate") && jobban_isbanned(O, "Mercenary") && jobban_isbanned(O, "Cyborg"))
+		if(jobban_isbanned(O, "Antagonist") && jobban_isbanned(O, "Mercenary") && jobban_isbanned(O, "Cyborg"))
 			continue
 		if(O.client && O.client.prefs && (MODE_MERCENARY in O.client.prefs.be_special_role))
 			question(O.client)
-			
+
 	spawn(600)
 		searching = 0
 		if(!used)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -46,7 +46,7 @@
 			src.updateUsrDialog()
 			return
 		var/mob/M = locate(href_list["traitormob"])
-		if(M.mind.special_role || jobban_isbanned(M, "Syndicate"))
+		if(M.mind.special_role || jobban_isbanned(M, "Antagonist"))
 			temptext = "<i>We have no need for you at this time. Have a pleasant day.</i><br>"
 			src.updateUsrDialog()
 			return

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -50,7 +50,7 @@ client/verb/JoinResponseTeam()
 		if(!send_emergency_team)
 			usr << "No emergency response team is currently being sent."
 			return
-		if(jobban_isbanned(usr, "Syndicate") || jobban_isbanned(usr, "Emergency Response Team") || jobban_isbanned(usr, "Security Officer"))
+		if(jobban_isbanned(usr, "Antagonist") || jobban_isbanned(usr, "Emergency Response Team") || jobban_isbanned(usr, "Security Officer"))
 			usr << "<span class='danger'>You are jobbanned from the emergency reponse team!</span>"
 			return
 		if(ert.current_antagonists.len >= ert.hard_cap)

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -26,8 +26,24 @@ var/jobban_keylist[0]		//to store the keys & ranks
 			if(config.usewhitelist && !check_whitelist(M))
 				return "Whitelisted Job"
 
+		var/static/list/antag_bantypes
+
+		if (isnull(antag_bantypes))
+			antag_bantypes = list()
+			for (var/antag_type in all_antag_types)
+				var/datum/antagonist/antag = all_antag_types[antag_type]
+				if (antag && antag.bantype)
+					antag_bantypes |= "[antag.bantype]"
+
+		// We manage antagonist bans at this end point.
+		// Alternative is to manage it at each call to jobban_isbanned, however,
+		// there is no actual reason why you should be able to play an antag if you're banned from all of them.
+		var/antag_ban = FALSE
+		if (rank in antag_bantypes)
+			antag_ban = TRUE
+
 		for (var/s in jobban_keylist)
-			if( findtext(s,"[M.ckey] - [rank]") == 1 )
+			if(findtext(s,"[M.ckey] - [rank]") == 1 || (antag_ban && findtext(s, "[M.ckey] - Antagonist") == 1))
 				var/startpos = findtext(s, "## ")+3
 				if(startpos && startpos<length(s))
 					var/text = copytext(s, startpos, 0)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -587,9 +587,9 @@
 		jobs += "</tr></table>"
 
 	//Antagonist (Orange)
-		var/isbanned_dept = jobban_isbanned(M, "Syndicate")
+		var/isbanned_dept = jobban_isbanned(M, "Antagonist")
 		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
-		jobs += "<tr bgcolor='ffeeaa'><th colspan='10'><a href='?src=\ref[src];jobban3=Syndicate;jobban4=\ref[M]'>Antagonist Positions</a></th></tr><tr align='center'>"
+		jobs += "<tr bgcolor='ffeeaa'><th colspan='10'><a href='?src=\ref[src];jobban3=Antagonist;jobban4=\ref[M]'>Antagonist Positions</a></th></tr><tr align='center'>"
 
 		// Antagonists.
 		for(var/antag_type in all_antag_types)

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -192,7 +192,7 @@ datum/ghosttrap/drone/transfer_personality(var/mob/candidate, var/mob/living/sil
 ***********************************/
 /datum/ghosttrap/syndicateborg
 	object = "syndicate cyborg"
-	ban_checks = list("Syndicate","AI","Cyborg")
+	ban_checks = list("Antagonist","AI","Cyborg")
 	pref_check = "BE_SYNTH"
 	ghost_trap_message = "They are occupying a syndicate cyborg now."
 	ghost_trap_role = "Syndicate Cyborg"


### PR DESCRIPTION
All full blanket antagonist bans are now classes as Antagonist, instead of Syndicate bans, as Syndicate refers to a specific subset of antags. This made global banning someone from all roles impossible.