### PR TITLE
Spark Fixes

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -110,9 +110,7 @@
 					M.Stun(power)
 					M.stuttering = max(M.stuttering, power)
 
-					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-					s.set_up(5, 1, M)
-					s.start()
+					spark(M, 5, alldirs)
 
 					if(prob(stunprob) && powerlevel >= 8)
 						M.adjustFireLoss(powerlevel * rand(6,10))

--- a/code/controllers/Processes/effects.dm
+++ b/code/controllers/Processes/effects.dm
@@ -78,6 +78,13 @@ var/datum/controller/process/effects/effect_master
 	effects_objects += E
 	enable()
 
+/datum/controller/process/effects/proc/queue_simple(var/obj/visual_effect/effect)
+	if (!effect || effect.gcDestroyed)
+		return
+
+	effects_visuals += effect
+	enable()
+
 /datum/controller/process/effects/statProcess()
 	..()
 	stat(null, "Effect process is [disabled ? "sleeping" : "processing"].")

--- a/code/controllers/Processes/effects.dm
+++ b/code/controllers/Processes/effects.dm
@@ -5,7 +5,7 @@
 var/datum/controller/process/effects/effect_master
 
 /var/list/datum/effect_system/effects_objects = list()	// The effect-spawning objects. Shouldn't be many of these.
-/var/list/obj/visual_effect/effects_visuals	= list()	// The visible component of an effect. Should be created by effect objects.
+/var/list/obj/visual_effect/effects_visuals	= list()	// The visible component of an effect. May be created without an effect object.
 
 /datum/controller/process/effects
 	var/tmp/list/processing_effects = list()
@@ -37,7 +37,7 @@ var/datum/controller/process/effects/effect_master
 				effects_objects += E
 
 			if (EFFECT_DESTROY)
-				returnToPool(E)
+				qdel(E)
 
 		F_SCHECK
 
@@ -61,7 +61,7 @@ var/datum/controller/process/effects/effect_master
 			if (EFFECT_DESTROY)
 				effects_visuals -= V
 				V.end()
-				returnToPool(V)
+				qdel(V)
 		
 		F_SCHECK
 
@@ -76,6 +76,13 @@ var/datum/controller/process/effects/effect_master
 		return
 		
 	effects_objects += E
+	enable()
+
+/datum/controller/process/effects/proc/queue_simple(var/obj/visual_effect/V)
+	if (!V || V.gcDestroyed)
+		return
+
+	effects_visuals += V
 	enable()
 
 /datum/controller/process/effects/statProcess()

--- a/code/controllers/Processes/effects.dm
+++ b/code/controllers/Processes/effects.dm
@@ -78,13 +78,6 @@ var/datum/controller/process/effects/effect_master
 	effects_objects += E
 	enable()
 
-/datum/controller/process/effects/proc/queue_simple(var/obj/visual_effect/effect)
-	if (!effect || effect.gcDestroyed)
-		return
-
-	effects_visuals += effect
-	enable()
-
 /datum/controller/process/effects/statProcess()
 	..()
 	stat(null, "Effect process is [disabled ? "sleeping" : "processing"].")

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -78,13 +78,13 @@
 /datum/teleport/proc/teleportChecks()
 		return 1
 
-/datum/teleport/proc/playSpecials(atom/location,datum/effect/effect/system/effect,sound)
+/datum/teleport/proc/playSpecials(atom/location,datum/effect_system/effect,sound)
 	if(location)
 		if(effect)
 			spawn(-1)
 				src = null
-				effect.attach(location)
-				effect.start()
+				effect.location = location
+				effect.queue()
 		if(sound)
 			spawn(-1)
 				src = null

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -7,8 +7,8 @@
 	var/atom/movable/teleatom //atom to teleport
 	var/atom/destination //destination to teleport to
 	var/precision = 0 //teleport precision
-	var/datum/effect/effect/system/effectin //effect to show right before teleportation
-	var/datum/effect/effect/system/effectout //effect to show right after teleportation
+	var/datum/effect_system/effectin //effect to show right before teleportation
+	var/datum/effect_system/effectout //effect to show right after teleportation
 	var/soundin //soundfile to play before teleportation
 	var/soundout //soundfile to play after teleportation
 	var/force_teleport = 1 //if false, teleport will use Move() proc (dense objects will prevent teleportation)
@@ -141,8 +141,7 @@
 
 /datum/teleport/instant/science/setEffects(datum/effect/effect/system/aeffectin,datum/effect/effect/system/aeffectout)
 	if(!aeffectin || !aeffectout)
-		var/datum/effect/effect/system/spark_spread/aeffect = new
-		aeffect.set_up(5, 1, teleatom)
+		var/datum/effect_system/sparks/aeffect = getFromPool(/datum/effect_system/sparks, null, FALSE, 5, alldirs)
 		effectin = effectin || aeffect
 		effectout = effectout || aeffect
 		return 1

--- a/code/game/gamemodes/antagspawner.dm
+++ b/code/game/gamemodes/antagspawner.dm
@@ -59,9 +59,7 @@
 			C.prefs.be_special_role ^= MODE_MERCENARY
 
 obj/item/weapon/antag_spawner/borg_tele/spawn_antag(client/C, turf/T)
