### PR TITLE
Directional Lighting [WIP]

### DIFF
--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -5,6 +5,7 @@
 	var/light_range = 0 // Range in tiles of the light.
 	var/light_color     // Hexadecimal RGB string representing the colour of the light.
 	var/uv_intensity	// How much UV light is being emitted by this object. Valid range: 0-255.
+	var/light_is_directional = FALSE	// Boolean for whether or not the light of the atom is directional.
 
 	var/tmp/datum/light_source/light // Our light source. Don't fuck with this directly unless you have a good reason!
 	var/tmp/list/light_sources       // Any light sources that are "inside" of us, for example, if src here was a mob that's carrying a flashlight, that flashlight's light source would be part of this list.

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -5,7 +5,7 @@
 	var/light_range = 0 // Range in tiles of the light.
 	var/light_color     // Hexadecimal RGB string representing the colour of the light.
 	var/uv_intensity	// How much UV light is being emitted by this object. Valid range: 0-255.
-	var/light_is_directional = FALSE	// Boolean for whether or not the light of the atom is directional.
+	var/light_is_directional = 0	// Integer for whether or not the light of the atom is directional. (Valid: 0, 1, 2)
 
 	var/tmp/datum/light_source/light // Our light source. Don't fuck with this directly unless you have a good reason!
 	var/tmp/list/light_sources       // Any light sources that are "inside" of us, for example, if src here was a mob that's carrying a flashlight, that flashlight's light source would be part of this list.

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -269,7 +269,6 @@
 				left_margin = SOUTHWEST
 				right_margin = NORTHWEST
 
-
 	FOR_DVIEW(var/turf/T, light_range, source_turf, INVISIBILITY_LIGHTING)
 		if (is_directional)
 			var/diff = get_dir(source_turf, T) - top_atom.dir

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -10,6 +10,7 @@
 	var/light_range      // The range of the emitted light.
 	var/light_color    // The colour of the light, string, decomposed by parse_light_color()
 	var/light_uv		// The intensity of UV light, between 0 and 255.
+	var/is_directional	// Whether or not the light is directional.
 
 	// Variables for keeping track of the colour.
 	var/lum_r
@@ -51,6 +52,7 @@
 	light_range = source_atom.light_range
 	light_color = source_atom.light_color
 	light_uv    = source_atom.uv_intensity
+	is_directional = source_atom.light_is_directional
 
 	parse_light_color()
 
@@ -235,7 +237,45 @@
 	applied_lum_b = lum_b
 	applied_lum_u = lum_u
 
+	var/left_margin
+	var/right_margin
+
+	if (is_directional == 1)
+		switch (top_atom.dir)
+			if (NORTH)
+				left_margin = WEST
+				right_margin = EAST
+			if (EAST)
+				left_margin = NORTH
+				right_margin = SOUTH
+			if (SOUTH)
+				left_margin = EAST
+				right_margin = WEST
+			else
+				left_margin = SOUTH
+				right_margin = NORTH
+	else if (is_directional == 2)
+		switch (top_atom.dir)
+			if (NORTH)
+				left_margin = NORTHWEST
+				right_margin = NORTHEAST
+			if (EAST)
+				left_margin = NORTHEAST
+				right_margin = SOUTHEAST
+			if (SOUTH)
+				left_margin = SOUTHEAST
+				right_margin = SOUTHWEST
+			else
+				left_margin = SOUTHWEST
+				right_margin = NORTHWEST
+
+
 	FOR_DVIEW(var/turf/T, light_range, source_turf, INVISIBILITY_LIGHTING)
+		if (is_directional)
+			var/diff = get_dir(source_turf, T) - top_atom.dir
+			if (diff && diff != left_margin && diff != right_margin)
+				continue
+
 		if (!T.lighting_corners_initialised)
 			T.generate_missing_corners()
 


### PR DESCRIPTION
Adds a pretty easy-to-use directional lighting system to the game which doesn't break the bank in terms of CPU overhead. This is all done with slight modifications to the present algorithm. Meaning, no special overhead, no major risk. However, as you can see, there is no mid-way "cone" effect. It's either wide beam or very narrow beam.

The cone effect would require a custom algorithm, and I fear it'll be relatively expensive. I still need to ponder on it. Cheapest method I can think of is:
* Start walking out from top_atom in its cardinal direction.
* For each 1 step in the cardinal, go get_dist(T, top_atom) amount of steps left and right (relatively).
* Conduct view() checks per every turf you walk into, if return 1, do the corner shit.
* Walk out until your get_dist(T, top_atom) >= light_range

You can see why I'm hesitant.

TODO:
- [ ] Fix the Estonian flashlights that happen with narrow beam.
- [ ] Update `smart_vis_update()` to match.

Preview:
**Narrow beam lights**
![Image of narrow beam](https://kama.skullnet.me/index.php/apps/files_sharing/ajax/publicpreview.php?x=1920&y=610&a=true&file=2017-02-06_00-19-04.png&t=YQsZTKfPsQL0kJw&scalingup=0)

**Wide beam lights**
![Image of wide beam](https://kama.skullnet.me/index.php/apps/files_sharing/ajax/publicpreview.php?x=1920&y=610&a=true&file=2017-02-06_00-19-36.png&t=CzvjoitO4WPZOUT&scalingup=0)