### PR TITLE
Minor atmos sanity refactor

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -46,17 +46,18 @@ Pipelines + Other Objects -> Pipe network
 		pipe_color = null
 	..()
 
-/obj/machinery/atmospherics/proc/initialize()
+/obj/machinery/atmospherics/proc/atmos_init()
 
-// Atmos machines are snowflakes and call initialize on themselves.
-// Do not refactor initialize() to Initialize() unless you know what you are doing.
+
+// atmos_init() and Initialize() must be separate, as atmos_init() can be called multiple times after the machine has been initialized.
+
 /obj/machinery/atmospherics/Initialize(mapload, ...)
 	if (no_special_init)
 		return ..()
 
 	. = ..()
 	if (mapload)
-		initialize()
+		atmos_init()
 
 /obj/machinery/atmospherics/attackby(atom/A, mob/user as mob)
 	if(istype(A, /obj/item/device/pipe_painter))

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -57,7 +57,7 @@ obj/machinery/atmospherics/binary
 
 		return ..()
 
-	initialize()
+	atmos_init()
 		if(node1 && node2) return
 
 		var/node2_connect = dir

--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -101,13 +101,13 @@
 			else if(dir & (EAST|WEST))
 				initialize_directions = EAST|WEST
 
-			initialize()
+			atmos_init()
 			build_network()
 			if (node1)
-				node1.initialize()
+				node1.atmos_init()
 				node1.build_network()
 			if (node2)
-				node2.initialize()
+				node2.atmos_init()
 				node2.build_network()
 		else
 			if(node1)

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -189,7 +189,7 @@
 
 	return 1
 
-/obj/machinery/atmospherics/binary/dp_vent_pump/initialize()
+/obj/machinery/atmospherics/binary/dp_vent_pump/atmos_init()
 	..()
 	if(frequency)
 		set_frequency(frequency)

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -123,7 +123,7 @@
 
 	return 1
 
-/obj/machinery/atmospherics/binary/passive_gate/initialize()
+/obj/machinery/atmospherics/binary/passive_gate/atmos_init()
 	..()
 	if(frequency)
 		set_frequency(frequency)

--- a/code/ATMOSPHERICS/components/binary_devices/pipeturbine.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pipeturbine.dm
@@ -96,13 +96,13 @@
 				else if(dir & (EAST|WEST))
 					initialize_directions = NORTH|SOUTH
 
-				initialize()
+				atmos_init()
 				build_network()
 				if (node1)
-					node1.initialize()
+					node1.atmos_init()
 					node1.build_network()
 				if (node2)
-					node2.initialize()
+					node2.atmos_init()
 					node2.build_network()
 			else
 				if(node1)
@@ -154,7 +154,7 @@
 
 		return null
 
-	initialize()
+	atmos_init()
 		if(node1 && node2) return
 
 		var/node2_connect = turn(dir, -90)

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -143,7 +143,7 @@ Thus, the two variables affect pump operation are set in New():
 		ui.open()					// open the new ui window
 		ui.set_auto_update(1)		// auto update every Master Controller tick
 
-/obj/machinery/atmospherics/binary/pump/initialize()
+/obj/machinery/atmospherics/binary/pump/atmos_init()
 	..()
 	if(frequency)
 		set_frequency(frequency)

--- a/code/ATMOSPHERICS/components/omni_devices/_omni_extras.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/_omni_extras.dm
@@ -40,10 +40,10 @@
 /datum/omni_port/proc/connect()
 	if(node)
 		return
-	master.initialize()
+	master.atmos_init()
 	master.build_network()
 	if(node)
-		node.initialize()
+		node.atmos_init()
 		node.build_network()
 
 /datum/omni_port/proc/disconnect()

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -242,7 +242,7 @@
 
 	return ..()
 
-/obj/machinery/atmospherics/omni/initialize()
+/obj/machinery/atmospherics/omni/atmos_init()
 	for(var/datum/omni_port/P in ports)
 		if(P.node || P.mode == 0)
 			continue

--- a/code/ATMOSPHERICS/components/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/portables_connector.dm
@@ -74,7 +74,7 @@
 
 	return ..()
 
-/obj/machinery/atmospherics/portables_connector/initialize()
+/obj/machinery/atmospherics/portables_connector/atmos_init()
 	if(node) return
 
 	var/node_connect = dir

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -124,7 +124,7 @@
 
 	return 1
 
