### PR TITLE
IPC Fixes & Nutrition Tweaks

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -360,6 +360,9 @@ var/global/datum/controller/occupations/job_master
 			job.equip_survival(H)
 			job.apply_fingerprints(H)
 
+			// Randomize nutrition. (Between 50-100% of max.)
+			H.nutrition = (rand(50, 100) * 0.01) * H.max_nutrition
+
 			//If some custom items could not be equipped before, try again now.
 			for(var/thing in custom_equip_leftovers)
 				var/datum/gear/G = gear_datums[thing]

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -403,7 +403,10 @@
 
 /obj/random/voidsuit/post_spawn(obj/item/clothing/suit/space/void/suit)
 	var/helmet = suitmap[suit]
-	new helmet(loc)
+	if (helmet)
+		new helmet(loc)
+	else
+		log_debug("random_obj (voidsuit): Type [suit.type] was unable to spawn a matching helmet!")
 	new /obj/item/clothing/shoes/magboots(loc)
 	if (damaged & prob(60))
 		suit.create_breaches(pick(BRUTE, BURN), rand(1, 5))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1207,7 +1207,6 @@
 
 	exhaust_threshold = species.exhaust_threshold
 	max_nutrition = BASE_MAX_NUTRITION * species.max_nutrition_factor
-	nutrition = (rand(25,100)*0.01)*max_nutrition//Starting nutrition is randomised between 25-100% of max
 
 	nutrition_loss = HUNGER_FACTOR * species.nutrition_loss_factor
 	if(species)

--- a/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
@@ -213,11 +213,9 @@
 	has_organ = list(
 		"brain" = /obj/item/organ/mmi_holder/posibrain/terminator,
 		"shielded cell" = /obj/item/organ/cell/terminator,
-		"optics" = /obj/item/organ/optical_sensor/terminator,
+		"optics" = /obj/item/organ/eyes/optical_sensor/terminator,
 		"data core" = /obj/item/organ/data
 		)
