### PR TITLE
Lawgiver and random fix

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -21,6 +21,8 @@
 
 // creates the random item
 /obj/random/proc/spawn_item()
+
+
 	var/build_path = item_to_spawn()
 	new build_path(loc)
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -27,8 +27,9 @@
 /obj/structure/closet/initialize()
 	..()
 	if(!opened)		// if closed, any item at the crate's loc is put in the contents
-		var/obj/item/I
+		var/obj/I
 		for(I in src.loc)
+			if (!istype(I, /obj/item) && !istype(I, /obj/random))continue
 			if(I.density || I.anchored || I == src) continue
 			I.forceMove(src)
 		// adjust locker size to hold all items with 5 units of free store room

--- a/code/modules/projectiles/guns/energy/lawgiver.dm
+++ b/code/modules/projectiles/guns/energy/lawgiver.dm
@@ -118,9 +118,9 @@
 
 /obj/item/weapon/gun/energy/lawgiver/hear_talk(mob/living/M in range(0,src), msg)
 	var/mob/living/carbon/human/H = M
-	if (!H)
+	if (!H || !istype(H))
 		return
-	if( (src.dna==usr.dna.unique_enzymes || emagged) && (src in usr.contents))
+	if( (src.dna==H.dna.unique_enzymes || emagged) && (src in usr.contents))
 		hear(msg)
 	return
 

--- a/code/modules/projectiles/guns/energy/lawgiver.dm
+++ b/code/modules/projectiles/guns/energy/lawgiver.dm
@@ -120,7 +120,7 @@
 	var/mob/living/carbon/human/H = M
 	if (!H || !istype(H))
 		return
-	if( (src.dna==H.dna.unique_enzymes || emagged) && (src in usr.contents))
+	if( (src.dna==H.dna.unique_enzymes || emagged) && (src in H.contents))
 		hear(msg)
 	return
 


### PR DESCRIPTION
Fixes an issue that popped up with obj/randoms, they werent getting sucked into lockers

Also fixes that lawgiver runtime.
The issue that previous fixes miss is that DM casts implicitly and without safety checks. Casting an animal to a human does not result in null. an istype check is needed