### PR TITLE
Cooking and Reagent Fixes

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -121,9 +121,10 @@
 //Cookers do differently, they use containers
 /obj/machinery/appliance/cooker/has_space(var/obj/item/I)
 
-	if (istype(I, /obj/item/weapon/reagent_containers/cooking_container) && cooking_objs.len < max_contents)
+	if (istype(I, /obj/item/weapon/reagent_containers/cooking_container))
 		//Containers can go into an empty slot
-		return 1
+		if (cooking_objs.len < max_contents)
+			return 1
 
 	else
 
@@ -137,6 +138,6 @@
 
 /obj/machinery/appliance/cooker/add_content(var/obj/item/I, var/mob/user)
 	var/datum/cooking_item/CI = ..()
-	if (CI.combine_target)
+	if (CI && CI.combine_target)
 		user << "The [I] will be used to make a [selected_option]. Output selection is returned to default for future items."
 		selected_option = null

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -312,6 +312,9 @@
 			var/atom/movable/R = r
 			R.loc = src //Move everything from the buffer back to the container
 
+		qdel(temp)//Delete buffer object
+		temp = null
+
 		//Any leftover reagents are divided amongst the foods
 		var/total = reagents.total_volume
 		for (var/obj/item/weapon/reagent_containers/food/snacks/S in cooked_items)
@@ -322,6 +325,7 @@
 
 		dispose(0) //clear out anything left
 		stop()
+
 		return
 
 /obj/machinery/microwave/proc/wzhzhzh(var/seconds as num) // Whoever named this proc is fucking literally Satan. ~ Z

--- a/code/modules/food/recipe.dm
+++ b/code/modules/food/recipe.dm
@@ -69,6 +69,10 @@
 /datum/recipe/proc/check_reagents(var/datum/reagents/avail_reagents)
 	if (!reagents || !reagents.len)
 		return 1
+
+	if (!avail_reagents)
+		return 0
+
 	. = 1
 	for (var/r_r in reagents)
 		var/aval_r_amnt = avail_reagents.get_reagent_amount(r_r)

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -28,6 +28,7 @@ var/list/holder_mob_icon_cache = list()
 	processing_objects.Add(src)
 
 /obj/item/weapon/holder/Destroy()
+	reagents = null
 	processing_objects.Remove(src)
 	if (contained)
 		release_mob()
@@ -123,6 +124,8 @@ var/list/holder_mob_icon_cache = list()
 		M.forceMove(T) //if the holder was placed into a disposal, this should place the animal in the disposal
 		M.reset_view()
 		M.Released()
+
+	contained = null
 
 	qdel(src)
 

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -26,6 +26,7 @@
 
 	if (!isnull(cooked_icon))
 		icon_state = cooked_icon
+		flat_icon = null //Force regenating the flat icon for coatings, since we've changed the icon of the thing being coated
 	..()
 
 	if (name == initial(name))


### PR DESCRIPTION
Went searching for the cause of the reagent runtime issues. I don't think i found it yet, but i found and fixed a couple things that could be causing it.

Most notable is an egregious bug that caused animals' reagent holder to be nulled after they're dropped from a holder.
Also adds a little safety check to recipes which may fix it.


Fixes two cooking bugs as well. One that was allowing extra containers to be inserted into an already-full oven (they nested inside other containers, it was messy) and a tiny issue with batter overlays being incorrect on cooked meats.