### PR TITLE
Multi Z isn't just for humanoids anymore!

### DIFF
--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -59,6 +59,7 @@
 	var/list/slime_mutation[4]
 
 	var/core_removal_stage = 0 //For removing cores.
+	can_climb = 0 //No limbs
 
 /mob/living/carbon/slime/Initialize(mapload, colour = "grey")
 	. = ..()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -90,6 +90,7 @@
 	var/response_disarm = "shoves"
 	var/response_harm   = "kicks"
 	var/harm_intent_damage = 15//based on 100 health, which is probably too much for a pai to have
+	can_climb = 1 //All the forms have limbs
 
 /mob/living/silicon/pai/attack_hand(mob/living/carbon/human/M as mob)
 	..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -29,6 +29,8 @@
 	var/obj/item/weapon/card/id/idcard
 	var/idcard_type = /obj/item/weapon/card/id/synthetic
 
+	can_climb = 0
+
 	#define SEC_HUD 1 //Security HUD mode
 	#define MED_HUD 2 //Medical HUD mode
 

--- a/code/modules/mob/living/simple_animal/bees.dm
+++ b/code/modules/mob/living/simple_animal/bees.dm
@@ -20,6 +20,7 @@
 	pass_flags = PASSTABLE
 	turns_per_move = 6
 	var/obj/machinery/portable_atmospherics/hydroponics/my_hydrotray
+	can_climb = 1 //They fly
 
 /mob/living/simple_animal/bee/Initialize(mapload, var/obj/machinery/beehive/new_parent)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -123,6 +123,8 @@
 	resistance = 10
 	construct_spells = list(/spell/aoe_turf/conjure/forcewall/lesser)
 
+	can_climb = 1 //It flies, its magic, and it has hands
+
 /mob/living/simple_animal/construct/armoured/Life()
 	weakened = 0
 	..()
@@ -169,6 +171,7 @@
 	see_in_dark = 7
 	attack_sound = 'sound/weapons/rapidslice.ogg'
 	construct_spells = list(/spell/targeted/ethereal_jaunt/shift)
+	can_climb = 1 //It flies, its magic
 
 /mob/living/simple_animal/construct/wraith/can_fall()
 	return FALSE
@@ -201,6 +204,7 @@
 	environment_smash = 1
 	attack_sound = 'sound/weapons/rapidslice.ogg'
 	can_repair = 1
+	can_climb = 1 //It flies, its magic
 	construct_spells = list(/spell/aoe_turf/conjure/construct/lesser,
 							/spell/aoe_turf/conjure/wall,
 							/spell/aoe_turf/conjure/floor,
@@ -233,6 +237,7 @@
 	resistance = 10
 	var/energy = 0
 	var/max_energy = 1000
+	can_climb = 1 //It flies, its magic
 	construct_spells = list(/spell/aoe_turf/conjure/forcewall/lesser)
 
 ////////////////////////Harvester////////////////////////////////
@@ -268,6 +273,8 @@
 			/spell/aoe_turf/conjure/forcewall/lesser
 		)
 	//Harvesters are endgame stuff, no harm giving them construct spells
+
+	can_climb = 1 //It flies, its magic, it has six limbs, it teleports, and it is endgame content
 
 /mob/living/simple_animal/construct/harvester/can_fall()
 	return FALSE

--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -70,6 +70,7 @@
 	min_oxy = 0
 
 	wizardy_spells = list(/spell/aoe_turf/conjure/forcewall)
+	can_climb = 1 //It flies, its magic
 
 /mob/living/simple_animal/familiar/pike/Allow_Spacemove(var/check_drift = 0)
 	return 1
@@ -102,6 +103,7 @@
 	attacktext = "clawed"
 
 	wizardy_spells = list(/spell/targeted/torment)
+	can_climb = 1 //Its humanoid
 
 /mob/living/simple_animal/familiar/horror/death()
 	..(null,"rapidly deteriorates")