-	var/datum/effect/effect/system/spark_spread/S = new /datum/effect/effect/system/spark_spread
-	S.set_up(4, 1, src)
-	S.start()
+	spark(T, 4, alldirs)
 	var/mob/living/silicon/robot/H = new /mob/living/silicon/robot/syndicate(T)
 	H.key = C.key
 	var/newname = sanitizeSafe(input(H,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -878,9 +878,7 @@
 		cell.update_icon()
 		cell = null
 
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
+	spark(Tsec, 3, alldirs)
 
 	new /obj/effect/decal/cleanable/blood/oil(src.loc)
 	unload(0)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -258,9 +258,7 @@
 	update_coverage()
 
 	//sparks
-	var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-	spark_system.set_up(5, 0, loc)
-	spark_system.start()
+	spark(loc, 5)
 	playsound(loc, "sparks", 50, 1)
 
 /obj/machinery/camera/proc/set_status(var/newstatus)

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -10,7 +10,7 @@
 	//Server linked to.
 	var/obj/machinery/message_server/linkedServer = null
 	//Sparks effect - For emag
-	var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread
+	var/datum/effect_system/sparks/spark_system
 	//Messages - Saves me time if I want to change something.
 	var/noserver = "<span class='alert'>ALERT: No server detected.</span>"
 	var/incorrectkey = "<span class='warning'>ALERT: Incorrect decryption key!</span>"
@@ -29,6 +29,9 @@
 	var/customjob		= "Admin"
 	var/custommessage 	= "This is a test, please ignore."
 
+/obj/machinery/computer/message_monitor/New()
+	..()
+	spark_system = bind_spark(src, 5)
 
 /obj/machinery/computer/message_monitor/attackby(obj/item/weapon/O as obj, mob/living/user as mob)
 	if(stat & (NOPOWER|BROKEN))
@@ -51,8 +54,7 @@
 		if(!isnull(src.linkedServer))
 			emag = 1
 			screen = 2
-			spark_system.set_up(5, 0, src)
-			src.spark_system.start()
+			src.spark_system.queue()
 			var/obj/item/weapon/paper/monitorkey/MK = new/obj/item/weapon/paper/monitorkey
 			MK.loc = src.loc
 			// Will help make emagging the console not so easy to get away with.

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -177,9 +177,7 @@ for reference:
 						user << "Barrier lock toggled off."
 						return
 				else
-					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-					s.set_up(2, 1, src)
-					s.start()
+					spark(src, 2, src)
 					visible_message("<span class='warning'>BZZzZZzZZzZT</span>")
 					return
 			return
@@ -241,9 +239,7 @@ for reference:
 	/*	var/obj/item/stack/rods/ =*/
 		getFromPool(/obj/item/stack/rods, Tsec)
 
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
+		spark(src, 3, alldirs)
 
 		explosion(src.loc,-1,-1,0)
 		if(src)
@@ -256,16 +252,12 @@ for reference:
 		src.req_access.Cut()
 		src.req_one_access.Cut()
 		user << "You break the ID authentication lock on \the [src]."
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(2, 1, src)
-		s.start()
+		spark(src, 2, alldirs)
 		visible_message("<span class='warning'>BZZzZZzZZzZT</span>")
 		return 1
 	else if (src.emagged == 1)
 		src.emagged = 2
 		user << "You short out the anchoring mechanism on \the [src]."
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(2, 1, src)
-		s.start()
+		spark(src, 2, 1)
 		visible_message("<span class='warning'>BZZzZZzZZzZT</span>")
 		return 1

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -717,9 +717,7 @@ About the new airlock wires panel:
 		if (istype(mover, /obj/item))
 			var/obj/item/i = mover
 			if (i.matter && (DEFAULT_WALL_MATERIAL in i.matter) && i.matter[DEFAULT_WALL_MATERIAL] > 0)
-				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-				s.set_up(5, 1, src)
-				s.start()
+				spark(src, 5, alldirs)
 	return ..()
 
 /obj/machinery/door/airlock/attack_hand(mob/user as mob)
@@ -955,9 +953,8 @@ About the new airlock wires panel:
 		if ((O.client && !( O.blinded )))
 			O.show_message("[src.name]'s control panel bursts open, sparks spewing out!")
 
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(5, 1, src)
-	s.start()
+	spark(src, 5, alldirs)
+	
 	update_icon()
 	return
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -429,9 +429,7 @@
 				take_damage(damage)
 		if(3.0)
 			if(prob(80))
-				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-				s.set_up(2, 1, src)
-				s.start()
+				spark(src, 2, alldirs)
 			var/damage = rand(100,150)
 			if (bolted)
 				damage *= 0.8

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -179,9 +179,7 @@
 	//Emags and ninja swords? You may pass.
 	if (istype(I, /obj/item/weapon/melee/energy/blade))
 		if(emag_act(10, user))
-			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-			spark_system.set_up(5, 0, src.loc)
-			spark_system.start()
+			spark(src.loc, 5)
 			playsound(src.loc, "sparks", 50, 1)
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			visible_message("<span class='warning'>The glass door was sliced open by [user]!</span>")

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -126,9 +126,7 @@
 
 
 	flick("migniter-spark", src)
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(2, 1, src)
-	s.start()
+	spark(src, 2, 1)
 	src.last_spark = world.time
 	use_power(1000)
 	var/turf/location = src.loc

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -158,9 +158,7 @@ datum/track/New(var/title_name, var/audio)
 
 	explosion(src.loc, 0, 0, 1, rand(1,2), 1)
 
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
+	spark(src, 3, alldirs)
 
 	new /obj/effect/decal/cleanable/blood/oil(src.loc)
 	qdel(src)

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -348,9 +348,7 @@
 	src.updateUsrDialog()
 
 /obj/machinery/microwave/proc/broke()
-	var/datum/effect/effect/system/spark_spread/s = new
-	s.set_up(2, 1, src)
-	s.start()
+	spark(src, 2, alldirs)
 	src.icon_state = "mwb" // Make it look all busted up and shit
 	src.visible_message("<span class='warning'>The microwave breaks!</span>") //Let them know they're stupid
 	src.broken = 2 // Make it broken so it can't be used util fixed

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -280,9 +280,7 @@ Class Procs:
 		return 0
 	if(!prob(prb))
 		return 0
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(5, 1, src)
-	s.start()
+	spark(src, 5, alldirs)
 	if (electrocute_mob(user, get_area(src), src, 0.7))
 		var/area/temp_area = get_area(src)
 		if(temp_area)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -55,7 +55,7 @@
 	var/shot_sound 			//what sound should play when the turret fires
 	var/eshot_sound			//what sound should play when the emagged turret fires
 
-	var/datum/effect/effect/system/spark_spread/spark_system	//the spark system, used for generating... sparks?
+	var/datum/effect_system/sparks/spark_system	//the spark system, used for generating... sparks?
 
 	var/wrenching = 0
 	var/last_target			//last target fired at, prevents turrets from erratically firing at all valid targets in range
@@ -81,9 +81,7 @@
 	req_one_access = list(access_security, access_heads)
 
 	//Sets up a spark system
-	spark_system = new /datum/effect/effect/system/spark_spread
-	spark_system.set_up(5, 0, src)
-	spark_system.attach(src)
+	spark_system = bind_spark(src, 5)
 
 	setup()
 
@@ -370,7 +368,7 @@ var/list/turret_icons
 
 	health -= force
 	if (force > 5 && prob(45))
-		spark_system.start()
+		spark_system.queue()
 	if(health <= 0)
 		die()	//the death process :(
 
@@ -425,7 +423,7 @@ var/list/turret_icons
 /obj/machinery/porta_turret/proc/die()	//called when the turret dies, ie, health <= 0
 	health = 0
 	stat |= BROKEN	//enables the BROKEN bit
-	spark_system.start()	//creates some sparks because they look cool
+	spark_system.queue()	//creates some sparks because they look cool
 	update_icon()
 
 /obj/machinery/porta_turret/process()

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -170,12 +170,14 @@
 	idle_power_usage = 10
 	active_power_usage = 2000
 	var/obj/machinery/computer/teleporter/com
+	var/datum/effect_system/sparks/spark_system
 
 
 /obj/machinery/teleport/hub/New()
 	..()
 	underlays.Cut()
 	underlays += image('icons/obj/stationobjs.dmi', icon_state = "tele-wires")
+	spark_system = bind_spark(src, 5, alldirs)
 
 /obj/machinery/teleport/hub/Bumped(M as mob|obj)
 	spawn()
@@ -201,9 +203,7 @@
 			com.one_time_use = 0
 			com.locked = null
 	else
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
+		spark_system.queue()
 		accurate = 1
 		spawn(3000)	accurate = 0 //Accurate teleporting for 5 minutes
 		for(var/mob/B in hearers(src, null))

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -274,7 +274,7 @@
 					set_ready_state(0)
 					if(do_after_cooldown(target))
 						if(disabled) return
-						chassis.spark_system.start()
+						chassis.spark_system.queue()
 						target:ChangeTurf(/turf/simulated/floor/plating)
 						playsound(target, 'sound/items/Deconstruct.ogg', 50, 1)
 						chassis.use_power(energy_drain)
@@ -283,7 +283,7 @@
 					set_ready_state(0)
 					if(do_after_cooldown(target))
 						if(disabled) return
-						chassis.spark_system.start()
+						chassis.spark_system.queue()
 						target:ChangeTurf(get_base_turf_by_area(target))
 						playsound(target, 'sound/items/Deconstruct.ogg', 50, 1)
 						chassis.use_power(energy_drain)
@@ -292,7 +292,7 @@
 					set_ready_state(0)
 					if(do_after_cooldown(target))
 						if(disabled) return
-						chassis.spark_system.start()
+						chassis.spark_system.queue()
 						qdel(target)
 						playsound(target, 'sound/items/Deconstruct.ogg', 50, 1)
 						chassis.use_power(energy_drain)
@@ -304,7 +304,7 @@
 						if(disabled) return
 						target:ChangeTurf(/turf/simulated/floor/plating)
 						playsound(target, 'sound/items/Deconstruct.ogg', 50, 1)
-						chassis.spark_system.start()
+						chassis.spark_system.queue()
 						chassis.use_power(energy_drain*2)
 				else if(istype(target, /turf/simulated/floor))
 					occupant_message("Building Wall...")
@@ -313,7 +313,7 @@
 						if(disabled) return
 						target:ChangeTurf(/turf/simulated/wall)
 						playsound(target, 'sound/items/Deconstruct.ogg', 50, 1)
-						chassis.spark_system.start()
+						chassis.spark_system.queue()
 						chassis.use_power(energy_drain*2)
 			if(2)
 				if(istype(target, /turf/simulated/floor))
@@ -321,7 +321,7 @@
 					set_ready_state(0)
 					if(do_after_cooldown(target))
 						if(disabled) return
-						chassis.spark_system.start()
+						chassis.spark_system.queue()
 						var/obj/machinery/door/airlock/T = new /obj/machinery/door/airlock(target)
 						T.autoclose = 1
 						playsound(target, 'sound/items/Deconstruct.ogg', 50, 1)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -50,7 +50,7 @@
 	var/add_req_access = 1
 	var/maint_access = 1
 	var/dna	//dna-locking the mech
-	var/datum/effect/effect/system/spark_spread/spark_system = new
+	var/datum/effect_system/sparks/spark_system
 	var/lights = 0
 	var/lights_power = 6
 
@@ -108,8 +108,6 @@
 	add_radio()
 	add_cabin()
 	add_airtank() //All mecha currently have airtanks. No need to check unless changes are made.
-	spark_system.set_up(2, 0, src)
-	spark_system.attach(src)
 	add_cell()
 	add_iterators()
 	removeVerb(/obj/mecha/verb/disconnect_from_port)
@@ -117,7 +115,8 @@
 	loc.Entered(src)
 	mechas_list += src //global mech list
 	narrator_message(FIRSTRUN)
-	return
+	
+	spark_system = bind_spark(src, 2)
 
 /obj/mecha/Destroy()
 	src.go_out()
@@ -595,7 +594,7 @@
 
 /obj/mecha/proc/update_health()
 	if(src.health > 0)
-		src.spark_system.start()
+		src.spark_system.queue()
 	else
 		qdel(src)
 	return
@@ -669,7 +668,8 @@
 		if(istype(Proj, /obj/item/projectile/beam/pulse))
 			ignore_threshold = 1
 		src.hit_damage(Proj.damage, Proj.check_armour, is_melee=0)
-		if(prob(25)) spark_system.start()
+		if(prob(25)) 
+			spark_system.queue()
 		src.check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),ignore_threshold)
 
 		//AP projectiles have a chance to cause additional damage
@@ -2252,7 +2252,7 @@
 					qdel(leaked_gas)
 		if(mecha.hasInternalDamage(MECHA_INT_SHORT_CIRCUIT))
 			if(mecha.get_charge())
-				mecha.spark_system.start()
+				mecha.spark_system.queue()
 				mecha.cell.charge -= min(20,mecha.cell.charge)
 				mecha.cell.maxcharge -= min(20,mecha.cell.maxcharge)
 		return

--- a/code/game/objects/effects/decals/Cleanable/robots.dm
+++ b/code/game/objects/effects/decals/Cleanable/robots.dm
@@ -22,9 +22,7 @@
 					var/obj/effect/decal/cleanable/blood/oil/streak = new(src.loc)
 					streak.update_icon()
 				else if (prob(10))
