### PR TITLE
Asteroid generation

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -80,6 +80,11 @@ datum/controller/game_controller/proc/setup_objects()
 	create_global_parallax_icons()
 	admin_notice(span("danger", "Done."))
 
+	if(config.generate_asteroid)
+		new /datum/random_map(null,0,0,2,255,255)
+		new /datum/random_map(null,0,0,3,255,255)
+		new /datum/random_map(null,0,0,4,255,255)
+
 	admin_notice(span("danger", "Setting up lighting."))
 	initialize_lighting()
 	admin_notice(span("danger", "Lighting Setup Completed."))


### PR DESCRIPTION
The asteroid will now actually generate. Currently using default Bay map generation. As far as I know no current alteration to mineral density, and all z-levels utilize the same variables.

According to Scopes;

> I said ages ago. The map gen need re-writing
It takes way too long een before people messed with the scheduler

As a result, the game will hiccup for a little before becoming playable. Very distressing to the user, but not a severe issue for testing.
