### PR TITLE
Bugfixes: Fax machines (again), crew record formatting, RnD machines and wallets

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -59,6 +59,9 @@
 			if("id")
 				icon_state = "walletid"
 				return
+			if("guest")
+				icon_state = "walletid"
+				return
 			if("silver")
 				icon_state = "walletid_silver"
 				return

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -42,6 +42,7 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 /obj/machinery/photocopier/faxmachine/attack_hand(mob/user as mob)
 	user.set_machine(src)
 
+	var/remaining_cooldown = get_remaining_cooldown()
 	var/dat = "Fax Machine<BR>"
 
 	var/scan_name
@@ -65,8 +66,8 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 		if(copyitem)
 			dat += "<a href='byond://?src=\ref[src];remove=1'>Remove Item</a><br><br>"
 
-			if(get_remaining_cooldown() > 0)
-				dat += "<b>Transmitter arrays realigning. Please stand by. [round(get_remaining_cooldown() / 10)] seconds remaining.</b><br>"
+			if(remaining_cooldown > 0)
+				dat += "<b>Transmitter arrays realigning. Please stand by. [round(remaining_cooldown / 10)] seconds remaining.</b><br>"
 
 			else
 
@@ -75,9 +76,9 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 				dat += "<b>Sending to:</b> <a href='byond://?src=\ref[src];dept=1'>[destination]</a><br>"
 
 		else
-			if(get_remaining_cooldown() > 0)
+			if(remaining_cooldown > 0)
 				dat += "Please insert paper to send via secure connection.<br><br>"
-				dat += "<b>Transmitter arrays realigning. Please stand by. [round(get_remaining_cooldown() / 10)] seconds remaining.</b><br>"
+				dat += "<b>Transmitter arrays realigning. Please stand by. [round(remaining_cooldown / 10)] seconds remaining.</b><br>"
 			else
 				dat += "Please insert paper to send via secure connection.<br><br>"
 
@@ -98,7 +99,7 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 	user << browse(dat, "window=copier")
 	onclose(user, "copier")
 
-	if (get_remaining_cooldown() > 0)
+	if (remaining_cooldown > 0)
 		spawn(50)
 			// Auto-refresh every 5 seconds, if cooldown is active
 			updateUsrDialog()

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -65,7 +65,7 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 		if(copyitem)
 			dat += "<a href='byond://?src=\ref[src];remove=1'>Remove Item</a><br><br>"
 
-			if(sendcooldown)
+			if(get_remaining_cooldown() > 0)
 				dat += "<b>Transmitter arrays realigning. Please stand by. [round(get_remaining_cooldown() / 10)] seconds remaining.</b><br>"
 
 			else
@@ -75,7 +75,7 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 				dat += "<b>Sending to:</b> <a href='byond://?src=\ref[src];dept=1'>[destination]</a><br>"
 
 		else
-			if(sendcooldown)
+			if(get_remaining_cooldown() > 0)
 				dat += "Please insert paper to send via secure connection.<br><br>"
 				dat += "<b>Transmitter arrays realigning. Please stand by. [round(get_remaining_cooldown() / 10)] seconds remaining.</b><br>"
 			else
@@ -98,7 +98,7 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 	user << browse(dat, "window=copier")
 	onclose(user, "copier")
 
-	if (sendcooldown != 0)
+	if (get_remaining_cooldown() > 0)
 		spawn(50)
 			// Auto-refresh every 5 seconds, if cooldown is active
 			updateUsrDialog()
@@ -107,7 +107,7 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 
 /obj/machinery/photocopier/faxmachine/Topic(href, href_list)
 	if(href_list["send"])
-		if (sendcooldown > 0)
+		if (get_remaining_cooldown() > 0)
 			// Rate-limit sending faxes
 			usr << "<span class='warning'>The fax machine isn't ready, yet!</span>"
 			updateUsrDialog()
@@ -189,8 +189,7 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 	.=..()
 	var/static/ui_update_delay = 0
 
