### PR TITLE
Parallax-related performance tweaks

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -90,7 +90,6 @@
 /datum/hud/proc/update_parallax()
 	var/client/C = mymob.client
 	if(C.prefs.parallax_togs & PARALLAX_SPACE)
-		SSparallax.parallax_on_clients |= C
 		for(var/obj/screen/parallax/bgobj in C.parallax)
 			C.screen |= bgobj
 		C.screen |= C.parallax_master
@@ -106,7 +105,6 @@
 	else
 		for(var/obj/screen/parallax/bgobj in C.parallax)
 			C.screen -= bgobj
-		SSparallax.parallax_on_clients -= C
 		C.screen -= C.parallax_master
 		C.screen -= C.parallax_spacemaster
 		C.parallax_dustmaster.color = list(0,0,0,0)

--- a/code/controllers/subsystems/parallax.dm
+++ b/code/controllers/subsystems/parallax.dm
@@ -7,9 +7,7 @@ var/datum/controller/subsystem/parallax/SSparallax
 	init_order = SS_INIT_PARALLAX
 	flags = SS_NO_FIRE
 
-	var/list/parallax_on_clients = list()
 	var/list/parallax_icon[(GRID_WIDTH**2)*3]
-	var/space_color = "#050505"
 	var/parallax_initialized = 0
 
 /datum/controller/subsystem/parallax/New()
@@ -18,8 +16,5 @@ var/datum/controller/subsystem/parallax/SSparallax
 /datum/controller/subsystem/parallax/Initialize(timeofday)
 	create_global_parallax_icons()
 	..(timeofday, TRUE)
-
-/datum/controller/subsystem/parallax/stat_entry()
-	..("C:[parallax_on_clients.len]")
 
 #undef GRID_WIDTH

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -17,6 +17,7 @@
 	//Also used on holdable mobs for the same info related to their held version
 
 	var/can_hold_mob = FALSE
+	var/list/contained_mobs
 
 // We don't really need this, and apparently defining it slows down GC.
 /*/atom/movable/Del()
@@ -203,8 +204,7 @@
 	anchored = 1
 
 /atom/movable/overlay/New()
-	for(var/x in src.verbs)
-		src.verbs -= x
+	verbs.Cut()
 	..()
 
 /atom/movable/overlay/attackby(a, b)
@@ -267,15 +267,17 @@ var/list/accessible_z_levels = list("8" = 5, "9" = 10, "7" = 15, "2" = 60)
 // Parallax stuff.
 
 /atom/movable/proc/update_client_hook(atom/destination)
-	if(locate(/mob) in src)
-		for(var/client/C in SSparallax.parallax_on_clients)
-			if((get_turf(C.eye) == destination) && (C.mob.hud_used))
-				C.mob.hud_used.update_parallax_values()
+	. = isturf(destination)
+	if (.)
+		for (var/thing in contained_mobs)
+			var/mob/M = thing
+			if (!M.client || !M.hud_used)
+				continue
+
+			if (get_turf(M.client.eye) == destination)
+				M.hud_used.update_parallax_values()
 
 /mob/update_client_hook(atom/destination)
-	if(locate(/mob) in src)
-		for(var/client/C in SSparallax.parallax_on_clients)
-			if((get_turf(C.eye) == destination) && (C.mob.hud_used))
-				C.mob.hud_used.update_parallax_values()
-	else if(client && hud_used)
+	. = ..()
+	if (. && hud_used && get_turf(client.eye) == destination)
 		hud_used.update_parallax_values()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1170,6 +1170,18 @@ mob/proc/yank_out_object()
 	else
 		return ..()
 
+/mob/forceMove(atom/dest)
+	var/atom/movable/AM
+	if (dest != loc && istype(dest, /atom/movable))
+		AM = dest
+		LAZYADD(AM.contained_mobs, src)
+	
+	if (istype(loc, /atom/movable))
+		AM = loc
+		LAZYREMOVE(AM.contained_mobs, src)
+	
+	. = ..()
+
 /mob/verb/northfaceperm()
 	set hidden = 1
 	set_face_dir(client.client_dir(NORTH))


### PR DESCRIPTION
Experimental tweaks to how parallax's movement hooks work; the current ones appear to be fairly expensive for _all_ movable movement, doing `locate(/mob) in src` on every `forceMove()`. This PR creates a new lazylist (`contained_mobs`) containing a list of every mob directly contained by an object. `contained_mobs` is updated on `mob/forceMove()`. 

Not sure how to handle mobs located deeper than directly inside an object.

Only alternative to this I see is to make SSparallax tick.