### PR TITLE
Update config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -192,10 +192,10 @@ var/list/gamemode_cache = list()
 	var/use_lib_nudge = 0 //Use the C library nudge instead of the python nudge.
 	var/use_overmap = 0
 
-	var/list/station_levels = list(1)				// Defines which Z-levels the station exists on.
-	var/list/admin_levels= list(2)					// Defines which Z-levels which are for admin functionality, for example including such areas as Central Command and the Syndicate Shuttle
-	var/list/contact_levels = list(1, 5)			// Defines which Z-levels which, for example, a Code Red announcement may affect
-	var/list/player_levels = list(1, 3, 4, 5, 6)	// Defines all Z-levels a character can typically reach
+	var/list/station_levels = list(3, 4, 5, 6, 7)				// Defines which Z-levels the station exists on.
+	var/list/admin_levels= list(1)					// Defines which Z-levels which are for admin functionality, for example including such areas as Central Command and the Syndicate Shuttle
+	var/list/contact_levels = list(3, 4, 5, 6)			// Defines which Z-levels which, for example, a Code Red announcement may affect
+	var/list/player_levels = list(2, 3, 4, 5, 6, 7, 8)	// Defines all Z-levels a character can typically reach
 	var/list/sealed_levels = list() 				// Defines levels that do not allow random transit at the edges.
 
 	// Event settings
@@ -253,9 +253,6 @@ var/list/gamemode_cache = list()
 	//API Rate limiting
 	var/api_rate_limit = 50
 	var/list/api_rate_limit_whitelist = list()
-
-	// Subsystems.
-	var/obj/effect/statclick/statclick
 
 	// Master Controller settings.
 	var/mc_init_tick_limit = TICK_LIMIT_MC_INIT_DEFAULT
@@ -720,6 +717,9 @@ var/list/gamemode_cache = list()
 
 				if("player_levels")
 					config.player_levels = text2numlist(value, ";")
+
+				if("sealed_levels")
+					config.sealed_levels = text2numlist(value, ";")
 
 				if("expected_round_length")
 					config.expected_round_length = MinutesToTicks(text2num(value))

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -175,9 +175,17 @@ ALLOW_ANTAG_HUD
 ## If ghosts use antagHUD they are no longer allowed to join the round.
 ANTAG_HUD_RESTRICTED
 
-## allow AI job
-ALLOW_AI
+## Prevents observers from joining as mice.
+#DISABLE_PLAYER_MICE
 
+## If enabled, observer-mice will only be able to understand other mice.
+#UNEDUCATED_MICE
+
+## How much time a drone fabricator will take to produce a single drone. In deciseconds.
+#DRONE_BUILD_TIME 1200
+
+## If set to 0, observers will be unable to spawn as drones. Default 1.
+#ALLOW_DRONE_SPAWN 1
 
 ## disable abandon mob
 # NORESPAWN
@@ -304,17 +312,20 @@ CHARACTER_SLOTS 10
 ## Uncomment to use overmap system for zlevel travel
 #USE_OVERMAP
 
-## Defines which Z-levels the station exists on.
-STATION_LEVELS 1
+## Defines which Z-levels the station exists on. Only set if you need to change the defaults.
+#STATION_LEVELS 3;4;5;6;7
 
-## Defines which Z-levels are used for admin functionality, such as Central Command and the Syndicate Shuttle
-ADMIN_LEVELS 2
+## Defines which Z-levels are used for admin functionality, such as Central Command and the Syndicate Shuttle. Only set if you need to change the defaults.
+#ADMIN_LEVELS 1
 
-## Defines which Z-levels which, for example, a Code Red announcement may affect
-CONTACT_LEVELS 1;5
+## Defines which Z-levels which, for example, a Code Red announcement may affect. Only set if you need to change the defaults.
+#CONTACT_LEVELS 3;4;5;6
 
-## Defines all Z-levels a character can typically reach
-PLAYER_LEVELS 1;3;4;5;6
+## Defines all Z-levels a character can typically reach. Only set if you need to change the defaults.
+#PLAYER_LEVELS 2;3;4;5;6;7;8
+
+## Defines which levels cannot be left via touching map borders. Only set if you need to change the defaults.
+#SEALED_LEVELS
 
 ## Expected round length in minutes
 EXPECTED_ROUND_LENGTH 180
@@ -441,6 +452,8 @@ API_RATE_LIMIT_WHITELIST 127.0.0.1
 
 # The maximum amount of a tick that the MC is permitted to use during server startup.
 # If not set will default to 98%.
+# You can set this high (~5000) for local testing to *maybe* speed up startup a bit at the cost of lagging the lobby.
+# Should be below 99 on a server actually used for play.
 #MC_TICKLIMIT_INIT 98
 
 


### PR DESCRIPTION
changes:
- Added some entries to the example config that were implemented but not listed.
- Updated level defaults to actually correct values.
- Added blurb about changing `MC_TICKLIMIT_INIT` on testing servers.
- Removed broken config option `ALLOW_AI`.
- Removed unused statclick var from configuration datum.
- Added config support for setting sealed levels.