### PR TITLE
Implement powersink surge

### DIFF
--- a/code/__defines/math_physics.dm
+++ b/code/__defines/math_physics.dm
@@ -26,3 +26,20 @@
 
 #define TICKS_IN_DAY 		24*60*60*10
 #define TICKS_IN_SECOND 	10
+
+// A neat little helper to convert the value X, that's between imin and imax, into a value
+// that's proportionally scaled and in range of omin and omax.
+#define MAP(x, imin, imax, omin, omax) ((x - imin) * (omax - omin) / (imax - imin) + omin)
+
+#define RAND_F(LOW, HIGH) (rand()*(HIGH-LOW) + LOW)
+
+//"fancy" math for calculating time in ms from tick_usage percentage and the length of ticks
+//percent_of_tick_used * (ticklag * 100(to convert to ms)) / 100(percent ratio)
+//collapsed to percent_of_tick_used * tick_lag
+#define TICK_DELTA_TO_MS(percent_of_tick_used) ((percent_of_tick_used) * world.tick_lag)
+#define TICK_USAGE_TO_MS(starting_tickusage) (TICK_DELTA_TO_MS(world.tick_usage-starting_tickusage))
+
+//time of day but automatically adjusts to the server going into the next day within the same round.
+//for when you need a reliable time number that doesn't depend on byond time.
+#define REALTIMEOFDAY (world.timeofday + (MIDNIGHT_ROLLOVER * MIDNIGHT_ROLLOVER_CHECK))
+#define MIDNIGHT_ROLLOVER_CHECK ( rollovercheck_last_timeofday != world.timeofday ? update_midnight_rollover() : midnight_rollovers )

--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -145,3 +145,7 @@
     . = num
     for (var/i = 0, i < iterations, i++)
         . = (1/3) * (num/(.**2)+2*.)
+
+// A neat little helper to convert the value X, that's between imin and imax, into a value
+// that's proportionally scaled and in range of omin and omax.
+#define MAP(x, imin, imax, omin, omax) ((x - imin) * (omax - omin) / (imax - imin) + omin)

--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -1,6 +1,3 @@
-// Macro functions.
-#define RAND_F(LOW, HIGH) (rand()*(HIGH-LOW) + LOW)
-
 // min is inclusive, max is exclusive
 /proc/Wrap(val, min, max)
 	var/d = max - min
@@ -129,23 +126,9 @@
 /proc/RoundUpToPowerOfTwo(var/val)
     return 2 ** -round(-log(2,val))
 
-//"fancy" math for calculating time in ms from tick_usage percentage and the length of ticks
-//percent_of_tick_used * (ticklag * 100(to convert to ms)) / 100(percent ratio)
-//collapsed to percent_of_tick_used * tick_lag
-#define TICK_DELTA_TO_MS(percent_of_tick_used) ((percent_of_tick_used) * world.tick_lag)
-#define TICK_USAGE_TO_MS(starting_tickusage) (TICK_DELTA_TO_MS(world.tick_usage-starting_tickusage))
-
-//time of day but automatically adjusts to the server going into the next day within the same round.
-//for when you need a reliable time number that doesn't depend on byond time.
-#define REALTIMEOFDAY (world.timeofday + (MIDNIGHT_ROLLOVER * MIDNIGHT_ROLLOVER_CHECK))
-#define MIDNIGHT_ROLLOVER_CHECK ( rollovercheck_last_timeofday != world.timeofday ? update_midnight_rollover() : midnight_rollovers )
-
 //Returns the cube root of the input number
 /proc/cubert(var/num, var/iterations = 10)
     . = num
     for (var/i = 0, i < iterations, i++)
         . = (1/3) * (num/(.**2)+2*.)
 
-// A neat little helper to convert the value X, that's between imin and imax, into a value
-// that's proportionally scaled and in range of omin and omax.
-#define MAP(x, imin, imax, omin, omax) ((x - imin) * (omax - omin) / (imax - imin) + omin)

--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -121,14 +121,14 @@
 	return sqrt(squaredNorm(x, y))
 
 /proc/IsPowerOfTwo(var/val)
-    return (val & (val-1)) == 0
+	return (val & (val-1)) == 0
 
 /proc/RoundUpToPowerOfTwo(var/val)
