### PR TITLE
Bugfixes: Dronesay and Underwear/Socks in Character Setup

### DIFF
--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -118,6 +118,9 @@
 
 	else if(href_list["gender"])
 		pref.gender = next_in_list(pref.gender, valid_player_genders)
+
+		var/datum/category_item/player_setup_item/general/equipment/equipment_item = category.items[4]
+		equipment_item.sanitize_character()	// sanitize equipment
 		return TOPIC_REFRESH
 
 	else if(href_list["age"])

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -42,13 +42,11 @@
 		pref.socks = null
 
 /datum/category_item/player_setup_item/general/equipment/content()
-	sanitize_character()
 	. += "<b>Equipment:</b><br>"
 	. += "Underwear: <a href='?src=\ref[src];change_underwear=1'><b>[get_key_by_value(get_undies(),pref.underwear)]</b></a><br>"
 	. += "Undershirt: <a href='?src=\ref[src];change_undershirt=1'><b>[get_key_by_value(undershirt_t,pref.undershirt)]</b></a><br>"
 	. += "Socks: <a href='?src=\ref[src];change_socks=1'><b>[get_key_by_value(get_gender_socks(),pref.socks)]</b></a><br>"
 	. += "Backpack Type: <a href='?src=\ref[src];change_backpack=1'><b>[backbaglist[pref.backbag]]</b></a><br>"
-
 
 /datum/category_item/player_setup_item/general/equipment/proc/get_undies()
 	return pref.gender == MALE ? underwear_m : underwear_f

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -35,14 +35,14 @@
 	var/undies = get_undies()
 	var/gender_socks = get_gender_socks()
 	if(!get_key_by_value(undies, pref.underwear))
-		pref.underwear = undies[undies[1]]
+		pref.underwear = null
 	if(!get_key_by_value(undershirt_t, pref.undershirt))
 		pref.undershirt = undershirt_t[undershirt_t[1]]
 	if(!get_key_by_value(gender_socks, pref.socks))
-		pref.socks = gender_socks[gender_socks[1]]
-
+		pref.socks = null
 
 /datum/category_item/player_setup_item/general/equipment/content()
+	sanitize_character()
 	. += "<b>Equipment:</b><br>"
 	. += "Underwear: <a href='?src=\ref[src];change_underwear=1'><b>[get_key_by_value(get_undies(),pref.underwear)]</b></a><br>"
 	. += "Undershirt: <a href='?src=\ref[src];change_undershirt=1'><b>[get_key_by_value(undershirt_t,pref.undershirt)]</b></a><br>"

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -39,6 +39,6 @@
 			if (istype(M, /mob/new_player))
 				continue
 			else if(M.stat == 2 &&  M.client.prefs.toggles & CHAT_GHOSTEARS)
-				if(M.client) M << "<b>[src]</b> transmits, \"[message]\""
+				M << "<b>[src]</b> transmits, \"[message]\""
 		return 1
 	return ..(message, 0)

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -34,7 +34,7 @@
 				D << "<b>[src]</b> transmits, \"[message]\""
 
 		for (var/mob/M in player_list)
-			if (isnull(M) || isnull(M.client))
+			if (isnull(M.client))
 				continue
 			if (istype(M, /mob/new_player))
 				continue

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -22,6 +22,10 @@
 		if (stat)
 			return 0
 
+		// Message must not be empty
+		if (isnull(message) || length(message) == 0)
+			return 0
+
 		var/list/listeners = hearers(5,src)
 		listeners |= src
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -23,7 +23,7 @@
 			return 0
 
 		// Message must not be empty
-		if (isnull(message) || length(message) == 0)
+		if (length(message) == 0)
 			return 0
 
 		var/list/listeners = hearers(5,src)

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -34,6 +34,8 @@
 				D << "<b>[src]</b> transmits, \"[message]\""
 
 		for (var/mob/M in player_list)
+			if (isnull(M) || isnull(M.client))
+				continue
 			if (istype(M, /mob/new_player))
 				continue
 			else if(M.stat == 2 &&  M.client.prefs.toggles & CHAT_GHOSTEARS)

--- a/html/changelogs/inselc-PR-2992.yml
+++ b/html/changelogs/inselc-PR-2992.yml
@@ -1,0 +1,7 @@
+author: inselc
+
+delete-after: True
+
+changes: 
+  - bugfix: "Drones are no longer able to transmit empty messages."
+  - bugfix: "Invalid underwear or socks selections will now automatically revert to 'None' when changing the character's gender."


### PR DESCRIPTION
This PR contains bugfixes for:
- Drones being able to transmit empty messages when talking in local drone chat ("dronesay")
- A possible runtime in dronesay, caused by a null-reference in player_list, or a mob not having a client
- Underwear and Socks selection in Character Setup breaking when switching genders.

Character loadout is now sanitized each time before it gets displayed. Invalid selections will be reset to "None", when changing the character's gender.
