### PR TITLE
Tactical Holster Fixes & Random Obj Runtime Fix

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -397,9 +397,9 @@
 	)
 	has_postspawn = TRUE
 
-/obj/random/voidsuit/New(var/_damaged = 0)
+/obj/random/voidsuit/New(loc, _damaged = 0)
 	damaged = _damaged
-	..()
+	..(loc)
 
 /obj/random/voidsuit/post_spawn(obj/item/clothing/suit/space/void/suit)
 	var/helmet = suitmap[suit]
@@ -436,9 +436,9 @@
 	)
 	has_postspawn = TRUE
 
-/obj/random/vendor/New(var/_depleted = 0)
+/obj/random/vendor/New(loc, _depleted = 0)
 	depleted = _depleted
-	..()
+	..(loc)
 
 /obj/random/vendor/post_spawn(obj/machinery/vending/V)
 	if (!depleted)

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -408,7 +408,7 @@
 	else
 		log_debug("random_obj (voidsuit): Type [suit.type] was unable to spawn a matching helmet!")
 	new /obj/item/clothing/shoes/magboots(loc)
-	if (damaged & prob(60))
+	if (damaged && prob(60))
 		suit.create_breaches(pick(BRUTE, BURN), rand(1, 5))
 
 /obj/random/vendor

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -402,7 +402,7 @@
 	..(loc)
 
 /obj/random/voidsuit/post_spawn(obj/item/clothing/suit/space/void/suit)
-	var/helmet = suitmap[suit]
+	var/helmet = suitmap[suit.type]
 	if (helmet)
 		new helmet(loc)
 	else

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -255,9 +255,10 @@
 
 /obj/item/clothing/suit/armor/tactical/New()
 	..()
-	holster = new(src)
-	holster.has_suit = 1//its inside a suit, we set  this so it can be drawn from
-	pockets = null//Tactical armour has internal holster instead of pockets, so we null this out
+	holster = new()
+	holster.on_attached(src)	//its inside a suit, we set  this so it can be drawn from
+	QDEL_NULL(pockets)	//Tactical armour has internal holster instead of pockets, so we null this out
+	overlays.Cut()	// Remove the holster's overlay.
 
 /obj/item/clothing/suit/armor/tactical/attackby(obj/item/W as obj, mob/user as mob)
 	..()

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -98,6 +98,9 @@
 		var/obj/item/clothing/under/S = src
 		if (S.accessories.len)
 			H = locate() in S.accessories
+	else if (istype(src, /obj/item/clothing/suit/armor/tactical))	// This armor is a snowflake and has an integrated holster.
+		var/obj/item/clothing/suit/armor/tactical/tacticool = src
+		H = tacticool.holster
 
 	if (!H)
 		usr << "<span class='warning'>Something is very wrong.</span>"

--- a/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
@@ -120,7 +120,7 @@
 		"r_foot" = list("path" = /obj/item/organ/external/foot/right/industrial)
 		)
 
-	appearance_flags = HAS_HAIR_COLOR
+	appearance_flags = HAS_EYE_COLOR
 
 	heat_level_1 = 600
 	heat_level_2 = 1200

--- a/html/changelogs/lohikar-PR-2043.yml
+++ b/html/changelogs/lohikar-PR-2043.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Fixed a bug where holstering didn't quite work right with tactical armor."

--- a/html/changelogs/lohikar-PR-2043.yml
+++ b/html/changelogs/lohikar-PR-2043.yml
@@ -2,3 +2,4 @@ author: Lohikar
 delete-after: True
 changes: 
   - bugfix: "Fixed a bug where holstering didn't quite work right with tactical armor."
+  - bugfix: "Industrial IPC units' eye controller firmware has been upgraded, fixing a bug where a unit's configured eye color would not display."


### PR DESCRIPTION
changes:
- Fixed some issues with tactical armor's holster.
- Made tactical armor qdel its child storage instead of just nulling it out.
- Hopefully fixed the runtimes with random voidsuits.
- Fixed a bug where random vendors were always depleted.
- Fixed a bug where industrials could not set their eye color.

Fixes #2041.
Hopefully fixes #1740.