### PR TITLE
Cameranet sorting fixes

### DIFF
--- a/code/controllers/subsystems/machinery.dm
+++ b/code/controllers/subsystems/machinery.dm
@@ -74,6 +74,10 @@
 			makepowernets()
 			powernet_update_queued = FALSE
 
+		if (cameranet.cameras_unsorted)
+			sortTim(cameranet.cameras, /proc/cmp_camera)
+			cameranet.cameras_unsorted = FALSE
+
 	var/list/curr_machinery = src.processing_machinery
 	var/list/curr_powersinks = src.processing_powersinks
 

--- a/code/modules/mob/freelook/ai/update_triggers.dm
+++ b/code/modules/mob/freelook/ai/update_triggers.dm
@@ -13,10 +13,13 @@
 		if(provides_camera_vision())
 			if(!updating)
 				updating = 1
-				spawn(BORG_CAMERA_BUFFER)
-					if(oldLoc != src.loc)
-						cameranet.updatePortableCamera(src.camera)
-					updating = 0
+				addtimer(CALLBACK(src, .proc/camera_post_move, oldLoc), BORG_CAMERA_BUFFER)
+
+/mob/living/silicon/robot/proc/camera_post_move(oldLoc)
+	if (oldLoc != loc)
+		cameranet.updatePortableCamera(camera)
+
+	updating = 0
 
 /mob/living/silicon/ai/Move()
 	var/oldLoc = src.loc
@@ -47,11 +50,8 @@
 /obj/machinery/camera/Initialize()
 	. = ..()
 	//Camera must be added to global list of all cameras no matter what...
-	if(cameranet.cameras_unsorted)
-		cameranet.cameras += src
-		cameranet.cameras_unsorted = 1
-	else
-		dd_insertObjectList(cameranet.cameras, src)
+	cameranet.cameras += src
+	cameranet.cameras_unsorted = TRUE
 	update_coverage(1)
 
 /obj/machinery/camera/Destroy()

--- a/code/modules/mob/freelook/chunk.dm
+++ b/code/modules/mob/freelook/chunk.dm
@@ -62,11 +62,13 @@
 	if(visible || update_now)
 		if(!updating)
 			updating = 1
-			spawn(UPDATE_BUFFER) // Batch large changes, such as many doors opening or closing at once
-				update()
-				updating = 0
+			addtimer(CALLBACK(src, .proc/doUpdate), UPDATE_BUFFER)
 	else
 		changed = 1
+
+/datum/chunk/proc/doUpdate()
+	update()
+	updating = 0
 
 // The actual updating.
 
@@ -142,6 +144,7 @@
 
 	for(var/turf in obscuredTurfs)
 		var/turf/t = turf
+		LAZYINITLIST(t.obfuscations)
 		if(!t.obfuscations[obfuscation.type])
 			var/image/obfuscation_static = image(obfuscation.icon, t, obfuscation.icon_state, OBFUSCATION_LAYER)
 			obfuscation_static.plane = 0

--- a/code/modules/mob/freelook/update_triggers.dm
+++ b/code/modules/mob/freelook/update_triggers.dm
@@ -7,7 +7,7 @@
 		VN.updateVisibility(A, opacity_check)
 
 /turf
-	var/list/image/obfuscations = new()
+	var/list/image/obfuscations
 
 /turf/drain_power()
 	return -1


### PR DESCRIPTION
changes:
- The cameranet is now actually sorted like it's supposed to be. Whoops.
- The obfuscations list on turfs is now only created when it is actually needed, instead of every turf in the game having the list created from the start.
- Visualnet update buffers now use timers instead of spawn.

Fixes #2186.