@@ -172,6 +174,7 @@
 	density = 0
 
 	wizardy_spells = list(/spell/targeted/subjugation)
+	can_climb = 1 //Cats can climb ladders, google it for videos
 
 
 /mob/living/simple_animal/mouse/familiar
@@ -197,6 +200,7 @@
 	unsuitable_atoms_damage = 1
 
 	supernatural = 1
+	can_climb = 1 //Rodents can climb ladders, google it for videos
 
 /mob/living/simple_animal/mouse/familiar/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -33,6 +33,7 @@
 	seek_speed = 5
 	pass_flags = PASSTABLE
 	possession_candidate = 1
+	can_climb = 1 //Cats can climb ladders, google it for videos
 
 /mob/living/simple_animal/cat/Life()
 	//MICE!
@@ -263,6 +264,7 @@
 	can_nap = 0 //No resting sprite
 	gender = NEUTER
 	holder_type = /obj/item/weapon/holder/cat/kitten
+	can_climb = 0 //Not as good as an adult cat
 
 /mob/living/simple_animal/cat/kitten/death()
 	.=..()

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -27,6 +27,8 @@
 	var/obj/item/inventory_head
 	var/obj/item/inventory_back
 
+	can_climb = 1 //Dogs can climb ladders, google it for videos
+
 /mob/living/simple_animal/corgi/Initialize()
 	. = ..()
 	nutrition = max_nutrition * 0.3	//Ian doesn't start with a full belly so will be hungry at roundstart
@@ -111,6 +113,7 @@
 	icon_state = "puppy"
 	icon_living = "puppy"
 	icon_dead = "puppy_dead"
+	can_climb = 0 //I guess this doggo is too small to reach the rungs
 
 //pupplies cannot wear anything.
 /mob/living/simple_animal/corgi/puppy/Topic(href, href_list)

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -21,6 +21,7 @@
 	seek_speed = 0.75
 
 	var/decompose_time = 18000
+	can_climb = 1  //Lizards are great climbers
 
 /mob/living/simple_animal/lizard/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -51,6 +51,7 @@
 
 	can_pull_size = 1
 	can_pull_mobs = MOB_PULL_NONE
+	can_climb = 1 //Rodents are great climbers
 
 	var/decompose_time = 18000
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -79,15 +79,16 @@
 	else
 		if ((world.time - timeofdeath) > decompose_time)
 			dust()
-			
+
 /mob/living/simple_animal/mouse/Destroy()
 	SSmob.all_mice -= src
-		
+
 	return ..()
-	
+
 //Pixel offsetting as they scamper around
 /mob/living/simple_animal/mouse/Move()
-	if(..())
+	.=..()
+	if(.)
 		if (prob(50))
 			pixel_x += rand(-2,2)
 			pixel_x = Clamp(pixel_x, -10, 10)
@@ -231,7 +232,7 @@
 				squeak(0)
 			else
 				squeak_loud(0)//You trod on its tail
-				
+
 	if(!health)
 		return
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -88,7 +88,7 @@
 
 //Pixel offsetting as they scamper around
 /mob/living/simple_animal/mouse/Move()
-	.=..()
+	. = ..()
 	if(.)
 		if (prob(50))
 			pixel_x += rand(-2,2)

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -34,6 +34,7 @@
 	minbodytemp = 0
 	heat_damage_per_tick = 20
 	mob_size = 10
+	can_climb = 1 //Humanoid
 
 
 /mob/living/simple_animal/hostile/alien/drone
@@ -157,6 +158,7 @@
 	speak = list("Shuhn","Shrunnph?","Shunpf")
 	emote_see = list("scratches the ground","shakes out it's mane","tinkles gently")
 	mob_size = 5
+	can_climb = 1 //Its basically a dog
 
 /mob/living/simple_animal/yithian
 	name = "yithian"

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -35,6 +35,7 @@
 	minbodytemp = 0
 
 	environment_smash = 1
+	can_climb = 1 //Flies
 
 	faction = "scarybat"
 	var/mob/living/owner

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -64,9 +64,9 @@
 	var/stance_step = 0
 
 	faction = "russian"
