### PR TITLE
Changed lobotomization to memory recall removal.

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -97,11 +97,11 @@
 
 	if(owner)
 		owner << "<span class='danger'>As part of your brain is drilled out, you feel your past self, your memories, your very being slip away...</span>"
-		owner << "<b>Your brain has been surgically altered to prepare for insertion into an MMI. Your memories and your former life have been surgically removed from your brain, and while your brain is in this state you remember nothing that ever came before this moment.</b>"
+		owner << "<b>Your brain has been surgically altered to remove your memory recall. Your ability to recall your former life has been surgically removed from your brain, and while your brain is in this state you remember nothing that ever came before this moment.</b>"
 
 	else if(brainmob)
 		brainmob << "<span class='danger'>As part of your brain is drilled out, you feel your past self, your memories, your very being slip away...</span>"
-		brainmob << "<b>Your brain has been surgically altered to prepare for insertion into an MMI. Your memories and your former life have been surgically removed from your brain, and while your brain is in this state you remember nothing that ever came before this moment.</b>"
+		brainmob << "<b>Your brain has been surgically altered to remove your memory recall. Your ability to recall your former life has been surgically removed from your brain, and while your brain is in this state you remember nothing that ever came before this moment.</b>"
 
 	return
 

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -97,18 +97,18 @@
 
 	if(owner)
 		owner << "<span class='danger'>As part of your brain is drilled out, you feel your past self, your memories, your very being slip away...</span>"
-		owner << "<b>You have been lobotomized. Your memories and your former life have been surgically removed from your brain, and while you are lobotomized you remember nothing that ever came before this moment.</b>"
+		owner << "<b>Your brain has been surgically altered to prepare for insertion into an MMI. Your memories and your former life have been surgically removed from your brain, and while your brain is in this state you remember nothing that ever came before this moment.</b>"
 
 	else if(brainmob)
 		brainmob << "<span class='danger'>As part of your brain is drilled out, you feel your past self, your memories, your very being slip away...</span>"
-		brainmob << "<b>You have been lobotomized. Your memories and your former life have been surgically removed from your brain, and while you are lobotomized you remember nothing that ever came before this moment.</b>"
+		brainmob << "<b>Your brain has been surgically altered to prepare for insertion into an MMI. Your memories and your former life have been surgically removed from your brain, and while your brain is in this state you remember nothing that ever came before this moment.</b>"
 
 	return
 
 /obj/item/organ/brain/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/weapon/surgicaldrill))
 		if(!lobotomized)
-			user.visible_message("<span class='danger'>[user] drills [src] deftly with [W], severing part of the brain!</span>")
+			user.visible_message("<span class='danger'>[user] drills [src] deftly with [W] into the brain!</span>")
 			lobotomize(user)
 		else
 			user << "<span class='notice'>The brain has already been operated on!</span>"

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -342,7 +342,7 @@
 		"<span class='warning'>Your hand slips, damaging the flesh in [target]'s [affected.name] with \the [tool]!</span>")
 		affected.createwound(BRUISE, 20)
 
-/datum/surgery_step/internal/lobotomize
+/datum/surgery_step/internal/mmiprep
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/manager = 95,
 	/obj/item/weapon/surgicaldrill = 75,
@@ -368,15 +368,15 @@
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/brain/B = target.op_stage.current_organ
-		user.visible_message("[user] begins lobotomizing [target]'s [B.name] with \the [tool].", \
-		"You start lobotomizing [target]'s [B.name] with \the [tool].")
+		user.visible_message("[user] begins to prepare [target]'s [B.name] for insertion into an MMI with \the [tool].", \
+		"You start to prepare [target]'s [B.name] for insertion into an MMI with \the [tool].")
 		target.custom_pain("Someone's scraping away at your [B.name]!",1)
 		..()
 
 	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/brain/B = target.op_stage.current_organ
-		user.visible_message("<span class='notice'>[user] has lobotomized [target]'s \the [B.name] with \the [tool].</span>" , \
-		"<span class='notice'>You have lobotomized [target]'s [B.name] with \the [tool].</span>")
+		user.visible_message("<span class='notice'>[user] has prepared [target]'s [B] for insertion into an MMI with \the [tool].</span>" , \
+		"<span class='notice'>You have prepared [target]'s [B] for insertion into an MMI with \the [tool].</span>")
 		B.lobotomize(user)
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -368,15 +368,15 @@
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/brain/B = target.op_stage.current_organ
-		user.visible_message("[user] begins to prepare [target]'s [B.name] for insertion into an MMI with \the [tool].", \
-		"You start to prepare [target]'s [B.name] for insertion into an MMI with \the [tool].")
-		target.custom_pain("Someone's scraping away at your [B.name]!",1)
+		user.visible_message("[user] begins to modify [target]'s [B] to remove their memory recall with \the [tool].", \
+		"You start to modify [target]'s [B] to remove their memory recall with \the [tool].")
+		target.custom_pain("Someone's scraping away at your [B]!",1)
 		..()
 
 	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/brain/B = target.op_stage.current_organ
-		user.visible_message("<span class='notice'>[user] has prepared [target]'s [B] for insertion into an MMI with \the [tool].</span>" , \
-		"<span class='notice'>You have prepared [target]'s [B] for insertion into an MMI with \the [tool].</span>")
+		user.visible_message("<span class='notice'>[user] has modified [target]'s [B] to remove their memory recall with \the [tool].</span>" , \
+		"<span class='notice'>You have removed [target]'s memory recall with \the [tool].</span>")
 		B.lobotomize(user)
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -342,7 +342,7 @@
 		"<span class='warning'>Your hand slips, damaging the flesh in [target]'s [affected.name] with \the [tool]!</span>")
 		affected.createwound(BRUISE, 20)
 
-/datum/surgery_step/internal/mmiprep
+/datum/surgery_step/internal/lobotomize
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/manager = 95,
 	/obj/item/weapon/surgicaldrill = 75,


### PR DESCRIPTION
* Changed the name of lobotomization to MMI preparation in messages displayed to players.
It still functions the same. This is due to concerns that a lobotomy would not have the described effect, and a medical professional (such as a character performing the surgery) would not call that one.