### PR TITLE
[New Map] Newton's Third Law

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -18,14 +18,14 @@
 
 	var/can_hold_mob = FALSE
 
+	var/tmp/z_levels_fallen = 0
+
 // We don't really need this, and apparently defining it slows down GC.
 /*/atom/movable/Del()
 	if(!QDELING(src) && loc)
 		testing("GC: -- [type] was deleted via del() rather than qdel() --")
 		crash_with("GC: -- [type] was deleted via del() rather than qdel() --") // stick a stack trace in the runtime logs
 	..()*/
-
-	var/z_levels_fallen = 0
 
 /atom/movable/Destroy()
 	. = ..()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -25,6 +25,8 @@
 		crash_with("GC: -- [type] was deleted via del() rather than qdel() --") // stick a stack trace in the runtime logs
 	..()*/
 
+	var/z_levels_fallen = 0
+
 /atom/movable/Destroy()
 	. = ..()
 	for(var/atom/movable/AM in contents)

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -11,6 +11,9 @@
 	max_temperature = 30000
 	infra_luminosity = 8
 	force = 40
+
+	w_class = 25
+
 	var/defence = 0
 	var/def_boost = 15
 	wreckage = /obj/effect/decal/mecha_wreckage/durand

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -15,6 +15,7 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/gygax
 	internal_damage_threshold = 35
 	max_equip = 3
+	w_class = 15
 
 /obj/mecha/combat/gygax/dark
 	desc = "A lightweight exosuit used by Heavy Asset Protection. A significantly upgraded Gygax security mech."

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -21,6 +21,7 @@
 	internal_damage_threshold = 25
 	force = 45
 	max_equip = 4
+	w_class = 35
 
 /obj/mecha/combat/marauder/seraph
 	desc = "Heavy-duty, command-type exosuit. This is a custom model, utilized only by high-ranking military personnel."
@@ -42,6 +43,7 @@
 	initial_icon = "mauler"
 	operation_req_access = list(access_syndicate)
 	wreckage = /obj/effect/decal/mecha_wreckage/mauler
+	w_class = 40
 
 /obj/mecha/combat/marauder/New()
 	..()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -25,6 +25,9 @@
 	unacidable = 1 //and no deleting hoomans inside
 	layer = MOB_LAYER //icon draw layer
 	infra_luminosity = 15 //byond implementation is bugged.
+
+	w_class = 20
+
 	var/initial_icon = null //Mech type for resetting icon. Only used for reskinning kits (see custom items)
 	var/can_move = 1
 	var/mob/living/carbon/occupant = null
@@ -117,7 +120,7 @@
 	loc.Entered(src)
 	mechas_list += src //global mech list
 	narrator_message(FIRSTRUN)
-	
+
 	spark_system = bind_spark(src, 2)
 
 /obj/mecha/Destroy()
@@ -666,7 +669,7 @@
 		if(istype(Proj, /obj/item/projectile/beam/pulse))
 			ignore_threshold = 1
 		src.hit_damage(Proj.damage, Proj.check_armour, is_melee=0)
-		if(prob(25)) 
+		if(prob(25))
 			spark_system.queue()
 		src.check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),ignore_threshold)
 
@@ -757,7 +760,7 @@
 //////////////////////
 
 /obj/mecha/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	
+
 	if(istype(W, /obj/item/mecha_parts/mecha_equipment))
 		var/obj/item/mecha_parts/mecha_equipment/E = W
 		spawn()
@@ -1928,9 +1931,9 @@
 	return icon_state
 
 /obj/mecha/attack_generic(var/mob/user, var/damage, var/attack_message)
-	
+
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	
+
 	if(!damage)
 		return 0
 

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -10,6 +10,7 @@
 	internal_damage_threshold = 35
 	deflect_chance = 15
 	step_energy_drain = 6
+	w_class = 15
 	var/obj/item/clothing/glasses/hud/health/mech/hud
 
 	New()

--- a/code/game/mecha/working/hoverpod.dm
+++ b/code/game/mecha/working/hoverpod.dm
@@ -12,6 +12,7 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/hoverpod
 	cargo_capacity = 5
 	max_equip = 3
