### PR TITLE
Poison Balance Tweaks

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -254,6 +254,7 @@
 	description = "A chemical element."
 	reagent_state = LIQUID
 	color = "#484848"
+	met_ingest = REM*0.2
 
 /datum/reagent/mercury/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
@@ -261,7 +262,8 @@
 			step(M, pick(cardinal))
 		if(prob(5))
 			M.emote(pick("twitch", "drool", "moan"))
-		M.adjustBrainLoss(2)
+
+		M.adjustBrainLoss(removed)
 
 /datum/reagent/phosphorus
 	name = "Phosphorus"
@@ -316,11 +318,11 @@
 	color = "#DB5008"
 	metabolism = REM * 2
 	touch_met = 50 // It's acid!
-	var/power = 5
+	var/power = 4
 	var/meltdose = 10 // How much is needed to melt
 
 /datum/reagent/acid/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.take_organ_damage(0, removed * power * 2)
+	M.take_organ_damage(0, removed * power)
 
 /datum/reagent/acid/affect_touch(var/mob/living/carbon/M, var/alien, var/removed) // This is the most interesting
 	if(ishuman(M))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -254,7 +254,7 @@
 	description = "A chemical element."
 	reagent_state = LIQUID
 	color = "#484848"
-	met_ingest = REM*0.2
+	ingest_met = REM*0.2
 
 /datum/reagent/mercury/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -195,7 +195,7 @@
 		return
 	M.SetParalysis(0)
 	M.SetWeakened(0)
-	M.adjustToxLoss(rand(3))
+	M.adjustToxLoss(rand(3)*removed)
 
 /datum/reagent/water/holywater
 	name = "Holy Water"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -141,6 +141,7 @@
 	M.confused = 0
 	M.sleeping = 0
 	M.jitteriness = 0
+	M.intoxication = 0
 	for(var/datum/disease/D in M.viruses)
 		D.spread = "Remissive"
 		D.stage--

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -6,7 +6,7 @@
 	description = "A toxic chemical."
 	reagent_state = LIQUID
 	color = "#CF3600"
-	metabolism = REM * 0.05 // 0.01 by default. They last a while and slowly kill you.
+	metabolism = REM * 0.1 // 0.02 by default. They last a while and slowly kill you.
 	var/strength = 4 // How much damage it deals per unit
 
 /datum/reagent/toxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -232,7 +232,7 @@
 	description = "Polytrinic acid is a an extremely corrosive chemical substance."
 	reagent_state = LIQUID
 	color = "#8E18A9"
-	power = 10
+	power = 6
 	meltdose = 4
 
 /datum/reagent/lexorin
@@ -246,7 +246,7 @@
 /datum/reagent/lexorin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	M.take_organ_damage(3 * removed, 0)
+	M.adjustOxyLoss(2 * removed)
 	if(M.losebreath < 15)
 		M.losebreath++
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -424,7 +424,7 @@
 		return
 	M.jitteriness = max(M.jitteriness - 5, 0)
 	if(prob(80))
-		M.adjustBrainLoss(removed)
+		M.adjustBrainLoss(3 * removed)
 	if(prob(50))
 		M.drowsyness = max(M.drowsyness, 3)
 	if(prob(10))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -424,7 +424,7 @@
 		return
 	M.jitteriness = max(M.jitteriness - 5, 0)
 	if(prob(80))
-		M.adjustBrainLoss(3 * removed)
+		M.adjustBrainLoss(removed)
 	if(prob(50))
 		M.drowsyness = max(M.drowsyness, 3)
 	if(prob(10))

--- a/html/changelogs/Nanako-Poisons.yml
+++ b/html/changelogs/Nanako-Poisons.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Reduced the power of several near-instadeath chems. Most notably mercury and polytrinic acid."
+  - tweak: "Buffed lexorin to be a bit less useless. Changeling death sting is more deadly now."


### PR DESCRIPTION
A small tweak patch to fix some odd balancing issues with certain chems. Generally homogenising the poison chems to have less instakill options and see a little more use from the less common ones

Majorly nerfed polytrinic acid, because it was lethal at 5u dose
Majorly nerfed mercury, it was a 30 second kill and its available in the dispenser.  

Minorly nerfed a couple of other things, mostly standardisation - factoring in removed where it wasn't before. doing flat effects every metabolism tick is generally bad. This was the issue with mercury.

Buffed the base metabolic rate of poisons. its still generally extremely slow

Buffed lexorin by removing the (irrelevant) brute damage and adding some extra oxyloss instead (doesn't heal due to the losebreath effect). This should make the changeling's death sting not entirely worthless.