### PR TITLE
Disable the lighting memory hack

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -13,7 +13,7 @@
 
 // If defined, a tiny random number will be added to lighting matrixes to prevent a memory leak bug in v510 and below.
 // Enabling this disables lighting rounding.
-#define LIGHTING_USE_MEMORY_HACK
+//#define LIGHTING_USE_MEMORY_HACK
 
 // If I were you I'd leave this alone.
 #define LIGHTING_BASE_MATRIX \


### PR DESCRIPTION
Disables the 510 lighting memory hack by default since we're on 511 now.

Will generate warnings in Travis until #2900 is merged.