### PR TITLE
Convert storage objects to initialize

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -462,8 +462,7 @@
 	name = "Diskette Box"
 	icon_state = "disk_kit"
 
-/obj/item/weapon/storage/box/disks/New()
-	..()
+/obj/item/weapon/storage/box/disks/fill()
 	new /obj/item/weapon/disk/data(src)
 	new /obj/item/weapon/disk/data(src)
 	new /obj/item/weapon/disk/data(src)

--- a/code/game/mecha/equipment/tracking_beacon.dm
+++ b/code/game/mecha/equipment/tracking_beacon.dm
@@ -136,8 +136,7 @@
 /obj/item/weapon/storage/box/mechabeacons
 	name = "Exosuit Control Beacons"
 
-/obj/item/weapon/storage/box/mechabeacons/New()
-	..()
+/obj/item/weapon/storage/box/mechabeacons/fill()
 	new /obj/item/mecha_parts/mecha_tracking/control(src)
 	new /obj/item/mecha_parts/mecha_tracking/control(src)
 	new /obj/item/mecha_parts/mecha_tracking/control(src)

--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -5,7 +5,7 @@
 	name = "bottle of Happy pills"
 	desc = "Highly illegal drug. When you want to see the rainbow."
 
-/obj/item/weapon/storage/pill_bottle/happy/New()
+/obj/item/weapon/storage/pill_bottle/happy/fill()
 	..()
 	new /obj/item/weapon/reagent_containers/pill/happy( src )
 	new /obj/item/weapon/reagent_containers/pill/happy( src )
@@ -19,7 +19,7 @@
 	name = "bottle of Zoom pills"
 	desc = "Highly illegal drug. Trade brain for speed."
 
-/obj/item/weapon/storage/pill_bottle/zoom/New()
+/obj/item/weapon/storage/pill_bottle/zoom/fill()
 	..()
 	new /obj/item/weapon/reagent_containers/pill/zoom( src )
 	new /obj/item/weapon/reagent_containers/pill/zoom( src )

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -55,7 +55,7 @@
 		)
 
 
-/obj/item/weapon/storage/belt/utility/full/New()
+/obj/item/weapon/storage/belt/utility/full/fill()
 	..()
 	new /obj/item/weapon/screwdriver(src)
 	new /obj/item/weapon/wrench(src)
@@ -65,7 +65,7 @@
 	new /obj/item/stack/cable_coil(src,30,pick("red","yellow","orange"))
 
 
-/obj/item/weapon/storage/belt/utility/atmostech/New()
+/obj/item/weapon/storage/belt/utility/atmostech/fill()
 	..()
 	new /obj/item/weapon/screwdriver(src)
 	new /obj/item/weapon/wrench(src)
@@ -154,7 +154,7 @@
 		/obj/item/device/soulstone
 		)
 
-/obj/item/weapon/storage/belt/soulstone/full/New()
+/obj/item/weapon/storage/belt/soulstone/full/fill()
 	..()
 	new /obj/item/device/soulstone(src)
 	new /obj/item/device/soulstone(src)
@@ -245,7 +245,7 @@
 		/obj/item/weapon/gun/energy/wand
 		)
 
-/obj/item/weapon/storage/belt/wands/full/New()
+/obj/item/weapon/storage/belt/wands/full/fill()
 	..()
 	new /obj/item/weapon/gun/energy/wand/fire(src)
 	new /obj/item/weapon/gun/energy/wand/polymorph(src)

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -13,7 +13,7 @@
 	desc = "To be applied to the head repeatedly."
 	icon_state ="bible"
 
-/obj/item/weapon/storage/bible/booze/New()
+/obj/item/weapon/storage/bible/booze/fill()
 	..()
 	new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer(src)
 	new /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer(src)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -26,10 +26,10 @@
 	icon_state = "box"
 	item_state = "syringe_kit"
 	var/foldable = /obj/item/stack/material/cardboard	// BubbleWrap - if set, can be folded (when empty) into a sheet of cardboard
-	var/maxHealth = 20//health is already defined
+	var/maxHealth = 20	//health is already defined
 
-/obj/item/weapon/storage/box/New()
-	..()
+/obj/item/weapon/storage/box/Initialize()
+	. = ..()
 	health = maxHealth
 
 /obj/item/weapon/storage/box/proc/damage(var/severity)
@@ -39,7 +39,6 @@
 /obj/item/weapon/storage/box/proc/check_health()
 	if (health <= 0)
 		qdel(src)
-
 
 /obj/item/weapon/storage/box/attack_generic(var/mob/user)
 
@@ -66,7 +65,6 @@
 				playsound(loc, toplay, 30, 1)
 			damage(damage)
 	..()
-
 
 /obj/item/weapon/storage/box/examine(var/mob/user)
 	..()
@@ -103,21 +101,22 @@
 /obj/item/weapon/storage/box/survival
 	autodrobe_no_remove = 1
 
-/obj/item/weapon/storage/box/survival/New()
+/obj/item/weapon/storage/box/survival/fill()
 	..()
 	new /obj/item/clothing/mask/breath( src )
 	new /obj/item/weapon/tank/emergency_oxygen(src)
 	for(var/obj/item/thing in contents)
 		thing.autodrobe_no_remove = 1
 
-/obj/item/weapon/storage/box/vox/New()
+/obj/item/weapon/storage/box/vox/fill()
 	..()
 	new /obj/item/clothing/mask/breath( src )
 	new /obj/item/weapon/tank/emergency_nitrogen( src )
 
 /obj/item/weapon/storage/box/engineer
 	autodrobe_no_remove = 1
-/obj/item/weapon/storage/box/engineer/New()
+
+/obj/item/weapon/storage/box/engineer/fill()
 	..()
 	new /obj/item/clothing/mask/breath( src )
 	new /obj/item/weapon/tank/emergency_oxygen/engi( src )
@@ -129,7 +128,7 @@
 	desc = "Contains sterile gloves."
 	icon_state = "latex"
 
-/obj/item/weapon/storage/box/gloves/New()
+/obj/item/weapon/storage/box/gloves/fill()
 	..()
 	new /obj/item/clothing/gloves/latex(src)
 	new /obj/item/clothing/gloves/latex(src)
@@ -144,7 +143,7 @@
 	desc = "This box contains masks of sterility."
 	icon_state = "sterile"
 
-/obj/item/weapon/storage/box/masks/New()
+/obj/item/weapon/storage/box/masks/fill()
 	..()
 	new /obj/item/clothing/mask/surgical(src)
 	new /obj/item/clothing/mask/surgical(src)
