### PR TITLE
Remove butanol from chemistry dispenser

### DIFF
--- a/code/modules/reagents/dispenser/dispenser_presets.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets.dm
@@ -18,7 +18,6 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/radium,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/water,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ethanol,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/butanol,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sacid,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tungsten

--- a/html/changelogs/lohikar-dispenser-removal.yml
+++ b/html/changelogs/lohikar-dispenser-removal.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - rscdel: "Removed butanol from the chemistry dispenser as it wasn't actually used for anything."


### PR DESCRIPTION
Removes butanol from chemistry's chemical dispenser, as it is not actually used in production of anything, unlike ethanol.