### PR TITLE
Newton's Thirdish Law

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -11,6 +11,7 @@
 	icon_state = "minimoog"
 	anchored = 1
 	density = 1
+	w_class = 5
 	var/datum/song/song
 	var/playing = 0
 	var/help = 0
@@ -26,6 +27,7 @@
 		name = "space piano"
 		desc = "This is a space piano, like a regular piano, but always in tune! Even if the musician isn't."
 		icon_state = "piano"
+		w_class = 15
 
 /obj/structure/device/piano/proc/playnote(var/note as text)
 	//world << "Note: [note]"

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -316,9 +316,7 @@
 		"With a loud thud, you land on \the [loc]!", "You hear a thud!")
 
 	var/z_velocity = 5*(levels_fallen**2)
-	var/damage = ((30 + z_velocity) + rand(-15,15))
-	apply_damage(damage, BRUTE)
-	apply_damage(damage, BRUTE)
+	var/damage = ((60 + z_velocity) + rand(-20,20))
 	apply_damage(damage, BRUTE)
 
 	// The only piece of duplicate code. I was so close. Soooo close. :ree:
@@ -351,9 +349,6 @@
 					"<span class='notice'>You hear an electric <i>*whirr*</i> right after the slam!</span>")
 				return FALSE
 
-	visible_message("\The [src] falls and lands on \the [loc]!",
-		"With a loud thud, you land on \the [loc]!", "You hear a thud!")
-
 	var/combat_roll = 1
 	if(lying)
 		combat_roll = 0.7 //If you're sleeping, you take less damage because your body is less rigid. It's science 'n shit.
@@ -363,33 +358,65 @@
 				"<span class='notice'>You tuck into a roll as you hit \the [loc], minimizing damage!</span>")
 
 	var/z_velocity = 5*(levels_fallen**2)
-	var/damage = (((25 * species.fall_mod) + z_velocity) + rand(-13,13)) * combat_roll
-	if(prob(20)) //landed on their head
-		apply_damage(damage, BRUTE, "head")
+	var/damage = (((60 * species.fall_mod) + z_velocity) + rand(-20,20)) * combat_roll
+	var/limb_damage = rand(0,damage/2)
 
-	else if(prob(20)) //landed on their arms
-		apply_damage(damage, BRUTE, "l_arm")
-		apply_damage(damage, BRUTE, "r_arm")
+	if(prob(30) && combat_roll >= 1) //landed on their head
+		apply_damage(limb_damage, BRUTE, "head")
+		visible_message("<span class='warning'>\The [src] falls and lands on their face!</span>",
+			"<span class='danger'>With a loud thud, you land on your head. Hard.</span>", "You hear a thud!")
+
+	else if(prob(30) && combat_roll >= 1) //landed on their arms
+		var/left_damage = rand(0,damage/4)
+		var/right_damage = rand(0,damage/4)
+		var/lefth_damage = rand(0,damage/4)
+		var/righth_damage = rand(0,damage/4)
+
+		apply_damage(left_damage, BRUTE, "l_arm")
+		apply_damage(right_damage, BRUTE, "r_arm")
 
 		if(prob(50))
-			apply_damage(rand(0, (damage/2)), BRUTE, "r_hand")
+			apply_damage(lefth_damage, BRUTE, "r_hand")
 		if(prob(50))
-			apply_damage(rand(0, (damage/2)), BRUTE, "l_hand")
+			apply_damage(righth_damage, BRUTE, "l_hand")
 
-	else //landed on their legs
-		apply_damage(10 + rand(10, damage), BRUTE, "l_leg")
-		apply_damage(10 + rand(10, damage), BRUTE, "r_leg")
+		limb_damage = left_damage + right_damage + lefth_damage + righth_damage
+
+		visible_message("<span class='warning'>\The [src] falls and lands arms first!</span>",
+			"<span class='danger'>You brace your fall with your arms, hitting \the [loc] with a loud thud.</span>", "You hear a thud!")
+
+	else if(prob(30) && combat_roll >= 1)//landed on their legs
+		var/left_damage = rand(0,damage/2)
+		var/right_damage = rand(0,damage/2)
+		var/leftf_damage = rand(0,damage/4)
+		var/rightf_damage = rand(0,damage/4)
+		var/groin_damage = rand(0,damage/4)
+
+
+		apply_damage(left_damage, BRUTE, "l_leg")
+		apply_damage(right_damage, BRUTE, "r_leg")
 
 		if(prob(50))