-	
-	var/always_space_mode = FALSE	// If true, bear will always be in BEARMODE_SPACE, regardless of surroundings.
 
+	var/always_space_mode = FALSE	// If true, bear will always be in BEARMODE_SPACE, regardless of surroundings.
+	can_climb = 1 //Google bear climbing ladder
 
 //SPACE BEARS! SQUEEEEEEEE~     OW! FUCK! IT BIT MY HAND OFF!!
 /mob/living/simple_animal/hostile/bear/Hudson
@@ -204,7 +204,7 @@
 
 				if(!L.client)
 					continue
-					
+
 				if(L.stat == CONSCIOUS)
 					if (dist < nearest_dist)
 						nearest_target = L

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -38,6 +38,7 @@
 	break_stuff_probability = 15
 
 	faction = "carp"
+	can_climb = 1 //flies
 
 /mob/living/simple_animal/hostile/carp/Allow_Spacemove(var/check_drift = 0)
 	return 1	//No drifting in space for space carp!	//original comments do not steal

--- a/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
@@ -25,6 +25,7 @@
 	response_disarm = "pushes"
 
 	known_commands = list("stay", "stop", "attack", "follow", "dance", "boogie", "boogy")
+	can_climb = 1 //Bears climb
 
 /mob/living/simple_animal/hostile/commanded/bear/hit_with_weapon(obj/item/O, mob/living/user, var/effective_force, var/hit_zone)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/commanded/guard_dog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/guard_dog.dm
@@ -40,6 +40,7 @@
 	known_commands = list("stay", "stop", "attack", "follow")
 
 	var/name_changed = 0
+	can_climb = 1 //See corgi
 
 /mob/living/simple_animal/hostile/commanded/dog/hit_with_weapon(obj/item/O, mob/living/user, var/effective_force, var/hit_zone)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -32,6 +32,7 @@
 	speed = 4
 
 	faction = "faithless"
+	can_climb = 1 //Humanoid, ghostly
 
 /mob/living/simple_animal/hostile/faithless/Allow_Spacemove(var/check_drift = 0)
 	return 1

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -35,6 +35,7 @@
 	move_to_delay = 6
 	speed = 3
 	mob_size = 6
+	can_climb = 1 //Spiders dont even need ladders to climb, they routinely walk up sheer walls
 
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/giant_spider/nurse

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -33,6 +33,7 @@
 	var/weapon1 = /obj/item/weapon/melee/energy/sword/pirate
 
 	faction = "pirate"
+	can_climb = 1 //Humanoid
 
 /mob/living/simple_animal/hostile/pirate/ranged
 	name = "Pirate Gunner"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
@@ -35,6 +35,7 @@
 	minbodytemp = 0
 
 	faction = "cavern"
+	can_climb = 1 //Flies, has arms
 
 /mob/living/simple_animal/hostile/retaliate/cavern_dweller/Allow_Spacemove(var/check_drift = 0)
 	return 1

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -37,3 +37,4 @@
 	heat_damage_per_tick = 15	//amount of damage applied if animal's body temperature is higher than maxbodytemp
 	cold_damage_per_tick = 10	//same as heat_damage_per_tick, only if the bodytemperature it's lower than minbodytemp
 	unsuitable_atoms_damage = 10
+	can_climb = 1 //Humanoid

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -48,6 +48,7 @@
 
 	var/has_loot = 1
 	faction = "malf_drone"
+	can_climb = 1 //Flies
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -32,7 +32,7 @@
 	unsuitable_atoms_damage = 15
 	faction = "russian"
 	status_flags = CANPUSH
-
+	can_climb = 1 //Humanoid
 
 /mob/living/simple_animal/hostile/russian/ranged
 	icon_state = "russianranged"

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -34,6 +34,7 @@
 	environment_smash = 1
 	faction = "syndicate"
 	status_flags = CANPUSH
