### PR TITLE
Centralized icon caches

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -153,6 +153,7 @@
 #include "code\controllers\subsystems\falling.dm"
 #include "code\controllers\subsystems\garbage-debug.dm"
 #include "code\controllers\subsystems\garbage.dm"
+#include "code\controllers\subsystems\icon_cache.dm"
 #include "code\controllers\subsystems\icon_smooth.dm"
 #include "code\controllers\subsystems\icon_updates.dm"
 #include "code\controllers\subsystems\ipintel.dm"

--- a/code/_helpers/overlay.dm
+++ b/code/_helpers/overlay.dm
@@ -4,7 +4,7 @@
 	if (!icon || !icon_state)
 		CRASH("Invalid parameters.")
 
-	var/list/m_cache = SSoverlays.holo_multiplier_cache
+	var/list/m_cache = SSicon_cache.holo_multiplier_cache
 	var/list/m_cache_icon
 	var/image/multiply
 	if (m_cache[icon])
@@ -25,7 +25,7 @@
 		)
 		m_cache_icon[icon_state] = multiply
 
-	var/list/a_cache = SSoverlays.holo_adder_cache
+	var/list/a_cache = SSicon_cache.holo_adder_cache
 	var/list/a_cache_icon = a_cache[icon]
 	var/image/overlay
 	if (!a_cache_icon)

--- a/code/controllers/subsystems/icon_cache.dm
+++ b/code/controllers/subsystems/icon_cache.dm
@@ -1,0 +1,34 @@
+/var/datum/controller/subsystem/icon_cache/SSicon_cache
+
+/datum/controller/subsystem/icon_cache
+	name = "Icon Cache"
+	flags = SS_NO_FIRE | SS_NO_INIT
+
+	var/list/bloody_cache = list()
+
+	var/list/holo_multiplier_cache = list()
+	var/list/holo_adder_cache = list()
+
+	var/list/image/fluidtrack_cache = list()
+
+	var/list/floor_decals = list()
+	var/list/flooring_cache = list()
+
+	var/list/mob_hat_cache = list()
+
+	var/list/magazine_icondata_keys = list()
+	var/list/magazine_icondata_states = list()
+
+/*
+	Global associative list for caching humanoid icons.
+	Index format m or f, followed by a string of 0 and 1 to represent bodyparts followed by husk fat hulk skeleton 1 or 0.
+	TODO: Proper documentation
+	icon_key is [species.race_key][g][husk][fat][hulk][skeleton][s_tone]
+*/
+	var/list/human_icon_cache = list()
+	var/list/tail_icon_cache = list()	//key is [species.race_key][r_skin][g_skin][b_skin]
+	var/list/light_overlay_cache = list()
+	var/list/limb_icon_cache = list()
+
+/datum/controller/subsystem/icon_cache/New()
+	NEW_SS_GLOBAL(SSicon_cache)

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -1,7 +1,5 @@
 #define DRYING_TIME 5 * 60*10                        //for 1 unit of depth in puddle (amount var)
 
-var/global/list/image/splatter_cache=list()
-
 /obj/effect/decal/cleanable/blood
 	name = "blood"
 	var/dryname = "dried blood"

--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -13,9 +13,6 @@
 // 5 seconds
 #define TRACKS_CRUSTIFY_TIME   50
 
