### PR TITLE
Implement new voting restrictions into config

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -196,10 +196,12 @@ datum/controller/vote
 		if(mode)
 			if(config.vote_no_dead && usr && !usr.client.holder)
 				if (isnewplayer(usr))
+					usr << "<span class='warning'>You must be playing or have been playing to start a vote.</span>"
 					return 0
 				else if (isobserver(usr))
 					var/mob/dead/observer/O = usr
 					if (O.started_as_observer)
+						usr << "<span class='warning'>You must be playing or have been playing to start a vote.</span>"
 						return 0
 			if(vote && vote >= 1 && vote <= choices.len)
 				if(current_votes[ckey])
@@ -216,6 +218,16 @@ datum/controller/vote
 				// Transfer votes are their own little special snowflake
 				var/next_allowed_time = 0
 				if (vote_type == "crew_transfer")
+					if (config.vote_no_dead && !usr.client.holder)
+						if (isnewplayer(usr))
+							usr << "<span class='warning'>You must be playing or have been playing to start a vote.</span>"
+							return 0
+						else if (isobserver(usr))
+							var/mob/dead/observer/O = usr
+							if (O.started_as_observer())
+								usr << "<span class='warning'>You must be playing or have been playing to start a vote.</span>"
+								return 0
+
 					if (last_transfer_vote)
 						next_allowed_time = (last_transfer_vote + config.vote_delay)
 					else

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -224,7 +224,7 @@ datum/controller/vote
 							return 0
 						else if (isobserver(usr))
 							var/mob/dead/observer/O = usr
-							if (O.started_as_observer())
+							if (O.started_as_observer)
 								usr << "<span class='warning'>You must be playing or have been playing to start a vote.</span>"
 								return 0
 

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -194,8 +194,13 @@ datum/controller/vote
 
 	proc/submit_vote(var/ckey, var/vote)
 		if(mode)
-			if(config.vote_no_dead && usr.stat == DEAD && !usr.client.holder)
-				return 0
+			if(config.vote_no_dead && usr && !usr.client.holder)
+				if (isnewplayer(usr))
+					return 0
+				else if (isobserver(usr))
+					var/mob/dead/observer/O = usr
+					if (O.started_as_observer)
+						return 0
 			if(vote && vote >= 1 && vote <= choices.len)
 				if(current_votes[ckey])
 					choices[choices[current_votes[ckey]]]--

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -162,7 +162,8 @@ VOTE_AUTOGAMEMODE_TIMELEFT 100
 ## min delay (deciseconds) before a transfer vote can be called (default 120 minutes)
 TRANSFER_TIMEOUT 72000
 
-## prevents dead players from voting or starting votes
+## Prevets lobby-sitters and ghosts who went straight from the lobby to observing from voting.
+## Ghosts who died will still be able to vote.
 #NO_DEAD_VOTE
 
 ## players' votes default to "No vote" (otherwise,  default to "No change")

--- a/html/changelogs/skul1l32-voting.yml
+++ b/html/changelogs/skul1l32-voting.yml
@@ -1,0 +1,6 @@
+author: Skull132
+
+delete-after: True
+
+changes:
+  - tweak: "Modified the voting limitation system to only prohibit voting for lobby sitters and ghosts who went straight from the lobby to observing."


### PR DESCRIPTION
As per the discussion. If NO_DEAD_VOTE is enabled, only new_player mobs and observers who went from the lobby to observing are barred from voting.