### PR TITLE
Remove holder access

### DIFF
--- a/code/controllers/Processes/scheduler.dm
+++ b/code/controllers/Processes/scheduler.dm
@@ -15,9 +15,9 @@
 /datum/controller/process/scheduler/doWork()
 	while (head && !PSCHED_CHECK_TICK)
 		if (head.destroyed)
+			head.kill()
 			head = head.next
 			tasks -= head
-			head.kill()
 			continue
 		if (head.trigger_time >= world.time)
 			return	// Nothing after this will be ready to fire.

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -36,22 +36,9 @@ var/list/holder_mob_icon_cache = list()
 	if (contained)
 		contained.examine(user)
 
-
-/obj/item/weapon/holder/GetID()
-	for(var/mob/M in contents)
-		var/obj/item/I = M.GetIdCard()
-		if(I)
-			return I
-	return null
-
-/obj/item/weapon/holder/GetAccess()
-	var/obj/item/I = GetID()
-	return I ? I.GetAccess() : ..()
-
 /obj/item/weapon/holder/attack_self()
 	for(var/mob/M in contents)
 		M.show_inv(usr)
-
 
 //Mob specific holders.
 /obj/item/weapon/holder/diona

--- a/html/changelogs/lohikar-PR-1906.yml
+++ b/html/changelogs/lohikar-PR-1906.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - rscdel: "Held mobs such as maintenance drones no longer act as ID cards."


### PR DESCRIPTION
changes:
- Mob holders no longer grant that mob's access.
- Fix bug where wrong task was killed on invalid head in scheduler.

Fixes #1785.