-/obj/machinery/atmospherics/trinary/filter/initialize()
+/obj/machinery/atmospherics/trinary/filter/atmos_init()
 	set_frequency(frequency)
 	..()
 
@@ -249,7 +249,7 @@ obj/machinery/atmospherics/trinary/filter/m_filter/New()
 		if(WEST)
 			initialize_directions = WEST|SOUTH|EAST
 
-/obj/machinery/atmospherics/trinary/filter/m_filter/initialize()
+/obj/machinery/atmospherics/trinary/filter/m_filter/atmos_init()
 	set_frequency(frequency)
 
 	if(node1 && node2 && node3) return

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -195,7 +195,7 @@ obj/machinery/atmospherics/trinary/mixer/t_mixer/New()
 		if(WEST)
 			initialize_directions = WEST|NORTH|SOUTH
 
-obj/machinery/atmospherics/trinary/mixer/t_mixer/initialize()
+obj/machinery/atmospherics/trinary/mixer/t_mixer/atmos_init()
 	..()
 	if(node1 && node2 && node3) return
 
@@ -241,7 +241,7 @@ obj/machinery/atmospherics/trinary/mixer/m_mixer/New()
 		if(WEST)
 			initialize_directions = WEST|SOUTH|EAST
 
-obj/machinery/atmospherics/trinary/mixer/m_mixer/initialize()
+obj/machinery/atmospherics/trinary/mixer/m_mixer/atmos_init()
 	..()
 	if(node1 && node2 && node3) return
 

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -71,7 +71,7 @@ obj/machinery/atmospherics/trinary
 
 		return ..()
 
-	initialize()
+	atmos_init()
 		if(node1 && node2 && node3) return
 
 		var/node1_connect = turn(dir, -180)

--- a/code/ATMOSPHERICS/components/tvalve.dm
+++ b/code/ATMOSPHERICS/components/tvalve.dm
@@ -182,11 +182,8 @@
 /obj/machinery/atmospherics/tvalve/machinery_process()
 	..()
 	. = PROCESS_KILL
-	//machines.Remove(src)
 
-	return
-
-/obj/machinery/atmospherics/tvalve/initialize()
+/obj/machinery/atmospherics/tvalve/atmos_init()
 	var/node1_dir
 	var/node2_dir
 	var/node3_dir
@@ -320,7 +317,7 @@
 
 
 
-/obj/machinery/atmospherics/tvalve/digital/initialize()
+/obj/machinery/atmospherics/tvalve/digital/atmos_init()
 	..()
 	if(frequency)
 		set_frequency(frequency)
@@ -384,7 +381,7 @@
 		if(WEST)
 			initialize_directions = EAST|WEST|SOUTH
 
-/obj/machinery/atmospherics/tvalve/mirrored/initialize()
+/obj/machinery/atmospherics/tvalve/mirrored/atmos_init()
 	var/node1_dir
 	var/node2_dir
 	var/node3_dir
@@ -458,7 +455,7 @@
 	if(frequency)
 		radio_connection = SSradio.add_object(src, frequency, RADIO_ATMOSIA)
 
-/obj/machinery/atmospherics/tvalve/mirrored/digital/initialize()
+/obj/machinery/atmospherics/tvalve/mirrored/digital/atmos_init()
 	..()
 	if(frequency)
 		set_frequency(frequency)

--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -32,7 +32,7 @@
 	component_parts += new /obj/item/stack/cable_coil(src, 2)
 	RefreshParts()
 
-/obj/machinery/atmospherics/unary/freezer/initialize()
+/obj/machinery/atmospherics/unary/freezer/atmos_init()
 	if(node)
 		return
 

--- a/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
@@ -18,7 +18,7 @@
 
 		return
 
-	initialize()
+	atmos_init()
 		if(!partner)
 			var/partner_connect = turn(dir,180)
 

--- a/code/ATMOSPHERICS/components/unary/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_source.dm
@@ -33,7 +33,7 @@
 
 	RefreshParts()
 
-/obj/machinery/atmospherics/unary/heater/initialize()
+/obj/machinery/atmospherics/unary/heater/atmos_init()
 	if(node)
 		return
 

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -118,7 +118,7 @@
 
 	return 1
 
