### PR TITLE
Aurorastationify Readme & Changelog Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# baystation12
+# Aurorastation
 
-[Website](http://baystation12.net/) - [Code](http://github.com/Baystation12/Baystation12/) - [IRC](http://baystation12.net/forums/viewtopic.php?f=12&t=5088)
+[Website](https://aurorastation.org/) - [Code](https://github.com/Aurorastation/Aurora.3)
 
 ---
 
 ### LICENSE
-Baystation12 is licensed under the GNU Affero General Public License version 3, which can be found in full in LICENSE-AGPL3.txt.
+Aurorastation is licensed under the GNU Affero General Public License version 3, which can be found in full in LICENSE-AGPL3.txt.
 
 Commits with a git authorship date prior to `1420675200 +0000` (2015/01/08 00:00) are licensed under the GNU General Public License version 3, which can be found in full in LICENSE-GPL3.txt.
 
@@ -18,11 +18,11 @@ See [here](https://www.gnu.org/licenses/why-affero-gpl.html) for more informatio
 ### GETTING THE CODE
 The simplest way to obtain the code is using the github .zip feature.
 
-Click [here](https://github.com/Baystation12/Baystation12/archive/master.zip) to get the latest code as a .zip file, then unzip it to wherever you want.
+Click [here](https://github.com/Aurorastation/Aurora.3/archive/master.zip) to get the latest stable code as a .zip file, then unzip it to wherever you want.
 
 The more complicated and easier to update method is using git.  You'll need to download git or some client from [here](http://git-scm.com/).  When that's installed, right click in any folder and click on "Git Bash".  When that opens, type in:
 
-    git clone https://github.com/Baystation12/Baystation12.git
+    git clone https://github.com/Aurorastation/Aurora.3.git
 
 (hint: hold down ctrl and press insert to paste into git bash)
 
@@ -30,7 +30,7 @@ This will take a while to download, but it provides an easier method for updatin
 
 Once the repository is in place, run this command:
 ```bash
-cd Baystation12
+cd Aurora.3
 git update-index --assume-unchanged baystation12.int
 ```
 Now git will ignore changes to the file baystation12.int.
@@ -45,7 +45,7 @@ This is a sourcecode-only release, so the next step is to compile the server fil
     
     baystation12.dmb - 0 errors, 0 warnings
 
-If you see any errors or warnings, something has gone wrong - possibly a corrupt download or the files extracted wrong, or a code issue on the main repo.  Ask on IRC.
+If you see any errors or warnings, something has gone wrong - possibly a corrupt download or the files extracted wrong, or a code issue on the main repo. Ask on the server Discord if you're completely lost.
 
 Once that's done, open up the config folder.  You'll want to edit config.txt to set the probabilities for different gamemodes in Secret and to set your server location so that all your players don't get disconnected at the end of each round.  It's recommended you don't turn on the gamemodes with probability 0, as they have various issues and aren't currently being tested, so they may have unknown and bizarre bugs.
 
@@ -78,16 +78,12 @@ When you have done this, you'll need to recompile the code, but then it should w
 
 ### Configuration
 
-For a basic setup, simply copy every file from config/example to config.
+For a basic setup, simply copy every file from config/example to config. 
+
+For more advanced setups, setting the server `tick_lag` in the config as well as configuring SQL are good first steps.
 
 ---
 
 ### SQL Setup
 
-The SQL backend for the library and stats tracking requires a MySQL server.  Your server details go in /config/dbconfig.txt, and the SQL schema is in /SQL/tgstation_schema.sql.  More detailed setup instructions arecoming soon, for now ask in our IRC channel.
-
----
-
-### IRC Bot Setup
-
-Included in the repo is an IRC bot capable of relaying adminhelps to a specified IRC channel/server (thanks to Skibiliano).  Instructions for bot setup are included in the /bot/ folder along with the bot/relay script itself.
+The SQL backend for the library and stats tracking requires a MySQL server, as does the optional SQL saves system. Your server details go in config/dbconfig.txt, and initial database setup is done with [flyway](https://flywaydb.org/). Detailed instructions can be found [here](https://github.com/Aurorastation/Aurora.3/tree/master/SQL).

--- a/code/global.dm
+++ b/code/global.dm
@@ -38,7 +38,7 @@ var/const/boss_name     = "Central Command"
 var/const/boss_short    = "Centcomm"
 var/const/company_name  = "NanoTrasen"
 var/const/company_short = "NT"
-var/game_version        = "Baystation12"
+var/game_version        = "Aurorastation"
 var/changelog_hash      = ""
 var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 442)
 

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -1,7 +1,7 @@
 /var/obj/effect/lobby_image = new/obj/effect/lobby_image()
 
 /obj/effect/lobby_image
-	name = "Baystation12"
+	name = "Aurorastation"
 	desc = "This shouldn't be read"
 	icon = 'icons/misc/title.dmi'
 	screen_loc = "WEST,SOUTH"

--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -25,7 +25,7 @@
 		<td valign='top'>
 			<div align='center'><font size='3'><b>Space Station 13</b></font></div>
 			
-			<p><div align='center'><font size='3'><a href="https://aurorastation.org/wiki/index.php?title=Main_Page">Wiki</a> | <a href="https://github.com/Baystation12/Baystation12/">Source code</a></font></div></p>
+			<p><div align='center'><font size='3'><a href="https://aurorastation.org/wiki/index.php?title=Main_Page">Wiki</a> | <a href="https://github.com/Aurorastation/Aurora.3">Source code</a></font></div></p>
             <font size='2'>Code licensed under <a href="http://www.gnu.org/licenses/agpl.html">AGPLv3</a>. Content licensed under <a href="http://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>.<br><br>
 			</td>
 	</tr>

--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
 <head>
-  <title>Baystation 12 Changelog</title>
+  <title>Aurorastation Changelog</title>
   <link rel="stylesheet" type="text/css" href="changelog.css">
   <base target="_blank" />
   <script type='text/javascript'>
@@ -25,25 +25,24 @@
 		<td valign='top'>
 			<div align='center'><font size='3'><b>Space Station 13</b></font></div>
 			
-			<p><div align='center'><font size='3'><a href="http://wiki.baystation12.net/">Wiki</a> | <a href="https://github.com/Baystation12/Baystation12/">Source code</a></font></div></p>
+			<p><div align='center'><font size='3'><a href="https://aurorastation.org/wiki/index.php?title=Main_Page">Wiki</a> | <a href="https://github.com/Baystation12/Baystation12/">Source code</a></font></div></p>
             <font size='2'>Code licensed under <a href="http://www.gnu.org/licenses/agpl.html">AGPLv3</a>. Content licensed under <a href="http://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>.<br><br>
-			<font size='2'><b>Visit our IRC channel:</b> #bs12 on irc.sorcery.net</font>
 			</td>
 	</tr>
 </table>
 
-<br><b>Baystation 12 Credit List</b>
+<br><b>Baystation 12 / Aurorastation Credit List</b>
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-            <font size='2'><b>Current Project Maintainers:</b> <a href='https://github.com/Baystation12?tab=members'>-Click Here-</a><br></font>
-			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Baystation12/Baystation12/graphs/contributors'>-Click Here-</a><br></font>
+            <font size='2'><b>Current Project Maintainers:</b> <a href='https://github.com/orgs/Aurorastation/people'>-Click Here-</a><br></font>
+			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Aurorastation/Aurora.3/graphs/contributors'>-Click Here-</a><br></font>
 			<font size='2'><b>Code:</b> Abi79, Aryn, Cael_Aislinn, Ccomp5950, Chinsky, cib, CompactNinja, DopeGhoti, Erthilo, Hawk_v3, Head, Ispil, JoeyJo0, Lexusjjss, Melonstorm, Miniature, Mloc, NerdyBoy1104, PsiOmegaDelta, SkyMarshal, Snapshot, Spectre, Strumpetplaya, Sunfall, Tastyfish, Uristqwerty<br></font>
 			<font size='2'><b>Sprites:</b> Apple_Master, Arcalane, Chinsky, CompactNinja, Deus Dactyl, Erthilo, Flashkirby, JoeyJo0, Miniature, Searif, Xenone, faux<br></font>
 			<font size='2'><b>Sounds:</b> Aryn<br></font>
             <font size='2'><b>Main Testers:</b> Anyone who has submitted a bug to the issue tracker<br></font>
-			<font size='2'><b>Thanks to:</b> /tg/ station, /vg/station, GoonStation devs, the original SpaceStation developers and Invisty for the title image.<br> Also a thanks to anybody who has contributed who is not listed here :( Ask to be added here on irc.</font>
-			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Baystation12/Baystation12/issues?labels=Bug&state=open">Issue Tracker</a>.<br></font>
+			<font size='2'><b>Thanks to:</b> /tg/ station, /vg/station, GoonStation devs, Baystation 12 devs, the original SpaceStation developers and FFrances for the title image.<br> Also a thanks to anybody who has contributed who is not listed here :( Ask to be added here on irc.</font>
+			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Aurorastation/Aurora.3/issues">Issue Tracker</a>.<br></font>
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
changes:
- Replaces some instances of `Baystation 12` with `Aurorastation`.
- Brings the README up-to-date with current SQL setup.
- Removed mentions to non-existent IRC channel.
- Updated changelog template to properly credit title image.
- Replaced bay website links with aurora equivalents.