-			apply_damage(rand(0, (damage/2)), BRUTE, "r_foot")
+			apply_damage(leftf_damage, BRUTE, "r_foot")
 		if(prob(50))
-			apply_damage(rand(0, (damage/2)), BRUTE, "l_foot")
+			apply_damage(leftf_damage, BRUTE, "l_foot")
 		if(prob(50))
-			apply_damage(rand(0, (damage/2)), BRUTE, "groin")
+			apply_damage(groin_damage, BRUTE, "groin")
 
-	apply_damage(damage, BRUTE, "chest")
+		visible_message("<span class='warning'>\The [src] falls and lands directly on their legs!</span>",
+			"<span class='danger'>You land on your feet, and the impact brings you to your knees.</span>")
 
-	Weaken(rand(0, damage/2))
+		limb_damage = left_damage + right_damage + leftf_damage + rightf_damage + groin_damage
+
+	else
+		limb_damage = 0
+		if(combat_roll >= 0.5)
+			visible_message("\The [src] falls and lands on \the [loc]!",
+				"With a loud thud, you land on \the [loc]!", "You hear a thud!")
+
+	apply_damage(damage - limb_damage, "chest")
+
+	Weaken(rand(damage/2, damage))
 
 	updatehealth()
 
@@ -426,10 +453,7 @@
 		return
 
 	var/z_velocity = 5*(levels_fallen**2)
-	var/damage = ((40 + z_velocity) + rand(-20,20))
-	take_damage(damage)
-	take_damage(damage)
-	take_damage(damage)
+	var/damage = ((60 + z_velocity) + rand(-20,20))
 	take_damage(damage)
 
 	playsound(loc, "sound/effects/bang.ogg", 100, 1)
@@ -441,10 +465,7 @@
 		return
 
 	var/z_velocity = 5*(levels_fallen**2)
-	var/damage = ((35 + z_velocity) + rand(-18,18))
-	health -= (damage * brute_dam_coeff)
-	health -= (damage * brute_dam_coeff)
-	health -= (damage * brute_dam_coeff)
+	var/damage = ((60 + z_velocity) + rand(-20,20))
 	health -= (damage * brute_dam_coeff)
 
 	playsound(loc, "sound/effects/clang.ogg", 75, 1)


### PR DESCRIPTION
Items falling now deal a set amount of damage based on velocity calculations, with no more randomisation. This damage is randomly distributed throughout the head and torso by first calculating the damage dealt to the head - anywhere between zero and 1/2th of total damage, and then calculating the damage to the torso - head damage subtracted from total damage.

The same applies somewhat to damage dealt to those who fall. It is now a raw 60 damage, plus any number between -20 and 20, with z-velocity calculated in. Humans that land on their head, legs, or arms will have their damage dealt with via similar calculations as used above for fall_collateral. The way they land will be advertised to them as well. It is now possible to land only on your chest, in which case all the damage gets applied to the chest. Combat rollers and sleepers can _only_ land on their chest, but take less damage.

Fall collateral damage is now more sane. Balance of power has been shifted from what was previously a high speed bias towards what I believe to be a more sane high weight bias. Also fixes some outright errors in calculation. No longer will rods and such deal 287 damage, but will now deal slightly more damage than what you'd get if you'd just thrown them, for the basic 1 z fall. Massive items (w_class >= 10) have been given a handicap, as most of them are missing some essential vars, meaning that durands still deal 75 damage.

Pianos have been buffed to w_class 15. Minimoogs have a w_class of 5.

People that are asleep take a little less fall damage. People that are prone take much less fall damage, because of combat rolls. This is most useful for people that have fallen from the bottom of the asteroid to the top of the asteroid, as unfortunately most other falls are instantaneous in duration.
