### PR TITLE
Directional lighting tweaks

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -66,6 +66,12 @@
 #define LIGHT_BROKEN 2
 #define LIGHT_BURNED 3
 
+// Some angle presets for directional lighting.
+#define LIGHT_OMNI null
+#define LIGHT_SEMI 180
+#define LIGHT_WIDE 90
+#define LIGHT_NARROW 45
+
 // Night lighting controller times
 // The time (in ticks based on worldtime2ticks()) that various actions trigger
 #define MORNING_LIGHT_RESET 252000       // 7am or 07:00 - lighting restores to normal in morning

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -11,6 +11,8 @@
 	var/unlocked = 0
 	var/open = 0
 	var/brightness_on = 8		//can't remember what the maxed out value is
+	light_color = LIGHT_COLOR_TUNGSTEN
+	light_wedge = LIGHT_WIDE
 
 /obj/machinery/floodlight/New()
 	src.cell = new(src)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -9,8 +9,7 @@
 	slot_flags = SLOT_BELT
 	light_color = LIGHT_COLOR_HALOGEN
 	uv_intensity = 50
-	//offset_light = 1
-	//diona_restricted_light = 1//Light emitted by this object or creature has limited interaction with diona
+	light_wedge = LIGHT_WIDE
 
 	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 20)
 
@@ -97,6 +96,7 @@
 	slot_flags = SLOT_EARS
 	brightness_on = 2
 	w_class = 1
+	light_wedge = LIGHT_OMNI
 
 /obj/item/device/flashlight/drone
 	name = "low-power flashlight"
@@ -117,6 +117,7 @@
 	uv_intensity = 60
 	matter = list(DEFAULT_WALL_MATERIAL = 100,"glass" = 70)
 	contained_sprite = 1
+	light_wedge = LIGHT_SEMI
 
 /obj/item/device/flashlight/maglight
 	name = "maglight"
@@ -131,6 +132,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 200,"glass" = 100)
 	hitsound = 'sound/weapons/smash.ogg'
 	contained_sprite = 1
+	light_wedge = LIGHT_NARROW
 
 
 // the desk lamps are a bit special
@@ -145,6 +147,7 @@
 	uv_intensity = 100
 	on = 1
 	slot_flags = 0 //No wearing desklamps
+	light_wedge = LIGHT_OMNI
 
 
 // green-shaded desk lamp
@@ -179,8 +182,7 @@
 	uv_intensity = 100
 	var/on_damage = 7
 	var/produce_heat = 1500
-	//offset_light = 0//Emits light all around, not directional
-	//diona_restricted_light = 0
+	light_wedge = LIGHT_OMNI
 
 /obj/item/device/flashlight/flare/New()
 	fuel = rand(800, 1000) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.
@@ -232,8 +234,7 @@
 	uv_intensity = 200
 	on = 1 //Bio-luminesence has one setting, on.
 	light_color = LIGHT_COLOR_SLIME_LAMP
-	//offset_light = 0//Emits light all around, not directional
-	//diona_restricted_light = 0
+	light_wedge = LIGHT_OMNI
 
 /obj/item/device/flashlight/slime/New()
 	..()
@@ -259,9 +260,8 @@
 	item_state = "glowstick"
 	contained_sprite = 1
 	uv_intensity = 255
-	//offset_light = 0
-	//diona_restricted_light = 0
 	var/fuel = 0
+	light_wedge = LIGHT_OMNI
 
 /obj/item/device/flashlight/glowstick/New()
 	fuel = rand(900, 1200)

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -10,6 +10,7 @@
 	heat_protection =    HEAD|FACE|EYES
 	cold_protection =    HEAD|FACE|EYES
 	brightness_on = 4
