### PR TITLE
Openturf fixes, dynamically lit holodeck, and quick-pickup tweaks

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -1050,13 +1050,14 @@ area/space/atmosalert()
 /area/holodeck
 	name = "\improper Holodeck"
 	icon_state = "Holodeck"
-	dynamic_lighting = 0
 	sound_env = LARGE_ENCLOSED
-	no_light_control = 1
-	station_area = 1
+	no_light_control = TRUE
+	station_area = TRUE
+	dynamic_lighting = FALSE
 
 /area/holodeck/alphadeck
 	name = "\improper Holodeck Alpha"
+	dynamic_lighting = TRUE
 
 /area/holodeck/source_plating
 	name = "\improper Holodeck - Off"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -189,23 +189,26 @@
 		var/obj/item/weapon/storage/S = W
 		if(S.use_to_pickup)
 			if(S.collection_mode) //Mode is set to collect all items on a tile and we clicked on a valid one.
-				if(isturf(src.loc))
+				if(isturf(loc))
 					var/list/rejections = list()
-					var/success = 0
-					var/failure = 0
+					var/success = FALSE
+					var/failure = FALSE
+					var/original_loc = user ? user.loc : null
 
-					for(var/obj/item/I in src.loc)
-						CHECK_TICK
+					for(var/obj/item/I in loc)
+						if (user && user.loc != original_loc)
+							break
 
-						if(I.type in rejections) // To limit bag spamming: any given type only complains once
+						if(rejections[I.type]) // To limit bag spamming: any given type only complains once
 							continue
 
 						if(!S.can_be_inserted(I))	// Note can_be_inserted still makes noise when the answer is no
-							rejections += I.type	// therefore full bags are still a little spammy
-							failure = 1
+							rejections[I.type] = TRUE	// therefore full bags are still a little spammy
+							failure = TRUE
+							CHECK_TICK
 							continue
 
-						success = 1
+						success = TRUE
 						S.handle_item_insertion(I, 1)	//The 1 stops the "You put the [src] into [S]" insertion message from being displayed.
 						CHECK_TICK	// Because people insist on picking up huge-ass piles of stuff.
 
@@ -218,8 +221,6 @@
 
 			else if(S.can_be_inserted(src))
 				S.handle_item_insertion(src)
-
-	return
 
 /obj/item/proc/talk_into(mob/M as mob, text)
 	return

--- a/code/modules/multiz/openspace.dm
+++ b/code/modules/multiz/openspace.dm
@@ -36,7 +36,10 @@
 	. = ..(dest)
 	if (bound_overlay)
 		// The overlay will handle cleaning itself up on non-openspace turfs.
-		bound_overlay.forceMove(get_step(src, UP))
+		if (isturf(dest))
+			bound_overlay.forceMove(get_step(src, UP))
+		else	// Not a turf, so we need to destroy immediately instead of waiting for the destruction timer to proc.
+			qdel(bound_overlay)
 
 /atom/movable/update_above()
 	if (!bound_overlay)


### PR DESCRIPTION
changes:
- The station's holodeck is now dynamically lit.
- Improved quick-pickup's tick checking & converted to assoc lists instead of `if (thing in list)`.
- Fixed an edge case where openspace overlays would not properly cleanup on forceMove to a non-turf.

Fixes #2941.