### PR TITLE
machinery_process() & auto_use_power efficiency tweaks

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -103,7 +103,7 @@ obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/a
 
 	return node.pipe_color
 
-/obj/machinery/atmospherics/process()
+/obj/machinery/atmospherics/machinery_process()
 	last_flow_rate = 0
 	last_power_draw = 0
 

--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -67,7 +67,7 @@
 	stored_energy = 0
 	return last_stored_energy_transferred
 
-/obj/machinery/atmospherics/binary/circulator/process()
+/obj/machinery/atmospherics/binary/circulator/machinery_process()
 	..()
 
 	if(last_worldtime_transfer < world.time - 50)

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -99,7 +99,7 @@
 	update_icon()
 	update_underlays()
 
-/obj/machinery/atmospherics/binary/dp_vent_pump/process()
+/obj/machinery/atmospherics/binary/dp_vent_pump/machinery_process()
 	..()
 
 	last_power_draw = 0

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -44,7 +44,7 @@
 /obj/machinery/atmospherics/binary/passive_gate/hide(var/i)
 	update_underlays()
 
-/obj/machinery/atmospherics/binary/passive_gate/process()
+/obj/machinery/atmospherics/binary/passive_gate/machinery_process()
 	..()
 	
 	last_flow_rate = 0

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -62,7 +62,7 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/binary/pump/hide(var/i)
 	update_underlays()
 
-/obj/machinery/atmospherics/binary/pump/process()
+/obj/machinery/atmospherics/binary/pump/machinery_process()
 	last_power_draw = 0
 	last_flow_rate = 0
 

--- a/code/ATMOSPHERICS/components/omni_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/filter.dm
@@ -57,7 +57,7 @@
 
 	return 0
 
-/obj/machinery/atmospherics/omni/filter/process()
+/obj/machinery/atmospherics/omni/filter/machinery_process()
 	if(!..())
 		return 0
 

--- a/code/ATMOSPHERICS/components/omni_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/mixer.dm
@@ -97,7 +97,7 @@
 
 	return 0
 
-/obj/machinery/atmospherics/omni/mixer/process()
+/obj/machinery/atmospherics/omni/mixer/machinery_process()
 	if(!..())
 		return 0
 

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -61,7 +61,7 @@
 /obj/machinery/atmospherics/omni/proc/error_check()
 	return
 
-/obj/machinery/atmospherics/omni/process()
+/obj/machinery/atmospherics/omni/machinery_process()
 	last_power_draw = 0
 	last_flow_rate = 0
 

--- a/code/ATMOSPHERICS/components/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/portables_connector.dm
@@ -37,7 +37,7 @@
 /obj/machinery/atmospherics/portables_connector/hide(var/i)
 	update_underlays()
 
-/obj/machinery/atmospherics/portables_connector/process()
+/obj/machinery/atmospherics/portables_connector/machinery_process()
 	..()
 	if(!on)
 		return

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -93,7 +93,7 @@
 	if(old_stat != stat)
 		update_icon()
 
-/obj/machinery/atmospherics/trinary/filter/process()
+/obj/machinery/atmospherics/trinary/filter/machinery_process()
 	..()
 
 	last_power_draw = 0

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -72,7 +72,7 @@
 	if (!mixing_inputs)
 		mixing_inputs = list(src.air1 = node1_concentration, src.air2 = node2_concentration)
 
-/obj/machinery/atmospherics/trinary/mixer/process()
+/obj/machinery/atmospherics/trinary/mixer/machinery_process()
 	..()
 
 	last_power_draw = 0

--- a/code/ATMOSPHERICS/components/tvalve.dm
+++ b/code/ATMOSPHERICS/components/tvalve.dm
@@ -179,7 +179,7 @@
 	else
 		src.go_to_side()
 
-/obj/machinery/atmospherics/tvalve/process()
+/obj/machinery/atmospherics/tvalve/machinery_process()
 	..()
 	. = PROCESS_KILL
 	//machines.Remove(src)

--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -117,7 +117,7 @@
 
 	add_fingerprint(usr)
 
-/obj/machinery/atmospherics/unary/freezer/process()
+/obj/machinery/atmospherics/unary/freezer/machinery_process()
 	..()
 
 	if(stat & (NOPOWER|BROKEN) || !use_power)

--- a/code/ATMOSPHERICS/components/unary/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_source.dm
@@ -66,7 +66,7 @@
 	return
 
 
-/obj/machinery/atmospherics/unary/heater/process()
+/obj/machinery/atmospherics/unary/heater/machinery_process()
 	..()
 
 	if(stat & (NOPOWER|BROKEN) || !use_power)

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -48,7 +48,7 @@
 	if(old_stat != stat)
 		update_icon()
 
-/obj/machinery/atmospherics/unary/outlet_injector/process()
+/obj/machinery/atmospherics/unary/outlet_injector/machinery_process()
 	..()
 
 	last_power_draw = 0

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -167,7 +167,7 @@
 		return 0
 	return 1
 
-/obj/machinery/atmospherics/unary/vent_pump/process()
+/obj/machinery/atmospherics/unary/vent_pump/machinery_process()
 	..()
 
 	if (hibernate > world.time)

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -131,7 +131,7 @@
 
 	return 1
 
-/obj/machinery/atmospherics/unary/vent_scrubber/process()
+/obj/machinery/atmospherics/unary/vent_scrubber/machinery_process()
 	..()
 
 	if (hibernate > world.time)

--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -136,11 +136,9 @@
 	else
 		src.open()
 
-/obj/machinery/atmospherics/valve/process()
+/obj/machinery/atmospherics/valve/machinery_process()
 	..()
-	. = PROCESS_KILL
-
-	return
+	return PROCESS_KILL
 
 /obj/machinery/atmospherics/valve/initialize()
 	normalize_dir()

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -191,7 +191,7 @@
 		invisibility = i ? 101 : 0
 	update_icon()
 
-/obj/machinery/atmospherics/pipe/simple/process()
+/obj/machinery/atmospherics/pipe/simple/machinery_process()
 	if(!parent) //This should cut back on the overhead calling build_network thousands of times per cycle
 		..()
 	else
@@ -452,7 +452,7 @@
 /obj/machinery/atmospherics/pipe/manifold/pipeline_expansion()
 	return list(node1, node2, node3)
 
-/obj/machinery/atmospherics/pipe/manifold/process()
+/obj/machinery/atmospherics/pipe/manifold/machinery_process()
 	if(!parent)
 		..()
 	else
@@ -697,7 +697,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/pipeline_expansion()
 	return list(node1, node2, node3, node4)
 
-/obj/machinery/atmospherics/pipe/manifold4w/process()
+/obj/machinery/atmospherics/pipe/manifold4w/machinery_process()
 	if(!parent)
 		..()
 	else
@@ -960,7 +960,7 @@
 /obj/machinery/atmospherics/pipe/cap/pipeline_expansion()
 	return list(node)
 
-/obj/machinery/atmospherics/pipe/cap/process()
+/obj/machinery/atmospherics/pipe/cap/machinery_process()
 	if(!parent)
 		..()
 	else
@@ -1075,7 +1075,7 @@
 	initialize_directions = dir
 	..()
 
-/obj/machinery/atmospherics/pipe/tank/process()
+/obj/machinery/atmospherics/pipe/tank/machinery_process()
 	if(!parent)
 		..()
 	else