-					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-					s.set_up(3, 1, src)
-					s.start()
+					spark(src, 3, alldirs)
 			if (step_to(src, get_step(src, direction), 0))
 				break
 

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -88,23 +88,6 @@ steam.start() -- spawns the effect
 					qdel(steam)
 
 /////////////////////////////////////////////
-//SPARK SYSTEM (like steam system)
-// The attach(atom/atom) proc is optional, and can be called to attach the effect
-// to something, like the RCD, so then you can just call start() and the sparks
-// will always spawn at the items location.
-/////////////////////////////////////////////
-
-/datum/effect/effect/system/spark_spread
-	var/datum/effect_system/sparks/S
-
-/datum/effect/effect/system/spark_spread/set_up(n = 3, c = 0, loca)
-	var/l = get_turf(loca)
-	S = bind_spark(l, n, c ? cardinal : alldirs)
-
-/datum/effect/effect/system/spark_spread/start()
-	S.queue()
-
-/////////////////////////////////////////////
 //// SMOKE SYSTEMS
 // direct can be optinally added when set_up, to make the smoke always travel in one direction
 // in case you wanted a vent to always smoke north for example
@@ -416,9 +399,7 @@ steam.start() -- spawns the effect
 
 	start()
 		if (amount <= 2)
-			var/datum/effect/effect/system/spark_spread/s = getFromPool(/datum/effect/effect/system/spark_spread)
-			s.set_up(2, 1, location)
-			s.start()
+			spark(location, 2)
 
 			for(var/mob/M in viewers(5, location))
 				M << "<span class='warning'>The solution violently explodes.</span>"

--- a/code/game/objects/effects/gibs.dm
+++ b/code/game/objects/effects/gibs.dm
@@ -28,9 +28,7 @@
 				qdel(D)
 
 		if(sparks)
-			var/datum/effect/effect/system/spark_spread/s = getFromPool(/datum/effect/effect/system/spark_spread)
-			s.set_up(2, 1, get_turf(location)) // Not sure if it's safe to pass an arbitrary object to set_up, todo
-			s.start()
+			spark(location, 2, alldirs)
 
 		for(var/i = 1, i<= gibtypes.len, i++)
 			if(gibamounts[i])

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -25,12 +25,11 @@
 		triggered = 1
 		call(src,triggerproc)(M)
 
-/obj/effect/mine/proc/triggerrad(obj)
+/obj/effect/mine/proc/triggerrad(var/mob/living/M)
 	spark(src, 3, alldirs)
-	if (istype(obj, /mob/living))
-		obj:apply_radiation(50)
-	randmutb(obj)
-	domutcheck(obj,null)
+	if (istype(M))
+		M.apply_radiation(50)
+
 	spawn(0)
 		qdel(src)
 
@@ -63,9 +62,11 @@
 	spawn(0)
 		qdel(src)
 
-/obj/effect/mine/proc/triggerkick(obj)
+/obj/effect/mine/proc/triggerkick(var/mob/M)
 	spark(src, 3, alldirs)
-	qdel(obj:client)	// wot
+	if (istype(M))
+		qdel(M.client)
+		
 	spawn(0)
 		qdel(src)
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -26,10 +26,9 @@
 		call(src,triggerproc)(M)
 
 /obj/effect/mine/proc/triggerrad(obj)
-	var/datum/effect/effect/system/spark_spread/s = getFromPool(/datum/effect/effect/system/spark_spread)
-	s.set_up(3, 1, src)
-	s.start()
-	obj:radiation += 50
+	spark(src, 3, alldirs)
+	if (istype(obj, /mob/living))
+		obj:apply_radiation(50)
 	randmutb(obj)
 	domutcheck(obj,null)
 	spawn(0)
@@ -39,9 +38,7 @@
 	if(ismob(obj))
 		var/mob/M = obj
 		M.Stun(30)
-	var/datum/effect/effect/system/spark_spread/s = getFromPool(/datum/effect/effect/system/spark_spread)
-	s.set_up(3, 1, src)
-	s.start()
+	spark(src, 3, alldirs)
 	spawn(0)
 		qdel(src)
 
@@ -67,10 +64,8 @@
 		qdel(src)
 
 /obj/effect/mine/proc/triggerkick(obj)
-	var/datum/effect/effect/system/spark_spread/s = getFromPool(/datum/effect/effect/system/spark_spread)
-	s.set_up(3, 1, src)
-	s.start()
-	qdel(obj:client)
+	spark(src, 3, alldirs)
+	qdel(obj:client)	// wot
 	spawn(0)
 		qdel(src)
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -957,9 +957,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			M.apply_effects(1,0,0,0,1)
 		message += "Your [P] flashes with a blinding white light! You feel weaker."
 	if(i>=85) //Sparks
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(2, 1, P.loc)
-		s.start()
+		spark(P.loc, 2)
 		message += "Your [P] begins to spark violently!"
 	if(i>45 && i<65 && prob(50)) //Nothing happens
 		message += "Your [P] bleeps loudly."

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -65,10 +65,7 @@
 
 /obj/item/device/chameleon/proc/disrupt(var/delete_dummy = 1)
 	if(active_dummy)
-		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread
-		spark_system.set_up(5, 0, src)
-		spark_system.attach(src)
-		spark_system.start()
+		spark(src, 5)
 		eject_all()
 		if(delete_dummy)
 			qdel(active_dummy)

--- a/code/game/objects/items/devices/magnetic_lock.dm
+++ b/code/game/objects/items/devices/magnetic_lock.dm
@@ -422,16 +422,7 @@
 		spark()
 
 /obj/item/device/magnetic_lock/proc/spark()
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-
-	if (target)
-		s.set_up(5, 1, target)
-	else
-		s.set_up(5, 1, src)
-
-	s.start()
-	spawn(5)
-		qdel(s)
+	spark(target ? target : src, 5, alldirs)
 
 #undef STATUS_INACTIVE
 #undef STATUS_ACTIVE

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -93,9 +93,7 @@
 				if(M)
 					M.moved_recently = 0
 		M << "<span class='danger'>You feel a sharp shock!</span>"
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, M)
-		s.start()
+		spark(M, 3)
 
 		M.Weaken(10)
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -394,9 +394,7 @@
 
 	throw_impact(atom/hit_atom)
 		..()
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
+		spark(src, 3, alldirs)
 		new /obj/effect/decal/cleanable/ash(src.loc)
 		src.visible_message("<span class='warning'>The [src.name] explodes!</span>","<span class='warning'>You hear a snap!</span>")
 		playsound(src, 'sound/effects/snap.ogg', 50, 1)
@@ -408,9 +406,7 @@
 		if(M.m_intent == "run")
 			M << "<span class='warning'>You step on the snap pop!</span>"
 
-			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-			s.set_up(2, 0, src)
-			s.start()
+			spark(src, 2)
 			new /obj/effect/decal/cleanable/ash(src.loc)
 			src.visible_message("<span class='warning'>The [src.name] explodes!</span>","<span class='warning'>You hear a snap!</span>")
 			playsound(src, 'sound/effects/snap.ogg', 50, 1)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -15,7 +15,7 @@
 	w_class = 3.0
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 50000)
-	var/datum/effect/effect/system/spark_spread/spark_system
+	var/datum/effect_system/sparks/spark_system
 	var/stored_matter = 0
 	var/working = 0
 	var/mode = 1
@@ -36,9 +36,7 @@
 
 /obj/item/weapon/rcd/New()
 	..()
-	src.spark_system = new /datum/effect/effect/system/spark_spread
-	spark_system.set_up(5, 0, src)
-	spark_system.attach(src)
+	src.spark_system = bind_spark(src, 5)
 
 /obj/item/weapon/rcd/Destroy()
 	qdel(spark_system)
@@ -64,7 +62,7 @@
 	if(++mode > 3) mode = 1
 	user << "<span class='notice'>Changed mode to '[modes[mode]]'</span>"
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
-	if(prob(20)) src.spark_system.start()
+	if(prob(20)) src.spark_system.queue()
 
 /obj/item/weapon/rcd/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -8,6 +8,11 @@
 	armor_penetration = 50
 	flags = NOBLOODY
 	can_embed = 0//No embedding pls
+	var/datum/effect_system/sparks/spark_system
+
+/obj/item/weapon/melee/energy/New()
+	spark_system = bind_spark(src, 5)
+	..()
 
 /obj/item/weapon/melee/energy/proc/activate(mob/living/user)
 	anchored = 1
@@ -174,10 +179,7 @@
 	if(active && default_parry_check(user, attacker, damage_source) && prob(50))
 		user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
 
-//		Disabled because lag. Immense amounts of lag.
-//		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-//		spark_system.set_up(5, 0, user.loc)
-//		spark_system.start()
+		spark_system.queue()
 		playsound(user.loc, 'sound/weapons/blade1.ogg', 50, 1)
 		return 1
 	return 0
@@ -212,15 +214,10 @@
 	flags = NOBLOODY
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	var/mob/living/creator
-	var/datum/effect/effect/system/spark_spread/spark_system
 
 /obj/item/weapon/melee/energy/blade/New()
-
-	spark_system = new /datum/effect/effect/system/spark_spread()
-	spark_system.set_up(5, 0, src)
-	spark_system.attach(src)
-
 	processing_objects |= src
+	..()
 
 /obj/item/weapon/melee/energy/blade/Destroy()
 	processing_objects -= src

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -111,9 +111,7 @@
 	. = ..()
 
 	if(.)
