### PR TITLE
Directional station lighting

### DIFF
--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -6,6 +6,8 @@
 	var/light_color     // Hexadecimal RGB string representing the colour of the light.
 	var/uv_intensity = 255	// How much UV light is being emitted by this object. Valid range: 0-255.
 	var/light_wedge		// The angle that the light's emission should be restricted to. null for omnidirectional.
+	var/light_wedge_invert = FALSE
+	var/light_allow_self = FALSE
 
 	var/tmp/datum/light_source/light // Our light source. Don't fuck with this directly unless you have a good reason!
 	var/tmp/list/light_sources       // Any light sources that are "inside" of us, for example, if src here was a mob that's carrying a flashlight, that flashlight's light source would be part of this list.

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -151,6 +151,9 @@
 	var/nightmode = FALSE
 	var/brightness_color = LIGHT_COLOR_HALOGEN
 	uv_intensity = 255
+	light_wedge = LIGHT_SEMI
+	light_allow_self = TRUE
+	light_wedge_invert = TRUE
 	var/status = LIGHT_OK		// LIGHT_OK, _EMPTY, _BURNED or _BROKEN
 	var/flickering = 0
 	var/light_type = /obj/item/weapon/light/tube		// the type of light item
@@ -173,6 +176,7 @@
 	desc = "A small lighting fixture."
 	light_type = /obj/item/weapon/light/bulb
 	supports_nightmode = FALSE
+	light_wedge = LIGHT_OMNI
 
 /obj/machinery/light/small/emergency
 	brightness_range = 6


### PR DESCRIPTION
This PR makes all tube lights (not small bulbs) emit 180-degree directional light.
Station areas are still illuminated, although some areas beside bulbs are less well lit. Seems to make the station seem slightly dimmer without changing overall brightness that much.
Increases impact of broken lights around corners - lights are only effective in the direction they're facing.
A few station hallways have small dark spots by their walls, this could be fixed with either further tweaks to directional lights, or by moving some of the tubes.

![2017-02-25_17-19-59](https://cloud.githubusercontent.com/assets/7097800/23335651/620b94b8-fb7f-11e6-9a5a-1109cffaabc8.png)
![2017-02-25_17-19-05](https://cloud.githubusercontent.com/assets/7097800/23335649/5c54050a-fb7f-11e6-9ae7-9b1c1ab04e4e.png)
