### PR TITLE
Lighting fixes

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -261,6 +261,6 @@ for reference:
 	else if (src.emagged == 1)
 		src.emagged = 2
 		user << "You short out the anchoring mechanism on \the [src]."
-		spark(src, 2, 1)
+		spark(src, 2, alldirs)
 		visible_message("<span class='warning'>BZZzZZzZZzZT</span>")
 		return 1

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -126,7 +126,7 @@
 
 
 	flick("migniter-spark", src)
-	spark(src, 2, 1)
+	spark(src, 2, alldirs)
 	src.last_spark = world.time
 	use_power(1000)
 	var/turf/location = src.loc

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -77,6 +77,7 @@
 		W.levelupdate()
 		. =  W
 
+	recalc_atom_opacity()
 	lighting_overlay = old_lighting_overlay
 	affecting_lights = old_affecting_lights
 	corners = old_corners

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -17,7 +17,7 @@
 	transform = matrix(WORLD_ICON_SIZE / 32, 0, (WORLD_ICON_SIZE - 32) / 2, 0, WORLD_ICON_SIZE / 32, (WORLD_ICON_SIZE - 32) / 2)
 	#endif
 
-/atom/movable/lighting_overlay/New(var/atom/loc, var/no_update = FALSE)
+/atom/movable/lighting_overlay/New(atom/loc, no_update = FALSE)
 	. = ..()
 	verbs.Cut()
 	global.all_lighting_overlays += src
@@ -47,18 +47,18 @@
 	var/turf/T = loc
 	if (!istype(T)) // Erm...
 		if (loc)
-			warning("A lighting overlay realised its loc was NOT a turf (actual loc: [loc], [loc.type]) in update_overlay() and got pooled!")
+			warning("A lighting overlay realised its loc was NOT a turf (actual loc: [loc], [loc.type]) in update_overlay() and got deleted!")
 
 		else
-			warning("A lighting overlay realised it was in nullspace in update_overlay() and got pooled!")
+			warning("A lighting overlay realised it was in nullspace in update_overlay() and got deleted!")
 
-		returnToPool(src)
+		qdel(src)
 		return
 
 	if (istype(T, /turf/space))
 		// I mean, this happens often and doesn't do any harm. Might as well silence the warning.
 		//warning("A lighting overlay realised it was attached to a space tile and got pooled!")
-		returnToPool(src)
+		qdel(src)
 		return
 
 	// To the future coder who sees this and thinks
@@ -102,7 +102,7 @@
 	return FALSE
 
 // Override here to prevent things accidentally moving around overlays.
-/atom/movable/lighting_overlay/forceMove(atom/destination, var/no_tp=FALSE, var/harderforce = FALSE)
+/atom/movable/lighting_overlay/forceMove(atom/destination, no_tp = FALSE, harderforce = FALSE)
 	if(harderforce)
 		L_PROF(loc, "overlay_forcemove")
 		. = ..()

--- a/code/modules/lighting/lighting_setup.dm
+++ b/code/modules/lighting/lighting_setup.dm
@@ -13,12 +13,12 @@
 
 // This repeats a bit of code from the lighting process.
 /proc/initialize_lighting()
-	admin_notice(span("danger", "Generating lighting overlays (1/4)..."))
+	admin_notice(span("danger", "Generating lighting overlays (1/4)..."), R_DEBUG)
 	for (var/zlevel = 1 to world.maxz)
 		create_lighting_overlays_zlevel(zlevel)
 		CHECK_TICK
 
-	admin_notice(span("danger", "Initializing light sources (2/4)..."))
+	admin_notice(span("danger", "Initializing light sources (2/4)..."), R_DEBUG)
 	var/num_lights = 0
 	var/list/lights = lighting_update_lights
 	lighting_update_lights = list()
@@ -43,9 +43,9 @@
 		num_lights++
 		CHECK_TICK
 
