### PR TITLE
IPC Lights

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -40,6 +40,8 @@
 	var/virus_immune
 	var/short_sighted
 	var/bald = 0
+	var/light_range
+	var/light_power
 
 	// Language/culture vars.
 	var/default_language = "Ceti Basic"		 // Default language is used when 'say' is used without modifiers.
@@ -438,3 +440,6 @@
 		return 0
 	H.hud_used.move_intent.update_move_icon(H)
 	return 1
+
+/datum/species/proc/get_light_color(hair_style)
+	return

--- a/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
@@ -17,6 +17,9 @@
 	icobase = 'icons/mob/human_races/r_human.dmi'
 	deform = 'icons/mob/human_races/robotic.dmi'
 
+	light_range = 0
+	light_power = 0
+
 	eyes = "eyes_s"
 	show_ssd = "completely quiescent"
 
@@ -48,6 +51,8 @@
 		"r_foot" = list("path" = /obj/item/organ/external/foot/right/shell)
 		)
 
+/datum/species/machine/shell/get_light_color(hair_style)
+	return
 
 /datum/species/machine/shell/handle_post_spawn(var/mob/living/carbon/human/H)
 	add_inherent_verbs(H)
@@ -128,6 +133,9 @@
 
 	sprint_speed_factor = 1.4
 
+/datum/species/machine/industrial/get_light_color(hair_style)
+	return LIGHT_COLOR_TUNGSTEN
+
 /datum/species/machine/industrial/handle_sprint_cost(var/mob/living/carbon/human/H, var/cost)
 	if (H.stat == CONSCIOUS)
 		H.bodytemperature += cost*0.9
@@ -155,6 +163,9 @@
 
 	icobase = 'icons/mob/human_races/r_terminator.dmi'
 	deform = 'icons/mob/human_races/r_terminator.dmi'
+
+	light_range = 0
+	light_power = 0
 
 	unarmed_types = list(/datum/unarmed_attack/terminator)
 	rarity_value = 20
@@ -231,6 +242,8 @@
 	sprint_speed_factor = 1.25
 	slowdown = 1
 
+/datum/species/machine/terminator/get_light_color(hair_style)
+	return
 
 /datum/species/machine/terminator/handle_sprint_cost(var/mob/living/carbon/human/H, var/cost)
 	if (H.stat == CONSCIOUS)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -355,6 +355,9 @@
 	icobase = 'icons/mob/human_races/r_machine.dmi'
 	deform = 'icons/mob/human_races/r_machine.dmi'
 
+	light_range = 2
+	light_power = 0.75
+
 	unarmed_types = list(/datum/unarmed_attack/punch)
 	rarity_value = 2
 
@@ -502,6 +505,59 @@ datum/species/machine/handle_post_spawn(var/mob/living/carbon/human/H)
 			query_details[":status"] = status
 			var/DBQuery/update_query = dbcon.NewQuery("UPDATE ss13_ipc_tracking SET tag_status = :status WHERE player_ckey = :ckey AND character_name = :character_name")
 			update_query.Execute(query_details)
+
+/datum/species/machine/get_light_color(hair_style)
+	// I hate this, but I can't think of a better way that doesn't involve
+	// rewriting hair.
+	var/reg = regex("(.+)\bIPC screen")
+	
+	if (!reg.Find(hair_style))
+		return
+	switch (reg.group[1])
+		if ("pink")
+			return LIGHT_COLOR_PINK
+
+		if ("red")
+			return LIGHT_COLOR_RED
+
+		if ("green")
+			return LIGHT_COLOR_GREEN
+
+		if ("blue")
+			return LIGHT_COLOR_BLUE
+
+		if ("breakout")
+			return LIGHT_COLOR_CYAN
+
+		if ("eight")
+			return LIGHT_COLOR_CYAN
+
+		if ("goggles")
+			return LIGHT_COLOR_RED
+
+		if ("heart")
+			return LIGHT_COLOR_PINK
+
+		if ("monoeye")
+			return LIGHT_COLOR_ORANGE
+
+		if ("nature")
+			return LIGHT_COLOR_CYAN
+
+		if ("orange")
+			return LIGHT_COLOR_ORANGE
+
+		if ("purple")
+			return LIGHT_COLOR_PURPLE
+
+		if ("shower")
+			return "#FFFFFF"
+
+		if ("static")
+			return "#FFFFFF"
+
+		if ("yellow")
+			return LIGHT_COLOR_YELLOW
 
 /datum/species/bug
 	name = "Vaurca Worker"

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -356,7 +356,7 @@
 	deform = 'icons/mob/human_races/r_machine.dmi'
 
 	light_range = 2
-	light_power = 0.25
+	light_power = 0.5
 
 	unarmed_types = list(/datum/unarmed_attack/punch)
 	rarity_value = 2

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -356,7 +356,7 @@
 	deform = 'icons/mob/human_races/r_machine.dmi'
 
 	light_range = 2
