### PR TITLE
Ruptured Power Conduit event

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1200,6 +1200,7 @@
 #include "code\modules\events\money_hacker.dm"
 #include "code\modules\events\money_lotto.dm"
 #include "code\modules\events\money_spam.dm"
+#include "code\modules\events\powerconduit.dm"
 #include "code\modules\events\prison_break.dm"
 #include "code\modules\events\radiation_storm.dm"
 #include "code\modules\events\random_antagonist.dm"

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -144,7 +144,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			75,		list(ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_GARDENER = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Clogged Vents",		/datum/event/vent_clog, 		70),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "False Alarm",		/datum/event/false_alarm, 		100),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Supply Drop",		/datum/event/supply_drop, 		80),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Supply Drop",		/datum/event/supply_drop, 		80)
 	)
 
 /datum/event_container/moderate
@@ -166,7 +166,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,	 					50, 	list(ASSIGNMENT_ENGINEER = 7)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		50,	list(ASSIGNMENT_SECURITY = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Viral Infection",			/datum/event/viral_infection, 			0,		list(ASSIGNMENT_MEDICAL = 12), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Major Vermin Infestation",	/datum/event/infestation, 				60,	list(ASSIGNMENT_JANITOR = 15, ASSIGNMENT_SECURITY = 15))
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Major Vermin Infestation",	/datum/event/infestation, 				60,	list(ASSIGNMENT_JANITOR = 15, ASSIGNMENT_SECURITY = 15)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "APC Overload",				/datum/event/powerconduit,				45, 	list(ASSIGNMENT_ENGINEER = 10)),
 
 	)

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -145,7 +145,6 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Clogged Vents",		/datum/event/vent_clog, 		70),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "False Alarm",		/datum/event/false_alarm, 		100),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Supply Drop",		/datum/event/supply_drop, 		80),
-
 	)
 
 /datum/event_container/moderate
@@ -168,6 +167,8 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		50,	list(ASSIGNMENT_SECURITY = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Viral Infection",			/datum/event/viral_infection, 			0,		list(ASSIGNMENT_MEDICAL = 12), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Major Vermin Infestation",	/datum/event/infestation, 				60,	list(ASSIGNMENT_JANITOR = 15, ASSIGNMENT_SECURITY = 15))
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "APC Overload",				/datum/event/powerconduit,				45, 	list(ASSIGNMENT_ENGINEER = 10)),
+
 	)
 
 /datum/event_container/major

--- a/code/modules/events/powerconduit.dm
+++ b/code/modules/events/powerconduit.dm
@@ -1,0 +1,29 @@
+//An event that is totally not a star trek reference.
+//An APC violently explodes, damaging and EMPing the surrounding area.
+//This will likely be harmful but not fatal for anyone nearby
+//The selection of APC is weighted by power throughput. Those supplying a lot of power to machines are more likely to be picked
+/datum/event/powerconduit
+	startWhen	= 1
+	announceWhen = 6
+	ic_name = "ruptured power conduit"
+	var/obj/machinery/power/apc/target
+	var/area/targetloc
+
+/datum/event/powerconduit/announce()
+	command_announcement.Announce("Ruptured power conduit detected in [targetloc]. Please dispatch engineering team to conduct repair.", "Station Powernet Integrity Alert")
+
+/datum/event/powerconduit/start()
+	var/list/apcs = list()
+	for (var/obj/machinery/power/apc/a in world)
+		if (!a.loc || !(a.z in config.station_levels))
+			continue
+
+		if (a.is_critical)
+			continue
+
+		apcs[a] = a.lastused_total
+
+	target = pickweight(apcs)
+	targetloc = get_area(target)
+
+	target.rupture()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1289,19 +1289,20 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 //Very violent failure caused by power overload. Dangerous to nearby personnel
 /obj/machinery/power/apc/proc/rupture()
 	var/turf/T = get_turf(src)
