### PR TITLE
Autodrobe Fixes

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -321,10 +321,10 @@
 			job.setup_account(H)
 
 			EquipCustom(H, job, H.client.prefs, custom_equip_leftovers, spawn_in_storage, custom_equip_slots)
-			
+
 			// This goes after custom loadout it doesn't prevent custom loadout stuff from being equipped.
 			job.equip_survival(H)
-			
+
 		job.equip(H)
 		job.apply_fingerprints(H)
 

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -321,10 +321,10 @@
 			job.setup_account(H)
 
 			EquipCustom(H, job, H.client.prefs, custom_equip_leftovers, spawn_in_storage, custom_equip_slots)
-
+			
 			// This goes after custom loadout it doesn't prevent custom loadout stuff from being equipped.
 			job.equip_survival(H)
-
+			
 		job.equip(H)
 		job.apply_fingerprints(H)
 
@@ -510,8 +510,6 @@
 		job.equip_backpack(H)
 		job.equip_survival(H)
 		job.setup_account(H)
-
-		spawn_in_storage = EquipCustomDeferred(H, H.client.prefs, custom_equip_leftovers, custom_equip_slots)
 
 		job.apply_fingerprints(H)
 
@@ -758,7 +756,6 @@
 						leftovers += thing
 					Debug("EC/([H]): [thing] failed mask/suit/head check; leftovers=[!!leftovers]")
 				else if (H.equip_to_slot_or_del(CI, G.slot))
-					CI.autodrobe_no_remove = TRUE
 					H << "<span class='notice'>Equipping you with \a [thing]!</span>"
 					custom_equip_slots += G.slot
 					Debug("EC/([H]): Equipped [CI] successfully.")
@@ -789,7 +786,6 @@
 			if (H.equip_to_slot_or_del(CI, G.slot))
 				to_chat(H, "<span class='notice'>Equipping you with \a [thing]!</span>")
 				used_slots += G.slot
-				CI.autodrobe_no_remove = TRUE
 				Debug("ECD/([H]): Equipped [thing] successfully.")
 
 			else


### PR DESCRIPTION
People no longer spawn with their custom gear. They now get them from the autodrobe. This prevents duplicate custom items and fixes the ID/jumpsuit issues with custom gear. People who ready up at round start still get their custom gear from the EquipRank proc.
Fixes #2512
Fixes #2587