### PR TITLE
Convert ion trails to new effect system

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1227,6 +1227,7 @@
 #include "code\modules\economy\Events_Mundane.dm"
 #include "code\modules\economy\TradeDestinations.dm"
 #include "code\modules\effects\effect_system.dm"
+#include "code\modules\effects\ion_trail_follow.dm"
 #include "code\modules\effects\visual_effect.dm"
 #include "code\modules\effects\sparks\procs.dm"
 #include "code\modules\effects\sparks\spawner.dm"

--- a/code/game/mecha/working/hoverpod.dm
+++ b/code/game/mecha/working/hoverpod.dm
@@ -13,14 +13,12 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/hoverpod
 	cargo_capacity = 5
 	max_equip = 3
-	var/datum/effect/effect/system/ion_trail_follow/ion_trail
+	var/datum/effect_system/ion_trail/ion_trail
 	var/stabilization_enabled = 1
 
-/obj/mecha/working/hoverpod/New()
-	..()
-	ion_trail = new /datum/effect/effect/system/ion_trail_follow()
-	ion_trail.set_up(src)
-	ion_trail.start()
+/obj/mecha/working/hoverpod/Initialize()
+	. = ..()
+	ion_trail = new(src)
 
 //Modified phazon code
 /obj/mecha/working/hoverpod/Topic(href, href_list)
@@ -48,7 +46,7 @@
 	if (!has_charge(step_energy_drain))
 		ion_trail.stop()
 	else
-		if (!ion_trail.on)
+		if (!ion_trail.isprocessing)
 			ion_trail.start()
 		if (stabilization_enabled)
 			return 1

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -294,63 +294,6 @@ steam.start() -- spawns the effect
 /datum/effect/effect/system/smoke_spread/mustard
 	smoke_type = /obj/effect/effect/smoke/mustard
 
-
-/////////////////////////////////////////////
-//////// Attach an Ion trail to any object, that spawns when it moves (like for the jetpack)
-/// just pass in the object to attach it to in set_up
-/// Then do start() to start it and stop() to stop it, obviously
-/// and don't call start() in a loop that will be repeated otherwise it'll get spammed!
-/////////////////////////////////////////////
-
-/obj/effect/effect/ion_trails
-	name = "ion trails"
-	icon_state = "ion_trails"
-	anchored = 1.0
-
-/datum/effect/effect/system/ion_trail_follow
-	var/turf/oldposition
-	var/processing = 1
-	var/on = 1
-
-	set_up(atom/atom)
-		attach(atom)
-		oldposition = get_turf(atom)
-
-	start()
-		if(!src.on)
-			src.on = 1
-			src.processing = 1
-		if(src.processing)
-			src.processing = 0
-			spawn(0)
-				var/turf/T = get_turf(src.holder)
-				if(T != src.oldposition)
-					if(istype(T, /turf/space))
-						var/obj/effect/effect/ion_trails/I = new /obj/effect/effect/ion_trails(src.oldposition)
-						src.oldposition = T
-						I.set_dir(src.holder.dir)
-						flick("ion_fade", I)
-						I.icon_state = "blank"
-						animate(I, alpha = 0, time = 18, easing = SINE_EASING | EASE_IN)
-						QDEL_IN(I, 20)
-
-					spawn(2)
-						if(src.on)
-							src.processing = 1
-							src.start()
-				else
-					spawn(2)
-						if(src.on)
-							src.processing = 1
-							src.start()
-
-	proc/stop()
-		src.processing = 0
-		src.on = 0
-
-
-
-
 /////////////////////////////////////////////
 //////// Attach a steam trail to an object (eg. a reacting beaker) that will follow it
 // even if it's carried of thrown.

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -38,7 +38,7 @@
 	w_class = 4.0
 	item_state = "jetpack"
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-	var/datum/effect/effect/system/ion_trail_follow/ion_trail
+	var/datum/effect_system/ion_trail/ion_trail
 	var/on = 0.0
 	var/stabilization_on = 0
 	var/warned = 0
@@ -47,8 +47,7 @@
 
 /obj/item/weapon/tank/jetpack/Initialize()
 	. = ..()
