### PR TITLE
Nerf Screenshaking

### DIFF
--- a/code/controllers/subsystems/explosives.dm
+++ b/code/controllers/subsystems/explosives.dm
@@ -9,7 +9,7 @@ var/datum/controller/subsystem/explosives/SSexplosives
 	priority = SS_PRIORITY_EXPLOSIVES
 
 	suspended = TRUE	// Start disabled, explosions will wake us if need be.
-	
+
 	var/list/work_queue
 	var/ticks_without_work = 0
 	var/list/explosion_turfs
@@ -157,7 +157,7 @@ var/datum/controller/subsystem/explosives/SSexplosives
 
 					//Deaf people will feel vibrations though
 					if (volume > 0)//Only shake camera if someone was close enough to hear it
-						shake_camera(M, min(60,max(2,(power*18) / dist)), min(3.5,((power*3) / dist)),0.05)
+						shake_camera(M, min(30,max(2,(power*2) / dist)), min(3,((power/3) / dist)),0.05)
 						//Maximum duration is 6 seconds, and max strength is 3.5
 						//Becuse values higher than those just get really silly
 
@@ -177,11 +177,11 @@ var/datum/controller/subsystem/explosives/SSexplosives
 	for(var/turf/T in trange(max_range, epicenter))
 		var/dist = sqrt((T.x - x0)**2 + (T.y - y0)**2)
 
-		if (dist < devastation_range)		
+		if (dist < devastation_range)
 			dist = 1
-		else if (dist < heavy_impact_range)	
+		else if (dist < heavy_impact_range)
 			dist = 2
-		else if (dist < light_impact_range)	
+		else if (dist < light_impact_range)
 			dist = 3
 		else
 			continue
@@ -191,7 +191,7 @@ var/datum/controller/subsystem/explosives/SSexplosives
 		if(T)
 			for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
 				var/atom/movable/AM = atom_movable
-				if(AM && AM.simulated)	
+				if(AM && AM.simulated)
 					AM.ex_act(dist)
 
 				CHECK_TICK
@@ -231,9 +231,9 @@ var/datum/controller/subsystem/explosives/SSexplosives
 
 	//This step applies the ex_act effects for the explosion, as planned in the previous step.
 	for(var/turf/T in explosion_turfs)
-		if(explosion_turfs[T] <= 0) 
+		if(explosion_turfs[T] <= 0)
 			continue
-		if(!T) 
+		if(!T)
 			continue
 
 		//Wow severity looks confusing to calculate... Fret not, I didn't leave you with any additional instructions or help. (just kidding, see the line under the calculation)

--- a/code/controllers/subsystems/explosives.dm
+++ b/code/controllers/subsystems/explosives.dm
@@ -157,8 +157,8 @@ var/datum/controller/subsystem/explosives/SSexplosives
 
 					//Deaf people will feel vibrations though
 					if (volume > 0)//Only shake camera if someone was close enough to hear it
-						shake_camera(M, min(30,max(2,(power*2) / dist)), min(3,((power/3) / dist)),0.05)
-						//Maximum duration is 6 seconds, and max strength is 3.5
+						shake_camera(M, min(30,max(2,(power*2) / dist)), min(3.5,((power/3) / dist)),0.05)
+						//Maximum duration is 3 seconds, and max strength is 3.5
 						//Becuse values higher than those just get really silly
 
 	if(adminlog)


### PR DESCRIPTION
Halves the max duration of screen shaking and adjusts the bottom line a bit. Previously, pretty much any explosion would have max intensity screen shaking because the minimum threshold was so high, and likewise for duration.

Standing right next to the epicenter of a sufficiently large explosion (I tested with size 16 bombs, the standard) will still cause some hefty screenshaking, as well as blindness and flash. However, standing at the very edge of an explosion, or standing next to a very small explosion's epicenter (such as an exploding durand or a frag grenade) will have only minor - but still notable (as all screenshaking is) screenshake.