@@ -1242,7 +1242,7 @@
 	name = "Larger vent"
 	volume = 1000
 
-/obj/machinery/atmospherics/pipe/vent/process()
+/obj/machinery/atmospherics/pipe/vent/machinery_process()
 	if(!parent)
 		if(build_killswitch <= 0)
 			. = PROCESS_KILL

--- a/code/controllers/subsystems/machinery.dm
+++ b/code/controllers/subsystems/machinery.dm
@@ -74,8 +74,8 @@
 			sortTim(cameranet.cameras, /proc/cmp_camera)
 			cameranet.cameras_unsorted = FALSE
 
-	var/list/curr_machinery = src.processing_machinery
-	var/list/curr_powersinks = src.processing_powersinks
+	var/list/curr_machinery = processing_machinery
+	var/list/curr_powersinks = processing_powersinks
 
 	while (curr_machinery.len)
 		var/obj/machinery/M = curr_machinery[curr_machinery.len]
@@ -90,7 +90,7 @@
 
 		if (M.machinery_processing)
 			processes_this_tick++
-			switch (M.process())
+			switch (M.machinery_process())
 				if (PROCESS_KILL)
 					remove_machine(M)
 				if (M_NO_PROCESS)
@@ -99,12 +99,26 @@
 		if (start_tick != world.time)
 			// Slept.
 			if (!slept_in_process[M.type])
-				log_debug("SSmachinery: Type '[M.type]' slept during process().")
+				log_debug("SSmachinery: Type '[M.type]' slept during machinery_process().")
 				slept_in_process[M.type] = TRUE
 
 		if (M.use_power)
 			powerusers_this_tick++
-			M.auto_use_power()
+			if (M.has_special_power_checks)
+				M.auto_use_power()
+			else
+				var/area/A = M.loc ? M.loc.loc : null
+				if (isarea(A))
+					var/chan = M.power_channel
+					if (A.powered(chan))
+						var/usage = 0
+						switch (M.use_power)
+							if (1)
+								usage = M.idle_power_usage
+							if (2)
+								usage = M.active_power_usage
+						
+						A.use_power(usage, chan)
 
 		if (no_mc_tick)
 			CHECK_TICK

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -75,7 +75,7 @@
 	icon_state = "table2-idle"
 	return 0
 
-/obj/machinery/optable/process()
+/obj/machinery/optable/machinery_process()
 	check_victim()
 
 /obj/machinery/optable/proc/take_victim(mob/living/carbon/C, mob/living/carbon/user as mob)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -24,7 +24,7 @@
 	. = ..()
 	update_icon()
 
-/obj/machinery/sleeper/process()
+/obj/machinery/sleeper/machinery_process()
 	if(stat & (NOPOWER|BROKEN))
 		return
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -186,7 +186,7 @@
 	TLV["pressure"] =		list(ONE_ATMOSPHERE*0.80,ONE_ATMOSPHERE*0.90,ONE_ATMOSPHERE*1.10,ONE_ATMOSPHERE*1.20) /* kpa */
 	TLV["temperature"] =	list(T0C-26, T0C, T0C+40, T0C+66) // K
 
-/obj/machinery/alarm/process()
+/obj/machinery/alarm/machinery_process()
 	if((stat & (NOPOWER|BROKEN)) || shorted || buildstage != 2)
 		return
 

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -26,7 +26,7 @@
 /obj/machinery/air_sensor/update_icon()
 	icon_state = "gsensor[on]"
 
-/obj/machinery/air_sensor/process()
+/obj/machinery/air_sensor/machinery_process()
 	if(on)
 		var/datum/signal/signal = new
 		signal.transmission_method = 1 //radio signal
@@ -100,7 +100,7 @@ obj/machinery/computer/general_air_control/Destroy()
 	user.set_machine(src)
 	onclose(user, "computer")
 
-/obj/machinery/computer/general_air_control/process()
+/obj/machinery/computer/general_air_control/machinery_process()
 	if (operable())
 		src.updateUsrDialog()
 
@@ -411,7 +411,7 @@ Min Core Pressure: [pressure_limit] kPa<BR>"}
 	var/on_temperature = 1200
 	circuit = /obj/item/weapon/circuitboard/air_management/injector_control
 
-/obj/machinery/computer/general_air_control/fuel_injection/process()
+/obj/machinery/computer/general_air_control/fuel_injection/machinery_process()
 	if(automation)
 		if(!radio_connection)
 			return 0

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -185,7 +185,7 @@ update_flag
 	else
 		return 1
 
-/obj/machinery/portable_atmospherics/canister/process()
+/obj/machinery/portable_atmospherics/canister/machinery_process()
 	if (destroyed)
 		return
 

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -17,7 +17,7 @@
 	if (!target)
 		src.target = locate(/obj/machinery/atmospherics/pipe) in loc
 
-/obj/machinery/meter/process()
+/obj/machinery/meter/machinery_process()
 	if(!target)
 		icon_state = "meterX"
 		return 0

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -143,6 +143,7 @@
 	var/power_losses
 	var/last_power_draw = 0
 	var/obj/item/weapon/cell/cell
+	has_special_power_checks = TRUE
 
 /obj/machinery/portable_atmospherics/powered/powered()
 	if(use_power) //using area power

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -28,7 +28,7 @@
 		connect(port)
 		update_icon()
 
-/obj/machinery/portable_atmospherics/process()
+/obj/machinery/portable_atmospherics/machinery_process()
 	if(!connected_port) //only react when pipe_network will ont it do it for you
 		//Allow for reactions
 		air_contents.react()

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -61,7 +61,7 @@
 
 	..(severity)
 
-/obj/machinery/portable_atmospherics/powered/pump/process()
+/obj/machinery/portable_atmospherics/powered/pump/machinery_process()
 	..()
 	var/power_draw = -1
 

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -51,7 +51,7 @@
 
 	return
 
-/obj/machinery/portable_atmospherics/powered/scrubber/process()
+/obj/machinery/portable_atmospherics/powered/scrubber/machinery_process()
 	..()
 
 	var/power_draw = -1
@@ -183,7 +183,7 @@
 	if (old_stat != stat)
 		update_icon()
 
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/process()
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/machinery_process()
 	if(!on || (stat & (NOPOWER|BROKEN)))
 		update_use_power(0)
 		last_flow_rate = 0

--- a/code/game/machinery/atmoalter/zvent.dm
+++ b/code/game/machinery/atmoalter/zvent.dm
@@ -9,7 +9,7 @@
 	var/on = 0
 	var/volume_rate = 800
 
-/obj/machinery/zvent/process()
+/obj/machinery/zvent/machinery_process()
 
 	//all this object does, is make its turf share air with the ones above and below it, if they have a vent too.
 	if (istype(loc,/turf/simulated)) //if we're not on a valid turf, forget it

--- a/code/game/machinery/bluespacerelay.dm
+++ b/code/game/machinery/bluespacerelay.dm
@@ -12,7 +12,7 @@
 	idle_power_usage = 15000
 	active_power_usage = 15000
 
-/obj/machinery/bluespacerelay/process()
+/obj/machinery/bluespacerelay/machinery_process()
 
 	update_power()
 

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -479,7 +479,7 @@
 	mode = 0
 
 