-
-	vision_organ = "optics"
 
 	has_limbs = list(
 		"chest" =  list("path" = /obj/item/organ/external/chest/terminator),

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -403,7 +403,7 @@
 	has_organ = list(
 		"brain" = /obj/item/organ/mmi_holder/posibrain,
 		"cell" = /obj/item/organ/cell,
-		"optics" = /obj/item/organ/optical_sensor,
+		"optics" = /obj/item/organ/eyes/optical_sensor,
 		"ipc tag" = /obj/item/organ/ipc_tag
 		)
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -27,6 +27,8 @@ var/list/organ_cache = list()
 	var/datum/species/species
 	var/emp_coeff = 1 //coefficient for damages taken by EMP, if the organ is robotic.
 
+	var/force_skintone = FALSE		// If true, icon generation will skip is-robotic checks. Used for synthskin limbs.
+
 /obj/item/organ/Destroy()
 	processing_objects -= src
 	if(!owner)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -939,7 +939,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		/*if(species && !(species.name in R.species_can_use && species.get_bodytype() != "Machine"))
 			R = basic_robolimb*/
 		if(R)
-			force_icon = R.icon
+			if (!force_skintone)
+				force_icon = R.icon
 			name = "[R.company] [initial(name)]"
 			desc = "[R.desc]"
 			if(R.paintable)

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -30,7 +30,7 @@ var/global/list/limb_icon_cache = list()
 	s_tone = null
 	s_col = null
 	h_col = null
-	if(status & ORGAN_ROBOT)
+	if(status & ORGAN_ROBOT && !force_skintone)
 		return
 	if(!isnull(dna.GetUIValue(DNA_UI_SKIN_TONE)) && (species.appearance_flags & HAS_SKIN_TONE))
 		s_tone = dna.GetUIValue(DNA_UI_SKIN_TONE)
@@ -40,8 +40,14 @@ var/global/list/limb_icon_cache = list()
 
 /obj/item/organ/external/head/sync_colour_to_human(var/mob/living/carbon/human/human)
 	..()
-	var/obj/item/organ/eyes/eyes = owner.internal_organs_by_name["eyes"]
-	if(eyes) eyes.update_colour()
+	var/obj/item/organ/eyes/eyes 
+	if (species.vision_organ)
+		eyes = owner.internal_organs_by_name[species.vision_organ]
+	else
+		eyes = owner.internal_organs_by_name["eyes"]
+
+	if(eyes) 
+		eyes.update_colour()
 
 /obj/item/organ/external/head/removed()
 	get_icon()
@@ -53,9 +59,9 @@ var/global/list/limb_icon_cache = list()
 	overlays.Cut()
 	if(!owner || !owner.species)
 		return
-	if(owner.species.has_organ["eyes"])
-		var/obj/item/organ/eyes/eyes = owner.internal_organs_by_name["eyes"]
-		if(species.eyes)
+	if(owner.species.has_organ["eyes"] || (owner.species.vision_organ && owner.species.has_organ[species.vision_organ]))
+		var/obj/item/organ/eyes/eyes = owner.internal_organs_by_name["eyes"] || owner.internal_organs_by_name[species.vision_organ]
+		if(eyes && species.eyes)
 			var/icon/eyes_icon = new/icon('icons/mob/human_face.dmi', species.eyes)
 			if(eyes)
 				eyes_icon.Blend(rgb(eyes.eye_colour[1], eyes.eye_colour[2], eyes.eye_colour[3]), ICON_ADD)
@@ -113,7 +119,7 @@ var/global/list/limb_icon_cache = list()
 
 			if(skeletal)
 				mob_icon = new /icon('icons/mob/human_races/r_skeleton.dmi', "[icon_name][gender ? "_[gender]" : ""]")
-			else if (status & ORGAN_ROBOT)
+			else if (status & ORGAN_ROBOT && !force_skintone)
 				mob_icon = new /icon('icons/mob/human_races/robotic.dmi', "[icon_name][gender ? "_[gender]" : ""]")
 			else
 				if (status & ORGAN_MUTATED)

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -94,15 +94,14 @@
 		owner.stat = 0
 		owner.visible_message("<span class='danger'>\The [owner] twitches visibly!</span>")
 
-/obj/item/organ/optical_sensor
+/obj/item/organ/eyes/optical_sensor
 	name = "optical sensor"
 	organ_tag = "optics"
-	parent_organ = "head"
 	icon = 'icons/obj/robot_component.dmi'
 	icon_state = "camera"
 	dead_icon = "camera_broken"
 
-/obj/item/organ/optical_sensor/New()
+/obj/item/organ/eyes/optical_sensor/New()
 	robotize()
 	..()
 
@@ -218,19 +217,8 @@
 	encased = null
 	emp_coeff = 0.5
 
-/obj/item/organ/optical_sensorterminator
-	name = "optical sensor"
-	organ_tag = "optics"
-	parent_organ = "head"
-	icon = 'icons/obj/robot_component.dmi'
-	icon_state = "camera"
-	dead_icon = "camera_broken"
+/obj/item/organ/eyes/optical_sensor/terminator
 	emp_coeff = 0.5
-
-/obj/item/organ/optical_sensor/terminator/New()
-	robotize()
-	..()
-
 
 /obj/item/organ/external/head/terminator/New()
 	robotize("Hephaestus Vulcanite Limb")
@@ -405,6 +393,7 @@
 	max_damage = 50 //made same as arm, since it is not vital
 	min_broken_damage = 30
 	encased = null
+	force_skintone = TRUE
 
 /obj/item/organ/external/head/shell/New()
 	robotize("Human Synthskin")
@@ -413,60 +402,81 @@
 /obj/item/organ/external/chest/shell
 	dislocated = -1
 	encased = null
+	force_skintone = TRUE
+
+
 /obj/item/organ/external/chest/shell/New()
 	robotize("Human Synthskin")
 	..()
 
 /obj/item/organ/external/groin/shell
 	dislocated = -1
+	force_skintone = TRUE
+
 /obj/item/organ/external/groin/shell/New()
 	robotize("Human Synthskin")
 	..()
 
 /obj/item/organ/external/arm/shell
 	dislocated = -1
+	force_skintone = TRUE
+
 /obj/item/organ/external/arm/shell/New()
 	robotize("Human Synthskin")
 	..()
 
 /obj/item/organ/external/arm/right/shell
 	dislocated = -1
+	force_skintone = TRUE
+
 /obj/item/organ/external/arm/right/shell/New()
 	robotize("Human Synthskin")
 	..()
 
 /obj/item/organ/external/leg/shell
 	dislocated = -1
+	force_skintone = TRUE
+
 /obj/item/organ/external/leg/shell/New()
 	robotize("Human Synthskin")
 	..()
 
 /obj/item/organ/external/leg/right/shell
 	dislocated = -1
+	force_skintone = TRUE
+
 /obj/item/organ/external/leg/right/shell/New()
 	robotize("Human Synthskin")
 	..()
 
 /obj/item/organ/external/foot/shell
 	dislocated = -1
+	force_skintone = TRUE
+
 /obj/item/organ/external/foot/shell/New()
 	robotize("Human Synthskin")
 	..()
 
 /obj/item/organ/external/foot/right/shell
 	dislocated = -1
+	force_skintone = TRUE
+
 /obj/item/organ/external/foot/right/shell/New()
 	robotize("Human Synthskin")
 	..()
 
 /obj/item/organ/external/hand/shell
 	dislocated = -1
+	force_skintone = TRUE
+
 /obj/item/organ/external/hand/shell/New()
 	robotize("Human Synthskin")
 	..()
 
 /obj/item/organ/external/hand/right/shell
 	dislocated = -1
+	force_skintone = TRUE
+
 /obj/item/organ/external/hand/right/shell/New()
 	robotize("Human Synthskin")
 	..()

--- a/html/changelogs/lohikar-fix-fowls-shit.yml
+++ b/html/changelogs/lohikar-fix-fowls-shit.yml
@@ -1,0 +1,6 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "An error in shell manufacturing processes has been corrected; shell units should now be produced with correct eye and skin coloration."
+  - bugfix: "Industrials now actually have visible eyes."
+  - tweak: "ERT, CCIA, BSTs, Wizards, and other non-station human-types now no longer skip breakfast before arriving at the station."


### PR DESCRIPTION
changes:
- Only normal crew mobs equipped by the job master spawn with randomized nutrition.
- Random nutrition's minimum nutrition value has been increased to 50%.
- IPC Shells' skin tone and eye color now functions correctly.
- Industrials' eyes now work correctly.
- Added a nullcheck to random voidsuit spawn.

Fixes #1909.
Fixes #1646.
Fixes #1503.
Probably fixes #1740.