### PR TITLE
Fix player controlled range hostiles mobs being unable to fire

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -85,6 +85,21 @@
 			return
 
 	if(src.attached && src.beaker)
+	
+		var/mob/living/carbon/human/T = attached
+
+		if(!istype(T))
+			return
+		
+		if(!T.dna)
+			return
+			
+		if(NOCLONE in T.mutations)
+			return
+
+		if(T.species.flags & NO_BLOOD)
+			return
+	
 		// Give blood
 		if(mode)
 			if(src.beaker.volume > 0)
@@ -98,17 +113,6 @@
 			// If the beaker is full, ping
 			if(amount == 0)
 				if(prob(5)) visible_message("\The [src] pings.")
-				return
-
-			var/mob/living/carbon/human/T = attached
-
-			if(!istype(T)) return
-			if(!T.dna)
-				return
-			if(NOCLONE in T.mutations)
-				return
-
-			if(T.species.flags & NO_BLOOD)
 				return
 
 			// If the human is losing too much blood, beep.

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -172,7 +172,7 @@
 
 /mob/living/simple_animal/hostile/proc/OpenFire(target_mob)
 	var/target = target_mob
-	visible_message("<span class='warning'> <b>[src]</b> fires at [target]!</span>", 1)
+	visible_message("<span class='warning'> <b>[src]</b> fires at [target]!</span>")
 
 	if(rapid)
 		var/datum/callback/shoot_cb = CALLBACK(src, .proc/shoot_wrapper, target, loc, src)
@@ -216,6 +216,13 @@
 				obstacle.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
 				return 1
 	return 0
+
+/mob/living/simple_animal/hostile/RangedAttack(atom/A, params) //Player firing
+	if(ranged)
+		setClickCooldown(attack_delay)
+		target = A
+		OpenFire(A)
+	..()
 
 
 /mob/living/simple_animal/hostile/proc/check_horde()

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -535,7 +535,7 @@ datum/design/circuit/telepad
 /datum/design/item/weapon/decloner
 	id = "decloner"
 	req_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
-	materials = list("gold" = 5000,"uranium" = 10000, "mutagen" = 40)
+	materials = list("gold" = 5000,"uranium" = 10000)
 	build_path = /obj/item/weapon/gun/energy/decloner
 	sort_string = "TAAAE"
 


### PR DESCRIPTION
Pretty much fixes hostiles mobs that had a ranged attack being unable to use it if they are controlled by a player, so, we can have human controlled cavern dwellers and combat drones(in case of adminbus).

Also, fixes a broken design that needed mutagen and being able to transfer reagens to species without blood using an iv.