### PR TITLE
Support - Remove sleep() calls in various Life() chains

### DIFF
--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -134,7 +134,7 @@
 
 	if(target)
 		if(Adjacent(target))
-			UnarmedAttack(target)
+			INVOKE_ASYNC(src, .proc/UnarmedAttack, target)
 			path = list()
 			target = null
 		else

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -173,7 +173,7 @@
 				break
 
 	if(target && get_turf(target) == loc)
-		UnarmedAttack(target)
+		INVOKE_ASYNC(src, .proc/UnarmedAttack, target)
 
 	if(target && get_turf(target) != loc && !path.len)
 		spawn(0)

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -49,7 +49,7 @@
 		if(patient)
 			if(Adjacent(patient))
 				if(!currently_healing)
-					UnarmedAttack(patient)
+					INVOKE_ASYNC(src, .proc/UnarmedAttack, patient)
 			else
 				if(path.len && (get_dist(patient, path[path.len]) > 2)) // We have a path, but it's off
 					path = list()

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -1,8 +1,8 @@
 //This function is for code that is shared by diona nymphs and gestalt
 
-#define TEMP_REGEN_STOP 223//Regen rate scales down linearly from normal to this temperature, stops completely below this value
-#define TEMP_REGEN_NORMAL 288//normal body temperature
-#define TEMP_INCREASE_REGEN_DOUBLE 700//Health regen is increased by 100% (additive) for every increment of this value we are above normal
+#define TEMP_REGEN_STOP 223 //Regen rate scales down linearly from normal to this temperature, stops completely below this value
+#define TEMP_REGEN_NORMAL 288 //normal body temperature
+#define TEMP_INCREASE_REGEN_DOUBLE 700 //Health regen is increased by 100% (additive) for every increment of this value we are above normal
 #define LIFETICK_INTERVAL_LESS	5
 
 #define NYMPH_ABSORB_NUTRITION	650
@@ -12,7 +12,7 @@
 #define REGROW_ENERGY_REQ	40
 
 
