### PR TITLE
Malf APC Tweaks

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -164,7 +164,9 @@
 		if(!(A.z in config.station_levels)) 		// Only station APCs
 			continue
 		if(A.hacker == user || A.aidisabled) 		// This one is already hacked, or AI control is disabled on it.
+			A.update_icon()
 			continue
+
 		remaining_apcs += A
 
 	var/duration = (remaining_apcs.len * 100)		// Calculates duration for announcing system

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -120,8 +120,7 @@
 	var/global/list/status_overlays_environ
 
 	var/datum/effect_system/sparks/spark_system
-
-	var/datum/effect_system/sparks/spark_system
+	
 	var/list/debuggers = list()		// soft-refs to debuggers that have completed the debug step on a hacked APC.
 	var/static/list/hackmsgs = list(	// Fluff messages for successful debugs.
 		"Core system fault detected.",

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -121,6 +121,16 @@
 
 	var/datum/effect_system/sparks/spark_system
 
+	var/datum/effect_system/sparks/spark_system
+	var/list/debuggers = list()		// soft-refs to debuggers that have completed the debug step on a hacked APC.
+	var/static/list/hackmsgs = list(	// Fluff messages for successful debugs.
+		"Core system fault detected.",
+		"Unable to interface with diagnostics module.",
+		"Corruption detected in APC filesystem tree.",
+		"Control interface corruption detected.",
+		"Software fault detected."
+	)
+
 /obj/machinery/power/apc/updateDialog()
 	if (stat & (BROKEN|MAINT))
 		return
@@ -373,7 +383,7 @@
 			update_state |= UPDATE_OPENED1
 		if(opened==2)
 			update_state |= UPDATE_OPENED2
-	else if(emagged || hacker || failure_timer)
+	else if(emagged || (hacker && hacker.system_override) || failure_timer)
 		update_state |= UPDATE_BLUESCREEN
 	else if(wiresexposed)
 		update_state |= UPDATE_WIREEXP
@@ -656,6 +666,40 @@
 			if (opened==2)
 				opened = 1
 			update_icon()
+	else if (istype(W, /obj/item/device/multitool) && !stat)
+		var/prev_diag = ("\ref[W]" in debuggers)
+		if (prev_diag)
+			user << span("notice", "You start to perform a factory reset on the APC...")
+			if (do_after(user, 20 SECONDS, act_target = src))
+				if (prob(20))
+					user << span("alert", "Error: Connection timed out.")
+					return
+
+				update_icon()
+				src.ping("\The [src] beeps, \"Settings restored to factory defaults.\"")
+				hacker << span("alert", "APC reset detected: [src]")
+
+				hacker.hacked_apcs -= src
+				hacker = null
+				debuggers.Cut()
+				return
+			else
+				user << span("alert", "Error: APC connection lost!")
+				return
+
+		else
+			user << span("notice", "You begin to run diagnostics on the APC...")
+			if (do_after(user, 10 SECONDS, act_target = src))
+				if (!hacker)
+					user << span("notice", "No fault detected.")
+					return
+
+				user << span("notice", "Diagnostics complete!")
+				user << span("alert", pick(hackmsgs))
+				user << span("alert", "Recommend factory reset.")
+				debuggers += "\ref[W]"
+			else
+				user << span("alert", "Error: APC connection lost!")
 	else
 		if ((stat & BROKEN) \
 				&& !opened \


### PR DESCRIPTION
changes:
- APCs no longer turn blue when hacked by a malfunctioning AI.
- Multitools can be used to 'diagnose' and reset hacked APCs.
- On system override, all hacked APCs will bluescreen.

APC reset has two steps: diagnosis, and reset.
- Diagnosis must be completed before reset, and takes 10 seconds. Can be run on non-hacked APCs to get fluff text.  An APC's diagnosis status is per-multitool, and is reset on APC replacement or reset.
- Reset takes 20 seconds and has a 20% chance to fail after that time, although it can be repeated without re-debugging as long as you use the same multitool.

Associated thread: https://forums.aurorastation.org/viewtopic.php?f=18&t=7845