-		var/datum/effect/effect/system/spark_spread/spark_system = getFromPool(/datum/effect/effect/system/spark_spread)
-		spark_system.set_up(5, 0, user.loc)
-		spark_system.start()
+		spark(user.loc, 5)
 		playsound(user.loc, 'sound/weapons/blade1.ogg', 50, 1)
 
 /obj/item/weapon/shield/energy/get_block_chance(mob/user, var/damage, atom/damage_source = null, mob/attacker = null)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -35,9 +35,7 @@
 				user << "<span class='warning'>Access Denied</span>"
 		else if(istype(W, /obj/item/weapon/melee/energy/blade))
 			if(emag_act(INFINITY, user, W, "The locker has been sliced open by [user] with an energy blade!", "You hear metal being sliced and sparks flying."))
-				var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-				spark_system.set_up(5, 0, src.loc)
-				spark_system.start()
+				W:spark_system.queue()
 				playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 				playsound(src.loc, "sparks", 50, 1)
 		if(!locked)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -34,9 +34,7 @@
 	attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(locked)
 			if (istype(W, /obj/item/weapon/melee/energy/blade) && emag_act(INFINITY, user, "You slice through the lock of \the [src]"))
-				var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-				spark_system.set_up(5, 0, src.loc)
-				spark_system.start()
+				W:spark_system.queue()
 				playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 				playsound(src.loc, "sparks", 50, 1)
 				return

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -86,9 +86,7 @@
 			user << "<span class='warning'>Access Denied</span>"
 	else if(istype(W, /obj/item/weapon/melee/energy/blade))
 		if(emag_act(INFINITY, user, "The locker has been sliced open by [user] with \an [W]!", "You hear metal being sliced and sparks flying."))
-			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-			spark_system.set_up(5, 0, src.loc)
-			spark_system.start()
+			W:spark_system.queue()
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			playsound(src.loc, "sparks", 50, 1)
 	else

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -80,9 +80,7 @@
 			W.forceMove(src.loc)
 	else if(istype(W, /obj/item/weapon/melee/energy/blade))//Attempt to cut open locker if locked
 		if(emag_act(INFINITY, user, "<span class='danger'>The locker has been sliced open by [user] with \an [W]</span>!", "<span class='danger'>You hear metal being sliced and sparks flying.</span>"))
-			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-			spark_system.set_up(5, 0, src.loc)
-			spark_system.start()
+			W:spark_system.queue()
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			playsound(src.loc, "sparks", 50, 1)
 	else if(!src.opened)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -32,9 +32,7 @@
 		if(isliving(usr))
 			var/mob/living/L = usr
 			if(L.electrocute_act(17, src))
-				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-				s.set_up(5, 1, src)
-				s.start()
+				spark(src, 5, alldirs)
 				if(usr.stunned)
 					return 2
 

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -61,16 +61,14 @@
 	A.updateicon()
 
 	flick("echair1", src)
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(12, 1, src)
-	s.start()
+	spark(src, 12, alldirs)
 	if(buckled_mob)
 		buckled_mob.burn_skin(85)
 		buckled_mob << "<span class='danger'>You feel a deep shock course through your body!</span>"
 		sleep(1)
 		buckled_mob.burn_skin(85)
 		buckled_mob.Stun(600)
-	visible_message("<span class='danger'>The electric chair went off!</span>", "<span class='danger'>You hear a deep sharp shock!</span>")
+	visible_message("<span class='danger'>The electric chair goes off!</span>", "<span class='danger'>You hear a deep sharp shock!</span>")
 
 	A.power_light = light
 	A.updateicon()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -195,9 +195,7 @@
 		if(electrocute_mob(user, C, src))
 			if(C.powernet)
 				C.powernet.trigger_warning()
-			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-			s.set_up(3, 1, src)
-			s.start()
+			spark(src, 3, alldirs)
 			if(user.stunned)
 				return 1
 		else

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -132,7 +132,7 @@
 		else if( istype(W, /obj/item/weapon/melee/energy/blade) )
 			var/obj/item/weapon/melee/energy/blade/EB = W
 
-			EB.spark_system.start()
+			EB.spark_system.queue()
 			user << "<span class='notice'>You slash \the [src] with \the [EB]; the thermite ignites!</span>"
 			playsound(src, "sparks", 50, 1)
 			playsound(src, 'sound/weapons/blade1.ogg', 50, 1)

--- a/code/game/turfs/turf_flick_animations.dm
+++ b/code/game/turfs/turf_flick_animations.dm
@@ -5,7 +5,7 @@
 		location = get_turf(target)
 	if(location && !target)
 		target = location
-	var/atom/movable/overlay/animation = getFromPool(/atom/movable/overlay, location)
+	var/obj/visual_effect/generic/animation = getFromPool(/obj/visual_effect/generic, location, sleeptime)
 	if(direction)
 		animation.set_dir(direction)
 	animation.icon = a_icon
@@ -14,7 +14,11 @@
 		animation.icon_state = a_icon_state
 	else
 		animation.icon_state = "blank"
-		animation.master = target
+		//animation.master = target
 		flick(flick_anim, animation)
-	spawn(max(sleeptime, 15))
-		qdel(animation)
+
+	effect_master.queue_simple(animation)
+
+/obj/visual_effect/generic/New(var/atom/movable/loc, var/life = 1 SECONDS)
+	life_ticks = life
+	..(loc)

--- a/code/game/turfs/turf_flick_animations.dm
+++ b/code/game/turfs/turf_flick_animations.dm
@@ -5,7 +5,7 @@
 		location = get_turf(target)
 	if(location && !target)
 		target = location
-	var/obj/visual_effect/generic/animation = getFromPool(/obj/visual_effect/generic, location, sleeptime)
+	var/atom/movable/overlay/animation = getFromPool(/atom/movable/overlay, location)
 	if(direction)
 		animation.set_dir(direction)
 	animation.icon = a_icon
@@ -14,11 +14,7 @@
 		animation.icon_state = a_icon_state
 	else
 		animation.icon_state = "blank"
-		//animation.master = target
+		animation.master = target
 		flick(flick_anim, animation)
-
-	effect_master.queue_simple(animation)
-
-/obj/visual_effect/generic/New(var/atom/movable/loc, var/life = 1 SECONDS)
-	life_ticks = life
-	..(loc)
+	spawn(max(sleeptime, 15))
+		qdel(animation)

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -34,10 +34,7 @@
 	//I couldn't get the normal way to work so this works.
 	//This whole section looks like a hack, I don't like it.
 	var/T = get_turf(usr)
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, T)
-	s.start()
-	var/mob/living/carbon/human/bst/bst = new(get_turf(T))
+	var/mob/living/carbon/human/bst/bst = new(T)
 //	bst.original_mob = usr
 	bst.anchored = 1
 	bst.ckey = usr.ckey
@@ -115,10 +112,9 @@
 	bst.add_language(LANGUAGE_BORER)
 
 	spawn(5)
-		s.start()
+		spark(T, 3, alldirs)
 		bst.anchored = 0
-		spawn(10)
-			qdel(s)
+
 	log_debug("Bluespace Tech Spawned: X:[bst.x] Y:[bst.y] Z:[bst.z] User:[src]")
 
 	feedback_add_details("admin_verb","BST")
@@ -155,11 +151,7 @@
 
 	src.custom_emote(1,"presses a button on their suit, followed by a polite bow.")
 	spawn(10)
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
-		spawn(5)
-			qdel(s)
+		spark(src, 5, alldirs)
 		if(key)
 			if(client.holder && client.holder.original_mob)
 				client.holder.original_mob.key = key

--- a/code/modules/awaymissions/trigger.dm
+++ b/code/modules/awaymissions/trigger.dm
@@ -22,13 +22,10 @@
 	M.Move(dest)
 
 	if(entersparks)
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(4, 1, src)
-		s.start()
+		spark(src, 4, alldirs)
+		
 	if(exitsparks)
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(4, 1, dest)
-		s.start()
+		spark(dest, 4, alldirs)
 
 	if(entersmoke)
 		var/datum/effect/effect/system/smoke_spread/s = new /datum/effect/effect/system/smoke_spread

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -415,7 +415,7 @@
 	interfaced_with = target
 	drain_loc = interfaced_with.loc
 
-	holder.spark_system.start()
+	holder.spark_system.queue()
 	playsound(H.loc, 'sound/effects/sparks2.ogg', 50, 1)
 
 	return 1
@@ -439,7 +439,7 @@
 	if(!H || !istype(H))
 		return 0
 
-	holder.spark_system.start()
+	holder.spark_system.queue()
 	playsound(H.loc, 'sound/effects/sparks2.ogg', 50, 1)
 
 	if(!holder.cell)

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -83,7 +83,7 @@
 	if(!M || !T)
 		return
 
-	holder.spark_system.start()
+	holder.spark_system.queue()
 	playsound(T, 'sound/effects/phasein.ogg', 25, 1)
 	playsound(T, 'sound/effects/sparks2.ogg', 50, 1)
 	anim(T,M,'icons/mob/mob.dmi',,"phasein",,M.dir)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -79,7 +79,7 @@
 
 	// Wiring! How exciting.]
 	var/datum/wires/rig/wires
