### PR TITLE
Fix some RTs - 03JUL2017

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -29,8 +29,7 @@
 /proc/get_area(O)
 	var/turf/loc = get_turf(O)
 	if(loc)
-		var/area/res = loc.loc
-		.= res
+		.= loc.loc
 
 /proc/get_area_name(N) //get area by its name
 	for(var/area/A in world)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -100,7 +100,8 @@
 	can_hold = list(/obj/item/weapon/ore)
 
 /obj/item/weapon/storage/bag/ore/drone
-	max_storage_space = 400
+	// this used to be 400. The inventory system FUCKING DIED at this.
+	max_storage_space = 200
 
 
 // -----------------------------

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -4,6 +4,10 @@
 // Do not remove this functionality without good reason, cough reagent_containers cough.
 // -Sayu
 
+// Because tick_checking this code gets funky (it's bound directly into user interaction)
+// We instead cap the amount of maximum storage space to 200. A loop that should be fine
+// for the server to handle without dying.
+#define STORAGE_SPACE_CAP 200
 
 /obj/item/weapon/storage
 	name = "storage"
@@ -254,11 +258,11 @@
 	var/obj/item/sample_object
 	var/number
 
-	New(obj/item/sample as obj)
-		if(!istype(sample))
-			qdel(src)
-		sample_object = sample
-		number = 1
+/datum/numbered_display/New(obj/item/sample as obj)
+	if(!istype(sample))
+		qdel(src)
+	sample_object = sample
+	number = 1
 
 //This proc determins the size of the inventory to be displayed. Please touch it only if you know what you're doing.
 /obj/item/weapon/storage/proc/orient2hud(mob/user as mob)
@@ -522,6 +526,10 @@
 /obj/item/weapon/storage/Initialize()
 	..()
 
+	if (max_storage_space > STORAGE_SPACE_CAP)
+		log_debug("STORAGE: [type] exceed STORAGE_SPACE_CAP. It has been reset to [STORAGE_SPACE_CAP].")
+		max_storage_space = STORAGE_SPACE_CAP
+
 	fill()
 
 	if(!allow_quick_empty)
@@ -666,3 +674,5 @@
 			return 1000
 
 		//return 2**(w_class-1) //1,2,4,8,16,...
+
+#undef STORAGE_SPACE_CAP

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -138,7 +138,12 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		if (pref.rlimb_data)
 			pref.rlimb_data = params2list(pref.rlimb_data)
 		if (pref.body_markings)
-			pref.body_markings = json_decode(pref.body_markings)
+			var/before = pref.body_markings
+			try
+				pref.body_markings = json_decode(pref.body_markings)
+			catch (var/exception/e)
+				log_debug("BODY MARKINGS: Caught [e]. Initial value: [before]")
+				pref.body_markings = list()
 
 	pref.r_hair			= sanitize_integer(pref.r_hair, 0, 255, initial(pref.r_hair))
 	pref.g_hair			= sanitize_integer(pref.g_hair, 0, 255, initial(pref.g_hair))
@@ -601,7 +606,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		var/disability_flag = text2num(href_list["disabilities"])
 		pref.disabilities ^= disability_flag
 		return TOPIC_REFRESH
-		
+
 	else if(href_list["toggle_clothing"])
 		pref.dress_mob = !pref.dress_mob
 		return TOPIC_REFRESH

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -266,9 +266,11 @@
 
 					//sealed pieces become airtight, protecting against diseases
 					if (!seal_target)
+						LAZYINITLIST(piece.armor)
 						piece.armor["bio"] = 100
 					else
-						piece.armor["bio"] = src.armor["bio"]
+						LAZYINITLIST(piece.armor)
+						piece.armor["bio"] = LAZYACCESS(src.armor, "bio") || 0
 
 				else
 					failed_to_seal = 1

--- a/code/modules/clothing/suits/hoodies.dm
+++ b/code/modules/clothing/suits/hoodies.dm
@@ -27,11 +27,17 @@
 	icon_state = "[initial(icon_state)]"
 	item_state = "[initial(item_state)]"
 	suittoggled = 0
+
+	// Hood got nuked. Probably because of RIGs or the like.
+	if (!hood)
+		MakeHood()
+		return
+
 	if(ishuman(hood.loc))
 		var/mob/living/carbon/H = hood.loc
 		H.unEquip(hood, 1)
 		H.update_inv_wear_suit()
-	hood.loc = src
+	hood.forceMove(src)
 
 /obj/item/clothing/suit/storage/hooded/dropped()
 	RemoveHood()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -67,7 +67,7 @@
 	var/obj/item/clothing/head/helmet = get_equipped_item(slot_head)
 	if(istype(helmet) && (helmet.body_parts_covered & HEAD) && (helmet.flags & STOPPRESSUREDAMAGE))
 		//we don't do an armor_check here because this is not an impact effect like a weapon swung with momentum, that either penetrates or glances off.
-		damage_mod = 1.0 - (helmet.armor["melee"]/100)
+		damage_mod = 1.0 - (LAZYACCESS(helmet.armor, "melee")/100)
 
 	var/total_damage = 0
 	for(var/i in 1 to 3)

--- a/code/modules/mob/living/simple_animal/bees.dm
+++ b/code/modules/mob/living/simple_animal/bees.dm
@@ -79,12 +79,12 @@
 				if ((worn_suit.flags & THICKMATERIAL))
 					prob_mult -= 0.7
 				else
-					prob_mult -= 0.01 * (min(worn_suit.armor["bio"],70)) // Is it sealed? I can't get to 70% of your body.
+					prob_mult -= 0.01 * (min(LAZYACCESS(worn_suit.armor, "bio"), 70)) // Is it sealed? I can't get to 70% of your body.
 			if(worn_helmet)
 				if ((worn_helmet.flags & THICKMATERIAL))
 					prob_mult -= 0.3
 				else