-	for (var/mob/living/L in range(5, src))
-		spark(get_turf(src), 8)
-		spark(get_turf(L), 8)
-		L.visible_message(span("danger","A streak of electricity arcs out from \the [src] and strikes [L]!"))
-		if (electrocute_mob(L, terminal.powernet, terminal))
-			//Electrocute proc does all the accounting for insulation
-			//If the target is successfully electrocuted then they're knocked unconscious for a while
-			spawn(5)
-				L.paralysis = max(100, L.paralysis)
-				L << span("danger", "The world goes black!")
+	for (var/mob/living/L in range(6, src))
+		//Hitting people through walls has a 50% chance to fail
+		if (prob(50) || (L in view(6, src)))
+			Beam(L,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5)
+			L.visible_message(span("danger","A streak of electricity arcs out from \the [src] and strikes [L]!"))
+			if (electrocute_mob(L, terminal.powernet, terminal))
+				//Electrocute proc does all the accounting for insulation
+				//If the target is successfully electrocuted then they're knocked unconscious for a while
+				spawn(5)
+					L.paralysis = max(40, L.paralysis)
+					L << span("danger", "The world goes black!")
 
-	explosion(T, -1, 0, 4, 7)
-	empulse(T, 3,6,1)
+	explosion(T, -1, 0, 3, 7)
+	empulse(T, 0,4,1)
 	log_and_message_admins("Power conduit ruptured at (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)")
 	if (!(stat & BROKEN))
 		set_broken()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1295,7 +1295,7 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 		L.visible_message(span("danger","A streak of electricity arcs out from \the [src] and strikes [L]!"))
 		if (electrocute_mob(L, terminal.powernet, terminal))
 			//Electrocute proc does all the accounting for insulation
-			L.paralysis = max(30, L.paralysis)
+			L.paralysis = max(100, L.paralysis)
 			L << span("danger", "The world goes black!")
 
 	explosion(T, -1, 0, 4, 7)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1279,10 +1279,31 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 	src.visible_message("<span class='notice'>[src]'s screen flickers with warnings briefly!</span>")
 	spawn(rand(2,5))
 		src.visible_message("<span class='notice'>[src]'s screen suddenly explodes in rain of sparks and small debris!</span>")
+		spark(get_turf(src), 8)
 		stat |= BROKEN
 		operating = 0
 		update_icon()
 		update()
+
+
+//Very violent failure caused by power overload. Dangerous to nearby personnel
+/obj/machinery/power/apc/proc/rupture()
+	var/turf/T = get_turf(src)
+	for (var/mob/living/L in range(5, src))
+		spark(get_turf(src), 8)
+		spark(get_turf(L), 8)
+		L.visible_message(span("danger","A streak of electricity arcs out from \the [src] and strikes [L]!"))
+		if (electrocute_mob(L, terminal.powernet, terminal))
+			//Electrocute proc does all the accounting for insulation
+			L.paralysis = max(30, L.paralysis)
+			L << span("danger", "The world goes black!")
+
+	explosion(T, -1, 0, 4, 7)
+	empulse(T, 3,6,1)
+	log_and_message_admins("Power conduit ruptured at (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)")
+	if (!(stat & BROKEN))
+		set_broken()
+
 
 // overload the lights in this APC area
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1295,8 +1295,10 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 		L.visible_message(span("danger","A streak of electricity arcs out from \the [src] and strikes [L]!"))
 		if (electrocute_mob(L, terminal.powernet, terminal))
 			//Electrocute proc does all the accounting for insulation
-			L.paralysis = max(100, L.paralysis)
-			L << span("danger", "The world goes black!")
+			//If the target is successfully electrocuted then they're knocked unconscious for a while
+			spawn(5)
+				L.paralysis = max(100, L.paralysis)
+				L << span("danger", "The world goes black!")
 
 	explosion(T, -1, 0, 4, 7)
 	empulse(T, 3,6,1)

--- a/html/changelogs/Nanako-Conduit.yml
+++ b/html/changelogs/Nanako-Conduit.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added an electrifying new event."


### PR DESCRIPTION
Adds a new, star trek inspired moderate event. An APC on the station overloads and violently explodes, releasing EMP and electrocuting everyone nearby, and knocking unconscious anyone lacking electrical protection. The explosion does not cause breaches unless its near an external window

The selection of APC is weighted by power output, so overtaxing one particular APC makes it far more likely to pop
APCs marked as critical (AI core, engine room, shuttle docks) are excluded

The intention here is to have more ways of stuff breaking for engineering to fix, give them some work in quieter times, and occasionally create an interesting event. 
The overload is very harmful, but not lethal to most mobs around.  Humans will be fine with a little ointment, IPCs will need to be dragged to robotics, but they'll live.

Weighting is set slightly above meteor shower, this is generally less harmful than meteors