### PR TITLE
Organ Runtime Fix

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -291,6 +291,8 @@
 // Shim until addtimer is merged or I figure out if it is safe to use scheduler for this.
 #define QDEL_IN(OBJ, TIME) spawn(TIME) qdel(OBJ)
 
+#define DEBUG_REF(D) (D ? "\ref[D]|[D] ([D.type])" : "NULL")
+
 //Recipe type defines. Used to determine what machine makes them
 #define MICROWAVE			0x1
 #define FRYER				0x2

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -84,7 +84,7 @@
 		var/mob/living/carbon/human/H = .
 		if(prob(poison_per_bite))
 			var/obj/item/organ/external/O = pick(H.organs)
-			if(!(O.robotic >= ORGAN_ROBOT))
+			if(!(O.status & ORGAN_ROBOT))
 				var/eggs = new /obj/effect/spider/eggcluster(O, src)
 				O.implants += eggs
 				H << "<span class='warning'>The [src] injects something into your [O.name]!</span>"

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -103,6 +103,11 @@ var/list/organ_cache = list()
 	if(loc != owner)
 		owner = null
 
+	if (QDELETED(src))
+		log_debug("QDELETED organ [DEBUG_REF(src)] had process() called!")
+		processing_objects -= src
+		return
+
 	//dead already, no need for more processing
 	if(status & ORGAN_DEAD)
 		return
@@ -117,6 +122,10 @@ var/list/organ_cache = list()
 		return
 
 	if(!owner)
+		if (QDELETED(reagents))
+			log_debug("Organ [DEBUG_REF(src)] had QDELETED reagents! Regenerating.")
+			create_reagents(5)
+
 		var/datum/reagent/blood/B = locate(/datum/reagent/blood) in reagents.reagent_list
 		if(B && prob(40))
 			reagents.remove_reagent("blood",0.1)


### PR DESCRIPTION
changes:
* Added a QDELETED check to organ processing so they won't continue to process if they were erroneously left in the processing objects list after being deleted.
* Fixed a bad robotic organ check on spiders.