-/obj/machinery/atmospherics/unary/outlet_injector/initialize()
+/obj/machinery/atmospherics/unary/outlet_injector/atmos_init()
 	..()
 
 	set_frequency(frequency)

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -39,7 +39,7 @@
 
 		return ..()
 
-	initialize()
+	atmos_init()
 		if(node) return
 
 		var/node_connect = dir

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -89,10 +89,10 @@
 	if(frequency)
 		radio_connection = register_radio(src, frequency, frequency, radio_filter_in)
 
-	initialize()
+	atmos_init()
 
 // Different from the above.
-/obj/machinery/atmospherics/unary/vent_pump/initialize()
+/obj/machinery/atmospherics/unary/vent_pump/atmos_init()
 	..()
 	broadcast_status()
 

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -53,9 +53,9 @@
 	if (frequency)
 		set_frequency(frequency)
 	
-	initialize()
+	atmos_init()
 
-/obj/machinery/atmospherics/unary/vent_scrubber/initialize()
+/obj/machinery/atmospherics/unary/vent_scrubber/atmos_init()
 	..()
 	broadcast_status()
 

--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -140,7 +140,7 @@
 	..()
 	return PROCESS_KILL
 
-/obj/machinery/atmospherics/valve/initialize()
+/obj/machinery/atmospherics/valve/atmos_init()
 	normalize_dir()
 
 	var/node1_dir
@@ -275,7 +275,7 @@
 	if(frequency)
 		radio_connection = SSradio.add_object(src, frequency, RADIO_ATMOSIA)
 
-/obj/machinery/atmospherics/valve/digital/initialize()
+/obj/machinery/atmospherics/valve/digital/atmos_init()
 	..()
 	if(frequency)
 		set_frequency(frequency)

--- a/code/ATMOSPHERICS/he_pipes.dm
+++ b/code/ATMOSPHERICS/he_pipes.dm
@@ -23,7 +23,7 @@ obj/machinery/atmospherics/pipe/simple/heat_exchanging
 	// BubbleWrap END
 		color = "#404040" //we don't make use of the fancy overlay system for colours, use this to set the default.
 
-	initialize()
+	atmos_init()
 		normalize_dir()
 		var/node1_dir
 		var/node2_dir
@@ -131,7 +131,7 @@ obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction
 				initialize_directions_he = WEST
 	// BubbleWrap END
 
-	initialize()
+	atmos_init()
 		for(var/obj/machinery/atmospherics/target in get_step(src,initialize_directions))
 			if(target.initialize_directions & get_dir(target,src))
 				node1 = target

--- a/code/ATMOSPHERICS/mainspipe.dm
+++ b/code/ATMOSPHERICS/mainspipe.dm
@@ -103,7 +103,7 @@ obj/machinery/atmospherics/mains_pipe
 		disconnect()
 		return ..()
 
-	initialize()
+	atmos_init()
 		for(var/i = 1 to nodes.len)
 			var/obj/machinery/atmospherics/mains_pipe/node = nodes[i]
 			if(node)
@@ -157,7 +157,7 @@ obj/machinery/atmospherics/mains_pipe/simple
 			var/have_node2 = nodes[2]?1:0
 			icon_state = "exposed[have_node1][have_node2][invisibility ? "-f" : "" ]"
 
-	initialize()
+	atmos_init()
 		normalize_dir()
 		var/node1_dir
 		var/node2_dir
@@ -205,7 +205,7 @@ obj/machinery/atmospherics/mains_pipe/manifold
 		..()
 		initialize_mains_directions = (NORTH|SOUTH|EAST|WEST) & ~dir
 
-	initialize()
+	atmos_init()
 		var/connect_directions = initialize_mains_directions
 
 		for(var/direction in cardinal)
@@ -269,7 +269,7 @@ obj/machinery/atmospherics/mains_pipe/manifold4w
 		nodes.len = 4
 		..()
 
-	initialize()
+	atmos_init()
 		for(var/obj/machinery/atmospherics/mains_pipe/target in get_step(src,NORTH))
 			if(target.initialize_mains_directions & get_dir(target,src))
 				nodes[1] = target
@@ -321,7 +321,7 @@ obj/machinery/atmospherics/mains_pipe/split
 		initialize_mains_directions = turn(dir, 90) | turn(dir, -90)
 		initialize_directions = dir // actually have a normal connection too
 
