### PR TITLE
Conveyor Tweaks

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -302,6 +302,7 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
 
 #define DEBUG_REF(D) (D ? "\ref[D]|[D] ([D.type])" : "NULL")
+#define PROCLOG(thing) log_debug("[THIS_PROC_TYPE_WEIRD]: [thing]")
 
 //Recipe type defines. Used to determine what machine makes them
 #define MICROWAVE			0x1

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -302,7 +302,11 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
 
 #define DEBUG_REF(D) (D ? "\ref[D]|[D] ([D.type])" : "NULL")
-#define PROCLOG(thing) log_debug("[THIS_PROC_TYPE_WEIRD]: [thing]")
+
+// These defines write to log_debug, prefixing the path to the current proc.
+//  When using them, try PROCLOG first. If it does not compile, try PROCLOG_WEIRD.
+#define PROCLOG(thing) log_debug("[THIS_PROC_TYPE]: [thing]")
+#define PROCLOG_WEIRD(thing) log_debug("[THIS_PROC_TYPE_WEIRD]: [thing]")
 
 //Recipe type defines. Used to determine what machine makes them
 #define MICROWAVE			0x1

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -88,7 +88,7 @@
 		return
 
 	if (!loc)
-		PROCLOG("loc is null, breaking self.")
+		PROCLOG_WEIRD("loc is null, breaking self.")
 		stat |= BROKEN
 		return
 

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -86,18 +86,38 @@
 		return
 	if(!operating)
 		return
+
+	if (!loc)
+		PROCLOG("loc is null, breaking self.")
+		stat |= BROKEN
+		return
+
 	use_power(100)
 
-	affecting = loc.contents - src		// moved items will be all in loc
-	spawn(1)	// slight delay to prevent infinite propagation due to map order	//TODO: please no spawn() in process(). It's a very bad idea
-		var/items_moved = 0
-		for(var/atom/movable/A in affecting)
-			if(!A.anchored)
-				if(A.loc == src.loc) // prevents the object from being affected if it's not currently here.
-					step(A,movedir)
-					items_moved++
-			if(items_moved >= 10)
-				break
+	var/list/affecting = loc.contents.Copy() - src
+	if (affecting.len)
+		addtimer(CALLBACK(src, .proc/post_process, affecting), 1)	// slight delay to prevent infinite propagation due to map order
+
+/obj/machinery/conveyor/proc/post_process(list/affecting)
+	var/items_moved = 0
+	for (var/thing in affecting)
+		var/atom/movable/AM = thing
+		if (AM.anchored || !AM.simulated)
+			continue
+
+		if (AM.loc != loc)	// prevents the object from being affected if it's not currently here.
+			continue
+
+		if (items_moved >= 10 || TICK_CHECK)
+			break
+
+		AM.conveyor_act(movedir)
+		items_moved++
+
+/atom/movable/proc/conveyor_act(move_dir)
+	set waitfor = FALSE
+	if (!anchored && simulated && has_gravity(src))
+		step(src, move_dir)
 
 // attack with item, place item on conveyor
 /obj/machinery/conveyor/attackby(var/obj/item/I, mob/user)


### PR DESCRIPTION
changes:
- Conveyor belts are now tick-checked.
- Added a `conveyor_act` proc so objects can override default conveyor behavior.
- Conveyor belts no longer affect objects in zero-G.
- Conveyor belts no longer use spawn.