### PR TITLE
Nightmode Tweaks 2: The Fixening

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -13,9 +13,7 @@ proc/worldtime2text(time = world.time, timeshift = 1)
 /proc/worldtime2hours()
 	if (!roundstart_hour)
 		worldtime2text()
-	. = (world.timeofday / (60 MINUTES)) + roundstart_hour
-	if (. > 24)
-		. -= 24
+	. = text2num(time2text(world.time + (36000 * roundstart_hour), "hh"))
 
 proc/worlddate2text()
 	return num2text(game_year) + "-" + time2text(world.timeofday, "MM-DD")

--- a/code/controllers/Processes/night_lighting.dm
+++ b/code/controllers/Processes/night_lighting.dm
@@ -3,7 +3,10 @@ var/datum/controller/process/night_lighting/nl_ctrl
 /datum/controller/process/night_lighting/
 	var/isactive = 0
 	var/firstrun = 1
-	var/manual_override = 0
+	var/manual_override = 0	
+		// 0 -> No manual override
+		// 1 -> Override via. player-set nightmode setting (like CE console)
+		// 2 -> Red-alert override.
 
 /datum/controller/process/night_lighting/proc/is_active()
 	return isactive
@@ -19,25 +22,23 @@ var/datum/controller/process/night_lighting/nl_ctrl
 		disabled = 1
 
 /datum/controller/process/night_lighting/preStart()
-	var/time = worldtime2hours()
-	if (time <= config.nl_finish || time >= config.nl_start)
-		activate()
-	else
-		deactivate()
+	doWork(FALSE)
 
-/datum/controller/process/night_lighting/doWork()
+/datum/controller/process/night_lighting/doWork(announce = TRUE)
 	if (manual_override)	// don't automatically change lighting if it was manually changed in-game
 		return
 
 	var/time = worldtime2hours()
 	if (time <= config.nl_finish || time >= config.nl_start)
 		if (!isactive)
-			command_announcement.Announce("Good evening. The time is [worldtime2text()]. \n\nThe automated systems aboard the [station_name()] will now dim lighting in the public hallways in order to accommodate the circadian rhythm of some species.", "Automated Lighting System", new_sound = 'sound/misc/bosuns_whistle.ogg')
 			activate()
+			if (announce)
+				command_announcement.Announce("Good evening. The time is [worldtime2text()]. \n\nThe automated systems aboard the [station_name()] will now dim lighting in the public hallways in order to accommodate the circadian rhythm of some species.", "Automated Lighting System", new_sound = 'sound/misc/bosuns_whistle.ogg')
 	else
 		if (isactive)
-			command_announcement.Announce("Good morning. The time is [worldtime2text()]. \n\nThe automated systems aboard the [station_name()] will now return the public hallway lighting levels to normal.", "Automated Lighting System", new_sound = 'sound/misc/bosuns_whistle.ogg')
 			deactivate()
+			if (announce)
+				command_announcement.Announce("Good morning. The time is [worldtime2text()]. \n\nThe automated systems aboard the [station_name()] will now return the public hallway lighting levels to normal.", "Automated Lighting System", new_sound = 'sound/misc/bosuns_whistle.ogg')
 
 // 'whitelisted' areas are areas that have nightmode explicitly enabled
 

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -25,16 +25,24 @@
 			if(SEC_LEVEL_GREEN)
 				security_announcement_down.Announce("[config.alert_desc_green]", "Attention! Security level lowered to green.")
 				security_level = SEC_LEVEL_GREEN
+				if (nl_ctrl.manual_override == 2)	// Disable override if it was set by code-red.
+					nl_ctrl.manual_override = 0
+					nl_ctrl.doWork(FALSE)	// Update night lighting if it was turned off by red alert.
 			if(SEC_LEVEL_BLUE)
 				if(security_level < SEC_LEVEL_BLUE)
 					security_announcement_up.Announce("[config.alert_desc_blue_upto]", "Attention! Security level elevated to blue.")
 				else
 					security_announcement_down.Announce("[config.alert_desc_blue_downto]", "Attention! Security level lowered to blue.")
 				security_level = SEC_LEVEL_BLUE
+				if (nl_ctrl.manual_override == 2)
+					nl_ctrl.manual_override = 0
+					nl_ctrl.doWork(FALSE)	// Update night lighting if it was turned off by red alert.
 			if(SEC_LEVEL_RED)
 				if(security_level < SEC_LEVEL_RED)
 					security_announcement_up.Announce("[config.alert_desc_red_upto]", "Attention! Security level elevated to red!")
 					nl_ctrl.deactivate(0)	// Disable nightmode globally
+					if (!nl_ctrl.manual_override)
+						nl_ctrl.manual_override = 2
 				else
 					security_announcement_down.Announce("[config.alert_desc_red_downto]", "Attention! Code red!")
 				security_level = SEC_LEVEL_RED

--- a/html/changelogs/lohikar-nightmodeagain.yml
+++ b/html/changelogs/lohikar-nightmodeagain.yml
@@ -1,0 +1,5 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "NanoTrasen has fired several designers in charge of stations' night-mode control systems after it was revealed that they did not actually know how time works."
+  - tweak: "Red-alert is now kind enough to restore the previous nightmode settings instead of forcing its standards of illumination on the crew."


### PR DESCRIPTION
I actually fixed it this time I swear

changes: 
- Nightmode now follows the station's time instead of some random time schedule that made no sense.
- Red alert will properly disable night mode now.
- Dropping from red alert will reset nightmode to the state it was in before red alert was triggered.