-	var/current_time = world.time
-	if (current_time > sendtime + sendcooldown)
+	if ((sendtime + sendcooldown) < world.time)
 		sendcooldown = 0
 
 /*
@@ -231,11 +230,13 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 		if( F.department == destination )
 			success = F.recievefax(copyitem)
 
+	if (success)
+		set_cooldown(normalfax_cooldown)
+
 	if (display_message)
 		// Normal fax
 		if (success)
 			visible_message("[src] beeps, \"Message transmitted successfully.\"")
-			sendcooldown = normalfax_cooldown
 		else
 			visible_message("[src] beeps, \"Error transmitting message.\"")
 	return success

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -114,7 +114,7 @@
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(src)
 			P.info = "<CENTER><B>Security Record</B></CENTER><BR>"
 			P.info += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nSex: [G.fields["sex"]]<BR>\nAge: [G.fields["age"]]<BR>\nFingerprint: [G.fields["fingerprint"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>"
-			P.info += "<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: [S.fields["criminal"]]<BR>\n<BR>\nMinor Crimes: [S.fields["mi_crim"]]<BR>\nDetails: [S.fields["mi_crim_d"]]<BR>\n<BR>\nMajor Crimes: [S.fields["ma_crim"]]<BR>\nDetails: [S.fields["ma_crim_d"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[S.fields["notes"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
+			P.info += "<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: [S.fields["criminal"]]<BR>\n<BR>\nMinor Crimes: [S.fields["mi_crim"]]<BR>\nDetails: [S.fields["mi_crim_d"]]<BR>\n<BR>\nMajor Crimes: [S.fields["ma_crim"]]<BR>\nDetails: [S.fields["ma_crim_d"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[replacetext(S.fields["notes"], "\n", "<BR>")]</pre><BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
 			var/counter = 1
 			while(S.fields["com_[counter]"])
 				P.info += "[S.fields["com_[counter]"]]<BR>"
@@ -151,8 +151,8 @@
 				var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(src)
 				var/info = "<CENTER><B>Medical Record</B></CENTER><BR>"
 				info += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nSex: [G.fields["sex"]]<BR>\nAge: [G.fields["age"]]<BR>\nFingerprint: [G.fields["fingerprint"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>"
-				
-				info += "<BR>\n<CENTER><B>Medical Data</B></CENTER><BR>\nBlood Type: [M.fields["b_type"]]<BR>\nDNA: [M.fields["b_dna"]]<BR>\n<BR>\nMinor Disabilities: [M.fields["mi_dis"]]<BR>\nDetails: [M.fields["mi_dis_d"]]<BR>\n<BR>\nMajor Disabilities: [M.fields["ma_dis"]]<BR>\nDetails: [M.fields["ma_dis_d"]]<BR>\n<BR>\nAllergies: [M.fields["alg"]]<BR>\nDetails: [M.fields["alg_d"]]<BR>\n<BR>\nCurrent Diseases: [M.fields["cdi"]] (per disease info placed in log/comment section)<BR>\nDetails: [M.fields["cdi_d"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[M.fields["notes"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
+
+				info += "<BR>\n<CENTER><B>Medical Data</B></CENTER><BR>\nBlood Type: [M.fields["b_type"]]<BR>\nDNA: [M.fields["b_dna"]]<BR>\n<BR>\nMinor Disabilities: [M.fields["mi_dis"]]<BR>\nDetails: [M.fields["mi_dis_d"]]<BR>\n<BR>\nMajor Disabilities: [M.fields["ma_dis"]]<BR>\nDetails: [M.fields["ma_dis_d"]]<BR>\n<BR>\nAllergies: [M.fields["alg"]]<BR>\nDetails: [M.fields["alg_d"]]<BR>\n<BR>\nCurrent Diseases: [M.fields["cdi"]] (per disease info placed in log/comment section)<BR>\nDetails: [M.fields["cdi_d"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[replacetext(M.fields["notes"], "\n", "<BR>")]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
 				var/counter = 1
 				while(M.fields["com_[counter]"])
 					info += "[M.fields["com_[counter]"]]<BR>"

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -114,7 +114,7 @@
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(src)
 			P.info = "<CENTER><B>Security Record</B></CENTER><BR>"
 			P.info += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nSex: [G.fields["sex"]]<BR>\nAge: [G.fields["age"]]<BR>\nFingerprint: [G.fields["fingerprint"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>"
-			P.info += "<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: [S.fields["criminal"]]<BR>\n<BR>\nMinor Crimes: [S.fields["mi_crim"]]<BR>\nDetails: [S.fields["mi_crim_d"]]<BR>\n<BR>\nMajor Crimes: [S.fields["ma_crim"]]<BR>\nDetails: [S.fields["ma_crim_d"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[replacetext(S.fields["notes"], "\n", "<BR>")]</pre><BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
+			P.info += "<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: [S.fields["criminal"]]<BR>\n<BR>\nMinor Crimes: [S.fields["mi_crim"]]<BR>\nDetails: [S.fields["mi_crim_d"]]<BR>\n<BR>\nMajor Crimes: [S.fields["ma_crim"]]<BR>\nDetails: [S.fields["ma_crim_d"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[replacetext(S.fields["notes"], "\n", "<BR>")]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
 			var/counter = 1
 			while(S.fields["com_[counter]"])
 				P.info += "[S.fields["com_[counter]"]]<BR>"

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -58,13 +58,21 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 			update_icon()
 
 /obj/machinery/r_n_d/circuit_imprinter/RefreshParts()
+	// Adjust reagent container volume to match combined volume of the inserted beakers
 	var/T = 0
 	for(var/obj/item/weapon/reagent_containers/glass/G in component_parts)
 		T += G.reagents.maximum_volume
 	create_reagents(T)
+	// Transfer all reagents from the beakers to internal reagent container
+	for(var/obj/item/weapon/reagent_containers/glass/G in component_parts)
+		G.reagents.trans_to_obj(src, G.reagents.total_volume)
+
+	// Adjust material storage capacity to scale with matter bin rating
 	max_material_storage = 0
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		max_material_storage += M.rating * 75000
+
+	// Adjust production speed to increase with manipulator rating
 	T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		T += M.rating
@@ -87,6 +95,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 
 /obj/machinery/r_n_d/circuit_imprinter/dismantle()
 	for(var/obj/I in component_parts)
+		// This will distribute all reagents amongst the contained beakers
 		if(istype(I, /obj/item/weapon/reagent_containers/glass/beaker))
 			reagents.trans_to_obj(I, reagents.total_volume)
 	for(var/f in materials)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -61,13 +61,21 @@
 	return t
 
 /obj/machinery/r_n_d/protolathe/RefreshParts()
+	// Adjust reagent container volume to match combined volume of the inserted beakers
 	var/T = 0
 	for(var/obj/item/weapon/reagent_containers/glass/G in component_parts)
 		T += G.reagents.maximum_volume
 	create_reagents(T)
+	// Transfer all reagents from the beakers to internal reagent container
+	for(var/obj/item/weapon/reagent_containers/glass/G in component_parts)
+		G.reagents.trans_to_obj(src, G.reagents.total_volume)
+
+	// Adjust material storage capacity to scale with matter bin rating
 	max_material_storage = 0
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		max_material_storage += M.rating * 75000
+
+	// Adjust production speed to increase with manipulator rating
 	T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		T += M.rating

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -309,6 +309,7 @@
 
 	src.visible_message("\blue \icon[src] [src] deactivates with a gentle shudder.")
 	qdel(suspension_field)
+	suspension_field = null
 	icon_state = "suspension2"
 
 /obj/machinery/suspension_gen/Destroy()

--- a/html/changelogs/inselc-PR-1987.yml
+++ b/html/changelogs/inselc-PR-1987.yml
@@ -1,0 +1,10 @@
+author: inselc
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed reagents disappearing from beakers when used to construct circuit imprinters and protolathes."
+  - bugfix: "Fixed fax machines getting stuck on '0 seconds remaining'."
+  - bugfix: "Suspension field generator can now be unwrenched again."
+  - bugfix: "Medical and security record notes formatting fixed to show line breaks for pAI on PDA, and on records in the filing cabinets."
+  - bugfix: "Wallet now showing correct sprite after inserting a guest pass."

--- a/nano/templates/pai_medrecords.tmpl
+++ b/nano/templates/pai_medrecords.tmpl
@@ -75,7 +75,7 @@ code/modules/mob/living/silicon/pai/software_modules.dm
 	</div>
 	<div class="item">
 		<div class="itemLabel">Important Notes</div>
-		<div class="itemContent">{{:data.medical.notes}}</div>
+		<div class="itemContent"><pre>{{:data.medical.notes}}</pre></div>
 	</div>
 {{/if}}
 

--- a/nano/templates/pai_secrecords.tmpl
+++ b/nano/templates/pai_secrecords.tmpl
@@ -65,7 +65,7 @@ code/modules/mob/living/silicon/pai/software_modules.dm
 	</div>
 	<div class="item">
 		<div class="itemLabel">Important Notes</div>
-		<div class="itemContent">{{:data.security.notes}}</div>
+		<div class="itemContent"><pre>{{:data.security.notes}}</pre></div>
 	</div>
 {{/if}}
 

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -654,7 +654,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         <span class="good">Details:		</span> <span class="average">{{:data.records.medical.alg_d}}	</span><br><br>
                         <span class="good">Current Disease:	</span> <span class="average">{{:data.records.medical.cdi}}		</span><br>
                         <span class="good">Details:		</span> <span class="average">{{:data.records.medical.alg_d}}	</span><br><br>
-                        <span class="good">Important Notes:	</span> <span class="average">{{:data.records.medical.notes}}	</span>
+                        <span class="good">Important Notes:	</span> <span class="average"><pre>{{:data.records.medical.notes}}</pre>	</span>
                     {{else}}
                         <span class="bad">
                             Medical Record Lost!
@@ -706,7 +706,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         <span class="good">Details:  </span><span class="average">{{:data.records.security.mi_crim_d}} </span><br><br>
                         <span class="good">Major Crimes:  </span><span class="average">{{:data.records.security.ma_crim}} </span><br>
                         <span class="good">Details:  </span><span class="average">{{:data.records.security.ma_crim_d}} </span><br><br>
-                        <span class="good">Important Notes:   </span><span class="average">{{:data.records.security.notes}} </span>
+                        <span class="good">Important Notes:   </span><span class="average"> <pre>{{:data.records.security.notes}}</pre> </span>
                     {{else}}
                         <span class="bad">
                             Security Record Lost!<br><br>


### PR DESCRIPTION
Trying to work off some of the older bugs on the issues list:
- Fix faxmachine getting stuck on "0 seconds remaining". **There may be a process scheduler issue which causes a long polling interval for the faxmachine's `process()`-method.**
- Replace newline in crew record notes with `<BR>` when generating the records in the filing cabinets.
- Surround crew record notes with "preformatted text" HTML tags on PDA / pAI screens.
- When constructing protolathes or circuit imprinters, transfer the reagents contained in the beakers to internal reagent container upon completion.
- Fix suspension field generator not clearing the qdel'd `suspension_field` reference. This fixes being unable to unwrench the generator, too.
- Fix wallet sprite still showing an empty wallet when inserting a guest pass.