-	var/datum/effect/effect/system/spark_spread/spark_system
+	var/datum/effect_system/sparks/spark_system
 
 /obj/item/weapon/rig/examine()
 	usr << "This is \icon[src][src.name]."
@@ -103,9 +103,7 @@
 	if((!req_access || !req_access.len) && (!req_one_access || !req_one_access.len))
 		locked = 0
 
-	spark_system = new()
-	spark_system.set_up(5, 0, src)
-	spark_system.attach(src)
+	spark_system = bind_spark(src, 5)
 
 	processing_objects |= src
 
@@ -725,7 +723,7 @@
 
 /obj/item/weapon/rig/proc/shock(mob/user)
 	if (electrocute_mob(user, cell, src)) //electrocute_mob() handles removing charge from the cell, no need to do that here.
-		spark_system.start()
+		spark_system.queue()
 		if(user.stunned)
 			return 1
 	return 0

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -215,9 +215,7 @@
 		var/turf/picked = pick(turfs)
 		if(!isturf(picked)) return
 
-		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-		spark_system.set_up(5, 0, user.loc)
-		spark_system.start()
+		spark(user, 5)
 		playsound(user.loc, "sparks", 50, 1)
 
 		user.loc = picked

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -32,14 +32,12 @@ log transactions
 	var/obj/item/weapon/card/held_card
 	var/editing_security_level = 0
 	var/view_screen = NO_SCREEN
-	var/datum/effect/effect/system/spark_spread/spark_system
+	var/datum/effect_system/sparks/spark_system
 
 /obj/machinery/atm/New()
 	..()
 	machine_id = "[station_name()] RT #[num_financial_terminals++]"
-	spark_system = new /datum/effect/effect/system/spark_spread
-	spark_system.set_up(5, 0, src)
-	spark_system.attach(src)
+	spark_system = bind_spark(src, 5)
 
 /obj/machinery/atm/process()
 	if(stat & NOPOWER)
@@ -68,7 +66,7 @@ log transactions
 
 	//short out the machine, shoot sparks, spew money!
 	emagged = 1
-	spark_system.start()
+	spark_system.queue()
 	spawn_money(rand(100,500),src.loc)
 	//we don't want to grief people by locking their id in an emagged ATM
 	release_held_id(user)

--- a/code/modules/effects/effect_system.dm
+++ b/code/modules/effects/effect_system.dm
@@ -2,6 +2,7 @@
 // The base type for the new processor-driven effect system.
 /datum/effect_system
 	var/atom/movable/holder	 	// The object this effect is attached to. If this is set, the effect will not be qdel()'d at end of processing.
+	var/turf/location 			// Where the effect is
 
 /datum/effect_system/New(var/queue = TRUE)
 	. = ..()
@@ -21,7 +22,10 @@
 	return FALSE
 
 /datum/effect_system/proc/process()
-	return holder ? EFFECT_HALT : EFFECT_DESTROY	// Terminate effect if it's not attached to something.
+	if (holder)
+		location = get_turf(holder)
+		return EFFECT_HALT
+	return EFFECT_DESTROY	// Terminate effect if it's not attached to something.
 
 /datum/effect_system/proc/bind(var/target)
 	holder = target

--- a/code/modules/effects/sparks/procs.dm
+++ b/code/modules/effects/sparks/procs.dm
@@ -1,9 +1,9 @@
 // -- Spark Procs --
 /proc/spark(var/atom/movable/loc, var/amount = 1, var/spread_dirs = cardinal)
-	getFromPool(/datum/effect_system/sparks, get_turf(loc), TRUE, amount, spread_dirs)
+	new /datum/effect_system/sparks(get_turf(loc), TRUE, amount, spread_dirs)
 
 /proc/bind_spark(var/atom/movable/loc, var/amount = 1, var/spread_dirs = cardinal)
-	var/datum/effect_system/sparks/S = getFromPool(/datum/effect_system/sparks, loc, FALSE, amount, spread_dirs)
+	var/datum/effect_system/sparks/S = new /datum/effect_system/sparks(loc, FALSE, amount, spread_dirs)
 	S.bind(loc)
 	return S
 

--- a/code/modules/effects/sparks/procs.dm
+++ b/code/modules/effects/sparks/procs.dm
@@ -1,6 +1,6 @@
 // -- Spark Procs --
-/proc/spark(var/turf/loc, var/amount = 1, var/spread_dirs = cardinal)
-	getFromPool(/datum/effect_system/sparks, loc, TRUE, amount, spread_dirs)
+/proc/spark(var/atom/movable/loc, var/amount = 1, var/spread_dirs = cardinal)
+	getFromPool(/datum/effect_system/sparks, get_turf(loc), TRUE, amount, spread_dirs)
 
 /proc/bind_spark(var/atom/movable/loc, var/amount = 1, var/spread_dirs = cardinal)
 	var/datum/effect_system/sparks/S = getFromPool(/datum/effect_system/sparks, loc, FALSE, amount, spread_dirs)

--- a/code/modules/effects/sparks/spawner.dm
+++ b/code/modules/effects/sparks/spawner.dm
@@ -2,7 +2,6 @@
 /datum/effect_system/sparks
 	var/amount = 1 				// How many sparks should we make
 	var/list/spread = list()	// Which directions we should create sparks.
-	var/turf/location 			// Where the effect is
 
 // Using the spark procs is preferred to directly instancing this.
 /datum/effect_system/sparks/New(var/atom/movable/loc, var/start_immediately = TRUE, var/amt = 1, var/list/spread_dirs = list())
@@ -17,8 +16,10 @@
 	if (amt)
 		amount = amt
 
-	if (spread_dirs.len)
+	if (spread_dirs)
 		spread = spread_dirs
+	else
+		spread = list()
 		
 	..(start_immediately)
 
@@ -29,27 +30,24 @@
 	return ..()
 
 /datum/effect_system/sparks/process()
-	var/total_sparks = 1
-	if (holder)
-		location = get_turf(holder)
+	. = ..()
 
+	var/total_sparks = 1
 	if (location)
-		var/obj/visual_effect/sparks/S = getFromPool(/obj/visual_effect/sparks, location, src, 0) //Trigger one on the tile it's on
+		var/obj/visual_effect/sparks/S = new /obj/visual_effect/sparks(location, src, 0) //Trigger one on the tile it's on
 		S.start()
 		effects_visuals += S	// Queue it.
 
-		while (total_sparks <= amount)
+		while (total_sparks <= src.amount)
 			playsound(location, "sparks", 100, 1)
 			var/direction = 0
 
-			if(!spread.len)
+			if (!src.spread.len)
 				direction = 0
 			else
-				direction = pick(spread)
+				direction = pick(src.spread)
 
-			S = getFromPool(/obj/visual_effect/sparks, location, src)
+			S = new /obj/visual_effect/sparks(location, src)
 			S.start(direction)	
 			effects_visuals += S
 			total_sparks++
-
-	return ..()

--- a/code/modules/effects/visual_effect.dm
+++ b/code/modules/effects/visual_effect.dm
@@ -10,9 +10,10 @@
 
 /obj/visual_effect/New(var/life_min = 3 SECONDS, var/life_max = 5 SECONDS)
 	..()
-	life_ticks_min = life_min
-	life_ticks_max = life_max
-	life_ticks = rand(life_ticks_min, life_ticks_max)
+	if (!life_ticks)
+		life_ticks_min = life_min
+		life_ticks_max = life_max
+		life_ticks = rand(life_ticks_min, life_ticks_max)
 
 // Called when the visual_effect is manifested.
 /obj/visual_effect/proc/start()

--- a/code/modules/effects/visual_effect.dm
+++ b/code/modules/effects/visual_effect.dm
@@ -10,10 +10,9 @@
 
 /obj/visual_effect/New(var/life_min = 3 SECONDS, var/life_max = 5 SECONDS)
 	..()
-	if (!life_ticks)
-		life_ticks_min = life_min
-		life_ticks_max = life_max
-		life_ticks = rand(life_ticks_min, life_ticks_max)
+	life_ticks_min = life_min
+	life_ticks_max = life_max
+	life_ticks = rand(life_ticks_min, life_ticks_max)
 
 // Called when the visual_effect is manifested.
 /obj/visual_effect/proc/start()

--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -30,9 +30,7 @@
 /datum/event/rogue_drone/end()
 	var/num_recovered = 0
 	for(var/mob/living/simple_animal/hostile/retaliate/malf_drone/D in drones_list)
-		var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-		sparks.set_up(3, 0, D.loc)
-		sparks.start()
+		spark(D.loc, 3)
 		D.z = config.admin_levels[1]
 		D.has_loot = 0
 

--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -18,12 +18,7 @@
 	new /obj/structure/closet/crate/loot(spawn_loc, rarity, quantity)
 	log_and_message_admins("Unusual container spawned at (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[spawn_loc.x];Y=[spawn_loc.y];Z=[spawn_loc.z]'>JMP</a>)")
 
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(10, 0, spawn_loc)
-	s.start()
-	spawn(2)
-		qdel(s)
-
+	spark(spawn_loc, 10, alldirs)
 
 /datum/event/supply_drop/announce()
 	if (prob(65))//Announce the location

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -200,9 +200,7 @@
 
 			for(var/turf/T in linkedholodeck)
 				if(prob(30))
-					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-					s.set_up(2, 1, T)
-					s.start()
+					spark(T, 2, alldirs)
 				T.ex_act(3)
 				T.hotspot_expose(1000,500,1)
 
