### PR TITLE
isopenturf() macro, update_above improvements

### DIFF
--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -58,9 +58,9 @@ turf/c_airblock(turf/other)
 	#ifdef MULTIZAS
 	if(other.z != src.z)
 		if(other.z < src.z)
-			if(!istype(src, /turf/simulated/open)) return BLOCKED
+			if(!isopenturf(src)) return BLOCKED
 		else
-			if(!istype(other, /turf/simulated/open)) return BLOCKED
+			if(!isopenturf(other)) return BLOCKED
 	#endif
 
 	if(((blocks_air & ZONE_BLOCKED) || (other.blocks_air & ZONE_BLOCKED)))

--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -20,14 +20,14 @@
 	} \
 	else if (B.z != A.z) { \
 		if (B.z < A.z) { \
-			if (!istype(A, /turf/simulated/open)) { \
+			if (!isopenturf(A)) { \
 				ret = BLOCKED; \
 			} else { \
 				ret = ZONE_BLOCKED; \
 			} \
 		} \
 		else { \
-			if (!istype(B, /turf/simulated/open)) { \
+			if (!isopenturf(B)) { \
 				ret = BLOCKED; \
 			} else { \
 				ret = ZONE_BLOCKED; \

--- a/code/__defines/subsystem-defines.dm
+++ b/code/__defines/subsystem-defines.dm
@@ -58,7 +58,7 @@
 #define STOP_VISUAL(visual)	visual.isprocessing = FALSE; SSeffects.visuals -= visual;
 
 // -- SSopenturf --
-#define CHECK_OO_EXISTENCE(OO) if (OO && !istype(OO.loc, /turf/simulated/open)) { qdel(OO); }
+#define CHECK_OO_EXISTENCE(OO) if (OO && !isopenturf(OO.loc)) { qdel(OO); }
 #define UPDATE_OO_IF_PRESENT CHECK_OO_EXISTENCE(bound_overlay); if (bound_overlay) { update_above(); }
 
 // -- SSfalling --

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -52,3 +52,5 @@
 #define send_rsc(target, rsc_content, rsc_name)             target << browse_rsc(rsc_content, rsc_name)
 
 #define CanInteract(user, state) (CanUseTopic(user, state) == STATUS_INTERACTIVE)
+
+#define isopenturf(target) istype(target, /turf/simulated/open)

--- a/code/controllers/subsystems/falling.dm
+++ b/code/controllers/subsystems/falling.dm
@@ -78,10 +78,10 @@
 		// Invokes fall_through() after the atom is moved to
 		// its new destination this cycle. Immediately invokes fall_impact and
 		// fall_collateral if the next turf is not open space.
-		if (istype(victim.loc, /turf/simulated/open))
+		if (isopenturf(victim.loc))
 			victim.forceMove(below)
 
-			if (istype(victim.loc, /turf/simulated/open))
+			if (isopenturf(victim.loc))
 				victim.fall_through()
 			else
 				// This is a lookahead. It removes any lag from being moved onto

--- a/code/controllers/subsystems/initialization/minimap.dm
+++ b/code/controllers/subsystems/initialization/minimap.dm
@@ -2,7 +2,7 @@
 // Seems to be much simpler/saner than /vg/'s implementation.
 
 // Turfs that will be colored as HOLOMAP_ROCK
-#define IS_ROCK(tile) (istype(tile, /turf/simulated/mineral) || istype(tile, /turf/simulated/floor/asteroid) || istype(tile, /turf/simulated/open))
+#define IS_ROCK(tile) (istype(tile, /turf/simulated/mineral) || istype(tile, /turf/simulated/floor/asteroid) || isopenturf(tile))
 
 // Turfs that will be colored as HOLOMAP_OBSTACLE
 #define IS_OBSTACLE(tile) ((!istype(tile, /turf/space) && istype(tile.loc, /area/mine/unexplored)) \

--- a/code/controllers/subsystems/openturf.dm
+++ b/code/controllers/subsystems/openturf.dm
@@ -195,6 +195,6 @@
 
 /datum/controller/subsystem/openturf/proc/calculate_depth(turf/simulated/open/T)
 	. = 0
-	while (T && istype(T.below, /turf/simulated/open))
+	while (T && isopenturf(T.below))
 		T = T.below
 		.++

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -43,7 +43,7 @@
 /obj/item/weapon/plastique/afterattack(atom/movable/target, mob/user, flag)
 	if (!flag)
 		return
-	if (ismob(target) || istype(target, /turf/unsimulated) || istype(target, /turf/simulated/shuttle)|| istype(target, /turf/simulated/open) || istype(target, /obj/item/weapon/storage/) || istype(target, /obj/item/clothing/accessory/storage/) || istype(target, /obj/item/clothing/under))
+	if (ismob(target) || istype(target, /turf/unsimulated) || istype(target, /turf/simulated/shuttle)|| isopenturf(target) || istype(target, /obj/item/weapon/storage/) || istype(target, /obj/item/clothing/accessory/storage/) || istype(target, /obj/item/clothing/under))
 		return
 	user << "Planting explosives..."
 	user.do_attack_animation(target)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -23,7 +23,7 @@
 /obj/structure/lattice/Initialize()
 	. = ..()
 	if (restrict_placement)
-		if(!(istype(loc, /turf/space) || istype(loc, /turf/simulated/open) || istype(loc, /turf/simulated/floor/asteroid)))
+		if(!(istype(loc, /turf/space) || isopenturf(loc) || istype(loc, /turf/simulated/floor/asteroid)))
 			return INITIALIZE_HINT_QDEL
 	for(var/obj/structure/lattice/LAT in loc)
 		if(LAT != src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -318,7 +318,7 @@ var/const/enterloopsanity = 100
 
 	if (roof_flags & ROOF_CLEANUP)
 		var/turf/above = GetAbove(src)
-		if (!above || istype(above, /turf/simulated/open))
+		if (!above || isopenturf(above))
 			return
 
 		above.ChangeTurf(/turf/simulated/open)

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -425,7 +425,7 @@ var/global/movement_disabled_exception //This is the client that calls the proc,
 
 	for(var/obj/machinery/door/airlock/A in machines)
 		var/turf/T = get_turf(A)
-		if(istype(T, /turf/space) || istype(T, /turf/simulated/floor/asteroid) || istype(T, /turf/simulated/open) || T.density)
+		if(istype(T, /turf/space) || istype(T, /turf/simulated/floor/asteroid) || isopenturf(T) || T.density)
 			usr << "Airlock [A] with bad turf at ([A.x],[A.y],[A.z]) in [T.loc]."
 
 /client/proc/get_bad_fdoors()

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -590,7 +590,7 @@
 				return 0
 
 		var/turf/leapEnd = get_step(TA, H.dir)
-		if (!leapEnd || istype(leapEnd, /turf/simulated/open) || istype(leapEnd, /turf/space)\
+		if (!leapEnd || isopenturf(leapEnd) || istype(leapEnd, /turf/space)\
 			|| leapEnd.density || leapEnd.contains_dense_objects())
 			to_chat(H, "<span class='warning'>There is no valid ledge to scale ahead of you!</span>")
 			return 0

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -342,7 +342,7 @@
 
 		turfs += T
 
-		if (istype(T, /turf/simulated/open) && T:below)
+		if (isopenturf(T) && T:below)
 			T = T:below	// Consider the turf below us as well. (Z-lights)
 			goto check_t
 

--- a/code/modules/lighting/lighting_source_novis.dm
+++ b/code/modules/lighting/lighting_source_novis.dm
@@ -76,7 +76,7 @@
 
 		CHECK_TICK
 
-		if (istype(T, /turf/simulated/open) && T:below)
+		if (isopenturf(T) && T:below)
 			T = T:below
 			goto check_t
 

--- a/code/modules/multiz/mobile_ladders.dm
+++ b/code/modules/multiz/mobile_ladders.dm
@@ -12,7 +12,7 @@
 
 /obj/item/weapon/ladder_mobile/proc/place_ladder(atom/A, mob/user)
 
-	if (istype(A, /turf/simulated/open))         //Place into open space
+	if (isopenturf(A))         //Place into open space
 		var/turf/below_loc = GetBelow(A)
 		if (!below_loc || (istype(/turf/space, below_loc)))
 			to_chat(user, "<span class='notice'>Why would you do that?! There is only infinite space there...</span>")
@@ -33,7 +33,7 @@
 
 	else if (istype(A, /turf/simulated/floor))        //Place onto Floor
 		var/turf/upper_loc = GetAbove(A)
-		if (!upper_loc || !istype(upper_loc,/turf/simulated/open))
+		if (!upper_loc || !isopenturf(upper_loc))
 			user << "<span class='notice'>There is something above. You can't deploy!</span>"
 			return
 		user.visible_message("<span class='warning'>[user] begins deploying \the [src] on \the [A].</span>",

--- a/code/modules/multiz/openspace.dm
+++ b/code/modules/multiz/openspace.dm
@@ -7,7 +7,7 @@
 
 /turf/Entered(atom/movable/thing, atom/oldLoc)
 	. = ..()
-	if (above && !thing.no_z_overlay && !thing.bound_overlay && !istype(oldLoc, /turf/simulated/open))
+	if (above && !thing.no_z_overlay && !thing.bound_overlay && !isopenturf(oldLoc))
 		above.update_icon()
 
 /turf/Destroy()
@@ -43,8 +43,11 @@
 		return
 
 	// check_existence returns TRUE if the overlay is valid.
-	if (bound_overlay.check_existence() && !bound_overlay.queued)
+	if (isopenturf(bound_overlay.loc) && !bound_overlay.queued)
 		SSopenturf.queued_overlays += bound_overlay
+		bound_overlay.queued = TRUE
+	else
+		qdel(bound_overlay)
 
 /atom/movable/proc/get_above_oo()
 	. = list()
@@ -136,21 +139,12 @@
 
 /atom/movable/openspace/overlay/forceMove(atom/dest)
 	. = ..()
-	if (istype(dest, /turf/simulated/open))
+	if (isopenturf(dest))
 		if (destruction_timer)
 			deltimer(destruction_timer)
 			destruction_timer = null
 	else if (!destruction_timer)
 		destruction_timer = addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, src), 10 SECONDS, TIMER_STOPPABLE)
-
-// Checks if we've moved off of an openturf.
-// Returns TRUE if we're continuing to exist, FALSE if we're deleting ourselves.
-/atom/movable/openspace/overlay/proc/check_existence()
-	if (!istype(loc, /turf/simulated/open))
-		qdel(src)
-		return FALSE
-	else
-		return TRUE
 
 // Called when the turf we're on is deleted/changed.
 /atom/movable/openspace/overlay/proc/owning_turf_changed()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -666,7 +666,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 				return
 ///// Z-Level Stuff
 		// check if the target is open space
-		if(istype(F, /turf/simulated/open))
+		if(isopenturf(F))
 			for(var/obj/structure/cable/LC in F)
 				if((LC.d1 == dirn && LC.d2 == 11 ) || ( LC.d2 == dirn && LC.d1 == 11))
 					user << "<span class='warning'>There's already a cable at that position.</span>"

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -164,10 +164,10 @@ datum/unit_test/wire_test/start_test()
 			continue
 
 		var/bad = 0
-		if (ladder.target_up && !istype(GetAbove(ladder), /turf/simulated/open))
+		if (ladder.target_up && !isopenturf(GetAbove(ladder)))
 			bad |= BLOCKED_UP
 
-		if (ladder.target_down && !istype(ladder.loc, /turf/simulated/open))
+		if (ladder.target_down && !isopenturf(ladder.loc))
 			bad |= BLOCKED_DOWN
 
 		if (bad)


### PR DESCRIPTION
changes:
- Added a `isopenturf()` macro, equivalent to `istype(thing, /turf/simulated/open)`.
- Converted most/all instances of `istype(/turf/simulated/open)` to `isopenturf()`.
- Made `update_above()`' aware of queue status & inlined a proc-call.