### PR TITLE
PAI Access Fix

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -53,16 +53,16 @@
 		playsound(src.loc, 'sound/machines/buzz-two.ogg', 20, 0)
 		return 0
 
-	pai.ID.access.Cut()
-	pai.ID.access = card.access.Copy()
-	pai.ID.registered_name = card.registered_name
+	pai.idcard.access.Cut()
+	pai.idcard.access = card.access.Copy()
+	pai.idcard.registered_name = card.registered_name
 	playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
-	user << "<span class='notice'>ID Registration for [pai.ID.registered_name] is a success. PAI access updated!</span>"
+	user << "<span class='notice'>ID Registration for [pai.idcard.registered_name] is a success. PAI access updated!</span>"
 	return 1
 
 /obj/item/device/paicard/proc/ID_readout()
-	if (pai.ID.registered_name)
-		return "<span class='notice'>Identity of owner: [pai.ID.registered_name] registered.</span>"
+	if (pai.idcard.registered_name)
+		return "<span class='notice'>Identity of owner: [pai.idcard.registered_name] registered.</span>"
 	else
 		return "<span class='warning'>No ID card registered! Please scan your ID to share access.</span>"
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -45,7 +45,7 @@
 		)
 
 	var/obj/item/weapon/pai_cable/cable		// The cable we produce and use when door or camera jacking
-	var/obj/item/weapon/card/id/ID = null	//Internal ID used to store copied owner access, and to check access for airlocks
+	idcard_type = /obj/item/weapon/card/id	//Internal ID used to store copied owner access, and to check access for airlocks
 
 	var/master				// Name of the one who commands us
 	var/master_dna			// DNA string for owner verification
@@ -140,14 +140,17 @@
 
 	//PDA
 	pda = new(src)
-	ID = new(src)
-	ID.registered_name = ""
 	spawn(5)
 		pda.ownjob = "Personal Assistant"
 		pda.owner = text("[]", src)
 		pda.name = pda.owner + " (" + pda.ownjob + ")"
 		pda.toff = 1
 	..()
+
+/mob/living/silicon/pai/init_id()
+	. = ..()
+	idcard.registered_name = ""
+
 
 /mob/living/silicon/pai/Login()
 	greet()

--- a/html/changelogs/Nanako-PAI-access.yml
+++ b/html/changelogs/Nanako-PAI-access.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed personal AI's having all-access to the station. They are now back to only having the access of their master."


### PR DESCRIPTION
Fixes a bug that gave PAI's all access.
It seems at some point silicons were changed to use an internal ID, and pais were given that same ID which had all access.

Changed it so their internal ID only has basic access and rerouted pai ID functions to it. This restores them to intended functionality, that is: They can only walk in public areas, and wherever their master has access, once the master has scanned their ID