### PR TITLE
Improved observ efficiency

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -268,7 +268,6 @@
 #include "code\datums\observation\destroyed.dm"
 #include "code\datums\observation\moved.dm"
 #include "code\datums\observation\observation.dm"
-#include "code\datums\observation\task_triggered.dm"
 #include "code\datums\radio\frequency.dm"
 #include "code\datums\radio\signal.dm"
 #include "code\datums\repositories\cameras.dm"

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -227,6 +227,7 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 // This should be overridden to remove all references pointing to the object being destroyed.
 // Return the appropriate QDEL_HINT; in most cases this is QDEL_HINT_QUEUE.
 /datum/proc/Destroy(force=FALSE)
+	destroyed_event.raise_event(src)
 	SSnanoui.close_uis(src)
 	tag = null
 	var/list/timers = active_timers

--- a/code/datums/observation/destroyed.dm
+++ b/code/datums/observation/destroyed.dm
@@ -2,7 +2,3 @@ var/datum/observ/destroyed/destroyed_event = new()
 
 /datum/observ/destroyed
 	name = "Destroyed"
-
-/datum/Destroy()
-	destroyed_event.raise_event(list(src))
-	. = ..()

--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -22,7 +22,7 @@ var/datum/observ/moved/moved_event = new()
 	var/old_loc = loc
 	. = ..()
 	if(.)
-		moved_event.raise_event(list(src, old_loc, loc))
+		moved_event.raise_event(src, old_loc, loc)
 
 /atom/movable/proc/move_to_destination(var/atom/movable/am, var/old_loc, var/new_loc)
 	var/turf/T = get_turf(new_loc)
@@ -34,7 +34,7 @@ var/datum/observ/moved/moved_event = new()
 
 /atom/Entered(var/atom/movable/am, atom/old_loc)
 	..()
-	moved_event.raise_event(list(am, old_loc, am.loc))
+	moved_event.raise_event(am, old_loc, am.loc)
 
 /atom/movable/Entered(var/atom/movable/am, atom/old_loc)
 	..()

--- a/code/datums/observation/task_triggered.dm
+++ b/code/datums/observation/task_triggered.dm
@@ -1,4 +1,0 @@
-var/datum/observ/task_triggered/task_triggered_event = new()
-
-/datum/observ/task_triggered
-	name = "Task Triggered"


### PR DESCRIPTION
changes:
- Lists are no longer created every time a movable moves (!)
- Lists are no longer created every time a datum is destroyed (!)
- Observation events now properly clean up references.
- Removed the unused `task_triggered` event.