### PR TITLE
Species remains fixes, soulstone and constructs tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -19,6 +19,7 @@
 	mob_size = 9
 	spawn_flags = CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR | HAS_SOCKS
+	remains_type = /obj/effect/decal/remains/human
 
 	stamina	=	130			  // Humans can sprint for longer than any other species
 	stamina_recovery = 5
@@ -227,6 +228,7 @@
 	name_language = "Rootsong"
 	ethanol_resistance = -1//Can't get drunk
 	mob_size = 12//Worker gestalts are 150kg
+	remains_type = /obj/effect/decal/cleanable/ash //no bones, so, they just turn into dust
 	blurb = "Commonly referred to (erroneously) as 'plant people', the Dionaea are a strange space-dwelling collective \
 	species hailing from Epsilon Ursae Minoris. Each 'diona' is a cluster of numerous cat-sized organisms called nymphs; \
 	there is no effective upper limit to the number that can fuse in gestalt, and reports exist	of the Epsilon Ursae \
@@ -378,6 +380,7 @@
 	secondary_langs = list("Encoded Audio Language")
 	ethanol_resistance = -1//Can't get drunk
 	radiation_mod = 0	// not affected by radiation
+	remains_type = /obj/effect/decal/remains/robot
 
 	// #TODO-MERGE: Check for balance and self-repair. If self-repair is a thing, RIP balance.
 	brute_mod = 0.8

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -170,6 +170,14 @@
 	attack_sound = 'sound/weapons/rapidslice.ogg'
 	construct_spells = list(/spell/targeted/ethereal_jaunt/shift)
 
+/mob/living/simple_animal/construct/wraith/can_fall()
+	return FALSE
+
+/mob/living/simple_animal/construct/wraith/can_ztravel()
+	return TRUE
+
+/mob/living/simple_animal/construct/wraith/CanAvoidGravity()
+	return TRUE
 
 /////////////////////////////Artificer/////////////////////////
 
@@ -260,6 +268,15 @@
 			/spell/aoe_turf/conjure/forcewall/lesser
 		)
 	//Harvesters are endgame stuff, no harm giving them construct spells
+
+/mob/living/simple_animal/construct/harvester/can_fall()
+	return FALSE
+
+/mob/living/simple_animal/construct/harvester/can_ztravel()
+	return TRUE
+
+/mob/living/simple_animal/construct/harvester/CanAvoidGravity()
+	return TRUE
 
 ////////////////Glow//////////////////
 /mob/living/simple_animal/construct/proc/add_glow()

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -117,14 +117,8 @@
 	for(var/obj/item/W in T)
 		T.drop_from_inventory(W)
 
-	if(isipc(T))
-		new /obj/effect/decal/remains/robot(T.loc)
-
-	else if(ishuman_species(T))
-		new /obj/effect/decal/remains/human(T.loc)
-		
-	else		
-		new /obj/effect/decal/remains/xeno(T.loc) //if neither is an ipc or human, xeno remains
+	var/obj/effect/decal/remains/remains = T.species.remains_type //spawns a skeleton based on the species remain type
+	new remains(T.loc)
 		
 	T.invisibility = 101
 

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -117,7 +117,15 @@
 	for(var/obj/item/W in T)
 		T.drop_from_inventory(W)
 
-	new /obj/effect/decal/remains/human(T.loc) //Spawns a skeleton
+	if(isipc(T))
+		new /obj/effect/decal/remains/robot(T.loc)
+
+	else if(ishuman_species(T))
+		new /obj/effect/decal/remains/human(T.loc)
+		
+	else		
+		new /obj/effect/decal/remains/xeno(T.loc) //if neither is an ipc or human, xeno remains
+		
 	T.invisibility = 101
 
 	var/atom/movable/overlay/animation = new /atom/movable/overlay( T.loc )


### PR DESCRIPTION
-species have the right remains_type now, ipcs will leave behind robot remains, humans will leave behind humans remains, dionae will just leave behind ashes and most xenos will leave behind xeno remains
-soulstones can now leave behind different types of remains depending on their victim species
-wraiths and harversts will not float over open turfs and can freely move around z-levels
