### PR TITLE
Cooking and Smallmob tweaks

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -155,3 +155,17 @@
 							user << desc
 							if(P && P.loc != src && !istype(P, /obj/item/stack/cable_coil))
 								user << "<span class='warning'>You cannot add that component to the machine!</span>"
+
+
+/obj/machinery/constructable_frame/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if (!mover)
+		return 1
+	if(istype(mover,/obj/item/projectile) && density)
+		if (prob(50))
+			return 1
+		else
+			return 0
+	else if(mover.checkpass(PASSTABLE))
+//Animals can run under them, lots of empty space
+		return 1
+	return ..()

--- a/code/game/machinery/kitchen/cooking_machines/_appliance.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_appliance.dm
@@ -118,7 +118,7 @@
 		usr << "Ghosts aren't allowed to toggle power switches"
 		return
 
-	if (usr.stat)
+	if (usr.stat || usr.restrained() || usr.incapacitated())
 		return
 
 	if (!Adjacent(usr))
@@ -149,7 +149,7 @@
 		usr << "Ghosts aren't allowed to mess with cooking machines!"
 		return
 
-	if (usr.stat)
+	if (usr.stat || usr.restrained() || usr.incapacitated())
 		return
 
 	if (!Adjacent(usr))

--- a/code/game/machinery/kitchen/cooking_machines/_appliance.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_appliance.dm
@@ -142,6 +142,15 @@
 	set name = "Choose output"
 	set category = "Object"
 
+	if (!isliving(usr))
+		usr << "Ghosts aren't allowed to mess with cooking machines!"
+		return
+
+	if (!Adjacent(usr))
+		if (!istype(usr, /mob/living/silicon))
+			usr << "You can't adjust the [src] from this distance, get closer!"
+			return
+
 	if(output_options.len)
 
 		var/choice = input("What specific food do you wish to make with \the [src]?") as null|anything in output_options+"Default"
@@ -390,10 +399,10 @@
 		for (var/r in results)
 			var/obj/item/weapon/reagent_containers/food/snacks/R = r
 			R.loc = C //Move everything from the buffer back to the container
-			qdel(temp) //delete buffer object
-			temp = null
 			R.cooked |= cook_type.
 
+		qdel(temp) //delete buffer object
+		temp = null
 		.=1 //None of the rest of this function is relevant for recipe cooking
 
 	else if(CI.combine_target)

--- a/code/game/machinery/kitchen/cooking_machines/_appliance.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_appliance.dm
@@ -118,8 +118,11 @@
 		usr << "Ghosts aren't allowed to toggle power switches"
 		return
 
+	if (usr.stat)
+		return
+
 	if (!Adjacent(usr))
-		if (!istype(usr, /mob/living/silicon))
+		if (!issilicon(usr))
 			usr << "You can't reach the power switch from there, get closer!"
 			return
 
@@ -146,8 +149,11 @@
 		usr << "Ghosts aren't allowed to mess with cooking machines!"
 		return
 
+	if (usr.stat)
+		return
+
 	if (!Adjacent(usr))
-		if (!istype(usr, /mob/living/silicon))
+		if (!issilicon(usr))
 			usr << "You can't adjust the [src] from this distance, get closer!"
 			return
 

--- a/code/game/machinery/kitchen/cooking_machines/_cooker_output.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker_output.dm
@@ -59,7 +59,7 @@
 	name = "personal pizza"
 	desc = "A personalized pan pizza meant for only one person."
 	icon_state = "personal_pizza"
-	size = 15
+	size = 20
 	w_class = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/bread
@@ -73,7 +73,7 @@
 	name = "pie"
 	desc = "Tasty pie."
 	icon_state = "piecustom"
-	size = 20
+	size = 25
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/cake
 	name = "cake"
@@ -86,68 +86,68 @@
 	name = "hot pocket"
 	desc = "You wanna put a bangin- oh, nevermind."
 	icon_state = "donk"
-	size = 5
+	size = 8
 	w_class = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/kebab
 	name = "kebab"
 	desc = "Remove this!"
 	icon_state = "kabob"
-	size = 7
+	size = 10
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/waffles
 	name = "waffles"
 	desc = "Made with love."
 	icon_state = "waffles"
-	size = 8
+	size = 12
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/cookie
 	name = "cookie"
 	desc = "Sugar snap!"
 	icon_state = "cookie"
