### PR TITLE
Changes Electrocute_act

### DIFF
--- a/baystation12.int
+++ b/baystation12.int
@@ -1,9 +1,6 @@
 // BEGIN_INTERNALS
 /*
-LAST_COMPILE_TIME: 1498933875
-DIR: code code\game code\game\machinery code\game\machinery\kitchen code\modules code\modules\mob code\modules\mob\living code\modules\mob\living\carbon code\modules\mob\living\carbon\human 
-AUTO_FILE_DIR: OFF
 MAP_ICON_TYPE: 0
-LAST_COMPILE_VERSION: 511.1377
+AUTO_FILE_DIR: OFF
 */
 // END_INTERNALS

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -408,12 +408,17 @@
 /mob/living/carbon/human/proc/get_idcard()
 	if(wear_id)
 		return wear_id.GetID()
-//now more shit and less good but now shocks more things
+
 /mob/living/carbon/human/electrocute_act(var/shock_damage, var/obj/source, var/base_siemens_coeff = 1.0, var/def_zone = null, var/tesla_shock = 0)
+	var/hairvar = 0
 	if(status_flags & GODMODE)	return 0	//godmode
 	if(!def_zone)
 		var/list/damage_areas = list() //The way this works is by damaging multiple areas in an "Arc" if no def_zone is provided. should be pretty easy to add more arcs if it's needed. though I can't imangine a situation that can apply.
-		switch (rand(1,6))
+		if(istype(user, /mob/living/carbon/human))
+			if(h_style == "Floorlength Braid" || h_style == "Very Long Hair")
+				hairvar = 1
+		var/count = hairvar == 1 ? rand(1, 7) : rand(1, 6)
+		switch (count)
 			if(1)
 				damage_areas = list("l_hand", "l_arm", "chest", "r_arm", "r_hand")
 			if(2)
@@ -425,10 +430,15 @@
 			if(5)
 				damage_areas = list("r_hand", "r_arm", "chest", "groin", "r_leg", "r_foot")
 			if(6)
-				damage_areas = list("r_hand", "r_arm", "chest", "groin", "l_leg", "l_foot")	
+				damage_areas = list("r_hand", "r_arm", "chest", "groin", "l_leg", "l_foot")
+			if(7)//snowflake arc - only happens when they have long hair.
+				damage_areas = list("r_hand", "r_arm", "chest", "head")
+				h_style = "skinhead"
+				visible_message("<span class='warning'>[src]'s hair gets a burst of electricty through it, burning and turning to dust!</span>", "<span class='danger'>your hair burns as the current flows through it, turning to dust!</span>", "<span class='notice'>You hear a crackling sound, and smell burned hair!.</span>")
+				update_hair()
 		if(gloves)
 			shock_damage *= gloves.siemens_coefficient
-		
+
 		for (var/area in damage_areas)
 			apply_damage(shock_damage, BURN, area)
 			shock_damage *= 0.8
@@ -436,8 +446,8 @@
 	var/obj/item/organ/external/affected_organ = get_organ(check_zone(def_zone))
 	var/siemens_coeff = base_siemens_coeff * get_siemens_coefficient_organ(affected_organ)
 	return ..(shock_damage, source, siemens_coeff, def_zone, tesla_shock)
-/mob/living/carbon/human/Topic(href, href_list)
 
+/mob/living/carbon/human/Topic(href, href_list)
 	if (href_list["refresh"])
 		if((machine)&&(in_range(src, usr)))
 			show_inv(machine)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -411,117 +411,31 @@
 //now more shit and less good but now shocks more things
 /mob/living/carbon/human/electrocute_act(var/shock_damage, var/obj/source, var/base_siemens_coeff = 1.0, var/def_zone = null, var/tesla_shock = 0)
 	if(status_flags & GODMODE)	return 0	//godmode
