### PR TITLE
Remove some world loops

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -33,7 +33,7 @@
 		.= res
 
 /proc/get_area_name(N) //get area by its name
-	for(var/area/A in world)
+	for(var/area/A in all_areas)
 		if(A.name == N)
 			return A
 	return 0

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -21,6 +21,7 @@ var/global/list/surgery_steps = list()				//list of all surgery steps  |BS12
 var/global/list/side_effects = list()				//list of all medical sideeffects types by thier names |BS12
 var/global/list/mechas_list = list()				//list of all mechs. Used by hostile mobs target tracking.
 var/global/list/joblist = list()					//list of all jobstypes, minus borg and AI
+var/global/list/brig_closets = list()				//list of all brig secure_closets. Used by brig timers. Probably should be converted to use SSwireless eventually.
 
 var/global/list/turfs = list()						//list of all turfs
 

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -757,47 +757,6 @@ proc/GaussRandRound(var/sigma,var/roundto)
 	if(A.vars.Find(lowertext(varname))) return 1
 	else return 0
 
-//Returns: all the areas in the world
-/proc/return_areas()
-	var/list/area/areas = list()
-	for(var/area/A in world)
-		areas += A
-	return areas
-
-//Returns: all the areas in the world, sorted.
-/proc/return_sorted_areas()
-	return sortAtom(return_areas())
-
-//Takes: Area type as text string or as typepath OR an instance of the area.
-//Returns: A list of all areas of that type in the world.
-/proc/get_areas(var/areatype)
-	if(!areatype) return null
-	if(istext(areatype)) areatype = text2path(areatype)
-	if(isarea(areatype))
-		var/area/areatemp = areatype
-		areatype = areatemp.type
-
-	var/list/areas = new/list()
-	for(var/area/N in world)
-		if(istype(N, areatype)) areas += N
-	return areas
-
-//Takes: Area type as text string or as typepath OR an instance of the area.
-//Returns: A list of all atoms	(objs, turfs, mobs) in areas of that type of that type in the world.
-/proc/get_area_all_atoms(var/areatype)
-	if(!areatype) return null
-	if(istext(areatype)) areatype = text2path(areatype)
-	if(isarea(areatype))
-		var/area/areatemp = areatype
-		areatype = areatemp.type
-
-	var/list/atoms = new/list()
-	for(var/area/N in world)
-		if(istype(N, areatype))
-			for(var/atom/A in N)
-				atoms += A
-	return atoms
-
 proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 	if(!original)
 		return null

--- a/code/controllers/subsystems/emergency_shuttle.dm
+++ b/code/controllers/subsystems/emergency_shuttle.dm
@@ -86,7 +86,7 @@ var/datum/controller/subsystem/emergency_shuttle/emergency_shuttle
 
 	evac = 1
 	priority_announcement.Announce("An emergency evacuation shuttle has been called. It will arrive in approximately [round(estimate_arrival_time()/60)] minutes.", new_sound = 'sound/AI/emergencyshuttlecalled.ogg')
-	for(var/area/A in world)
+	for(var/area/A in all_areas)
 		if(istype(A, /area/hallway))
 			A.readyalert()
 
@@ -114,7 +114,7 @@ var/datum/controller/subsystem/emergency_shuttle/emergency_shuttle
 	if (evac)
 		priority_announcement.Announce("The emergency shuttle has been recalled.", new_sound = 'sound/AI/emergencyshuttlerecalled.ogg')
 
-		for(var/area/A in world)
+		for(var/area/A in all_areas)
 			if(istype(A, /area/hallway))
 				A.readyreset()
 		evac = 0

--- a/code/controllers/subsystems/initialization/misc_late.dm
+++ b/code/controllers/subsystems/initialization/misc_late.dm
@@ -47,9 +47,9 @@
 	for (var/area/A in world)
 		all_areas += A
 
-	sortTim(all_areas, /proc/cmp_text_asc)
+	sortTim(all_areas, /proc/cmp_name_asc)
 
 /proc/sorted_add_area(area/A)
 	all_areas += A
 