@@ -174,7 +173,7 @@
 	desc = "A box full of compressed gas cartridges."
 	icon_state = "syringe"
 
-/obj/item/weapon/storage/box/syringes/New()
+/obj/item/weapon/storage/box/syringes/fill()
 	..()
 	new /obj/item/weapon/syringe_cartridge( src )
 	new /obj/item/weapon/syringe_cartridge( src )
@@ -189,7 +188,7 @@
 	name = "box of beakers"
 	icon_state = "beaker"
 
-/obj/item/weapon/storage/box/beakers/New()
+/obj/item/weapon/storage/box/beakers/fill()
 	..()
 	new /obj/item/weapon/reagent_containers/glass/beaker( src )
 	new /obj/item/weapon/reagent_containers/glass/beaker( src )
@@ -203,7 +202,7 @@
 	name = "box of DNA injectors"
 	desc = "This box contains injectors it seems."
 
-/obj/item/weapon/storage/box/injectors/New()
+/obj/item/weapon/storage/box/injectors/fill()
 	..()
 	new /obj/item/weapon/dnainjector/h2m(src)
 	new /obj/item/weapon/dnainjector/h2m(src)
@@ -216,7 +215,7 @@
 	name = "box of blank shells"
 	desc = "It has a picture of a gun and several warning symbols on the front."
 
-/obj/item/weapon/storage/box/blanks/New()
+/obj/item/weapon/storage/box/blanks/fill()
 	..()
 	new /obj/item/ammo_casing/shotgun/blank(src)
 	new /obj/item/ammo_casing/shotgun/blank(src)
@@ -230,7 +229,7 @@
 	name = "box of beanbag shells"
 	desc = "It has a picture of a gun and several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
 
-/obj/item/weapon/storage/box/beanbags/New()
+/obj/item/weapon/storage/box/beanbags/fill()
 	..()
 	new /obj/item/ammo_casing/shotgun/beanbag(src)
 	new /obj/item/ammo_casing/shotgun/beanbag(src)
@@ -244,7 +243,7 @@
 	name = "box of shotgun slugs"
 	desc = "It has a picture of a gun and several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
 
-/obj/item/weapon/storage/box/shotgunammo/New()
+/obj/item/weapon/storage/box/shotgunammo/fill()
 	..()
 	new /obj/item/ammo_casing/shotgun(src)
 	new /obj/item/ammo_casing/shotgun(src)
@@ -258,7 +257,7 @@
 	name = "box of shotgun shells"
 	desc = "It has a picture of a gun and several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
 
-/obj/item/weapon/storage/box/shotgunshells/New()
+/obj/item/weapon/storage/box/shotgunshells/fill()
 	..()
 	new /obj/item/ammo_casing/shotgun/pellet(src)
 	new /obj/item/ammo_casing/shotgun/pellet(src)
@@ -272,7 +271,7 @@
 	name = "box of illumination shells"
 	desc = "It has a picture of a gun and several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
 
-/obj/item/weapon/storage/box/flashshells/New()
+/obj/item/weapon/storage/box/flashshells/fill()
 	..()
 	new /obj/item/ammo_casing/shotgun/flash(src)
 	new /obj/item/ammo_casing/shotgun/flash(src)
@@ -286,7 +285,7 @@
 	name = "box of stun shells"
 	desc = "It has a picture of a gun and several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
 
-/obj/item/weapon/storage/box/stunshells/New()
+/obj/item/weapon/storage/box/stunshells/fill()
 	..()
 	new /obj/item/ammo_casing/shotgun/stunshell(src)
 	new /obj/item/ammo_casing/shotgun/stunshell(src)
@@ -300,7 +299,7 @@
 	name = "box of practice shells"
 	desc = "It has a picture of a gun and several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
 
-/obj/item/weapon/storage/box/practiceshells/New()
+/obj/item/weapon/storage/box/practiceshells/fill()
 	..()
 	new /obj/item/ammo_casing/shotgun/practice(src)
 	new /obj/item/ammo_casing/shotgun/practice(src)
@@ -314,7 +313,7 @@
 	name = "box of 14.5mm shells"
 	desc = "It has a picture of a gun and several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
 
-/obj/item/weapon/storage/box/sniperammo/New()
+/obj/item/weapon/storage/box/sniperammo/fill()
 	..()
 	new /obj/item/ammo_casing/a145(src)
 	new /obj/item/ammo_casing/a145(src)
@@ -329,7 +328,7 @@
 	desc = "A box containing 7 antipersonnel flashbang grenades.<br> WARNING: These devices are extremely dangerous and can cause blindness or deafness in repeated use."
 	icon_state = "flashbang"
 
-/obj/item/weapon/storage/box/flashbangs/New()
+/obj/item/weapon/storage/box/flashbangs/fill()
 	..()
 	new /obj/item/weapon/grenade/flashbang(src)
 	new /obj/item/weapon/grenade/flashbang(src)
@@ -344,7 +343,7 @@
 	desc = "A box containing 7 tear gas grenades. A gas mask is printed on the label.<br> WARNING: Exposure carries risk of serious injury or death. Keep away from persons with lung conditions."
 	icon_state = "flashbang"
 
-/obj/item/weapon/storage/box/teargas/New()
+/obj/item/weapon/storage/box/teargas/fill()
 	..()
 	new /obj/item/weapon/grenade/chem_grenade/teargas(src)
 	new /obj/item/weapon/grenade/chem_grenade/teargas(src)
@@ -358,7 +357,7 @@
 	desc = "A box full of smoke grenades, used by special law enforcement teams and military organisations. Provides cover, confusion, and distraction."
 	icon_state = "flashbang"
 
-/obj/item/weapon/storage/box/smokebombs/New()
+/obj/item/weapon/storage/box/smokebombs/fill()
 	..()
 	new /obj/item/weapon/grenade/smokebomb(src)
 	new /obj/item/weapon/grenade/smokebomb(src)
@@ -373,7 +372,7 @@
 	desc = "A box containing 5 military grade EMP grenades.<br> WARNING: Do not use near unshielded electronics or biomechanical augmentations, death or permanent paralysis may occur."
 	icon_state = "flashbang"
 
-/obj/item/weapon/storage/box/emps/New()
+/obj/item/weapon/storage/box/emps/fill()
 	..()
 	new /obj/item/weapon/grenade/empgrenade(src)
 	new /obj/item/weapon/grenade/empgrenade(src)
@@ -386,7 +385,7 @@
 	desc = "A box containing 5 smoke bombs."
 	icon_state = "flashbang"
 
-/obj/item/weapon/storage/box/smokes/New()
+/obj/item/weapon/storage/box/smokes/fill()
 	..()
 	new /obj/item/weapon/grenade/smokebomb(src)
 	new /obj/item/weapon/grenade/smokebomb(src)