+	w_class = 10
 	var/datum/effect/effect/system/ion_trail_follow/ion_trail
 	var/stabilization_enabled = 1
 
@@ -51,7 +52,7 @@
 			ion_trail.start()
 		if (stabilization_enabled)
 			return 1
-	
+
 	return ..()
 
 //these three procs overriden to play different sounds

--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -22,12 +22,15 @@ proc/log_and_message_admins_many(var/list/mob/users, var/message)
 	message_admins("[english_list(user_keys)] [message]")
 
 proc/admin_attack_log(var/mob/attacker, var/mob/victim, var/attacker_message, var/victim_message, var/admin_message)
+	var/jmp_link = ""
 	if(victim)
 		victim.attack_log += text("\[[time_stamp()]\] <font color='orange'>[key_name(attacker)] - [victim_message]</font>")
+		jmp_link = " (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[victim.x];Y=[victim.y];Z=[victim.z]'>JMP</a>)"
 	if(attacker)
 		attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>[key_name(victim)] - [attacker_message]</font>")
+		jmp_link = " (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[attacker.x];Y=[attacker.y];Z=[attacker.z]'>JMP</a>)"
 
-	msg_admin_attack("[key_name(attacker)] [admin_message] [key_name(victim)] (INTENT: [attacker? uppertext(attacker.a_intent) : "N/A"]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[attacker.x];Y=[attacker.y];Z=[attacker.z]'>JMP</a>)",ckey=key_name(attacker),ckey_target=key_name(victim))
+	msg_admin_attack("[key_name(attacker)] [admin_message] [key_name(victim)] (INTENT: [attacker? uppertext(attacker.a_intent) : "N/A"])[jmp_link]",ckey=key_name(attacker),ckey_target=key_name(victim))
 
 proc/admin_attacker_log_many_victims(var/mob/attacker, var/list/mob/victims, var/attacker_message, var/victim_message, var/admin_message)
 	if(!victims || !victims.len)

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "ore1"
 	w_class = 2
+	throwforce = 10.0
 	var/datum/geosample/geologic_data
 	var/material
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -46,7 +46,6 @@
 
 	var/failed_last_breath = 0 //This is used to determine if the mob failed a breath. If they did fail a brath, they will attempt to breathe each tick, otherwise just once per 4 ticks.
 	var/possession_candidate // Can be possessed by ghosts if unplayed.
-	var/z_levels_fallen = 0 //For z-level damage stacking.
 
 	var/list/stomach_contents	//This is moved here from carbon defines
 	var/composition_reagent

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -248,7 +248,8 @@
 		z_levels_fallen = 0 // turns out they didn't hit anything solid. Lucky them.
 		return 0
 
-	z_levels_fallen += 1
+	if(!z_levels_fallen)
+		z_levels_fallen = 1
 
 	visible_message("\The [src] falls from the level above and slams onto \the [landing]!", "You hear something slam onto the floor.")
 
@@ -269,47 +270,49 @@
 	if(weight >= 3 && fallforce <= 5)
 		fallforce = throw_range
 
-	var/speed = z_levels_fallen*throw_speed
+	var/speed = throw_speed
 	var/mass = (weight/THROWNOBJ_KNOCKBACK_DIVISOR)+density+opacity
 	var/momentum = speed*mass
 	var/damage = fallforce*(speed/THROWFORCE_SPEED_DIVISOR)*momentum
 
-	var/miss_chance = max(15*(z_levels_fallen-1), 0)
+	var/miss_chance = 15
 
-	if(!prob(miss_chance))
-		for(var/mob/living/L in landing)
-			if(L != src)
+	for(var/mob/living/L in landing)
+		if(L != src)
 
-				if(istype(src,/obj/vehicle))
-					var/obj/vehicle/V = src
-					if(L == V.load)
-						continue
+			if(istype(src,/obj/vehicle))
+				var/obj/vehicle/V = src
+				if(L == V.load)
+					continue
 
-				if(istype(L,/mob/living/carbon/human))
+			if(prob(miss_chance))
+				continue
 
