### PR TITLE
Soft-delete fixes & Tajara Coffee overdose tweak

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -249,6 +249,13 @@
 
 	screen_loc = "CENTER:[base_offset_x],CENTER:[base_offset_y]"
 
+/client/proc/cleanup_parallax_references()
+	parallax_dustmaster = null
+	parallax_master = null
+	parallax_spacemaster = null
+	LAZYCLEARLIST(parallax)
+	LAZYCLEARLIST(parallax_movable)
+
 #undef PARALLAX4_ICON_NUMBER
 #undef PARALLAX3_ICON_NUMBER
 #undef PARALLAX2_ICON_NUMBER

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -36,8 +36,6 @@
 	update_icon()
 
 /obj/item/stack/Destroy()
-	if(uses_charge)
-		return 1
 	if (src && usr && usr.machine == src)
 		usr << browse(null, "window=stack")
 	return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -11,6 +11,7 @@
 		for(var/atom/movable/AM in client.screen)
 			qdel(AM)
 		client.screen = list()
+		client.cleanup_parallax_references()
 	if (mind)
 		mind.handle_mob_deletion(src)
 	for(var/infection in viruses)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -14,13 +14,11 @@
 	canmove = 0
 
 	anchored = 1	//  don't get pushed around
+	simulated = FALSE
 
 	New()
-		mob_list += src
-
-	Destroy()
-		mob_list -= src
-		return ..()
+		..()
+		dead_mob_list -= src
 
 	verb/new_player_panel()
 		set src = usr

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -834,20 +834,9 @@
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
-/datum/reagent/nutriment/coffee/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	..()
-	if(alien == IS_TAJARA)
-		M.adjustToxLoss(2 * removed)
-		M.make_jittery(4)
-		return
-
-
 /datum/reagent/drink/coffee/overdose(var/mob/living/carbon/M, var/alien)
 	if(alien == IS_DIONA)
 		return
-	if(alien == IS_TAJARA)
-		M.adjustToxLoss(4 * REM)
-		M.apply_effect(3, STUTTER)
 	M.make_jittery(5)
 
 /datum/reagent/drink/coffee/icecoffee

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -18,6 +18,9 @@
 		if (!modifier)
 			modifier = M.add_modifier(/datum/modifier/adrenaline, MODIFIER_REAGENT, src, _strength = 0.6, override = MODIFIER_OVERRIDE_STRENGTHEN)
 
+/datum/reagent/inaprovaline/Destroy()
+	QDEL_NULL(modifier)
+	return ..()
 
 /datum/reagent/bicaridine
 	name = "Bicaridine"
@@ -272,6 +275,9 @@
 	if (!modifier)
 		modifier = M.add_modifier(/datum/modifier/adrenaline, MODIFIER_REAGENT, src, _strength = 1, override = MODIFIER_OVERRIDE_STRENGTHEN)
 
+/datum/reagent/synaptizine/Destroy()
+	QDEL_NULL(modifier)
+	return ..()
 
 
 /datum/reagent/alkysine
@@ -365,6 +371,9 @@
 	if (!modifier)
 		modifier = M.add_modifier(/datum/modifier/stimulant, MODIFIER_REAGENT, src, _strength = 1, override = MODIFIER_OVERRIDE_STRENGTHEN)
 
+/datum/reagent/hyperzine/Destroy()
+	QDEL_NULL(modifier)
+	return ..()
 
 #define ETHYL_INTOX_COST	3 //The cost of power to remove one unit of intoxication from the patient
 #define ETHYL_REAGENT_POWER	20 //The amount of power in one unit of ethyl

--- a/html/changelogs/lohikar-PR-2749.yml
+++ b/html/changelogs/lohikar-PR-2749.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - rscdel: "Coffee overdoses no longer poison Tajara."


### PR DESCRIPTION
changes:
- Fixed issues with parallax objects not deleting properly due to hanging refs. (this also seems to fix some mob delete failures, like BSTs)
- Fixed issues with hyperzine, inaprovaline, and synaptazine not soft-deleting due to hanging modifier references.
- Removed coffee overdoses poisoning Tajara at Mofo's request.