@@ -399,7 +398,7 @@
 	desc = "A box containing 5 experimental photon disruption grenades."
 	icon_state = "flashbang"
 
-/obj/item/weapon/storage/box/anti_photons/New()
+/obj/item/weapon/storage/box/anti_photons/fill()
 	..()
 	new /obj/item/weapon/grenade/anti_photon(src)
 	new /obj/item/weapon/grenade/anti_photon(src)
@@ -412,7 +411,7 @@
 	desc = "A box containing 5 military grade fragmentation grenades.<br> WARNING: Live explosives. Misuse may result in serious injury or death."
 	icon_state = "flashbang"
 
-/obj/item/weapon/storage/box/frags/New()
+/obj/item/weapon/storage/box/frags/fill()
 	..()
 	new /obj/item/weapon/grenade/frag(src)
 	new /obj/item/weapon/grenade/frag(src)
@@ -425,7 +424,7 @@
 	desc = "Box full of scum-bag tracking utensils."
 	icon_state = "implant"
 
-/obj/item/weapon/storage/box/trackimp/New()
+/obj/item/weapon/storage/box/trackimp/fill()
 	..()
 	new /obj/item/weapon/implantcase/tracking(src)
 	new /obj/item/weapon/implantcase/tracking(src)
@@ -440,7 +439,7 @@
 	desc = "Box of stuff used to implant chemicals."
 	icon_state = "implant"
 
-/obj/item/weapon/storage/box/chemimp/New()
+/obj/item/weapon/storage/box/chemimp/fill()
 	..()
 	new /obj/item/weapon/implantcase/chem(src)
 	new /obj/item/weapon/implantcase/chem(src)
@@ -455,7 +454,7 @@
 	desc = "This box contains nerd glasses."
 	icon_state = "glasses"
 
-/obj/item/weapon/storage/box/rxglasses/New()
+/obj/item/weapon/storage/box/rxglasses/fill()
 	..()
 	new /obj/item/clothing/glasses/regular(src)
 	new /obj/item/clothing/glasses/regular(src)
@@ -469,7 +468,7 @@
 	name = "box of drinking glasses"
 	desc = "It has a picture of drinking glasses on it."
 
-/obj/item/weapon/storage/box/drinkingglasses/New()
+/obj/item/weapon/storage/box/drinkingglasses/fill()
 	..()
 	new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
 	new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
@@ -484,7 +483,7 @@
 	icon_state = "implant"
 	item_state = "syringe_kit"
 
-/obj/item/weapon/storage/box/cdeathalarm_kit/New()
+/obj/item/weapon/storage/box/cdeathalarm_kit/fill()
 	..()
 	new /obj/item/weapon/implanter(src)
 	new /obj/item/weapon/implantcase/death_alarm(src)
@@ -498,7 +497,7 @@
 	name = "box of condiment bottles"
 	desc = "It has a large ketchup smear on it."
 
-/obj/item/weapon/storage/box/condimentbottles/New()
+/obj/item/weapon/storage/box/condimentbottles/fill()
 	..()
 	new /obj/item/weapon/reagent_containers/food/condiment(src)
 	new /obj/item/weapon/reagent_containers/food/condiment(src)
@@ -511,7 +510,7 @@
 	name = "box of paper cups"
 	desc = "It has pictures of paper cups on the front."
 	
-/obj/item/weapon/storage/box/cups/New()
+/obj/item/weapon/storage/box/cups/fill()
 	..()
 	new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
 	new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
@@ -526,7 +525,7 @@
 	desc = "<B>Instructions:</B> <I>Heat in microwave. Product will cool if not eaten within seven minutes.</I>"
 	icon_state = "donk_kit"
 
-/obj/item/weapon/storage/box/donkpockets/New()
+/obj/item/weapon/storage/box/donkpockets/fill()
 	..()
 	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
@@ -540,7 +539,7 @@
 	desc = "<B>Instructions:</B> <I>Crush bottom of package to initiate chemical heating. Wait for 20 seconds before consumption. Product will cool if not eaten within seven minutes.</I>"
 	icon_state = "donk_kit"
 
-/obj/item/weapon/storage/box/sinpockets/New()
+/obj/item/weapon/storage/box/sinpockets/fill()
 	..()
 	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
@@ -556,7 +555,7 @@
 	icon_state = "monkeycubebox"
 	can_hold = list(/obj/item/weapon/reagent_containers/food/snacks/monkeycube)
 	
-/obj/item/weapon/storage/box/monkeycubes/New()
+/obj/item/weapon/storage/box/monkeycubes/fill()
 	..()
 	if(src.type == /obj/item/weapon/storage/box/monkeycubes)
 		for(var/i = 1; i <= 5; i++)
@@ -566,7 +565,7 @@
 	name = "farwa cube box"
 	desc = "Drymate brand farwa cubes, shipped from Adhomai. Just add water!"
 	
-/obj/item/weapon/storage/box/monkeycubes/farwacubes/New()
+/obj/item/weapon/storage/box/monkeycubes/farwacubes/fill()
 	..()
 	for(var/i = 1; i <= 5; i++)
 		new /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped/farwacube(src)
@@ -575,7 +574,7 @@
 	name = "stok cube box"
 	desc = "Drymate brand stok cubes, shipped from Moghes. Just add water!"
 	
-/obj/item/weapon/storage/box/monkeycubes/stokcubes/New()
+/obj/item/weapon/storage/box/monkeycubes/stokcubes/fill()
 	..()
 	for(var/i = 1; i <= 5; i++)
 		new /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped/stokcube(src)
@@ -584,7 +583,7 @@
 	name = "neaera cube box"
 	desc = "Drymate brand neaera cubes, shipped from Jargon 4. Just add water!"
 	
-/obj/item/weapon/storage/box/monkeycubes/neaeracubes/New()
+/obj/item/weapon/storage/box/monkeycubes/neaeracubes/fill()
 	..()
 	for(var/i = 1; i <= 5; i++)
 		new /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped/neaeracube(src)
@@ -594,7 +593,7 @@
 	desc = "Has so many empty IDs."
 	icon_state = "id"
 
-/obj/item/weapon/storage/box/ids/New()
+/obj/item/weapon/storage/box/ids/fill()
 	..()
 	new /obj/item/weapon/card/id(src)
 	new /obj/item/weapon/card/id(src)
@@ -609,7 +608,7 @@
 	desc = "A box full of R.O.B.U.S.T. Cartridges, used by Security."
 	icon_state = "pda"
 
