### PR TITLE
Cascade performance tweaks

### DIFF
--- a/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
@@ -17,12 +17,17 @@
 
 /turf/unsimulated/wall/supermatter/Initialize()
 	. = ..()
-	// Kick-start the timer chain.
-	addtimer(CALLBACK(src, .proc/tick), 5 SECONDS)
+	START_PROCESSING(SScalamity, src)
 
-/turf/unsimulated/wall/supermatter/proc/tick()
+/turf/unsimulated/wall/supermatter/process()
+	if (!(SScalamity.times_fired % 2))
+		// SScalamity ticks every 2s, we want to process every 4.
+		return
+
+
 	// No more available directions? Bail.
 	if(avail_dirs.len == 0)
+		STOP_PROCESSING(SScalamity, src)
 		return
 
 	// Choose a direction.
@@ -37,9 +42,7 @@
 		addtimer(CALLBACK(src, .proc/after_tick, T), 10)
 
 	if((spawned & (NORTH|SOUTH|EAST|WEST)) == (NORTH|SOUTH|EAST|WEST))
-		return
-
-	addtimer(CALLBACK(src, .proc/tick), 5 SECONDS)
+		STOP_PROCESSING(SScalamity, src)
 
 /turf/unsimulated/wall/supermatter/proc/after_tick(turf/T)
 	T.lighting_clear_overlay()

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -57,6 +57,8 @@ var/global/universe_has_ended = 0
 	// Disable Nar-Sie.
 	cult.allow_narsie = 0
 
+	SSgarbage.collection_timeout = 20 MINUTES	// Yeah, no point trying to hard-del stuff at this point.
+
 	PlayerSet()
 
 	new /obj/singularity/narsie/large/exit(pick(endgame_exits))


### PR DESCRIPTION
changes:
- Cascade turfs now use SScalamity to tick instead of addtimer loops.
- On universal-state change to Cascade, SSgarbage's GC timeout period is set to 20 minutes, as we really don't care about hard-dels when the round ends in 5 minutes.