+	can_climb = 1 //Humanoid
 
 /mob/living/simple_animal/hostile/syndicate/death()
 	..()

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -82,6 +82,8 @@
 	//Parrots are kleptomaniacs. This variable ... stores the item a parrot is holding.
 	var/obj/item/held_item = null
 
+	can_climb = 1 //Flies
+
 
 /mob/living/simple_animal/parrot/Initialize()
 	. = ..()
@@ -760,9 +762,9 @@
 
 /mob/living/simple_animal/parrot/can_fall()
 	return FALSE
-	
+
 /mob/living/simple_animal/parrot/can_ztravel()
 	return TRUE
-	
+
 /mob/living/simple_animal/parrot/CanAvoidGravity()
 	return TRUE

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -28,6 +28,7 @@
 	faction = "cult"
 	status_flags = CANPUSH
 	hunger_enabled = 0
+	can_climb = 1 //Flies
 
 /mob/living/simple_animal/shade/cultify()
 	return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -100,6 +100,8 @@
 	var/can_nap = 0
 	var/icon_rest = null
 
+	can_climb = 0 //Default false, will justify setting it to 1 on a casebycase basis
+
 /mob/living/simple_animal/proc/beg(var/atom/thing, var/atom/holder)
 	visible_emote("gazes longingly at [holder]'s [thing]",0)
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -111,7 +111,7 @@
 	verbs -= /mob/verb/observe
 	health = maxHealth
 	if (mob_size)
-		nutrition_step = mob_size * 0.03 * metabolic_factor
+		nutrition_step = mob_size * 0.024 * metabolic_factor
 		bite_factor = mob_size * 0.3
 		max_nutrition *= 1 + (nutrition_step*4)//Max nutrition scales faster than costs, so bigger creatures eat less often
 		reagents = new/datum/reagents(stomach_size_mult*mob_size, src)

--- a/code/modules/mob/living/simple_animal/worm.dm
+++ b/code/modules/mob/living/simple_animal/worm.dm
@@ -46,6 +46,7 @@
 	var/atom/currentlyEating //what the worm is currently eating
 	var/eatingDuration = 0 //how long he's been eating it for
 
+
 	head
 		name = "space worm head"
 		icon_state = "spacewormhead"

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -158,6 +158,7 @@
 
 	var/can_pull_size = 10              // Maximum w_class the mob can pull.
 	var/can_pull_mobs = MOB_PULL_LARGER // Whether or not the mob can pull other mobs.
+	var/can_climb = 1 //Whether the mob can climb ladders
 
 	var/datum/dna/dna = null//Carbon
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -16,7 +16,7 @@
  * Verb for the mob to move down a z-level if possible.
  */
 /mob/verb/down()
-	set name = "Move Down"
+	set name = "Move Downwards"
 	set category = "IC"
 
 	if(zMove(DOWN))
@@ -36,9 +36,18 @@
 		return eyeobj.zMove(direction)
 
 	// Check if we can actually travel a Z-level.
-	if (!can_ztravel())
+	if (!can_ztravel(direction))
 		to_chat(src, "<span class='warning'>You lack means of travel in that direction.</span>")
 		return FALSE
+
+	if (isliving(src))
+		var/mob/living/L = src
+		if (L.is_ventcrawling)
+			var/obj/machinery/atmospherics/pipe/zpipe/ZPIPE = L.loc
+			if (!ZPIPE || !istype(ZPIPE))
+				return FALSE
+
+			return ZPIPE.handle_z_crawl(L, direction)
 
 	var/turf/destination = (direction == UP) ? GetAbove(src) : GetBelow(src)
 
@@ -102,13 +111,23 @@
  * @return	TRUE if the mob can move a Z-level of its own volition.
  *			FALSE otherwise.
  */
-/mob/proc/can_ztravel()
+/mob/proc/can_ztravel(var/direction)
 	return FALSE
 
