### PR TITLE
Fixes #1932 and converts airlock_electronics.dm to absolute paths

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -1,4 +1,5 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
+// Please do not use relative paths.
 
 /obj/item/weapon/airlock_electronics
 	name = "airlock electronics"
@@ -15,69 +16,70 @@
 	var/one_access = 0 //if set to 1, door would receive req_one_access instead of req_access
 	var/last_configurator = null
 	var/locked = 1
+	var/inuse = 0 // no double-spending
 
-	attack_self(mob/user as mob)
-		if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
-			return ..(user)
+/obj/item/weapon/airlock_electronics/attack_self(mob/user as mob)
+	if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
+		return ..(user)
 
-		var/mob/living/carbon/human/H = user
-		if(H.getBrainLoss() >= 60)
-			return
+	var/mob/living/carbon/human/H = user
+	if(H.getBrainLoss() >= 60)
+		return
 
-		var/t1 = text("<B>Access control</B><br>\n")
+	var/t1 = text("<B>Access control</B><br>\n")
 
 
-		if (last_configurator)
-			t1 += "Operator: [last_configurator]<br>"
+	if (last_configurator)
+		t1 += "Operator: [last_configurator]<br>"
 
-		if (locked)
-			t1 += "<a href='?src=\ref[src];login=1'>Swipe ID</a><hr>"
-		else
-			t1 += "<a href='?src=\ref[src];logout=1'>Block</a><hr>"
+	if (locked)
+		t1 += "<a href='?src=\ref[src];login=1'>Swipe ID</a><hr>"
+	else
+		t1 += "<a href='?src=\ref[src];logout=1'>Block</a><hr>"
 
-			t1 += "Access requirement is set to "
-			t1 += one_access ? "<a style='color: green' href='?src=\ref[src];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=\ref[src];one_access=1'>ALL</a><hr>"
+		t1 += "Access requirement is set to "
+		t1 += one_access ? "<a style='color: green' href='?src=\ref[src];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=\ref[src];one_access=1'>ALL</a><hr>"
 
-			t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=\ref[src];access=all'>All</a><br>"
+		t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=\ref[src];access=all'>All</a><br>"
 
-			t1 += "<br>"
+		t1 += "<br>"
 
-			var/list/accesses = get_all_station_access()
-			for (var/acc in accesses)
-				var/aname = get_access_desc(acc)
+		var/list/accesses = get_all_station_access()
+		for (var/acc in accesses)
+			var/aname = get_access_desc(acc)
 
