### PR TITLE
SStimer: logging of flushes

### DIFF
--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -40,6 +40,8 @@ var/datum/controller/subsystem/timer/SStimer
 	var/lit = last_invoke_tick
 	var/last_check = world.time - TIMER_NO_INVOKE_WARNING
 
+	var/static/list/spent = list()
+
 	if(!bucket_count)
 		last_invoke_tick = world.time
 
@@ -86,7 +88,6 @@ var/datum/controller/subsystem/timer/SStimer
 		if (MC_TICK_CHECK)
 			return
 
-	var/static/list/spent = list()
 	var/static/datum/timedevent/timer
 	var/static/datum/timedevent/head
 

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -27,6 +27,9 @@ var/datum/controller/subsystem/timer/SStimer
 	var/static/last_invoke_warning = 0
 	var/static/bucket_auto_reset = TRUE
 
+	// Logging. Remove once timers have been diagnosed.
+	var/static/times_flushed = 0
+
 /datum/controller/subsystem/timer/New()
 	NEW_SS_GLOBAL(SStimer)
 
@@ -47,7 +50,8 @@ var/datum/controller/subsystem/timer/SStimer
 		WARNING(msg)
 		if(bucket_auto_reset)
 			bucket_resolution = 0
-		
+
+		log_ss(name, times_flushed ? "Timers flushed [times_flushed] times." : "Timers never flushed!")
 		log_ss(name, "Active timers at tick [world.time]:")
 		for(var/I in processing)
 			var/datum/timedevent/TE = I
@@ -127,6 +131,8 @@ var/datum/controller/subsystem/timer/SStimer
 		bucket_list[practical_offset++] = null
 		if (MC_TICK_CHECK)
 			return
+
+	times_flushed++
 
 	bucket_count -= length(spent)
 

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -52,6 +52,7 @@ var/datum/controller/subsystem/timer/SStimer
 			bucket_resolution = 0
 
 		log_ss(name, times_flushed ? "Timers flushed [times_flushed] times." : "Timers never flushed!")
+		log_ss(name, "Spent timers count: [spent ? spent.len : "0"].")
 		log_ss(name, "Active timers at tick [world.time]:")
 		for(var/I in processing)
 			var/datum/timedevent/TE = I


### PR DESCRIPTION
Suspicions arise that during the round initialization, SStimer is getting hammered enough that it is never able to clear out its spent timers list. This adds logging of this.