-	sortTim(all_areas, /proc/cmp_text_asc)
+	sortTim(all_areas, /proc/cmp_name_asc)

--- a/code/controllers/subsystems/machinery.dm
+++ b/code/controllers/subsystems/machinery.dm
@@ -14,6 +14,7 @@
 	var/tmp/powerusers_this_tick = 0
 
 	var/list/all_cameras = list()
+	var/list/all_status_displays = list()	// Note: This contains both ai_status_display and status_display.
 
 	var/rcon_update_queued = FALSE
 	var/powernet_update_queued = FALSE
@@ -25,6 +26,7 @@
 
 /datum/controller/subsystem/machinery/Recover()
 	all_cameras = SSmachinery.all_cameras
+	recipe_datums = SSmachinery.recipe_datums
 
 /datum/controller/subsystem/machinery/proc/queue_rcon_update()
 	rcon_update_queued = TRUE

--- a/code/controllers/subsystems/pai.dm
+++ b/code/controllers/subsystems/pai.dm
@@ -11,6 +11,7 @@
 	var/inquirer = null
 	var/list/pai_candidates = list()
 	var/list/asked = list()
+	var/list/all_pai_devices = list()
 
 	var/askDelay = 1 MINUTE
 
@@ -107,7 +108,7 @@
 			if("submit")
 				if(candidate)
 					candidate.ready = 1
-					for(var/obj/item/device/paicard/p in world)
+					for(var/obj/item/device/paicard/p in all_pai_devices)
 						if(p.looking_for_personality == 1)
 							p.alertUpdate()
 				usr << browse(null, "window=paiRecruit")

--- a/code/controllers/subsystems/power.dm
+++ b/code/controllers/subsystems/power.dm
@@ -14,9 +14,9 @@
 	var/list/rcon_breaker_units_by_tag = list()
 
 	var/list/breaker_boxes = list()
+	var/list/smes_units = list()
 
 	var/list/all_cables = list()
-
 	var/list/all_sensors = list()
 
 	var/list/powernets = list()
@@ -43,7 +43,7 @@
 	rcon_breaker_units.Cut()
 	rcon_breaker_units_by_tag.Cut()
 
-	for(var/obj/machinery/power/smes/buildable/SMES in machines)
+	for(var/obj/machinery/power/smes/buildable/SMES in smes_units)
 		if(SMES.RCon_tag && (SMES.RCon_tag != "NO_TAG") && SMES.RCon)
 			rcon_smes_units += SMES
 			rcon_smes_units_by_tag[SMES.RCon_tag] = SMES

--- a/code/controllers/subsystems/processing/plants.dm
+++ b/code/controllers/subsystems/processing/plants.dm
@@ -47,11 +47,6 @@
 		S.uid = "[seeds.len]"
 		S.roundstart = 1
 
-	// Make sure any seed packets that were mapped in are updated
-	// correctly (since the seed datums did not exist a tick ago).
-	for(var/obj/item/seeds/S in world)
-		S.update_seed()
-
 	//Might as well mask the gene types while we're at it.
 	var/list/used_masks = list()
 	var/list/plant_traits = ALL_GENES

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -3,11 +3,11 @@
 	if(announce)
 		command_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", new_sound = 'sound/AI/poweroff.ogg')
 
-	for(var/obj/machinery/power/smes/buildable/S in world)
+	for(var/obj/machinery/power/smes/buildable/S in SSpower.smes_units)
 		S.energy_fail(rand(15 * severity,30 * severity))
 
 
-	for(var/obj/machinery/power/apc/C in world)
+	for(var/obj/machinery/power/apc/C in machines)
 		if(!C.is_critical)
 			C.energy_fail(rand(40 * severity,150 * severity))
 
@@ -16,10 +16,10 @@
 
 	if(announce)
 		command_announcement.Announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
