### PR TITLE
RnD Deconstruction Fix

### DIFF
--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -102,7 +102,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 		if(materials[f] >= SHEET_MATERIAL_AMOUNT)
 			var/path = getMaterialType(f)
 			if(path)
-				var/obj/item/stack/S = new f(loc)
+				var/obj/item/stack/S = new path(loc)
 				S.amount = round(materials[f] / SHEET_MATERIAL_AMOUNT)
 	..()
 

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -90,7 +90,7 @@
 		if(materials[f] >= SHEET_MATERIAL_AMOUNT)
 			var/path = getMaterialType(f)
 			if(path)
-				var/obj/item/stack/S = new f(loc)
+				var/obj/item/stack/S = new path(loc)
 				S.amount = round(materials[f] / SHEET_MATERIAL_AMOUNT)
 	..()
 

--- a/html/changelogs/lohikar-rndfix.yml
+++ b/html/changelogs/lohikar-rndfix.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Fixed a bug where RnD machinery with materials inserted could not be disassembled."


### PR DESCRIPTION
changes:
- Fixed a bug where the Circuit Imprinter & the Protolathe tried to `new()` a material name instead of the material's type on deconstruct. This fixes a runtime preventing deconstruction when the machine contained materials.

Fixes #2080.