### PR TITLE
Add noose people

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -675,3 +675,5 @@ datum/species/machine/handle_post_spawn(var/mob/living/carbon/human/H)
 /datum/species/bug/handle_post_spawn(var/mob/living/carbon/human/H)
 	H.gender = NEUTER
 	return ..()
+
+// lol


### PR DESCRIPTION
Adds the "Living Noose" species, as requested numerous times by Alberyk.

Details about their mechanics and lore will be unveiled shortly.