### PR TITLE
Make connecting turfs into an assoc list

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -146,7 +146,8 @@ zone/proc/movables()
 	for(var/turf/T in contents)
 		CHECK_TICK
 
-		for(var/atom/movable/A in T)
+		for(var/aa in T)
+			var/atom/movable/A = aa
 			if(!A.simulated || A.anchored || istype(A, /obj/effect) || istype(A, /mob/eye))
 				continue
 			. += A

--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -53,7 +53,7 @@ turf/c_airblock(turf/other)
 	#endif
 	if(((blocks_air & AIR_BLOCKED) || (other.blocks_air & AIR_BLOCKED)))
 		return BLOCKED
-	
+
 	//Z-level handling code. Always block if there isn't an open space.
 	#ifdef MULTIZAS
 	if(other.z != src.z)
@@ -68,9 +68,10 @@ turf/c_airblock(turf/other)
 			return ZONE_BLOCKED
 		else
 			return AIR_BLOCKED
-			
+
 	var/result = 0
-	for(var/atom/movable/M in contents)
+	for(var/mm in contents)
+		var/atom/movable/M = mm
 		result |= M.c_airblock(other)
 		if(result == BLOCKED) return BLOCKED
 	return result

--- a/code/ZAS/ConnectionGroup.dm
+++ b/code/ZAS/ConnectionGroup.dm
@@ -97,8 +97,11 @@ Class Procs:
 		var/atom/movable/M = thing
 
 		//If they're already being tossed, don't do it again.
-		if(M.last_airflow > world.time - vsc.airflow_delay) continue
-		if(M.airflow_speed) continue
+		if(M.last_airflow > world.time - vsc.airflow_delay)
+			continue
+
+		if(M.airflow_speed)
+			continue
 
 		//Check for knocking people over
 		if(ismob(M) && differential > vsc.airflow_stun_pressure)
@@ -108,9 +111,13 @@ Class Procs:
 
 		if(M.check_airflow_movable(differential))
 			//Check for things that are in range of the midpoint turfs.
-			var/list/close_turfs = connecting_turfs & RANGE_TURFS(world.view, M)
+			var/list/close_turfs = list()
+			for (var/T in RANGE_TURFS(world.view, M))
+				if (connecting_turfs[T])
+					close_turfs += T
 
-			if(!close_turfs.len) continue
+			if(!close_turfs.len)
+				continue
 
 			M.airflow_dest = pick(close_turfs) //Pick a random midpoint to fly towards.
 
@@ -118,6 +125,8 @@ Class Procs:
 				M.RepelAirflowDest(differential/5)
 			else
 				M.GotoAirflowDest(differential/10)
+
+		CHECK_TICK
 
 /connection_edge/zone/var/zone/B
 
@@ -133,7 +142,7 @@ Class Procs:
 
 /connection_edge/zone/add_connection(connection/c)
 	. = ..()
-	connecting_turfs += c.A
+	connecting_turfs[c.A] = TRUE
 
 /connection_edge/zone/remove_connection(connection/c)
 	connecting_turfs -= c.A
@@ -204,11 +213,11 @@ Class Procs:
 
 /connection_edge/unsimulated/add_connection(connection/c)
 	. = ..()
-	connecting_turfs.Add(c.B)
+	connecting_turfs[c.B] = TRUE
 	air.group_multiplier = coefficient
 
 /connection_edge/unsimulated/remove_connection(connection/c)
-	connecting_turfs.Remove(c.B)
+	connecting_turfs -= c.B
 	air.group_multiplier = coefficient
 	. = ..()
 

--- a/code/ZAS/ConnectionGroup.dm
+++ b/code/ZAS/ConnectionGroup.dm
@@ -93,6 +93,7 @@ Class Procs:
 /connection_edge/proc/recheck()
 
 /connection_edge/proc/flow(list/movable, differential, repelled)
+	set waitfor = FALSE
 	for(var/thing in movable)
 		var/atom/movable/M = thing
 
@@ -174,6 +175,7 @@ Class Procs:
 			attracted = B.movables()
 			repelled = A.movables()
 
+		// These are async, with waitfor = FALSE
 		flow(attracted, abs(differential), 0)
 		flow(repelled, abs(differential), 1)
 
@@ -238,6 +240,7 @@ Class Procs:
 	var/differential = A.air.return_pressure() - air.return_pressure()
 	if(abs(differential) >= vsc.airflow_lightest_pressure)
 		var/list/attracted = A.movables()
+		// This call is async, with waitfor = FALSE
 		flow(attracted, abs(differential), differential < 0)
 
 	if(equiv)

--- a/code/ZAS/Zone.dm
+++ b/code/ZAS/Zone.dm
@@ -115,7 +115,8 @@ Class Procs:
 		#endif
 
 	//rebuild the old zone's edges so that they will be possessed by the new zone
-	for(var/connection_edge/E in edges)
+	for(var/ee in edges)
+		var/connection_edge/E = ee
 		if(E.contains_zone(into))
 			continue //don't need to rebuild this edge
 		for(var/T in E.connecting_turfs)
@@ -183,7 +184,8 @@ Class Procs:
 	var/zone_edges = 0
 	var/space_edges = 0
 	var/space_coefficient = 0
-	for(var/connection_edge/E in edges)
+	for(var/ee in edges)
+		var/connection_edge/E = ee
 		if(E.type == /connection_edge/zone) zone_edges++
 		else
 			space_edges++

--- a/code/ZAS/Zone.dm
+++ b/code/ZAS/Zone.dm
@@ -118,7 +118,7 @@ Class Procs:
 	for(var/connection_edge/E in edges)
 		if(E.contains_zone(into))
 			continue //don't need to rebuild this edge
-		for(var/turf/T in E.connecting_turfs)
+		for(var/T in E.connecting_turfs)
 			SSair.mark_for_update(T)
 
 /zone/proc/c_invalidate()


### PR DESCRIPTION
Turns `connecting_turfs` into an associated list. From testing a few years ago, assoc lists performed quite well when it came to key-access at runtime. This then allows us to make the loop at ConnectionGroup.dm:112 into a stable one, complexity wise. Only O(world.view^2) instead of O(connecting_turfs.len * world.view^2).

All references to connecting_turfs were edited to match this.