### PR TITLE
Protohuman Fixes, Transform Procs, and Genetics Fixes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -325,6 +325,7 @@
 #include "code\game\dna\dna_modifier.dm"
 #include "code\game\dna\genes\disabilities.dm"
 #include "code\game\dna\genes\gene.dm"
+#include "code\game\dna\genes\monkey.dm"
 #include "code\game\dna\genes\powers.dm"
 #include "code\game\gamemodes\antagspawner.dm"
 #include "code\game\gamemodes\events.dm"

--- a/code/game/dna/genes/monkey.dm
+++ b/code/game/dna/genes/monkey.dm
@@ -1,175 +1,33 @@
 /datum/dna/gene/monkey
-	name="Monkey"
+	name = "Monkey"
 
 /datum/dna/gene/monkey/New()
-	block=MONKEYBLOCK
+	block = MONKEYBLOCK
 
 /datum/dna/gene/monkey/can_activate(var/mob/M,var/flags)
-	return istype(M, /mob/living/carbon/human) || istype(M,/mob/living/carbon/monkey)
+	return ishuman(M)
 
-/datum/dna/gene/monkey/activate(var/mob/living/M, var/connected, var/flags)
-	if(!istype(M,/mob/living/carbon/human))
-		//testing("Cannot monkey-ify [M], type is [M.type].")
-		return
-	var/mob/living/carbon/human/H = M
-	H.transforming = 1
-	var/list/implants = list() //Try to preserve implants.
-	for(var/obj/item/weapon/implant/W in H)
-		implants += W
-		W.loc = null
-
-	if(!connected)
-		for(var/obj/item/W in (H.contents-implants))
-			if (W==H.w_uniform) // will be teared
-				continue
-			H.drop_from_inventory(W)
-		M.transforming = 1
-		M.canmove = 0
-		M.icon = null
-		M.invisibility = 101
-		var/atom/movable/overlay/animation = new( M.loc )
-		animation.icon_state = "blank"
-		animation.icon = 'icons/mob/mob.dmi'
-		animation.master = src
-		flick("h2monkey", animation)
-		sleep(48)
-		qdel(animation)
-
-
-	var/mob/living/carbon/monkey/O = null
-	if(H.species.primitive)
-		O = new H.species.primitive(src)
+/datum/dna/gene/monkey/activate(var/mob/living/carbon/C)
+	var/mob/living/carbon/human/H
+	if(ishuman(C))
+		H = C
 	else
-		H.gib() //Trying to change the species of a creature with no primitive var set is messy.
+		return
+	if(!islesserform(H))
+		H = H.monkeyize(1)
+		H.name = H.species.get_random_name() // keep the realname
+
+/datum/dna/gene/monkey/deactivate(var/mob/living/carbon/C)
+	var/mob/living/carbon/human/H
+	if(ishuman(C))
+		H = C
+	else
 		return
 
-	if(M)
-		if (M.dna)
-			O.dna = M.dna.Clone()
-			M.dna = null
+	if(islesserform(H))
+		H = H.humanize(1) // woo transform procs!
 