+	light_wedge = LIGHT_WIDE
 	sprite_sheets = list(
 		"Tajara" = 'icons/mob/species/tajaran/helmet.dmi',
 		"Skrell" = 'icons/mob/species/skrell/helmet.dmi',

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -28,6 +28,7 @@
 	action_button_name = "Toggle Helmet Light"
 	light_overlay = "helmet_light"
 	brightness_on = 4
+	light_wedge = LIGHT_WIDE
 	on = 0
 
 /obj/item/clothing/head/helmet/space/initialize()

--- a/code/modules/effects/sparks/_spark_docs.dm
+++ b/code/modules/effects/sparks/_spark_docs.dm
@@ -1,8 +1,8 @@
 /*
 
-/proc/spark(var/turf/loc, var/amount = 1, var/spread_dirs = cardinal)
+/proc/spark(var/atom/movable/loc, var/amount = 1, var/spread_dirs = cardinal)
 Creates a spark system that is destroyed once the animation completes.
-	loc:	The location this effect should be created at.
+	loc:	The location this effect should be created at. Does not need to be a turf.
 	amount:	How many spark-tiles should be created.
 	spread_dirs:	The directions the sparks should spread in. 'cardinal' if not specified.
 

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -6,7 +6,6 @@
 	var/light_color     // Hexadecimal RGB string representing the colour of the light.
 	var/uv_intensity = 255	// How much UV light is being emitted by this object. Valid range: 0-255.
 	var/light_wedge		// The angle that the light's emission should be restricted to. null for omnidirectional.
-	var/light_self = TRUE	// If the light should also affect our tile. Requires light_wedge to be set.
 
 	var/tmp/datum/light_source/light // Our light source. Don't fuck with this directly unless you have a good reason!
 	var/tmp/list/light_sources       // Any light sources that are "inside" of us, for example, if src here was a mob that's carrying a flashlight, that flashlight's light source would be part of this list.

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -35,7 +35,6 @@
 	var/tmp/cached_origin_x	// The last known X coord of the origin.
 	var/tmp/cached_origin_y	// The last known Y coord of the origin.
 	var/tmp/old_direction	// The last known direction of the origin.
-	var/tmp/cached_ab		// We don't actually need to save this, just nice for debugging.
 	var/tmp/targ_sign			
 	var/tmp/test_x_offset
 	var/tmp/test_y_offset
@@ -274,12 +273,12 @@
 	switch (top_atom.dir)
 		if (NORTH)
 			limit_a_t = angle + 90
-			limit_b_t = angle
+			limit_b_t = -(angle) + 90
 			test_x_offset = cached_origin_x
 			test_y_offset = cached_origin_y + 1
 
 		if (SOUTH)
-			limit_a_t = -(angle)
+			limit_a_t = (angle) - 90
 			limit_b_t = -(angle) - 90
 			test_x_offset = cached_origin_x
 			test_y_offset = cached_origin_y - 1
@@ -302,8 +301,7 @@
 	limit_b_x = POLAR_TO_CART_X(light_range + 10, limit_b_t)
 	limit_b_y = POLAR_TO_CART_Y(light_range + 10, limit_b_t)
 	// This won't change unless the origin or dir changes, might as well do it here.
-	cached_ab = PSEUDO_WEDGE(limit_a_x, limit_a_y, limit_b_x, limit_b_y)	
-	targ_sign = cached_ab > 0
+	targ_sign = PSEUDO_WEDGE(limit_a_x, limit_a_y, limit_b_x, limit_b_y) > 0
 
 // I know this is 2D, calling it a cone anyways. Fuck the system.
 // Returns true if the test point is NOT inside the cone.

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -264,8 +264,10 @@
 	if (front.has_opaque_atom)
 		do_offset = FALSE
 
-	test_x_offset = cached_origin_x = T.x
-	test_y_offset = cached_origin_y = T.y
+	cached_origin_x = T.x
+	test_x_offset = cached_origin_x
+	cached_origin_y = T.y
+	test_y_offset = cached_origin_y
 	old_direction = top_atom.dir
 
 	var/angle = light_angle / 2

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -11,7 +11,6 @@
 	var/light_color    	// The colour of the light, string, decomposed by parse_light_color()
 	var/light_uv		// The intensity of UV light, between 0 and 255.
 	var/light_angle		// The light's emission angle, in degrees.
-	var/light_self = TRUE	// If FALSE, the light won't emit onto its own tile. Good with light_angle.
 
 	// Variables for keeping track of the colour.
 	var/lum_r
@@ -68,7 +67,6 @@
 	light_color = source_atom.light_color
 	light_uv    = source_atom.uv_intensity
 	light_angle = source_atom.light_wedge
-	light_self  = source_atom.light_self
 
 	parse_light_color()
 
@@ -200,10 +198,6 @@
 		light_angle = source_atom.light_wedge
 		. = 1
 
-	if (source_atom.light_self != light_self)
-		light_self = source_atom.light_self
-		. = 1
-
 // Decompile the hexadecimal colour into lumcounts of each perspective.
 /datum/light_source/proc/parse_light_color()
 	if (light_color)
@@ -265,8 +259,13 @@
 	if (T.x == cached_origin_x && T.y == cached_origin_y && old_direction == top_atom.dir)
 		return
 
-	cached_origin_x = T.x
-	cached_origin_y = T.y
+	var/do_offset = TRUE
+	var/turf/front = get_step(T, top_atom.dir)
+	if (front.has_opaque_atom)
+		do_offset = FALSE
+
+	test_x_offset = cached_origin_x = T.x
+	test_y_offset = cached_origin_y = T.y
 	old_direction = top_atom.dir
 
 	var/angle = light_angle / 2
@@ -274,26 +273,26 @@
 		if (NORTH)
 			limit_a_t = angle + 90
 			limit_b_t = -(angle) + 90
-			test_x_offset = cached_origin_x
-			test_y_offset = cached_origin_y + 1
+			if (do_offset)
+				test_y_offset += 1
 
 		if (SOUTH)
 			limit_a_t = (angle) - 90
 			limit_b_t = -(angle) - 90
-			test_x_offset = cached_origin_x
-			test_y_offset = cached_origin_y - 1
+			if (do_offset)
+				test_y_offset -= 1
 
 		if (EAST)
 			limit_a_t = angle
 			limit_b_t = -(angle)
-			test_x_offset = cached_origin_x + 1
-			test_y_offset = cached_origin_y
+			if (do_offset)
+				test_x_offset += 1
 
 		if (WEST)
 			limit_a_t = angle + 180
 			limit_b_t = -(angle) - 180
-			test_x_offset = cached_origin_x - 1
-			test_y_offset = cached_origin_y
+			if (do_offset)
+				test_x_offset -= 1
 
 	// Convert our angle + range into a vector.
 	limit_a_x = POLAR_TO_CART_X(light_range + 10, limit_a_t)
@@ -349,9 +348,6 @@
 		Tx = T.x
 		Ty = T.y
 		if (light_angle && check_light_cone(Tx, Ty))
-			continue
-
-		if (!light_self && Tx == cached_origin_x && Ty == cached_origin_y)	// Shouldn't need to check Z.
 			continue
 
 		if (!T.lighting_corners_initialised)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -34,7 +34,10 @@
 	name = "lantern"
 	icon_state = "lantern"
 	desc = "A mining lantern."
-	brightness_on = 6			// luminosity when on
+	brightness_on = 4			// luminosity when on
+	light_power = 0.75
+	light_wedge = LIGHT_OMNI
+	light_color = LIGHT_COLOR_FIRE
 
 /*****************************Pickaxe********************************/
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -13,6 +13,8 @@
 	mob_swap_flags = ROBOT|MONKEY|SLIME|SIMPLE_ANIMAL
 	mob_push_flags = ~HEAVY //trundle trundle
 
+	light_wedge = LIGHT_WIDE
+
 	var/lights_on = 0 // Is our integrated light on?
 	var/used_power_this_tick = 0
 	var/sight_mode = 0


### PR DESCRIPTION
changes:
- Flashlights now default to `LIGHT_WIDE` directional lighting.
- Glowsticks, Lamps, Flares, and Slime Cores use `LIGHT_OMNI`.
- Maglights use `LIGHT_NARROW`.
- Heavy-duty flashlights use `LIGHT_SEMI`.
- EVA suits default to `LIGHT_WIDE`.
- Lanterns use `LIGHT_OMNI`, as well as now having a more appropriate light color.
- Floodlights use `LIGHT_WIDE`, as well as having a more appropriate light color.
- Synthetics default to `LIGHT_WIDE`. (including drones)
- Added some predefined `light_wedge` values to the lighting defines file.
- Fixed some bad angles that screwed up north/south lights in some cases.

![2017-02-24_18-01-59](https://cloud.githubusercontent.com/assets/7097800/23326260/aea6a876-fac1-11e6-9ce0-e66cd3109d52.png)
![2017-02-24_18-46-05](https://cloud.githubusercontent.com/assets/7097800/23326262/b60c827a-fac1-11e6-9754-928ef599b4a5.png)
![2017-02-24_18-47-55](https://cloud.githubusercontent.com/assets/7097800/23326290/c98c88b8-fac1-11e6-8091-89ef825e12ff.png)
![2017-02-24_18-48-18](https://cloud.githubusercontent.com/assets/7097800/23326298/d74777c4-fac1-11e6-8a73-0eb7a4638ec8.png)
![2017-02-24_18-48-55](https://cloud.githubusercontent.com/assets/7097800/23326319/f34c3126-fac1-11e6-944d-00807301ce5e.png)
![2017-02-25_13-08-58](https://cloud.githubusercontent.com/assets/7097800/23334052/a8c5646a-fb5c-11e6-9fef-24cda4800f52.png)
![2017-02-25_12-37-55](https://cloud.githubusercontent.com/assets/7097800/23334054/ab6ab95e-fb5c-11e6-8880-4b078a955029.png)