-/obj/item/weapon/storage/box/seccarts/New()
+/obj/item/weapon/storage/box/seccarts/fill()
 	..()
 	new /obj/item/weapon/cartridge/security(src)
 	new /obj/item/weapon/cartridge/security(src)
@@ -624,7 +623,7 @@
 	desc = "A box full of handcuffs."
 	icon_state = "handcuff"
 
-/obj/item/weapon/storage/box/handcuffs/New()
+/obj/item/weapon/storage/box/handcuffs/fill()
 	..()
 	new /obj/item/weapon/handcuffs(src)
 	new /obj/item/weapon/handcuffs(src)
@@ -639,7 +638,7 @@
 	desc = "A box full of zipties."
 	icon_state = "handcuff"
 
-/obj/item/weapon/storage/box/handcuffs/New()
+/obj/item/weapon/storage/box/handcuffs/fill()
 	..()
 	new /obj/item/weapon/handcuffs/ziptie(src)
 	new /obj/item/weapon/handcuffs/ziptie(src)
@@ -654,7 +653,7 @@
 	desc = "<B><FONT color='red'>WARNING:</FONT></B> <I>Keep out of reach of children</I>."
 	icon_state = "mousetraps"
 
-/obj/item/weapon/storage/box/mousetraps/New()
+/obj/item/weapon/storage/box/mousetraps/fill()
 	..()
 	new /obj/item/device/assembly/mousetrap( src )
 	new /obj/item/device/assembly/mousetrap( src )
@@ -667,7 +666,7 @@
 	name = "box of pill bottles"
 	desc = "It has pictures of pill bottles on its front."
 
-/obj/item/weapon/storage/box/pillbottles/New()
+/obj/item/weapon/storage/box/pillbottles/fill()
 	..()
 	new /obj/item/weapon/storage/pill_bottle( src )
 	new /obj/item/weapon/storage/pill_bottle( src )
@@ -681,7 +680,7 @@
 	name = "box of spray bottles"
 	desc = "It has pictures of spray bottles on its front."
 	
-/obj/item/weapon/storage/box/spraybottles/New()
+/obj/item/weapon/storage/box/spraybottles/fill()
 	..()
 	new /obj/item/weapon/reagent_containers/spray( src )
 	new /obj/item/weapon/reagent_containers/spray( src )
@@ -698,7 +697,7 @@
 	icon_state = "spbox"
 	can_hold = list(/obj/item/toy/snappop)
 	
-/obj/item/weapon/storage/box/snappops/New()
+/obj/item/weapon/storage/box/snappops/fill()
 	..()
 	for(var/i=1; i <= 8; i++)
 		new /obj/item/toy/snappop(src)
@@ -713,7 +712,7 @@
 	slot_flags = SLOT_BELT
 	can_hold = list(/obj/item/weapon/flame/match)
 
-/obj/item/weapon/storage/box/matches/New()
+/obj/item/weapon/storage/box/matches/fill()
 	..()
 	for(var/i=1; i <= 10; i++)
 		new /obj/item/weapon/flame/match(src)
@@ -732,7 +731,7 @@
 	desc = "Contains autoinjectors."
 	icon_state = "syringe"
 	
-/obj/item/weapon/storage/box/autoinjectors/New()
+/obj/item/weapon/storage/box/autoinjectors/fill()
 	..()
 	for (var/i; i < 7; i++)
 		new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
@@ -745,34 +744,34 @@
 	item_state = "syringe_kit"
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
 
-/obj/item/weapon/storage/box/lights/New()
-	..()
+/obj/item/weapon/storage/box/lights/Initialize()	// TODO-STORAGE: Initialize()?
+	. = ..()
 	make_exact_fit()
 
-/obj/item/weapon/storage/box/lights/bulbs/New()
+/obj/item/weapon/storage/box/lights/bulbs/fill()
+	..()
 	for(var/i = 0; i < 21; i++)
 		new /obj/item/weapon/light/bulb(src)
-	..()
 
 /obj/item/weapon/storage/box/lights/tubes
 	name = "box of replacement tubes"
 	icon_state = "lighttube"
 
-/obj/item/weapon/storage/box/lights/tubes/New()
+/obj/item/weapon/storage/box/lights/tubes/fill()
+	..()
 	for(var/i = 0; i < 21; i++)
 		new /obj/item/weapon/light/tube(src)
-	..()
 
 /obj/item/weapon/storage/box/lights/mixed
 	name = "box of replacement lights"
 	icon_state = "lightmixed"
 
-/obj/item/weapon/storage/box/lights/mixed/New()
+/obj/item/weapon/storage/box/lights/mixed/fill()
+	..()
 	for(var/i = 0; i < 14; i++)
 		new /obj/item/weapon/light/tube(src)
 	for(var/i = 0; i < 7; i++)
 		new /obj/item/weapon/light/bulb(src)
-	..()
 
 /obj/item/weapon/storage/box/freezer
 	name = "portable freezer"
@@ -789,26 +788,27 @@
 	name = "kitchen supplies"
 	desc = "Contains an assortment of utensils and containers useful in the preparation of food and drinks."
 
-/obj/item/weapon/storage/box/kitchen/New()
+/obj/item/weapon/storage/box/kitchen/fill()
 	new /obj/item/weapon/material/knife(src)//Should always have a knife
 
-	var/list/utensils = list(/obj/item/weapon/material/kitchen/rollingpin,
-/obj/item/weapon/reagent_containers/glass/beaker,
-/obj/item/weapon/material/kitchen/utensil/fork,
-/obj/item/weapon/reagent_containers/food/condiment/enzyme,
-/obj/item/weapon/material/kitchen/utensil/spoon,
-/obj/item/weapon/material/kitchen/utensil/knife,
-/obj/item/weapon/reagent_containers/food/drinks/shaker)
+	var/list/utensils = list(
+		/obj/item/weapon/material/kitchen/rollingpin,
+		/obj/item/weapon/reagent_containers/glass/beaker,
+		/obj/item/weapon/material/kitchen/utensil/fork,
+		/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+		/obj/item/weapon/material/kitchen/utensil/spoon,
+		/obj/item/weapon/material/kitchen/utensil/knife,
+		/obj/item/weapon/reagent_containers/food/drinks/shaker
+	)
 	for (var/i = 0,i<6,i++)
 		var/type = pick(utensils)
 		new type(src)
-	..()
 
 /obj/item/weapon/storage/box/snack
 	name = "rations box"
 	desc = "Contains a random assortment of preserved foods. Guaranteed to remain edible* in room-temperature longterm storage for centuries!"
 