-/mob/dead/observer/can_ztravel()
+/mob/living/can_ztravel(var/direction)
+	if (is_ventcrawling)
+		var/obj/machinery/atmospherics/P = loc
+		if (P && istype(P) && P.can_z_crawl(src, direction))
+			return TRUE
+	return FALSE
+
+
+/mob/dead/observer/can_ztravel(var/direction)
 	return TRUE
 
-/mob/living/carbon/human/can_ztravel()
+/mob/living/carbon/human/can_ztravel(var/direction)
+	.=..()
+
 	if(incapacitated())
 		return FALSE
 
@@ -120,7 +139,9 @@
 			if(T.density)
 				return TRUE
 
-/mob/living/silicon/robot/can_ztravel()
+/mob/living/silicon/robot/can_ztravel(var/direction)
+	.=..()
+
 	if(incapacitated() || is_dead())
 		return FALSE
 
@@ -191,7 +212,7 @@
 	//Ladders too
 	if(below && locate(/obj/structure/ladder) in below)
 		return FALSE
-		
+
 
 	// The var/climbers API is implemented here.
 	if (LAZYLEN(dest.climbers) && (src in dest.climbers))

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -117,7 +117,7 @@
 /mob/living/can_ztravel(var/direction)
 	if (is_ventcrawling)
 		var/obj/machinery/atmospherics/P = loc
-		if (P && istype(P) && P.can_z_crawl(src, direction))
+		if (istype(P) && P.can_z_crawl(src, direction))
 			return TRUE
 	return FALSE
 
@@ -126,7 +126,7 @@
 	return TRUE
 
 /mob/living/carbon/human/can_ztravel(var/direction)
-	.=..()
+	. = ..()
 
 	if(incapacitated())
 		return FALSE

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -55,11 +55,11 @@
 	. = ..()
 
 /obj/machinery/atmospherics/pipe/zpipe/Topic(href, href_list)
-	.=..()
+	. = ..()
 	if (href_list["crawl_user"])
 		var/mob/living/L = locate(href_list["crawl_user"])
 		var/direction = text2num(href_list["crawl_dir"])
-		if (L && istype(L))
+		if (istype(L))
 			return L.zMove(direction)
 
 /obj/machinery/atmospherics/pipe/zpipe/hide(var/i)

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -8,6 +8,11 @@
 	name = "upwards pipe"
 	desc = "A pipe segment to connect upwards."
 
+	var/travel_verbname = "UNDEFINED"
+	var/travel_direction_verb = "UNDEFINED"
+	var/travel_direction_name = "UNDEFINED"
+	var/travel_direction = "UNDEFINED"
+
 	volume = 70
 
 	dir = SOUTH
@@ -42,6 +47,20 @@
 			initialize_directions = EAST
 		if(SOUTHWEST)
 			initialize_directions = SOUTH
+
+/obj/machinery/atmospherics/pipe/zpipe/Entered(atom/movable/Obj)
+	if(istype(Obj, /mob/living))
+		var/mob/living/L = Obj
+		L << span("notice", "You are in a vertical pipe section. Use <a href='?src=\ref[src];crawl_user=\ref[L];crawl_dir=[travel_direction]'>[travel_verbname]</a> from the IC menu to [travel_direction_verb] a level.")
+	. = ..()
+
+/obj/machinery/atmospherics/pipe/zpipe/Topic(href, href_list)
+	.=..()
+	if (href_list["crawl_user"])
+		var/mob/living/L = locate(href_list["crawl_user"])
+		var/direction = text2num(href_list["crawl_dir"])
+		if (L && istype(L))
+			return L.zMove(direction)
 
 /obj/machinery/atmospherics/pipe/zpipe/hide(var/i)
 	if(istype(loc, /turf/simulated))
@@ -117,6 +136,11 @@
 
 	name = "upwards pipe"
 	desc = "A pipe segment to connect upwards."
+	travel_verbname = "Move Upwards"
+	travel_direction_verb = "ascend"
+	travel_direction_name = "up"
+	travel_direction = UP
+
 
 /obj/machinery/atmospherics/pipe/zpipe/up/initialize()
 	normalize_dir()