-// color-dir-dry
-var/global/list/image/fluidtrack_cache=list()
-
 /datum/fluidtrack
 	var/direction=0
 	var/basecolor="#A10808"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -568,7 +568,7 @@ var/list/global/slot_flags_enumeration = list(
 		return
 
 	//if we haven't made our blood_overlay already
-	if( !blood_overlay )
+	if(!blood_overlay)
 		generate_blood_overlay()
 
 	//apply the blood-splatter overlay if it isn't already in there
@@ -587,14 +587,17 @@ var/list/global/slot_flags_enumeration = list(
 	if(blood_overlay)
 		return
 
+	blood_overlay = SSicon_cache.bloody_cache[type]
+	if (blood_overlay)
+		blood_overlay = image(blood_overlay)	// Copy instead of getting a ref, we're going to mutate this.
+		return
+
 	var/icon/I = new /icon(icon, icon_state)
 	I.Blend(new /icon('icons/effects/blood.dmi', rgb(255,255,255)),ICON_ADD) //fills the icon_state with white (except where it's transparent)
-	I.Blend(new /icon('icons/effects/blood.dmi', "itemblood"),ICON_MULTIPLY) //adds blood and the remaining white areas become transparant
+	I.Blend(new /icon('icons/effects/blood.dmi', "itemblood"),ICON_MULTIPLY) //adds blood and the remaining white areas become transparent
 
-	//not sure if this is worth it. It attaches the blood_overlay to every item of the same type if they don't have one already made.
-	for(var/obj/item/A in world)
-		if(A.type == type && !A.blood_overlay)
-			A.blood_overlay = image(I)
+	blood_overlay = image(I)
+	SSicon_cache.bloody_cache[type] = blood_overlay
 
 /obj/item/proc/showoff(mob/user)
 	for (var/mob/M in view(user))

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -1,7 +1,6 @@
 // These are objects that destroy themselves and add themselves to the
 // decal list of the floor under them. Use them rather than distinct icon_states
 // when mapping in interesting floor designs.
-var/list/floor_decals = list()
 
 /obj/effect/floor_decal
 	name = "floor decal"
@@ -11,6 +10,7 @@ var/list/floor_decals = list()
 
 /obj/effect/floor_decal/LateInitialize()
 	var/turf/T = get_turf(src)
+	var/list/floor_decals = SSicon_cache.floor_decals
 	if(istype(T, /turf/simulated/floor) || istype(T, /turf/unsimulated/floor))
 		var/cache_key = "[alpha]-[color]-[dir]-[icon_state]-[layer]"
 		if(!floor_decals[cache_key])

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -1,5 +1,3 @@
-var/list/flooring_cache = list()
-
 /turf/simulated/floor/update_icon(var/update_neighbors)
 	cut_overlays()
 
@@ -79,6 +77,7 @@ var/list/flooring_cache = list()
 			F.update_icon()
 
 /turf/simulated/floor/proc/get_flooring_overlay(var/cache_key, var/icon_base, var/icon_dir = 0)
+	var/list/flooring_cache = SSicon_cache.flooring_cache
 	if(!flooring_cache[cache_key])
 		var/image/I = image(icon = flooring.icon, icon_state = icon_base, dir = icon_dir)
 		I.layer = layer

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -339,25 +339,24 @@ BLIND     // can't see anything
 
 /obj/item/clothing/head/update_icon(var/mob/user)
 
-	overlays.Cut()
+	cut_overlays()
 	var/mob/living/carbon/human/H
 	if(istype(user,/mob/living/carbon/human))
 		H = user
 
 	if(on)
-
 		// Generate object icon.
-		if(!light_overlay_cache["[light_overlay]_icon"])
-			light_overlay_cache["[light_overlay]_icon"] = image("icon" = 'icons/obj/light_overlays.dmi', "icon_state" = "[light_overlay]")
-		overlays |= light_overlay_cache["[light_overlay]_icon"]
+		if(!SSicon_cache.light_overlay_cache["[light_overlay]_icon"])
+			SSicon_cache.light_overlay_cache["[light_overlay]_icon"] = image("icon" = 'icons/obj/light_overlays.dmi', "icon_state" = "[light_overlay]")
+		add_overlay(SSicon_cache.light_overlay_cache["[light_overlay]_icon"])
 
 		// Generate and cache the on-mob icon, which is used in update_inv_head().
 		var/cache_key = "[light_overlay][H ? "_[H.species.get_bodytype()]" : ""]"
-		if(!light_overlay_cache[cache_key])
+		if(!SSicon_cache.light_overlay_cache[cache_key])
 			var/use_icon = 'icons/mob/light_overlays.dmi'
 			if(H && sprite_sheets && sprite_sheets[H.species.get_bodytype()])
 				use_icon = sprite_sheets[H.species.get_bodytype()]
-			light_overlay_cache[cache_key] = image("icon" = use_icon, "icon_state" = "[light_overlay]")
+			SSicon_cache.light_overlay_cache[cache_key] = image("icon" = use_icon, "icon_state" = "[light_overlay]")
 
 	if(H)
 		H.update_inv_head()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1,12 +1,4 @@
-/*
-	Global associative list for caching humanoid icons.
-	Index format m or f, followed by a string of 0 and 1 to represent bodyparts followed by husk fat hulk skeleton 1 or 0.
-	TODO: Proper documentation
-	icon_key is [species.race_key][g][husk][fat][hulk][skeleton][s_tone]
-*/
-var/global/list/human_icon_cache = list()
-var/global/list/tail_icon_cache = list() //key is [species.race_key][r_skin][g_skin][b_skin]
-var/global/list/light_overlay_cache = list()
+// Human caches have been moved to SSicon_cache.
 
 	///////////////////////
 	//UPDATE_ICONS SYSTEM//
@@ -295,8 +287,8 @@ var/global/list/damage_icon_parts = list()
 
 	icon_key = "[icon_key][husk ? 1 : 0][fat ? 1 : 0][hulk ? 1 : 0][skeleton ? 1 : 0]"
 	var/icon/base_icon
-	if(update_icons != 2 && human_icon_cache[icon_key])//If update_icons is 2, then we forcibly generate a new icon
-		base_icon = human_icon_cache[icon_key]
+	if(update_icons != 2 && SSicon_cache.human_icon_cache[icon_key])//If update_icons is 2, then we forcibly generate a new icon
+		base_icon = SSicon_cache.human_icon_cache[icon_key]
 	else
 		//BEGIN CACHED ICON GENERATION.
 		var/obj/item/organ/external/chest = get_organ("chest")
@@ -338,7 +330,7 @@ var/global/list/damage_icon_parts = list()
 			husk_over.Blend(mask, ICON_ADD)
 			base_icon.Blend(husk_over, ICON_OVERLAY)
 
-		human_icon_cache[icon_key] = base_icon
+		SSicon_cache.human_icon_cache[icon_key] = base_icon
 
 	//END CACHED ICON GENERATION.
 	stand_icon.Blend(base_icon,ICON_OVERLAY)
@@ -819,8 +811,8 @@ var/global/list/damage_icon_parts = list()
 		if(istype(head,/obj/item/clothing/head))
 			var/obj/item/clothing/head/hat = head
 			var/cache_key = "[hat.light_overlay]_[species.get_bodytype()]"
-			if(hat.on && light_overlay_cache["[cache_key]"])
-				standing.overlays |= light_overlay_cache["[cache_key]"]
+			if(hat.on && SSicon_cache.light_overlay_cache["[cache_key]"])
+				standing.overlays |= SSicon_cache.light_overlay_cache["[cache_key]"]
 
 		standing.color = head.color
 		overlays_standing[HEAD_LAYER] = standing
@@ -1215,7 +1207,7 @@ var/global/list/damage_icon_parts = list()
 		return
 		
 	var/icon_key = "[species.race_key][r_skin][g_skin][b_skin][r_hair][g_hair][b_hair]"
-	var/icon/tail_icon = tail_icon_cache[icon_key]
+	var/icon/tail_icon = SSicon_cache.tail_icon_cache[icon_key]
 	if(!tail_icon)
 		//generate a new one
 		tail_icon = new/icon(icon = (species.tail_animation? species.tail_animation : 'icons/effects/species.dmi'))
@@ -1225,7 +1217,7 @@ var/global/list/damage_icon_parts = list()
 			var/icon/hair_icon = icon('icons/effects/species.dmi', "[species.tail]_[species.tail_hair]")
 			hair_icon.Blend(rgb(r_hair, g_hair, b_hair), ICON_ADD)
 			tail_icon.Blend(hair_icon, ICON_OVERLAY)
-		tail_icon_cache[icon_key] = tail_icon
+		SSicon_cache.tail_icon_cache[icon_key] = tail_icon
 
 	return tail_icon
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -1,5 +1,5 @@
-var/list/mob_hat_cache = list()
 /proc/get_hat_icon(var/obj/item/hat, var/offset_x = 0, var/offset_y = 0)
+	var/list/mob_hat_cache = SSicon_cache.mob_hat_cache
 	var/t_state = hat.icon_state
 	if(hat.item_state_slots && hat.item_state_slots[slot_head_str])
 		t_state = hat.item_state_slots[slot_head_str]

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -1,5 +1,3 @@
-var/global/list/limb_icon_cache = list()
-
 /obj/item/organ/external/set_dir()
 	return
 
@@ -140,6 +138,7 @@ var/global/list/limb_icon_cache = list()
 					mob_icon.Blend(rgb(s_col[1], s_col[2], s_col[3]), ICON_ADD)
 
 			if(body_hair && islist(h_col) && h_col.len >= 3)
+				var/list/limb_icon_cache = SSicon_cache.limb_icon_cache
 				var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
 				if(!limb_icon_cache[cache_key])
 					var/icon/I = icon(species.icobase, "[icon_name]_[body_hair]")

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -11,7 +11,6 @@
 	icon_state = "gsmes"
 	var/cells_amount = 0
 	var/capacitors_amount = 0
-	var/global/list/br_cache = null
 
 /obj/machinery/power/smes/batteryrack/New()
 	..()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -89,8 +89,8 @@
 	var/list/icon_keys = list()		//keys
 	var/list/ammo_states = list()	//values
 
-/obj/item/ammo_magazine/New()
-	..()
+/obj/item/ammo_magazine/Initialize()
+	. = ..()
 	if(multiple_sprites)
 		initialize_magazine_icondata(src)
 
@@ -142,11 +142,12 @@
 	..()
 	user << "There [(stored_ammo.len == 1)? "is" : "are"] [stored_ammo.len] round\s left!"
 
-//magazine icon state caching
-/var/global/list/magazine_icondata_keys = list()
-/var/global/list/magazine_icondata_states = list()
+//magazine icon state caching (caching lists are in SSicon_cache)
 
 /proc/initialize_magazine_icondata(var/obj/item/ammo_magazine/M)
+	var/list/magazine_icondata_keys = SSicon_cache.magazine_icondata_keys
+	var/list/magazine_icondata_states = SSicon_cache.magazine_icondata_states
+
 	var/typestr = "[M.type]"
 	if(!(typestr in magazine_icondata_keys) || !(typestr in magazine_icondata_states))
 		magazine_icondata_cache_add(M)
@@ -155,6 +156,9 @@
 	M.ammo_states = magazine_icondata_states[typestr]
 
 /proc/magazine_icondata_cache_add(var/obj/item/ammo_magazine/M)
+	var/list/magazine_icondata_keys = SSicon_cache.magazine_icondata_keys
+	var/list/magazine_icondata_states = SSicon_cache.magazine_icondata_states
+
 	var/list/icon_keys = list()
 	var/list/ammo_states = list()
 	var/list/states = icon_states(M.icon)


### PR DESCRIPTION
changes:
- Blood overlays are now cached and do not involve world iteration.
- Moved every global icon cache I could find into a new SS for organization & easier debugging. SS does not fire or init.