### PR TITLE
ZAS zones don't cross z-levels with MultiZAS

### DIFF
--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -1,6 +1,6 @@
 
 //#define ZASDBG
-//#define MULTIZAS
+#define MULTIZAS
 
 #define AIR_BLOCKED 1
 #define ZONE_BLOCKED 2
@@ -22,11 +22,15 @@
 		if (B.z < A.z) { \
 			if (!istype(A, /turf/simulated/open)) { \
 				ret = BLOCKED; \
+			} else { \
+				ret = ZONE_BLOCKED; \
 			} \
 		} \
 		else { \
 			if (!istype(B, /turf/simulated/open)) { \
 				ret = BLOCKED; \
+			} else { \
+				ret = ZONE_BLOCKED; \
 			} \
 		} \
 	} \


### PR DESCRIPTION
Makes openturf stop ZAS zone propagation, so it would have smaller lists to scan while navigating air around. In effect, they work similarly to doors.