### PR TITLE
Queued table icon updates

### DIFF
--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -1,17 +1,18 @@
-#define SS_INIT_MISC_FIRST         18
-#define SS_INIT_SEEDS              17	// Plant controller setup.
-#define SS_INIT_ASTEROID           16	// Asteroid generation.
-#define SS_INIT_SHUTTLE            15	// Shuttle setup.
-#define SS_INIT_PARALLAX           14	// Parallax image cache generation. Must run before ghosts are able to join.
-#define SS_INIT_ATOMS              13	// World initialization. Will trigger lighting updates. Observers can join after this loads.
-#define SS_INIT_POWER              12	// Initial powernet build.
-#define SS_INIT_CARGO              11	// Random warehouse generation. Runs after SSatoms because it assumes objects are initialized when it runs.
-#define SS_INIT_PIPENET            10	// Initial pipenet build.
-#define SS_INIT_MACHINERY           9	// Machinery prune and powernet build.
-#define SS_INIT_WIRELESS            8	// Wireless pair queue flush.
-#define SS_INIT_AIR                 7	// Air setup and pre-bake.
-#define SS_INIT_NIGHT               6	// Nightmode controller. Will trigger lighting updates.
-#define SS_INIT_SMOOTHING           5	// Object icon smoothing. Creates overlays.
+#define SS_INIT_MISC_FIRST         19
+#define SS_INIT_SEEDS              18	// Plant controller setup.
+#define SS_INIT_ASTEROID           17	// Asteroid generation.
+#define SS_INIT_SHUTTLE            16	// Shuttle setup.
+#define SS_INIT_PARALLAX           15	// Parallax image cache generation. Must run before ghosts are able to join.
+#define SS_INIT_ATOMS              14	// World initialization. Will trigger lighting updates. Observers can join after this loads.
+#define SS_INIT_POWER              13	// Initial powernet build.
+#define SS_INIT_CARGO              12	// Random warehouse generation. Runs after SSatoms because it assumes objects are initialized when it runs.
+#define SS_INIT_PIPENET            11	// Initial pipenet build.
+#define SS_INIT_MACHINERY          10	// Machinery prune and powernet build.
+#define SS_INIT_WIRELESS            9	// Wireless pair queue flush.
+#define SS_INIT_AIR                 8	// Air setup and pre-bake.
+#define SS_INIT_NIGHT               7	// Nightmode controller. Will trigger lighting updates.
+#define SS_INIT_SMOOTHING           6	// Object icon smoothing. Creates overlays.
+#define SS_INIT_ICON_UPDATE         5	// Icon update queue flush. Should run before overlays.
 #define SS_INIT_OVERLAY             4	// Overlay flush.
 #define SS_INIT_OPENTURF            3	// Openturf flush. Should run after SSoverlay & SSicon_smooth so it copies the smoothed sprites. Causes lighting updates if starlight is enabled.
 #define SS_INIT_MISC                2	// Subsystems without an explicitly set initialization order start here.

--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -25,8 +25,9 @@
 
 // SS_TICKER
 #define SS_PRIORITY_OVERLAY        500	// Applies overlays. May cause overlay pop-in if it gets behind.
-#define SS_PRIORITY_ORBIT          30	// Orbit datum updates.
 #define SS_PRIORITY_SMOOTHING      35   // Smooth turf generation.
+#define SS_PRIORITY_ORBIT          30	// Orbit datum updates.
+#define SS_PRIORITY_ICON_UPDATE    20	// Queued icon updates. Mostly used by APCs and tables.
 
 // Normal
 #define SS_PRIORITY_TICKER         200	// Gameticker.
@@ -42,7 +43,6 @@
 #define SS_PRIORITY_ALARMS         50
 #define SS_PRIORITY_PLANTS         40	// Spreading plant effects.
 #define SS_PRIORITY_EFFECTS        35	// Effect master (Sparks)
-#define SS_PRIORITY_ICON_UPDATE    30	// Queued icon updates. Mostly used by APCs.
 #define SS_PRIORITY_AIR            25	// ZAS processing.
 #define SS_PRIORITY_LIGHTING       20	// Queued lighting engine updates.
 #define SS_PRIORITY_AIRFLOW        15	// Handles object movement due to ZAS airflow.

--- a/code/controllers/subsystems/icon_updates.dm
+++ b/code/controllers/subsystems/icon_updates.dm
@@ -2,25 +2,24 @@
 
 /datum/controller/subsystem/icon
 	name = "Icon Updates"
-	flags = SS_BACKGROUND | SS_NO_INIT
 	wait = 1	// ds
 	priority = SS_PRIORITY_ICON_UPDATE
+	init_order = SS_INIT_ICON_UPDATE
 	
 	var/list/queue = list()
