### PR TITLE
Fix ZAS defines

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2157,7 +2157,6 @@
 #include "code\unit_tests\ss_test.dm"
 #include "code\unit_tests\unit_test.dm"
 #include "code\unit_tests\zas_tests.dm"
-#include "code\ZAS\_docs.dm"
 #include "code\ZAS\Airflow.dm"
 #include "code\ZAS\Atom.dm"
 #include "code\ZAS\Connection.dm"

--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -55,7 +55,7 @@ turf/c_airblock(turf/other)
 		return BLOCKED
 	
 	//Z-level handling code. Always block if there isn't an open space.
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	if(other.z != src.z)
 		if(other.z < src.z)
 			if(!istype(src, /turf/simulated/open)) return BLOCKED

--- a/code/ZAS/ConnectionGroup.dm
+++ b/code/ZAS/ConnectionGroup.dm
@@ -58,13 +58,12 @@ Class Procs:
 */
 
 
-/connection_edge/var/zone/A
-
-/connection_edge/var/list/connecting_turfs = list()
-/connection_edge/var/direct = 0
-/connection_edge/var/sleeping = 1
-
-/connection_edge/var/coefficient = 0
+/connection_edge
+	var/zone/A
+	var/list/connecting_turfs = list()
+	var/direct = 0
+	var/sleeping = 1
+	var/coefficient = 0
 
 /connection_edge/New()
 	CRASH("Cannot make connection edge without specifications.")
@@ -115,11 +114,10 @@ Class Procs:
 
 			M.airflow_dest = pick(close_turfs) //Pick a random midpoint to fly towards.
 
-			if(repelled) spawn if(M) M.RepelAirflowDest(differential/5)
-			else spawn if(M) M.GotoAirflowDest(differential/10)
-
-
-
+			if(repelled)
+				M.RepelAirflowDest(differential/5)
+			else
+				M.GotoAirflowDest(differential/10)
 
 /connection_edge/zone/var/zone/B
 

--- a/code/ZAS/ConnectionManager.dm
+++ b/code/ZAS/ConnectionManager.dm
@@ -37,7 +37,7 @@ Class Procs:
 /connection_manager/var/connection/E
 /connection_manager/var/connection/W
 
-#ifdef ZLEVELS
+#ifdef MULTIZAS
 /connection_manager/var/connection/U
 /connection_manager/var/connection/D
 #endif
@@ -57,7 +57,7 @@ Class Procs:
 			if(check(W)) return W
 			else return null
 
-		#ifdef ZLEVELS
+		#ifdef MULTIZAS
 		if(UP)
 			if(check(U)) return U
 			else return null
@@ -73,7 +73,7 @@ Class Procs:
 		if(EAST) E = c
 		if(WEST) W = c
 
-		#ifdef ZLEVELS
+		#ifdef MULTIZAS
 		if(UP) U = c
 		if(DOWN) D = c
 		#endif
@@ -83,7 +83,7 @@ Class Procs:
 	if(check(S)) S.update()
 	if(check(E)) E.update()
 	if(check(W)) W.update()
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	if(check(U)) U.update()
 	if(check(D)) D.update()
 	#endif
@@ -93,7 +93,7 @@ Class Procs:
 	if(check(S)) S.erase()
 	if(check(E)) E.erase()
 	if(check(W)) W.erase()
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	if(check(U)) U.erase()
 	if(check(D)) D.erase()
 	#endif

--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -17,7 +17,7 @@
 		//dbg(blocked)
 		return 1
 
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	for(var/d = 1, d < 64, d *= 2)
 	#else
 	for(var/d = 1, d < 16, d *= 2)
@@ -59,7 +59,7 @@
 	var/check_dirs = get_zone_neighbours(src)
 	var/unconnected_dirs = check_dirs
 	var/to_check = list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	to_check += list(NORTHUP, EASTUP, WESTUP, SOUTHUP, NORTHDOWN, EASTDOWN, WESTDOWN, SOUTHDOWN)
 	#endif
 	for(var/dir in to_check)
@@ -79,7 +79,7 @@
 	. = 0
 	if(istype(T) && T.zone)
 		var/to_check = cardinal.Copy()
-		#ifdef ZLEVELS
+		#ifdef MULTIZAS
 		to_check += list(UP, DOWN)
 		#endif
 		for(var/dir in to_check)
@@ -118,7 +118,7 @@
 	open_directions = 0
 
 	var/list/postponed
-	#ifdef ZLEVELS
+	#ifdef MULTIZAS
 	for(var/d = 1, d < 64, d *= 2)
 	#else
 	for(var/d = 1, d < 16, d *= 2)

--- a/code/ZAS/_docs.dm
+++ b/code/ZAS/_docs.dm
@@ -26,12 +26,3 @@ Notes for people who used ZAS before:
 		var/zone/connected_zone = edge.get_connected_zone(zone)
 
 */
-
-//#define ZASDBG
-#define ZLEVELS
-
-#define AIR_BLOCKED 1
-#define ZONE_BLOCKED 2
-#define BLOCKED 3
-
-#define ZONE_MIN_SIZE 14 //zones with less than this many turfs will always merge, even if the connection is not direct

--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -1,6 +1,6 @@
 
 //#define ZASDBG
-//#define ZLEVELS
+#define MULTIZAS
 
 #define AIR_BLOCKED 1
 #define ZONE_BLOCKED 2


### PR DESCRIPTION
Properly moves ZAS defines into the ZAS defines file & removes docs file from compile. `ZLEVELS` has been renamed to `MULTIZAS` to better explain what it does.