-	size = 3
+	size = 6
 	w_class = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/donut
 	name = "filled donut"
 	desc = "Donut eat this!" // kill me
 	icon_state = "donut"
-	size = 5
+	size = 8
 	w_class = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/jawbreaker
 	name = "flavored jawbreaker"
 	desc = "It's like cracking a molar on a rainbow."
 	icon_state = "jawbreaker"
-	size = 2
+	size = 4
 	w_class = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/candybar
 	name = "flavored chocolate bar"
 	desc = "Made in a factory downtown."
 	icon_state = "bar"
-	size = 3
+	size = 6
 	w_class = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/sucker
 	name = "flavored sucker"
 	desc = "Suck, suck, suck."
 	icon_state = "sucker"
-	size = 2
+	size = 4
 	w_class = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/jelly
 	name = "jelly"
 	desc = "All your friends will be jelly."
 	icon_state = "jellycustom"
-	size = 6
+	size = 8
 
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/cereal
 	name = "cereal"
 	desc = "Crispy and flaky"
 	icon_state = "cereal_box"
-	size = 20
+	size = 30
 	w_class = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/variable/cereal/New()

--- a/code/game/machinery/kitchen/cooking_machines/container.dm
+++ b/code/game/machinery/kitchen/cooking_machines/container.dm
@@ -5,7 +5,7 @@
 /obj/item/weapon/reagent_containers/cooking_container
 	icon = 'icons/obj/cooking_machines.dmi'
 	var/shortname
-	var/max_space = 15//Maximum sum of w-classes of foods in this container at once
+	var/max_space = 20//Maximum sum of w-classes of foods in this container at once
 	var/max_reagents = 80//Maximum units of reagents
 
 /obj/item/weapon/reagent_containers/cooking_container/New()

--- a/code/game/machinery/kitchen/cooking_machines/fryer.dm
+++ b/code/game/machinery/kitchen/cooking_machines/fryer.dm
@@ -9,26 +9,25 @@
 	food_color = "#FFAD33"
 	cooked_sound = 'sound/machines/ding.ogg'
 	appliancetype = FRYER
-	active_power_usage	= 48000
+	active_power_usage	= 24000
 	//24 KW, based on real world values for a large commercial fryer.
-	//And then doubled, because this is an extra wide twin unit
 
 	optimal_power = 0.35
 
-	idle_power_usage = 7200
+	idle_power_usage = 6000
 	//Power used to maintain temperature once it's heated.
-	//Going with 15% of the active power. This is a somewhat arbitrary value
+	//Going with 25% of the active power. This is a somewhat arbitrary value
 
-	resistance = 240000
+	resistance = 90000
 	//By default, about 15 mins to heat up.
 
-	max_contents = 4
+	max_contents = 2
 	container_type = /obj/item/weapon/reagent_containers/cooking_container/fryer
 
 	stat = POWEROFF//Starts turned off
 
 	var/datum/reagents/oil
-	var/optimal_oil = 18000//180 litres of cooking oil
+	var/optimal_oil = 9000//90 litres of cooking oil
 
 
 /obj/machinery/appliance/cooker/fryer/examine(var/mob/user)
@@ -39,12 +38,12 @@
 /obj/machinery/appliance/cooker/fryer/New()
 	..()
 	oil = new/datum/reagents(optimal_oil * 1.25, src)
-	var/variance = rand()*0.05
+	var/variance = rand()*0.15
 	//Fryer is always a little below full, but its usually negligible
 
 	if (prob(20))
 		//Sometimes the fryer will start with much less than full oil, significantly impacting efficiency until filled
-		variance = rand()*0.3
+		variance = rand()*0.5
 	oil.add_reagent("cornoil", optimal_oil*(1 - variance))
 
 /obj/machinery/appliance/cooker/fryer/heat_up()

--- a/code/game/machinery/kitchen/cooking_machines/oven.dm
+++ b/code/game/machinery/kitchen/cooking_machines/oven.dm
@@ -12,7 +12,8 @@
 	active_power_usage	= 19000
 	//Based on a double deck electric convection oven
 
-	idle_power_usage	= 5700
+	resistance = 72000
+	idle_power_usage	= 6000
 	//uses 30% power to stay warm
 	optimal_power = 0.2
 

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -411,3 +411,12 @@
 		if ("dispose")
 			dispose()
 	return
