### PR TITLE
Round-end statistics

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -209,6 +209,7 @@
 #include "code\datums\mixed.dm"
 #include "code\datums\modules.dm"
 #include "code\datums\server_greeting.dm"
+#include "code\datums\statistic.dm"
 #include "code\datums\supplypacks.dm"
 #include "code\datums\diseases\appendicitis.dm"
 #include "code\datums\diseases\beesease.dm"

--- a/code/controllers/subsystems/statistics.dm
+++ b/code/controllers/subsystems/statistics.dm
@@ -38,7 +38,6 @@
 			qdel(S)
 			continue
 
-		log_debug("SSfeedback: Initialized new statistic type '[type]', name=[S.name],key=[S.key]")
 		simple_statistics[S.key] = S
 
 	sortTim(simple_statistics, /proc/cmp_name_asc, TRUE)

--- a/code/controllers/subsystems/statistics.dm
+++ b/code/controllers/subsystems/statistics.dm
@@ -126,8 +126,7 @@
 	feedback_add_details("radio_usage","RC-[rc_msg_amt]")
 
 	for (var/datum/statistic/S in simple_statistics)
-		if (S.key)
-			log_debug("SSfeedback: Writing [S] to database.")
+		if (S.write_to_database && S.key)
 			S.write_to_database()
 
 	feedback_set_details("round_end","[time2text(world.realtime)]") //This one MUST be the last one that gets set.

--- a/code/controllers/subsystems/statistics.dm
+++ b/code/controllers/subsystems/statistics.dm
@@ -21,6 +21,8 @@
 	var/list/msg_cargo = list()
 	var/list/msg_service = list()
 
+	var/list/datum/statistic/simple_statistics = list()
+
 	var/list/datum/feedback_variable/feedback = list()
 
 /datum/controller/subsystem/statistics/New()
@@ -29,6 +31,17 @@
 /datum/controller/subsystem/statistics/Initialize(timeofday)
 	if (!config.kick_inactive && !(config.sql_enabled && config.sql_stats))
 		can_fire = FALSE
+
+	for (var/type in subtypesof(/datum/statistic) - list(/datum/statistic/numeric, /datum/statistic/grouped))
+		var/datum/statistic/S = new type
+		if (!S.name)
+			qdel(S)
+			continue
+
+		log_debug("SSfeedback: Initialized new statistic type '[type]', name=[S.name],key=[S.key]")
+		simple_statistics[S.key] = S
+
+	sortTim(simple_statistics, /proc/cmp_name_asc, TRUE)
 
 /datum/controller/subsystem/statistics/fire()
 	// Handle AFK.
@@ -113,8 +126,22 @@
 	feedback_add_details("radio_usage","PDA-[pda_msg_amt]")
 	feedback_add_details("radio_usage","RC-[rc_msg_amt]")
 
+	for (var/datum/statistic/S in simple_statistics)
+		if (S.key)
+			log_debug("SSfeedback: Writing [S] to database.")
+			S.write_to_database()
 
 	feedback_set_details("round_end","[time2text(world.realtime)]") //This one MUST be the last one that gets set.
+
+/datum/controller/subsystem/statistics/proc/print_round_end_message()
+	var/list/dat = list()
+	dat += "<h3>Round Statistics</h3>"
+	for (var/statistic in simple_statistics)
+		var/datum/statistic/S = simple_statistics[statistic]
+		if (S.broadcast_at_roundend && S.has_value())
+			dat += span("notice", "<b>[S]:</b> [S.get_roundend_lines()]")
+
+	to_chat(world, dat.Join("\n"))
 
 // Called on world reboot.
 /datum/controller/subsystem/statistics/Shutdown()
@@ -266,3 +293,17 @@
 		if(!query.Execute())
 			var/err = query.ErrorMsg()
 			log_game("SQL ERROR during death reporting. Error : \[[err]\]\n")
+
+/datum/controller/subsystem/statistics/proc/IncrementSimpleStat(stat)
+	. = TRUE
+	var/datum/statistic/numeric/S = simple_statistics[stat]
+	if (!S)
+		return FALSE
+	S.increment_value()
+
+/datum/controller/subsystem/statistics/proc/IncrementGroupedStat(stat, key)
+	. = TRUE
+	var/datum/statistic/grouped/S = simple_statistics[stat]
+	if (!S)
+		return FALSE
+	S.increment_value(key)

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -284,6 +284,8 @@ var/datum/controller/subsystem/ticker/SSticker
 	for(var/i in total_antagonists)
 		log_game("[i]s[total_antagonists[i]].")
 
+	SSfeedback.print_round_end_message()
+
 	return 1
 
 /datum/controller/subsystem/ticker/proc/send_tip_of_the_round()