-					prob_mult -= 0.01 *(min(worn_helmet.armor["bio"],30))// Is your helmet sealed? I can't get to 30% of your body.
+					prob_mult -= 0.01 *(min(LAZYACCESS(worn_helmet.armor, "bio"), 30))// Is your helmet sealed? I can't get to 30% of your body.
 			if( prob(sting_prob*prob_mult) && (M.stat == CONSCIOUS || (M.stat == UNCONSCIOUS && prob(25*prob_mult))) ) // Try to sting! If you're not moving, think about stinging.
 				M.apply_damage(min(strength*0.85,2)+mut, BURN, sharp=1) // Stinging. The more mutated I am, the harder I sting.
 				M.apply_damage(max(strength*1.7,(round(feral/10,1)*(max((round(strength/20,1)),1)))+toxic), TOX) // Bee venom based on how angry I am and how many there are of me!

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -171,7 +171,7 @@
 	if(owner)
 		replaced(owner)
 		sync_colour_to_human(owner)
-		
+
 	addtimer(CALLBACK(src, .proc/get_icon), 1)
 
 	if ((status & ORGAN_PLANT))
@@ -272,12 +272,14 @@
 				spillover += max(0, burn - can_inflict)
 
 		//If there are still hurties to dispense
-		if (spillover)
+		if (spillover && owner)
 			owner.shock_stage += spillover * config.organ_damage_spillover_multiplier
 
 	// sync the organ's damage with its wounds
 	src.update_damages()
-	owner.updatehealth() //droplimb will call updatehealth() again if it does end up being called
+
+	if (owner)
+		owner.updatehealth() //droplimb will call updatehealth() again if it does end up being called
 
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner && !is_stump())

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -229,7 +229,7 @@
 			brute -= brute / 2
 
 	if(status & ORGAN_BROKEN && prob(40) && brute)
-		if (!(owner.species && (owner.species.flags & NO_PAIN)))
+		if (owner && !(owner.species && (owner.species.flags & NO_PAIN)))
 			owner.emote("scream")	//getting hit on broken hand hurts
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -17,14 +17,14 @@ var/global/list/gps_by_type = list()
 
 /obj/item/device/gps/Initialize()
 	. = ..()
-	GPS_list.Add(src)
+	GPS_list += src
 	LAZYADD(gps_by_type["[type]"], src)
 	gpstag = "[gps_prefix][LAZYLEN(gps_by_type["[type]"])]"
 	name = "global positioning system ([gpstag])"
 	add_overlay("working")
 
 /obj/item/device/gps/Destroy()
-	GPS_list.Remove(src)
+	GPS_list -= src
 	var/list/typelist = gps_by_type["[type]"]
 	LAZYREMOVE(typelist, src)
 	return ..()
@@ -57,7 +57,7 @@ var/global/list/gps_by_type = list()
 			var/turf/pos = get_turf(G)
 			var/area/gps_area = get_area(G)
 			var/tracked_gpstag = G.gpstag
-			if(G.emped == 1)
+			if(G.emped == 1 || !pos)
 				t += "<BR>[tracked_gpstag]: ERROR"
 			else
 				t += "<BR>[tracked_gpstag]: [format_text(gps_area.name)] ([pos.x], [pos.y], [pos.z])"

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -17,7 +17,8 @@ proc/infection_check(var/mob/living/carbon/M, var/vector = "Airborne")
 			var/obj/item/I = M.wear_mask
 			//masks provide a small bonus and can replace overall bio protection
 			if(I)
-				score = max(score, round(0.06*I.armor["bio"]))
+				var/bio_armor = LAZYACCESS(I.armor, "bio") || 0
+				score = max(score, round(0.06 * bio_armor))
 				if (istype(I, /obj/item/clothing/mask))
 					score += 1 //this should be added after
 
@@ -51,7 +52,7 @@ proc/infection_check(var/mob/living/carbon/M, var/vector = "Airborne")
 	if (vector == "Airborne")
 		var/obj/item/I = M.wear_mask
 		if (istype(I))
-			protection = max(protection, I.armor["bio"])
+			protection = max(protection, LAZYACCESS(I.armor, "bio") || 0)
 
 	return prob(protection)
 


### PR DESCRIPTION
Fix the most common RTs from Sunday's testing. 

Also works on orebags. Limits their capacity to 200, as anything higher than that breaks the fancy inventory system something awful. Maybe I should write a UT to test and confirm this. Expanding: I don't think TICK_CHECK in inventory procs is a good idea, without fully implementing a non-fancy storage subclass. Non-fancy would just be speedy without all of the fancy inventory orientation bullshit. But CBA to do that now and I'm not sure if it's worth it for the edgecase of drone satchels atm.

Runtimes in question:
```
The following runtime has occurred 137 time(s).
runtime error: bad index
proc name: infection check (/proc/infection_check)

The following runtime has occurred 129 time(s).
runtime error: Cannot read null.name
proc name: attack self (/obj/item/device/gps/attack_self)

The following runtime has occurred 50 time(s).
runtime error: Unknown value: 0
proc name: sanitize character (/datum/category_item/player_setup_item/general/body/sanitize_character)

The following runtime has occurred 49 time(s).
runtime error: Cannot read null.loc
proc name: RemoveHood (/obj/item/clothing/suit/storage/hooded/proc/RemoveHood)

The following runtime has occurred 49 time(s).
runtime error: Cannot execute null.updatehealth().
proc name: take damage (/obj/item/organ/external/take_damage)
```