+
+
+/obj/machinery/microwave/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if (!mover)
+		return 1
+	if(mover.checkpass(PASSTABLE))
+	//Animals can run under them, lots of empty space
+		return 1
+	return ..()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -316,3 +316,17 @@
 		else
 			user << "<span class='notice'>You need to activate the weapon to do that!</span>"
 			return
+
+
+/obj/structure/girder/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if (!mover)
+		return 1
+	if(istype(mover,/obj/item/projectile) && density)
+		if (prob(50))
+			return 1
+		else
+			return 0
+	else if(mover.checkpass(PASSTABLE))
+//Animals can run under them, lots of empty space
+		return 1
+	return ..()

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -35,7 +35,7 @@
 
 /mob/living/simple_animal/lizard/attack_hand(mob/living/carbon/human/M as mob)
 	if (src.stat == DEAD)//If the creature is dead, we don't pet it, we just pickup the corpse on click
-		get_scooped(M)
+		get_scooped(M, usr)
 		return
 	else
 		..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -131,7 +131,7 @@
 
 /mob/living/simple_animal/mouse/attack_hand(mob/living/carbon/human/M as mob)
 	if (src.stat == DEAD)//If the mouse is dead, we don't pet it, we just pickup the corpse on click
-		get_scooped(M)
+		get_scooped(M, usr)
 		return
 	else
 		..()
@@ -150,7 +150,7 @@
 	if(!istype(H) || !Adjacent(H)) return ..()
 
 	if(H.a_intent == "help")
-		get_scooped(H)
+		get_scooped(H, usr)
 		return
 	else
 		return ..()

--- a/code/modules/mob/living/simple_animal/friendly/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mushroom.dm
@@ -37,7 +37,7 @@
 
 /mob/living/simple_animal/mushroom/attack_hand(mob/living/carbon/human/M as mob)
 	if (src.stat == DEAD)//If the creature is dead, we don't pet it, we just pickup the corpse on click
-		get_scooped(M)
+		get_scooped(M, usr)
 		return
 	else
 		..()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -72,7 +72,6 @@
 
 	//We'll assume that the batter isnt going to be regurgitated and eaten by someone else. Only show this once
 	if (data["cooked"] != 1)
-		world << "cooked is [data["cooked"]]"
 		if (!messaged)
 			M << "Ugh, this raw [name] tastes disgusting."
 			nutriment_factor *= 0.5
@@ -102,7 +101,6 @@
 
 //Handles setting the temperature when oils are mixed
 /datum/reagent/nutriment/coating/mix_data(var/newdata, var/newamount)
-	world << "Coating mixed with new coating, setting cooked to [newdata["cooked"]]"
 	if (!data)
 		data = list()
 
@@ -265,7 +263,6 @@
 
 /datum/reagent/nutriment/triglyceride/oil/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	var/dfactor = heatdamage(M)
-	world << "Oil touch. dfactor [dfactor]"
 	if (dfactor)
 		M.take_organ_damage(0, removed * 1.5 * dfactor)
 		data["temperature"] -= (6 * removed) / (1 + volume*0.1)//Cools off as it burns you

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -281,8 +281,6 @@
 /obj/structure/reagent_dispensers/cookingoil/New()
 		..()
 		reagents.add_reagent("cornoil",capacity)
-		world << "Cooking oil spawned!"
-		world << "[src] spawned in [src.loc], [src.x], [src.y], [src.z]"
 
 /obj/structure/reagent_dispensers/cookingoil/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.get_structure_damage())

--- a/html/changelogs/Nanako-tweaks.yml
+++ b/html/changelogs/Nanako-tweaks.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: N3X15
+author: Nanako
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/Nanako-tweaks.yml
+++ b/html/changelogs/Nanako-tweaks.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Small creatures and projectiles can now move over girders and machinery frames. 50% chance to stop projectiles."
+  - bugfix: "Fixed an incorrect message with small creatures climbing onto people."


### PR DESCRIPTION
Just an assorted package of little things:

Scales down the deep fryer, reducing its power usage, oil reservoir and  cooking containers. Should help with complaints about power usage

Fixes up numbers so that cookers heat up in 15 minutes as intended

Adjusts the normal size of all conbination cooking items, so its harder to reach crazy sizes

Removes some debug messages

Fixes user not being populated in get_scooped procs, which was preventing the special "X climbs onto Y" message from appearing when a mouse drags themselves onto a human

adds passtable code to girders and empty machine frames, allowing small mobs to crawl over them and projectiles to sometimes (50% chance) pass over