-	for(var/obj/machinery/power/apc/C in world)
+	for(var/obj/machinery/power/apc/C in machines)
 		if(C.cell && (C.z in config.station_levels))
 			C.cell.charge = C.cell.maxcharge
-	for(var/obj/machinery/power/smes/S in world)
+	for(var/obj/machinery/power/smes/S in SSpower.smes_units)
 		var/area/current_area = get_area(S)
 		if(current_area.type in skipped_areas || isNotStationLevel(S.z))
 			continue
@@ -31,7 +31,7 @@
 
 	if(announce)
 		command_announcement.Announce("All SMESs on [station_name()] have been recharged. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
-	for(var/obj/machinery/power/smes/S in world)
+	for(var/obj/machinery/power/smes/S in SSpower.smes_units)
 		if(isNotStationLevel(S.z))
 			continue
 		S.charge = S.capacity

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -16,7 +16,7 @@
 	sleep(15) //Adds a delay to notifying the cyborgs, which looks slightly more realistic. This should only pause the post_setup proc.
 	var/malf_ai = select_active_ai_with_fewest_borgs()
 	if (malf_ai)
-		for (var/mob/living/silicon/robot/borg in world) //This is similar to baystation's solution, but without a notification.
+		for (var/mob/living/silicon/robot/borg in silicon_mob_list) //This is similar to baystation's solution, but without a notification.
 			borg.connect_to_ai(malf_ai) //This will do nothing if the borg is synced before this line of code.
 			notify_borg(borg)
 	else

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -54,6 +54,7 @@
 	var/datum/wires/mulebot/wires = null
 
 	var/bloodiness = 0		// count of bloodiness
+	var/static/total_mules = 0
 
 /obj/machinery/bot/mulebot/Initialize()
 	. = ..()
@@ -67,11 +68,9 @@
 		SSradio.add_object(src, control_freq, filter = RADIO_MULEBOT)
 		SSradio.add_object(src, beacon_freq, filter = RADIO_NAVBEACONS)
 
-	var/count = 0
-	for(var/obj/machinery/bot/mulebot/other in world)
-		count++
+	total_mules++
 	if(!suffix)
-		suffix = "#[count]"
+		suffix = "#[total_mules]"
 	name = "Mulebot ([suffix])"
 
 /obj/machinery/bot/mulebot/Destroy()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -525,7 +525,7 @@
 
 
 /proc/is_relay_online()
-    for(var/obj/machinery/bluespacerelay/M in world)
+    for(var/obj/machinery/bluespacerelay/M in machines)
         if(M.stat == 0)
             return 1
     return 0

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -131,7 +131,7 @@
 					dat += "<a href='?src=\ref[src];screen=1'>Back</a>"
 					dat += "<br><b>Medical Robots:</b>"
 					var/bdat = null
-					for(var/mob/living/bot/medbot/M in world)
+					for(var/mob/living/bot/medbot/M in mob_list)
 
 						if(M.z != src.z)	continue	//only find medibots on the same z-level as the computer
 						var/turf/bl = get_turf(M)

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -13,8 +13,11 @@
 	var/title = "Mass Driver Controls"
 
 /obj/machinery/computer/pod/Initialize()
-	. = ..()
-	for(var/obj/machinery/mass_driver/M in world)
+	..()
+	. = INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/computer/pod/LateInitialize()
+	for(var/obj/machinery/mass_driver/M in machines)
 		if(M.id == id)
 			connected = M
 			return
@@ -27,19 +30,19 @@
 		viewers(null, null) << "Cannot locate mass driver connector. Cancelling firing sequence!"
 		return
 
-	for(var/obj/machinery/door/blast/M in world)
+	for(var/obj/machinery/door/blast/M in machines)
 		if(M.id == id)
 			M.open()
 
 	sleep(20)
 
-	for(var/obj/machinery/mass_driver/M in world)
+	for(var/obj/machinery/mass_driver/M in machines)
 		if(M.id == id)
 			M.power = connected.power
 			M.drive()
 
 	sleep(50)
-	for(var/obj/machinery/door/blast/M in world)
+	for(var/obj/machinery/door/blast/M in machines)
 		if(M.id == id)
 			M.close()
 			return

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -48,7 +48,7 @@
 		if(F.id == src.id)
 			targets += F
 
-	for(var/obj/structure/closet/secure_closet/brig/C in world)
+	for(var/obj/structure/closet/secure_closet/brig/C in brig_closets)
 		if(C.id == src.id)
 			targets += C
 

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -220,23 +220,20 @@
 	var/datum/radio_frequency/radio_connection
 
 
-	New()
-		..()
+	Initialize()
+		. = ..()
 
 		if(autolink)
-			for(var/obj/machinery/magnetic_module/M in world)
-				if(M.freq == frequency && M.code == code)
-					magnets.Add(M)
-
-
-		spawn(45)	// must wait for map loading to finish
-			if(SSradio)
-				radio_connection = SSradio.add_object(src, frequency, RADIO_MAGNETS)
-
+			. = INITIALIZE_HINT_LATELOAD
+			radio_connection = SSradio.add_object(src, frequency, RADIO_MAGNETS)
 
 		if(path) // check for default path
 			filter_path() // renders rpath
 
+	LateInitialize()
+		for(var/obj/machinery/magnetic_module/M in machines)
+			if(M.freq == frequency && M.code == code)
+				magnets.Add(M)
 
 	process()
 		if(magnets.len == 0 && autolink)

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -233,13 +233,13 @@
 	LateInitialize()
 		for(var/obj/machinery/magnetic_module/M in machines)
 			if(M.freq == frequency && M.code == code)
-				magnets.Add(M)
+				magnets += M
 
 	process()
 		if(magnets.len == 0 && autolink)
 			for(var/obj/machinery/magnetic_module/M in world)
 				if(M.freq == frequency && M.code == code)
-					magnets.Add(M)
+					magnets += M
 
 
 	attack_ai(mob/user as mob)

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -47,18 +47,18 @@
 	var/const/STATUS_DISPLAY_CUSTOM = 99
 
 /obj/machinery/status_display/Destroy()
-	if(SSradio)
-		SSradio.remove_object(src,frequency)
+	SSmachinery.all_status_displays -= src
+	SSradio.remove_object(src,frequency)
 	return ..()
 
 // register for radio system
 /obj/machinery/status_display/Initialize()
 	. = ..()
-	if(SSradio)
-		if (hears_arrivals)
-			SSradio.add_object(src, frequency, RADIO_ARRIVALS)
-		else
-			SSradio.add_object(src, frequency)
+	SSmachinery.all_status_displays += src
+	if (hears_arrivals)
+		SSradio.add_object(src, frequency, RADIO_ARRIVALS)
+	else
+		SSradio.add_object(src, frequency)
 
 // timed process
 /obj/machinery/status_display/machinery_process()

--- a/code/game/machinery/status_display_ai.dm
+++ b/code/game/machinery/status_display_ai.dm
@@ -38,7 +38,7 @@ var/list/ai_status_emotions = list(
 
 /proc/set_ai_status_displays(mob/user as mob)
 	var/emote = get_ai_emotion(user)
-	for (var/obj/machinery/M in machines) //change status
+	for (var/obj/machinery/M in SSmachinery.all_status_displays) //change status
 		if(istype(M, /obj/machinery/ai_status_display))
 			var/obj/machinery/ai_status_display/AISD = M
 			AISD.emotion = emote
@@ -67,7 +67,15 @@ var/list/ai_status_emotions = list(
 
 	var/emotion = "Neutral"
 
-/obj/machinery/ai_status_display/attack_ai/(mob/user as mob)
+/obj/machinery/ai_status_display/Initialize()
+	. = ..()
+	SSmachinery.all_status_displays += src
+
+/obj/machinery/ai_status_display/Destroy()
+	SSmachinery.all_status_displays -= src
+	return ..()
+
+/obj/machinery/ai_status_display/attack_ai(mob/user as mob)
 	var/emote = get_ai_emotion(user)
 	src.emotion = emote
 	src.update()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -380,7 +380,7 @@
 
 /obj/machinery/mecha_part_fabricator/proc/sync()
 	sync_message = "Error: no console found."
-	for(var/obj/machinery/computer/rdconsole/RDC in get_area_all_atoms(get_area(src)))
+	for(var/obj/machinery/computer/rdconsole/RDC in get_area(src))
 		if(!RDC.sync)
 			continue
 		for(var/datum/tech/T in RDC.files.known_tech)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -20,10 +20,12 @@
 /obj/item/device/paicard/Initialize()
 	. = ..()
 	add_overlay("pai_off")
+	SSpai.all_pai_devices += src
 
 /obj/item/device/paicard/Destroy()
+	SSpai.all_pai_devices -= src
 	//Will stop people throwing friend pAIs into the singularity so they can respawn
-	if(!isnull(pai))
+	if(pai)
 		pai.death(0)
 	return ..()
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -372,11 +372,20 @@
 		new /obj/item/weapon/reagent_containers/syringe/ld50_syringe/choral(src)
 
 
+// These are special snowflakes that need to be in a global list.
 /obj/structure/closet/secure_closet/brig
 	name = "brig locker"
 	req_access = list(access_brig)
 	anchored = 1
 	var/id = null
+
+	Initialize()
+		. = ..()
+		brig_closets += src
+
+	Destroy()
+		brig_closets -= src
+		return ..
 
 	fill()
 		new /obj/item/clothing/under/color/orange( src )

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -385,7 +385,7 @@
 
 	Destroy()
 		brig_closets -= src
-		return ..
+		return ..()
 
 	fill()
 		new /obj/item/clothing/under/color/orange( src )

--- a/code/modules/admin/secrets/fun_secrets/fix_all_lights.dm
+++ b/code/modules/admin/secrets/fun_secrets/fix_all_lights.dm
@@ -6,5 +6,5 @@
 	if(!.)
 		return
 
-	for(var/obj/machinery/light/L in world)
+	for(var/obj/machinery/light/L in machines)
 		L.fix()

--- a/code/modules/admin/secrets/random_events/gravity.dm
+++ b/code/modules/admin/secrets/random_events/gravity.dm
@@ -16,7 +16,7 @@
 		return
 
 	gravity_is_on = !gravity_is_on
-	for(var/area/A in world)
+	for(var/area/A in all_areas)
 		A.gravitychange(gravity_is_on,A)
 
 	feedback_inc("admin_secrets_fun_used",1)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -313,7 +313,7 @@
 				newmeme.clearHUD()
 
 				var/found = 0
-				for(var/mob/living/carbon/human/H in world) if(H.client && !H.parasites.len)
+				for(var/mob/living/carbon/human/H in player_list) if(!H.parasites.len)
 					found = 1
 					newmeme.enter_host(H)
 

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -4,7 +4,7 @@
 /mob/dead/observer/on_mob_jump()
 	stop_following()
 
-/client/proc/Jump(var/area/A in return_sorted_areas())
+/client/proc/Jump(var/area/A in all_areas)
 	set name = "Jump to Area"
 	set desc = "Area to jump to"
 	set category = "Admin"
@@ -150,7 +150,7 @@
 	set name = "Send Mob"
 	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
 		return
-	var/area/A = input(usr, "Pick an area.", "Pick an area") in return_sorted_areas()
+	var/area/A = input(usr, "Pick an area.", "Pick an area") in all_areas
 	if(A)
 		if(config.allow_admin_jump)
 			M.on_mob_jump()

--- a/code/modules/events/gravity.dm
+++ b/code/modules/events/gravity.dm
@@ -10,16 +10,14 @@
 
 /datum/event/gravity/start()
 	gravity_is_on = 0
-	for(var/area/A in world)
-		if(A.z in config.station_levels)
-			A.gravitychange(gravity_is_on, A)
+	for(var/area/A in the_station_areas)
+		A.gravitychange(gravity_is_on, A)
 
 /datum/event/gravity/end()
 	if(!gravity_is_on)
 		gravity_is_on = 1
 
-		for(var/area/A in world)
-			if(A.z in config.station_levels)
-				A.gravitychange(gravity_is_on, A)
+		for(var/area/A in the_station_areas)
+			A.gravitychange(gravity_is_on, A)
 
 		command_announcement.Announce("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.", "Gravity Restored")

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -50,7 +50,7 @@
 	if(areas && areas.len > 0)
 		var/my_department = "[station_name()] firewall subroutines"
 		var/rc_message = "An unknown malicious program has been detected in the [english_list(areaName)] lighting and airlock control systems at [worldtime2text()]. Systems will be fully compromised within approximately three minutes. Direct intervention is required immediately.<br>"
-		for(var/obj/machinery/message_server/MS in world)
+		for(var/obj/machinery/message_server/MS in machines)
 			MS.send_rc_message("Engineering", my_department, rc_message, "", "", 2)
 		for(var/mob/living/silicon/ai/A in player_list)
 			A << "<span class='danger'>Malicious program detected in the [english_list(areaName)] lighting and airlock control systems by [my_department].</span>"

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -8,7 +8,7 @@
 
 	remove_ai_verbs(src)
 
-	for(var/obj/machinery/ai_status_display/O in world)
+	for(var/obj/machinery/ai_status_display/O in SSmachinery.all_status_displays)
 		spawn( 0 )
 		O.mode = 2
 		if (istype(loc, /obj/item/weapon/aicard))

--- a/code/modules/mob/living/silicon/ai/logout.dm
+++ b/code/modules/mob/living/silicon/ai/logout.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon/ai/Logout()
 	..()
-	for(var/obj/machinery/ai_status_display/O in world) //change status
+	for(var/obj/machinery/ai_status_display/O in SSmachinery.all_status_displays) //change status
 		O.mode = 0
 	if(!isturf(loc))
 		if (client)

--- a/code/modules/mob/living/silicon/decoy/death.dm
+++ b/code/modules/mob/living/silicon/decoy/death.dm
@@ -3,6 +3,6 @@
 	icon_state = "ai-crash"
 	spawn(10)
 		explosion(loc, 3, 6, 12, 15)
-	for(var/obj/machinery/ai_status_display/O in world) //change status
+	for(var/obj/machinery/ai_status_display/O in SSmachinery.all_status_displays) //change status
 		O.mode = 2
 	return ..(gibbed)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -65,8 +65,6 @@
 	var/datum/effect_system/sparks/big_spark
 	var/datum/effect_system/sparks/small_spark
 
-	var/static/list/smesImageCache
-
 /obj/machinery/power/smes/drain_power(var/drain_check, var/surge, var/amount = 0)
 
 	if(drain_check)
@@ -76,9 +74,15 @@
 	charge -= smes_amt
 	return smes_amt / SMESRATE
 
+/obj/machinery/power/smes/Destroy()
+	QDEL_NULL(big_spark)
+	QDEL_NULL(small_spark)
+	SSpower.smes_units -= src
+	return ..()	// TODO: Properly clean up terminal.
 
 /obj/machinery/power/smes/Initialize()
 	. = ..()
+	SSpower.smes_units += src
 	big_spark = bind_spark(src, 5, alldirs)
 	small_spark = bind_spark(src, 3)
 	if(!powernet)


### PR DESCRIPTION
changes:
- Replaces a lot of in-world loops with more specific lists.
- Recipes are now copied in SSmachinery/Recover()
- Fixed bad sorting on `all_areas` list.
- Added skeleton Destroy() to SMESes as they did not have one and are failing to GC.

Seems to shorten SSatoms init a bit, maybe from removal of in-world in MULEs?