### PR TITLE
Fix manhacks attacking traitors, pirates and mercenaries

### DIFF
--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -18,6 +18,8 @@ var/datum/antagonist/mercenary/mercs
 	initial_spawn_req = 4
 	initial_spawn_target = 4
 
+	faction = "syndicate"
+
 /datum/antagonist/mercenary/New()
 	..()
 	mercs = src

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -15,6 +15,8 @@ var/datum/antagonist/raider/raiders
 	hard_cap_round = 10
 	initial_spawn_req = 4
 	initial_spawn_target = 6
+	
+	faction = "syndicate"
 
 	id_type = /obj/item/weapon/card/id/syndicate
 

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -6,6 +6,8 @@ var/datum/antagonist/traitor/traitors
 	restricted_jobs = list("Internal Affairs Agent", "Head of Security", "Captain")
 	protected_jobs = list("Security Officer", "Warden", "Detective")
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
+	
+	faction = "syndicate"
 
 /datum/antagonist/traitor/New()
 	..()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -507,6 +507,10 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		if(!(S.status & ORGAN_ROBOT) || user.a_intent != I_HELP)
 			return ..()
 
+		if(M.isSynthetic() && M == user)
+			user << "<span class='warning'>You can't repair damage to your own body - it's against OH&S.</span>"
+			return	
+
 		if(S.burn_dam)
 			if(S.burn_dam < ROBOLIMB_SELF_REPAIR_CAP)
 				S.heal_damage(0,15,0,1)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -497,7 +497,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 ///////////////////////////////////
 
 //you can use wires to heal robotics
-/obj/item/stack/cable_coil/afterattack(mob/living/M as mob, var/mob/user)
+/obj/item/stack/cable_coil/afterattack(var/mob/living/M, var/mob/user)
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -497,7 +497,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 ///////////////////////////////////
 
 //you can use wires to heal robotics
-/obj/item/stack/cable_coil/afterattack(var/mob/M, var/mob/user)
+/obj/item/stack/cable_coil/afterattack(mob/living/M as mob, var/mob/user)
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M

--- a/html/changelogs/alberky-PR-manhack.yml
+++ b/html/changelogs/alberky-PR-manhack.yml
@@ -1,0 +1,5 @@
+author: Alberyk
+
+delete-after: True
+
+  - bugfix: "Fix manhacks attacking traitors, heisters and mercenaries."

--- a/html/changelogs/alberky-PR-manhack.yml
+++ b/html/changelogs/alberky-PR-manhack.yml
@@ -2,4 +2,6 @@ author: Alberyk
 
 delete-after: True
 
- - bugfix: "Fix manhacks attacking traitors, heisters and mercenaries."
+changes: 
+ - bugfix: "Fixed manhacks attacking traitors, heisters and mercenaries."
+ - bugfix: "Fixed ipcs being able to repair themselves using cable coil."

--- a/html/changelogs/alberky-PR-manhack.yml
+++ b/html/changelogs/alberky-PR-manhack.yml
@@ -2,4 +2,4 @@ author: Alberyk
 
 delete-after: True
 
-  - bugfix: "Fix manhacks attacking traitors, heisters and mercenaries."
+ - bugfix: "Fix manhacks attacking traitors, heisters and mercenaries."

--- a/html/changelogs/alberky-PR-manhack.yml
+++ b/html/changelogs/alberky-PR-manhack.yml
@@ -3,5 +3,5 @@ author: Alberyk
 delete-after: True
 
 changes: 
- - bugfix: "Fixed manhacks attacking traitors, heisters and mercenaries."
- - bugfix: "Fixed ipcs being able to repair themselves using cable coil."
+  - bugfix: "Fixed manhacks attacking traitors, heisters and mercenaries."
+  - bugfix: "Fixed ipcs being able to repair themselves using cable coil."


### PR DESCRIPTION
This should fix manhacks attacking traitors, heisters and mercenaries, and yes this was tested.
Also fix ipcs being able to repair themselves with cable coil.