### PR TITLE
Abstract machinery, intercom listener, and directional hardhat lights

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -466,6 +466,8 @@
 #include "code\game\machinery\wall_frames.dm"
 #include "code\game\machinery\washing_machine.dm"
 #include "code\game\machinery\wishgranter.dm"
+#include "code\game\machinery\abstract\abstract.dm"
+#include "code\game\machinery\abstract\intercom_listener.dm"
 #include "code\game\machinery\atmoalter\area_atmos_computer.dm"
 #include "code\game\machinery\atmoalter\canister.dm"
 #include "code\game\machinery\atmoalter\meter.dm"

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -286,6 +286,7 @@
 
 #define get_turf(A) (get_step(A, 0))
 #define QDELETED(TARGET) (!TARGET || TARGET.gcDestroyed)
+#define QDEL_NULL(thing) qdel(thing); thing = null
 
 //Recipe type defines. Used to determine what machine makes them
 #define MICROWAVE			0x1

--- a/code/game/machinery/abstract/abstract.dm
+++ b/code/game/machinery/abstract/abstract.dm
@@ -1,0 +1,48 @@
+/*
+	- Abstract machinery -
+	
+	Pretty much designed for whenever you want something that is not a machine to interact with the power grid.
+	Better to use one of these to be notified of power changes than poll with process().
+	
+*/
+
+/obj/machinery/abstract
+	name = "impossible device"
+	desc = "No matter how hard you look at it, you have no idea what it is. (please inform coders if you see this)"
+	simulated = FALSE
+	anchored = 1
+	var/should_process = FALSE
+	mouse_opacity = 0
+	invisibility = INVISIBILITY_ABSTRACT
+	
+/obj/machinery/abstract/attack_ai(mob/user as mob)
+	return
+
+/obj/machinery/abstract/attack_hand(mob/user as mob)
+	return
+
+/obj/machinery/abstract/emp_act(severity)
+	return		// No EMPing these.
+
+/obj/machinery/abstract/ex_act(severity)
+	return
+
+/obj/machinery/abstract/tesla_act()
+	return
+
+/obj/machinery/abstract/singularity_act()
+	return
+
+/obj/machinery/abstract/singularity_pull()
+	return
+
+/obj/machinery/abstract/singuloCanEat()
+	return FALSE
+
+/obj/machinery/abstract/operable(additional_flags = 0)
+	return TRUE
+
+/obj/machinery/abstract/get_process_type()
+	. = ..()
+	if (!should_process)
+		. &= ~M_PROCESSES

--- a/code/game/machinery/abstract/abstract.dm
+++ b/code/game/machinery/abstract/abstract.dm
@@ -13,7 +13,6 @@
 	anchored = 1
 	var/should_process = FALSE
 	mouse_opacity = 0
-	invisibility = INVISIBILITY_ABSTRACT
 	
 /obj/machinery/abstract/attack_ai(mob/user as mob)
 	return

--- a/code/game/machinery/abstract/intercom_listener.dm
+++ b/code/game/machinery/abstract/intercom_listener.dm
@@ -1,0 +1,25 @@
+/obj/machinery/abstract/intercom_listener
+	name = "intercom power interface"
+	desc = "You shouldn't see this."
+	power_channel = EQUIP
+
+	var/obj/item/device/radio/intercom/master
+
+/obj/machinery/abstract/intercom_listener/New(atom/loc, obj/item/device/radio/intercom/owner)
+	if (QDELETED(owner))
+		warning("intercom_listener created with QDELETED intercom!")
+		qdel(src)
+	else
+		master = owner
+
+/obj/machinery/abstract/intercom_listener/Destroy()
+	master = null
+	return ..()
+
+/obj/machinery/abstract/intercom_listener/power_change()
+	if (master)
+		var/state = powered(power_channel)
+		master.power_change(state)
+	else
+		warning("intercom_listener got power_change but has no master!")
+		qdel(src)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -7,7 +7,7 @@
 	canhear_range = 2
 	flags = CONDUCT | NOBLOODY
 	var/number = 0
-	var/last_tick //used to delay the powercheck
+	var/obj/machinery/abstract/intercom_listener/power_interface
 
 /obj/item/device/radio/intercom/custom
 	name = "station intercom (Custom)"
@@ -46,7 +46,7 @@
 
 /obj/item/device/radio/intercom/New()
 	..()
-	processing_objects += src
+	power_interface = new(loc, src)
 
 /obj/item/device/radio/intercom/department/medbay/New()
 	..()
@@ -78,8 +78,8 @@
 	internal_channels[num2text(SYND_FREQ)] = list(access_syndicate)
 
 /obj/item/device/radio/intercom/Destroy()
-	processing_objects -= src
-	..()
+	QDEL_NULL(power_interface)
+	return ..()
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)
@@ -106,23 +106,23 @@
 
 	return canhear_range
 
-/obj/item/device/radio/intercom/process()
-	if(((world.timeofday - last_tick) > 30) || ((world.timeofday - last_tick) < 0))
-		last_tick = world.timeofday
+/obj/item/device/radio/intercom/proc/power_change(has_power)
+	if (!src.loc)
+		on = 0
+	else
+		on = has_power
 
-		if(!src.loc)
-			on = 0
-		else
-			var/area/A = get_area(src)
-			if(!A)
-				on = 0
-			else
-				on = A.powered(EQUIP) // set "on" to the power status
+	update_icon()
 
-		if(!on)
-			icon_state = "intercom-p"
-		else
-			icon_state = "intercom"
+/obj/item/device/radio/intercom/forceMove(atom/dest)
+	power_interface.forceMove(dest)
+	..(dest)
+
+/obj/item/device/radio/intercom/update_icon()
+	if (on)
+		icon_state = "intercom"
+	else
+		icon_state = "intercom-p"
 
 /obj/item/device/radio/intercom/broadcasting
 	broadcasting = 1

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -71,7 +71,7 @@
 	item_state = "candlebox5"
 	throwforce = 2
 	slot_flags = SLOT_BELT
-
+	max_storage_space = 5
 
 /obj/item/weapon/storage/fancy/candle_box/New()
 	..()

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -8,6 +8,7 @@
 	armor = list(melee = 30, bullet = 5, laser = 20,energy = 10, bomb = 20, bio = 10, rad = 20)
 	flags_inv = 0
 	siemens_coefficient = 0.9
+	light_wedge = LIGHT_WIDE
 
 /obj/item/clothing/head/hardhat/orange
 	icon_state = "hardhat0_orange"


### PR DESCRIPTION
changes:
- Added an abstract-machinery helper type for interacting with power systems without duplicating power code.
- Changed intercoms to use abstract machines to handle power state changes instead of polling with `process()`.
- Hardhat lights are now directional (`LIGHT_WIDE`)
- Fixes #1922.