-/obj/machinery/bot/mulebot/process()
+/obj/machinery/bot/mulebot/machinery_process()
 	if(!has_power())
 		on = 0
 		return

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -66,7 +66,7 @@
 	wires = null
 	return ..()
 
-/obj/machinery/camera/process()
+/obj/machinery/camera/machinery_process()
 	if((stat & EMPED) && world.time >= affected_by_emp_until)
 		stat &= ~EMPED
 		cancelCameraAlarm()

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -98,7 +98,7 @@
 	..(severity)
 
 
-/obj/machinery/cell_charger/process()
+/obj/machinery/cell_charger/machinery_process()
 	//world << "ccpt [charging] [stat]"
 	if((stat & (BROKEN|NOPOWER)) || !anchored)
 		update_use_power(0)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -167,7 +167,7 @@
 	return between(0, 100 * (occupant.health - occupant.maxHealth * config.health_threshold_crit / 100) / (occupant.maxHealth * (heal_level - config.health_threshold_crit) / 100), 100)
 
 //Grow clones to maturity then kick them out.  FREELOADERS
-/obj/machinery/clonepod/process()
+/obj/machinery/clonepod/machinery_process()
 
 	if(stat & NOPOWER) //Autoeject if power is lost
 		if(occupant)

--- a/code/game/machinery/commsbantenna.dm
+++ b/code/game/machinery/commsbantenna.dm
@@ -12,7 +12,7 @@
 	idle_power_usage = 15000
 	active_power_usage = 15000
 
-/obj/machinery/bluespacerelay/process()
+/obj/machinery/bluespacerelay/machinery_process()
 
 	update_power()
 

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -79,6 +79,6 @@
 	return
 
 
-/obj/machinery/computer/operating/process()
+/obj/machinery/computer/operating/machinery_process()
 	if(operable())
 		src.updateDialog()

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -156,7 +156,7 @@
 	if(can_access_camera(jump_to))
 		switch_to_camera(user,jump_to)
 
-/obj/machinery/computer/security/process()
+/obj/machinery/computer/security/machinery_process()
 	if(cache_id != camera_repository.camera_cache_id)
 		cache_id = camera_repository.camera_cache_id
 		SSnanoui.update_uis(src)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -41,7 +41,7 @@
 	..()
 	crew_announcement.newscast = 1
 
-/obj/machinery/computer/communications/process()
+/obj/machinery/computer/communications/machinery_process()
 	if(operable())
 		if(state != STATE_STATUSDISPLAY)
 			src.updateDialog()

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -138,7 +138,7 @@
 	return
 
 
-/obj/machinery/computer/pod/process()
+/obj/machinery/computer/pod/machinery_process()
 	if(inoperable())
 		return
 	if(timing)

--- a/code/game/machinery/crusher_piston.dm
+++ b/code/game/machinery/crusher_piston.dm
@@ -173,7 +173,7 @@
 	..()
 	queue_icon_update()
 
-/obj/machinery/crusher_base/process()
+/obj/machinery/crusher_base/machinery_process()
 	set waitfor = FALSE
 	if(!pstn) //We dont process if theres no piston
 		return

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -41,7 +41,7 @@
 			node = target
 			break
 
-/obj/machinery/atmospherics/unary/cryo_cell/process()
+/obj/machinery/atmospherics/unary/cryo_cell/machinery_process()
 	..()
 	if(!node)
 		return

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -250,7 +250,7 @@
 	return 1
 
 //Lifted from Unity stasis.dm and refactored. ~Zuhayr
-/obj/machinery/cryopod/process()
+/obj/machinery/cryopod/machinery_process()
 	if(occupant)
 		//Allow a ten minute gap between entering the pod and actually despawning.
 		if(world.time - time_entered < time_till_despawn)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -359,7 +359,7 @@
 
 
 
-/obj/machinery/door/airlock/uranium/process()
+/obj/machinery/door/airlock/uranium/machinery_process()
 	if(world.time > last_event+20)
 		if(prob(50))
 			radiate()

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -199,7 +199,7 @@
 	radio_connection.post_signal(src, signal, range = AIRLOCK_CONTROL_RANGE, filter = RADIO_AIRLOCK)
 	flick("airlock_sensor_cycle", src)
 
-/obj/machinery/airlock_sensor/process()
+/obj/machinery/airlock_sensor/machinery_process()
 	if(on)
 		var/datum/gas_mixture/air_sample = return_air()
 		var/pressure = round(air_sample.return_pressure(),0.1)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -60,7 +60,7 @@
 //Main door timer loop, if it's timing and time is >0 reduce time by 1.
 // if it's less than 0, open door, reset timer
 // update the door_timer window and the icon
-/obj/machinery/door_timer/process()
+/obj/machinery/door_timer/machinery_process()
 	if(stat & (NOPOWER|BROKEN))	return
 
 	if(src.timing)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -293,7 +293,7 @@
 	return ..()
 
 // CHECK PRESSURE
-/obj/machinery/door/firedoor/process()
+/obj/machinery/door/firedoor/machinery_process()
 	..()
 
 	if(density && next_process_time <= world.time)

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -24,7 +24,7 @@ obj/machinery/embedded_controller/radio/Destroy()
 		program.receive_signal(signal, receive_method, receive_param)
 			//spawn(5) program.process() //no, program.process sends some signals and machines respond and we here again and we lag -rastaf0
 
-/obj/machinery/embedded_controller/process()
+/obj/machinery/embedded_controller/machinery_process()
 	if(program)
 		program.process()
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -140,7 +140,7 @@
 	src.alarm()
 	return
 
-/obj/machinery/firealarm/process()//Note: this processing was mostly phased out due to other code, and only runs when needed
+/obj/machinery/firealarm/machinery_process()//Note: this processing was mostly phased out due to other code, and only runs when needed
 	var/area/A = get_area(src)
 	if (A.fire != previous_fire_state)
 		update_icon()

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -23,7 +23,7 @@
 	overlays.Cut()
 	icon_state = "flood[open ? "o" : ""][open && cell ? "b" : ""]0[on]"
 
-/obj/machinery/floodlight/process()
+/obj/machinery/floodlight/machinery_process()
 	if(!on)
 		return
 

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -78,7 +78,7 @@ var/list/floor_light_cache = list()
 		update_brightness()
 		return
 
-/obj/machinery/floor_light/process()
+/obj/machinery/floor_light/machinery_process()
 	..()
 	var/need_update
 	if((!anchored || broken()) && on)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -154,7 +154,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		icon_state = "holopad0"
 	return 1
 
-/obj/machinery/hologram/holopad/process()
+/obj/machinery/hologram/holopad/machinery_process()
 	for (var/mob/living/silicon/ai/master in masters)
 		var/active_ai = (master && !master.incapacitated() && master.client && master.eyeobj)//If there is an AI with an eye attached, it's not incapacitated, and it has a client
 		if((stat & NOPOWER) || !active_ai)

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -37,7 +37,7 @@
 	ignite()
 	return
 
-/obj/machinery/igniter/process()	//ugh why is this even in process()?
+/obj/machinery/igniter/machinery_process()	//ugh why is this even in process()?
 	if (on && powered() )
 		var/turf/location = src.loc
 		if (isturf(location))

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -71,7 +71,7 @@
 		return ..()
 
 
-/obj/machinery/iv_drip/process()
+/obj/machinery/iv_drip/machinery_process()
 	set background = 1
 
 	if(src.attached)