-	var/list/currentrun
 
 /datum/controller/subsystem/icon/New()
 	NEW_SS_GLOBAL(SSicon_update)
 
 /datum/controller/subsystem/icon/stat_entry()
-	..("Q:[queue.len] P:[LAZYLEN(currentrun)]")
+	..("QU:[queue.len]")
 
-/datum/controller/subsystem/icon/fire(resumed = FALSE)
-	if (!resumed)
-		currentrun = queue
-		queue = list()
+/datum/controller/subsystem/icon/Initialize()
+	fire(FALSE, TRUE)
+	..()
 
-	var/list/curr = currentrun
+/datum/controller/subsystem/icon/fire(resumed = FALSE, no_mc_tick = FALSE)
+	var/list/curr = queue
 
 	if (!curr.len)
 		suspend()
@@ -34,7 +33,9 @@
 		A.update_icon()
 		A.last_icon_update = world.time
 
-		if (MC_TICK_CHECK)
+		if (no_mc_tick)
+			CHECK_TICK
+		else if (MC_TICK_CHECK)
 			return
 
 /atom

--- a/code/controllers/subsystems/icon_updates.dm
+++ b/code/controllers/subsystems/icon_updates.dm
@@ -2,7 +2,8 @@
 
 /datum/controller/subsystem/icon
 	name = "Icon Updates"
-	wait = 1	// ds
+	wait = 1	// ticks
+	flags = SS_TICKER
 	priority = SS_PRIORITY_ICON_UPDATE
 	init_order = SS_INIT_ICON_UPDATE
 	

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -78,7 +78,7 @@
 	color = "#ffffff"
 	alpha = 255
 	update_connections(1)
-	update_icon()
+	queue_icon_update()
 	update_desc()
 	update_material()
 
@@ -87,7 +87,7 @@
 	reinforced = null
 	update_connections(1) // Update tables around us to ignore us (material=null forces no connections)
 	for(var/obj/structure/table/T in oview(src, 1))
-		T.update_icon()
+		T.queue_icon_update()
 	return ..()
 
 /obj/structure/table/examine(mob/user)
@@ -107,7 +107,7 @@
 		remove_reinforced(W, user)
 		if(!reinforced)
 			update_desc()
-			update_icon()
+			queue_icon_update()
 			update_material()
 		return 1
 
@@ -116,7 +116,7 @@
 		                              "<span class='notice'>You remove the carpet from \the [src].</span>")
 		new /obj/item/stack/tile/carpet(loc)
 		carpeted = 0
-		update_icon()
+		queue_icon_update()
 		return 1
 
 	if(!carpeted && material && istype(W, /obj/item/stack/tile/carpet))
@@ -125,7 +125,7 @@
 			user.visible_message("<span class='notice'>\The [user] adds \the [C] to \the [src].</span>",
 			                              "<span class='notice'>You add \the [C] to \the [src].</span>")
 			carpeted = 1
-			update_icon()
+			queue_icon_update()
 			return 1
 		else
 			user << "<span class='warning'>You don't have enough carpet!</span>"
@@ -134,9 +134,9 @@
 		remove_material(W, user)
 		if(!material)
 			update_connections(1)
-			update_icon()
+			queue_icon_update()
 			for(var/obj/structure/table/T in oview(src, 1))
-				T.update_icon()
+				T.queue_icon_update()
 			update_desc()
 			update_material()
 		return 1
@@ -161,7 +161,7 @@
 		material = common_material_add(W, user, "plat")
 		if(material)
 			update_connections(1)
-			update_icon()
+			queue_icon_update()
 			update_desc()
 			update_material()
 		return 1
@@ -194,7 +194,7 @@
 	reinforced = common_material_add(S, user, "reinforc")
 	if(reinforced)
 		update_desc()
-		update_icon()
+		queue_icon_update()
 		update_material()
 
 /obj/structure/table/proc/update_desc()
@@ -419,9 +419,8 @@
 		if(material && T.material && material.name == T.material.name && flipped == T.flipped)
 			connection_dirs |= T_dir
 		if(propagate)
-			spawn(0)
-				T.update_connections()
-				T.update_icon()
+			INVOKE_ASYNC(T, .update_connections)
+			INVOKE_ASYNC(T, /atom/.proc/queue_icon_update)
 
 	connections = dirs_to_corner_states(connection_dirs)
 


### PR DESCRIPTION
changes:
- Tables now use `queue_icon_update()` to trigger icon updates.
- SSicon_update has been promoted to `SS_TICKER` to reduce delay in icon updates.
- SSicon_update now only has one queue.

This should prevent excessive table icon updates & mitigate table-lag from nar'sie.