-	if (!def_zone) //if no Defined zone.
-		switch (rand(1,6))// These go through 5 different "arcs", scaling down the given damage value per limb effeccted. so the foot will never get as damaged as the hand, ideally.
-			if (1)//Left hand to Right Hand, checks if there's gloves
-				if (gloves)
-					shock_damage *= gloves.siemens_coefficient
-				apply_damage(shock_damage, BURN, "l_hand")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "l_arm")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "chest")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "r_arm")
-				if (gloves)
-					shock_damage *= gloves.siemens_coefficient
-				else
-					shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "r_hand")
-				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
-			if (2)//Right Hand to Left Hand
-				if (gloves)
-					shock_damage *= gloves.siemens_coefficient
-				apply_damage(shock_damage, BURN, "r_hand")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "r_arm")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "chest")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "l_arm")
-				if (gloves)
-					shock_damage *= gloves.siemens_coefficient
-				else
-					shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "l_hand")
-				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
-			if (3)//Left Hand to Left Foot
-				if (gloves)
-					shock_damage *= gloves.siemens_coefficient
-				apply_damage(shock_damage, BURN, "l_hand")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "l_arm")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "chest")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "groin")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "l_leg")
-				if (shoes)
-					shock_damage *= shoes.siemens_coefficient
-				else
-					shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "l_foot")
-				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
-			if (4)//Left Hand to Right Foot
-				if (gloves)
-					shock_damage *= gloves.siemens_coefficient
-				apply_damage(shock_damage, BURN, "l_hand")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "l_arm")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "chest")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "groin")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "r_leg")
-				if (shoes)
-					shock_damage *= shoes.siemens_coefficient
-				else
-					shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "r_foot")
-				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
-			if (5)//Right Hand to Left Foot
-				if (gloves)
-					shock_damage *= gloves.siemens_coefficient
-				apply_damage(shock_damage, BURN, "r_hand")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "r_arm")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "chest")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "groin")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "l_leg")
-				if (shoes)
-					shock_damage *= shoes.siemens_coefficient
-				else
-					shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "l_foot")
-				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
-			if (6)//Right hand to Right foot
-				if (gloves)
-					shock_damage *= gloves.siemens_coefficient
-				apply_damage(shock_damage, BURN, "r_hand")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "r_arm")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "chest")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "groin")
-				shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "r_leg")
-				if (shoes)
-					shock_damage *= shoes.siemens_coefficient
-				else
-					shock_damage *= 0.8
-				apply_damage(shock_damage, BURN, "r_foot")
-				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
+	if(!def_zone)
+		var/list/damage_areas = list() //The way this works is by damaging multiple areas in an "Arc" if no def_zone is provided. should be pretty easy to add more arcs if it's needed. though I can't imangine a situation that can apply.
+		switch (rand(1,6))
+			if(1)
+				damage_areas = list("l_hand", "l_arm", "chest", "r_arm", "r_hand")
+			if(2)
+				damage_areas = list("r_hand", "r_arm", "chest", "l_arm", "L_hand")
+			if(3)
+				damage_areas = list("l_hand", "l_arm", "chest", "groin", "l_leg", "l_foot")
+			if(4)
+				damage_areas = list("l_hand", "l_arm", "chest", "groin", "r_leg", "r_foot")
+			if(5)
+				damage_areas = list("r_hand", "r_arm", "chest", "groin", "r_leg", "r_foot")
+			if(6)
+				damage_areas = list("r_hand", "r_arm", "chest", "groin", "l_leg", "l_foot")	
+		if(gloves)
+			shock_damage *= gloves.siemens_coefficient
+		
+		for (var/area in damage_areas)
+			apply_damage(shock_damage, BURN, area)
+			shock_damage *= 0.8
+		visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
 	var/obj/item/organ/external/affected_organ = get_organ(check_zone(def_zone))
 	var/siemens_coeff = base_siemens_coeff * get_siemens_coefficient_organ(affected_organ)
 	return ..(shock_damage, source, siemens_coeff, def_zone, tesla_shock)
-
-
 /mob/living/carbon/human/Topic(href, href_list)
 
 	if (href_list["refresh"])

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -408,18 +408,117 @@
 /mob/living/carbon/human/proc/get_idcard()
 	if(wear_id)
 		return wear_id.GetID()
-
-//Removed the horrible safety parameter. It was only being used by ninja code anyways.
-//Now checks siemens_coefficient of the affected area by default
+//now more shit and less good but now shocks more things
 /mob/living/carbon/human/electrocute_act(var/shock_damage, var/obj/source, var/base_siemens_coeff = 1.0, var/def_zone = null, var/tesla_shock = 0)
 	if(status_flags & GODMODE)	return 0	//godmode