--- a/code/datums/statistic.dm
+++ b/code/datums/statistic.dm
@@ -1,0 +1,112 @@
+/datum/statistic
+	var/name
+	var/key
+	var/write_to_database = FALSE
+	var/broadcast_at_roundend = TRUE
+
+/datum/statistic/proc/set_value()
+	WARNING("Statistic [type] does not have set_value implemented.")
+
+/datum/statistic/proc/get_value()
+	WARNING("Statistic [type] does not have get_valie implemented.")
+
+/datum/statistic/proc/increment_value()
+	WARNING("Statistic [type] does not have increment_value implemented.")
+
+/datum/statistic/proc/write_to_database()
+
+/datum/statistic/proc/get_roundend_lines()	// Must be a string or something stringifiable.
+
+/datum/statistic/proc/has_value()
+
+// key-num pairs.
+/datum/statistic/grouped
+	var/list/values = list()
+
+/datum/statistic/grouped/set_value(key, value)
+	LAZYINITLIST(values[key])
+	values[key] = value
+
+/datum/statistic/grouped/get_value(key)
+	return LAZYACCESS(values, key)
+
+/datum/statistic/grouped/increment_value(key)
+	set_value(key, get_value(key) + 1)
+
+// Just a num.
+/datum/statistic/numeric
+	var/value = 0
+
+/datum/statistic/numeric/set_value(val)
+	value = val
+
+/datum/statistic/numeric/get_value()
+	return value
+
+/datum/statistic/numeric/increment_value()
+	value++
+
+/datum/statistic/numeric/write_to_database()
+	feedback_set(key, value)
+
+/datum/statistic/numeric/get_roundend_lines()
+	. = "[value]"
+
+/datum/statistic/numeric/has_value()
+	return value > 1
+
+/datum/statistic/numeric/openturf_falls
+	name = "Human Open Space Falls"
+	key = "openturf_human_falls"
+	write_to_database = TRUE
+
+/datum/statistic/numeric/openturf_deaths
+	name = "Human Open Space Fatalities"
+	key = "openturf_human_deaths"
+	write_to_database = TRUE
+
+/datum/statistic/numeric/gibbings
+	name = "Gibbings"
+	key = "gibs"
+
+/datum/statistic/numeric/clonings
+	name = "Clones Produced"
+	key = "clones"
+
+/datum/statistic/grouped/most_deaths
+	name = "Most Overall Deaths (by ckey)"
+	key = "ckey_deaths"
+
+/datum/statistic/grouped/most_deaths/has_value()
+	if (!values.len)
+		return FALSE
+
+	var/sum
+	for (var/value in values)
+		sum += values[value]
+
+	if (sum != values.len)
+		return TRUE
+
+	return FALSE
+
+/datum/statistic/grouped/most_deaths/get_roundend_lines()
+	sortTim(values, /proc/cmp_numeric_dsc, TRUE)
+	var/ckey = values[1]
+	. = "[ckey], with [values[ckey]] deaths."
+
+/hook/death/proc/increment_statistics(mob/living/carbon/human/H, gibbed)
+	. = TRUE
+	if (!H.ckey)
+		return
+
+	SSfeedback.IncrementGroupedStat("ckey_deaths", H.ckey)
+	if (gibbed)
+		SSfeedback.IncrementSimpleStat("gibs")
+
+/hook/clone/proc/increment_statistics(mob/living/carbon/human/H)
+	. = TRUE
+	if (!H.ckey)
+		return
+
+	SSfeedback.IncrementSimpleStat("clones")

--- a/code/datums/statistic.dm
+++ b/code/datums/statistic.dm
@@ -8,7 +8,7 @@
 	WARNING("Statistic [type] does not have set_value implemented.")
 
 /datum/statistic/proc/get_value()
-	WARNING("Statistic [type] does not have get_valie implemented.")
+	WARNING("Statistic [type] does not have get_value implemented.")
 
 /datum/statistic/proc/increment_value()
 	WARNING("Statistic [type] does not have increment_value implemented.")

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -372,14 +372,14 @@
 		playsound(src.loc, "sound/weapons/smash.ogg", 75, 1)
 
 	// Stats.
-	feedback_inc("human_openturf_falls", 1)
+	SSfeedback.IncrementSimpleStat("openturf_human_falls")
 	addtimer(CALLBACK(src, .proc/post_fall_death_check), 2 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE)
 
 	return TRUE
 
 /mob/living/carbon/human/proc/post_fall_death_check()
 	if (stat == DEAD)
-		feedback_inc("human_openturf_fatalities", 1)
+		SSfeedback.IncrementSimpleStat("openturf_human_deaths")
 
 /mob/living/carbon/human/bst/fall_impact()
 	return FALSE

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -371,7 +371,15 @@
 	else
 		playsound(src.loc, "sound/weapons/smash.ogg", 75, 1)
 
+	// Stats.
+	feedback_inc("human_openturf_falls", 1)
+	addtimer(CALLBACK(src, .proc/post_fall_death_check), 2 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE)
+
 	return TRUE
+
+/mob/living/carbon/human/proc/post_fall_death_check()
+	if (stat == DEAD)
+		feedback_inc("human_openturf_fatalities", 1)
 
 /mob/living/carbon/human/bst/fall_impact()
 	return FALSE


### PR DESCRIPTION
This PR adds a system to display round statistics at the end of the round, with the option of logging said statistics to the feedback database.

Tracked stats:
- Most deaths by ckey.
- Number of people cloned.
- Number of times humans have fallen into openturfs.
- Number of times humans have died from falling into openturfs.
- Number of times humans have been gibbed.