### PR TITLE
Queued icon update tweaks

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -1,4 +1,4 @@
-#define LIGHTING_INTERVAL       2     // Frequency, in 1/10ths of a second, of the lighting process.
+#define LIGHTING_INTERVAL       1     // Frequency, in 1/10ths of a second, of the lighting process.
 
 #define LIGHTING_HEIGHT         1 // height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone
 #define LIGHTING_ROUND_VALUE    1 / 200 //Value used to round lumcounts, values smaller than 1/255 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.

--- a/code/__defines/subsystem-defines.dm
+++ b/code/__defines/subsystem-defines.dm
@@ -59,7 +59,7 @@
 
 // -- SSopenturf --
 #define CHECK_OO_EXISTENCE(OO) if (OO && !istype(OO.loc, /turf/simulated/open)) { qdel(OO); }
-#define UPDATE_OO_IF_PRESENT CHECK_OO_EXISTENCE(bound_overlay); if (bound_overlay) { update_oo(); }
+#define UPDATE_OO_IF_PRESENT CHECK_OO_EXISTENCE(bound_overlay); if (bound_overlay) { update_above(); }
 
 // -- SSfalling --
 #define ADD_FALLING_ATOM(atom) if (!atom.multiz_falling) { atom.multiz_falling = 1; SSfalling.falling[atom] = 0; }

--- a/code/controllers/subsystems/falling.dm
+++ b/code/controllers/subsystems/falling.dm
@@ -8,7 +8,7 @@
 
 /datum/controller/subsystem/falling
 	name = "Falling"
-	flags = SS_NO_INIT | SS_TICKER | SS_KEEP_TIMING
+	flags = SS_NO_INIT
 	wait = 1
 
 	var/list/falling = list()

--- a/code/controllers/subsystems/icon_updates.dm
+++ b/code/controllers/subsystems/icon_updates.dm
@@ -32,6 +32,7 @@
 
 		A.icon_update_queued = FALSE
 		A.update_icon()
+		A.update_above()
 		A.last_icon_update = world.time
 
 		if (no_mc_tick)
@@ -40,8 +41,8 @@
 			return
 
 /atom
-	var/last_icon_update
-	var/icon_update_queued
+	var/tmp/last_icon_update
+	var/tmp/icon_update_queued
 	var/icon_update_delay
 
 /atom/proc/update_icon()

--- a/code/controllers/subsystems/openturf.dm
+++ b/code/controllers/subsystems/openturf.dm
@@ -182,7 +182,7 @@
 			OO.layer = 1e6
 
 		if (OO.bound_overlay)	// If we have a bound overlay, queue it too.
-			OO.update_oo()
+			OO.update_above()
 
 		if (no_mc_tick)
 			CHECK_TICK

--- a/code/game/machinery/crusher_piston.dm
+++ b/code/game/machinery/crusher_piston.dm
@@ -167,7 +167,7 @@
 			holographic_overlay(src, icon, "[asmtype]-overlay-green")
 	if(panel_open)
 		add_overlay("[asmtype]-hatch")
-	update_oo()	
+	update_above()	
 
 /obj/machinery/crusher_base/power_change()
 	..()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -626,8 +626,7 @@ About the new airlock wires panel:
 			set_light(0)
 			has_set_boltlight = FALSE
 
-	update_oo()
-	return
+	update_above()
 
 /obj/machinery/door/airlock/do_animate(animation)
 	switch(animation)

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -120,7 +120,7 @@
 #endif 
 
 	if (bound_overlay)
-		update_oo()
+		update_above()
 
 // Variety of overrides so the overlays don't get affected by weird things.
 

--- a/code/modules/multiz/openspace.dm
+++ b/code/modules/multiz/openspace.dm
@@ -1,3 +1,5 @@
+/atom/proc/update_above()
+
 /turf
 	// Reference to any open turf that might be above us to speed up atom Entered() updates.
 	var/tmp/turf/simulated/open/above
@@ -11,6 +13,10 @@
 /turf/Destroy()
 	above = null
 	return ..()
+
+/turf/update_above()
+	if (istype(above))
+		above.update_icon()
 
 /atom/movable
 	var/tmp/atom/movable/openspace/overlay/bound_overlay	// The overlay that is directly mirroring us that we proxy movement to.
@@ -32,7 +38,7 @@
 		// The overlay will handle cleaning itself up on non-openspace turfs.
 		bound_overlay.forceMove(get_step(src, UP))
 
-/atom/movable/proc/update_oo()
+/atom/movable/update_above()
 	if (!bound_overlay)
 		return
 


### PR DESCRIPTION
changes:
- Queued icon updates now update the atom's associated openspace overlay or openturf.
- `update_oo()` renamed to `update_above()`, and moved up to `/atom`. Only meaningful on `/turf` (updates above openturf if present) and `/atom/movable` (updates associated OO if present).
- Demoted SSfalling to a regular subsystem (1ds tickrate).
- Increased SSlighting's tickrate from 2 ds to 1 ds.