### PR TITLE
Adjusts the tech levels for certain weapons

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -534,7 +534,7 @@ datum/design/circuit/telepad
 
 /datum/design/item/weapon/decloner
 	id = "decloner"
-	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
+	req_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
 	materials = list("gold" = 5000,"uranium" = 10000, "mutagen" = 40)
 	build_path = /obj/item/weapon/gun/energy/decloner
 	sort_string = "TAAAE"
@@ -620,7 +620,7 @@ datum/design/item/weapon/railgun
 	id = "railgun"
 	name = "railgun"
 	desc = "An advanced rifle that magnetically propels hyperdense rods at breakneck speeds to devastating effect."
-	req_tech = list(TECH_COMBAT = 8, TECH_PHORON = 2, TECH_MATERIAL = 7, TECH_MAGNET = 4, TECH_POWER = 5, TECH_ILLEGAL = 3)
+	req_tech = list(TECH_COMBAT = 6, TECH_PHORON = 2, TECH_MATERIAL = 7, TECH_MAGNET = 4, TECH_POWER = 5, TECH_ILLEGAL = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 75000, "glass" = 18750, "phoron" = 11250, "gold" = 7500, "silver" = 7500)
 	build_path = /obj/item/weapon/gun/projectile/automatic/railgun
 	sort_string = "TVCAA"
@@ -694,7 +694,7 @@ datum/design/item/weapon/lasercannon
 
 datum/design/item/weapon/decloner
 	id = "decloner"
-	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
+	req_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
 	materials = list("gold" = 5000,"uranium" = 10000)
 	build_path = /obj/item/weapon/gun/energy/decloner
 	sort_string = "TVKAA"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -534,7 +534,7 @@ datum/design/circuit/telepad
 
 /datum/design/item/weapon/decloner
 	id = "decloner"
-	req_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
+	req_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
 	materials = list("gold" = 5000,"uranium" = 10000, "mutagen" = 40)
 	build_path = /obj/item/weapon/gun/energy/decloner
 	sort_string = "TAAAE"
@@ -691,13 +691,6 @@ datum/design/item/weapon/lasercannon
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 1000, "diamond" = 2000)
 	build_path = /obj/item/weapon/gun/energy/rifle/laser/heavy
 	sort_string = "TVJAA"
-
-datum/design/item/weapon/decloner
-	id = "decloner"
-	req_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
-	materials = list("gold" = 5000,"uranium" = 10000)
-	build_path = /obj/item/weapon/gun/energy/decloner
-	sort_string = "TVKAA"
 
 datum/design/item/weapon/mousegun
 	id = "mousegun"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -620,7 +620,7 @@ datum/design/item/weapon/railgun
 	id = "railgun"
 	name = "railgun"
 	desc = "An advanced rifle that magnetically propels hyperdense rods at breakneck speeds to devastating effect."
-	req_tech = list(TECH_COMBAT = 6, TECH_PHORON = 2, TECH_MATERIAL = 7, TECH_MAGNET = 4, TECH_POWER = 5, TECH_ILLEGAL = 3)
+	req_tech = list(TECH_COMBAT = 7, TECH_PHORON = 2, TECH_MATERIAL = 7, TECH_MAGNET = 4, TECH_POWER = 5, TECH_ILLEGAL = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 75000, "glass" = 18750, "phoron" = 11250, "gold" = 7500, "silver" = 7500)
 	build_path = /obj/item/weapon/gun/projectile/automatic/railgun
 	sort_string = "TVCAA"

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -537,7 +537,7 @@
 	name = "Teleporter"
 	desc = "An exosuit module that allows teleportation to any position in view."
 	id = "mech_teleporter"
-	req_tech = list(TECH_BLUESPACE = 10, TECH_MAGNET = 5)
+	req_tech = list(TECH_BLUESPACE = 6, TECH_MAGNET = 5)
 	build_path = /obj/item/mecha_parts/mecha_equipment/teleporter
 
 /datum/design/item/mecha/rcd

--- a/html/changelogs/Printer16-ResearchPrice.yml
+++ b/html/changelogs/Printer16-ResearchPrice.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Printer16
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "The railgun, decloner, and mech teleporter have had their research print requirements decreased."


### PR DESCRIPTION
This makes it possible to get the railgun and decloner eaiser. It's still rare and costly. Also made it possible to get the mech teleporter (It's really not as good as some people think) by using antag items to get bluespace research up to 6. Also removed a duplicate decloner fab.

Items that can get research up to 8/9:
Rocket launcher (Adminbus only)
Z8 Bullpup (Cargo/ERT)
Assault shotgun (Vault safe RnG)
Antag sniper rifle (anti-material rifle)
Dragunov (y tho)
Cult Sword
Staff of Change
Deathsquad Pulse Rifle

Items that can get research up to 7 (combat tech 6):
Mecha heavy pulse rifle
eglavie
LWAP sniper rifle
Lawgiver
All wands of something
Gatling Laser
Thermal Lance
Thermal Drill
Any automatic rifle
The L6 Saw
The Tranq Rifle

End result: You can use any of the items listed above to get a railgun/decloner instead of only the guns listed in the first category. Still rare and hard to get (And not that good of a gun if you use it wrong because it only has two shots which have a good chance at missing).