-/obj/item/weapon/storage/box/snack/New()
+/obj/item/weapon/storage/box/snack/fill()
 	var/list/snacks = list(
 			/obj/item/weapon/reagent_containers/food/snacks/koisbar,
 			/obj/item/weapon/reagent_containers/food/snacks/candy,
@@ -835,14 +835,12 @@
 	for (var/i = 0,i<7,i++)
 		var/type = pick(snacks)
 		new type(src)
-	..()
 
 /obj/item/weapon/storage/box/stims
 	name = "stimpack value kit"
 	desc = "A box with several stimpack medipens for the economical miner."
 	icon_state = "syringe"
 
-/obj/item/weapon/storage/box/stims/New()
-	..()
+/obj/item/weapon/storage/box/stims/fill()
 	for(var/i in 1 to 4)
 		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/stimpack(src)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -52,11 +52,9 @@
 		/obj/item/weapon/reagent_containers/food/snacks/boiledegg
 		)
 
-/obj/item/weapon/storage/fancy/egg_box/New()
-	..()
+/obj/item/weapon/storage/fancy/egg_box/fill()
 	for(var/i=1; i <= storage_slots; i++)
 		new /obj/item/weapon/reagent_containers/food/snacks/egg(src)
-	return
 
 /*
  * Candle Box
@@ -73,11 +71,9 @@
 	slot_flags = SLOT_BELT
 	max_storage_space = 5
 
-/obj/item/weapon/storage/fancy/candle_box/New()
-	..()
+/obj/item/weapon/storage/fancy/candle_box/fill()
 	for(var/i=1; i <= 5; i++)
 		new /obj/item/weapon/flame/candle(src)
-	return
 
 /*
  * Crayon Box
@@ -94,7 +90,7 @@
 		/obj/item/weapon/pen/crayon
 	)
 
-/obj/item/weapon/storage/fancy/crayons/New()
+/obj/item/weapon/storage/fancy/crayons/fill()
 	..()
 	new /obj/item/weapon/pen/crayon/red(src)
 	new /obj/item/weapon/pen/crayon/orange(src)
@@ -137,16 +133,17 @@
 	can_hold = list(/obj/item/clothing/mask/smokable/cigarette, /obj/item/weapon/flame/lighter)
 	icon_type = "cigarette"
 
-/obj/item/weapon/storage/fancy/cigarettes/New()
-	..()
+/obj/item/weapon/storage/fancy/cigarettes/Initialize()
+	. = ..()
 	flags |= NOREACT
+	create_reagents(15 * storage_slots)	//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
+
+/obj/item/weapon/storage/fancy/cigarettes/fill()
 	for(var/i = 1 to storage_slots)
 		new /obj/item/clothing/mask/smokable/cigarette(src)
-	create_reagents(15 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
 
 /obj/item/weapon/storage/fancy/cigarettes/update_icon()
 	icon_state = "[initial(icon_state)][contents.len]"
-	return
 
 /obj/item/weapon/storage/fancy/cigarettes/remove_from_storage(obj/item/W as obj, atom/new_location)
 		var/obj/item/clothing/mask/smokable/cigarette/C = W
@@ -181,7 +178,7 @@
 	icon_state = "Bpacket"
 	item_state = "Bpacket" //Doesn't have an inhand state, but neither does dromedary, so, ya know..
 
-	New()
+	fill()
 		..()
 		fill_cigarre_package(src,list("fuel" = 15))
 
@@ -198,12 +195,15 @@
 	can_hold = list(/obj/item/clothing/mask/smokable/cigarette/cigar)
 	icon_type = "cigar"
 
-/obj/item/weapon/storage/fancy/cigar/New()
-	..()
+/obj/item/weapon/storage/fancy/cigar/Initialize()
+	. = ..()
 	flags |= NOREACT
+	create_reagents(15 * storage_slots)
+
+/obj/item/weapon/storage/fancy/cigar/fill()
+	..()
 	for(var/i = 1 to storage_slots)
 		new /obj/item/clothing/mask/smokable/cigarette/cigar(src)
-	create_reagents(15 * storage_slots)
 
 /obj/item/weapon/storage/fancy/cigar/update_icon()
 	icon_state = "[initial(icon_state)][contents.len]"
@@ -243,11 +243,10 @@
 	can_hold = list(/obj/item/weapon/reagent_containers/glass/beaker/vial)
 
 
-/obj/item/weapon/storage/fancy/vials/New()
+/obj/item/weapon/storage/fancy/vials/fill()
 	..()
 	for(var/i=1; i <= storage_slots; i++)
 		new /obj/item/weapon/reagent_containers/glass/beaker/vial(src)
-	return
 
 /obj/item/weapon/storage/lockbox/vials
 	name = "secure vial storage box"
@@ -261,9 +260,9 @@
 	storage_slots = 6
 	req_access = list(access_virology)
 
-/obj/item/weapon/storage/lockbox/vials/New()
-	..()
-	update_icon()
+/obj/item/weapon/storage/lockbox/vials/Initialize()
+	. = ..()
+	queue_icon_update()
 
 /obj/item/weapon/storage/lockbox/vials/update_icon(var/itemremoved = 0)
 	var/total_contents = src.contents.len - itemremoved

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -22,7 +22,7 @@
 	icon_state = "ointment"
 	item_state = "firstaid-ointment"
 
-	New()
+	fill()
 		..()
 		if (empty) return
 
@@ -41,7 +41,7 @@
 /obj/item/weapon/storage/firstaid/regular
 	icon_state = "firstaid"
 
-	New()
+	fill()
 		..()
 		if (empty) return
 		new /obj/item/stack/medical/bruise_pack(src)
@@ -59,7 +59,7 @@
 	icon_state = "antitoxin"
 	item_state = "firstaid-toxin"
 
-	New()
+	fill()
 		..()
 		if (empty) return
 
@@ -80,7 +80,7 @@
 	icon_state = "o2"
 	item_state = "firstaid-o2"
 
-	New()
+	fill()
 		..()
 		if (empty) return
 		new /obj/item/weapon/reagent_containers/pill/dexalin( src )
@@ -98,7 +98,7 @@
 	icon_state = "advfirstaid"
 	item_state = "firstaid-advanced"
 
-/obj/item/weapon/storage/firstaid/adv/New()
+/obj/item/weapon/storage/firstaid/adv/fill()
 	..()
 	if (empty) return
 	new /obj/item/weapon/reagent_containers/hypospray/autoinjector( src )
@@ -116,7 +116,7 @@
 	icon_state = "bezerk"
 	item_state = "firstaid-advanced"
 
-/obj/item/weapon/storage/firstaid/combat/New()
+/obj/item/weapon/storage/firstaid/combat/fill()
 	..()
 	if (empty) return
 	new /obj/item/weapon/storage/pill_bottle/bicaridine(src)
@@ -134,7 +134,7 @@
 	icon_state = "purplefirstaid"
 	item_state = "firstaid-advanced"
 
-/obj/item/weapon/storage/firstaid/surgery/New()
+/obj/item/weapon/storage/firstaid/surgery/fill()
 	..()
 	if (empty) return
 	new /obj/item/weapon/bonesetter(src)
@@ -155,7 +155,7 @@
 	desc = "A NanoTrasen care package for moderately injured miners."
 	icon_state = "brute"
 
-/obj/item/weapon/storage/firstaid/brute/New()
+/obj/item/weapon/storage/firstaid/brute/fill()
 		..()
 		if (empty) return
 		new /obj/item/stack/medical/bruise_pack(src)
@@ -186,7 +186,7 @@
 	name = "bottle of Dylovene pills"
 	desc = "Contains pills used to counter toxins."
 
-	New()
+	fill()
 		..()
 		new /obj/item/weapon/reagent_containers/pill/antitox( src )
 		new /obj/item/weapon/reagent_containers/pill/antitox( src )
@@ -200,7 +200,7 @@
 	name = "bottle of Bicaridine pills"
 	desc = "Contains pills used to stabilize the severely injured."
 
-/obj/item/weapon/storage/pill_bottle/bicaridine/New()
+/obj/item/weapon/storage/pill_bottle/bicaridine/fill()
     ..()
     new /obj/item/weapon/reagent_containers/pill/bicaridine(src)
     new /obj/item/weapon/reagent_containers/pill/bicaridine(src)
@@ -214,7 +214,7 @@
 	name = "bottle of Dexalin Plus pills"
 	desc = "Contains pills used to treat extreme cases of oxygen deprivation."
 
-/obj/item/weapon/storage/pill_bottle/dexalin_plus/New()
+/obj/item/weapon/storage/pill_bottle/dexalin_plus/fill()
     ..()
     new /obj/item/weapon/reagent_containers/pill/dexalin_plus(src)
     new /obj/item/weapon/reagent_containers/pill/dexalin_plus(src)
@@ -228,7 +228,7 @@
 	name = "bottle of Dermaline pills"
 	desc = "Contains pills used to treat burn wounds."
 
-/obj/item/weapon/storage/pill_bottle/dermaline/New()
+/obj/item/weapon/storage/pill_bottle/dermaline/fill()
     ..()
     new /obj/item/weapon/reagent_containers/pill/dermaline(src)
     new /obj/item/weapon/reagent_containers/pill/dermaline(src)
@@ -242,7 +242,7 @@
 	name = "bottle of Dylovene pills"
 	desc = "Contains pills used to treat toxic substances in the blood."
 
-/obj/item/weapon/storage/pill_bottle/dylovene/New()
+/obj/item/weapon/storage/pill_bottle/dylovene/fill()
     ..()
     new /obj/item/weapon/reagent_containers/pill/dylovene(src)
     new /obj/item/weapon/reagent_containers/pill/dylovene(src)
@@ -256,7 +256,7 @@
 	name = "bottle of Inaprovaline pills"
 	desc = "Contains pills used to stabilize patients."
 
-	New()
+	fill()
 		..()
 		new /obj/item/weapon/reagent_containers/pill/inaprovaline( src )
 		new /obj/item/weapon/reagent_containers/pill/inaprovaline( src )
@@ -270,7 +270,7 @@
 	name = "bottle of kelotane pills"
 	desc = "Contains pills used to treat burns."
 
-	New()
+	fill()
 		..()
 		new /obj/item/weapon/reagent_containers/pill/kelotane( src )
 		new /obj/item/weapon/reagent_containers/pill/kelotane( src )
@@ -284,7 +284,7 @@
 	name = "bottle of Spaceacillin pills"
 	desc = "A theta-lactam antibiotic. Effective against many diseases likely to be encountered in space."
 
-/obj/item/weapon/storage/pill_bottle/spaceacillin/New()
+/obj/item/weapon/storage/pill_bottle/spaceacillin/fill()
     ..()
     new /obj/item/weapon/reagent_containers/pill/spaceacillin(src)
     new /obj/item/weapon/reagent_containers/pill/spaceacillin(src)
@@ -298,7 +298,7 @@
 	name = "bottle of Tramadol pills"
 	desc = "Contains pills used to relieve pain."
 
-	New()
+	fill()
 		..()
 		new /obj/item/weapon/reagent_containers/pill/tramadol( src )
 		new /obj/item/weapon/reagent_containers/pill/tramadol( src )
@@ -312,7 +312,7 @@
 	name = "bottle of Citalopram pills"
 	desc = "Contains pills used to stabilize a patient's mood."
 
-	New()
+	fill()
 		..()
 		new /obj/item/weapon/reagent_containers/pill/citalopram( src )
 		new /obj/item/weapon/reagent_containers/pill/citalopram( src )

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -112,7 +112,7 @@
 	icon_closed = "medalbox"
 	icon_broken = "medalbox+b"
 
-/obj/item/weapon/storage/lockbox/medal/New()
+/obj/item/weapon/storage/lockbox/medal/fill()
 	..()
 	new /obj/item/clothing/accessory/medal/conduct(src)
 	new /obj/item/clothing/accessory/medal/conduct(src)

--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -19,12 +19,11 @@
 	can_hold = list(/obj/item/weapon/reagent_containers/food/snacks/donut)
 	foldable = /obj/item/stack/material/cardboard
 
-/obj/item/weapon/storage/box/donut/New()
+/obj/item/weapon/storage/box/donut/fill()
 	..()
 	for(var/i=1; i <= startswith; i++)
 		new /obj/item/weapon/reagent_containers/food/snacks/donut/normal(src)
 	update_icon()
-	return
 
 /obj/item/weapon/storage/box/donut/update_icon()
 	cut_overlays()

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -16,7 +16,7 @@
 	attack_verb = list("robusted")
 	var/stunhit = 0
 
-/obj/item/weapon/storage/toolbox/Initialize(mapload)
+/obj/item/weapon/storage/toolbox/Initialize()
 	. = ..()
 	update_force()
 
@@ -25,8 +25,7 @@
 	icon_state = "red"
 	item_state = "toolbox_red"
 
-	Initialize()
-		. = ..()
+	fill()
 		new /obj/item/weapon/crowbar/red(src)
 		new /obj/item/weapon/extinguisher/mini(src)
 		if(prob(50))
@@ -40,8 +39,7 @@
 	icon_state = "blue"
 	item_state = "toolbox_blue"
 
-	Initialize()
-		. = ..()
+	fill()
 		new /obj/item/weapon/screwdriver(src)
 		new /obj/item/weapon/wrench(src)
 		new /obj/item/weapon/weldingtool(src)
@@ -54,8 +52,7 @@
 	icon_state = "yellow"
 	item_state = "toolbox_yellow"
 
-	Initialize()
-		. = ..()
+	fill()
 		var/color = pick("red","yellow","green","blue","pink","orange","cyan","white")
 		new /obj/item/weapon/screwdriver(src)
 		new /obj/item/weapon/wirecutters(src)
@@ -75,8 +72,7 @@
 	origin_tech = list(TECH_COMBAT = 1, TECH_ILLEGAL = 1)
 	force = 7.0
 
-	Initialize()
-		. = ..()
+	fill()
 		new /obj/item/clothing/gloves/yellow(src)
 		new /obj/item/weapon/screwdriver(src)
 		new /obj/item/weapon/wrench(src)
@@ -120,7 +116,7 @@
 	max_storage_space = 8
 	var/filled = FALSE
 
-/obj/item/weapon/storage/toolbox/lunchbox/New()
+/obj/item/weapon/storage/toolbox/lunchbox/fill()
 	..()
 	if(filled)
 		var/list/lunches = lunchables_lunches()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -80,7 +80,7 @@
 /obj/item/weapon/storage/box/syndie_kit/imp_freedom
 	name = "boxed freedom implant (with injector)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_freedom/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_freedom/fill()
 	..()
 	var/obj/item/weapon/implanter/O = new(src)
 	O.imp = new /obj/item/weapon/implant/freedom(O)
@@ -90,15 +90,14 @@
 /obj/item/weapon/storage/box/syndie_kit/imp_compress
 	name = "box (C)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_compress/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_compress/fill()
 	new /obj/item/weapon/implanter/compressed(src)
 	..()
-	return
 
 /obj/item/weapon/storage/box/syndie_kit/imp_explosive
 	name = "box (E)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_explosive/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_explosive/fill()
 	new /obj/item/weapon/implanter/explosive(src)
 	..()
 	return
@@ -106,7 +105,7 @@
 /obj/item/weapon/storage/box/syndie_kit/imp_uplink
 	name = "boxed uplink implant (with injector)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_uplink/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_uplink/fill()
 	..()
 	var/obj/item/weapon/implanter/O = new(src)
 	O.imp = new /obj/item/weapon/implant/uplink(O)
@@ -116,19 +115,19 @@
 /obj/item/weapon/storage/box/syndie_kit/space
 	name = "boxed space suit and helmet"
 
-/obj/item/weapon/storage/box/syndie_kit/space/New()
+/obj/item/weapon/storage/box/syndie_kit/space/fill()
 	..()
 	new /obj/item/clothing/suit/space/syndicate(src)
 	new /obj/item/clothing/head/helmet/space/syndicate(src)
 	new /obj/item/clothing/mask/gas/syndicate(src)
 	new /obj/item/weapon/tank/emergency_oxygen/double(src)
-	return
+
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"
 	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
 
-/obj/item/weapon/storage/box/syndie_kit/chameleon/New()
+/obj/item/weapon/storage/box/syndie_kit/chameleon/fill()
 	..()
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/clothing/head/chameleon(src)
@@ -144,7 +143,7 @@
 	name = "clerical kit"
 	desc = "Comes with all you need to fake paperwork. Assumes you have passed basic writing lessons."
 
-/obj/item/weapon/storage/box/syndie_kit/clerical/New()
+/obj/item/weapon/storage/box/syndie_kit/clerical/fill()
 	..()
 	new /obj/item/weapon/stamp/chameleon(src)
 	new /obj/item/weapon/pen/chameleon(src)
@@ -156,7 +155,7 @@
 	name = "spy kit"
 	desc = "For when you want to conduct voyeurism from afar."
 
-/obj/item/weapon/storage/box/syndie_kit/spy/New()
+/obj/item/weapon/storage/box/syndie_kit/spy/fill()
 	..()
 	new /obj/item/device/spy_bug(src)
 	new /obj/item/device/spy_bug(src)
@@ -170,7 +169,7 @@
 	name = "\improper Smooth operator"
 	desc = "9mm with silencer kit."
 
-/obj/item/weapon/storage/box/syndie_kit/g9mm/New()
+/obj/item/weapon/storage/box/syndie_kit/g9mm/fill()
 	..()
 	new /obj/item/weapon/gun/projectile/pistol(src)
 	new /obj/item/weapon/silencer(src)
@@ -179,7 +178,7 @@
 	name = "toxin kit"
 	desc = "An apple will not be enough to keep the doctor away after this."
 
-/obj/item/weapon/storage/box/syndie_kit/toxin/New()
+/obj/item/weapon/storage/box/syndie_kit/toxin/fill()
 	..()
 	new /obj/item/weapon/reagent_containers/glass/beaker/vial/random/toxin(src)
 	new /obj/item/weapon/reagent_containers/syringe(src)
@@ -188,7 +187,7 @@
 	name = "\improper Tricky smokes"
 	desc = "Comes with the following brands of cigarettes, in this order: 2xFlash, 2xSmoke, 1xMindBreaker, 1xTricordrazine. Avoid mixing them up."
 
-/obj/item/weapon/storage/box/syndie_kit/cigarette/New()
+/obj/item/weapon/storage/box/syndie_kit/cigarette/fill()
 	..()
 	var/obj/item/weapon/storage/fancy/cigarettes/pack
 	pack = new /obj/item/weapon/storage/fancy/cigarettes(src)
@@ -229,7 +228,7 @@
 	name = "Electrowarfare and Voice Synthesiser kit"
 	desc = "Kit for confounding organic and synthetic entities alike."
 
-/obj/item/weapon/storage/box/syndie_kit/ewar_voice/New()
+/obj/item/weapon/storage/box/syndie_kit/ewar_voice/fill()
 	..()
 	new /obj/item/rig_module/electrowarfare_suite(src)
 	new /obj/item/rig_module/voice(src)
@@ -240,9 +239,7 @@
 	desc = "An ominous briefcase that has the unmistakeable smell of old, stale, cigarette smoke, and gives those who look at it a bad feeling."
 
 
-
-
-/obj/item/weapon/storage/secure/briefcase/money/New()
+/obj/item/weapon/storage/secure/briefcase/money/fill()
 	..()
 	new /obj/item/weapon/spacecash/c1000(src)
 	new /obj/item/weapon/spacecash/c1000(src)
@@ -254,5 +251,3 @@
 	new /obj/item/weapon/spacecash/c1000(src)
 	new /obj/item/weapon/spacecash/c1000(src)
 	new /obj/item/weapon/spacecash/c1000(src)
-
-

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -84,18 +84,40 @@
 	else
 		return ..()
 
-/obj/item/weapon/storage/wallet/random/New()
+/obj/item/weapon/storage/wallet/random/fill()
 	..()
-	var/item1_type = pick( /obj/item/weapon/spacecash/c10,/obj/item/weapon/spacecash/c100,/obj/item/weapon/spacecash/c1000,/obj/item/weapon/spacecash/c20,/obj/item/weapon/spacecash/c200,/obj/item/weapon/spacecash/c50, /obj/item/weapon/spacecash/c500)
+	var/item1_type = pick(                \
+		/obj/item/weapon/spacecash/c10,   \
+		/obj/item/weapon/spacecash/c100,  \
+		/obj/item/weapon/spacecash/c1000, \
+		/obj/item/weapon/spacecash/c20,   \
+		/obj/item/weapon/spacecash/c200,  \
+		/obj/item/weapon/spacecash/c50,   \
+		/obj/item/weapon/spacecash/c500   \
+	)
 	var/item2_type
 	if(prob(50))
-		item2_type = pick( /obj/item/weapon/spacecash/c10,/obj/item/weapon/spacecash/c100,/obj/item/weapon/spacecash/c1000,/obj/item/weapon/spacecash/c20,/obj/item/weapon/spacecash/c200,/obj/item/weapon/spacecash/c50, /obj/item/weapon/spacecash/c500)
-	var/item3_type = pick( /obj/item/weapon/coin/silver, /obj/item/weapon/coin/silver, /obj/item/weapon/coin/gold, /obj/item/weapon/coin/iron, /obj/item/weapon/coin/iron, /obj/item/weapon/coin/iron )
+		item2_type = pick(                    \
+			/obj/item/weapon/spacecash/c10,   \
+			/obj/item/weapon/spacecash/c100,  \
+			/obj/item/weapon/spacecash/c1000, \
+			/obj/item/weapon/spacecash/c20,   \
+			/obj/item/weapon/spacecash/c200,  \
+			/obj/item/weapon/spacecash/c50,   \
+			/obj/item/weapon/spacecash/c500   \
+		)
+	var/item3_type = pick(            \
+		/obj/item/weapon/coin/silver, \
+		/obj/item/weapon/coin/silver, \
+		/obj/item/weapon/coin/gold,   \
+		/obj/item/weapon/coin/iron,   \
+		/obj/item/weapon/coin/iron,   \
+		/obj/item/weapon/coin/iron    \
+	)
 
-	spawn(2)
-		if(item1_type)
-			new item1_type(src)
-		if(item2_type)
-			new item2_type(src)
-		if(item3_type)
-			new item3_type(src)
+	if(item1_type)
+		new item1_type(src)
+	if(item2_type)
+		new item2_type(src)
+	if(item3_type)
+		new item3_type(src)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -199,7 +199,7 @@
 	origin_tech = list(TECH_ILLEGAL = 3)
 	var/global/list/clothing_choices
 
-/obj/item/weapon/storage/backpack/chameleon/New()
+/obj/item/weapon/storage/backpack/chameleon/fill()
 	..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/weapon/storage/backpack/satchel/withwallet)

--- a/code/modules/detectivework/tools/crimekit.dm
+++ b/code/modules/detectivework/tools/crimekit.dm
@@ -9,7 +9,7 @@
 	max_storage_space = 35
 	contained_sprite = 1
 
-/obj/item/weapon/storage/briefcase/crimekit/New()
+/obj/item/weapon/storage/briefcase/crimekit/fill()
 	..()
 	new /obj/item/weapon/storage/box/swabs(src)
 	new /obj/item/weapon/storage/box/fingerprints(src)

--- a/code/modules/detectivework/tools/storage.dm
+++ b/code/modules/detectivework/tools/storage.dm
@@ -6,7 +6,7 @@
 	can_hold = list(/obj/item/weapon/forensics/swab)
 	storage_slots = 14
 
-/obj/item/weapon/storage/box/swabs/New()
+/obj/item/weapon/storage/box/swabs/fill()
 	..()
 	for(var/i=0;i<storage_slots,i++) // Fill 'er up.
 		new /obj/item/weapon/forensics/swab(src)
@@ -16,7 +16,7 @@
 	icon_state = "solution_trays"
 	storage_slots = 7
 
-/obj/item/weapon/storage/box/slides/New()
+/obj/item/weapon/storage/box/slides/fill()
 	..()
 	for(var/i=0;i<storage_slots,i++)
 		new /obj/item/weapon/forensics/slide(src)
@@ -26,7 +26,7 @@
 	desc = "A box claiming to contain evidence bags."
 	storage_slots = 6
 
-/obj/item/weapon/storage/box/evidence/New()
+/obj/item/weapon/storage/box/evidence/fill()
 	..()
 	for(var/i=0;i<storage_slots,i++)
 		new /obj/item/weapon/evidencebag(src)
@@ -39,7 +39,7 @@
 	can_hold = list(/obj/item/weapon/sample/print)
 	storage_slots = 14
 
-/obj/item/weapon/storage/box/fingerprints/New()
+/obj/item/weapon/storage/box/fingerprints/fill()
 	..()
 	for(var/i=0;i<storage_slots,i++)
 		new /obj/item/weapon/sample/print(src)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -27,7 +27,7 @@
 	name = "flora disk box"
 	desc = "A box of flora data disks, apparently."
 
-/obj/item/weapon/storage/box/botanydisk/New()
+/obj/item/weapon/storage/box/botanydisk/fill()
 	..()
 	for(var/i = 0;i<7;i++)
 		new /obj/item/weapon/disk/botany(src)

--- a/code/modules/research/xenoarchaeology/tools/tools_pickaxe.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_pickaxe.dm
@@ -169,7 +169,7 @@
 	max_w_class = 3
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
 
-/obj/item/weapon/storage/box/excavation/New()
+/obj/item/weapon/storage/box/excavation/fill()
 	..()
 	new /obj/item/weapon/pickaxe/brush(src)
 	new /obj/item/weapon/pickaxe/one_pick(src)


### PR DESCRIPTION
changes:
- Converted storage objects to Initialize().
- Removed timer from storage New/Initialize in favor of LateInitialize.
- Removed some pointless `src` from storage objects.
- Fixed GC of some screen objects used by storage objects.
- Changed storage objects' filling to be done by `fill()` instead of `New()`/`Initialize()`.

Medkits actually work this time!