### PR TITLE
Vendor Exploit Fix

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -181,6 +181,13 @@
 		var/paid = 0
 		var/handled = 0
 
+		if (currently_vending.amount < 1)
+			visible_message(span("warning","\The [src] buzzes and flashes a message on its LCD: <b>\"Out of stock.\"</b>"))
+			src.status_error = 1
+			playsound(src.loc, 'sound/machines/buzz-two.ogg', 35, 1)
+			currently_vending = null
+			return
+
 		if (I) //for IDs and PDAs and wallets with IDs
 			paid = pay_with_card(I,W)
 			handled = 1
@@ -321,6 +328,10 @@
 		visible_message("<span class='info'>\The [usr] swipes \the [ID_container] through \the [src].</span>")
 	var/datum/money_account/customer_account = get_account(I.associated_account_number)
 	if (!customer_account)
+		//Allow BSTs to take stuff from vendors, for debugging and adminbus purposes
+		if (I.assignment == "Bluespace Technician")
+			return 1
+
 		src.status_message = "Error: Unable to access account. Please contact technical support if problem persists."
 		src.status_error = 1
 		return 0

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -329,7 +329,7 @@
 	var/datum/money_account/customer_account = get_account(I.associated_account_number)
 	if (!customer_account)
 		//Allow BSTs to take stuff from vendors, for debugging and adminbus purposes
-		if (I.assignment == "Bluespace Technician")
+		if (istype(I, /obj/item/weapon/card/id/bst))
 			return 1
 
 		src.status_message = "Error: Unable to access account. Please contact technical support if problem persists."
@@ -518,6 +518,9 @@
 		nanomanager.update_uis(src)
 
 /obj/machinery/vending/proc/vend(datum/data/vending_product/R, mob/user)
+	if (!R || R.amount < 1)
+		return
+
 	if((!allowed(usr)) && !emagged && scan_id)	//For SECURE VENDING MACHINES YEAH
 		usr << "<span class='warning'>Access denied.</span>"	//Unless emagged of course
 		flick(src.icon_deny,src)
@@ -526,6 +529,8 @@
 	src.status_message = "Vending..."
 	src.status_error = 0
 	nanomanager.update_uis(src)
+
+
 
 	if (R.category & CAT_COIN)
 		if(!coin)

--- a/html/changelogs/Nanako-Vendorfix.yml
+++ b/html/changelogs/Nanako-Vendorfix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed an exploit that allowed duplicating items in vendors and buying more than the vendor has."


### PR DESCRIPTION
Fixes a pretty severe exploit where spambuying from a vendor allows you to purchase a larger quantity than the vendor has. Coupled with the ability to add things, this is basically infinite item duplication. How did we not notice this before now?

I kept the spam buying, because it's pretty nifty, but added a safety check to ensure there's one remaining to buy


In addition, adds a little exception that allows bluespace technicians to take free stuff from vendors. Largely for debugging. I'm sick of having to spawn as a crewmember to do anything vendor related, this will save a bit of development time in the long run.