@@ -155,6 +179,10 @@
 
 	name = "downwards pipe"
 	desc = "A pipe segment to connect downwards."
+	travel_verbname = "Move Downwards"
+	travel_direction_verb = "descend"
+	travel_direction_name = "down"
+	travel_direction = DOWN
 
 /obj/machinery/atmospherics/pipe/zpipe/down/initialize()
 	normalize_dir()

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -103,6 +103,9 @@
 	if(incapacitated())
 		to_chat(src, "<span class='warning'>You are physically unable to climb \the [ladder].</span>")
 		return FALSE
+	if (!can_climb)
+		to_chat(src, "<span class='warning'>You lack the dexterity or limbs to climb \the [ladder].</span>")
+		return FALSE
 	return TRUE
 
 /mob/observer/ghost/may_climb_ladders(var/ladder)

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -45,6 +45,9 @@
 	attack_hand(user)
 	return
 
+/obj/structure/ladder/attack_generic(var/mob/M)
+	attack_hand(M)
+
 /obj/structure/ladder/attack_hand(var/mob/M)
 	if(!M.may_climb_ladders(src))
 		return

--- a/code/modules/ventcrawl/ventcrawl_atmospherics.dm
+++ b/code/modules/ventcrawl/ventcrawl_atmospherics.dm
@@ -96,3 +96,31 @@ obj/machinery/atmospherics/trinary/isConnectable(var/obj/machinery/atmospherics/
 
 /obj/machinery/atmospherics/unary/isConnectable(var/obj/machinery/atmospherics/target)
 	return (target == node || ..())
+
+
+/obj/machinery/atmospherics/proc/can_z_crawl(var/mob/living/L, var/direction)
+	return FALSE
+
+
+/obj/machinery/atmospherics/pipe/zpipe/can_z_crawl(var/mob/living/L, var/direction)
+	if (L.is_ventcrawling && L.loc == src)
+		if (node2 && check_connect_types(node2,src))
+			if (direction == travel_direction)
+				return TRUE
+
+
+/obj/machinery/atmospherics/proc/handle_z_crawl(var/mob/living/L, var/direction)
+	return
+
+
+//For now, since Z pipes only go in an L shape, ie with a single vertical direction, the direction parameter is ignored
+//We'll keep it here for future extensibility incase pipes are added that can go both vertical ways
+/obj/machinery/atmospherics/pipe/zpipe/handle_z_crawl(var/mob/living/L, var/direction)
+	//We'll assume the initial safety checks are done
+	L << span("notice", "You start climbing [travel_direction_name] the pipe. This will take a while...")
+	playsound(loc, 'sound/machines/ventcrawl.ogg', 100, 1, 3) //Vertical climbing is extra loud
+	if (!do_after(L, 100, needhand = 0, act_target = get_turf(src)) || !can_z_crawl(L, direction))
+		L << span("danger", "You gave up on climbing [travel_direction_name] the pipe.")
+		return FALSE
+
+	return ventcrawl_to(L, node2, null)


### PR DESCRIPTION
Non humanoid creatures seem to have been left out of the vertical revolution. This  PR fixes that.

Main feature is that ventcrawling between Z levels now works perfectly. It takes 10 seconds to climb up or down a pipe. When a user steps onto a vertical pipe they get a message in chat with a link to click, or they can use the move up/down verbs

Secondly, enabled ladders for most  nonhumanoid mobs. ~~It doesnt seem worth adding an exception mechanic for those~~ Nevermind, we're doing it. Added a can_climb var, set it to default to 1 for most mobs, 0 for silicon, simple animal and metroid, manual whitelisting within those categories. Each one has a justification written beside it in a comment.  See below for today's epic debate on what should be able to climb ladders.

Aside from that, very minor changes:
1. Altered the name of the down verb to Move Downwards, it  was annoying me that the two werent consistent
2. In response to user feedback, reduced the hunger rate of animals by 20%