### PR TITLE
Icon caching & human icon tweaks

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -744,7 +744,7 @@ as a single icon. Useful for when you want to manipulate an icon via the above a
 			curblend = BLEND_OVERLAY
 			add = icon(I:icon, I:icon_state, I:dir)
 		else // 'I' is an appearance object.
-			add = getFlatIcon(new/image(I), curdir, curicon, curstate, curblend)
+			add = getFlatIcon(new/image(I), curdir, curicon, curstate, curblend, TRUE)
 
 		// Find the new dimensions of the flat icon to fit the added overlay
 		addX1 = min(flatX1, I:pixel_x+1)

--- a/code/controllers/subsystems/icon_cache.dm
+++ b/code/controllers/subsystems/icon_cache.dm
@@ -28,7 +28,10 @@
 	var/list/human_icon_cache = list()
 	var/list/tail_icon_cache = list()	//key is [species.race_key][r_skin][g_skin][b_skin]
 	var/list/light_overlay_cache = list()
-	var/list/limb_icon_cache = list()
+	var/list/body_hair_cache = list()
+	var/list/damage_icon_parts = list()
+	// [icon]-[icon_state]-[limb_name]-[color]
+	var/list/markings_cache = list()
 
 /datum/controller/subsystem/icon_cache/New()
 	NEW_SS_GLOBAL(SSicon_cache)

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -75,10 +75,17 @@
 
 	for(var/M in markings)
 		var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
-		var/icon/mark_s = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[limb_name]")
-		mark_s.Blend(markings[M]["color"], ICON_ADD)
-		overlays |= mark_s //So when it's not on your body, it has icons
-		mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
+		var/m_color = markings[M]["color"]
+		var/cache_key = "[mark_style.icon]-[mark_style.icon_state]-[limb_name]-[m_color]"
+
+		var/icon/finished_icon = SSicon_cache.markings_cache[cache_key]
+		if (!finished_icon)
+			finished_icon = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[limb_name]")
+			finished_icon.Blend(m_color, ICON_ADD)
+			SSicon_cache.markings_cache[cache_key] = finished_icon
+
+		add_overlay(finished_icon) //So when it's not on your body, it has icons
+		mob_icon.Blend(finished_icon, ICON_OVERLAY) //So when it's on your body, it has icons
 
 	if(owner.f_style)
 		var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[owner.f_style]
@@ -147,13 +154,20 @@
 			//Body markings, does not include head, duplicated (sadly) above.
 			for(var/M in markings)
 				var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
-				var/icon/mark_s = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[limb_name]")
-				mark_s.Blend(markings[M]["color"], ICON_ADD)
-				overlays |= mark_s //So when it's not on your body, it has icons
-				mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
+				var/m_color = markings[M]["color"]
+				var/cache_key = "[mark_style.icon]-[mark_style.icon_state]-[limb_name]-[m_color]"
+
+				var/icon/finished_icon = SSicon_cache.markings_cache[cache_key]
+				if (!finished_icon)
+					finished_icon = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[limb_name]")
+					finished_icon.Blend(m_color, ICON_ADD)
+					SSicon_cache.markings_cache[cache_key] = finished_icon
+
+				add_overlay(finished_icon) //So when it's not on your body, it has icons
+				mob_icon.Blend(finished_icon, ICON_OVERLAY) //So when it's on your body, it has icons
 
 			if(body_hair && islist(h_col) && h_col.len >= 3)
-				var/list/limb_icon_cache = SSicon_cache.limb_icon_cache
+				var/list/limb_icon_cache = SSicon_cache.body_hair_cache
 				var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
 				if(!limb_icon_cache[cache_key])
 					var/icon/I = icon(species.icobase, "[icon_name]_[body_hair]")


### PR DESCRIPTION
changes:
- Body marking icons are now cached in SSicon_cache.
- Renamed the body-hair cache (used only by Resomi) to make it more clear what it is.
- Humans now use SSoverlay for applying overlays, though they force-compile instead of waiting for it to tick.
- Fixed a bug where `getFlatIcon()` did not work properly with SSoverlay overlays.