### PR TITLE
Catwalk hoisting and other fixes, take two.

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -92,7 +92,7 @@
 		..()
 
 /obj/structure/lattice/catwalk/hoist_act(turf/dest)
-	for (var/A in src)
+	for (var/A in loc)
 		var/atom/movable/AM = A
 		AM.hoist_act(dest)
 	..()

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -260,4 +260,12 @@
 	return 1
 
 /atom/movable/proc/hoist_act(turf/dest)
-	src.forceMove(dest)
+    if (anchored)
+        return FALSE
+
+    forceMove(dest)
+    return TRUE
+
+/obj/mecha/hoist_act(turf/dest)
+	forceMove(dest)
+	return TRUE


### PR DESCRIPTION
* Unanchored catwalks can raise and lower objects on them.
* Mechs can be hoisted using catwalks.

forgive me for i have sinned