### PR TITLE
Fixes robotics limbs not counting for the mob's total health

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -8,8 +8,6 @@
 	var/total_burn  = 0
 	var/total_brute = 0
 	for(var/obj/item/organ/external/O in organs)	//hardcoded to streamline things a bit
-		if((O.status & ORGAN_ROBOT) && !O.vital)
-			continue //*non-vital* robot limbs don't count towards shock and crit
 		total_brute += O.brute_dam
 		total_burn  += O.burn_dam
 
@@ -70,16 +68,12 @@
 /mob/living/carbon/human/getBruteLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in organs)
-		if((O.status & ORGAN_ROBOT) && !O.vital)
-			continue //robot limbs don't count towards shock and crit
 		amount += O.brute_dam
 	return amount
 
 /mob/living/carbon/human/getFireLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in organs)
-		if((O.status & ORGAN_ROBOT) && !O.vital)
-			continue //robot limbs don't count towards shock and crit
 		amount += O.burn_dam
 	return amount
 

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -4,9 +4,6 @@
 /obj/item/organ/external/head/ipc
 	dislocated = -1
 	can_intake_reagents = 0
-	vital = 1 //because it is now hosting the posibrain
-	max_damage = 50 //made same as arm, since it is not vital
-	min_broken_damage = 30
 	encased = "support frame"
 
 /obj/item/organ/external/head/ipc/New()
@@ -16,6 +13,7 @@
 /obj/item/organ/external/chest/ipc
 	dislocated = -1
 	encased = "support frame"
+	
 /obj/item/organ/external/chest/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -23,6 +21,7 @@
 /obj/item/organ/external/groin/ipc
 	dislocated = -1
 	encased = "support frame"
+	
 /obj/item/organ/external/groin/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -30,6 +29,7 @@
 /obj/item/organ/external/arm/ipc
 	dislocated = -1
 	encased = "support frame"
+	
 /obj/item/organ/external/arm/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -37,6 +37,7 @@
 /obj/item/organ/external/arm/right/ipc
 	dislocated = -1
 	encased = "support frame"
+	
 /obj/item/organ/external/arm/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -44,12 +45,14 @@
 /obj/item/organ/external/leg/ipc
 	dislocated = -1
 	encased = "support frame"
+	
 /obj/item/organ/external/leg/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
 
 /obj/item/organ/external/leg/right/ipc
 	dislocated = -1
+	
 /obj/item/organ/external/leg/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -57,6 +60,7 @@
 /obj/item/organ/external/foot/ipc
 	dislocated = -1
 	encased = "support frame"
+	
 /obj/item/organ/external/foot/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -64,6 +68,7 @@
 /obj/item/organ/external/foot/right/ipc
 	dislocated = -1
 	encased = "support frame"
+	
 /obj/item/organ/external/foot/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -71,6 +76,7 @@
 /obj/item/organ/external/hand/ipc
 	dislocated = -1
 	encased = "support frame"
+	
 /obj/item/organ/external/hand/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -78,6 +84,7 @@
 /obj/item/organ/external/hand/right/ipc
 	dislocated = -1
 	encased = "support frame"
+	
 /obj/item/organ/external/hand/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -220,8 +227,6 @@
 	dislocated = -1
 	can_intake_reagents = 0
 	vital = 0
-	max_damage = 50 //made same as arm, since it is not vital
-	min_broken_damage = 30
 	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
@@ -329,9 +334,7 @@
 /obj/item/organ/external/head/industrial
 	dislocated = -1
 	can_intake_reagents = 0
-	vital = 0
-	max_damage = 50 //made same as arm, since it is not vital
-	min_broken_damage = 30
+	vital = 1
 	encased = "support frame"
 
 /obj/item/organ/external/head/industrial/New()
@@ -425,9 +428,7 @@
 /obj/item/organ/external/head/shell
 	dislocated = -1
 	can_intake_reagents = 0
-	vital = 0
-	max_damage = 50 //made same as arm, since it is not vital
-	min_broken_damage = 30
+	vital = 1
 	encased = "support frame"
 	force_skintone = TRUE
 

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -4,6 +4,9 @@
 /obj/item/organ/external/head/ipc
 	dislocated = -1
 	can_intake_reagents = 0
+	vital = 1 //because it is now hosting the posibrain
+	max_damage = 50 //made same as arm, since it is not vital
+	min_broken_damage = 30
 	encased = "support frame"
 
 /obj/item/organ/external/head/ipc/New()
@@ -13,7 +16,6 @@
 /obj/item/organ/external/chest/ipc
 	dislocated = -1
 	encased = "support frame"
-	
 /obj/item/organ/external/chest/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -21,7 +23,6 @@
 /obj/item/organ/external/groin/ipc
 	dislocated = -1
 	encased = "support frame"
-	
 /obj/item/organ/external/groin/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -29,7 +30,6 @@
 /obj/item/organ/external/arm/ipc
 	dislocated = -1
 	encased = "support frame"
-	
 /obj/item/organ/external/arm/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -37,7 +37,6 @@
 /obj/item/organ/external/arm/right/ipc
 	dislocated = -1
 	encased = "support frame"
-	
 /obj/item/organ/external/arm/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -45,14 +44,12 @@
 /obj/item/organ/external/leg/ipc
 	dislocated = -1
 	encased = "support frame"
-	
 /obj/item/organ/external/leg/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
 
 /obj/item/organ/external/leg/right/ipc
 	dislocated = -1
-	
 /obj/item/organ/external/leg/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -60,7 +57,6 @@
 /obj/item/organ/external/foot/ipc
 	dislocated = -1
 	encased = "support frame"
-	
 /obj/item/organ/external/foot/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -68,7 +64,6 @@
 /obj/item/organ/external/foot/right/ipc
 	dislocated = -1
 	encased = "support frame"
-	
 /obj/item/organ/external/foot/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -76,7 +71,6 @@
 /obj/item/organ/external/hand/ipc
 	dislocated = -1
 	encased = "support frame"
-	
 /obj/item/organ/external/hand/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -84,7 +78,6 @@
 /obj/item/organ/external/hand/right/ipc
 	dislocated = -1
 	encased = "support frame"
-	
 /obj/item/organ/external/hand/right/ipc/New()
 	robotize("Hephaestus Integrated Limb")
 	..()
@@ -227,6 +220,8 @@
 	dislocated = -1
 	can_intake_reagents = 0
 	vital = 0
+	max_damage = 50 //made same as arm, since it is not vital
+	min_broken_damage = 30
 	encased = "reinforced support frame"
 	emp_coeff = 0.5
 
@@ -334,7 +329,9 @@
 /obj/item/organ/external/head/industrial
 	dislocated = -1
 	can_intake_reagents = 0
-	vital = 1
+	vital = 0
+	max_damage = 50 //made same as arm, since it is not vital
+	min_broken_damage = 30
 	encased = "support frame"
 
 /obj/item/organ/external/head/industrial/New()
@@ -428,7 +425,9 @@
 /obj/item/organ/external/head/shell
 	dislocated = -1
 	can_intake_reagents = 0
-	vital = 1
+	vital = 0
+	max_damage = 50 //made same as arm, since it is not vital
+	min_broken_damage = 30
 	encased = "support frame"
 	force_skintone = TRUE
 


### PR DESCRIPTION
Robotic limbs didn't count for total health due to bay changes, this pr will revert said changes. Also, changes the health and broken damage of the ipc's head to be equal to everyone else.