@@ -294,9 +292,7 @@
 			if(L.name=="Atmospheric Test Start")
 				spawn(20)
 					var/turf/T = get_turf(L)
-					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-					s.set_up(2, 1, T)
-					s.start()
+					spark(T, 2, alldirs)
 					if(T)
 						T.temperature = 5000
 						T.hotspot_expose(50000,50000,1)

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -264,9 +264,7 @@
 	if(active && default_parry_check(user, attacker, damage_source) && prob(50))
 		user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
 
-		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-		spark_system.set_up(5, 0, user.loc)
-		spark_system.start()
+		spark(user.loc, 5)
 		playsound(user.loc, 'sound/weapons/blade1.ogg', 50, 1)
 		return 1
 	return 0

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -316,9 +316,7 @@
 
 		if(turfs.len)
 			// Moves the mob, causes sparks.
-			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-			s.set_up(3, 1, get_turf(target))
-			s.start()
+			spark(target, 3, alldirs)
 			var/turf/picked = get_turf(pick(turfs))                      // Just in case...
 			new/obj/effect/decal/cleanable/molten_item(get_turf(target)) // Leave a pile of goo behind for dramatic effect...
 			target.loc = picked                                          // And teleport them to the chosen location.

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -38,6 +38,8 @@
 	var/need_update_field = 0
 	var/need_player_check = 0
 
+	var/datum/effect_system/sparks/spark_system
+
 /obj/machinery/mining/drill/New()
 
 	..()
@@ -48,6 +50,8 @@
 	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
 	component_parts += new /obj/item/weapon/stock_parts/micro_laser(src)
 	component_parts += new /obj/item/weapon/cell/high(src)
+
+	spark_system = bind_spark(src, 3)
 
 	RefreshParts()
 
@@ -208,15 +212,11 @@
 			if(supported && panel_open)
 				if(cell)
 					system_error("unsealed cell fitting error")
-					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-					s.set_up(3, 1, src.loc)
-					s.start()
+					spark_system.queue()
 					sleep(20)
-					s.set_up(3, 1, src.loc)
-					s.start()
+					spark_system.queue()
 					sleep(10)
-					s.set_up(3, 1, src.loc)
-					s.start()
+					spark_system.queue()
 					sleep(10)
 					if(panel_open)
 						if(prob(70))

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -226,9 +226,7 @@ var/list/cleanbot_types // Going to use this to generate a list of types once th
 	if(prob(50))
 		new /obj/item/robot_parts/l_arm(Tsec)
 
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
+	spark(src, 3, alldirs)
 	qdel(src)
 	return
 

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -43,9 +43,7 @@
 		else
 			new /obj/item/clothing/suit/armor/vest(Tsec)
 
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
+	spark(src, 3, alldirs)
 
 	new /obj/effect/decal/cleanable/blood/oil(Tsec)
 	qdel(src)

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -265,9 +265,7 @@
 	if(prob(50))
 		new /obj/item/robot_parts/l_arm(Tsec)
 
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
+	spark(src, 3, alldirs)
 	qdel(src)
 	return
 

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -283,9 +283,7 @@
 		new /obj/item/robot_parts/l_arm(Tsec)
 	var/obj/item/stack/tile/floor/T = new /obj/item/stack/tile/floor(Tsec)
 	T.amount = amount
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
+	spark(src, 3, alldirs)
 	qdel(src)
 
 /mob/living/bot/floorbot/proc/addTiles(var/am)

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -258,9 +258,8 @@
 		reagent_glass.loc = Tsec
 		reagent_glass = null
 
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
+	spark(src, 3, alldirs)
+
 	qdel(src)
 	return
 

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -322,9 +322,7 @@
 	if(prob(50))
 		new /obj/item/robot_parts/l_arm(Tsec)
 
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
+	spark(src, 3, alldirs)
 
 	new /obj/effect/decal/cleanable/blood/oil(Tsec)
 	qdel(src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -125,9 +125,7 @@
 			"\red You hear a light zapping." \
 		)
 
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(5, 1, loc)
-	s.start()
+	spark(loc, 5, alldirs)
 
 	return shock_damage
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -77,12 +77,7 @@
 			stance_damage += 2
 			if(prob(10))
 				visible_message("\The [src]'s [E.name] [pick("twitches", "shudders")] and sparks!")
-				var/datum/effect/effect/system/spark_spread/spark_system = new ()
-				spark_system.set_up(5, 0, src)
-				spark_system.attach(src)
-				spark_system.start()
-				spawn(10)
-					qdel(spark_system)
+				spark(src, 5)
 		else if (E.is_broken() || !E.is_usable())
 			stance_damage += 1
 		else if (E.is_dislocated())
@@ -160,12 +155,7 @@
 
 			emote("me", 1, "drops what they were holding, their [E.name] malfunctioning!")
 
-			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-			spark_system.set_up(5, 0, src)
-			spark_system.attach(src)
-			spark_system.start()
-			spawn(10)
-				qdel(spark_system)
+			spark(src, 5)
 
 //Handles chem traces
 /mob/living/carbon/human/proc/handle_trace_chems()

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -96,9 +96,7 @@
 		playsound(user, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 		user.visible_message("<span class='danger'>[user] shoves hard, sending [target] flying!</span>")
 		var/T = get_turf(user)
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, T)
-		s.start()
+		spark(T, 3, alldirs)
 		step_away(target,user,15)
 		sleep(1)
 		step_away(target,user,15)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -90,7 +90,7 @@
 	//var/jetpack = 0
 	var/obj/item/weapon/tank/jetpack/carbondioxide/synthetic/jetpack = null
 	var/datum/effect/effect/system/ion_trail_follow/ion_trail = null
-	var/datum/effect/effect/system/spark_spread/spark_system//So they can initialize sparks whenever/N
+	var/datum/effect_system/sparks/spark_system//So they can initialize sparks whenever/N
 	var/jeton = 0
 	var/killswitch = 0
 	var/killswitch_time = 60
@@ -111,9 +111,7 @@
 	)
 
 /mob/living/silicon/robot/New(loc,var/unfinished = 0)
-	spark_system = new /datum/effect/effect/system/spark_spread()
-	spark_system.set_up(5, 0, src)
-	spark_system.attach(src)
+	spark_system = bind_spark(src, 5)
 
 	add_language("Robot Talk", 1)
 	add_language(LANGUAGE_EAL, 1)
@@ -463,7 +461,8 @@
 
 /mob/living/silicon/robot/bullet_act(var/obj/item/projectile/Proj)
 	..(Proj)
-	if(prob(75) && Proj.damage > 0) spark_system.start()
+	if(prob(75) && Proj.damage > 0) 
+		spark_system.queue()
 	return 2
 
 /mob/living/silicon/robot/attackby(obj/item/weapon/W as obj, mob/user as mob)
@@ -696,7 +695,7 @@
 
 	else
 		if(W.force && !(istype(W, /obj/item/device/robotanalyzer) || istype(W, /obj/item/device/healthanalyzer)) )
-			spark_system.start()
+			spark_system.queue()
 		return ..()
 
 /mob/living/silicon/robot/attack_hand(mob/user)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -84,9 +84,7 @@
 /mob/living/silicon/electrocute_act(var/shock_damage, var/obj/source, var/siemens_coeff = 1.0)
 
 	if (istype(source, /obj/machinery/containment_field))
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, loc)
-		s.start()
+		spark(loc, 5, alldirs)
 
 		shock_damage *= 0.75	//take reduced damage
 		take_overall_damage(0, shock_damage)

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -48,9 +48,7 @@
 	..()
 	visible_message("<b>[src]</b> blows apart!")
 	new /obj/effect/decal/cleanable/blood/gibs/robot(src.loc)
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
+	spark(src, 3, alldirs)
 	qdel(src)
 	return
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -85,25 +85,21 @@
 
 	//repair a bit of damage
 	if(prob(1))
-		src.visible_message("\red \icon[src] [src] shudders and shakes as some of it's damaged systems come back online.")
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
+		src.visible_message(span("alert", "\The [src] shudders and shakes as some of its damaged systems come back online."))
+		spark(src, 3, alldirs)
 		health += rand(25,100)
 
 	//spark for no reason
 	if(prob(5))
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
+		spark(src, 3, alldirs)
 
 	//sometimes our targetting sensors malfunction, and we attack anyone nearby
 	if(prob(disabled ? 0 : 1))
 		if(hostile_drone)
-			src.visible_message("\blue \icon[src] [src] retracts several targetting vanes, and dulls it's running lights.")
+			src.visible_message(span("notice", "\The [src] retracts several targetting vanes, and dulls its running lights."))
 			hostile_drone = 0
 		else
-			src.visible_message("\red \icon[src] [src] suddenly lights up, and additional targetting vanes slide into place.")
+			src.visible_message(span("alert", "\The [src] suddenly lights up, and additional targetting vanes slide into place."))
 			hostile_drone = 1
 
 	if(health / maxHealth > 0.9)
@@ -124,20 +120,19 @@
 		exploding = 0
 		if(!disabled)
 			if(prob(50))
-				src.visible_message("\blue \icon[src] [src] suddenly shuts down!")
+				src.visible_message(span("notice", "\The [src] suddenly shuts down!"))
 			else