-		if (M.suiciding)
-			O.suiciding = M.suiciding
-			M.suiciding = null
-
-
-	for(var/datum/disease/D in M.viruses)
-		O.viruses += D
-		D.affected_mob = O
-		M.viruses -= D
-
-
-	for(var/obj/T in (M.contents-implants))
-		qdel(T)
-
-	O.loc = M.loc
-
-	if(M.mind)
-		M.mind.transfer_to(O)	//transfer our mind to the cute little monkey
-
-	if (connected) //inside dna thing
-		var/obj/machinery/dna_scannernew/C = connected
-		O.loc = C
-		C.occupant = O
-		connected = null
-	O.real_name = text("monkey ([])",copytext(md5(M.real_name), 2, 6))
-	O.take_overall_damage(M.getBruteLoss() + 40, M.getFireLoss())
-	O.adjustToxLoss(M.getToxLoss() + 20)
-	O.adjustOxyLoss(M.getOxyLoss())
-	O.stat = M.stat
-	O.a_intent = I_HURT
-	for (var/obj/item/weapon/implant/I in implants)
-		I.loc = O
-		I.implanted = O
-//		O.update_icon = 1	//queue a full icon update at next life() call
-	qdel(M)
-	return
-
-/datum/dna/gene/monkey/deactivate(var/mob/living/M, var/connected, var/flags)
-	if(!istype(M,/mob/living/carbon/monkey))
-		//testing("Cannot humanize [M], type is [M.type].")
-		return
-	var/mob/living/carbon/monkey/Mo = M
-	Mo.transforming = 1
-	var/list/implants = list() //Still preserving implants
-	for(var/obj/item/weapon/implant/W in Mo)
-		implants += W
-		W.loc = null
-	if(!connected)
-		for(var/obj/item/W in (Mo.contents-implants))
-			Mo.drop_from_inventory(W)
-		M.transforming = 1
-		M.canmove = 0
-		M.icon = null
-		M.invisibility = 101
-		var/atom/movable/overlay/animation = new( M.loc )
-		animation.icon_state = "blank"
-		animation.icon = 'icons/mob/mob.dmi'
-		animation.master = src
-		flick("monkey2h", animation)
-		sleep(48)
-		qdel(animation)
-
-	var/mob/living/carbon/human/O
-	if(Mo.greaterform)
-		O = new(src, Mo.greaterform)
-	else
-		O = new(src)
-
-	if (M.dna.GetUIState(DNA_UI_GENDER))
-		O.gender = FEMALE
-	else
-		O.gender = MALE
-
-	if (M)
-		if (M.dna)
-			O.dna = M.dna.Clone()
-			M.dna = null
-
-		if (M.suiciding)
-			O.suiciding = M.suiciding
-			M.suiciding = null
-
-	for(var/datum/disease/D in M.viruses)
-		O.viruses += D
-		D.affected_mob = O
-		M.viruses -= D
-
-	//for(var/obj/T in M)
-	//	qdel(T)
-
-	O.loc = M.loc
-
-	if(M.mind)
-		M.mind.transfer_to(O)	//transfer our mind to the human
-
-	if (connected) //inside dna thing
-		var/obj/machinery/dna_scannernew/C = connected
-		O.loc = C
-		C.occupant = O
-		connected = null
-
-	var/i
-	while (!i)
-		var/randomname
-		if (O.gender == MALE)
-			randomname = capitalize(pick(first_names_male) + " " + capitalize(pick(last_names)))
-		else
-			randomname = capitalize(pick(first_names_female) + " " + capitalize(pick(last_names)))
-		if (findname(randomname))
-			continue
-		else
-			O.real_name = randomname
-			O.dna.real_name = randomname
-			i++
-	O.UpdateAppearance()
-	O.take_overall_damage(M.getBruteLoss(), M.getFireLoss())
-	O.adjustToxLoss(M.getToxLoss())
-	O.adjustOxyLoss(M.getOxyLoss())
-	O.stat = M.stat
-	for (var/obj/item/weapon/implant/I in implants)
-		I.loc = O
-		I.implanted = O
-//		O.update_icon = 1	//queue a full icon update at next life() call
-	qdel(M)
-	return
+		if(!H.dna.real_name)
+			var/randomname = H.species.get_random_name()
+			H.real_name = randomname
+			H.dna.real_name = randomname

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -87,7 +87,7 @@
 	organs_by_name = null
 	bad_internal_organs = null
 	bad_external_organs = null
-	
+
 	QDEL_NULL(DS)
 	// qdel and null out our equipment.
 	QDEL_NULL(shoes)
@@ -1128,7 +1128,7 @@
 	else
 		usr << "<span class='warning'>You failed to check the pulse. Try again.</span>"
 
-/mob/living/carbon/human/proc/set_species(var/new_species, var/default_colour)
+/mob/living/carbon/human/proc/set_species(var/new_species, var/default_colour, var/kpg=0)
 
 	if(!dna)
 		if(!new_species)
@@ -1180,7 +1180,7 @@
 
 	species.create_organs(src)
 
-	species.handle_post_spawn(src)
+	species.handle_post_spawn(src,kpg) // should be zero by default
 
 	maxHealth = species.total_health
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -317,13 +317,18 @@
 			H.verbs |= verb_path
 	return
 
-/datum/species/proc/handle_post_spawn(var/mob/living/carbon/human/H) //Handles anything not already covered by basic species assignment.
+/datum/species/proc/handle_post_spawn(var/mob/living/carbon/human/H,var/kpg = 0) //Handles anything not already covered by basic species assignment. Keepgene value should only be used by genetics.
 	add_inherent_verbs(H)
 	H.mob_bump_flag = bump_flag
 	H.mob_swap_flags = swap_flags
 	H.mob_push_flags = push_flags
 	H.pass_flags = pass_flags
 	H.mob_size = mob_size
+	if(!kpg)
+		if(islesserform(H))
+			H.dna.SetSEState(MONKEYBLOCK,1)
+		else
+			H.dna.SetSEState(MONKEYBLOCK,0)
 
 /datum/species/proc/handle_death(var/mob/living/carbon/human/H, var/gibbed = 0) //Handles any species-specific death events (such as dionaea nymph spawns).
 	return

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -60,12 +60,23 @@
 	icobase = 'icons/mob/human_races/monkeys/r_farwa.dmi'
 	deform = 'icons/mob/human_races/monkeys/r_farwa.dmi'
 
