### PR TITLE
No More Psyborgs (Fixes #2077, adds Industrial Frame functionality requested by Cake)

### DIFF
--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -32,7 +32,7 @@
 
 	cell = new/obj/item/weapon/cell()	//comes with the crappy default power cell - high-capacity ones shouldn't be hard to find
 	cell.loc = src
-	
+
 // Checks whether the cooling unit is being worn on the back/suit slot.
 // That way you can't carry it in your hands while it's running to cool yourself down.
 /obj/item/device/suit_cooling_unit/proc/is_in_slot()
@@ -48,7 +48,7 @@
 
 	if (!is_in_slot())
 		return
-		
+
 	var/mob/living/carbon/human/H = loc
 
 	var/efficiency = 1 - H.get_pressure_weakness()		//you need to have a good seal for effective cooling
@@ -197,6 +197,10 @@
 	if (on)
 		if (attached_to_suit(src.loc))
 			user << "It's switched on and running."
+		else if (istype(src.loc, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = src.loc
+			if (H.get_species()=="Industrial Frame")
+				user << "It's switched on and running, connected to the cooling systems of [H]."
 		else
 			user << "It's switched on, but not attached to anything."
 	else

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -133,6 +133,9 @@
 
 	pressure_adjustment_coefficient = min(1,max(pressure_adjustment_coefficient,0)) // So it isn't less than 0 or larger than 1.
 
+	if(src.get_species() == "Industrial Frame")
+		pressure_adjustment_coefficient = 0 // woo, back-mounted cooling!
+
 	return pressure_adjustment_coefficient
 
 // Calculate how much of the enviroment pressure-difference affects the human.
@@ -169,11 +172,18 @@
 	if(species.vision_organ)
 		vision = internal_organs_by_name[species.vision_organ]
 
-	if(!vision) // Presumably if a species has no vision organs, they see via some other means.
+	if(species.vision_organ && !vision) // eyes have been removed via surgery or other means
+		vision = "removed" // as nothing is done with it later in this proc this is an okay fix, should probably be fixed better later
+
+	if(vision == "removed") // quick fix because otherwise a removed vision organ would let you see
+		eye_blind =  1
+		blinded =    1
+		eye_blurry = 1
+	else if(!vision) // Presumably if a species has no vision organs, they see via some other means.
 		eye_blind =  0
 		blinded =    0
 		eye_blurry = 0
-	else if(vision.is_broken())   // Vision organs cut out or broken? Permablind.
+	else if(vision.is_broken())   // Vision organs cut out or broken? Permablind. (Doesn't seem to apply if the vision organ has been removed via surgery.)
 		eye_blind =  1
 		blinded =    1
 		eye_blurry = 1

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -172,20 +172,18 @@
 	if(species.vision_organ)
 		vision = internal_organs_by_name[species.vision_organ]
 
-	if(species.vision_organ && !vision) // eyes have been removed via surgery or other means
-		vision = "removed" // as nothing is done with it later in this proc this is an okay fix, should probably be fixed better later
-
-	if(vision == "removed") // quick fix because otherwise a removed vision organ would let you see
-		eye_blind =  1
-		blinded =    1
-		eye_blurry = 1
-	else if(!vision) // Presumably if a species has no vision organs, they see via some other means.
-		eye_blind =  0
-		blinded =    0
-		eye_blurry = 0
-	else if(vision.is_broken())   // Vision organs cut out or broken? Permablind. (Doesn't seem to apply if the vision organ has been removed via surgery.)
-		eye_blind =  1
-		blinded =    1
+	if (!vision)
+		if (species.vision_organ) // if they should have eyes but don't, they can't see
+			eye_blind = 1
+			blinded = 1
+			eye_blurry = 1
+		else // if they're not supposed to have a vision organ, then they must see by some other means
+			eye_blind = 0
+			blinded = 0
+			eye_blurry = 0
+	else if (vision.is_broken()) // if their eyes have been damaged or detached, they're blinded
+		eye_blind = 1
+		blinded = 1
 		eye_blurry = 1
 	else
 		//blindness

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -341,6 +341,7 @@
 /obj/item/organ/external/chest/industrial
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/chest/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
@@ -348,6 +349,7 @@
 /obj/item/organ/external/groin/industrial
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/groin/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
@@ -355,6 +357,7 @@
 /obj/item/organ/external/arm/industrial
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/arm/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
@@ -362,6 +365,7 @@
 /obj/item/organ/external/arm/right/industrial
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/arm/right/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
@@ -369,6 +373,7 @@
 /obj/item/organ/external/leg/industrial
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/leg/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
@@ -376,6 +381,7 @@
 /obj/item/organ/external/leg/right/industrial
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/leg/right/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
@@ -383,6 +389,7 @@
 /obj/item/organ/external/foot/industrial
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/foot/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
@@ -390,6 +397,7 @@
 /obj/item/organ/external/foot/right/industrial
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/foot/right/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
@@ -397,6 +405,7 @@
 /obj/item/organ/external/hand/industrial
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/hand/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
@@ -404,6 +413,7 @@
 /obj/item/organ/external/hand/right/industrial
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/hand/right/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -7,7 +7,7 @@
 	vital = 1 //because it is now hosting the posibrain
 	max_damage = 50 //made same as arm, since it is not vital
 	min_broken_damage = 30
-	encased = null
+	encased = "support frame"
 
 /obj/item/organ/external/head/ipc/New()
 	robotize("Hephaestus Integrated Limb")
@@ -15,31 +15,35 @@
 
 /obj/item/organ/external/chest/ipc
 	dislocated = -1
-	encased = null
+	encased = "support frame"
 /obj/item/organ/external/chest/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
 
 /obj/item/organ/external/groin/ipc
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/groin/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
 
 /obj/item/organ/external/arm/ipc
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/arm/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
 
 /obj/item/organ/external/arm/right/ipc
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/arm/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
 
 /obj/item/organ/external/leg/ipc
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/leg/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -52,24 +56,28 @@
 
 /obj/item/organ/external/foot/ipc
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/foot/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
 
 /obj/item/organ/external/foot/right/ipc
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/foot/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
 
 /obj/item/organ/external/hand/ipc
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/hand/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
 
 /obj/item/organ/external/hand/right/ipc
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/hand/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -214,7 +222,7 @@
 	vital = 0
 	max_damage = 50 //made same as arm, since it is not vital
 	min_broken_damage = 30
-	encased = null
+	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
 /obj/item/organ/eyes/optical_sensor/terminator
@@ -226,7 +234,7 @@
 
 /obj/item/organ/external/chest/terminator
 	dislocated = -1
-	encased = null
+	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
 /obj/item/organ/external/chest/terminator/New()
@@ -235,6 +243,7 @@
 
 /obj/item/organ/external/groin/terminator
 	dislocated = -1
+	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
 /obj/item/organ/external/groin/terminator/New()
@@ -243,6 +252,7 @@
 
 /obj/item/organ/external/arm/terminator
 	dislocated = -1
+	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
 /obj/item/organ/external/arm/terminator/New()
@@ -251,6 +261,7 @@
 
 /obj/item/organ/external/arm/right/terminator
 	dislocated = -1
+	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
 /obj/item/organ/external/arm/right/terminator/New()
@@ -259,6 +270,7 @@
 
 /obj/item/organ/external/leg/terminator
 	dislocated = -1
+	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
 /obj/item/organ/external/leg/terminator/New()
@@ -267,6 +279,7 @@
 
 /obj/item/organ/external/leg/right/terminator
 	dislocated = -1
+	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
 /obj/item/organ/external/leg/right/terminator/New()
@@ -275,6 +288,7 @@
 
 /obj/item/organ/external/foot/terminator
 	dislocated = -1
+	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
 /obj/item/organ/external/foot/terminator/New()
@@ -283,6 +297,7 @@
 
 /obj/item/organ/external/foot/right/terminator
 	dislocated = -1
+	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
 /obj/item/organ/external/foot/right/terminator/New()
@@ -291,6 +306,7 @@
 
 /obj/item/organ/external/hand/terminator
 	dislocated = -1
+	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
 /obj/item/organ/external/hand/terminator/New()
@@ -299,6 +315,7 @@
 
 /obj/item/organ/external/hand/right/terminator
 	dislocated = -1
+	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
 /obj/item/organ/external/hand/right/terminator/New()
@@ -315,7 +332,7 @@
 	vital = 0
 	max_damage = 50 //made same as arm, since it is not vital
 	min_broken_damage = 30
-	encased = null
+	encased = "support frame"
 
 /obj/item/organ/external/head/industrial/New()
 	robotize("Hephaestus Industrial Limb")
@@ -323,61 +340,70 @@
 
 /obj/item/organ/external/chest/industrial
 	dislocated = -1
-	encased = null
+	encased = "support frame"
 /obj/item/organ/external/chest/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
 
 /obj/item/organ/external/groin/industrial
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/groin/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
 
 /obj/item/organ/external/arm/industrial
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/arm/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
 
 /obj/item/organ/external/arm/right/industrial
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/arm/right/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
 
 /obj/item/organ/external/leg/industrial
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/leg/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
 
 /obj/item/organ/external/leg/right/industrial
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/leg/right/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
 
 /obj/item/organ/external/foot/industrial
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/foot/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
 
 /obj/item/organ/external/foot/right/industrial
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/foot/right/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
 
 /obj/item/organ/external/hand/industrial
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/hand/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
 
 /obj/item/organ/external/hand/right/industrial
 	dislocated = -1
+	encased = "support frame"
 /obj/item/organ/external/hand/right/industrial/New()
 	robotize("Hephaestus Industrial Limb")
 	..()
@@ -392,7 +418,7 @@
 	vital = 0
 	max_damage = 50 //made same as arm, since it is not vital
 	min_broken_damage = 30
-	encased = null
+	encased = "support frame"
 	force_skintone = TRUE
 
 /obj/item/organ/external/head/shell/New()
@@ -401,7 +427,7 @@
 
 /obj/item/organ/external/chest/shell
 	dislocated = -1
-	encased = null
+	encased = "support frame"
 	force_skintone = TRUE
 
 
@@ -411,6 +437,7 @@
 
 /obj/item/organ/external/groin/shell
 	dislocated = -1
+	encased = "support frame"
 	force_skintone = TRUE
 
 /obj/item/organ/external/groin/shell/New()
@@ -419,6 +446,7 @@
 
 /obj/item/organ/external/arm/shell
 	dislocated = -1
+	encased = "support frame"
 	force_skintone = TRUE
 
 /obj/item/organ/external/arm/shell/New()
@@ -427,6 +455,7 @@
 
 /obj/item/organ/external/arm/right/shell
 	dislocated = -1
+	encased = "support frame"
 	force_skintone = TRUE
 
 /obj/item/organ/external/arm/right/shell/New()
@@ -435,6 +464,7 @@
 
 /obj/item/organ/external/leg/shell
 	dislocated = -1
+	encased = "support frame"
 	force_skintone = TRUE
 
 /obj/item/organ/external/leg/shell/New()
@@ -443,6 +473,7 @@
 
 /obj/item/organ/external/leg/right/shell
 	dislocated = -1
+	encased = "support frame"
 	force_skintone = TRUE
 
 /obj/item/organ/external/leg/right/shell/New()
@@ -451,6 +482,7 @@
 
 /obj/item/organ/external/foot/shell
 	dislocated = -1
+	encased = "support frame"
 	force_skintone = TRUE
 
 /obj/item/organ/external/foot/shell/New()
@@ -459,6 +491,7 @@
 
 /obj/item/organ/external/foot/right/shell
 	dislocated = -1
+	encased = "support frame"
 	force_skintone = TRUE
 
 /obj/item/organ/external/foot/right/shell/New()
@@ -467,6 +500,7 @@
 
 /obj/item/organ/external/hand/shell
 	dislocated = -1
+	encased = "support frame"
 	force_skintone = TRUE
 
 /obj/item/organ/external/hand/shell/New()
@@ -475,6 +509,7 @@
 
 /obj/item/organ/external/hand/right/shell
 	dislocated = -1
+	encased = "support frame"
 	force_skintone = TRUE
 
 /obj/item/organ/external/hand/right/shell/New()

--- a/html/changelogs/Moondancer-PR-2076.yml
+++ b/html/changelogs/Moondancer-PR-2076.yml
@@ -1,0 +1,5 @@
+author: MoondancerPony
+delete-after: True
+changes: 
+  - bugfix: "Taught roboticists how to properly remove IPC organs."
+  - tweak: "IPC organs are now encased."

--- a/html/changelogs/Moondancer-PR-2076.yml
+++ b/html/changelogs/Moondancer-PR-2076.yml
@@ -1,5 +1,0 @@
-author: MoondancerPony
-delete-after: True
-changes: 
-  - bugfix: "Taught roboticists how to properly remove IPC organs."
-  - tweak: "IPC organs are now encased."

--- a/html/changelogs/Moondancer-PR-2087.yml
+++ b/html/changelogs/Moondancer-PR-2087.yml
@@ -1,0 +1,5 @@
+author: MoondancerPony
+delete-after: True
+changes: 
+  - bugfix: "Removed blind IPC clairvoyance. IPCs can no longer see when their optics have been removed."
+  - tweak: "Industrial IPCs are now officially rated for low-pressure usage."


### PR DESCRIPTION
* Stopped IPCs from being able to see without optics installed.
* Made Industrial Frames actually pressure-proof, which allows them to use suit coolers on their back.
(Apologies for accidentally including some old commits. They've already been merged, anyway, so I hope it's not too much trouble.)