-				src.visible_message("\blue \icon[src] [src] suddenly lies still and quiet.")
+				src.visible_message(span("notice", "\The [src] suddenly lies still and quiet."))
 			disabled = rand(150, 600)
 			walk(src,0)
 
 	if(exploding && prob(20))
 		if(prob(50))
-			src.visible_message("\red \icon[src] [src] begins to spark and shake violenty!")
+			src.visible_message(span("alert", "\The [src] begins to spark and shake violenty!"))
 		else
-			src.visible_message("\red \icon[src] [src] sparks and shakes like it's about to explode!")
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
+			src.visible_message(span("alert", "\The [src] sparks and shakes like it's about to explode!"))
+
+		spark(src, 3, alldirs)
 
 	if(!exploding && !disabled && prob(explode_chance))
 		exploding = 1
@@ -164,9 +159,7 @@
 /mob/living/simple_animal/hostile/retaliate/malf_drone/Destroy()
 	//some random debris left behind
 	if(has_loot)
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
+		spark(src, 3, alldirs)
 		var/obj/O
 
 		//shards

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -163,7 +163,5 @@
 	..(null,"is smashed into pieces!")
 	var/T = get_turf(src)
 	new /obj/effect/gibspawner/robot(T)
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, T)
-	s.start()
+	spark(T, 3, alldirs)
 	qdel(src)

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -19,12 +19,10 @@
 	if(!computer)
 		return
 
-	computer.visible_message("<span class='notice'>\The [computer]'s screen brightly flashes and loud electrical buzzing is heard.</span>")
+	computer.visible_message("<span class='notice'>\The [computer]'s screen brightly flashes and emits a loud electrical buzzing.</span>")
 	computer.enabled = 0
 	computer.update_icon()
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(10, 1, computer.loc)
-	s.start()
+	spark(computer.loc, 10, alldirs)
 
 	if(computer.hard_drive)
 		qdel(computer.hard_drive)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1050,12 +1050,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			"<span class='danger'>Your [src.name] explodes!</span>",\
 			"<span class='danger'>You hear an explosion!</span>")
 		explosion(get_turf(owner),-1,-1,2,3)
-		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-		spark_system.set_up(5, 0, victim)
-		spark_system.attach(owner)
-		spark_system.start()
-		spawn(10)
-			qdel(spark_system)
+		spark(victim, 5)
 		qdel(src)
 
 /obj/item/organ/external/proc/disfigure(var/type = "brute")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -119,6 +119,8 @@
 	var/global/list/status_overlays_lighting
 	var/global/list/status_overlays_environ
 
+	var/datum/effect_system/sparks/spark_system
+
 /obj/machinery/power/apc/updateDialog()
 	if (stat & (BROKEN|MAINT))
 		return
@@ -175,6 +177,8 @@
 		name = "[area.name] APC"
 		stat |= MAINT
 		src.update_icon()
+
+	spark_system = bind_spark(src, 5, alldirs)
 
 /obj/machinery/power/apc/Destroy()
 	src.update()
@@ -560,9 +564,7 @@
 			if (C.amount >= 10 && !terminal && opened && has_electronics != 2)
 				var/obj/structure/cable/N = T.get_cable_node()
 				if (prob(50) && electrocute_mob(usr, N, N))
-					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-					s.set_up(5, 1, src)
-					s.start()
+					spark(src, 5, alldirs)
 					if(user.stunned)
 						return
 				C.use(10)
@@ -582,9 +584,7 @@
 		if(do_after(user, 50))
 			if(terminal && opened && has_electronics!=2)
 				if (prob(50) && electrocute_mob(usr, terminal.powernet, terminal))
-					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-					s.set_up(5, 1, src)
-					s.start()
+					spark_system.queue()
 					if(usr.stunned)
 						return
 				new /obj/item/stack/cable_coil(loc,10)
@@ -731,9 +731,7 @@
 
 		if(isipc(H) && H.a_intent == I_GRAB)
 			if(emagged || stat & BROKEN)
-				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-				s.set_up(3, 1, src)
-				s.start()
+				spark_system.queue()
 				H << "<span class='danger'>The APC power currents surge eratically, damaging your chassis!</span>"
 				H.adjustFireLoss(10, 0)
 			else if(src.cell && src.cell.charge > 0)
@@ -752,9 +750,7 @@
 					if (H.nutrition > H.max_nutrition)
 						H.nutrition = H.max_nutrition
 					if (prob(0.5))
-						var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-						s.set_up(3, 1, src)
-						s.start()
+						spark_system.queue()
 						H << "<span class='danger'>The APC power currents surge eratically, damaging your chassis!</span>"
 						H.adjustFireLoss(10, 0)
 
@@ -1025,9 +1021,7 @@
 			smoke.set_up(3, 0, src.loc)
 			smoke.attach(src)
 			smoke.start()
-			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-			s.set_up(3, 1, src)
-			s.start()
+			spark_system.queue()
 			visible_message("<span class='danger'>The [src.name] suddenly lets out a blast of smoke and some sparks!</span>", \
 							"<span class='danger'>You hear sizzling electronics.</span>")
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -196,9 +196,7 @@ var/list/possible_cable_coil_colours = list(
 	if(!prob(prb))
 		return 0
 	if (electrocute_mob(user, powernet, src, siemens_coeff))
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
+		spark(src, 5, alldirs)
 		if(usr.stunned)
 			return 1
 	return 0

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -27,6 +27,12 @@
 	var/_wifi_id
 	var/datum/wifi/receiver/button/emitter/wifi_receiver
 
+	var/datum/effect_system/sparks/spark_system
+
+/obj/machinery/power/emitter/New()
+	..()
+	spark_system = bind_spark(src, 5, alldirs)
+
 /obj/machinery/power/emitter/verb/rotate()
 	set name = "Rotate"
 	set category = "Object"
@@ -135,9 +141,7 @@
 
 		playsound(src.loc, 'sound/weapons/emitter.ogg', 25, 1)
 		if(prob(35))
-			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-			s.set_up(5, 1, src)
-			s.start()
+			spark_system.queue()
 
 		var/obj/item/projectile/beam/emitter/A = new /obj/item/projectile/beam/emitter( src.loc )
 		A.damage = round(power_per_shot/EMITTER_DAMAGE_POWER_TRANSFER)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -49,6 +49,8 @@
 	var/building_terminal = 0 //Suggestions about how to avoid clickspam building several terminals accepted!
 	var/obj/machinery/power/terminal/terminal = null
 	var/should_be_mapped = 0 // If this is set to 0 it will send out warning on New()
+	var/datum/effect_system/sparks/big_spark
+	var/datum/effect_system/sparks/small_spark
 
 /obj/machinery/power/smes/drain_power(var/drain_check, var/surge, var/amount = 0)
 
@@ -62,6 +64,8 @@
 
 /obj/machinery/power/smes/New()
 	..()
+	big_spark = bind_spark(src, 5, alldirs)
+	small_spark = bind_spark(src, 3)
 	spawn(5)
 		if(!powernet)
 			connect_to_network()
@@ -295,9 +299,7 @@
 				playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
 				if(do_after(user, 50))
 					if (prob(50) && electrocute_mob(usr, terminal.powernet, terminal))
-						var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-						s.set_up(5, 1, src)
-						s.start()
+						big_spark.queue()
 						building_terminal = 0
 						if(usr.stunned)
 							return 0
@@ -402,9 +404,7 @@
 			qdel(src)
 			return
 		else if(prob(15)) //Power drain
-			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-			s.set_up(3, 1, src)
-			s.start()
+			small_spark.queue()
 			if(prob(50))
 				emp_act(1)
 			else

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -88,9 +88,7 @@
 // This also causes the SMES to quickly discharge, and has small chance of damaging output APCs.
 /obj/machinery/power/smes/buildable/process()
 	if(!grounding && (Percentage() > 5))
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
+		spark(src, 5, alldirs)
 		charge -= (output_level_max * SMESRATE)
 		if(prob(1)) // Small chance of overload occuring since grounding is disabled.
 			apcs_overload(5,10,20)
@@ -176,7 +174,6 @@
 
 
 	// Preparations
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	// Check if user has protected gloves.
 	var/user_protected = 0
 	if(h_user.gloves)
@@ -191,8 +188,7 @@
 		if (0 to 15)
 			// Small overcharge
 			// Sparks, Weak shock
-			s.set_up(2, 1, src)
-			s.start()
+			small_spark.queue()	// This belongs to the parent SMES type.
 			if (user_protected && prob(80))
 				h_user << "Small electrical arc almost burns your hand. Luckily you had your gloves on!"
 			else
@@ -204,8 +200,7 @@
 		if (16 to 35)
 			// Medium overcharge
 			// Sparks, Medium shock, Weak EMP
-			s.set_up(4,1,src)
-			s.start()
+			big_spark.queue()
 			if (user_protected && prob(25))
 				h_user << "Medium electrical arc sparks and almost burns your hand. Luckily you had your gloves on!"
 			else
@@ -220,8 +215,8 @@
 		if (36 to 60)
 			// Strong overcharge
 			// Sparks, Strong shock, Strong EMP, 10% light overload. 1% APC failure
-			s.set_up(7,1,src)
-			s.start()
+			big_spark.queue()
+			big_spark.queue()
 			if (user_protected)
 				h_user << "Strong electrical arc sparks between you and [src], ignoring your gloves and burning your hand!"
 				h_user.adjustFireLoss(rand(25,60))
@@ -240,9 +235,9 @@
 		if (61 to INFINITY)
 			// Massive overcharge
 			// Sparks, Near - instantkill shock, Strong EMP, 25% light overload, 5% APC failure. 50% of SMES explosion. This is bad.
-			s.set_up(10,1,src)
-			s.start()
-			h_user << "Massive electrical arc sparks between you and [src]. Last thing you can think about is \"Oh shit...\""
+			big_spark.queue()
+			big_spark.queue()
+			h_user << "A massive electrical arc sparks between you and \the [src]. The last thing that goes through your mind is \"Oh shit...\"."
 			// Remember, we have few gigajoules of electricity here.. Turn them into crispy toast.
 			h_user.adjustFireLoss(rand(150,195))
 			h_user.Paralyse(25)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -146,9 +146,7 @@
 
 /obj/item/weapon/gun/energy/mousegun/handle_post_fire(mob/user, atom/target, var/pointblank=0, var/reflex=0, var/playemote = 1)
 	var/T = get_turf(user)
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, T)
-	s.start()
+	spark(T, 3, alldirs)
 	failcheck()
 	..()
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -192,9 +192,7 @@
 			if (M.mob_size <= 2 && (M.find_type() & TYPE_ORGANIC))
 				M.visible_message("<span class='danger'>[M] bursts like a balloon!</span>")
 				M.gib()