-	initialize()
+	atmos_init()
 		var/node1_dir
 		var/node2_dir
 		var/node3_dir
@@ -422,7 +422,7 @@ obj/machinery/atmospherics/mains_pipe/split3
 		initialize_mains_directions = dir
 		initialize_directions = cardinal & ~dir // actually have a normal connection too
 
-	initialize()
+	atmos_init()
 		var/node1_dir
 		var/supply_node_dir
 		var/scrubbers_node_dir
@@ -516,7 +516,7 @@ obj/machinery/atmospherics/mains_pipe/cap
 	update_icon()
 		icon_state = "cap[invisibility ? "-f" : ""]"
 
-	initialize()
+	atmos_init()
 		for(var/obj/machinery/atmospherics/mains_pipe/target in get_step(src,dir))
 			if(target.initialize_mains_directions & get_dir(target,src))
 				nodes[1] = target
@@ -569,7 +569,7 @@ obj/machinery/atmospherics/mains_pipe/valve
 		else
 			icon_state = "[hide?"h":""]mvalve[open]"
 
-	initialize()
+	atmos_init()
 		normalize_dir()
 		var/node1_dir
 		var/node2_dir
@@ -607,7 +607,7 @@ obj/machinery/atmospherics/mains_pipe/valve
 		open = 1
 		update_icon()
 
-		initialize()
+		atmos_init()
 
 		return 1
 
@@ -666,7 +666,7 @@ obj/machinery/atmospherics/mains_pipe/valve
 		var/id = null
 		var/datum/radio_frequency/radio_connection
 
-		initialize()
+		atmos_init()
 			..()
 			if(frequency)
 				set_frequency(frequency)

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -272,7 +272,7 @@
 /obj/machinery/atmospherics/pipe/simple/update_underlays()
 	return
 
-/obj/machinery/atmospherics/pipe/simple/initialize()
+/obj/machinery/atmospherics/pipe/simple/atmos_init()
 	normalize_dir()
 	var/node1_dir
 	var/node2_dir
@@ -544,7 +544,7 @@
 	..()
 	update_icon()
 
-/obj/machinery/atmospherics/pipe/manifold/initialize()
+/obj/machinery/atmospherics/pipe/manifold/atmos_init()
 	var/connect_directions = (NORTH|SOUTH|EAST|WEST)&(~dir)
 
 	for(var/direction in cardinal)
@@ -818,7 +818,7 @@
 		invisibility = i ? 101 : 0
 	update_icon()
 
-/obj/machinery/atmospherics/pipe/manifold4w/initialize()
+/obj/machinery/atmospherics/pipe/manifold4w/atmos_init()
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,1))
 		if(target.initialize_directions & 2)
@@ -998,7 +998,7 @@
 	cut_overlays()
 	add_overlay(icon_manager.get_atmos_icon("pipe", , pipe_color, "cap"))
 
-/obj/machinery/atmospherics/pipe/cap/initialize()
+/obj/machinery/atmospherics/pipe/cap/atmos_init()
 	for(var/obj/machinery/atmospherics/target in get_step(src, dir))
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
@@ -1103,7 +1103,7 @@
 /obj/machinery/atmospherics/pipe/tank/hide()
 	update_underlays()
 
-/obj/machinery/atmospherics/pipe/tank/initialize()
+/obj/machinery/atmospherics/pipe/tank/atmos_init()
 	var/connect_direction = dir
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,connect_direction))
@@ -1273,7 +1273,7 @@
 	else
 		icon_state = "exposed"
 
-/obj/machinery/atmospherics/pipe/vent/initialize()
+/obj/machinery/atmospherics/pipe/vent/atmos_init()
 	var/connect_direction = dir
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,connect_direction))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -33,7 +33,7 @@
 		beaker.loc = get_step(loc, SOUTH) //Beaker is carefully ejected from the wreckage of the cryotube
 	return ..()
 
