### PR TITLE
Removes cloaking devices

### DIFF
--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -33,9 +33,3 @@
 	name = "Chameleon-Projector"
 	item_cost = 8
 	path = /obj/item/device/chameleon
-
-/datum/uplink_item/item/stealth_items/cloak
-	name = "Cloaking Device"
-	item_cost = 12
-	path = /obj/item/weapon/cloaking_device
-	desc = "An advanced battery-powered miniature cloaking device that renders the holder invisible. Consumes a lot of power."

--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -218,7 +218,7 @@ var/list/global/random_stock_rare = list(
 	"energyshield" = 2,
 	"hardsuit" = 0.75,
 	"cluster" = 2.0,
-	"cloak" = 0.75,
+	"ladder" = 3,
 	"sword" = 0.5,
 	"ims" = 1.5,
 	"exogear" = 1.5,
@@ -1412,8 +1412,8 @@ var/list/global/random_stock_large = list(
 			new /obj/item/weapon/shield/energy(L)
 		if("cluster")
 			new /obj/item/weapon/grenade/flashbang/clusterbang(L)
-		if("cloak")
-			new /obj/item/weapon/cloaking_device(L)
+		if("ladder")
+			new /obj/item/weapon/ladder_mobile(L)
 		if("sword")
 			new /obj/random/sword(L)
 		if("ims")


### PR DESCRIPTION
This pr will replace the cloaking device from cargo warehouse spawn,, because they pretty much fall under the same level of bullshit as thermals and etc, with the new portable ladders.

Also, removes from the traitor uplink, because it is only used for combat it seems, defeating the purpose of being a stealth item. The chameleon projector is a better, and far less bullshit item, to cover the same purpose.