-				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-				s.set_up(3, 1, M)
-				s.start()
+				spark(M, 3, alldirs)
 			else if (iscarbon(M) && M.contents.len)
 				for (var/obj/item/weapon/holder/H in M.contents)
 					if (!H.contained)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -605,9 +605,7 @@
 
 /datum/chemical_reaction/flash_powder/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(2, 1, location)
-	s.start()
+	spark(location, 2, alldirs)
 	for(var/mob/living/carbon/M in viewers(world.view, location))
 		switch(get_dist(M, location))
 			if(0 to 3)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -78,7 +78,7 @@
 
 	if (istype(target, /mob/living/silicon/robot))
 		var/mob/living/silicon/robot/R = target
-		R.spark_system.start()
+		R.spark_system.queue()
 
 	return 1
 

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
@@ -6,19 +6,15 @@
 /datum/artifact_effect/teleport/DoEffectTouch(var/mob/user)
 	var/weakness = GetAnomalySusceptibility(user)
 	if(prob(100 * weakness))
-		user << "\red You are suddenly zapped away elsewhere!"
+		user << span("alert", "You are suddenly zapped away elsewhere!")
 		if (user.buckled)
 			user.buckled.unbuckle_mob()
 
-		var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-		sparks.set_up(3, 0, get_turf(user))
-		sparks.start()
+		spark(get_turf(user), 3)
 
 		user.Move(pick(trange(50, get_turf(holder))))
 
-		sparks = new /datum/effect/effect/system/spark_spread()
-		sparks.set_up(3, 0, user.loc)
-		sparks.start()
+		spark(get_turf(user), 3)
 
 /datum/artifact_effect/teleport/DoEffectAura()
 	if(holder)
@@ -26,18 +22,15 @@
 		for (var/mob/living/M in range(src.effectrange,T))
 			var/weakness = GetAnomalySusceptibility(M)
 			if(prob(100 * weakness))
-				M << "\red You are displaced by a strange force!"
+				M << span("alert", "You are displaced by a strange force!")
 				if(M.buckled)
 					M.buckled.unbuckle_mob()
 
-				var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-				sparks.set_up(3, 0, get_turf(M))
-				sparks.start()
+				spark(get_turf(M), 3)
 
 				M.Move(pick(trange(50, T)))
-				sparks = new /datum/effect/effect/system/spark_spread()
-				sparks.set_up(3, 0, M.loc)
-				sparks.start()
+				
+				spark(get_turf(M), 3)
 
 /datum/artifact_effect/teleport/DoEffectPulse()
 	if(holder)
@@ -45,15 +38,12 @@
 		for (var/mob/living/M in range(src.effectrange, T))
 			var/weakness = GetAnomalySusceptibility(M)
 			if(prob(100 * weakness))
-				M << "\red You are displaced by a strange force!"
+				M << span("alert", "You are displaced by a strange force!")
 				if(M.buckled)
 					M.buckled.unbuckle_mob()
 
-				var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-				sparks.set_up(3, 0, get_turf(M))
-				sparks.start()
+				spark(get_turf(M), 3)
 
 				M.Move(pick(trange(50, T)))
-				sparks = new /datum/effect/effect/system/spark_spread()
-				sparks.set_up(3, 0, M.loc)
-				sparks.start()
+				
+				spark(get_turf(M), 3)

--- a/code/modules/shieldgen/shield_capacitor.dm
+++ b/code/modules/shieldgen/shield_capacitor.dm
@@ -33,9 +33,7 @@
 		user << "Controls are now [src.locked ? "locked." : "unlocked."]"
 		. = 1
 		updateDialog()
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(5, 1, src)
-	s.start()
+	spark(src, 5, alldirs)
 
 /obj/machinery/shield_capacitor/attackby(obj/item/W, mob/user)
 
@@ -46,10 +44,10 @@
 			user << "Controls are now [src.locked ? "locked." : "unlocked."]"
 			updateDialog()
 		else
-			user << "\red Access denied."
+			user << span("alert", "Access denied.")
 	else if(istype(W, /obj/item/weapon/wrench))
 		src.anchored = !src.anchored
-		src.visible_message("\blue \icon[src] [src] has been [anchored ? "bolted to the floor" : "unbolted from the floor"] by [user].")
+		src.visible_message(span("notice", "\The [src] has been [anchored ? "bolted to the floor" : "unbolted from the floor"] by \the [user]."))
 
 		if(anchored)
 			spawn(0)

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -51,9 +51,8 @@
 		user << "Controls are now [src.locked ? "locked." : "unlocked."]"
 		. = 1
 		updateDialog()
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(5, 1, src)
-	s.start()
+
+	spark(src, 5, alldirs)
 
 /obj/machinery/shield_gen/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/weapon/card/id))
@@ -63,10 +62,10 @@
 			user << "Controls are now [src.locked ? "locked." : "unlocked."]"
 			updateDialog()
 		else
-			user << "\red Access denied."
+			user << span("alert", "Access denied.")
 	else if(istype(W, /obj/item/weapon/wrench))
 		src.anchored = !src.anchored
-		src.visible_message("\blue \icon[src] [src] has been [anchored?"bolted to the floor":"unbolted from the floor"] by [user].")
+		src.visible_message(span("notice", "\The [src] has been [anchored ? "bolted to the floor":"unbolted from the floor"] by \the [user]."))
 
 		if(active)
 			toggle()

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -174,9 +174,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		if(istype(target,/mob/living) && message)
 			target << text("[message]")
 		if(sparks_spread)
-			var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-			sparks.set_up(sparks_amt, 0, location) //no idea what the 0 is
-			sparks.start()
+			spark(location, sparks_amt)
 		if(smoke_spread)
 			if(smoke_spread == 1)
 				var/datum/effect/effect/system/smoke_spread/smoke = new /datum/effect/effect/system/smoke_spread()

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -114,9 +114,7 @@
 		return
 
 	if(istype(W, /obj/item/weapon/melee/energy/blade))
-		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-		spark_system.set_up(5, 0, src.loc)
-		spark_system.start()
+		W:spark_system.queue()
 		playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 		playsound(src.loc, "sparks", 50, 1)
 		user.visible_message("<span class='danger'>\The [src] was sliced apart by [user]!</span>")

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -151,7 +151,5 @@
 /obj/item/weapon/rcs/attackby(var/obj/item/O, var/mob/user)
 	if (istype(O, /obj/item/weapon/card/emag) && !emagged)
 		emagged = 1
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
+		spark(src, 5, alldirs)
 		user << "<span class='caution'>You emag the RCS. Click on it to toggle between modes.</span>"

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -137,9 +137,7 @@
 
 /obj/machinery/computer/telescience/proc/sparks()
 	if(telepad)
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, get_turf(telepad))
-		s.start()
+		spark(telepad, 5, alldirs)
 	else
 		return
 
@@ -195,9 +193,7 @@
 			// use a lot of power
 			use_power(power * 10)
 
-			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-			s.set_up(5, 1, get_turf(telepad))
-			s.start()
+			spark(telepad, 5, alldirs)
 
 			temp_msg = "Teleport successful.<BR>"
 			if(teles_left < 10)
@@ -205,10 +201,7 @@
 			else
 				temp_msg += "Data printed below."
 
-			var/sparks = get_turf(target)
-			var/datum/effect/effect/system/spark_spread/y = new /datum/effect/effect/system/spark_spread
-			y.set_up(5, 1, sparks)
-			y.start()
+			spark(telepad, 5, alldirs)
 
 			var/turf/source = target
 			var/turf/dest = get_turf(telepad)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -118,8 +118,7 @@
 	..()
 
 	if (prob(20))
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, src)
+		spark(src, 5, alldirs)
 
 	healthcheck()
 


### PR DESCRIPTION
changes:
- Removed shim for old spark system.
- Converted all calls to old spark system with calls to new one.
- Processor-based effects are no longer pooled, as it had minimal performance impact and was breaking things.
- Tweaked some visible_messages for rogue drones.
- PB effects' handling of location is now done at the `/datum/effect_system` level.