### PR TITLE
Partially/lazy help #2331

### DIFF
--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -96,7 +96,7 @@ var/global/list/turbolifts = list()
 			if(istype(AM, /mob/living))
 				var/mob/living/M = AM
 				M.gib()
-			else if(AM.simulated)
+			else if(AM.simulated && !istype(AM, /mob/eye))
 				qdel(AM)
 
 	origin.move_contents_to(destination)


### PR DESCRIPTION
Lazy fix for #2331 .

Unsure if there's a better way to go about it, as setting `simulated` to TRUE for AI eyes might result in loss of functionality we've had thus far (eye not moving with shuttles, for example).