-	src.ion_trail = new /datum/effect/effect/system/ion_trail_follow()
-	src.ion_trail.set_up(src)
+	ion_trail = new(src)
 
 /obj/item/weapon/tank/jetpack/Destroy()
 	QDEL_NULL(ion_trail)

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -397,12 +397,12 @@
 /obj/item/rig_module/maneuvering_jets/installed()
 	..()
 	jets.holder = holder
-	jets.ion_trail.set_up(holder)
+	jets.ion_trail.bind(holder)
 
 /obj/item/rig_module/maneuvering_jets/removed()
 	..()
 	jets.holder = null
-	jets.ion_trail.set_up(jets)
+	jets.ion_trail.bind(jets)
 
 /obj/item/rig_module/foam_sprayer
 

--- a/code/modules/effects/effect_system.dm
+++ b/code/modules/effects/effect_system.dm
@@ -19,10 +19,7 @@
 /datum/effect_system/proc/queue()
 	if (holder)
 		set_loc(holder)
-	if (SSeffects)
-		QUEUE_EFFECT(src)
-		return TRUE
-	return FALSE
+	QUEUE_EFFECT(src)
 
 /datum/effect_system/process(elapsed)
 	if (holder)

--- a/code/modules/effects/ion_trail_follow.dm
+++ b/code/modules/effects/ion_trail_follow.dm
@@ -1,0 +1,44 @@
+/datum/effect_system/ion_trail
+	var/turf/old_location
+
+/datum/effect_system/ion_trail/New(atom/source_atom)
+	if (source_atom)
+		bind(source_atom)
+	
+	..(FALSE)
+
+/datum/effect_system/ion_trail/process()
+	. = ..()
+	if (!location)
+		return
+
+	. = EFFECT_CONTINUE
+
+	if (old_location != location)
+		if (location.is_hole)	// openspace or space.
+			var/obj/effect/effect/ion_trails/I = new(old_location)
+			if (holder)
+				I.set_dir(holder.dir)
+
+			flick("ion_fade", I)
+			I.icon_state = "blank"
+			animate(I, alpha = 0, time = 18, easing = SINE_EASING | EASE_IN)
+			QDEL_IN(I, 20)
+
+		old_location = location
+
+/datum/effect_system/ion_trail/proc/start()
+	QUEUE_EFFECT(src)
+
+/datum/effect_system/ion_trail/proc/stop()
+	STOP_EFFECT(src)
+	old_location = null
+
+/datum/effect_system/ion_trail/Destroy()
+	old_location = null
+	return ..()
+
+/obj/effect/effect/ion_trails
+	name = "ion trails"
+	icon_state = "ion_trails"
+	anchored = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -23,7 +23,7 @@
 	projectiletype = /obj/item/projectile/beam/drone
 	projectilesound = 'sound/weapons/laser3.ogg'
 	destroy_surroundings = 0
-	var/datum/effect/effect/system/ion_trail_follow/ion_trail
+	var/datum/effect_system/ion_trail/ion_trail
 
 	//the drone randomly switches between these states because it's malfunctioning
 	var/hostile_drone = 0
@@ -54,8 +54,7 @@
 	if(prob(5))
 		projectiletype = /obj/item/projectile/beam/pulse/drone
 		projectilesound = 'sound/weapons/pulse2.ogg'
-	ion_trail = new
-	ion_trail.set_up(src)
+	ion_trail = new(src)
 	ion_trail.start()
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/Allow_Spacemove(var/check_drift = 0)

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -18,13 +18,12 @@
 	var/space_speed = 1
 	var/bike_icon = "bike"
 
-	var/datum/effect/effect/system/ion_trail_follow/ion
+	var/datum/effect_system/ion_trail/ion
 	var/kickstand = 1
 
 /obj/vehicle/bike/New()
 	..()
-	ion = new /datum/effect/effect/system/ion_trail_follow()
-	ion.set_up(src)
+	ion = new(src)
 	turn_off()
 	overlays += image('icons/obj/bike.dmi', "[icon_state]_off_overlay", MOB_LAYER + 1)
 	icon_state = "[bike_icon]_off"
@@ -146,6 +145,6 @@
 
 
 /obj/vehicle/bike/Destroy()
-	qdel(ion)
+	QDEL_NULL(ion)
 
 	return ..()


### PR DESCRIPTION
Converts the ion trail effect to use SSeffects instead of a spawn-loop for processing, as well as makes it also manifest on openturfs instead of just space.