-/obj/machinery/atmospherics/unary/cryo_cell/initialize()
+/obj/machinery/atmospherics/unary/cryo_cell/atmos_init()
 	if(node) return
 	var/node_connect = dir
 	for(var/obj/machinery/atmospherics/target in get_step(src,node_connect))

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -462,16 +462,16 @@ Buildable meters
 			P.initialize_directions = pipe_dir
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_SUPPLY_STRAIGHT, PIPE_SUPPLY_BENT)
@@ -481,16 +481,16 @@ Buildable meters
 			P.initialize_directions = pipe_dir
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_SCRUBBERS_STRAIGHT, PIPE_SCRUBBERS_BENT)
@@ -500,16 +500,16 @@ Buildable meters
 			P.initialize_directions = pipe_dir
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_UNIVERSAL)
@@ -519,16 +519,16 @@ Buildable meters
 			P.initialize_directions = pipe_dir
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_HE_STRAIGHT, PIPE_HE_BENT)
@@ -536,16 +536,16 @@ Buildable meters
 			P.set_dir(src.dir)
 			P.initialize_directions = pipe_dir //this var it's used to know if the pipe is bent or not
 			P.initialize_directions_he = pipe_dir
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_CONNECTOR)		// connector
@@ -556,10 +556,10 @@ Buildable meters
 				C.name = pipename
 			var/turf/T = C.loc
 			C.level = !T.is_plating() ? 2 : 1
-			C.initialize()
+			C.atmos_init()
 			C.build_network()
 			if (C.node)
-				C.node.initialize()
+				C.node.atmos_init()
 				C.node.build_network()
 
 
@@ -571,19 +571,19 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (QDELETED(M))
 				usr << pipefailtext
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
 				M.node3.build_network()
 
 		if(PIPE_SUPPLY_MANIFOLD)		//manifold
@@ -594,19 +594,19 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (!M)
 				usr << "There's nothing to connect this manifold to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
 				M.node3.build_network()
 
 		if(PIPE_SCRUBBERS_MANIFOLD)		//manifold
@@ -617,19 +617,19 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (!M)
 				usr << "There's nothing to connect this manifold to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
 				M.node3.build_network()
 
 		if(PIPE_MANIFOLD4W)		//4-way manifold
@@ -640,22 +640,22 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (QDELETED(M))
 				usr << pipefailtext
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
 				M.node3.build_network()
 			if (M.node4)
-				M.node4.initialize()
+				M.node4.atmos_init()
 				M.node4.build_network()
 
 		if(PIPE_SUPPLY_MANIFOLD4W)		//4-way manifold
@@ -667,22 +667,22 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (!M)
 				usr << "There's nothing to connect this manifold to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
 				M.node3.build_network()
 			if (M.node4)
-				M.node4.initialize()
+				M.node4.atmos_init()
 				M.node4.build_network()
 
 		if(PIPE_SCRUBBERS_MANIFOLD4W)		//4-way manifold
@@ -694,22 +694,22 @@ Buildable meters
 			//M.New()
 			var/turf/T = M.loc
 			M.level = !T.is_plating() ? 2 : 1
-			M.initialize()
+			M.atmos_init()
 			if (!M)
 				usr << "There's nothing to connect this manifold to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			M.build_network()
 			if (M.node1)
-				M.node1.initialize()
+				M.node1.atmos_init()
 				M.node1.build_network()
 			if (M.node2)
-				M.node2.initialize()
+				M.node2.atmos_init()
 				M.node2.build_network()
 			if (M.node3)
-				M.node3.initialize()
+				M.node3.atmos_init()
 				M.node3.build_network()
 			if (M.node4)
-				M.node4.initialize()
+				M.node4.atmos_init()
 				M.node4.build_network()
 
 		if(PIPE_JUNCTION)
@@ -717,16 +717,16 @@ Buildable meters
 			P.set_dir(src.dir)
 			P.initialize_directions = src.get_pdir()
 			P.initialize_directions_he = src.get_hdir()
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext //"There's nothing to connect this pipe to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_UVENT)		//unary vent
@@ -737,10 +737,10 @@ Buildable meters
 				V.name = pipename
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
-			V.initialize()
+			V.atmos_init()
 			V.build_network()
 			if (V.node)
-				V.node.initialize()
+				V.node.atmos_init()
 				V.node.build_network()
 
 
@@ -752,15 +752,15 @@ Buildable meters
 				V.name = pipename
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
-			V.initialize()
+			V.atmos_init()
 			V.build_network()
 			if (V.node1)
 //					world << "[V.node1.name] is connected to valve, forcing it to update its nodes."
-				V.node1.initialize()
+				V.node1.atmos_init()
 				V.node1.build_network()
 			if (V.node2)
 //					world << "[V.node2.name] is connected to valve, forcing it to update its nodes."
