### PR TITLE
Fix constructed borgs being utterly broken

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -201,7 +201,7 @@
 				user << "<span class='warning'>This [W] does not seem to fit.</span>"
 				return
 
-			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), unfinished = 1)
+			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), TRUE)
 			if(!O)	return
 
 			user.drop_item()


### PR DESCRIPTION
`New()` was runtiming since it can't pass named arguments.