### PR TITLE
Attempting fixes for some hoist bugs.

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -90,3 +90,9 @@
 		queue_smooth_neighbors(src)
 	else
 		..()
+
+/obj/structure/lattice/catwalk/hoist_act(turf/dest)
+	for (var/A in src)
+		var/atom/movable/AM = A
+		AM.hoist_act(dest)
+	..()

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -78,7 +78,7 @@
 	if (!dest.Adjacent(source_hoist.hoistee))
 		return
 
-	source_hoist.consistency_check()
+	source_hoist.check_consistency()
 
 	var/turf/desturf = dest
 	source_hoist.hoistee.forceMove(desturf)
@@ -260,4 +260,4 @@
 	return 1
 
 /atom/movable/proc/hoist_act(turf/dest)
-	src.forceMove(move_dest)
+	src.forceMove(dest)


### PR DESCRIPTION
* Hoists now release hoistees if they wriggle out somehow. Shouldn't happen anyway, but `consistency_check` should handle any odd shenanigans.
* Silicons should be able to be hoisted. Buckling wasn't anchoring them, for some strange reason.
* Fixed a bad message, where `[user]` was used instead of `[usr]`.
* You can't directly unbuckle people from hoist hooks.