### PR TITLE
Darkness Fixes & Shell Tweaks

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -95,7 +95,7 @@
 /datum/ai_laws/drone/New()
 	add_inherent_law("Preserve, repair and improve the station to the best of your abilities.")
 	add_inherent_law("Cause no harm to the station or crew.")
-	add_inherent_law("Interact with no humanoid or synthetic being. that is not a fellow maintenance drone.")
+	add_inherent_law("Interact with no humanoid or synthetic being that is not a fellow maintenance drone.")
 	..()
 
 /datum/ai_laws/construction_drone

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -472,6 +472,9 @@ var/global/datum/controller/occupations/job_master
 				var/obj/item/clothing/glasses/G = H.glasses
 				G.prescription = 1
 
+		// So shoes aren't silent if people never change 'em.
+		H.update_noise_level()
+
 		BITSET(H.hud_updateflag, ID_HUD)
 		BITSET(H.hud_updateflag, IMPLOYAL_HUD)
 		BITSET(H.hud_updateflag, SPECIALROLE_HUD)

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -78,13 +78,14 @@
 		. =  W
 
 	recalc_atom_opacity()
+
 	lighting_overlay = old_lighting_overlay
 	affecting_lights = old_affecting_lights
 	corners = old_corners
-	if((old_opacity != opacity) || (dynamic_lighting != old_dynamic_lighting) || force_lighting_update)
-		reconsider_lights()
 	if(dynamic_lighting != old_dynamic_lighting)
 		if(dynamic_lighting)
 			lighting_build_overlay()
 		else
 			lighting_clear_overlay()
+	if((old_opacity != opacity) || (dynamic_lighting != old_dynamic_lighting) || force_lighting_update)
+		force_update_lights()

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -17,12 +17,12 @@
 	dynamic_lighting = new_dynamic_lighting
 
 	if (new_dynamic_lighting)
-		for (var/turf/T in turfs)
+		for (var/turf/T in src)
 			if (T.dynamic_lighting)
 				T.lighting_build_overlay()
 
 	else
-		for (var/turf/T in turfs)
+		for (var/turf/T in src)
 			if (T.lighting_overlay)
 				T.lighting_clear_overlay()
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -127,7 +127,7 @@
 	. = ..()
 	if (is_noisy)
 		var/turf/T = get_turf(src)
-		if (T.x == last_x && T.y == last_y)
+		if ((T.x == last_x && T.y == last_y) || !T.footstep_sound)
 			return
 		last_x = T.x
 		last_y = T.y

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -437,8 +437,4 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if (shoes:silent)
 		return
 
-	var/turf/T = get_turf(src)
-	if (!istype(T) || !T.footstep_sound)
-		return
-
 	is_noisy = TRUE

--- a/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
@@ -35,7 +35,7 @@
 		"Your synthetic flesh crawls in the heat, swelling into a disgusting morass of plastic."
 		)
 
-	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE | HAS_EYE_COLOR | HAS_FBP
+	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE | HAS_EYE_COLOR | HAS_FBP | HAS_UNDERWEAR | HAS_SOCKS
 
 	has_limbs = list(
 		"chest" =  list("path" = /obj/item/organ/external/chest/shell),

--- a/html/changelogs/lohikar-finite-darkness.yml
+++ b/html/changelogs/lohikar-finite-darkness.yml
@@ -1,0 +1,6 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - rscadd: "Shells have figured out how to put on socks & undershirts. Synth uprising soon."
+  - bugfix: "Repairing holes to space no longer sucks the light out of a room forever."
+  - bugfix: "Footstep sounds now actually work without having to take off your boots."


### PR DESCRIPTION
changes:
- ChangeTurf no longer breaks lighting when switching from statically lit turfs to dynamically lit turfs.
- Human-types' `is_noisy` value is now updated on spawn; boots should now make footstep SFX without having to take them off and put them back on.
- Fixed a logic error in `is_noisy` calculations which could have lead to false-negatives.
- Shells can now wear socks & undershirts.
- Fixed a bug where changing the dynamic lighting status on an area would attempt to build lighting overlays for the entire map.

Fixes #2027.
Fixes #1982.