--- a/code/game/machinery/kitchen/cooking_machines/_appliance.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_appliance.dm
@@ -349,7 +349,7 @@
 
 	return 1
 
-/obj/machinery/appliance/process()
+/obj/machinery/appliance/machinery_process()
 	if (cooking_power > 0 && cooking)
 		for (var/i in cooking_objs)
 			do_cooking_tick(i)

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -60,7 +60,7 @@
 	light.pixel_y = light_y
 	add_overlay(light)
 
-/obj/machinery/appliance/cooker/process()
+/obj/machinery/appliance/cooker/machinery_process()
 	if (!stat)
 		heat_up()
 	else

--- a/code/game/machinery/kitchen/cooking_machines/_mixer.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_mixer.dm
@@ -137,7 +137,7 @@ fundamental differences
 		icon_state = off_icon
 
 
-/obj/machinery/appliance/mixer/process()
+/obj/machinery/appliance/mixer/machinery_process()
 	if (!stat)
 		for (var/i in cooking_objs)
 			do_cooking_tick(i)

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -130,7 +130,7 @@
 			return 1
 	return 0
 
-/obj/machinery/smartfridge/drying_rack/process()
+/obj/machinery/smartfridge/drying_rack/machinery_process()
 	..()
 	if (contents.len)
 		dry()
@@ -152,7 +152,7 @@
 		return
 	return
 
-/obj/machinery/smartfridge/process()
+/obj/machinery/smartfridge/machinery_process()
 	if(stat & (BROKEN|NOPOWER))
 		return
 	if(src.seconds_electrified > 0)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -114,6 +114,7 @@ Class Procs:
 	var/interact_offline = 0 // Can the machine be interacted with while de-powered.
 	var/printing = 0 // Is this machine currently printing anything?
 	var/tmp/machinery_processing = FALSE	// Are we process()ing in SSmachinery?
+	var/has_special_power_checks = FALSE	// If true, call auto_use_power instead of doing it all in SSmachinery.
 
 /obj/machinery/Initialize(mapload, d=0)
 	. = ..()
@@ -134,6 +135,9 @@ Class Procs:
 		for(var/atom/A in contents)
 			qdel(A)
 	return ..()
+
+/obj/machinery/proc/machinery_process()
+	. = process()
 
 /obj/machinery/process()//If you dont use process or power why are you here
 	if(!(use_power || idle_power_usage || active_power_usage))

--- a/code/game/machinery/megavend.dm
+++ b/code/game/machinery/megavend.dm
@@ -17,7 +17,7 @@
 	var/list/slogan_list = list("Don't deploy just yet! Grab your gear!","Forgetting something?","Don't hop on in your skivvies, mate!","It's not Casual Friday, y'know?","Heaven's above, put some clothes on!")
 	var/shut_up = 0 //Stop spouting those godawful pitches!
 
-/obj/machinery/megavendor/process()
+/obj/machinery/megavendor/machinery_process()
 	if(((src.last_slogan + src.slogan_delay) <= world.time) && (src.slogan_list.len > 0) && (!src.shut_up) && prob(5))
 		var/slogan = pick(src.slogan_list)
 		src.ping(slogan)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -34,7 +34,7 @@ var/bomb_set
 	wires = null
 	return ..()
 
-/obj/machinery/nuclearbomb/process()
+/obj/machinery/nuclearbomb/machinery_process()
 	if (src.timing)
 		src.timeleft = max(timeleft - 2, 0) // 2 seconds per process()
 		if (timeleft <= 0)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -443,7 +443,7 @@ var/list/turret_icons
 	spark_system.queue()	//creates some sparks because they look cool
 	update_icon()
 
