### PR TITLE
Minor Lighting Process Improvements

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -71,11 +71,6 @@
 #define MORNING_LIGHT_RESET 252000       // 7am or 07:00 - lighting restores to normal in morning
 #define NIGHT_LIGHT_ACTIVE 648000        // 6pm or 18:00 - night lighting mode activates
 
-// Update type flags.
-#define UPDATE_SCHEDULE 0	// Default behavior. Schedule an update with lighting process.
-#define UPDATE_NOW 1		// Update right now, fuck the scheduler. May cause lag.
-#define UPDATE_NONE 2		// Don't trigger an update at all. Useful if you're triggering the update manually.
-
 // Some brightness/range defines for objects.
 #define L_WALLMOUNT_POWER 0.4
 #define L_WALLMOUNT_RANGE 2

--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -5,7 +5,6 @@
 #define LIGHTING_ROUND_VALUE    1 / 128 //Value used to round lumcounts, values smaller than 1/255 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
 
 #define LIGHTING_ICON 'icons/effects/lighting_overlay.png' // icon used for lighting shading effects
-#define DARKNESS_ICON 'icons/effects/darkness.png'	
 
 #define LIGHTING_SOFT_THRESHOLD 0.001 // If the max of the lighting lumcounts of each spectrum drops below this, disable luminosity on the lighting overlays.
 

--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -1,5 +1,4 @@
 #define LIGHTING_INTERVAL       10     // Frequency, in 1/10ths of a second, of the lighting process.
-#define LIGHTING_SLEEP_DELAY	5	// How many ticks spend idle before the lighting process will go to sleep.
 
 #define LIGHTING_HEIGHT         1 // height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone
 #define LIGHTING_ROUND_VALUE    1 / 128 //Value used to round lumcounts, values smaller than 1/255 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.

--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -1,4 +1,5 @@
-#define LIGHTING_INTERVAL       1    // Frequency, in 1/10ths of a second, of the lighting process.
+#define LIGHTING_INTERVAL       10     // Frequency, in 1/10ths of a second, of the lighting process.
+#define LIGHTING_SLEEP_DELAY	5	// How many ticks spend idle before the lighting process will go to sleep.
 
 #define LIGHTING_HEIGHT         1 // height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone
 #define LIGHTING_ROUND_VALUE    1 / 128 //Value used to round lumcounts, values smaller than 1/255 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.

--- a/code/controllers/Processes/lighting.dm
+++ b/code/controllers/Processes/lighting.dm
@@ -18,7 +18,6 @@
 	var/list/curr_corners = list()
 	var/list/curr_overlays = list()
 	var/list/resume_pos = 0
-	var/tmp/ticks_idle = 0
 
 /datum/controller/process/lighting/setup()
 	name = "lighting"
@@ -28,22 +27,13 @@
 
 /datum/controller/process/lighting/statProcess()
 	..()
-	stat(null, "Currently [disabled ? "sleeping" : "running"], server tick usage is [world.tick_usage].")
+	stat(null, "Server tick usage is [world.tick_usage].")
 	stat(null, "[all_lighting_overlays.len] overlays ([all_lighting_corners.len] corners)")
 	stat(null, "Lights: [lighting_update_lights.len] queued, [curr_lights.len] processing")
 	stat(null, "Corners: [lighting_update_corners.len] queued, [curr_corners.len] processing")
 	stat(null, "Overlays: [lighting_update_overlays.len] queued, [curr_overlays.len] processing")
 
 /datum/controller/process/lighting/doWork()
-	if (!lighting_update_lights.len && !lighting_update_corners.len && !lighting_update_overlays.len)
-		ticks_idle++
-	else
-		ticks_idle = 0
-
-	if (ticks_idle > LIGHTING_SLEEP_DELAY)
-		disable()
-		return
-
 	// -- SOURCES --
 	if (resume_pos == STAGE_NONE)
 		curr_lights = lighting_update_lights

--- a/code/modules/lighting/lighting_setup.dm
+++ b/code/modules/lighting/lighting_setup.dm
@@ -29,7 +29,7 @@
 
 		if (!L) continue
 
-		if (L.check() || L.destroyed || L.force_update)
+		if (L.destroyed || L.check() || L.force_update)
 			L.remove_lum()
 			if(!L.destroyed)
 				L.apply_lum()

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -64,9 +64,10 @@
 	return ..()
 
 // Kill ourselves.
-/datum/light_source/proc/destroy()
+/datum/light_source/proc/destroy(var/no_update = FALSE)
 	destroyed = TRUE
-	force_update()
+	if (!no_update)
+		force_update()
 	if (source_atom && source_atom.light_sources)
 		source_atom.light_sources -= src
 
@@ -143,7 +144,7 @@
 // Will check if we actually need to update, and update any variables that may need to be updated.
 /datum/light_source/proc/check()
 	if (!source_atom || !light_range || !light_power)
-		destroy()
+		destroy(no_update = TRUE)
 		return 1
 
 	if (!top_atom)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -100,9 +100,6 @@
 // Picks either scheduled or instant updates based on current server load.
 #define INTELLIGENT_UPDATE 							\
 	if (world.tick_usage > TICK_LIMIT || !ticker || ticker.current_state <= GAME_STATE_SETTING_UP) {	\
-		if (lighting_process && lighting_process.disabled) {  \
-			lighting_process.disabled = FALSE;		\
-		}                                           \
 		QUEUE_UPDATE;								\
 	}												\
 	else {											\

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -98,8 +98,8 @@
 
 // Picks either scheduled or instant updates based on current server load.
 #define INTELLIGENT_UPDATE 							\
-	if (world.tick_usage > TICK_LIMIT || !ticker) {	\
-		if (ticker && lighting_process.disabled) {  \
+	if (world.tick_usage > TICK_LIMIT || !ticker || ticker.current_state <= GAME_STATE_SETTING_UP) {	\
+		if (lighting_process && lighting_process.disabled) {  \
 			lighting_process.disabled = FALSE;		\
 		}                                           \
 		QUEUE_UPDATE;								\

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -99,6 +99,9 @@
 // Picks either scheduled or instant updates based on current server load.
 #define INTELLIGENT_UPDATE 							\
 	if (world.tick_usage > TICK_LIMIT || !ticker) {	\
+		if (ticker && lighting_process.disabled) {  \
+			lighting_process.disabled = FALSE;		\
+		}                                           \
 		QUEUE_UPDATE;								\
 	}												\
 	else {											\


### PR DESCRIPTION
This PR reduces the tick rate of the lighting process from 1 ds interval to 10 ds interval, and removes some pointless updates from `Destroy()`.

Also removes some left over defines from `update_type` and darkness overlays that I forgot to remove earlier.

Fixes #1683.