-	light_power = 0.75
+	light_power = 0.25
 
 	unarmed_types = list(/datum/unarmed_attack/punch)
 	rarity_value = 2

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -509,54 +509,50 @@ datum/species/machine/handle_post_spawn(var/mob/living/carbon/human/H)
 /datum/species/machine/get_light_color(hair_style)
 	// I hate this, but I can't think of a better way that doesn't involve
 	// rewriting hair.
-	var/reg = regex("(.+)\bIPC screen")
-	
-	if (!reg.Find(hair_style))
-		return
-	switch (reg.group[1])
-		if ("pink")
+	switch (hair_style)
+		if ("pink IPC screen")
 			return LIGHT_COLOR_PINK
 
-		if ("red")
+		if ("red IPC screen")
 			return LIGHT_COLOR_RED
 
-		if ("green")
+		if ("green IPC screen")
 			return LIGHT_COLOR_GREEN
 
-		if ("blue")
+		if ("blue IPC screen")
 			return LIGHT_COLOR_BLUE
 
-		if ("breakout")
+		if ("breakout IPC screen")
 			return LIGHT_COLOR_CYAN
 
-		if ("eight")
+		if ("eight IPC screen")
 			return LIGHT_COLOR_CYAN
 
-		if ("goggles")
+		if ("goggles IPC screen")
 			return LIGHT_COLOR_RED
 
-		if ("heart")
+		if ("heart IPC screen")
 			return LIGHT_COLOR_PINK
 
-		if ("monoeye")
+		if ("monoeye IPC screen")
 			return LIGHT_COLOR_ORANGE
 
-		if ("nature")
+		if ("nature IPC screen")
 			return LIGHT_COLOR_CYAN
 
-		if ("orange")
+		if ("orange IPC screen")
 			return LIGHT_COLOR_ORANGE
 
-		if ("purple")
+		if ("purple IPC screen")
 			return LIGHT_COLOR_PURPLE
 
-		if ("shower")
+		if ("shower IPC screen")
 			return "#FFFFFF"
 
-		if ("static")
+		if ("static IPC screen")
 			return "#FFFFFF"
 
-		if ("yellow")
+		if ("yellow IPC screen")
 			return LIGHT_COLOR_YELLOW
 
 /datum/species/bug

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -394,7 +394,10 @@ var/global/list/damage_icon_parts = list()
 				if (!col)
 					col = "#FFFFFF"
 					
-				set_light(species.light_range, species.light_power, col, uv = 0, angle = LIGHT_WIDE)		
+				set_light(species.light_range, species.light_power, col, uv = 0, angle = LIGHT_WIDE)
+				
+	else if (species.light_range)
+		set_light(FALSE)	
 		
 	overlays_standing[HAIR_LAYER]	= image(face_standing)
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -389,12 +389,12 @@ var/global/list/damage_icon_parts = list()
 
 			face_standing.Blend(hair_s, ICON_OVERLAY)
 
-	if (h_style && species && species.light_range)
-		var/col = species.get_light_color(h_style)
-		if (!col)
-			col = "#FFFFFF"
-			
-		set_light(species.light_range, species.light_power, col, uv = 0, angle = LIGHT_WIDE)
+			if (species.light_range)
+				var/col = species.get_light_color(h_style)
+				if (!col)
+					col = "#FFFFFF"
+					
+				set_light(species.light_range, species.light_power, col, uv = 0, angle = LIGHT_WIDE)		
 		
 	overlays_standing[HAIR_LAYER]	= image(face_standing)
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -389,6 +389,13 @@ var/global/list/damage_icon_parts = list()
 
 			face_standing.Blend(hair_s, ICON_OVERLAY)
 
+	if (h_style && species && species.light_range)
+		var/col = species.get_light_color(h_style)
+		if (!col)
+			col = "#FFFFFF"
+			
+		set_light(species.light_range, species.light_power, col, uv = 0, angle = LIGHT_WIDE)
+		
 	overlays_standing[HAIR_LAYER]	= image(face_standing)
 
 	if(update_icons)   update_icons()

--- a/html/changelogs/lohikar-ipc-lights.yml
+++ b/html/changelogs/lohikar-ipc-lights.yml
@@ -1,4 +1,4 @@
 author: Lohikar
 delete-after: True
 changes: 
-  - rscadd: "IPCs now emit a tiny bit of light, colored according to their type and screen color. (shells exempt)"
+  - rscadd: "IPCs (not including shells) now emit a small amount of light, colored according to their type and screen color."

--- a/html/changelogs/lohikar-ipc-lights.yml
+++ b/html/changelogs/lohikar-ipc-lights.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - rscadd: "IPCs now emit a tiny bit of light, colored according to their type and screen color. (shells exempt)"


### PR DESCRIPTION
changes:
- IPCs now emit a weak light based on the color of their screen.

The system for making species emit light is modular, and Shells+HKs have been excluded from light emission.

![2017-02-26_23-14-42 sbook](https://cloud.githubusercontent.com/assets/7097800/23349491/5fe66ba4-fc79-11e6-84d1-5104d4c4a738.png)
![2017-02-26_23-14-34 sbook](https://cloud.githubusercontent.com/assets/7097800/23349492/61e0ea88-fc79-11e6-9fbe-05136f334a9d.png)