-
-	if (!def_zone)
-		def_zone = pick("l_hand", "r_hand")
-
+	if (!def_zone) //if no Defined zone.
+		switch (rand(1,6))// These go through 5 different "arcs", scaling down the given damage value per limb effeccted. so the foot will never get as damaged as the hand, ideally.
+			if (1)//Left hand to Right Hand, checks if there's gloves
+				if (gloves)
+					shock_damage *= gloves.siemens_coefficient
+				apply_damage(shock_damage, BURN, "l_hand")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "l_arm")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "chest")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "r_arm")
+				if (gloves)
+					shock_damage *= gloves.siemens_coefficient
+				else
+					shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "r_hand")
+				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
+			if (2)//Right Hand to Left Hand
+				if (gloves)
+					shock_damage *= gloves.siemens_coefficient
+				apply_damage(shock_damage, BURN, "r_hand")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "r_arm")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "chest")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "l_arm")
+				if (gloves)
+					shock_damage *= gloves.siemens_coefficient
+				else
+					shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "l_hand")
+				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
+			if (3)//Left Hand to Left Foot
+				if (gloves)
+					shock_damage *= gloves.siemens_coefficient
+				apply_damage(shock_damage, BURN, "l_hand")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "l_arm")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "chest")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "groin")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "l_leg")
+				if (shoes)
+					shock_damage *= shoes.siemens_coefficient
+				else
+					shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "l_foot")
+				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
+			if (4)//Left Hand to Right Foot
+				if (gloves)
+					shock_damage *= gloves.siemens_coefficient
+				apply_damage(shock_damage, BURN, "l_hand")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "l_arm")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "chest")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "groin")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "r_leg")
+				if (shoes)
+					shock_damage *= shoes.siemens_coefficient
+				else
+					shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "r_foot")
+				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
+			if (5)//Right Hand to Left Foot
+				if (gloves)
+					shock_damage *= gloves.siemens_coefficient
+				apply_damage(shock_damage, BURN, "r_hand")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "r_arm")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "chest")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "groin")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "l_leg")
+				if (shoes)
+					shock_damage *= shoes.siemens_coefficient
+				else
+					shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "l_foot")
+				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
+			if (6)//Right hand to Right foot
+				if (gloves)
+					shock_damage *= gloves.siemens_coefficient
+				apply_damage(shock_damage, BURN, "r_hand")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "r_arm")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "chest")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "groin")
+				shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "r_leg")
+				if (shoes)
+					shock_damage *= shoes.siemens_coefficient
+				else
+					shock_damage *= 0.8
+				apply_damage(shock_damage, BURN, "r_foot")
+				visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")
 	var/obj/item/organ/external/affected_organ = get_organ(check_zone(def_zone))
 	var/siemens_coeff = base_siemens_coeff * get_siemens_coefficient_organ(affected_organ)
-
 	return ..(shock_damage, source, siemens_coeff, def_zone, tesla_shock)
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -685,3 +685,7 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	src << span("notice","You are now [resting ? "resting" : "getting up"]")
 
 	update_icons()
+//Todo: add snowflakey shit to it.
+/mob/living/simple_animal/electrocute_act(var/shock_damage, var/obj/source, var/base_siemens_coeff = 1.0, var/def_zone = null, var/tesla_shock = 0)
+	apply_damage(shock_damage, BURN,)
+	visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -687,5 +687,5 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	update_icons()
 //Todo: add snowflakey shit to it.
 /mob/living/simple_animal/electrocute_act(var/shock_damage, var/obj/source, var/base_siemens_coeff = 1.0, var/def_zone = null, var/tesla_shock = 0)
-	apply_damage(shock_damage, BURN,)
+	apply_damage(shock_damage, BURN)
 	visible_message("<span class='warning'>[src] was shocked by [source]!</span>", "<span class='danger'>You are shocked by [source]!</span>", "<span class='notice'>You hear an electrical crack.</span>")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -685,6 +685,7 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	src << span("notice","You are now [resting ? "resting" : "getting up"]")
 
 	update_icons()
+	
 //Todo: add snowflakey shit to it.
 /mob/living/simple_animal/electrocute_act(var/shock_damage, var/obj/source, var/base_siemens_coeff = 1.0, var/def_zone = null, var/tesla_shock = 0)
 	apply_damage(shock_damage, BURN)


### PR DESCRIPTION
As it works currently: Electrocute_act, the proc called when anybody gets shocked, has several problems.

As it is now - it only damages the hand. These changes Allow it to "arc" through one of 6 possible arcs:
*left to right hand
*right to left hand
*right hand to right foot
*right hand to left foot
*left hand to right foot
*left hand to left foot

*Snowflake hand to head to hair to ground fuck the braid

the "arcs" Check the `siemens_coefficient` of the entry and exit points of the Arcs when calculating damage - So you won't take any damage if you have insulated gloves, and I'm not sure if any shoes have that. but it tries to calculate it anyway. Who knows, Janitor might be buffed.

I've also taken the 60 seconds it took to add the proc to simple_animals. it's just flat damage right now though. I'll probably spruce it up in the future if nobody else does.

The proc _shouldn't in theory_ work any differently if you provided a `def_zone` for it to target - it'll still just damage the one area. but if no specific area is provided. it'll "arc"
