### PR TITLE
More discreet shells

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -39,7 +39,7 @@
 
 	msg += "<EM>[src.name]</EM>"
 
-	if(species.name != "Human")
+	if(!species.hide_name)
 		msg += ", a <b><font color='[species.flesh_color]'>[species.name]</font></b>"
 	msg += "!\n"
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -7,7 +7,8 @@
 	// Descriptors and strings.
 	var/name                                             // Species name.
 	var/name_plural                                      // Pluralized name (since "[name]s" is not always valid)
-	var/short_name											 // Shortened form of the name, for code use. Must be exactly 3 letter long, and all lowercase
+	var/hide_name = FALSE                                // If TRUE, the species' name won't be visible on examine.
+	var/short_name                                       // Shortened form of the name, for code use. Must be exactly 3 letter long, and all lowercase
 	var/blurb = "A completely nondescript species."      // A brief lore summary for use in the chargen screen.
 	var/bodytype
 	var/age_min = 17

--- a/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
@@ -1,5 +1,6 @@
 /datum/species/machine/shell
 	name = "Shell Frame"
+	hide_name = TRUE
 	short_name = "jak"
 	name_plural = "Shells"
 	bodytype = "Human"

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -1,5 +1,6 @@
 /datum/species/human
 	name = "Human"
+	hide_name = TRUE
 	short_name = "hum"
 	name_plural = "Humans"
 	bodytype = "Human"

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -16,6 +16,7 @@
 /obj/item/organ/external/chest/ipc
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/chest/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -23,6 +24,7 @@
 /obj/item/organ/external/groin/ipc
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/groin/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -30,6 +32,7 @@
 /obj/item/organ/external/arm/ipc
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/arm/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -37,6 +40,7 @@
 /obj/item/organ/external/arm/right/ipc
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/arm/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -44,12 +48,14 @@
 /obj/item/organ/external/leg/ipc
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/leg/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
 
 /obj/item/organ/external/leg/right/ipc
 	dislocated = -1
+
 /obj/item/organ/external/leg/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -57,6 +63,7 @@
 /obj/item/organ/external/foot/ipc
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/foot/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -64,6 +71,7 @@
 /obj/item/organ/external/foot/right/ipc
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/foot/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -71,6 +79,7 @@
 /obj/item/organ/external/hand/ipc
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/hand/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -78,6 +87,7 @@
 /obj/item/organ/external/hand/right/ipc
 	dislocated = -1
 	encased = "support frame"
+
 /obj/item/organ/external/hand/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -116,7 +126,7 @@
 /obj/item/organ/ipc_tag
 	name = "identification tag"
 	organ_tag = "ipc tag"
-	parent_organ = "groin"
+	parent_organ = "head"
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "gps-c"
 	dead_icon = "gps-c"

--- a/html/changelogs/lohikar-shell-stealth.yml
+++ b/html/changelogs/lohikar-shell-stealth.yml
@@ -2,3 +2,4 @@ author: Lohikar
 delete-after: True
 changes: 
   - tweak: "Examining a human-type will no longer explicitly tell you if they are a shell. Are your co-workers really what they say they are?"
+  - tweak: "IPC Tags are now located in the head. As such, you no longer need to stare at an IPC's groin to identify it."

--- a/html/changelogs/lohikar-shell-stealth.yml
+++ b/html/changelogs/lohikar-shell-stealth.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - tweak: "Examining a human-type will no longer explicitly tell you if they are a shell. Are your co-workers really what they say they are?"


### PR DESCRIPTION
changes:
- Shells Frames' species no longer show up on examine. They can still be detected via. other means such as checking pulse, health scanners, or them being damaged.
- IPC Tags are now located in the head instead of the groin.

Note: This does not affect tags showing up on examine. They must be manually removed from the shell to completely disguise their examine text.