### PR TITLE
Processing tweaks

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -68,7 +68,6 @@
 
 	var/damagetaken = 0
 	var/empowered = 0 //Number of empowered, higher-damage shots remaining
-	var/processing = 0
 	var/mob/living/sacrifice //Holds a reference to a mob that is a pending sacrifice
 	var/mob/living/sacrificer //A reference to the last mob that attempted to sacrifice something. So we can message them
 	//Sacrifier is also used in target handling. the pylon will not bite the hand that feeds it. Noncultist colleagues are fair game though
@@ -101,7 +100,7 @@
 
 
 /obj/structure/cult/pylon/Destroy()
-	processing_objects.Remove(src)
+	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 
 //Another subtype which starts with infinite empower shots. For empowered adminbus
@@ -134,9 +133,7 @@
 
 /obj/structure/cult/pylon/proc/start_process()
 	process_interval = 1
-	if (!processing)
-		processing_objects += src
-		processing = 1
+	START_PROCESSING(SSprocessing, src)
 
 
 //If the pylon goes a long time without shooting anything, it will consider slowing down processing
@@ -186,8 +183,7 @@
 /obj/structure/cult/pylon/process()
 	ticks++
 	if(!check_process())
-		processing_objects.Remove(src)
-		processing = 0
+		STOP_PROCESSING(SSprocessing, src)
 		return
 
 	switch (pylonmode)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -374,7 +374,6 @@
 
 	var/last_valid_turf = null
 	var/can_move = 1
-	var/processing = 0
 	var/mob/owner_mob = null
 	var/datum/vampire/owner_vampire = null
 	var/warning_level = 0
@@ -382,9 +381,7 @@
 /obj/effect/dummy/veil_walk/Destroy()
 	eject_all()
 
-	if (processing)
-		processing_objects -= src
-		processing = 0
+	STOP_PROCESSING(SSprocessing, src)
 
 	return ..()
 
@@ -467,13 +464,10 @@
 
 	desc += " Its features look faintly alike [owner.name]'s."
 
-	processing = 1
-	processing_objects += src
+	START_PROCESSING(SSprocessing, src)
 
 /obj/effect/dummy/veil_walk/proc/deactivate()
-	if (processing)
-		processing_objects -= src
-		processing = 0
+	STOP_PROCESSING(SSprocessing, src)
 
 	can_move = 0
 

--- a/code/game/objects/items/devices/magnetic_lock.dm
+++ b/code/game/objects/items/devices/magnetic_lock.dm
@@ -112,8 +112,7 @@
 			user.visible_message("<span class='danger'>[user] bashes [src] with [I]!</span>", "<span class='danger'>You strike [src] with [I], damaging it!</span>")
 			takedamage(I.force)
 			playsound(loc, "sound/weapons/genhit[rand(1,3)].ogg", I.force*3, 1)
-			spawn(3)
-				playsound(loc, "sound/effects/sparks[rand(1,4)].ogg", 30, 1)
+			addtimer(CALLBACK(GLOBAL_PROC, /proc/playsound, loc, "sound/effects/sparks[rand(1,4)].ogg", 30, 1), 3, TIMER_CLIENT_TIME)
 			return
 		else
 			user.visible_message("<span class='danger'>[user] hits [src] with [I] but fails to damage it.</span>", "<span class='warning'>You hit [src] with [I], [I.force >= 10 ? "and it almost makes a dent!" : "but it appears to have no visible effect."]</span>")
@@ -342,7 +341,7 @@
 			target_node2 = null
 		anchored = 0
 
-		processing_objects.Remove(src)
+		STOP_PROCESSING(SSprocessing, src)
 		last_process_time = 0
 
 /obj/item/device/magnetic_lock/proc/attach(var/obj/machinery/door/airlock/newtarget as obj)
@@ -352,7 +351,7 @@
 	target = newtarget
 
 	last_process_time = world.time
-	processing_objects.Add(src)
+	START_PROCESSING(SSprocessing, src)
 	anchored = 1
 
 	spawn(-15)
@@ -419,10 +418,7 @@
 		return
 
 	if (prob(50))
-		spark()
-
-/obj/item/device/magnetic_lock/proc/spark()
-	spark(target ? target : src, 5, alldirs)
+		spark(target ? target : src, 5, alldirs)
 
 #undef STATUS_INACTIVE
 #undef STATUS_ACTIVE

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -26,7 +26,7 @@
 	var/obj/structure/cable/attached		// the attached cable
 
 /obj/item/device/powersink/Destroy()
-	processing_objects.Remove(src)
+	STOP_PROCESSING(SSprocessing, src)
 	processing_power_items.Remove(src)
 	return ..()
 
@@ -49,7 +49,7 @@
 				return
 		else
 			if (mode == 2)
-				processing_objects.Remove(src) // Now the power sink actually stops draining the station's power if you unhook it. --NeoFite
+				STOP_PROCESSING(SSprocessing, src)
 				processing_power_items.Remove(src)
 			anchored = 0
 			mode = 0
@@ -72,14 +72,14 @@
 			src.visible_message("<span class='notice'>[user] activates [src]!</span>")
 			mode = 2
 			icon_state = "powersink1"
-			processing_objects.Add(src)
+			START_PROCESSING(SSprocessing, src)
 			processing_power_items.Add(src)
 		if(2)  //This switch option wasn't originally included. It exists now. --NeoFite
 			src.visible_message("<span class='notice'>[user] deactivates [src]!</span>")
 			mode = 1
 			set_light(0)
 			icon_state = "powersink0"
-			processing_objects.Remove(src)
+			STOP_PROCESSING(SSprocessing, src)
 			processing_power_items.Remove(src)
 
 /obj/item/device/powersink/pwr_drain()

--- a/code/game/objects/items/devices/radio_jammer.dm
+++ b/code/game/objects/items/devices/radio_jammer.dm
@@ -89,8 +89,7 @@ proc/within_jamming_range(var/atom/test) // tests if an object is near a radio j
 	user.put_in_active_hand(src)
 
 /obj/item/device/radiojammer/improvised/Destroy()
-	if (active)
-		processing_objects.Remove(src)
+	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 
 
@@ -121,10 +120,10 @@ proc/within_jamming_range(var/atom/test) // tests if an object is near a radio j
 	if (active)
 		active_radio_jammers += src
 		icon_state = icon_state_active
-		processing_objects.Add(src)
+		START_PROCESSING(SSprocessing, src)
 
 		last_updated = world.time
 	else
 		active_radio_jammers -= src
 		icon_state = icon_state_inactive
-		processing_objects.Remove(src)
+		STOP_PROCESSING(SSprocessing, src)

--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -28,10 +28,10 @@
 /obj/item/device/t_scanner/proc/set_active(var/active)
 	on = active
 	if(on)
-		processing_objects.Add(src)
+		START_PROCESSING(SSprocessing, src)
 		flicker = 0
 	else
-		processing_objects.Remove(src)
+		STOP_PROCESSING(SSprocessing, src)
 		set_user_client(null)
 	update_icon()
 


### PR DESCRIPTION
changes:
- Converted some objects that were using the `processing_objects` list + a processing var to the `START/STOP_PROCESSING` macros and SSprocessing.
- Converted a spawn to a timer.

Fixes #2294.