### PR TITLE
Makes gun closets unmovable unless certain tools are used

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -8,6 +8,9 @@
 	icon_locked ="base"
 	icon_closed ="base"
 	icon_opened = "base"
+	anchored = 1
+	canbemoved = 0
+	
 
 /obj/structure/closet/secure_closet/guncabinet/Initialize()
 	..()

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -9,7 +9,7 @@
 	icon_closed ="base"
 	icon_opened = "base"
 	anchored = 1
-	canbemoved = 0
+	canbemoved = 1
 	
 
 /obj/structure/closet/secure_closet/guncabinet/Initialize()

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -5,6 +5,7 @@
 	icon_state = "secure1"
 	density = 1
 	opened = 0
+	anchored = 0
 	var/locked = 1
 	var/broken = 0
 	var/large = 1
@@ -13,6 +14,9 @@
 	icon_opened = "secureopen"
 	var/icon_broken = "securebroken"
 	var/icon_off = "secureoff"
+	var/canbemoved = 0 // if it can be moved by people using the right tools
+	var/screwed = 1 // if its screwed in place
+	var/wrenched = 1 // if its wrenched down
 	wall_mounted = 0 //never solid (You can always pass over it)
 	health = 200
 
@@ -83,6 +87,38 @@
 			W:spark_system.queue()
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			playsound(src.loc, "sparks", 50, 1)
+	else if(istype(W, /obj/item/weapon/screwdriver) && canbemoved)
+		if(screwed)
+			user << "<span class='notice'>You start to unscrew the locker from the floor...</span>"
+			playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
+			if (do_after(user, 10 SECONDS, act_target = src))
+				user << "<span class='notice'>You unscrew the locker!</span>"
+				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
+				screwed = 0
+		else if(!screwed && wrenched)
+			user << "<span class='notice'>You start to screw the locker to the floor...</span>"
+			playsound(src, 'sound/items/Welder.ogg', 80, 1)
+			if (do_after(user, 15, act_target = src))
+				user << "<span class='notice'>You screw the locker!</span>"
+				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
+				screwed = 1
+	else if(istype(W, /obj/item/weapon/wrench) && canbemoved)
+		if(wrenched && !screwed)
+			user << "<span class='notice'>You start to unfasten the bolts holding the locker in place...</span>"
+			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+			if (do_after(user, 15 SECONDS, act_target = src))
+				user << "<span class='notice'>You unfasten the locker's bolts!</span>"
+				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				wrenched = 0
+				anchored = 0
+		else if(!wrenched)
+			user << "<span class='notice'>You start to fasten the bolts holding the locker in place...</span>"
+			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+			if (do_after(user, 15, act_target = src))
+				user << "<span class='notice'>You fasten the locker's bolts!</span>"
+				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				wrenched = 1
+				anchored = 1
 	else if(!src.opened)
 		togglelock(user)//Attempt to lock locker if closed
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -87,7 +87,7 @@
 			W:spark_system.queue()
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			playsound(src.loc, "sparks", 50, 1)
-	else if(istype(W, /obj/item/weapon/screwdriver) && canbemoved)
+	else if(isscrewdriver(W) && canbemoved)
 		if(screwed)
 			user << "<span class='notice'>You start to unscrew the locker from the floor...</span>"
 			playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
@@ -102,7 +102,7 @@
 				user << "<span class='notice'>You screw the locker!</span>"
 				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				screwed = 1
-	else if(istype(W, /obj/item/weapon/wrench) && canbemoved)
+	else if(iswrench(W) && canbemoved)
 		if(wrenched && !screwed)
 			user << "<span class='notice'>You start to unfasten the bolts holding the locker in place...</span>"
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -267,7 +267,8 @@
 		/obj/item/weapon/reagent_containers/food,
 		/obj/item/seeds,
 		/obj/item/weapon/grown,
-		/obj/item/trash
+		/obj/item/trash,
+		/obj/item/weapon/reagent_containers/cooking_container
 		)
 
 /obj/item/weapon/gripper/no_use //Used when you want to hold and put items in other things, but not able to 'use' the item

--- a/html/changelogs/arrow768-borg-service-gripper.yml
+++ b/html/changelogs/arrow768-borg-service-gripper.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Service borgs can use cooking containers with their gripper."


### PR DESCRIPTION
For a gun closet to be moved a screwdriver and wrench has to be used on them in that order.
Fixes #2690