### PR TITLE
Add floor catwalks

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -1,13 +1,14 @@
-var/global/list/datum/stack_recipe/rod_recipes = list ( \
-	new/datum/stack_recipe("grille", /obj/structure/grille, 2, time = 10, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("mine track", /obj/structure/track, 3, time = 10, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("cane", /obj/item/weapon/cane, 1, time = 6), \
-	new/datum/stack_recipe("crowbar", /obj/item/weapon/crowbar, 1, time = 6), \
-	new/datum/stack_recipe("screwdriver", /obj/item/weapon/screwdriver, 1, time = 12), \
-	new/datum/stack_recipe("wrench", /obj/item/weapon/wrench, 1, time = 6), \
-	new/datum/stack_recipe("spade", /obj/item/weapon/shovel/spade, 2, time = 12), \
-	new/datum/stack_recipe("bolt", /obj/item/weapon/arrow, 1, time = 6)
-	)
+var/global/list/datum/stack_recipe/rod_recipes = list(
+	new /datum/stack_recipe("grille", /obj/structure/grille, 2, time = 10, one_per_turf = TRUE, on_floor = TRUE),
+	new /datum/stack_recipe("floor-mounted catwalk", /obj/structure/lattice/catwalk/indoor, 4, time = 10, one_per_turf = TRUE, on_floor = TRUE),
+	new /datum/stack_recipe("mine track", /obj/structure/track, 3, time = 10, one_per_turf = TRUE, on_floor = TRUE),
+	new /datum/stack_recipe("cane", /obj/item/weapon/cane, 1, time = 6),
+	new /datum/stack_recipe("crowbar", /obj/item/weapon/crowbar, 1, time = 6),
+	new /datum/stack_recipe("screwdriver", /obj/item/weapon/screwdriver, 1, time = 12),
+	new /datum/stack_recipe("wrench", /obj/item/weapon/wrench, 1, time = 6),
+	new /datum/stack_recipe("spade", /obj/item/weapon/shovel/spade, 2, time = 12),
+	new /datum/stack_recipe("bolt", /obj/item/weapon/arrow, 1, time = 6)
+)
 
 /obj/item/stack/rods
 	name = "metal rod"

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -3,11 +3,12 @@
 	desc = "A lightweight support lattice."
 	icon = 'icons/obj/smooth/lattice.dmi'
 	icon_state = "lattice"
-	density = 0
-	anchored = 1.0
+	density = FALSE
+	anchored = TRUE
 	w_class = 3
 	layer = 2.3 //under pipes
 	//	flags = CONDUCT
+	var/restrict_placement = TRUE
 	smooth = SMOOTH_MORE
 	canSmoothWith = list(
 		/obj/structure/lattice,
@@ -21,11 +22,10 @@
 
 /obj/structure/lattice/Initialize()
 	. = ..()
-///// Z-Level Stuff
-	if(!(istype(src.loc, /turf/space) || istype(src.loc, /turf/simulated/open) || istype(src.loc, /turf/simulated/floor/asteroid)))
-///// Z-Level Stuff
-		return INITIALIZE_HINT_QDEL
-	for(var/obj/structure/lattice/LAT in src.loc)
+	if (restrict_placement)
+		if(!(istype(loc, /turf/space) || istype(loc, /turf/simulated/open) || istype(loc, /turf/simulated/floor/asteroid)))
+			return INITIALIZE_HINT_QDEL
+	for(var/obj/structure/lattice/LAT in loc)
 		if(LAT != src)
 			qdel(LAT)
 
@@ -38,7 +38,6 @@
 	return
 
 /obj/structure/lattice/attackby(obj/item/C as obj, mob/user as mob)
-
 	if (istype(C, /obj/item/stack/tile/floor))
 		var/turf/T = get_turf(src)
 		T.attackby(C, user) //BubbleWrap - hand this off to the underlying turf instead
@@ -66,12 +65,28 @@
 	smooth = SMOOTH_TRUE
 	canSmoothWith = null
 
-/obj/structure/lattice/catwalk/Initialize()
-	. = ..()
-///// Z-Level Stuff
-	if(!(istype(src.loc, /turf/space) || istype(src.loc, /turf/simulated/open) || istype(src.loc, /turf/simulated/floor/asteroid)))
-///// Z-Level Stuff
-		return INITIALIZE_HINT_QDEL
-	for(var/obj/structure/lattice/catwalk/LAT in src.loc)
-		if(LAT != src)
-			qdel(LAT)
+// Special catwalk that can be placed on regular flooring.
+/obj/structure/lattice/catwalk/indoor
+	desc = "A floor-mounted catwalk designed to protect pipes & station wiring from passing feet."
+	restrict_placement = FALSE
+	can_be_unanchored = TRUE
+	layer = 2.7	// Above wires.
+
+/obj/structure/lattice/catwalk/attackby(obj/item/C, mob/user)
+	if (iswelder(C))
+		var/obj/item/weapon/weldingtool/WT = C
+		if (do_after(user, 5, act_target = src) && WT.remove_fuel(1, user))
+			user << "<span class='notice'>You slice apart [src].</span>"
+			playsound(src, 'sound/items/Welder.ogg', 50, 1)
+			new /obj/item/stack/rods{amount = 3}(loc)
+			qdel(src)
+
+/obj/structure/lattice/catwalk/indoor/attackby(obj/item/C, mob/user)
+	if (isscrewdriver(C))
+		anchored = !anchored
+		user << "<span class='notice'>You [anchored ? "" : "un"]anchor [src]."
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
+		queue_smooth(src)
+		queue_smooth_neighbors(src)
+	else
+		..()

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -84,7 +84,7 @@
 /obj/structure/lattice/catwalk/indoor/attackby(obj/item/C, mob/user)
 	if (isscrewdriver(C))
 		anchored = !anchored
-		user << "<span class='notice'>You [anchored ? "" : "un"]anchor [src]."
+		user << "<span class='notice'>You [anchored ? "" : "un"]anchor [src].</span>"
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 		queue_smooth(src)
 		queue_smooth_neighbors(src)


### PR DESCRIPTION
Adds floor-mounted catwalks, a special variant of catwalks that can be placed on regular turfs without deleting themselves.
Constructed with 4 rods from the rod construction menu, and are layered above wiring and power terminals. Can be disassembled with a welder, or (un)anchored with a screwdriver.

![2017-06-21_17-01-49](https://user-images.githubusercontent.com/7097800/27410559-fca5b5ba-56ad-11e7-8a92-6d27db105074.png)