-	admin_notice(span("danger", "Processed [num_lights] light sources."))
+	admin_notice(span("danger", "Processed [num_lights] light sources."), R_DEBUG)
 
-	admin_notice(span("danger", "Initializing lighting corners (3/4)..."))
+	admin_notice(span("danger", "Initializing lighting corners (3/4)..."), R_DEBUG)
 	var/num_corners = 0
 	var/list/corners = lighting_update_corners
 	lighting_update_corners = list()
@@ -63,8 +63,8 @@
 
 		CHECK_TICK
 
-	admin_notice(span("danger", "Processed [num_corners] light corners."))
-	admin_notice(span("danger", "Initializing lighting overlays (4/4)..."))
+	admin_notice(span("danger", "Processed [num_corners] light corners."), R_DEBUG)
+	admin_notice(span("danger", "Initializing lighting overlays (4/4)..."), R_DEBUG)
 	var/num_overlays = 0
 	var/list/overlays = lighting_update_overlays
 	lighting_update_overlays = list()
@@ -81,4 +81,4 @@
 		num_overlays++
 		CHECK_TICK
 
-	admin_notice(span("danger", "Processed [num_overlays] light overlays."))
+	admin_notice(span("danger", "Processed [num_overlays] light overlays."), R_DEBUG)

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -39,10 +39,10 @@
 
 	var/area/A = loc
 	if (A.dynamic_lighting && dynamic_lighting)
-		if (!lighting_corners_initialised)
+		if (!lighting_corners_initialised || !corners)
 			generate_missing_corners()
 
-		getFromPool(/atom/movable/lighting_overlay, src)
+		new /atom/movable/lighting_overlay(src)
 
 		for (var/datum/lighting_corner/C in corners)
 			if (!C.active) // We would activate the corner, calculate the lighting for it.
@@ -55,7 +55,7 @@
 #define SCALE(targ,min,max) (targ - min) / (max - min)
 
 // Used to get a scaled lumcount.
-/turf/proc/get_lumcount(var/minlum = 0, var/maxlum = 1)
+/turf/proc/get_lumcount(minlum = 0, maxlum = 1)
 	if (!lighting_overlay)
 		return 0.5
 
@@ -70,7 +70,7 @@
 	return CLAMP01(totallums)
 
 // Gets the current UV illumination of the turf. Always 100% for space & other static-lit tiles.
-/turf/proc/get_uv_lumcount(var/minlum = 0, var/maxlum = 1)
+/turf/proc/get_uv_lumcount(minlum = 0, maxlum = 1)
 	if (!lighting_overlay)
 		return 1
 
@@ -97,21 +97,21 @@
 			return 	// No need to continue if we find something opaque.
 
 // If an opaque movable atom moves around we need to potentially update visibility.
-/turf/Entered(var/atom/movable/Obj, var/atom/OldLoc)
+/turf/Entered(atom/movable/Obj, atom/OldLoc)
 	. = ..()
 
 	if (Obj && Obj.opacity)
 		has_opaque_atom = TRUE // Make sure to do this before reconsider_lights(), incase we're on instant updates. Guaranteed to be on in this case.
 		reconsider_lights()
 
-/turf/Exited(var/atom/movable/Obj, var/atom/newloc)
+/turf/Exited(atom/movable/Obj, atom/newloc)
 	. = ..()
 
 	if (Obj && Obj.opacity)
 		recalc_atom_opacity() // Make sure to do this before reconsider_lights(), incase we're on instant updates.
 		reconsider_lights()
 
-/turf/change_area(var/area/old_area, var/area/new_area)
+/turf/change_area(area/old_area, area/new_area)
 	if (new_area.dynamic_lighting != old_area.dynamic_lighting)
 		if (new_area.dynamic_lighting)
 			lighting_build_overlay()


### PR DESCRIPTION
Changes:
- Fixes #1949.
- Removes some pooling in favor of new-qdel.
- Lighting startup spam is now correctly sent to `R_DEBUG`.
- Fixes some spark runtimes.