### PR TITLE
Fix ipcs, dionae and species without dna getting mutations

### DIFF
--- a/code/game/dna/dna2_domutcheck.dm
+++ b/code/game/dna/dna2_domutcheck.dm
@@ -5,6 +5,12 @@
 // flags: See below, bitfield.
 #define MUTCHK_FORCED        1
 /proc/domutcheck(var/mob/living/M, var/connected=null, var/flags=0)
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.species && H.species.flags & NO_SCAN)
+			return
+			
 	for(var/datum/dna/gene/gene in dna_genes)
 		if(!M || !M.dna)
 			return

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -23,6 +23,10 @@
 // Give Random Bad Mutation to M
 /proc/randmutb(var/mob/living/M)
 	if(!M) return
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.species && H.species.flags & NO_SCAN)
+			return
 	M.dna.check_integrity()
 	var/block = pick(GLASSESBLOCK,COUGHBLOCK,FAKEBLOCK,NERVOUSBLOCK,CLUMSYBLOCK,TWITCHBLOCK,HEADACHEBLOCK,BLINDBLOCK,DEAFBLOCK,HALLUCINATIONBLOCK)
 	M.dna.SetSEState(block, 1)
@@ -30,6 +34,10 @@
 // Give Random Good Mutation to M
 /proc/randmutg(var/mob/living/M)
 	if(!M) return
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.species && H.species.flags & NO_SCAN)
+			return
 	M.dna.check_integrity()
 	var/block = pick(HULKBLOCK,XRAYBLOCK,FIREBLOCK,TELEBLOCK,NOBREATHBLOCK,REMOTEVIEWBLOCK,REGENERATEBLOCK,INCREASERUNBLOCK,REMOTETALKBLOCK,MORPHBLOCK,BLENDBLOCK,NOPRINTSBLOCK,SHOCKIMMUNITYBLOCK,SMALLSIZEBLOCK)
 	M.dna.SetSEState(block, 1)


### PR DESCRIPTION
May it be via rad storm or other bullshit, this will make sure that species with the NO_SCAN will suffer no dna mutations from storms and etc, no more ipcs with hulk or blind blocks ON.