-				V.node2.initialize()
+				V.node2.atmos_init()
 				V.node2.build_network()
 
 		if(PIPE_PUMP)		//gas pump
@@ -771,13 +771,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_GAS_FILTER)		//gas filter
@@ -788,16 +788,16 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 			if (P.node3)
-				P.node3.initialize()
+				P.node3.atmos_init()
 				P.node3.build_network()
 
 		if(PIPE_GAS_MIXER)		//gas mixer
@@ -808,16 +808,16 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 			if (P.node3)
-				P.node3.initialize()
+				P.node3.atmos_init()
 				P.node3.build_network()
 
 		if(PIPE_GAS_FILTER_M)		//gas filter mirrored
@@ -828,16 +828,16 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 			if (P.node3)
-				P.node3.initialize()
+				P.node3.atmos_init()
 				P.node3.build_network()
 
 		if(PIPE_GAS_MIXER_T)		//gas mixer-t
@@ -848,16 +848,16 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 			if (P.node3)
-				P.node3.initialize()
+				P.node3.atmos_init()
 				P.node3.build_network()
 
 		if(PIPE_GAS_MIXER_M)		//gas mixer mirrored
@@ -868,16 +868,16 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 			if (P.node3)
-				P.node3.initialize()
+				P.node3.atmos_init()
 				P.node3.build_network()
 
 		if(PIPE_SCRUBBER)		//scrubber
@@ -888,10 +888,10 @@ Buildable meters
 				S.name = pipename
 			var/turf/T = S.loc
 			S.level = !T.is_plating() ? 2 : 1
-			S.initialize()
+			S.atmos_init()
 			S.build_network()
 			if (S.node)
-				S.node.initialize()
+				S.node.atmos_init()
 				S.node.build_network()
 
 		if(PIPE_INSULATED_STRAIGHT, PIPE_INSULATED_BENT)
@@ -900,16 +900,16 @@ Buildable meters
 			P.initialize_directions = pipe_dir
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			if (QDELETED(P))
 				usr << pipefailtext
 				return 1
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_MTVALVE)		//manual t-valve
@@ -920,16 +920,16 @@ Buildable meters
 				V.name = pipename
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
-			V.initialize()
+			V.atmos_init()
 			V.build_network()
 			if (V.node1)
-				V.node1.initialize()
+				V.node1.atmos_init()
 				V.node1.build_network()
 			if (V.node2)
-				V.node2.initialize()
+				V.node2.atmos_init()
 				V.node2.build_network()
 			if (V.node3)
-				V.node3.initialize()
+				V.node3.atmos_init()
 				V.node3.build_network()
 
 		if(PIPE_MTVALVEM)		//manual t-valve
@@ -940,46 +940,46 @@ Buildable meters
 				V.name = pipename
 			var/turf/T = V.loc
 			V.level = !T.is_plating() ? 2 : 1
-			V.initialize()
+			V.atmos_init()
 			V.build_network()
 			if (V.node1)
-				V.node1.initialize()
+				V.node1.atmos_init()
 				V.node1.build_network()
 			if (V.node2)
-				V.node2.initialize()
+				V.node2.atmos_init()
 				V.node2.build_network()
 			if (V.node3)
-				V.node3.initialize()
+				V.node3.atmos_init()
 				V.node3.build_network()
 
 		if(PIPE_CAP)
 			var/obj/machinery/atmospherics/pipe/cap/C = new(src.loc)
 			C.set_dir(dir)
 			C.initialize_directions = pipe_dir
-			C.initialize()
+			C.atmos_init()
 			C.build_network()
 			if(C.node)
-				C.node.initialize()
+				C.node.atmos_init()
 				C.node.build_network()
 
 		if(PIPE_SUPPLY_CAP)
 			var/obj/machinery/atmospherics/pipe/cap/hidden/supply/C = new(src.loc)
 			C.set_dir(dir)
 			C.initialize_directions = pipe_dir
-			C.initialize()
+			C.atmos_init()
 			C.build_network()
 			if(C.node)
-				C.node.initialize()
+				C.node.atmos_init()
 				C.node.build_network()
 
 		if(PIPE_SCRUBBERS_CAP)
 			var/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers/C = new(src.loc)
 			C.set_dir(dir)
 			C.initialize_directions = pipe_dir