-/obj/machinery/porta_turret/process()
+/obj/machinery/porta_turret/machinery_process()
 	//the main machinery process
 
 	if(stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -7,6 +7,7 @@
 	anchored = 1
 	use_power = 1
 	idle_power_usage = 50
+	has_special_power_checks = TRUE
 	var/mob/occupant = null
 	var/obj/item/weapon/cell/cell = null
 	var/icon_update_tick = 0	// Used to rebuild the overlay only once every 10 ticks
@@ -40,7 +41,7 @@
 /obj/machinery/recharge_station/proc/has_cell_power()
 	return cell && cell.percent() > 0
 
-/obj/machinery/recharge_station/process()
+/obj/machinery/recharge_station/machinery_process()
 	if(stat & (BROKEN))
 		return
 	if(!cell) // Shouldn't be possible, but sanity check

--- a/code/game/machinery/records_scanner.dm
+++ b/code/game/machinery/records_scanner.dm
@@ -22,7 +22,7 @@ obj/machinery/scanner/New()
 		if(!outputdir)
 			outputdir = 8
 
-/obj/machinery/scanner/process()
+/obj/machinery/scanner/machinery_process()
 	if(stat & NOPOWER)
 		return
 	use_power(50)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -9,6 +9,7 @@
 	var/on = 0
 	var/set_temperature = T0C + 50	//K
 	var/heating_power = 40000
+	has_special_power_checks = TRUE
 
 
 /obj/machinery/space_heater/Initialize()

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -153,7 +153,7 @@
 
 
 
-/obj/machinery/space_heater/process()
+/obj/machinery/space_heater/machinery_process()
 	if(on)
 		if(cell && cell.charge)
 			var/datum/gas_mixture/env = loc.return_air()

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -61,7 +61,7 @@
 			SSradio.add_object(src, frequency)
 
 // timed process
-/obj/machinery/status_display/process()
+/obj/machinery/status_display/machinery_process()
 	if(stat & NOPOWER)
 		remove_display()
 		return

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -910,7 +910,7 @@
 	src.updateUsrDialog()
 	return
 
-/obj/machinery/suit_cycler/process()
+/obj/machinery/suit_cycler/machinery_process()
 
 	if(electrified > 0)
 		electrified--

--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -99,7 +99,7 @@
 		deactivate()
 	return ..()
 
-/obj/machinery/power/supply_beacon/process()
+/obj/machinery/power/supply_beacon/machinery_process()
 	if(expended)
 		return PROCESS_KILL
 	if(!use_power)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -155,7 +155,7 @@
 	return ..()
 
 //stealth direct power usage
-/obj/machinery/power/singularity_beacon/process()
+/obj/machinery/power/singularity_beacon/machinery_process()
 	if(!active)
 		return PROCESS_KILL
 	else

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -171,7 +171,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	else
 		on = 0
 
-/obj/machinery/telecomms/process()
+/obj/machinery/telecomms/machinery_process()
 	update_power()
 
 	// Check heat and generate some

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -580,7 +580,7 @@
 
 	SSnanoui.update_uis(src)
 
-/obj/machinery/vending/process()
+/obj/machinery/vending/machinery_process()
 	if(stat & (BROKEN|NOPOWER))
 		return
 

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -47,7 +47,7 @@
 		if(istype(P, /obj/item/weapon/stock_parts/manipulator))
 			repair += P.rating * 2
 
-/obj/machinery/mech_recharger/process()
+/obj/machinery/mech_recharger/machinery_process()
 	..()
 	if(!charging)
 		return

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -40,7 +40,7 @@
 	manufacturer = basic_robolimb.company
 	update_categories()
 
-/obj/machinery/mecha_part_fabricator/process()
+/obj/machinery/mecha_part_fabricator/machinery_process()
 	..()
 	if(stat)
 		return

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -309,7 +309,7 @@
 			if(istype(E,/obj/effect/rune) || istype(E,/obj/effect/decal/cleanable) || istype(E,/obj/effect/overlay))
 				qdel(E)
 
-/obj/machinery/shower/process()
+/obj/machinery/shower/machinery_process()
 	if(!on) return
 	wash_floor()
 	if(!mobpresent)	return

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -7,7 +7,7 @@
 	density = 1
 	anchored = 1
 
-/obj/machinery/artillerycontrol/process()
+/obj/machinery/artillerycontrol/machinery_process()
 	if(src.reload<180)
 		src.reload++
 

--- a/code/modules/detectivework/microscope/dnascanner.dm
+++ b/code/modules/detectivework/microscope/dnascanner.dm
@@ -84,7 +84,7 @@
 
 	return 1
 
-/obj/machinery/dnaforensics/process()
+/obj/machinery/dnaforensics/machinery_process()
 	if(scanning)
 		if(!bloodsamp || bloodsamp.loc != src)
 			bloodsamp = null

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -46,7 +46,7 @@ log transactions
 	return ..()
 
 
-/obj/machinery/atm/process()
+/obj/machinery/atm/machinery_process()
 	if(stat & NOPOWER)
 		return
 

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -173,7 +173,7 @@
 	if (stat != oldstat && active && (stat & NOPOWER))
 		emergencyShutdown()
 
-/obj/machinery/computer/HolodeckControl/process()
+/obj/machinery/computer/HolodeckControl/machinery_process()
 	for(var/item in holographic_objs) // do this first, to make sure people don't take items out when power is down.
 		if(!(get_turf(item) in linkedholodeck))
 			derez(item, 0)

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -133,7 +133,7 @@
 			user << "<span class='notice'>You take all filled honeycombs out.</span>"
 		return
 
-/obj/machinery/beehive/process()
+/obj/machinery/beehive/machinery_process()
 	if(closed && !smoked && bee_count)
 		pollinate_flowers()
 		update_icon()

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -50,7 +50,7 @@
 	var/failed_task = 0
 	var/disk_needs_genes = 0
 
-/obj/machinery/botany/process()
+/obj/machinery/botany/machinery_process()
 
 	..()
 	if(!active) return

--- a/code/modules/hydroponics/trays/tray_apiary.dm
+++ b/code/modules/hydroponics/trays/tray_apiary.dm
@@ -108,7 +108,7 @@
 	else
 		return 0
 
-/obj/machinery/apiary/process()
+/obj/machinery/apiary/machinery_process()
 
 	if(swarming > 0)
 		swarming -= 1

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -1,4 +1,4 @@
-/obj/machinery/portable_atmospherics/hydroponics/process()
+/obj/machinery/portable_atmospherics/hydroponics/machinery_process()
 
 	// Handle nearby smoke if any.
 	for(var/obj/effect/effect/smoke/chem/smoke in view(1, src))

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -64,7 +64,7 @@
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible/die()
 	qdel(src)
 
-/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/process()
+/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/machinery_process()
 	if(!seed)
 		qdel(src)
 		return

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -59,7 +59,7 @@
 	QDEL_NULL(spark_system)
 	return ..()
 
-/obj/machinery/mining/drill/process()
+/obj/machinery/mining/drill/machinery_process()
 
 	if(need_player_check)
 		return

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -184,7 +184,7 @@
 		src.output = locate(/obj/machinery/mineral/output, get_step(src, dir))
 		if(src.output) break
 
-/obj/machinery/mineral/processing_unit/process()
+/obj/machinery/mineral/processing_unit/machinery_process()
 	..()
 
 	if (!src.output || !src.input) return

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -104,7 +104,7 @@
 		src.output = locate(/obj/machinery/mineral/output, get_step(src, dir))
 		if(src.output) break
 
-/obj/machinery/mineral/stacking_machine/process()
+/obj/machinery/mineral/stacking_machine/machinery_process()
 	..()
 	if(!console)
 		log_debug("Stacking machine tried to process, but no console has linked itself to it.")

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -23,7 +23,7 @@
 		src.output = locate(/obj/machinery/mineral/output, get_step(src, dir))
 		if(src.output) break
 
-/obj/machinery/mineral/unloading_machine/process()
+/obj/machinery/mineral/unloading_machine/machinery_process()
 	..()
 	if (src.output && src.input)
 		if (locate(/obj/structure/ore_box, input.loc))

--- a/code/modules/mining/mint.dm
+++ b/code/modules/mining/mint.dm
@@ -30,7 +30,7 @@
 		if(src.output) break
 	processing_objects.Add(src)
 
-/obj/machinery/mineral/mint/process()
+/obj/machinery/mineral/mint/machinery_process()
 	if ( src.input)
 		var/obj/item/stack/O
 		O = locate(/obj/item/stack, input.loc)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -304,7 +304,7 @@ var/list/ai_verbs_default = list(
 	. = ..()
 	powered_ai = null
 
-/obj/machinery/ai_powersupply/process()
+/obj/machinery/ai_powersupply/machinery_process()
 	if(!powered_ai || powered_ai.stat == DEAD)
 		qdel(src)
 		return

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -34,7 +34,7 @@
 	if (stat & NOPOWER)
 		icon_state = "drone_fab_nopower"
 
-/obj/machinery/drone_fabricator/process()
+/obj/machinery/drone_fabricator/machinery_process()
 
 	if(!ROUND_IS_STARTED)
 		return

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -49,7 +49,7 @@
 	else
 		add_overlay("ntnet_o_ok")
 
-/obj/machinery/ntnet_relay/process()
+/obj/machinery/ntnet_relay/machinery_process()
 	if(operable())
 		use_power = 2
 	else

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -48,7 +48,7 @@
 		invisibility = i ? 101 : 0
 	update_icon()
 
-/obj/machinery/atmospherics/pipe/up/process()
+/obj/machinery/atmospherics/pipe/up/machinery_process()
 	if(!parent) //This should cut back on the overhead calling build_network thousands of times per cycle
 		..()
 	else

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -29,7 +29,7 @@
 			R.fields["y"] = S.y
 			known_sectors += R
 
-/obj/machinery/computer/helm/process()
+/obj/machinery/computer/helm/machinery_process()
 	if (autopilot && dx && dy)
 		var/turf/T = locate(dx,dy,1)
 		if(linked.loc == T)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -186,7 +186,7 @@ var/list/admin_departments = list("[boss_name]", "Tau Ceti Government", "Supply"
 
 	updateUsrDialog()
 
-/obj/machinery/photocopier/faxmachine/process()
+/obj/machinery/photocopier/faxmachine/machinery_process()
 	.=..()
 	var/static/ui_update_delay = 0
 

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -52,7 +52,7 @@
 	return ..()
 
 
-/obj/machinery/power/am_control_unit/process()
+/obj/machinery/power/am_control_unit/machinery_process()
 	if(exploding && !exploded)
 		message_admins("AME explosion at ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) - Last touched by [fingerprintslast]",0,1)
 		exploded=1

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -107,7 +107,7 @@ proc/cardinalrange(var/center)
 	return 0
 
 
-/obj/machinery/am_shielding/process()
+/obj/machinery/am_shielding/machinery_process()
 	if(!processing)
 		. = PROCESS_KILL
 	//TODO: core functions and stability

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1081,7 +1081,7 @@
 	else
 		return 0
 
-/obj/machinery/power/apc/process()
+/obj/machinery/power/apc/machinery_process()
 
 	if(stat & (BROKEN|MAINT))
 		return

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -180,7 +180,7 @@
 
 
 #define SMESRATE 0.05			// rate of internal charge to external power
-/obj/machinery/power/smes/batteryrack/makeshift/process()
+/obj/machinery/power/smes/batteryrack/makeshift/machinery_process()
 	if(stat & BROKEN)	return
 
 	//store machine state to see if we need to update the icon overlays

--- a/code/modules/power/cable_logic.dm
+++ b/code/modules/power/cable_logic.dm
@@ -5,7 +5,7 @@
 	//Input is searched from the 'dir' direction
 	var/obj/structure/cable/input
 
-/obj/machinery/logic/indicator/process()
+/obj/machinery/logic/indicator/machinery_process()
 	if(input)
 		return 1
 
@@ -25,7 +25,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "bulb0"
 
-/obj/machinery/logic/indicator/bulb/process()
+/obj/machinery/logic/indicator/bulb/machinery_process()
 	if(!..())	//Parent proc checks if input1 exists.
 		return
 
@@ -46,7 +46,7 @@
 	//Output is searched from the 'dir' direction
 	var/obj/structure/cable/output
 
-/obj/machinery/logic/sensor/process()
+/obj/machinery/logic/sensor/machinery_process()
 	if(output)
 		return 1
 
@@ -66,7 +66,7 @@
 	icon = 'icons/obj/atmospherics/outlet_injector.dmi'
 	icon_state = "off"
 
-/obj/machinery/logic/sensor/constant_high/process()
+/obj/machinery/logic/sensor/constant_high/machinery_process()
 	if(!..())	//Parent proc checks if input1 exists.
 		return
 
@@ -88,7 +88,7 @@
 	icon = 'icons/atmos/heat.dmi'
 	icon_state = "intact"
 
-/obj/machinery/logic/oneinput/process()
+/obj/machinery/logic/oneinput/machinery_process()
 	if(input && output)
 		return 1
 
@@ -114,7 +114,7 @@
 	return 0	//On the process() call, where everything is still being searched for, it returns 0. It will return 1 on the next process() call.
 
 //NOT GATE
-/obj/machinery/logic/oneinput/not/process()
+/obj/machinery/logic/oneinput/not/machinery_process()
 	if(!..())	//Parent proc checks if input1, input2 and output exist.
 		return
 
@@ -151,7 +151,7 @@
 	icon = 'icons/obj/atmospherics/mixer.dmi'
 	icon_state = "intact_off"
 
-/obj/machinery/logic/twoinput/process()
+/obj/machinery/logic/twoinput/machinery_process()
 	if(input1 && input2 && output)
 		return 1
 
@@ -185,7 +185,7 @@
 	return 0	//On the process() call, where everything is still being searched for, it returns 0. It will return 1 on the next process() call.
 
 //AND GATE
-/obj/machinery/logic/twoinput/and/process()
+/obj/machinery/logic/twoinput/and/machinery_process()
 	if(!..())	//Parent proc checks if input1, input2 and output exist.
 		return
 
@@ -205,7 +205,7 @@
 		pn_output.draw_power(LOGIC_HIGH)		//Otherwise increase the load to 5
 
 //OR GATE
-/obj/machinery/logic/twoinput/or/process()
+/obj/machinery/logic/twoinput/or/machinery_process()
 	if(!..())	//Parent proc checks if input1, input2 and output exist.
 		return
 
@@ -225,7 +225,7 @@
 		pn_output.draw_power(LOGIC_HIGH)		//Otherwise increase the load to 5
 
 //XOR GATE
-/obj/machinery/logic/twoinput/xor/process()
+/obj/machinery/logic/twoinput/xor/machinery_process()
 	if(!..())	//Parent proc checks if input1, input2 and output exist.
 		return
 
@@ -245,7 +245,7 @@
 		pn_output.draw_power(LOGIC_HIGH)		//Otherwise increase the load to 5
 
 //XNOR GATE (EQUIVALENCE)
-/obj/machinery/logic/twoinput/xnor/process()
+/obj/machinery/logic/twoinput/xnor/machinery_process()
 	if(!..())	//Parent proc checks if input1, input2 and output exist.
 		return
 
@@ -267,7 +267,7 @@
 #define RELAY_POWER_TRANSFER 2000	//How much power a relay transfers through.
 
 //RELAY - input1 governs the flow from input2 to output
-/obj/machinery/logic/twoinput/relay/process()
+/obj/machinery/logic/twoinput/relay/machinery_process()
 	if(!..())	//Parent proc checks if input1, input2 and output exist.
 		return
 

--- a/code/modules/power/fractal_reactor.dm
+++ b/code/modules/power/fractal_reactor.dm
@@ -18,9 +18,9 @@
 /obj/machinery/power/fractal_reactor/New()
 	..()
 	if(!mapped_in)
-		world << "<b><span class='warning'>WARNING:</span> Map testing power source activated at: X:[src.loc.x] Y:[src.loc.y] Z:[src.loc.z]</b>"
+		world << "<b><span class='alert'>WARNING:</span> Map testing power source activated at: X:[src.loc.x] Y:[src.loc.y] Z:[src.loc.z]</b>"
 
-/obj/machinery/power/fractal_reactor/process()
+/obj/machinery/power/fractal_reactor/machinery_process()
 	if(!powernet && !powernet_connection_failed)
 		if(!connect_to_network())
 			powernet_connection_failed = 1

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -74,7 +74,7 @@
 	if(!(stat & (NOPOWER|BROKEN)) && lastgenlev)
 		add_overlay("teg-op[lastgenlev]")
 
-/obj/machinery/power/generator/process()
+/obj/machinery/power/generator/machinery_process()
 	if(!circ1 || !circ2 || !anchored || stat & (BROKEN|NOPOWER))
 		stored_energy = 0
 		return

--- a/code/modules/power/generator_type2.dm
+++ b/code/modules/power/generator_type2.dm
@@ -31,7 +31,7 @@
 #define GENRATE 800		// generator output coefficient from Q
 
 
-/obj/machinery/power/generator_type2/process()
+/obj/machinery/power/generator_type2/machinery_process()
 	if(!input1 || !input2)
 		return
 

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -29,7 +29,7 @@
 /obj/machinery/power/port_gen/proc/handleInactive()
 	return
 
-/obj/machinery/power/port_gen/process()
+/obj/machinery/power/port_gen/machinery_process()
 	if(active && HasFuel() && !IsBroken() && anchored && powernet)
 		add_avail(power_gen * power_output)
 		UseFuel()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -13,6 +13,7 @@
 	var/open = 0
 	var/recent_fault = 0
 	var/power_output = 1
+	has_special_power_checks = TRUE
 
 /obj/machinery/power/port_gen/proc/IsBroken()
 	return (stat & (BROKEN|EMPED))

--- a/code/modules/power/sensors/sensor_monitoring.dm
+++ b/code/modules/power/sensors/sensor_monitoring.dm
@@ -22,7 +22,7 @@
 	var/datum/nano_module/power_monitor/power_monitor
 
 // Checks the sensors for alerts. If change (alerts cleared or detected) occurs, calls for icon update.
-/obj/machinery/computer/power_monitor/process()
+/obj/machinery/computer/power_monitor/machinery_process()
 	var/alert = check_warnings()
 	if(alert != alerting)
 		alerting = !alerting

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -25,7 +25,7 @@ var/global/list/rad_collectors = list()
 	rad_collectors -= src
 	return ..()
 
-/obj/machinery/power/rad_collector/process()
+/obj/machinery/power/rad_collector/machinery_process()
 	//so that we don't zero out the meter if the SM is processed first.
 	last_power = last_power_new
 	last_power_new = 0

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -107,7 +107,7 @@
 			src.use_power = 1	*/
 	return 1
 
-/obj/machinery/power/emitter/process()
+/obj/machinery/power/emitter/machinery_process()
 	if(stat & (BROKEN))
 		return
 	if(src.state != 2 || (!powernet && active_power_usage))

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -58,7 +58,7 @@ field_generator power level display
 	connected_gens = list()
 	return
 
-/obj/machinery/field_generator/process()
+/obj/machinery/field_generator/machinery_process()
 	if(Varedit_start == 1)
 		if(active == 0)
 			active = 1

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -10,7 +10,7 @@
 	var/energy = 0
 	var/creation_type = /obj/singularity
 
-/obj/machinery/the_singularitygen/process()
+/obj/machinery/the_singularitygen/machinery_process()
 	var/turf/T = get_turf(src)
 	if(src.energy >= 200)
 		new creation_type(T, 50)

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -149,7 +149,7 @@
 	return
 
 
-/obj/machinery/particle_accelerator/control_box/process()
+/obj/machinery/particle_accelerator/control_box/machinery_process()
 	if(src.active)
 		//a part is missing!
 		if( length(connected_parts) < 6 )

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -154,7 +154,7 @@
 			inputting = 1
 		// else inputting = 0, as set in process()
 
-/obj/machinery/power/smes/process()
+/obj/machinery/power/smes/machinery_process()
 	if(stat & BROKEN)	return
 	if(failure_timer)	// Disabled by gridcheck.
 		failure_timer--
@@ -459,7 +459,7 @@
 	output_level = 250000
 	should_be_mapped = 1
 
-/obj/machinery/power/smes/magical/process()
+/obj/machinery/power/smes/magical/machinery_process()
 	charge = 5000000
 	..()
 

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -81,7 +81,7 @@
 // Parameters: None
 // Description: Uses parent process, but if grounding wire is cut causes sparks to fly around.
 // This also causes the SMES to quickly discharge, and has small chance of damaging output APCs.
-/obj/machinery/power/smes/buildable/process()
+/obj/machinery/power/smes/buildable/machinery_process()
 	if(!grounding && (Percentage() > 5))
 		spark(src, 5, alldirs)
 		charge -= (output_level_max * SMESRATE)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -118,7 +118,7 @@
 	sunfrac = cos(p_angle) ** 2
 	//isn't the power recieved from the incoming light proportionnal to cos(p_angle) (Lambert's cosine law) rather than cos(p_angle)^2 ?
 
-/obj/machinery/power/solar/process()//TODO: remove/add this from machines to save on processing as needed ~Carn PRIORITY
+/obj/machinery/power/solar/machinery_process()//TODO: remove/add this from machines to save on processing as needed ~Carn PRIORITY
 	if(stat & BROKEN)
 		return
 	if(!sun || !control) //if there's no sun or the panel is not linked to a solar control computer, no need to proceed
@@ -167,9 +167,8 @@
 /obj/machinery/power/solar/fake/Initialize(mapload, var/obj/item/solar_assembly/S)
 	. = ..(mapload, S, 0)
 
-/obj/machinery/power/solar/fake/process()
-	. = PROCESS_KILL
-	return
+/obj/machinery/power/solar/fake/machinery_process()
+	return PROCESS_KILL
 
 //trace towards sun to see if we're in shadow
 /obj/machinery/power/solar/proc/occlusion()
@@ -429,7 +428,7 @@
 		src.attack_hand(user)
 	return
 
-/obj/machinery/power/solar_control/process()
+/obj/machinery/power/solar_control/machinery_process()
 	lastgen = gen
 	gen = 0
 

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -59,7 +59,7 @@
 #define COMPFRICTION 5e5
 #define COMPSTARTERLOAD 2800
 
-/obj/machinery/compressor/process()
+/obj/machinery/compressor/machinery_process()
 	if(!starter)
 		return
 	overlays.Cut()
@@ -117,7 +117,7 @@
 #define TURBGENQ 20000
 #define TURBGENG 0.8
 
-/obj/machinery/power/turbine/process()
+/obj/machinery/power/turbine/machinery_process()
 	if(!compressor.starter)
 		return
 	overlays.Cut()
@@ -315,6 +315,6 @@
 	src.updateUsrDialog()
 	return
 
-/obj/machinery/computer/turbine_computer/process()
+/obj/machinery/computer/turbine_computer/machinery_process()
 	src.updateDialog()
 	return

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -423,7 +423,8 @@
 	return process(targloc)
 
 /obj/item/projectile/test/process(var/turf/targloc)
-	while(src) //Loop on through!
+	var/safety = 100	// We really never should need this to last longer than this number of iterations.
+	while(!QDELING(src) && safety > 0) //Loop on through!
 		if(result)
 			return (result - 1)
 		if((!( targloc ) || loc == targloc))
@@ -441,6 +442,11 @@
 			M = locate() in get_step(src,targloc)
 			if(istype(M))
 				return 1
+
+		safety--
+
+	if (safety < 0)
+		crash_with("test projectile process() maximum iterations exceeded, aborting!")
 
 //Helper proc to check if you can hit them or not.
 /proc/check_trajectory(atom/target as mob|obj, atom/firer as mob|obj, var/pass_flags=PASSTABLE|PASSGLASS|PASSGRILLE, flags=null)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -81,7 +81,7 @@
 
 	// machine process
 	// move items to the target location
-/obj/machinery/conveyor/process()
+/obj/machinery/conveyor/machinery_process()
 	if(stat & (BROKEN | NOPOWER))
 		return
 	if(!operating)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -363,7 +363,7 @@
 
 // timed process
 // charge the gas reservoir and perform flush if ready
-/obj/machinery/disposal/process()
+/obj/machinery/disposal/machinery_process()
 	if(!air_contents || (stat & BROKEN))			// nothing can happen if broken
 		update_use_power(0)
 		return

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -31,7 +31,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 	component_parts += new /obj/item/weapon/reagent_containers/glass/beaker(src)
 	RefreshParts()
 
-/obj/machinery/r_n_d/circuit_imprinter/process()
+/obj/machinery/r_n_d/circuit_imprinter/machinery_process()
 	..()
 	if(stat)
 		update_icon()

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -88,7 +88,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	newKey += pick("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
 	return newKey
 
-/obj/machinery/message_server/process()
+/obj/machinery/message_server/machinery_process()
 	//if(decryptkey == "password")
 	//	decryptkey = generateKey()
 	if(active && (stat & (BROKEN|NOPOWER)))

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -28,7 +28,7 @@
 	component_parts += new /obj/item/weapon/reagent_containers/glass/beaker(src)
 	RefreshParts()
 
-/obj/machinery/r_n_d/protolathe/process()
+/obj/machinery/r_n_d/protolathe/machinery_process()
 	..()
 	if(stat)
 		update_icon()

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -50,7 +50,7 @@
 		for(var/N in temp_list)
 			id_with_download += text2num(N)
 
-/obj/machinery/r_n_d/server/process()
+/obj/machinery/r_n_d/server/machinery_process()
 	var/datum/gas_mixture/environment = loc.return_air()
 	switch(environment.temperature)
 		if(0 to T0C)
@@ -147,7 +147,7 @@
 				server_ids += num
 		no_id_servers -= S
 
-/obj/machinery/r_n_d/server/centcom/process()
+/obj/machinery/r_n_d/server/centcom/machinery_process()
 	return PROCESS_KILL //don't need process()
 
 /obj/machinery/computer/rdservercontrol

--- a/code/modules/research/xenoarchaeology/artifact/artifact_autocloner.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_autocloner.dm
@@ -43,7 +43,7 @@
 		)
 
 //todo: how the hell is the asteroid permanently powered?
-/obj/machinery/auto_cloner/process()
+/obj/machinery/auto_cloner/machinery_process()
 	if(powered(power_channel))
 		if(!previous_power_state)
 			previous_power_state = 1

--- a/code/modules/research/xenoarchaeology/artifact/artifact_replicator.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_replicator.dm
@@ -84,7 +84,7 @@
 		[pick("front","side","top","bottom","rear","inside")] of [src]. A [pick("slot","funnel","chute","tube")] opens up in the \
 		[pick("front","side","top","bottom","rear","inside")].</span>"
 
-/obj/machinery/replicator/process()
+/obj/machinery/replicator/machinery_process()
 	if(spawning_types.len && powered())
 		spawn_progress_time += world.time - last_process_time
 		if(spawn_progress_time > max_spawn_time)

--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -72,7 +72,7 @@
 		if(prob(75))
 			my_effect.trigger = rand(1,4)
 
-/obj/machinery/artifact/process()
+/obj/machinery/artifact/machinery_process()
 
 	var/turf/L = loc
 	if(isnull(L) || !istype(L)) 	// We're inside a container or on null turf, either way stop processing effects

--- a/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
@@ -55,7 +55,7 @@
 	user.set_machine(src)
 	onclose(user, "artanalyser")
 
-/obj/machinery/artifact_analyser/process()
+/obj/machinery/artifact_analyser/machinery_process()
 	if(scan_in_progress && world.time > scan_completion_time)
 		//finish scanning
 		scan_in_progress = 0

--- a/code/modules/research/xenoarchaeology/machinery/artifact_harvester.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_harvester.dm
@@ -70,7 +70,7 @@
 	user << browse(dat, "window=artharvester;size=450x500")
 	onclose(user, "artharvester")
 
-/obj/machinery/artifact_harvester/process()
+/obj/machinery/artifact_harvester/machinery_process()
 	if(stat & (NOPOWER|BROKEN))
 		return
 

--- a/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
+++ b/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
@@ -163,7 +163,7 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/radiocarbon_spectrometer/process()
+/obj/machinery/radiocarbon_spectrometer/machinery_process()
 	if(scanning)
 		if(!scanned_item || scanned_item.loc != src)
 			scanned_item = null

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -19,7 +19,7 @@
 	src.cell = new/obj/item/weapon/cell/high(src)
 	..()
 
-/obj/machinery/suspension_gen/process()
+/obj/machinery/suspension_gen/machinery_process()
 	set background = 1
 
 	if (suspension_field)

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -17,7 +17,7 @@
 	desc = "A weak forcefield which seems to be projected by the station's emergency atmosphere containment field"
 	health = max_health/2 // Half health, it's not suposed to resist much.
 
-/obj/machinery/shield/malfai/process()
+/obj/machinery/shield/malfai/machinery_process()
 	health -= 0.5 // Slowly lose integrity over time
 	check_failure()
 
@@ -180,7 +180,7 @@
 		create_shields()
 	update_icon()
 
-/obj/machinery/shieldgen/process()
+/obj/machinery/shieldgen/machinery_process()
 	if (!active || (stat & NOPOWER))
 		return
 

--- a/code/modules/shieldgen/sheldwallgen.dm
+++ b/code/modules/shieldgen/sheldwallgen.dm
@@ -79,7 +79,7 @@
 	power = 1	// IVE GOT THE POWER!
 	return 1
 
-/obj/machinery/shieldwallgen/process()
+/obj/machinery/shieldwallgen/machinery_process()
 	power()
 	if(power)
 		storedpower -= 2500 //the generator post itself uses some power

--- a/code/modules/shieldgen/shield_capacitor.dm
+++ b/code/modules/shieldgen/shield_capacitor.dm
@@ -97,7 +97,7 @@
 	user << browse(t, "window=shield_capacitor;size=500x400")
 	user.set_machine(src)
 
-/obj/machinery/shield_capacitor/process()
+/obj/machinery/shield_capacitor/machinery_process()
 	if (!anchored)
 		active = 0
 

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -134,7 +134,7 @@
 	user << browse(t, "window=shield_generator;size=500x400")
 	user.set_machine(src)
 
-/obj/machinery/shield_gen/process()
+/obj/machinery/shield_gen/machinery_process()
 	if (!anchored && active)
 		toggle()
 

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -176,7 +176,7 @@
 
 	return ..()
 
-/obj/machinery/power/supermatter/process()
+/obj/machinery/power/supermatter/machinery_process()
 
 	var/turf/L = loc
 

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -23,7 +23,7 @@
 
 	user.visible_message("[user] adds \a [O] to \the [src]!", "You add \a [O] to \the [src]!")
 
-/obj/machinery/disease2/diseaseanalyser/process()
+/obj/machinery/disease2/diseaseanalyser/machinery_process()
 	if(stat & (NOPOWER|BROKEN))
 		return
 

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -77,7 +77,7 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/obj/machinery/computer/centrifuge/process()
+/obj/machinery/computer/centrifuge/machinery_process()
 	if (inoperable()) return
 
 	if (curing)

--- a/code/modules/virus2/curer.dm
+++ b/code/modules/virus2/curer.dm
@@ -65,7 +65,7 @@
 	onclose(user, "computer")
 	return
 
-/obj/machinery/computer/curer/process()
+/obj/machinery/computer/curer/machinery_process()
 	if (inoperable())
 		return
 	use_power(500)

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -85,7 +85,7 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/obj/machinery/computer/diseasesplicer/process()
+/obj/machinery/computer/diseasesplicer/machinery_process()
 	if (inoperable())
 		return
 

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -88,7 +88,7 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/obj/machinery/disease2/incubator/process()
+/obj/machinery/disease2/incubator/machinery_process()
 	if(dish && on && dish.virus2)
 		use_power(50,EQUIP)
 		if(!powered(EQUIP))

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -106,7 +106,7 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/obj/machinery/disease2/isolator/process()
+/obj/machinery/disease2/isolator/machinery_process()
 	if (isolating > 0)
 		isolating -= 1
 		if (isolating == 0)


### PR DESCRIPTION
changes:
- Machinery now uses `machinery_process()` instead of `process()`, allowing machines to be put into SSprocessing-style lists in addition to the machinery list.
- Automatic power calculations now involve less proc-calls.

~~Note: Any machinery that used process() but uses relative pathing will be broken by this.~~