-					var/mob/living/carbon/human/H = L
-					H.apply_damage(rand(damage/2, damage), BRUTE, "head")
-					H.apply_damage(damage, BRUTE, "chest")
+			if(istype(L,/mob/living/carbon/human))
 
-					if(damage >= THROWNOBJ_KNOCKBACK_SPEED)
-						H.Weaken(rand(damage/4, damage/2))
-				else
-					L.apply_damage(damage, BRUTE)
-					L.apply_damage(rand(damage/2, damage), BRUTE)
+				var/mob/living/carbon/human/H = L
+				H.apply_damage(rand(damage/2, damage), BRUTE, "head")
+				H.apply_damage(damage, BRUTE, "chest")
 
-				if(damage >= 1)
-					L.visible_message(
-						"<span class='warning'>[L] has been hit by [src].</span>",
-						"<span class='warning'>[src] has landed ontop of you!</span>"
-						)
-					if(ismob(src))
-						src << "<span class='warning'>You've fallen onto something hard!</span>"
-					admin_attack_log((ismob(src) ? src : null), L, "fell onto", "was fallen on by", "fell ontop of")
-					var/numerator = rand(1,3)
-					playsound(L.loc, "sound/weapons/genhit[numerator].ogg", 75, 1)
+				if(damage >= THROWNOBJ_KNOCKBACK_SPEED)
+					H.Weaken(rand(damage/4, damage/2))
+			else
+				L.apply_damage(damage, BRUTE)
+				L.apply_damage(rand(damage/2, damage), BRUTE)
 
-    . = z_levels_fallen
-    z_levels_fallen = 0
+			if(damage >= 1)
+				L.visible_message(
+					"<span class='warning'>[L] has been hit by [src].</span>",
+					"<span class='warning'>[src] has landed ontop of you!</span>"
+					)
+				if(ismob(src))
+					src << "<span class='warning'>You've fallen onto something hard!</span>"
+				admin_attack_log((ismob(src) ? src : null), L, "fell onto", "was fallen on by", "fell ontop of")
+				var/numerator = rand(1,3)
+				playsound(L.loc, "sound/weapons/genhit[numerator].ogg", 75, 1)
+
+	. = z_levels_fallen
+	z_levels_fallen = 0
 
 /obj/vehicle/handle_fall(var/turf/landing)
 

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -12,6 +12,9 @@
 
 	fire_dam_coeff = 0.6
 	brute_dam_coeff = 0.5
+
+	w_class = 8
+
 	var/protection_percent = 60
 
 	var/land_speed = 10 //if 0 it can't go on turf

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -17,6 +17,8 @@
 	buckle_movable = 1
 	buckle_lying = 0
 
+	w_class = 10
+
 	var/attack_log = null
 	var/on = 0
 	var/health = 0	//do not forget to set health for your vehicle!


### PR DESCRIPTION
Implements true falling hazards. Objects that fall will now deal damage to _all_ mobs on their landing tile, their damage dependent on various variables such as throwforce, throw_speed, w_class, mob_size, throw_range, etc.

Implements damage being dealt to both vehicles and mecha when they fall. Mecha will no longer float on openspace instead of falling.

Adds w_class to some objects that needed it for the system to account them properly.

Mecha will now break any lattices or catwalks they attempt to balance on, sending them plumetting below.

Currently falling on a mob will _not_ break your fall in any way, meaning you take full fall damage.

Altogether the person being fallen upon will take more a percentage more damage than the person falling, and will be stunned for slightly longer - all assuming RNGesus does not strike down in anger.

Some sample damage reports, from testing;

> Test assumes that the target is a naked human, and the object is dropped from one Z level above.
Damage involves one full damage being dealt to the chest and one rolled damage being dealt to the head, if human.
Thus, these damage reports are just vague indicators.

**Mouse:** 1.8 damage. Mouse dies.

**Paper:** 0 damage

**Rock:** 10.8 damage

**Bike:** 42.5. Bike took 30 damage.

**Human:** 51.8 damage

**Vaurca:** 74 damage

**Cow:** 105.6 damage. Cow dies.

**Durand:** 114 damage. Damage to Durand untested.

**Mauler:** 276.2 damage. Head gibbed. Damage to Mauler untested.




