### PR TITLE
Fix species without mouths being able to chew on hands while cuffed

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -88,7 +88,7 @@ var/last_chew = 0
 	if (!H.handcuffed) return
 	if (H.a_intent != I_HURT) return
 	if (H.zone_sel.selecting != "mouth") return
-	if (!H.check_has_mouth())
+	if (!H.check_has_mouth()) return
 	if (H.wear_mask) return
 	if (istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket)) return
 

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -88,6 +88,7 @@ var/last_chew = 0
 	if (!H.handcuffed) return
 	if (H.a_intent != I_HURT) return
 	if (H.zone_sel.selecting != "mouth") return
+	if (!H.check_has_mouth())
 	if (H.wear_mask) return
 	if (istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket)) return
 


### PR DESCRIPTION
Pretty much check for the lack of mouths in the user, so, that will stop ipcs and other species without mouth to chew on their hands to get off cuffs.