### PR TITLE
Embrace no longer supporting 510

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -11,10 +11,6 @@
 
 #define LIGHTING_SOFT_THRESHOLD 0.001 // If the max of the lighting lumcounts of each spectrum drops below this, disable luminosity on the lighting overlays.
 
-// If defined, a tiny random number will be added to lighting matrixes to prevent a memory leak bug in v510 and below.
-// Enabling this disables lighting rounding.
-//#define LIGHTING_USE_MEMORY_HACK
-
 // If I were you I'd leave this alone.
 #define LIGHTING_BASE_MATRIX \
 	list            \
@@ -110,7 +106,3 @@
 
 // Just so we can avoid unneeded proc calls when profiling is disabled.
 #define L_PROF(O,T) if (lighting_profiling) {lprof_write(O,T);}
-
-#if !defined(LIGHTING_USE_MEMORY_HACK) && DM_VERSION < 511
-#warn You appear to be using a pre-511 version of BYOND, but have the memory leak hack disabled. You may encounter server crashes due to a memory leak in BYOND 510 and below's handling of color matrixes.
-#endif

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -336,13 +336,8 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 // as text so you don't necessarily fuck with an object's ability to be garbage collected.
 #define SOFTREF(A) "\ref[A]"
 
-// A slightly stronger version of the above that does type validation for you.
-#if DM_VERSION >= 511
 // This only works on 511 because it relies on 511's `var/something = foo = bar` syntax.
 #define WEAKREF(D) (istype(D, /datum) && !D:gcDestroyed ? (D:weakref ? D:weakref : (D:weakref = new(D))) : null)
-#else
-#define WEAKREF(D) _weakref(D)
-#endif
 
 #define ADD_VERB_IN(the_atom,time,verb) addtimer(CALLBACK(the_atom, /atom/.proc/add_verb, verb), time, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_NO_HASH_WAIT)
 #define ADD_VERB_IN_IF(the_atom,time,verb,callback) addtimer(CALLBACK(the_atom, /atom/.proc/add_verb, verb, callback), time, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_NO_HASH_WAIT)

--- a/code/datums/weakref.dm
+++ b/code/datums/weakref.dm
@@ -5,16 +5,6 @@
 	var/ref
 
 
-#if DM_VERSION < 511
-// Don't use this directly, use the WEAKREF macro.
-/proc/_weakref(datum/D)
-	if(!istype(D) || QDELETED(D))
-		return
-	if(!D.weakref)
-		D.weakref = new(D)
-	return D.weakref
-#endif
-
 /datum/weakref/New(datum/D)
 	ref = SOFTREF(D)
 

--- a/code/global.dm
+++ b/code/global.dm
@@ -1,6 +1,6 @@
 //#define TESTING
-#if DM_VERSION < 510
-#error Your version of BYOND is too old to compile the code. At least BYOND 510 is required.
+#if DM_VERSION < 511
+#error Your version of BYOND is too old to compile the code. At least BYOND 511 is required.
 #endif
 
 

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -105,7 +105,7 @@
 		needs_update = TRUE
 		update_overlays(FALSE)
 		SSlighting.corner_queue += src
-	else 
+	else
 		update_overlays(TRUE)
 
 /datum/lighting_corner/proc/update_overlays(var/now = FALSE)
@@ -119,17 +119,10 @@
 	else if (mx < LIGHTING_SOFT_THRESHOLD)
 		. = 0 // 0 means soft lighting.
 
-#ifdef LIGHTING_USE_MEMORY_HACK
-	cache_r  = lum_r * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
-	cache_g  = lum_g * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
-	cache_b  = lum_b * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
-	cache_mx = mx
-#else
 	cache_r  = round(lum_r * ., LIGHTING_ROUND_VALUE) || LIGHTING_SOFT_THRESHOLD
 	cache_g  = round(lum_g * ., LIGHTING_ROUND_VALUE) || LIGHTING_SOFT_THRESHOLD
 	cache_b  = round(lum_b * ., LIGHTING_ROUND_VALUE) || LIGHTING_SOFT_THRESHOLD
 	cache_mx = round(mx, LIGHTING_ROUND_VALUE)
-#endif
 
 	for (var/TT in masters)
 		var/turf/T = TT
@@ -144,7 +137,7 @@
 	crash_with("Some fuck [force ? "force-" : ""]deleted a lighting corner.")
 	if (!force)
 		return QDEL_HINT_LETMELIVE
-		
+
 	SSlighting.lighting_corners -= src
 	return ..()
 

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -22,7 +22,7 @@
 	var/turf/T         = loc // If this runtimes atleast we'll know what's creating overlays in things that aren't turfs.
 	T.lighting_overlay = src
 	T.luminosity       = 0
-	
+
 	needs_update = TRUE
 	SSlighting.overlay_queue += src
 
@@ -38,7 +38,7 @@
 	if (istype(T))
 		T.lighting_overlay = null
 		T.luminosity = 1
-	
+
 	return ..()
 
 // This is a macro PURELY so that the if below is actually readable.
@@ -71,8 +71,6 @@
 	var/max = max(cr.cache_mx, cg.cache_mx, cb.cache_mx, ca.cache_mx)
 	luminosity = max > LIGHTING_SOFT_THRESHOLD
 
-// The RNG introduced by LIGHTING_USE_MEMORY_HACK makes this shortcut ineffective.
-#ifndef LIGHTING_USE_MEMORY_HACK
 	var/rr = cr.cache_r
 	var/rg = cr.cache_g
 	var/rb = cr.cache_b
@@ -123,15 +121,6 @@
 				ar, ag, ab, 0,
 				0, 0, 0, 1
 			)
-#else 
-	color = list(
-		cr.cache_r, cr.cache_g, cr.cache_b, 0,
-		cg.cache_r, cg.cache_g, cg.cache_b, 0,
-		cb.cache_r, cb.cache_g, cb.cache_b, 0,
-		ca.cache_r, ca.cache_g, ca.cache_b, 0,
-		0, 0, 0, 1
-	)
-#endif 
 
 	// If we're on an openturf, update the shadower object too.
 	// We could queue an icon update for the entire OT, but this involves less overhead.


### PR DESCRIPTION
With the introduction of PR #3023 , 510 and lower are no longer supported. So I removed all compile time defines that were meant to allow for its support and bumped the compiler error guard.