### PR TITLE
Swap brains to absoloute pathing

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -9,45 +9,40 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "brain1"
 
-	New()
-		var/datum/reagents/R = new/datum/reagents(1000)
-		reagents = R
-		R.my_atom = src
-		..()
+/mob/living/carbon/brain/Destroy()
+	if(key)				//If there is a mob connected to this thing. Have to check key twice to avoid false death reporting.
+		if(stat!=DEAD)	//If not dead.
+			death(1)	//Brains can die again. AND THEY SHOULD AHA HA HA HA HA HA
+		ghostize()		//Ghostize checks for key so nothing else is necessary.
+	return ..()
 
-	Destroy()
-		if(key)				//If there is a mob connected to this thing. Have to check key twice to avoid false death reporting.
-			if(stat!=DEAD)	//If not dead.
-				death(1)	//Brains can die again. AND THEY SHOULD AHA HA HA HA HA HA
-			ghostize()		//Ghostize checks for key so nothing else is necessary.
-		return ..()
+/mob/living/carbon/brain/say_understands(var/other)//Goddamn is this hackish, but this say code is so odd
+	if (istype(other, /mob/living/silicon/ai))
+		if(!(container && istype(container, /obj/item/device/mmi)))
+			return 0
+		else
+			return 1
+	else if (istype(other, /mob/living/silicon/decoy))
+		if(!(container && istype(container, /obj/item/device/mmi)))
+			return 0
+		else
+			return 1
+	else if (istype(other, /mob/living/silicon/pai))
+		if(!(container && istype(container, /obj/item/device/mmi)))
+			return 0
+		else
+			return 1
+	else if (istype(other, /mob/living/silicon/robot))
+		if(!(container && istype(container, /obj/item/device/mmi)))
+			return 0
+		else
+			return 1
+	else if (istype(other, /mob/living/carbon/human))
+		return 1
+	else if (istype(other, /mob/living/carbon/slime))
+		return 1
 
-	say_understands(var/other)//Goddamn is this hackish, but this say code is so odd
-		if (istype(other, /mob/living/silicon/ai))
-			if(!(container && istype(container, /obj/item/device/mmi)))
-				return 0
-			else
-				return 1
-		if (istype(other, /mob/living/silicon/decoy))
-			if(!(container && istype(container, /obj/item/device/mmi)))
-				return 0
-			else
-				return 1
-		if (istype(other, /mob/living/silicon/pai))
-			if(!(container && istype(container, /obj/item/device/mmi)))
-				return 0
-			else
-				return 1
-		if (istype(other, /mob/living/silicon/robot))
-			if(!(container && istype(container, /obj/item/device/mmi)))
-				return 0
-			else
-				return 1
-		if (istype(other, /mob/living/carbon/human))
-			return 1
-		if (istype(other, /mob/living/carbon/slime))
-			return 1
-		return ..()
+	return ..()
 
 /mob/living/carbon/brain/update_canmove()
 	if(in_contents_of(/obj/mecha) || istype(loc, /obj/item/device/mmi))
@@ -55,6 +50,7 @@
 		use_me = 1
 	else
 		canmove = 0
+
 	return canmove
 
 /mob/living/carbon/brain/binarycheck()


### PR DESCRIPTION
Mobs are touchy things, so having them on relative pathing is a sin.

~~Also swaps an `if x n` chain to an `if/[elif x (n - 1)]` because it's faster.~~ Probably nevermind because they all signify a return point. But hey. /ASCIIshrug