### PR TITLE
More macros

### DIFF
--- a/code/ZAS/Connection.dm
+++ b/code/ZAS/Connection.dm
@@ -60,8 +60,8 @@ Class Procs:
 
 /connection/New(turf/simulated/A, turf/simulated/B)
 	#ifdef ZASDBG
-	ASSERT(SSair.has_valid_zone(A))
-	//ASSERT(SSair.has_valid_zone(B))
+	ASSERT(TURF_HAS_VALID_ZONE(A))
+	//ASSERT(TURF_HAS_VALID_ZONE(B))
 	#endif
 	src.A = A
 	src.B = B

--- a/code/ZAS/Zone.dm
+++ b/code/ZAS/Zone.dm
@@ -66,7 +66,7 @@ Class Procs:
 #ifdef ZASDBG
 	ASSERT(!invalid)
 	ASSERT(istype(T))
-	ASSERT(!SSair.has_valid_zone(T))
+	ASSERT(!TURF_HAS_VALID_ZONE(T))
 #endif
 	var/datum/gas_mixture/turf_air = T.return_air()
 	add_tile_air(turf_air)

--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -13,6 +13,8 @@
 #define CANPASS_PROC 3
 #define CANPASS_NEVER 4
 
+#define TURF_HAS_VALID_ZONE(T) (istype(T, /turf/simulated) && T:zone && !T:zone:invalid)
+
 #ifdef MULTIZAS
 #define ATMOS_CANPASS_TURF(ret,A,B) \
 	if (A.blocks_air & AIR_BLOCKED || B.blocks_air & AIR_BLOCKED) { \

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -164,6 +164,7 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 //Area flags, possibly more to come
 #define RAD_SHIELDED 1 //shielded from radiation, clearly
 #define SPAWN_ROOF   2 // if we should attempt to spawn a roof above us.
+#define HIDE_FROM_HOLOMAP 4 // if we shouldn't be drawn on station holomaps
 
 // Custom layer definitions, supplementing the default TURF_LAYER, MOB_LAYER, etc.
 #define DOOR_OPEN_LAYER 2.7		//Under all objects if opened. 2.7 due to tables being at 2.6
@@ -369,3 +370,6 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #endif 
 
 #define DEFAULT_SIGHT (SEE_SELF|SEE_BLACKNESS)
+
+#define isStationLevel(Z) ((Z) in config.station_levels)
+#define isNotStationLevel(Z) !isStationLevel(Z)

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -61,12 +61,6 @@
 
 	return heard
 
-/proc/isStationLevel(var/level)
-	return level in config.station_levels
-
-/proc/isNotStationLevel(var/level)
-	return !isStationLevel(level)
-
 /proc/isPlayerLevel(var/level)
 	return level in config.player_levels
 

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -180,7 +180,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		var/turf/T = curr_tiles[curr_tiles.len]
 		curr_tiles.len--
 
-		if (QDELETED(T))
+		if (!T)
 			if (no_mc_tick)
 				CHECK_TICK
 			else if (MC_TICK_CHECK)
@@ -303,12 +303,6 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		return BLOCKED
 	ATMOS_CANPASS_TURF(., B, A)
 	return ablock | .
-
-/datum/controller/subsystem/air/proc/has_valid_zone(turf/simulated/T)
-	#ifdef ZASDBG
-	ASSERT(istype(T))
-	#endif
-	return istype(T) && T.zone && !T.zone.invalid
 
 /datum/controller/subsystem/air/proc/merge(zone/A, zone/B)
 	#ifdef ZASDBG

--- a/code/controllers/subsystems/initialization/minimap.dm
+++ b/code/controllers/subsystems/initialization/minimap.dm
@@ -59,7 +59,11 @@
 	for(var/x = 1 to world.maxx)
 		for(var/y = 1 to world.maxy)
 			var/turf/tile = locate(x, y, zlevel)
-			if(tile && tile.loc:holomapAlwaysDraw())
+			var/area/A
+			if(tile)
+				A = tile.loc
+				if (A.flags & HIDE_FROM_HOLOMAP)
+					continue
 				if(IS_ROCK(tile))
 					continue
 				if(IS_OBSTACLE(tile))

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -570,7 +570,7 @@ area/space/atmosalert()
 
 
 /area/maintenance
-	flags = RAD_SHIELDED
+	flags = RAD_SHIELDED | HIDE_FROM_HOLOMAP
 	sound_env = TUNNEL_ENCLOSED
 	turf_initializer = new /datum/turf_initializer/maintenance()
 	ambience = list(
@@ -581,9 +581,6 @@ area/space/atmosalert()
 		'sound/ambience/ambimaint5.ogg'
 	)
 	station_area = 1
-
-/area/maintenance/holomapAlwaysDraw()
-	return FALSE
 
 /area/maintenance/civ
 	name = "\improper Civilian Maintenance"
@@ -1547,9 +1544,7 @@ area/space/atmosalert()
 	name = "\improper Vault"
 	icon_state = "nuke_storage"
 	holomap_color = null
-
-/area/security/nuke_storage/holomapAlwaysDraw()
-	return FALSE
+	flags = HIDE_FROM_HOLOMAP
 
 /area/security/checkpoint
 	name = "\improper Security Checkpoint"
@@ -1976,9 +1971,7 @@ area/space/atmosalert()
 
 /area/turret_protected
 	station_area = 1
-
-/area/turret_protected/holomapAlwaysDraw()
-	return FALSE
+	flags = HIDE_FROM_HOLOMAP
 
 /area/turret_protected/ai_upload
 	name = "\improper AI Upload Chamber"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -385,11 +385,3 @@ var/list/mob/living/forced_ambiance_list = new
 	if (turfs.len)
 		return pick(turfs)
 	else return null
-
-
-// Whether the turfs in the area should be drawn onto the "base" holomap.
-/area/proc/holomapAlwaysDraw()
-	return TRUE
-
-/area/shuttle/holomapAlwaysDraw()
-	return FALSE

--- a/code/game/area/asteroid_areas.dm
+++ b/code/game/area/asteroid_areas.dm
@@ -12,9 +12,7 @@
 /area/mine/unexplored
 	name = "Mine"
 	icon_state = "unexplored"
-
-/area/mine/unexplored/holomapAlwaysDraw()
-	return FALSE
+	flags = HIDE_FROM_HOLOMAP
 
 //S
 

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -1,8 +1,8 @@
 //Config stuff
 #define SUPPLY_DOCKZ 3         //Z-level of the Dock.
 #define SUPPLY_STATIONZ 1       //Z-level of the Station.
-#define SUPPLY_STATION_AREATYPE "/area/supply/station" //Type of the supply shuttle area for station
-#define SUPPLY_DOCK_AREATYPE "/area/supply/dock"	//Type of the supply shuttle area for dock
+#define SUPPLY_STATION_AREATYPE /area/supply/station //Type of the supply shuttle area for station
+#define SUPPLY_DOCK_AREATYPE /area/supply/dock	//Type of the supply shuttle area for dock
 
 //Supply packs are in /code/defines/obj/supplypacks.dm
 //Computers are in /code/game/machinery/computer/supply.dm
@@ -16,7 +16,7 @@
 	icon_state = "shuttle3"
 	requires_power = 0
 	station_area = 1
-	dynamic_lighting = 0
+	flags = SPAWN_ROOF | HIDE_FROM_HOLOMAP
 
 /area/supply/dock
 	name = "Supply Shuttle"

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -51,6 +51,8 @@
 
 	. = ..()
 	levelupdate(mapload)
+	if (!mapload)
+		updateVisibility(src)
 
 /turf/simulated/proc/AddTracks(var/typepath,var/bloodDNA,var/comingdir,var/goingdir,var/bloodcolor="#A10808")
 	var/obj/effect/decal/cleanable/blood/tracks/tracks = locate(typepath) in src

--- a/code/modules/mob/freelook/update_triggers.dm
+++ b/code/modules/mob/freelook/update_triggers.dm
@@ -16,11 +16,6 @@
 	updateVisibility(src)
 	return ..()
 
-/turf/simulated/Initialize()
-	. = ..()
-	updateVisibility(src)
-
-
 // STRUCTURES
 
 /obj/structure/Destroy()
@@ -33,8 +28,8 @@
 	updateVisibility(src)
 	return ..()
 
-/obj/effect/New()
-	..()
+/obj/effect/Initialize()
+	. = ..()
 	updateVisibility(src)
 
 // DOORS

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -1,7 +1,7 @@
 /datum/gas_mixture
 	//Associative list of gas moles.
 	//Gases with 0 moles are not tracked and are pruned by update_values()
-	var/list/gas = list()
+	var/list/gas
 	//Temperature in Kelvin of this gas mix.
 	var/temperature = 0
 
@@ -19,6 +19,7 @@
 	volume = _volume
 	temperature = _temperature
 	group_multiplier = _group_multiplier
+	gas = list()
 
 /datum/gas_mixture/proc/get_gas(gasid)
 	if(!gas.len)


### PR DESCRIPTION
changes:
- Holomaps now use an area flag instead of a proc to determine which areas do not draw on the holomap.
- The supply shuttle once more has a roof.
- The supply shuttle's landing zone is now dynamically lit.
- Turfs only generate visibility updates on Initialize() after mapload - visualnet is not initialized by then anyways.
- Merged `/datum/gas_mixture/(init)` into `/datum/gas_mixture/New()`.
- Converted a ZAS proc into a macro.
- Made ZAS attempt to remove a turf from a zone instead of always rebuilding it in a certain case.
- Macroized two misc procs.

Fixes #2947.