-				if (!conf_access || !conf_access.len || !(acc in conf_access))
-					t1 += "<a href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
-				else if(one_access)
-					t1 += "<a style='color: green' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
-				else
-					t1 += "<a style='color: red' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
-
-		t1 += text("<p><a href='?src=\ref[];close=1'>Close</a></p>\n", src)
-
-		user << browse(t1, "window=airlock_electronics")
-		onclose(user, "airlock")
-
-	Topic(href, href_list)
-		..()
-		if (usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
-			return
-		if (href_list["close"])
-			usr << browse(null, "window=airlock")
-			return
-
-		if (href_list["login"])
-			if(istype(usr,/mob/living/silicon))
-				src.locked = 0
-				src.last_configurator = usr.name
+			if (!conf_access || !conf_access.len || !(acc in conf_access))
+				t1 += "<a href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
+			else if(one_access)
+				t1 += "<a style='color: green' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
 			else
-				var/obj/item/I = usr.get_active_hand()
-				if (istype(I, /obj/item/device/pda))
-					var/obj/item/device/pda/pda = I
-					I = pda.id
-				if (I && src.check_access(I))
-					src.locked = 0
-					src.last_configurator = I:registered_name
+				t1 += "<a style='color: red' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
+
+	t1 += text("<p><a href='?src=\ref[];close=1'>Close</a></p>\n", src)
+
+	user << browse(t1, "window=airlock_electronics")
+	onclose(user, "airlock")
+
+/obj/item/weapon/airlock_electronics/Topic(href, href_list)
+	..()
+	if (usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
+		return
+	if (href_list["close"])
+		usr << browse(null, "window=airlock")
+		return
+
+	if (href_list["login"])
+		if(istype(usr,/mob/living/silicon))
+			src.locked = 0
+			src.last_configurator = usr.name
+		else
+			var/obj/item/I = usr.get_active_hand()
+			if (istype(I, /obj/item/device/pda))
+				var/obj/item/device/pda/pda = I
+				I = pda.id
+			if (I && src.check_access(I))
+				src.locked = 0
+				src.last_configurator = I:registered_name
 
 		if (locked)
 			return
@@ -93,22 +95,21 @@
 
 		attack_self(usr)
 
-	proc
-		toggle_access(var/acc)
-			if (acc == "all")
+/obj/item/weapon/airlock_electronics/proc/toggle_access(var/acc)
+	if (acc == "all")
+		conf_access = null
+	else
+		var/req = text2num(acc)
+
+		if (conf_access == null)
+			conf_access = list()
+
+		if (!(req in conf_access))
+			conf_access += req
+		else
+			conf_access -= req
+			if (!conf_access.len)
 				conf_access = null
-			else
-				var/req = text2num(acc)
-
-				if (conf_access == null)
-					conf_access = list()
-
-				if (!(req in conf_access))
-					conf_access += req
-				else
-					conf_access -= req
-					if (!conf_access.len)
-						conf_access = null
 
 
 /obj/item/weapon/airlock_electronics/secure

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -218,6 +218,7 @@
 			user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
 			EL.inuse = 1
 			if(do_after(user, 40))
+				EL.inuse = 0
 				if(!src) return
 				user.drop_item()
 				EL.forceMove(src)
@@ -225,7 +226,9 @@
 				src.state = 2
 				src.name = "Near finished Airlock Assembly"
 				src.electronics = EL
-			EL.inuse = 0 //Save two lines by doing it here, and ensure it's always set to zero.
+			else
+				EL.inuse = 0
+				EL.forceMove(src)
 
 	else if(istype(W, /obj/item/weapon/crowbar) && state == 2 )
 		//This should never happen, but just in case I guess

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -212,17 +212,22 @@
 			src.state = 0
 
 	else if(istype(W, /obj/item/weapon/airlock_electronics) && state == 1)
-		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-		user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
-
-		if(do_after(user, 40))
-			if(!src) return
-			user.drop_item()
-			W.loc = src
-			user << "<span class='notice'>You installed the airlock electronics!</span>"
-			src.state = 2
-			src.name = "Near finished Airlock Assembly"
-			src.electronics = W
+		var/obj/item/weapon/airlock_electronics/EL = W
+		if(!EL.inuse)
+			playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
+			user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
+			EL.inuse = 1
+			if(do_after(user, 40))
+				EL.inuse = 0
+				if(!src) return
+				user.drop_item()
+				W.loc = src
+				user << "<span class='notice'>You installed the airlock electronics!</span>"
+				src.state = 2
+				src.name = "Near finished Airlock Assembly"
+				src.electronics = W
+			else
+				EL.inuse = 0
 
 	else if(istype(W, /obj/item/weapon/crowbar) && state == 2 )
 		//This should never happen, but just in case I guess

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -218,16 +218,14 @@
 			user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
 			EL.inuse = 1
 			if(do_after(user, 40))
-				EL.inuse = 0
 				if(!src) return
 				user.drop_item()
-				W.loc = src
+				EL.forcemove(src)
 				user << "<span class='notice'>You installed the airlock electronics!</span>"
 				src.state = 2
 				src.name = "Near finished Airlock Assembly"
-				src.electronics = W
-			else
-				EL.inuse = 0
+				src.electronics = EL
+			EL.inuse = 0 //Save two lines by doing it here, and ensure it's always set to zero.
 
 	else if(istype(W, /obj/item/weapon/crowbar) && state == 2 )
 		//This should never happen, but just in case I guess

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -228,7 +228,6 @@
 				src.electronics = EL
 			else
 				EL.inuse = 0
-				EL.forceMove(src)
 
 	else if(istype(W, /obj/item/weapon/crowbar) && state == 2 )
 		//This should never happen, but just in case I guess

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -220,7 +220,7 @@
 			if(do_after(user, 40))
 				if(!src) return
 				user.drop_item()
-				EL.forcemove(src)
+				EL.forceMove(src)
 				user << "<span class='notice'>You installed the airlock electronics!</span>"
 				src.state = 2
 				src.name = "Near finished Airlock Assembly"

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -182,7 +182,6 @@ obj/structure/windoor_assembly/Destroy()
 						src.electronics = EL
 					else
 						EL.inuse = 0
-						EL.forceMove(src)
 
 			//Screwdriver to remove airlock electronics. Step 6 undone.
 			else if(istype(W, /obj/item/weapon/screwdriver) && src.electronics)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -167,19 +167,22 @@ obj/structure/windoor_assembly/Destroy()
 
 			//Adding airlock electronics for access. Step 6 complete.
 			else if(istype(W, /obj/item/weapon/airlock_electronics) && W:icon_state != "door_electronics_smoked")
-				playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-				user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
-
-				if(do_after(user, 40))
-					if(!src) return
-
-					user.drop_item()
-					W.loc = src
-					user << "<span class='notice'>You've installed the airlock electronics!</span>"
-					src.name = "Near finished Windoor Assembly"
-					src.electronics = W
-				else
-					W.loc = src.loc
+				var/obj/item/weapon/airlock_electronics/EL = W
+				if(!EL.inuse)
+					playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
+					user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
+					EL.inuse = 1
+					if(do_after(user, 40))
+						EL.inuse = 0
+						if(!src) return
+						user.drop_item()
+						EL.loc = src
+						user << "<span class='notice'>You've installed the airlock electronics!</span>"
+						src.name = "Near finished Windoor Assembly"
+						src.electronics = EL
+					else
+						EL.inuse = 0
+						EL.loc = src.loc
 
 			//Screwdriver to remove airlock electronics. Step 6 undone.
 			else if(istype(W, /obj/item/weapon/screwdriver) && src.electronics)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -176,13 +176,13 @@ obj/structure/windoor_assembly/Destroy()
 						EL.inuse = 0
 						if(!src) return
 						user.drop_item()
-						EL.loc = src
+						EL.forcemove(src)
 						user << "<span class='notice'>You've installed the airlock electronics!</span>"
 						src.name = "Near finished Windoor Assembly"
 						src.electronics = EL
 					else
 						EL.inuse = 0
-						EL.loc = src.loc
+						EL.forcemove(src)
 
 			//Screwdriver to remove airlock electronics. Step 6 undone.
 			else if(istype(W, /obj/item/weapon/screwdriver) && src.electronics)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -176,13 +176,13 @@ obj/structure/windoor_assembly/Destroy()
 						EL.inuse = 0
 						if(!src) return
 						user.drop_item()
-						EL.forcemove(src)
+						EL.forceMove(src)
 						user << "<span class='notice'>You've installed the airlock electronics!</span>"
 						src.name = "Near finished Windoor Assembly"
 						src.electronics = EL
 					else
 						EL.inuse = 0
-						EL.forcemove(src)
+						EL.forceMove(src)
 
 			//Screwdriver to remove airlock electronics. Step 6 undone.
 			else if(istype(W, /obj/item/weapon/screwdriver) && src.electronics)

--- a/html/changelogs/MoondancerPony-PR-[2053].yml
+++ b/html/changelogs/MoondancerPony-PR-[2053].yml
@@ -1,0 +1,4 @@
+author: MoondancerPony
+delete-after: True
+changes: 
+  - bugfix: "Eliminated the possibility for 'double-spending' airlock electronics, duplicating boards and allowing you to complete multiple airlocks with one board."


### PR DESCRIPTION
* Fixed #1932 by adding an 'inuse' variable to airlock electronics and setting/checking whether it's in use when constructing doors.
* Converted airlock_electronics.dm to absolute paths from relative paths.