-	greater_form = "Tajaran"
+	greater_form = "Tajara"
 	default_language = "Farwa"
 	flesh_color = "#AFA59E"
 	base_color = "#333333"
 	tail = "farwatail"
 	holder_type = /obj/item/weapon/holder/monkey/farwa
+
+/datum/species/monkey/tajaran/get_random_name()
+	return "farwa ([rand(100,999)])" // HACK HACK HACK, oh lords of coding please forgive me!
+
+/datum/species/monkey/tajaran/m_sai
+	name = "M'sai Farwa"
+	greater_form = "M'sai Tajara"
+
+/datum/species/monkey/tajaran/zhan_khazan
+	name = "Zhan-Khazan Farwa"
+	greater_form = "Zhan-Khazan Tajara"
 
 /datum/species/monkey/skrell
 	name = "Neaera"

--- a/code/modules/mob/living/carbon/human/species/station/tajaran_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/tajaran_subspecies.dm
@@ -23,6 +23,8 @@
 	heat_level_2 = 360 //RaceDefault 380 Default 400
 	heat_level_3 = 700 //RaceDefault 800 Default 1000
 
+	primitive_form = "Zhan-Khazan Farwa"
+
 	num_alternate_languages = 1 // Only one Extra Language
 
 /datum/species/tajaran/m_sai
@@ -47,5 +49,7 @@
 	heat_level_1 = 340 //RaceDefault 330 Default 360
 	heat_level_2 = 390 //RaceDefault 380 Default 400
 	heat_level_3 = 900 //RaceDefault 800 Default 1000
+
+	primitive_form = "M'sai Farwa"
 
 	secondary_langs = list(LANGUAGE_SIIK_MAAS, LANGUAGE_SIIK_TAJR, LANGUAGE_SIGN_TAJARA)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/proc/monkeyize()
+/mob/living/carbon/human/proc/monkeyize(var/kpg=0)
 	if (transforming)
 		return
 	for(var/obj/item/W in src)
@@ -11,8 +11,6 @@
 	stunned = 1
 	icon = null
 	invisibility = 101
-	for(var/t in organs)
-		qdel(t)
 	var/atom/movable/overlay/animation = new /atom/movable/overlay( loc )
 	animation.icon_state = "blank"
 	animation.icon = 'icons/mob/mob.dmi'
@@ -33,13 +31,54 @@
 	for(var/obj/item/W in src)
 		drop_from_inventory(W)
 	set_species(species.primitive_form)
-	dna.SetSEState(MONKEYBLOCK,1)
-	dna.SetSEValueRange(MONKEYBLOCK,0xDAC, 0xFFF)
+	if(!kpg)
+		dna.SetSEState(MONKEYBLOCK,1)
 
 	src << "<B>You are now [species.name]. </B>"
 	qdel(animation)
 
 	return src
+
+/mob/living/carbon/human/proc/humanize(var/kpg=0) // we needed this a lot to be honest, why wasn't it made before?
+	if (transforming)
+		return
+	for(var/obj/item/W in src)
+		drop_from_inventory(W)
+	regenerate_icons()
+	transforming = 1
+	canmove = 0
+	stunned = 1
+	icon = null
+	invisibility = 101
+	var/atom/movable/overlay/animation = new /atom/movable/overlay( loc )
+	animation.icon_state = "blank"
+	animation.icon = 'icons/mob/mob.dmi'
+	animation.master = src
+	flick("monkey2h", animation)
+	sleep(48)
+
+	transforming = 0
+	stunned = 0
+	update_canmove()
+	invisibility = initial(invisibility)
+
+	if(!species.greater_form) //If the creature in question has no greater form set, this is going to be messy.
+		gib()
+		return
+
+	for(var/obj/item/W in src)
+		drop_from_inventory(W)
+	set_species(species.greater_form)
+	if(!kpg)
+		dna.SetSEState(MONKEYBLOCK,0)
+
+	src << "<B>You are now [species.name]. </B>"
+	qdel(animation)
+
+	return src
+
+
+
 
 /mob/new_player/AIize()
 	spawning = 1

--- a/html/changelogs/MoondancerPony-PR-[2059].yml
+++ b/html/changelogs/MoondancerPony-PR-[2059].yml
@@ -1,0 +1,7 @@
+author: MoondancerPony
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed protohumans."
+  - rscadd: "Tajaran subspecies now have their own subspecies of Farwa."


### PR DESCRIPTION
* Added a `Humanize()` proc that converts from lesser to greater form.
* Made `Monkeyize()`, `Humanize()`, `handle_post_spawn()`, and `set_species` take a 'keepgenes' argument that tells whether or not to keep or override the gene for lesser or greater form.
* Fixed what I presume is a typo in defining the 'hard' genetics bounds.
* Made `MONKEYBLOCK` actually functional.