-    return 2 ** -round(-log(2,val))
+	return 2 ** -round(-log(2,val))
 
 //Returns the cube root of the input number
 /proc/cubert(var/num, var/iterations = 10)
-    . = num
-    for (var/i = 0, i < iterations, i++)
-        . = (1/3) * (num/(.**2)+2*.)
+	. = num
+	for (var/i = 0, i < iterations, i++)
+		. = (1/3) * (num/(.**2)+2*.)
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -18,7 +18,7 @@
 	var/apc_drain_rate = 5000 		// Max. amount drained from single APC. In Watts.
 	var/dissipation_rate = 20000	// Passive dissipation of drained power. In Watts.
 	var/power_drained = 0 			// Amount of power drained.
-	var/max_power = 8e8				// Detonation point.
+	var/max_power = 8e8				// Detonation point. Roughly 18 minutes with default setup.
 	var/mode = 0					// 0 = off, 1=clamped (off), 2=operating
 	var/drained_this_tick = 0		// This is unfortunately necessary to ensure we process powersinks BEFORE other machinery such as APCs.
 
@@ -127,7 +127,7 @@
 	else
 		PN = null
 
-	if(power_drained > max_power * 0.95)
+	if(power_drained > max_power * 0.98)	// Lower the screeching period. It was pretty long during testing.
 		playsound(src, 'sound/effects/screech.ogg', 100, 1, 1)
 
 	if(power_drained >= max_power)
@@ -153,7 +153,7 @@
 
 		if (dist < 1)
 			dist = 1	// For later calculations.
-		else if (dist > 28)
+		else if (dist > 24)
 			continue	// Out of range.
 
 		// Map it to a range of [3, 1] for severity.
@@ -175,7 +175,7 @@
 		var/atom/aa = A
 		aa.emp_act(dist)
 
-		if (prob(25 * dist))
+		if (prob(15 * dist))
 			explosion(aa.loc, 0, 0, 3, 4)
 
 	// Also destroy the source.

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1313,17 +1313,19 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 
 // overload the lights in this APC area
 
-/obj/machinery/power/apc/proc/overload_lighting(var/chance = 100)
-	if(/* !get_connection() || */ !operating || shorted)
+/obj/machinery/power/apc/proc/overload_lighting(var/chance = 100, var/force = FALSE)
+	if((!operating || shorted) && !force)
 		return
-	if( cell && cell.charge>=20)
-		cell.use(20);
+
+	if(force || (cell && cell.charge >= 20))
+		cell.use(20)	// Draining an empty cell is fine.
+
 		spawn(0)
-			for(var/obj/machinery/light/L in area)
-				if(prob(chance))
+			for (var/obj/machinery/light/L in area)
+				if (prob(chance))
 					L.on = 1
 					L.broken()
-				sleep(1)
+					sleep(1)
 
 /obj/machinery/power/apc/proc/flicker_all()
 	var/offset = 0

--- a/html/changelogs/skull132-powersinks.yml
+++ b/html/changelogs/skull132-powersinks.yml
@@ -1,0 +1,6 @@
+author: Skull132
+
+delete-after: True
+
+changes:
+  - tweak: "Modified the powersink to cause a large powersurge upon reaching its capacity, as opposed to flat out exploding violently. Powersurge causes EMP like effects on connected power nodes, light bursting, and small explosions. Said effects get lessen the further out the items are from range."


### PR DESCRIPTION
Implements suggestion https://forums.aurorastation.org/viewtopic.php?f=21&p=78011 in the following fashion:
- Powersinks explode ~18 minutes after being placed on normal SMES setup. Obviously more input from engineering will make this process go faster.
-  Upon reaching their capacity, they will now cause a larger area power surge. The surge will smash all lights belonging to APCs within close to moderate proximity, and call EMP act on all connected powernet items that are within range (severity depending on distance). All of those items have a small chance to cause a minor explosion as well, primarily because EMP act is fucking whimpy.

[Preview](https://kama.skullnet.me/index.php/s/AE6ejFJghToXjmG)

Note that since that preview was done, the chance of exploding has been lowered, so there won't be as many.