### PR TITLE
Fixes #2939

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -524,15 +524,6 @@
 	mind.special_role = ""
 
 //Animals
-/*
-/mob/living/simple_animal/mind_initialize()
-	..()
-	mind.assigned_role = "Animal"
-
-/mob/living/simple_animal/corgi/mind_initialize()
-	..()
-	mind.assigned_role = "Corgi"
-*/
 /mob/living/simple_animal/shade/mind_initialize()
 	..()
 	mind.assigned_role = "Shade"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -524,6 +524,7 @@
 	mind.special_role = ""
 
 //Animals
+/*
 /mob/living/simple_animal/mind_initialize()
 	..()
 	mind.assigned_role = "Animal"
@@ -531,7 +532,7 @@
 /mob/living/simple_animal/corgi/mind_initialize()
 	..()
 	mind.assigned_role = "Corgi"
-
+*/
 /mob/living/simple_animal/shade/mind_initialize()
 	..()
 	mind.assigned_role = "Shade"
@@ -564,3 +565,11 @@
 /mob/living/simple_animal/hostile/faithless/wizard/mind_initialize()
 	..()
 	mind.assigned_role = "Space Wizard"
+
+/mob/living/simple_animal/familiar/mind_initialize()
+	..()
+	mind.assigned_role = "Familiar"
+
+/mob/living/simple_animal/mouse/familiar/familiar/mind_initialize()
+	..()
+	mind.assigned_role = "Familiar"

--- a/code/modules/spells/contracts.dm
+++ b/code/modules/spells/contracts.dm
@@ -50,6 +50,7 @@
 		user.mind.assigned_role = "Apprentice"
 		user << "<span class='notice'>With the signing of this paper you agree to become \the [contract_master]'s apprentice in the art of wizardry.</span>"
 		user.faction = "Space Wizard"
+		wizards.add_antagonist_mind(user.mind,1)
 		new /obj/item/weapon/spellbook/student(get_turf(user))
 		return 1
 	return 0


### PR DESCRIPTION
Fixes #2939 by removing the simple animal mind datum that replaced the assigned_role with animal instead of keeping as it is.
Also, adds apprentices to the wizard antag list, allowing them to use aooc and etc.