### PR TITLE
Openturf tweaks & SSmob sleep detection

### DIFF
--- a/code/controllers/subsystems/mob.dm
+++ b/code/controllers/subsystems/mob.dm
@@ -5,6 +5,8 @@
 	flags = SS_NO_INIT
 	priority = SS_PRIORITY_MOB
 
+	var/list/slept = list()
+
 	var/list/currentrun = list()
 	var/list/all_mice = list()	// Contains all *living* mice.
 
@@ -35,7 +37,14 @@
 				return
 			continue
 
+		var/time = world.time
+
 		M.Life()
+
+		if (time != world.time && !slept[M.type])
+			slept[M.type] = TRUE
+			var/diff = world.time - time
+			log_debug("SSmob: Type '[M.type]' slept for [diff] ds in Life()! Suppressing further warnings.")
 
 		if (MC_TICK_CHECK)
 			return

--- a/code/controllers/subsystems/openturf.dm
+++ b/code/controllers/subsystems/openturf.dm
@@ -93,6 +93,8 @@
 
 		// Update the openturf itself.
 		T.appearance = T.below
+		T.name = initial(T.name)
+		T.desc = "Below seems to be \a [T.below]."
 
 		// Handle space parallax & starlight.
 		if (T.is_above_space())

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -79,6 +79,7 @@
 /atom/movable/Destroy()
 	var/turf/T = loc
 	if (opacity && istype(T))
+		T.recalc_atom_opacity()
 		T.reconsider_lights()
 
 	. = ..()

--- a/code/modules/multiz/openspace.dm
+++ b/code/modules/multiz/openspace.dm
@@ -18,11 +18,7 @@
 
 /atom/movable/Destroy()
 	. = ..()
-	if (bound_overlay)
-		if (istype(bound_overlay.loc, /turf/simulated/open))
-			bound_overlay.loc:update_icon()
-
-		QDEL_NULL(bound_overlay)
+	QDEL_NULL(bound_overlay)
 
 /atom/movable/Move()
 	. = ..()


### PR DESCRIPTION
changes:
- Openturfs no longer copy the below turf's name.
- Openturfs' desc now lists the name of the below turf instead of copying the below turf's desc.
- SSmob now detects sleeping Life() procs.