### PR TITLE
Window Booping Fix

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -351,10 +351,15 @@ client/verb/set_context_menu_enabled(Enable as num)
 	if(!A || !x || !y || !A.x || !A.y) return
 	var/dx = A.x - x
 	var/dy = A.y - y
-	if(!dx && !dy) return
 
 	var/direction
-	if(abs(dx) < abs(dy))
+	if (loc == A.loc)
+		if (A.flags & ON_BORDER)
+			direction = A.dir
+		else
+			return
+
+	else if(abs(dx) < abs(dy))
 		if(dy > 0)	direction = NORTH
 		else		direction = SOUTH
 	else

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -144,7 +144,12 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 	var/pixel_x_diff = 0
 	var/pixel_y_diff = 0
-	var/direction = get_dir(src, A)
+	var/direction
+	if (loc == A.loc)
+		if (A.flags & ON_BORDER)
+			direction = A.dir
+	else
+		direction = get_dir(src, A)
 	switch(direction)
 		if(NORTH)
 			pixel_y_diff = 8
@@ -166,6 +171,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 		if(SOUTHWEST)
 			pixel_x_diff = -8
 			pixel_y_diff = -8
+		else
+			return 0//No valid direction
 	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 2)
 	animate(pixel_x = pixel_x - pixel_x_diff, pixel_y = pixel_y - pixel_y_diff, time = 2)
 

--- a/html/changelogs/Nanako-Windowboop.yml
+++ b/html/changelogs/Nanako-Windowboop.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: N3X15
+author: Nanako
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/Nanako-Windowboop.yml
+++ b/html/changelogs/Nanako-Windowboop.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Facing and attack animations now work properly with windows on your tile"


### PR DESCRIPTION
A minor issue that's annoyed me for a long time;
This PR adds ON_BORDER support for attack animations and atom facing, causing you to face and strike in the correct direction when dealing with border objects on the same tile as you. Previously these things would fail and do no animation/facing change

Afaik, border objects really just means single pane windows and windoors right now.