### PR TITLE
Openturf throw fix & minor refactors

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -192,6 +192,10 @@
 	src.thrower = null
 	src.throw_source = null
 
+	if (isturf(loc))
+		var/turf/Tloc = loc
+		Tloc.Entered(src)
+
 
 //Overlays
 /atom/movable/overlay

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -15,13 +15,13 @@
 	var/volume_rate = 500              //Needed for borg jetpack transfer
 	action_button_name = "Toggle Jetpack"
 
-/obj/item/weapon/tank/jetpack/New()
-	..()
+/obj/item/weapon/tank/jetpack/Initialize()
+	. = ..()
 	src.ion_trail = new /datum/effect/effect/system/ion_trail_follow()
 	src.ion_trail.set_up(src)
 
 /obj/item/weapon/tank/jetpack/Destroy()
-	qdel(ion_trail)
+	QDEL_NULL(ion_trail)
 	return ..()
 
 /obj/item/weapon/tank/jetpack/examine(mob/user)
@@ -93,10 +93,9 @@
 	icon_state = "jetpack-void"
 	item_state =  "jetpack-void"
 
-/obj/item/weapon/tank/jetpack/void/New()
-	..()
+/obj/item/weapon/tank/jetpack/void/Initialize()
+	. = ..()
 	air_contents.adjust_gas("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/jetpack/oxygen
 	name = "jetpack (oxygen)"
@@ -104,10 +103,9 @@
 	icon_state = "jetpack"
 	item_state = "jetpack"
 
-/obj/item/weapon/tank/jetpack/oxygen/New()
-	..()
+/obj/item/weapon/tank/jetpack/oxygen/Initialize()
+	. = ..()
 	air_contents.adjust_gas("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/jetpack/carbondioxide
 	name = "jetpack (carbon dioxide)"
@@ -116,10 +114,9 @@
 	icon_state = "jetpack-black"
 	item_state =  "jetpack-black"
 
-/obj/item/weapon/tank/jetpack/carbondioxide/New()
-	..()
+/obj/item/weapon/tank/jetpack/carbondioxide/Initialize()
+	. = ..()
 	air_contents.adjust_gas("carbon_dioxide", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/jetpack/carbondioxide/synthetic
 	name = "Synthetic Jetpack"

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -17,16 +17,15 @@
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 
 
-	New()
-		..()
-		air_contents.adjust_gas("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-		return
+/obj/item/weapon/tank/oxygen/Initialize()
+	. = ..()
+	air_contents.adjust_gas("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
 
 
-	examine(mob/user)
-		if(..(user, 0) && air_contents.gas["oxygen"] < 10)
-			user << text("<span class='warning'>The meter on \the [src] indicates you are almost out of oxygen!</span>")
-			//playsound(usr, 'sound/effects/alert.ogg', 50, 1)
+/obj/item/weapon/tank/oxygen/examine(mob/user)
+	if(..(user, 0) && air_contents.gas["oxygen"] < 10)
+		user << text("<span class='warning'>The meter on \the [src] indicates you are almost out of oxygen!</span>")
+		//playsound(usr, 'sound/effects/alert.ogg', 50, 1)
 
 
 /obj/item/weapon/tank/oxygen/yellow
@@ -47,14 +46,12 @@
 	icon_state = "anesthetic"
 	item_state = "an_tank"
 
-/obj/item/weapon/tank/anesthetic/New()
-	..()
+/obj/item/weapon/tank/anesthetic/Initialize()
+	. = ..()
 
 	air_contents.gas["oxygen"] = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
 	air_contents.gas["sleeping_agent"] = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
 	air_contents.update_values()
-
-	return
 
 /*
  * Air
@@ -64,18 +61,14 @@
 	desc = "Mixed anyone?"
 	icon_state = "oxygen"
 
-
 	examine(mob/user)
 		if(..(user, 0) && air_contents.gas["oxygen"] < 1 && loc==user)
 			user << "<span class='danger'>The meter on the [src.name] indicates you are almost out of air!</span>"
 			user << sound('sound/effects/alert.ogg')
 
-/obj/item/weapon/tank/air/New()
-	..()
-
-	src.air_contents.adjust_multi("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD, "nitrogen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD)
-
-	return
+/obj/item/weapon/tank/air/Initialize()
+	. = ..()
+	air_contents.adjust_multi("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD, "nitrogen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD)
 
 
 /*
@@ -89,12 +82,9 @@
 	flags = CONDUCT
 	slot_flags = null	//they have no straps!
 
-
-/obj/item/weapon/tank/phoron/New()
-	..()
-
-	src.air_contents.adjust_gas("phoron", (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
-	return
+/obj/item/weapon/tank/phoron/Initialize()
+	. = ..()
+	air_contents.adjust_gas("phoron", (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
 
 /obj/item/weapon/tank/phoron/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
@@ -125,17 +115,15 @@
 	volume = 2 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
 
 
-	New()
-		..()
-		src.air_contents.adjust_gas("oxygen", (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-
-		return
+/obj/item/weapon/tank/emergency_oxygen/Initialize()
+	. = ..()
+	air_contents.adjust_gas("oxygen", (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
 
 
-	examine(mob/user)
-		if(..(user, 0) && air_contents.gas["oxygen"] < 0.2 && loc==user)
-			user << text("<span class='danger'>The meter on the [src.name] indicates you are almost out of air!</span>")
-			user << sound('sound/effects/alert.ogg')
+/obj/item/weapon/tank/emergency_oxygen/examine(mob/user)
+	if(..(user, 0) && air_contents.gas["oxygen"] < 0.2 && loc==user)
+		user << text("<span class='danger'>The meter on the [src.name] indicates you are almost out of air!</span>")
+		user << sound('sound/effects/alert.ogg')
 
 /obj/item/weapon/tank/emergency_oxygen/engi
 	name = "extended-capacity emergency oxygen tank"
@@ -160,18 +148,16 @@
 	force = 4.0
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 	volume = 2
+
 	
-	New()
-		..()
-		src.air_contents.adjust_gas("nitrogen", (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
+/obj/item/weapon/tank/emergency_nitrogen/Initialize()
+	. = ..()
+	air_contents.adjust_gas("nitrogen", (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
 
-		return
-
-
-	examine(mob/user)
-		if(..(user, 0) && air_contents.gas["nitrogen"] < 0.2 && loc==user)
-			user << text("<span class='danger'>The meter on \the [src] indicates you are almost out of air!</span>")
-			user << sound('sound/effects/alert.ogg')
+/obj/item/weapon/tank/emergency_nitrogen/examine(mob/user)
+	if(..(user, 0) && air_contents.gas["nitrogen"] < 0.2 && loc==user)
+		user << text("<span class='danger'>The meter on \the [src] indicates you are almost out of air!</span>")
+		user << sound('sound/effects/alert.ogg')
 
 /*
  * Nitrogen
@@ -182,12 +168,10 @@
 	icon_state = "oxygen_fr"
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 
+/obj/item/weapon/tank/nitrogen/Initialize()
+	. = ..()
 
-/obj/item/weapon/tank/nitrogen/New()
-	..()
-
-	src.air_contents.adjust_gas("nitrogen", (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
-	return
+	air_contents.adjust_gas("nitrogen", (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
 
 /obj/item/weapon/tank/nitrogen/examine(mob/user)
 	if(..(user, 0) && air_contents.gas["nitrogen"] < 10)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -29,19 +29,18 @@
 	var/volume = 70
 	var/manipulated_by = null		//Used by _onclick/hud/screen_objects.dm internals to determine if someone has messed with our tank or not.
 						//If they have and we haven't scanned it with the PDA or gas analyzer then we might just breath whatever they put in it.
-/obj/item/weapon/tank/New()
-	..()
+/obj/item/weapon/tank/Initialize()
+	. = ..()
 
-	src.air_contents = new /datum/gas_mixture()
-	src.air_contents.volume = volume //liters
-	src.air_contents.temperature = T20C
+	air_contents = new /datum/gas_mixture()
+	air_contents.volume = volume //liters
+	air_contents.temperature = T20C
+
 	START_PROCESSING(SSprocessing, src)
 	update_gauge()
-	return
 
 /obj/item/weapon/tank/Destroy()
-	if(air_contents)
-		qdel(air_contents)
+	QDEL_NULL(air_contents)
 
 	STOP_PROCESSING(SSprocessing, src)
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -650,13 +650,20 @@
 	if(!active)
 		active = 1
 		usr << "<span class='notice'>You activate the pinpointer</span>"
-		workdisk(user)
+		START_PROCESSING(SSfast_process, src)
 	else
 		active = 0
 		icon_state = "pinoff"
 		usr << "<span>You deactivate the pinpointer</span>"
+		STOP_PROCESSING(SSfast_process, src)
 
-/obj/item/weapon/ore_radar/proc/workdisk(var/user)
+/obj/item/weapon/ore_radar/process()
+	if (active)
+		workdisk()
+	else
+		STOP_PROCESSING(SSfast_process, src)
+
+/obj/item/weapon/ore_radar/proc/workdisk()
 	if(!src.loc)
 		active = 0
 
@@ -665,8 +672,8 @@
 
 	var/closest = 15
 
-	for(var/turf/simulated/mineral/random/R in orange(14,user))
-		var/dist = get_dist(user, R)
+	for(var/turf/simulated/mineral/random/R in orange(14,loc))
+		var/dist = get_dist(loc, R)
 		if(dist < closest)
 			closest = dist
 			sonar = R
@@ -674,8 +681,8 @@
 	if(!sonar)
 		icon_state = "pinonnull"
 		return
-	set_dir(get_dir(user,sonar))
-	switch(get_dist(user,sonar))
+	set_dir(get_dir(loc,sonar))
+	switch(get_dist(loc,sonar))
 		if(0)
 			icon_state = "pinondirect"
 		if(1 to 8)
@@ -684,7 +691,6 @@
 			icon_state = "pinonmedium"
 		if(16 to INFINITY)
 			icon_state = "pinonfar"
-	spawn(5) .()
 
 /**********************Jaunter**********************/
 

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -82,6 +82,7 @@
 /turf/simulated/open/Entered(atom/movable/mover)
 	..()
 	mover.fall()
+	update_icon()
 
 // override to make sure nothing is hidden
 /turf/simulated/open/levelupdate()


### PR DESCRIPTION
changes:
- Thrown objects will now fire Entered() on the turf they land on. As a result, they will now fall if they land on an openturf.
- Openturfs now queue an icon update if something falls down.
- `/obj/item/weapon/ore_radar` converted to use SSfast_process instead of a spawn loop.
- Converted hand-held tanks' New() to Initialize().

Note: This PR allows grenades to be thrown down openturfs.