### PR TITLE
Actually fixed #1163 this time.

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -63,7 +63,7 @@
 			target << "Extreme danger.  Termination codes detected.  Scrambling security codes and automatic AI unlink triggered."
 			target.ResetSecurityCodes()
 		else
-			message_admins("<span class='notice'>[key_name_admin(usr)] detonated [target.name]!</span>")
+			message_admins("[key_name_admin(usr)] detonated [target.name]!")
 			log_game("[key_name(usr)] detonated [target.name]!",ckey=key_name(usr))
 			target << "<span class='danger'>Self-destruct command received.</span>"
 			spawn(10)
@@ -93,7 +93,7 @@
 			return
 
 		target.SetLockdown(!target.lockcharge) // Toggle.
-		message_admins("<span class='notice'>[key_name_admin(usr)] [target.lockcharge ? "locked down" : "released"] [target.name]!</span>")
+		message_admins("[key_name_admin(usr)] [target.lockcharge ? "locked down" : "released"] [target.name]!")
 		log_game("[key_name(usr)] [target.lockcharge ? "locked down" : "released"] [target.name]!",ckey=key_name(usr))
 		target << (target.lockcharge ? "You have been locked down!" : "Your lockdown has been lifted!")
 
@@ -119,7 +119,7 @@
 		if(!target || !istype(target))
 			return
 
-		message_admins("<span class='notice'>[key_name_admin(usr)] emagged [target.name] using robotic console!</span>")
+		message_admins("[key_name_admin(usr)] emagged [target.name] using robotic console!")
 		log_game("[key_name(usr)] emagged [target.name] using robotic console!",ckey=key_name(usr))
 		target.emagged = 1
 		target << "<span class='notice'>Failsafe protocols overriden. New tools available.</span>"
@@ -142,7 +142,7 @@
 			user << "Self-destruct aborted - safety active"
 			return
 
-		message_admins("<span class='notice'>[key_name_admin(usr)] detonated all cyborgs!</span>")
+		message_admins("[key_name_admin(usr)] detonated all cyborgs!")
 		log_game("[key_name(usr)] detonated all cyborgs!",ckey=key_name(usr))
 
 		for(var/mob/living/silicon/robot/R in mob_list)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -92,15 +92,10 @@
 		if(!target || !istype(target))
 			return
 
-		message_admins("<span class='notice'>[key_name_admin(usr)] [target.canmove ? "locked down" : "released"] [target.name]!</span>")
-		log_game("[key_name(usr)] [target.canmove ? "locked down" : "released"] [target.name]!",ckey=key_name(usr))
-		target.canmove = !target.canmove
-		if (target.lockcharge)
-			target.lockcharge = !target.lockcharge
-			target << "Your lockdown has been lifted!"
-		else
-			target.lockcharge = !target.lockcharge
-			target << "You have been locked down!"
+		target.SetLockdown(!target.lockcharge) // Toggle.
+		message_admins("<span class='notice'>[key_name_admin(usr)] [target.lockcharge ? "locked down" : "released"] [target.name]!</span>")
+		log_game("[key_name(usr)] [target.lockcharge ? "locked down" : "released"] [target.name]!",ckey=key_name(usr))
+		target << (target.lockcharge ? "You have been locked down!" : "Your lockdown has been lifted!")
 
 	// Remotely hacks the cyborg. Only antag AIs can do this and only to linked cyborgs.
 	else if (href_list["hack"])
@@ -179,7 +174,7 @@
 		robot["name"] = R.name
 		if(R.stat)
 			robot["status"] = "Not Responding"
-		else if (!R.canmove)
+		else if (R.lockcharge) // changed this from !R.canmove to R.lockcharge because of issues with lockdown and chairs
 			robot["status"] = "Lockdown"
 		else
 			robot["status"] = "Operational"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -954,6 +954,11 @@
 	gib()
 	return
 
+/mob/living/silicon/robot/update_canmove() // to fix lockdown issues w/ chairs
+    if(lockcharge)
+        canmove = 0
+    return ..()
+
 /mob/living/silicon/robot/proc/UnlinkSelf()
 	disconnect_from_ai()
 	lawupdate = 0

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -955,9 +955,10 @@
 	return
 
 /mob/living/silicon/robot/update_canmove() // to fix lockdown issues w/ chairs
-    if(lockcharge)
-        canmove = 0
-    return ..()
+	. = ..()
+	if (lockcharge)
+		canmove = 0
+		. = 0
 
 /mob/living/silicon/robot/proc/UnlinkSelf()
 	disconnect_from_ai()


### PR DESCRIPTION
* Made the robotics control console check for `R.lockcharge` instead of `!R.canmove` to avoid issues with chairs.
* Gave silicons their own custom `/update_canmove()` proc to deal with lockdown.
* Made the robotics control console use `SetLockdown()`, like the lockdown wire.