### PR TITLE
Machinery performance tweaks

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -101,4 +101,7 @@ var/list/restricted_camera_networks = list(NETWORK_ERT,NETWORK_MERCENARY,"Secret
 // Misc process flags.
 #define M_PROCESSES 0x1
 #define M_USES_POWER 0x2
-#define M_NO_PROCESS 0x4
+
+// If this is returned from a machine's process() proc, the machine will stop processing but 
+// will continue to have power calculations done.
+#define M_NO_PROCESS 27

--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -96,3 +96,9 @@ var/list/restricted_camera_networks = list(NETWORK_ERT,NETWORK_MERCENARY,"Secret
 #define ATMOS_DEFAULT_VOLUME_FILTER 200 // L.
 #define ATMOS_DEFAULT_VOLUME_MIXER  200 // L.
 #define ATMOS_DEFAULT_VOLUME_PIPE   70  // L.
+
+
+// Misc process flags.
+#define M_PROCESSES 0x1
+#define M_USES_POWER 0x2
+#define M_NO_PROCESS 0x4

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -285,3 +285,4 @@
   )
 
 #define get_turf(A) (get_step(A, 0))
+#define NULL_OR_GC(TARGET) (!TARGET || TARGET.gcDestroyed)

--- a/code/controllers/Processes/machinery.dm
+++ b/code/controllers/Processes/machinery.dm
@@ -16,6 +16,7 @@ var/global/list/ticking_machines		= list()
 	var/type = M.get_process_type()
 	if (type)
 		machines += M
+		
 	if (type & M_PROCESSES)
 		ticking_machines += M
 

--- a/code/controllers/Processes/scheduler.dm
+++ b/code/controllers/Processes/scheduler.dm
@@ -10,7 +10,7 @@
 
 /datum/controller/process/scheduler/setup()
 	name = "scheduler"
-	schedule_interval = 3 SECONDS
+	schedule_interval = 2 SECONDS
 	scheduled_tasks = list()
 	scheduler = src
 

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -100,8 +100,8 @@ obj/machinery/computer/general_air_control/Destroy()
 	onclose(user, "computer")
 
 /obj/machinery/computer/general_air_control/process()
-	..()
-	src.updateUsrDialog()
+	if (operable())
+		src.updateUsrDialog()
 
 /obj/machinery/computer/general_air_control/receive_signal(datum/signal/signal)
 	if(!signal || signal.encryption) return

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -174,11 +174,7 @@ var/global/list/engineering_networks = list(
 	assembly.upgrades.Add(new /obj/item/device/assembly/prox_sensor(assembly))
 	setPowerUsage()
 	if(!(src in machines))
-		if(!machinery_sort_required && ticker)
-			dd_insertObjectList(machines, src)
-		else
-			machines += src
-			machinery_sort_required = 1
+		add_machine(src)
 	update_coverage()
 
 /obj/machinery/camera/proc/setPowerUsage()

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -80,5 +80,5 @@
 
 
 /obj/machinery/computer/operating/process()
-	if(..())
+	if(operable())
 		src.updateDialog()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -42,7 +42,7 @@
 	crew_announcement.newscast = 1
 
 /obj/machinery/computer/communications/process()
-	if(..())
+	if(operable())
 		if(state != STATE_STATUSDISPLAY)
 			src.updateDialog()
 

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -23,11 +23,6 @@
 	power_change()
 	update_icon()
 
-/obj/machinery/computer/process()
-	if(stat & (NOPOWER|BROKEN))
-		return 0
-	return 1
-
 /obj/machinery/computer/emp_act(severity)
 	if(prob(20/severity)) set_broken()
 	..()

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -144,7 +144,7 @@
 
 
 /obj/machinery/computer/pod/process()
-	if(!..())
+	if(inoperable())
 		return
 	if(timing)
 		if(time > 0)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1076,7 +1076,7 @@ About the new airlock wires panel:
 
 //						playsound(src.loc, 'sound/machines/buzz-two.ogg', 50, 0)
 //						next_beep_at = world.time + SecondsToTicks(10)
-					close_door_at = world.time + 6
+					close_door_in(6)
 					return
 	for(var/turf/turf in locs)
 		for(var/atom/movable/AM in turf)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -125,7 +125,11 @@
 	return
 
 /obj/machinery/door/proc/close_door_in(var/time = 5 SECONDS)
-	if (close_task)
+	if (time < 2 SECONDS)	// Too short duration for the scheduler.
+		spawn(time)
+			src.auto_close()
+
+	else if (close_task)
 		// Update the time.
 		close_task.trigger_task_in(time)
 	else

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -133,14 +133,14 @@
 		// Update the time.
 		close_task.trigger_task_in(time)
 	else
-		schedule_task_with_source_in(time, src, /obj/machinery/door/proc/auto_close)
+		close_task = schedule_task_with_source_in(time, src, /obj/machinery/door/proc/auto_close)
 
 /obj/machinery/door/proc/close_hatch_in(var/time = 5 SECONDS)
 	if (hatch_task)
 		// Update the time.
 		hatch_task.trigger_task_in(time)
 	else
-		schedule_task_with_source_in(time, src, /obj/machinery/door/proc/auto_close_hatch)
+		hatch_task = schedule_task_with_source_in(time, src, /obj/machinery/door/proc/auto_close_hatch)
 
 /obj/machinery/door/proc/auto_close()
 	close()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -30,8 +30,8 @@
 	var/obj/item/stack/material/steel/repairing
 	var/block_air_zones = 1 //If set, air zones cannot merge across the door even when it is opened.
 	var/open_duration = 150//How long it stays open
-	var/close_task
-	var/hatch_task
+	var/datum/scheduled_task/close_task
+	var/datum/scheduled_task/hatch_task
 
 	var/hashatch = 0//If 1, this door has hatches, and certain small creatures can move through them without opening the door
 	var/hatchstate = 0//0: closed, 1: open
@@ -41,8 +41,6 @@
 	var/hatch_colour = "#FFFFFF"
 	var/hatch_open_sound = 'sound/machines/hatch_open.ogg'
 	var/hatch_close_sound = 'sound/machines/hatch_close.ogg'
-
-	var/hatchclosetime //A world.time value to tell us when the hatch should close
 
 	var/image/hatch_image
 
@@ -108,7 +106,7 @@
 		hatchstate = 1
 		update_icon()
 		playsound(src.loc, hatch_open_sound, 40, 1, -1)
-	hatchclosetime = world.time + 29
+	close_hatch_in(29)
 
 	if (istype(mover, /mob/living))
 		var/mob/living/S = mover
@@ -129,14 +127,14 @@
 /obj/machinery/door/proc/close_door_in(var/time = 5 SECONDS)
 	if (close_task)
 		// Update the time.
-		close_task:trigger_task_in(time)
+		close_task.trigger_task_in(time)
 	else
 		schedule_task_with_source_in(time, src, /obj/machinery/door/proc/auto_close)
 
 /obj/machinery/door/proc/close_hatch_in(var/time = 5 SECONDS)
 	if (hatch_task)
 		// Update the time.
-		hatch_task:trigger_task_in(time)
+		hatch_task.trigger_task_in(time)
 	else
 		schedule_task_with_source_in(time, src, /obj/machinery/door/proc/auto_close_hatch)
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -118,14 +118,11 @@ Class Procs:
 	..(l)
 	if(d)
 		set_dir(d)
-	if(!machinery_sort_required && ticker)
-		dd_insertObjectList(machines, src)
-	else
-		machines += src
-		machinery_sort_required = 1
+
+	add_machine(src)
 
 /obj/machinery/Destroy()
-	machines -= src
+	remove_machine(src)
 	if(component_parts)
 		for(var/atom/A in component_parts)
 			if(A.loc == src) // If the components are inside the machine, delete them.
@@ -141,7 +138,12 @@ Class Procs:
 	if(!(use_power || idle_power_usage || active_power_usage))
 		return PROCESS_KILL
 
-	return
+	return M_NO_PROCESS
+
+/obj/machinery/proc/get_process_type()
+	. |= M_PROCESSES
+	if (use_power || idle_power_usage || active_power_usage)
+		. |= M_USES_POWER
 
 /obj/machinery/emp_act(severity)
 	if(use_power && stat == 0)

--- a/code/game/machinery/status_display_ai.dm
+++ b/code/game/machinery/status_display_ai.dm
@@ -37,7 +37,8 @@ var/list/ai_status_emotions = list(
 	return emotions
 
 /proc/set_ai_status_displays(mob/user as mob)
-	var/emote = pick_ai_status_emote()
+	var/list/ai_emotions = get_ai_emotions(user.ckey)
+	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
 	for (var/obj/machinery/M in machines) //change status
 		if(istype(M, /obj/machinery/ai_status_display))
 			var/obj/machinery/ai_status_display/AISD = M
@@ -51,10 +52,6 @@ var/list/ai_status_emotions = list(
 				SD.friendc = 1
 			else
 				SD.friendc = 0
-
-/proc/pick_ai_status_emote()
-	var/list/ai_emotions = get_ai_emotions(user.ckey)
-	return input("Please, select a status!", "AI Status", null, null) in ai_emotions
 
 /obj/machinery/ai_status_display
 	icon = 'icons/obj/status_display.dmi'
@@ -72,7 +69,8 @@ var/list/ai_status_emotions = list(
 	var/emotion = "Neutral"
 
 /obj/machinery/ai_status_display/attack_ai/(mob/user as mob)
-	var/emote = pick_ai_status_emote()
+	var/list/ai_emotions = get_ai_emotions(user.ckey)
+	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
 	src.emotion = emote
 	src.update()
 

--- a/code/game/machinery/status_display_ai.dm
+++ b/code/game/machinery/status_display_ai.dm
@@ -74,7 +74,7 @@ var/list/ai_status_emotions = list(
 	src.emotion = emote
 
 /obj/machinery/ai_status_display/process()
-	return
+	return M_NO_PROCESS
 
 /obj/machinery/ai_status_display/proc/update()
 	if(mode==0) //Blank

--- a/code/game/machinery/status_display_ai.dm
+++ b/code/game/machinery/status_display_ai.dm
@@ -37,8 +37,7 @@ var/list/ai_status_emotions = list(
 	return emotions
 
 /proc/set_ai_status_displays(mob/user as mob)
-	var/list/ai_emotions = get_ai_emotions(user.ckey)
-	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
+	var/emote = get_ai_emotion(user)
 	for (var/obj/machinery/M in machines) //change status
 		if(istype(M, /obj/machinery/ai_status_display))
 			var/obj/machinery/ai_status_display/AISD = M
@@ -69,10 +68,12 @@ var/list/ai_status_emotions = list(
 	var/emotion = "Neutral"
 
 /obj/machinery/ai_status_display/attack_ai/(mob/user as mob)
-	var/list/ai_emotions = get_ai_emotions(user.ckey)
-	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
+	var/emote = get_ai_emotion(user)
 	src.emotion = emote
 	src.update()
+
+/proc/get_ai_emotion(mob/user as mob)
+	return input(user, "Please, select a status!", "AI Status", null, null) in get_ai_emotions(user.ckey)
 
 /obj/machinery/ai_status_display/proc/update()
 	switch (mode)

--- a/code/game/machinery/status_display_ai.dm
+++ b/code/game/machinery/status_display_ai.dm
@@ -69,12 +69,7 @@ var/list/ai_status_emotions = list(
 	var/emotion = "Neutral"
 
 /obj/machinery/ai_status_display/attack_ai/(mob/user as mob)
-	var/list/ai_emotions = get_ai_emotions(user.ckey)
-	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
-	src.emotion = emote
-
-/obj/machinery/ai_status_display/process()
-	return M_NO_PROCESS
+	set_ai_status_displays(user)
 
 /obj/machinery/ai_status_display/proc/update()
 	if(mode==0) //Blank

--- a/code/game/machinery/status_display_ai.dm
+++ b/code/game/machinery/status_display_ai.dm
@@ -37,8 +37,7 @@ var/list/ai_status_emotions = list(
 	return emotions
 
 /proc/set_ai_status_displays(mob/user as mob)
-	var/list/ai_emotions = get_ai_emotions(user.ckey)
-	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
+	var/emote = pick_ai_status_emote()
 	for (var/obj/machinery/M in machines) //change status
 		if(istype(M, /obj/machinery/ai_status_display))
 			var/obj/machinery/ai_status_display/AISD = M
@@ -52,6 +51,10 @@ var/list/ai_status_emotions = list(
 				SD.friendc = 1
 			else
 				SD.friendc = 0
+
+/proc/pick_ai_status_emote()
+	var/list/ai_emotions = get_ai_emotions(user.ckey)
+	return input("Please, select a status!", "AI Status", null, null) in ai_emotions
 
 /obj/machinery/ai_status_display
 	icon = 'icons/obj/status_display.dmi'
@@ -69,21 +72,21 @@ var/list/ai_status_emotions = list(
 	var/emotion = "Neutral"
 
 /obj/machinery/ai_status_display/attack_ai/(mob/user as mob)
-	set_ai_status_displays(user)
+	var/emote = pick_ai_status_emote()
+	src.emotion = emote
+	src.update()
 
 /obj/machinery/ai_status_display/proc/update()
-	if(mode==0) //Blank
-		overlays.Cut()
-		return
+	switch (mode)
+		if (0)	// Blank
+			overlays.Cut()
 
-	if(mode==1)	// AI emoticon
-		var/datum/ai_emotion/ai_emotion = ai_status_emotions[emotion]
-		set_picture(ai_emotion.overlay)
-		return
+		if (1)	// AI emoticon
+			var/datum/ai_emotion/ai_emotion = ai_status_emotions[emotion]
+			set_picture(ai_emotion.overlay)
 
-	if(mode==2)	// BSOD
-		set_picture("ai_bsod")
-		return
+		if (2)	// BSOD
+			set_picture("ai_bsod")
 
 /obj/machinery/ai_status_display/proc/set_picture(var/state)
 	picture_state = state

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -184,7 +184,7 @@
 				holographic_mobs -= C
 				C.derez()
 
-	if(!..())
+	if(inoperable())
 		return
 	if(active)
 		use_power(item_power_usage * (holographic_objs.len + holographic_mobs.len))

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -29,7 +29,6 @@
 			known_sectors += R
 
 /obj/machinery/computer/helm/process()
-	..()
 	if (autopilot && dx && dy)
 		var/turf/T = locate(dx,dy,1)
 		if(linked.loc == T)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -2,6 +2,7 @@
 //
 // consists of light fixtures (/obj/machinery/light) and light tube/bulb items (/obj/item/weapon/light)
 
+#define LIGHTING_POWER_FACTOR 40		//20W per unit luminosity
 
 // status values shared between lighting fixtures and items
 #define LIGHT_OK 0
@@ -245,7 +246,6 @@
 
 // update the icon_state and luminosity of the light depending on its state
 /obj/machinery/light/proc/update(var/trigger = 1)
-
 	update_icon()
 	if(on)
 		if (check_update())
@@ -265,6 +265,7 @@
 					set_light(0)
 			else
 				use_power = 2
+				active_power_usage = light_range * LIGHTING_POWER_FACTOR
 				if (supports_nightmode && nightmode)
 					set_light(night_brightness_range, night_brightness_power, brightness_color, uv = brightness_uv)
 				else
@@ -566,20 +567,6 @@
 			if (prob(50))
 				broken()
 	return
-
-//blob effect
-
-
-// timed process
-// use power
-
-#define LIGHTING_POWER_FACTOR 40		//20W per unit luminosity
-
-
-/obj/machinery/light/process()
-	if(on)
-		use_power(light_range * LIGHTING_POWER_FACTOR, LIGHT)
-
 
 // called when area power state changes
 /obj/machinery/light/power_change()

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -78,8 +78,7 @@
 		ui.open()
 
 /obj/machinery/computer/centrifuge/process()
-	..()
-	if (stat & (NOPOWER|BROKEN)) return
+	if (inoperable()) return
 
 	if (curing)
 		curing -= 1

--- a/code/modules/virus2/curer.dm
+++ b/code/modules/virus2/curer.dm
@@ -66,9 +66,7 @@
 	return
 
 /obj/machinery/computer/curer/process()
-	..()
-
-	if(stat & (NOPOWER|BROKEN))
+	if (inoperable())
 		return
 	use_power(500)
 

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -86,7 +86,7 @@
 		ui.open()
 
 /obj/machinery/computer/diseasesplicer/process()
-	if(stat & (NOPOWER|BROKEN))
+	if (inoperable())
 		return
 
 	if(scanning)

--- a/html/changelogs/lohikar-pr-1744.yml
+++ b/html/changelogs/lohikar-pr-1744.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Fixed AIs being unable to set status displays by clicking on them."


### PR DESCRIPTION
changes:
- Machines' `process()` has been separated from `auto_use_power()`.
- Lights no longer `process()` and instead use `auto_use_power()` for power calculations.
- Computers that didn't really need to `process()` no longer `process()`.
- Airlocks now use the scheduler to auto-close instead of `process()`ing.
- Fixed a bug where clicking on an AI Status display to set its status did not work.

known issues:
- [x] AI Status Displays cannot be changed.
- [x] Door close delays have a 2-second inaccuracy due to tick rate of `scheduler`, so shorted timing-circuits won't work correctly.