### PR TITLE
Logging Fixes

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -78,7 +78,7 @@
 /proc/log_attack(text,level=5,ckey="",ckey_target="")
 	if (config.log_attack)
 		game_log("ATTACK", text)
-	send_gelf_log(short_message=text, long_message="[time_stamp()]: [text]",level=5,category="ATTACK",additional_data=list("_ckey"=html_encode(ckey),"_ckey_target"=html_encode(ckey_target)))
+	send_gelf_log(short_message=text, long_message="[time_stamp()]: [text]",level=level,category="ATTACK",additional_data=list("_ckey"=html_encode(ckey),"_ckey_target"=html_encode(ckey_target)))
 
 /proc/log_adminsay(text)
 	if (config.log_adminchat)

--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -38,11 +38,11 @@
 					src.authorized += W:registered_name
 					if (src.auth_need - src.authorized.len > 0)
 						message_admins("[key_name_admin(user)] has authorized early shuttle launch")
-						log_game("[user.ckey] has authorized early shuttle launch",key_name(user))
+						log_game("[user.ckey] has authorized early shuttle launch",ckey=key_name(user))
 						world << text("<span class='notice'><b>Alert: [] authorizations needed until shuttle is launched early</b></span>", src.auth_need - src.authorized.len)
 					else
 						message_admins("[key_name_admin(user)] has launched the shuttle")
-						log_game("[user.ckey] has launched the shuttle early",key_name(user))
+						log_game("[user.ckey] has launched the shuttle early",ckey=key_name(user))
 						world << "<span class='notice'><b>Alert: Shuttle launch time shortened to 10 seconds!</b></span>"
 						emergency_shuttle.set_launch_countdown(10)
 						//src.authorized = null

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -600,7 +600,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		var/mob/dead/observer/M = O
 		if (M.client && alert(src, "They are still connected. Are you sure, they will loose connection.", "Confirmation", "Yes", "No") != "Yes")
 			return
-	log_admin("[key_name(usr)] deleted [O] at ([O.x],[O.y],[O.z])",,admin_key=key_name(usr))
+	log_admin("[key_name(usr)] deleted [O] at ([O.x],[O.y],[O.z])",admin_key=key_name(usr))
 	message_admins("[key_name_admin(usr)] deleted [O] at ([O.x],[O.y],[O.z])", 1)
 	feedback_add_details("admin_verb","DEL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
* Fixes log level not passed at attack log messages
* Fixes ckey being passed to the level field, instead of the ckey field on certain log messages, causing the log message to be dropped by GL as its expecting a integer and not a string.

No changelog, as its not effecting the users