### PR TITLE
Fixes #2773

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -798,6 +798,9 @@
 	else if(href_list["boot2"])
 		var/mob/M = locate(href_list["boot2"])
 		if (ismob(M))
+			if(!check_rights(R_MOD, 0) && !check_rights(R_ADMIN, 0)) 
+				usr << "<span class='warning'>You do not have the appropriate permissions to boot users!</span>"
+				return
 			if(!check_if_greater_rights_than(M.client))
 				return
 			var/reason = sanitize(input("Please enter reason"))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -798,7 +798,7 @@
 	else if(href_list["boot2"])
 		var/mob/M = locate(href_list["boot2"])
 		if (ismob(M))
-			if(!check_rights(R_MOD, 0) && !check_rights(R_ADMIN, 0)) 
+			if(!check_rights(R_MOD|R_ADMIN, 0)) 
 				usr << "<span class='warning'>You do not have the appropriate permissions to boot users!</span>"
 				return
 			if(!check_if_greater_rights_than(M.client))


### PR DESCRIPTION
Stop non admins or mods kicking people.

Will admit I haven't personally tested it
(Note the old player panel used to hide commands that staff couldn't use if they didn't have permissions, all of these topic messages should be checked for correct ranks)

* Please describe the intent of your changes in a clear fashion. 
I did.
* Please make sure that, in the case of icon or mapping changes, you include images of these changes in the PR's description. 
No need.