-#define LANGUAGE_POINTS_TO_LEARN	3//The number of samples of a language required to learn it
+#define LANGUAGE_POINTS_TO_LEARN	3 //The number of samples of a language required to learn it
 var/list/diona_banned_languages = list(
 	/datum/language/cult,
 	/datum/language/cultcommon,
@@ -21,14 +21,14 @@ var/list/diona_banned_languages = list(
 	/datum/language/binary/drone)
 
 
-/mob/living/carbon/proc/diona_handle_light(var/datum/dionastats/DS)//Carbon is the highest common denominator between gestalts and nymphs. They will share light code
+/mob/living/carbon/proc/diona_handle_light(var/datum/dionastats/DS) //Carbon is the highest common denominator between gestalts and nymphs. They will share light code
 	//if light_organ is non null, then we're working with a gestalt. otherwise nymph
 
 
-	var/light_amount = DS.last_lightlevel//If we're not re-fetching the light level then we'll use a recent cached version
+	var/light_amount = DS.last_lightlevel //If we're not re-fetching the light level then we'll use a recent cached version
 
-	if (life_tick % 2 == 0)//Only fetch the lightlevel every other proc to save performance
-		if (DS.last_location != loc || life_tick % 4 == 0)//Fetch it even less often if we haven't moved since last check
+	if (life_tick % 2 == 0) //Only fetch the lightlevel every other proc to save performance
+		if (DS.last_location != loc || life_tick % 4 == 0) //Fetch it even less often if we haven't moved since last check
 			light_amount = get_lightlevel_diona(DS)
 			DS.last_lightlevel = light_amount
 
@@ -43,7 +43,7 @@ var/list/diona_banned_languages = list(
 	else	//If light is <=0 then it hurts instead
 
 		//var/severity = DS.stored_energy - (DS.stored_energy*2)
-		var/severity = light_amount*-1//Get a positive value which is the severity of the damage
+		var/severity = light_amount*-1 //Get a positive value which is the severity of the damage
 		diona_darkness_damage(severity, DS)
 	diona_handle_lightmessages(DS)
 
@@ -55,18 +55,18 @@ var/list/diona_banned_languages = list(
 
 	var/radiation = total_radiation
 
-	if (radiation && DS.stored_energy < (DS.max_energy * 0.8))//Radiation can provide energy in place of light
+	if (radiation && DS.stored_energy < (DS.max_energy * 0.8)) //Radiation can provide energy in place of light
 		radiation -= 2
 		DS.stored_energy += 2
 
-	radiation -= 0.5//Radiation is gradually wasted if its not used for something
+	radiation -= 0.5 //Radiation is gradually wasted if its not used for something
 
 
 //This proc handles when diona take damage from being in darkness
 /mob/living/carbon/proc/diona_darkness_damage(var/severity, var/datum/dionastats/DS)
 	adjustBruteLoss(severity*DS.trauma_factor)
 	adjustHalLoss(severity*DS.pain_factor, 1)
-	DS.stored_energy = 0//We reset the energy back to zero after calculating the damage. dont want it to go negative
+	DS.stored_energy = 0 //We reset the energy back to zero after calculating the damage. dont want it to go negative
 
 	//If the diona in question is a gestalt, then all the nymphs inside it will suffer damage too
 	if (DS.dionatype == DIONA_WORKER)
@@ -74,8 +74,8 @@ var/list/diona_banned_languages = list(
 			D.adjustBruteLoss(severity*DS.trauma_factor*0.5)
 
 
-#define diona_max_pressure 100//kpa, Highest pressure that has an effect
-#define diona_nutrition_factor 0.5//nutrients we gain per proc at max pressure
+#define diona_max_pressure 100 //kpa, Highest pressure that has an effect
+#define diona_nutrition_factor 0.5 //nutrients we gain per proc at max pressure
 /mob/living/carbon/proc/diona_handle_air(var/datum/dionastats/DS, var/pressure)
 	//Diona don't need to breathe, and can survive happily in a vacuum
 	//But diona gestalts gain nutrition by extracting matter from gases in the air. If a gestalt spends a long time in space or on the asteroid, it may need to actually eat food
@@ -134,7 +134,7 @@ var/list/diona_banned_languages = list(
 		if (CL > 0)
 			if (radiation > 0)
 				value = min(CL, radiation, 2*HF)
-				adjustHalLoss(value*-3,1)//Halloss heals more quickly
+				adjustHalLoss(value*-3,1) //Halloss heals more quickly
 				radiation -= value
 				CL = getHalLoss()
 
@@ -153,7 +153,7 @@ var/list/diona_banned_languages = list(
 				value = min(CL, radiation, 2*HF)
 				adjustBruteLoss(value*-1)
 				radiation -= value
-				CL = getBruteLoss()//After adjusting it, recalculate for the lighthealing
+				CL = getBruteLoss() //After adjusting it, recalculate for the lighthealing
 
 			value = min(CL, DS.stored_energy, 1*HF)
 			adjustBruteLoss(value*-1)
@@ -215,8 +215,8 @@ var/list/diona_banned_languages = list(
 			if (CL > 0)
 				if (radiation > 0)
 					value = min(CL, radiation, 2*HF*LIFETICK_INTERVAL_LESS)
-					adjustCloneLoss(value/-2.5)//Genetic damage, should diona ever suffer it, heals much more slowly.
-					radiation -= value//Most likely the only time they'll cloneloss is escaping from being partially devoured
+					adjustCloneLoss(value/-2.5) //Genetic damage, should diona ever suffer it, heals much more slowly.
+					radiation -= value //Most likely the only time they'll cloneloss is escaping from being partially devoured
 					CL = getCloneLoss()
 
 				value = min(CL, DS.stored_energy, 1*HF*LIFETICK_INTERVAL_LESS)
@@ -286,7 +286,7 @@ var/list/diona_banned_languages = list(
 					limb_exists = 1
 					break
 
-			if (!limb_exists)//We've found a limb which is missing!
+			if (!limb_exists) //We've found a limb which is missing!
 				break
 			else
 				path = null
@@ -294,10 +294,10 @@ var/list/diona_banned_languages = list(
 
 		if (path)
 			if (DS.stored_energy < REGROW_ENERGY_REQ)
-				src << "<span class='danger'>You try to regrow a lost limb, but you lack the energy. Find more light!</span>"
+				to_chat(src, "<span class='danger'>You try to regrow a lost limb, but you lack the energy. Find more light!</span>")
 				return
 			if (nutrition < REGROW_FOOD_REQ)
-				src << "<span class='danger'>You try to regrow a lost limb, but you lack the biomass. Find some food!</span>"
+				to_chat(src, "<span class='danger'>You try to regrow a lost limb, but you lack the biomass. Find some food!</span>")
 				return
 			DS.stored_energy -= REGROW_ENERGY_REQ
 			nutrition -= REGROW_FOOD_REQ
@@ -319,18 +319,18 @@ var/list/diona_banned_languages = list(
 					organ_exists = 1
 					break
 
-			if (!organ_exists)//We've found an organ which is missing!
+			if (!organ_exists) //We've found an organ which is missing!
 				break
 			else
 				path = null
 
 		if (path)
 			if (DS.stored_energy < REGROW_ENERGY_REQ)
-				src << "<span class='danger'>You try to regrow a lost organ, but you lack the energy. Find more light!</span>"
+				to_chat(src, "<span class='danger'>You try to regrow a lost organ, but you lack the energy. Find more light!</span>")
 				return
 
 			if (nutrition < REGROW_FOOD_REQ)
-				src << "<span class='danger'>You try to regrow a lost organ, but you lack the biomass. Find some food!</span>"
+				to_chat(src, "<span class='danger'>You try to regrow a lost organ, but you lack the biomass. Find some food!</span>")
 				return
 
 			DS.stored_energy -= REGROW_ENERGY_REQ
@@ -338,10 +338,10 @@ var/list/diona_banned_languages = list(
 			var/obj/item/organ/O = new path(src)
 			internal_organs_by_name[O.organ_tag] = O
 			internal_organs.Add(O)
-			src << "<span class='danger'>You feel a shifting sensation inside you as your nymphs move apart to make space, forming a new [O.name]</span>"
+			to_chat(src, "<span class='danger'>You feel a shifting sensation inside you as your nymphs move apart to make space, forming a new [O.name]</span>")
 			regenerate_icons()
-			DS.LMS = max(2, DS.LMS)//Prevents a message about darkness in light areas
-			update_dionastats()//Re-find the organs in case they were lost or regained
+			DS.LMS = max(2, DS.LMS) //Prevents a message about darkness in light areas
+			update_dionastats() //Re-find the organs in case they were lost or regained
 			updatehealth()
 			return
 
@@ -352,7 +352,7 @@ var/list/diona_banned_languages = list(
 			if (D.stat == DEAD || D.health <= 0)
 				D.health = 1
 				D.stat = CONSCIOUS
-				src << "<span class='danger'>You feel a stirring within you as [D.name] returns to life!</span>"
+				to_chat(src, "<span class='danger'>You feel a stirring within you as [D.name] returns to life!</span>")
 				updatehealth()
 				return
 				//Only one per proc
@@ -361,7 +361,7 @@ var/list/diona_banned_languages = list(
 		if (topup_nymphs(1))
 			DS.stored_energy -= REGROW_ENERGY_REQ
 			nutrition -= REGROW_FOOD_REQ
-			src << "<span class='danger'>You feel a stirring inside you as a new nymph is born within your trunk!</span>"
+			to_chat(src, "<span class='danger'>You feel a stirring inside you as a new nymph is born within your trunk!</span>")
 
 	updatehealth()
 
@@ -377,10 +377,10 @@ var/list/diona_banned_languages = list(
 	B.touch_turf(get_turf(src))
 	regenerate_icons()
 
-	DS.LMS = min(2, DS.LMS)//Prevents a message about darkness in light areas
+	DS.LMS = min(2, DS.LMS) //Prevents a message about darkness in light areas
 	DS.regening_organ = FALSE
 
-	update_dionastats()//Re-find the organs in case they were lost or regained
+	update_dionastats() //Re-find the organs in case they were lost or regained
 	updatehealth()
 
 //MESSAGE FUNCTIONS
@@ -395,41 +395,41 @@ var/list/diona_banned_languages = list(
 	//6: Dying: You've collapsed from pain and are dying. theres nothing below this but death
 	DS.EP = DS.stored_energy / DS.max_energy
 
-	if (DS.LMS == 1)//If we're full
-		if (DS.EP <= 0.8 && DS.last_lightlevel <= 0)//But at <=80% energy
+	if (DS.LMS == 1) //If we're full
+		if (DS.EP <= 0.8 && DS.last_lightlevel <= 0) //But at <=80% energy
 			DS.LMS = 2
-			src << "<span class='warning'>The darkness makes you uncomfortable.</span>"
+			to_chat(src, "<span class='warning'>The darkness makes you uncomfortable.</span>")
 
 	else if (DS.LMS == 2)
 		if (DS.EP >= 0.99)
 			DS.LMS = 1
-			src << "You bask in the light"
+			to_chat(src, "You bask in the light")
 		else if (DS.EP <= 0.4 && DS.last_lightlevel <= 0)
 			DS.LMS = 3
-			src << "<span class='warning'>You feel lethargic as your energy drains away. Find some light soon!</span>"
+			to_chat(src, "<span class='warning'>You feel lethargic as your energy drains away. Find some light soon!</span>")
 
 	else if (DS.LMS == 3)
 		if (DS.EP >= 0.5)
 			DS.LMS = 2
-			src << "You feel a little more energised as you return to the light. Stay awhile."
+			to_chat(src, "You feel a little more energised as you return to the light. Stay awhile.")
 		else if (DS.EP <= 0.0 && DS.last_lightlevel <= 0)
 			DS.LMS = 4
-			src << "<span class='danger'>You feel sensory distress as your tendrils start to wither in the darkness. You will die soon without light.</span>"
+			to_chat(src, "<span class='danger'>You feel sensory distress as your tendrils start to wither in the darkness. You will die soon without light.</span>")
 	//From here down, we immediately return to state 3 if we get any light
 	else
-		if (DS.EP > 0.0)//If there's any light at all, we can be saved
-			src << "At long last, light! Treasure it, savour it, hold onto it."
+		if (DS.EP > 0.0) //If there's any light at all, we can be saved
+			to_chat(src, "At long last, light! Treasure it, savour it, hold onto it.")
 			DS.LMS = 3
 		else if(DS.last_lightlevel <= 0)
-			var/HP = 1 //diona_get_health(DS) / DS.max_health//HP  = health-percentage
+			var/HP = 1 //HP  = health-percentage
 			if (DS.LMS == 4)
 				if (HP < 0.6)
-					src << "<span class='danger'>The darkness burns. Your nymphs decay and wilt You are in mortal danger!</span>"
+					to_chat(src, "<span class='danger'>The darkness burns. Your nymphs decay and wilt You are in mortal danger!</span>")
 					DS.LMS = 5
 
 			else if (DS.LMS == 5)
 				if (paralysis > 0)
-					src << "<span class='danger'>Your body has reached critical integrity, it can no longer move. The end comes soon.</span>"
+					to_chat(src, "<span class='danger'>Your body has reached critical integrity, it can no longer move. The end comes soon.</span>")
 					DS.LMS = 6
 			else if (DS.LMS == 6)
 				return
@@ -479,7 +479,7 @@ var/list/diona_banned_languages = list(
 	for (var/datum/language/L in languages)
 		if (!(L in host.languages))
 			host.add_language(L.name)
-			host << "<span class='notice'><font size=3>[src] has passed on its knowledge of the [L.name] language to you!</font></span>"
+			to_chat(host, "<span class='notice'><font size=3>[src] has passed on its knowledge of the [L.name] language to you!</font></span>")
 
 	languages = host.languages.Copy()
 
@@ -490,7 +490,7 @@ var/list/diona_banned_languages = list(
 /mob/living/carbon/alien/diona/proc/split_languages(var/mob/living/carbon/host)
 	languages.Cut()
 
-	add_language(species.default_language)//They always have rootsong
+	add_language(species.default_language) //They always have rootsong
 
 	for (var/datum/language/L in host.languages)
 		var/chance = 40
@@ -498,14 +498,14 @@ var/list/diona_banned_languages = list(
 		if (istype(L, /datum/language/diona))
 			continue
 
-		if (istype(L, /datum/language/common))//more likely to keep common
+		if (istype(L, /datum/language/common)) //more likely to keep common
 			chance = 85
 
 
 		if (prob(chance))
 			add_language(L.name)
 		else
-			src << "<span class='danger'>You have forgotten the [L.name] language!</span>"
+			to_chat(src, "<span class='danger'>You have forgotten the [L.name] language!</span>")
 
 //DIONASTATS DEFINES
 
@@ -515,7 +515,7 @@ var/list/diona_banned_languages = list(
 /datum/dionastats
 	var/max_energy //how much energy the diona can store. will determine how long its energy lasts in darkness
 	var/stored_energy //how much is currently stored
-	var/EP//Energy percentage.
+	var/EP //Energy percentage.
 	var/trauma_factor //Multiplied with severity to determine how much damage the diona takes in darkness
 	var/pain_factor //Multiplied with severity to determine how much pain the diona takes in darkness
 	var/max_health = 100
@@ -526,17 +526,17 @@ var/list/diona_banned_languages = list(
 	var/regening_organ = FALSE // Tracking whether or not an organ is currently
                                // being regenreated.
 
-	var/restrictedlight_factor = 0.8//A value between 0 and 1 that determines how much we nerf the strength of certain worn lights
+	var/restrictedlight_factor = 0.8 //A value between 0 and 1 that determines how much we nerf the strength of certain worn lights
 		//1 means flashlights work normally., 0 means they do nothing
 
-	var/obj/item/organ/diona/node/light_organ = null//The organ this gestalt uses to recieve light. This is left null for nymphs
-	var/obj/item/organ/diona/nutrients/nutrient_organ = null//Organ
-	var/LMS = 1//Lightmessage state. Switching between states gives the user a message
-	var/dionatype//1 = nymph, 2 = worker gestalt
+	var/obj/item/organ/diona/node/light_organ = null //The organ this gestalt uses to recieve light. This is left null for nymphs
+	var/obj/item/organ/diona/nutrients/nutrient_organ = null //Organ
+	var/LMS = 1 //Lightmessage state. Switching between states gives the user a message
+	var/dionatype //1 = nymph, 2 = worker gestalt
 
 
 /datum/dionastats/Destroy()
-	light_organ = null//Nulling out these references to prevent GC errors
+	light_organ = null //Nulling out these references to prevent GC errors
 	nutrient_organ = null
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -49,15 +49,15 @@
 	if(!stat && !resting && !buckled)
 		if(prob(1))
 			visible_emote(pick("dances around","chases their tail"),0)
-			spawn(0)
-				for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
-					set_dir(i)
-					sleep(1)
+			INVOKE_ASYNC(src, .proc/do_dance, list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
 
+/mob/living/simple_animal/corgi/proc/do_dance(list/directions = list())
+	for(var/i in directions)
+		set_dir(i)
+		sleep(1)
 
 /mob/living/simple_animal/corgi/beg(var/atom/thing, var/atom/holder)
 	visible_emote("stares at the [thing] that [holder] has with sad puppy eyes.",0)
-
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/corgi
 	name = "Corgi meat"
@@ -74,10 +74,7 @@
 					foodtarget = 0
 					stop_automated_movement = 0
 					turns_since_scan = 0
-			spawn(0)
-				for(var/i in list(1,2,4,8,4,2,1,2))
-					set_dir(i)
-					sleep(1)
+			INVOKE_ASYNC(src, .proc/do_dance, list(1,2,4,8,4,2,1,2))
 	else
 		..()
 
@@ -168,7 +165,4 @@
 
 		if(prob(1))
 			visible_emote(pick("dances around","chases her tail"),0)
-			spawn(0)
-				for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
-					set_dir(i)
-					sleep(1)
+			INVOKE_ASYNC(src, .proc/do_dance, list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))

--- a/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
@@ -44,26 +44,28 @@
 /mob/living/simple_animal/hostile/commanded/bear/misc_command(var/mob/speaker,var/text)
 	stay_command()
 	stance = COMMANDED_MISC //nothing can stop this ride
-	spawn(0)
-		src.visible_message("\The [src] starts to dance!.")
-		var/datum/gender/G = gender_datums[gender]
-		for(var/i in 1 to 10)
-			if(stance != COMMANDED_MISC || incapacitated()) //something has stopped this ride.
-				return
-			var/message = pick(\
-							"moves [G.his] head back and forth!",\
-							"bobs [G.his] booty!",\
-							"shakes [G.his] paws in the air!",\
-							"wiggles [G.his] ears!",\
-							"taps [G.his] foot!",\
-							"shrugs [G.his] shoulders!",\
-							"dances like you've never seen!")
-			if(dir != WEST)
-				set_dir(WEST)
-			else
-				set_dir(EAST)
-			src.visible_message("\The [src] [message]")
-			sleep(30)
-		stance = COMMANDED_STOP
-		set_dir(SOUTH)
-		src.visible_message("\The [src] bows, finished with [G.his] dance.")
+	INVOKE_ASYNC(src, .proc/command_dance)
+
+/mob/living/simple_animal/hostile/commanded/bear/proc/command_dance()
+	visible_message("\The [src] starts to dance!.")
+	var/datum/gender/G = gender_datums[gender]
+	for(var/i in 1 to 10)
+		if(stance != COMMANDED_MISC || incapacitated()) //something has stopped this ride.
+			return
+		var/message = pick(
+						"moves [G.his] head back and forth!",
+						"bobs [G.his] booty!",
+						"shakes [G.his] paws in the air!",
+						"wiggles [G.his] ears!",
+						"taps [G.his] foot!",
+						"shrugs [G.his] shoulders!",
+						"dances like you've never seen!")
+		if(dir != WEST)
+			set_dir(WEST)
+		else
+			set_dir(EAST)
+		visible_message("\The [src] [message]")
+		sleep(30)
+	stance = COMMANDED_STOP
+	set_dir(SOUTH)
+	visible_message("\The [src] bows, finished with [G.his] dance.")

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -365,12 +365,18 @@
 /datum/disease2/effect/sneeze
 	name = "Coldingtons Effect"
 	stage = 1
-	activate(var/mob/living/carbon/mob,var/multiplier)
+	activate(var/mob/living/carbon/mob, var/multiplier)
 		if (prob(30))
 			mob << "<span class='warning'>You feel like you are about to sneeze!</span>"
-		sleep(5)
+		addtimer(CALLBACK(src, .proc/do_sneeze, mob, multiplier), 5)
+
+
+	proc/do_sneeze(mob/living/carbon/mob, multiplier)
+		if (QDELETED(mob))
+			return
+
 		mob.say("*sneeze")
-		for(var/mob/living/carbon/M in get_step(mob,mob.dir))
+		for(var/mob/living/carbon/M in get_step(mob, mob.dir))
 			mob.spread_disease_to(M)
 		if (prob(50))
 			var/obj/effect/decal/cleanable/mucus/M = new(get_turf(mob))


### PR DESCRIPTION
Removes:
* sleep in floorbot/Life() (Fixes #2578)
* sleep in medbot/Life()
* sleep in farmbot/Life()
* a sleep in Diona specific proc chains, which sneaked into human/Life()
* a sleep in coldingtons/activate, which sneaked into human/Life()
* sleep in bear/misc_command (uncertain if this was ever called in Life(), but hey!)
* sleep in corgi/*/Life

This covers all debug references I could find on graylog from the past 30 days.

Refactors:
* Removes Nanako-style comments from diona_base.dm which break formatting in VSCode and Github
* Swaps diona_base.dm to use `to_chat` over `<<`