-			C.initialize()
+			C.atmos_init()
 			C.build_network()
 			if(C.node)
-				C.node.initialize()
+				C.node.atmos_init()
 				C.node.build_network()
 
 		if(PIPE_PASSIVE_GATE)		//passive gate
@@ -990,13 +990,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_VOLUME_PUMP)		//volume pump
@@ -1007,13 +1007,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 
 		if(PIPE_HEAT_EXCHANGE)		// heat exchanger
@@ -1024,10 +1024,10 @@ Buildable meters
 				C.name = pipename
 			var/turf/T = C.loc
 			C.level = !T.is_plating() ? 2 : 1
-			C.initialize()
+			C.atmos_init()
 			C.build_network()
 			if (C.node)
-				C.node.initialize()
+				C.node.atmos_init()
 				C.node.build_network()
 ///// Z-Level stuff
 		if(PIPE_UP)
@@ -1038,13 +1038,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 		if(PIPE_DOWN)
 			var/obj/machinery/atmospherics/pipe/zpipe/down/P = new(src.loc)
@@ -1054,13 +1054,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 		if(PIPE_SUPPLY_UP)
 			var/obj/machinery/atmospherics/pipe/zpipe/up/supply/P = new(src.loc)
@@ -1070,13 +1070,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 		if(PIPE_SUPPLY_DOWN)
 			var/obj/machinery/atmospherics/pipe/zpipe/down/supply/P = new(src.loc)
@@ -1086,13 +1086,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 		if(PIPE_SCRUBBERS_UP)
 			var/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers/P = new(src.loc)
@@ -1102,13 +1102,13 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 		if(PIPE_SCRUBBERS_DOWN)
 			var/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers/P = new(src.loc)
@@ -1118,26 +1118,26 @@ Buildable meters
 				P.name = pipename
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 			if (P.node1)
-				P.node1.initialize()
+				P.node1.atmos_init()
 				P.node1.build_network()
 			if (P.node2)
-				P.node2.initialize()
+				P.node2.atmos_init()
 				P.node2.build_network()
 ///// Z-Level stuff
 		if(PIPE_OMNI_MIXER)
 			var/obj/machinery/atmospherics/omni/mixer/P = new(loc)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 		if(PIPE_OMNI_FILTER)
 			var/obj/machinery/atmospherics/omni/filter/P = new(loc)
 			var/turf/T = P.loc
 			P.level = !T.is_plating() ? 2 : 1
-			P.initialize()
+			P.atmos_init()
 			P.build_network()
 
 	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)

--- a/code/game/objects/items/weapons/circuitboards/machinery/unary_atmos.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/unary_atmos.dm
@@ -22,10 +22,10 @@
 	//TODO: Move this stuff into the relevant constructor when pipe/construction.dm is cleaned up.
 	U.dir = src.machine_dir
 	U.initialize_directions = src.init_dirs
-	U.initialize()
+	U.atmos_init()
 	U.build_network()
 	if (U.node)
-		U.node.initialize()
+		U.node.atmos_init()
 		U.node.build_network()
 
 /obj/item/weapon/circuitboard/unary_atmos/heater

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -132,7 +132,7 @@
 	travel_direction_name = "up"
 	travel_direction = UP
 
-/obj/machinery/atmospherics/pipe/zpipe/up/initialize()
+/obj/machinery/atmospherics/pipe/zpipe/up/atmos_init()
 	normalize_dir()
 	var/node1_dir
 
@@ -175,7 +175,7 @@
 	travel_direction_name = "down"
 	travel_direction = DOWN
 
-/obj/machinery/atmospherics/pipe/zpipe/down/initialize()
+/obj/machinery/atmospherics/pipe/zpipe/down/atmos_init()
 	normalize_dir()
 	var/node1_dir
 

--- a/code/modules/overmap/ships/engines/thermal.dm
+++ b/code/modules/overmap/ships/engines/thermal.dm
@@ -53,7 +53,7 @@
 	var/effective_pressure = 3000
 	var/datum/ship_engine/thermal/controller
 
-/obj/machinery/atmospherics/unary/engine/initialize()
+/obj/machinery/atmospherics/unary/engine/atmos_init()
 	. = ..()
 	controller = new(src)
 


### PR DESCRIPTION
Renames Atmos machinery's `initialize()` proc to `atmos_init()`, to better distinguish it from atom `Initialize()`.