### PR TITLE
Laser Rebalance

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -126,5 +126,5 @@
 
 	firemodes = list(
 		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, modifystate="epistolstun", fire_sound='sound/weapons/Taser.ogg'),
-		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam, modifystate="epistolkill", fire_sound='sound/weapons/Laser.ogg')
+		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam/pistol, modifystate="epistolkill", fire_sound='sound/weapons/Laser.ogg')
 		)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -1,8 +1,11 @@
+/obj/item/projectile/beam/pistol
+	damage = 25
+
 /obj/item/projectile/beam
 	name = "laser"
 	icon_state = "laser"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage = 40
+	damage = 30
 	damage_type = BURN
 	check_armour = "laser"
 	eyeblur = 4
@@ -25,14 +28,13 @@
 	eyeblur = 2
 
 /obj/item/projectile/beam/midlaser
-	damage = 40
+	damage = 30
 	armor_penetration = 10
 
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	damage = 60
-	armor_penetration = 30
 
 	muzzle_type = /obj/effect/projectile/laser_heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser_heavy/tracer
@@ -42,7 +44,7 @@
 	name = "xray beam"
 	icon_state = "xray"
 	damage = 25
-	armor_penetration = 50
+	armor_penetration = 30
 
 	muzzle_type = /obj/effect/projectile/xray/muzzle
 	tracer_type = /obj/effect/projectile/xray/tracer
@@ -52,7 +54,6 @@
 	name = "pulse"
 	icon_state = "u_laser"
 	damage = 50
-	armor_penetration = 30
 
 	muzzle_type = /obj/effect/projectile/laser_pulse/muzzle
 	tracer_type = /obj/effect/projectile/laser_pulse/tracer

--- a/html/changelogs/Nanako-Lasers.yml
+++ b/html/changelogs/Nanako-Lasers.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Reduced the damage of common laser weapons by ~25%. pistols a little more"


### PR DESCRIPTION
I've been meaning to do this for months, many many months. and i was originally planning to roll it into research work, but ive decided that it's best to do this alone so it can recieve debate and discussion.

This PR reduces the damage of most normal lasers by 25%, down to 30 per shot. Pistols are reduced slightly more, to 25 per shot.
In addition it also strips or reduces armor penetration in most cases.

I will explain these changes:

 Lasers have too many advantages. Their damage far outstrips most ballistic weapons, the tactical advantage of shooting through windows and doors is immense, negating a lot of cover. They can be recharged easily, negating a need to create or order ammo, and they cause no internal wounds, giving an odd perception of acceptability

Farthermore, they are hitscan weapons. This is not to be overlooked. Not using projectiles means they are a lot more accurate, which greatly reduces the loss in their damage from inaccuracy, and means that the shooter doesnt have to predict motion in order to hit a moving target

In addition, almost everything is weak to them. There are very, very few things that are especially weak to ballistic weapons. Most targets that have special weaknesses - from synthetics to exosuits to vaurca to unathi to walls, have a weakness against energy weapons or a resistance to things that aren't energy.

These are a lot of things that could be worked on seperately, but the damage is, and woiuld remain the core problem. three hits to take down any unarmoured personnel is too little, and this is a step in the direction of making ganking less sudden

Even for a scifi setting, they are too good. A laser rifle solves all problems, and security never needs to order more advanced gear. They are too good at literally everything, and all other weapons are sidelined in a conflict. Too many antags stories have been ended by a sudden laser volley, its a very anticlimactic method.




As to armor penetration, baymerge sneaked that in, and put it on several things that didn't need the buff. I already had plans to code that mechanic, and its nice they did it for me. While it is an interesting mechanic and has a place here, the values were far too high, and on far too many weapons. My changes to armor penetration almost restore it to its former state. I have plans to make sparing use of it in future.

Lastly, but not least, the high damage of laser weapons is a blocker to some of my plans with researching advanced lasers. Their damage is already so high that theres no room for improvement without making things a silly murderfest. I have plans to allow researching a more advanced weapon in future that may go a bit higher, but. it will never be as strong as lasers are now. But the lack of that is not a loss. extremely high damage isnt needed. And regardless of future development, i believe there are enough reasons for these changes now.

At 30 damage, laser rifles will not be marginalised. They will still have more than competent damage, and still be used for all the other factors of instant hits, window passing, ease of recharging and countering most weaknesses. But its my hope that this change will allow other weapons to be somewhat more viable. And in the face of a really severe threat, force security to order some larger ordnance