### PR TITLE
Insulated Stungloves retain their Siemens coefficient

### DIFF
--- a/code/modules/clothing/gloves/stungloves.dm
+++ b/code/modules/clothing/gloves/stungloves.dm
@@ -25,7 +25,9 @@
 
 		C.use(2)
 		wired = 1
-		siemens_coefficient = 3.0
+		if (!istype(src, /obj/item/clothing/gloves/yellow))
+    		siemens_coefficient = 3
+		..()
 		user << "<span class='notice'>You wrap some wires around the [src].</span>"
 		update_icon()
 		return

--- a/code/modules/clothing/gloves/stungloves.dm
+++ b/code/modules/clothing/gloves/stungloves.dm
@@ -26,8 +26,8 @@
 		C.use(2)
 		wired = 1
 		if (!istype(src, /obj/item/clothing/gloves/yellow))
-    		siemens_coefficient = 3
-		..()
+			siemens_coefficient = 3
+			..()
 		user << "<span class='notice'>You wrap some wires around the [src].</span>"
 		update_icon()
 		return

--- a/code/modules/clothing/gloves/stungloves.dm
+++ b/code/modules/clothing/gloves/stungloves.dm
@@ -25,7 +25,7 @@
 
 		C.use(2)
 		wired = 1
-		if (!istype(src, /obj/item/clothing/gloves/yellow))
+		if (!istype(src, /obj/item/clothing/gloves/yellow) && !istype(src, /obj/item/clothing/gloves/fyellow))
 			siemens_coefficient = 3
 			..()
 		user << "<span class='notice'>You wrap some wires around the [src].</span>"

--- a/html/changelogs/Ezuo-siemens_coefficient.yml
+++ b/html/changelogs/Ezuo-siemens_coefficient.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Ezuo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Some pesky, no good engineers have revised the blueprints for stun gloves, and as such insulated gloves are no longer affected by wiring."


### PR DESCRIPTION
Changes the code for gloves of the yellow and fyellow type to retain their Siemens coefficient after wires have been added to them. Also a changelog file.