### PR TITLE
BLEND_MULTIPLY for area overlays

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -6,6 +6,7 @@
 /area
 	var/global/global_uid = 0
 	var/uid
+	blend_mode = BLEND_MULTIPLY
 
 /area/New()
 	icon_state = ""


### PR DESCRIPTION
changes:
- Areas now use `BLEND_MULTIPLY` for area effects, which looks better in general.

![tebtj3](https://cloud.githubusercontent.com/assets/7097800/23319083/c4a5eb36-fa9a-11e6-939d-a81d6187d9f1.gif)
