### PR TITLE
Improve Open Turf Traversal

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -33,12 +33,12 @@
 		power_light = 0
 		power_equip = 0
 		power_environ = 0
-		
+
 	if (!mapload)
 		power_change()		// all machines set to current power level, also updates lighting icon
 
 	blend_mode = BLEND_MULTIPLY
-	
+
 	. = ..()
 
 /area/proc/get_contents()
@@ -50,7 +50,7 @@
 		var/obj/machinery/camera/C = thing
 		if (!isturf(C.loc))
 			continue
-		
+
 		if (C.loc.loc == src)
 			. += C
 
@@ -316,7 +316,7 @@ var/list/mob/living/forced_ambiance_list = new
 
 	if(istype(mob,/mob/living/carbon/human/))
 		var/mob/living/carbon/human/H = mob
-		if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.item_flags & NOSLIP))
+		if(H.Check_Shoegrip(FALSE))
 			return
 
 		if(H.m_intent == "run")

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -8,23 +8,22 @@
  * @return	A jetpack instance if one is found. Null otherwise.
  */
 /proc/GetJetpack(var/mob/living/carbon/human/H)
-	if (H)
-		// Search the human for a jetpack. Either on back or on a RIG that's on
-		// on their back.
-		if(istype(H))
-			// Skip sanity check for H.back, as istype can safely handle a null.
-			if (istype(H.back, /obj/item/weapon/tank/jetpack))
-				return H.back
-			else if (istype(H.back, /obj/item/weapon/rig))
-				var/obj/item/weapon/rig/rig = H.back
-				for (var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
-					return module.jets
-		// See if we have a robot instead, and look for their jetpack.
-		else if (istype(H, /mob/living/silicon/robot))
-			var/mob/living/silicon/robot/R = H
-			if (R.module)
-				for (var/obj/item/weapon/tank/jetpack/J in R.module.modules)
-					return J
+	// Search the human for a jetpack. Either on back or on a RIG that's on
+	// on their back.
+	if(istype(H))
+		// Skip sanity check for H.back, as istype can safely handle a null.
+		if (istype(H.back, /obj/item/weapon/tank/jetpack))
+			return H.back
+		else if (istype(H.back, /obj/item/weapon/rig))
+			var/obj/item/weapon/rig/rig = H.back
+			for (var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
+				return module.jets
+	// See if we have a robot instead, and look for their jetpack.
+	else if (istype(H, /mob/living/silicon/robot))
+		var/mob/living/silicon/robot/R = H
+		if (R.module)
+			for (var/obj/item/weapon/tank/jetpack/J in R.module.modules)
+				return J
 
 	return null
 

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -1,3 +1,33 @@
+/**
+ * Returns a jetpack if the param is a human mob and said human mob is wearing
+ * a jetpack on their back, or has a RIG on their back with the jetpack module
+ * installed.
+ *
+ * @param	H Either a human or a robot mob. Is type and sanity checked.
+ *
+ * @return	A jetpack instance if one is found. Null otherwise.
+ */
+/proc/GetJetpack(var/mob/living/carbon/human/H)
+	if (H)
+		// Search the human for a jetpack. Either on back or on a RIG that's on
+		// on their back.
+		if(istype(H))
+			// Skip sanity check for H.back, as istype can safely handle a null.
+			if (istype(H.back, /obj/item/weapon/tank/jetpack))
+				return H.back
+			else if (istype(H.back, /obj/item/weapon/rig))
+				var/obj/item/weapon/rig/rig = H.back
+				for (var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
+					return module.jets
+		// See if we have a robot instead, and look for their jetpack.
+		else if (istype(H, /mob/living/silicon/robot))
+			var/mob/living/silicon/robot/R = H
+			if (R.module)
+				for (var/obj/item/weapon/tank/jetpack/J in R.module.modules)
+					return J
+
+	return null
+
 /obj/item/weapon/tank/jetpack
 	name = "jetpack (empty)"
 	desc = "A tank of compressed gas for use as propulsion in zero-gravity areas. Use with caution."

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -456,7 +456,7 @@
 	name = "bluespace technician's shoes"
 	desc = "A pair of black shoes with extra grip. The letters 'BST' are stamped on the side."
 	icon_state = "black"
-	flags = NOSLIP
+	item_flags = NOSLIP
 	canremove = 0
 
 /obj/item/clothing/shoes/black/bst/attack_hand()

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -241,7 +241,7 @@
 
 /obj/item/clothing/shoes/magboots/typec/attack_self(mob/user)
 	if(src.magpulse)
-		flags &= ~NOSLIP
+		item_flags &= ~NOSLIP
 		magpulse = 0
 		canremove = 1
 		user << "You relax your deathgrip on the flooring."
@@ -255,7 +255,7 @@
 			return
 
 
-		flags |= NOSLIP
+		item_flags |= NOSLIP
 		magpulse = 1
 		canremove = 0	//kinda hard to take off magclaws when you are gripping them tightly.
 		user << "You dig your claws deeply into the flooring, bracing yourself."
@@ -266,7 +266,7 @@
 	..()
 	if(src.magpulse)
 		user.visible_message("The [src] go limp as they are removed from [usr]'s feet.", "The [src] go limp as they are removed from your feet.")
-		flags &= ~NOSLIP
+		item_flags &= ~NOSLIP
 		magpulse = 0
 		canremove = 1
 

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -72,7 +72,7 @@
 		var/can_grab = 1
 		if(istype(victim, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = victim
-			if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.item_flags & NOSLIP))
+			if(H.Check_Shoegrip(FALSE))
 				can_grab = 0
 		if(can_grab)
 			src.visible_message("<span class='danger'>Tendrils lash out from \the [src] and drag \the [victim] in!</span>")

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -80,15 +80,7 @@
 	if(restrained())	return 0
 
 	//Do we have a working jetpack?
-	var/obj/item/weapon/tank/jetpack/thrust
-	if(back)
-		if(istype(back,/obj/item/weapon/tank/jetpack))
-			thrust = back
-		else if(istype(back,/obj/item/weapon/rig))
-			var/obj/item/weapon/rig/rig = back
-			for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
-				thrust = module.jets
-				break
+	var/obj/item/weapon/tank/jetpack/thrust = GetJetpack(src)
 
 	if(thrust)
 		if(((!check_drift) || (check_drift && thrust.stabilization_on)) && (!lying) && (thrust.allow_thrust(0.01, src)))

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -111,8 +111,8 @@
 
 	return prob_slip
 
-/mob/living/carbon/human/Check_Shoegrip()
-	if(species.flags & NO_SLIP)
+/mob/living/carbon/human/Check_Shoegrip(checkSpecies = TRUE)
+	if(checkSpecies && (species.flags & NO_SLIP))
 		return 1
 	if(shoes && (shoes.item_flags & NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots))  //magboots + dense_object = no floating
 		return 1

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -34,7 +34,7 @@
 		return 0
 
 	var/area/area = get_area(src)
-	if(direction == UP && area.has_gravity)
+	if(direction == UP && area.has_gravity && !usr.CanAvoidGravity())
 		to_chat(usr, "<span class='warning'>Gravity stops you from moving upward.</span>")
 		return 0
 
@@ -65,6 +65,38 @@
 		forceMove(destination)
 	else
 		to_chat(usr, "<span class='notice'>There is nothing of interest in this direction.</span>")
+
+/**
+ * @brief	Used to determine whether or not a given mob can override gravity when
+ * attempting to Z-move UP.
+ *
+ * Returns FALSE in standard mob cases. Exists for carbon/human and other child overrides.
+ *
+ * @return	TRUE if the mob can Z-move up despite gravity.
+ *			FALSE otherwise.
+ */
+/mob/proc/CanAvoidGravity()
+	return FALSE
+
+/mob/living/carbon/human/CanAvoidGravity()
+	if (!restrained())
+		var/obj/item/weapon/tank/jetpack/thrust = null
+
+		if(back)
+			if(istype(back,/obj/item/weapon/tank/jetpack))
+				thrust = back
+			else if(istype(back,/obj/item/weapon/rig))
+				var/obj/item/weapon/rig/rig = back
+
+				for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
+					thrust = module.jets
+					break
+
+		if (thrust && thrust.stabilization_on &&\
+			!lying && thrust.allow_thrust(0.01, src))
+			return TRUE
+
+	return ..()
 
 /mob/proc/can_ztravel()
 	return 0
@@ -154,6 +186,27 @@
 
 	if((locate(/obj/structure/disposalpipe/up) in below) || locate(/obj/machinery/atmospherics/pipe/zpipe/up in below))
 		return FALSE
+
+/mob/living/carbon/human/can_fall()
+	// Special condition for jetpack mounted folk!
+	if (!restrained())
+		var/obj/item/weapon/tank/jetpack/thrust = null
+
+		if(back)
+			if(istype(back,/obj/item/weapon/tank/jetpack))
+				thrust = back
+			else if(istype(back,/obj/item/weapon/rig))
+				var/obj/item/weapon/rig/rig = back
+
+				for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
+					thrust = module.jets
+					break
+
+		if (thrust && thrust.stabilization_on &&\
+			!lying && thrust.allow_thrust(0.01, src))
+			return FALSE
+
+	return ..()
 
 /atom/movable/proc/handle_fall(var/turf/landing)
 	Move(landing)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -80,17 +80,7 @@
 
 /mob/living/carbon/human/CanAvoidGravity()
 	if (!restrained())
-		var/obj/item/weapon/tank/jetpack/thrust = null
-
-		if(back)
-			if(istype(back,/obj/item/weapon/tank/jetpack))
-				thrust = back
-			else if(istype(back,/obj/item/weapon/rig))
-				var/obj/item/weapon/rig/rig = back
-
-				for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
-					thrust = module.jets
-					break
+		var/obj/item/weapon/tank/jetpack/thrust = GetJetpack(src)
 
 		if (thrust && !lying && thrust.allow_thrust(0.01, src))
 			return TRUE
@@ -189,17 +179,7 @@
 /mob/living/carbon/human/can_fall()
 	// Special condition for jetpack mounted folk!
 	if (!restrained())
-		var/obj/item/weapon/tank/jetpack/thrust = null
-
-		if(back)
-			if(istype(back,/obj/item/weapon/tank/jetpack))
-				thrust = back
-			else if(istype(back,/obj/item/weapon/rig))
-				var/obj/item/weapon/rig/rig = back
-
-				for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
-					thrust = module.jets
-					break
+		var/obj/item/weapon/tank/jetpack/thrust = GetJetpack(src)
 
 		if (thrust && thrust.stabilization_on &&\
 			!lying && thrust.allow_thrust(0.01, src))

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -87,6 +87,14 @@
 
 	return ..()
 
+/mob/living/silicon/robot/CanAvoidGravity()
+	var/obj/item/weapon/tank/jetpack/thrust = GetJetpack(src)
+
+	if (thrust && thrust.allow_thrust(0.02, src))
+		return TRUE
+
+	return ..()
+
 /mob/proc/can_ztravel()
 	return 0
 
@@ -184,6 +192,14 @@
 		if (thrust && thrust.stabilization_on &&\
 			!lying && thrust.allow_thrust(0.01, src))
 			return FALSE
+
+	return ..()
+
+/mob/living/silicon/robot/can_fall()
+	var/obj/item/weapon/tank/jetpack/thrust = GetJetpack(src)
+
+	if (thrust && thrust.stabilization_on && thrust.allow_thrust(0.02, src))
+		return FALSE
 
 	return ..()
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -92,8 +92,7 @@
 					thrust = module.jets
 					break
 
-		if (thrust && thrust.stabilization_on &&\
-			!lying && thrust.allow_thrust(0.01, src))
+		if (thrust && !lying && thrust.allow_thrust(0.01, src))
 			return TRUE
 
 	return ..()

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -29,6 +29,17 @@
 
 	var/tmp/depth
 
+// An override of turf/Enter() to make it so that magboots allow you to stop
+// falling off the damned rock.
+/turf/simulated/open/Enter(mob/living/carbon/human/mover, atom/oldloc)
+	if (istype(mover) && isturf(oldloc))
+		if (istype(mover.shoes, /obj/item/clothing/shoes/magboots) && (mover.shoes.item_flags & NOSLIP))
+			to_chat(mover,span("notice",
+				"You are stopped from falling off the edge by \the [mover.shoes] you're wearing!"))
+			return 0
+
+	return ..()
+
 /turf/simulated/open/proc/is_above_space()
 	var/turf/T = GetBelow(src)
 	while (T && T.is_hole)
@@ -49,7 +60,7 @@
 	if (istype(above))
 		above.update()
 		above = null
-		
+
 	below = null
 	return ..()
 

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -32,7 +32,7 @@
 // An override of turf/Enter() to make it so that magboots allow you to stop
 // falling off the damned rock.
 /turf/simulated/open/Enter(mob/living/carbon/human/mover, atom/oldloc)
-	if (istype(mover) && isturf(oldloc))
+	if (istype(mover) && isturf(oldloc) && !istype(oldloc, /turf/simulated/open))
 		if (mover.Check_Shoegrip(FALSE))
 			to_chat(mover,span("notice",
 				"You are stopped from falling off the edge by \the [mover.shoes] you're wearing!"))

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -33,7 +33,7 @@
 // falling off the damned rock.
 /turf/simulated/open/Enter(mob/living/carbon/human/mover, atom/oldloc)
 	if (istype(mover) && isturf(oldloc))
-		if (istype(mover.shoes, /obj/item/clothing/shoes/magboots) && (mover.shoes.item_flags & NOSLIP))
+		if (mover.Check_Shoegrip(FALSE))
 			to_chat(mover,span("notice",
 				"You are stopped from falling off the edge by \the [mover.shoes] you're wearing!"))
 			return 0


### PR DESCRIPTION
Aims to improve open turf traversal and interaction by doing two things:
* If a mob is wearing magboots and has enabled magboots, they are now unable to walk onto an open turf. This includes open space turfs. It makes magboots useful again for miners, on the asteroid!
* If a mob is wearing a jetpack with jetpack stabilization enabled (and the jetpack active), they can walk onto the open turf but **will not fall down**. They can now also, simply by having the jetpack active, move upwards. Keeping stabilization off in this stage will allow them to pop-up and down if they want, leading to hilarity.
* Touches mob/proc/Check_Shoegrip() and makes it more useful + more used.