### PR TITLE
Minor storage & SSair init fixes

### DIFF
--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -161,9 +161,9 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 
 		admin_notice(span("danger", "Air settling completed in [(REALTIMEOFDAY - starttime)/10] seconds!"), R_DEBUG)
 
-	..()
+	..(timeofday)
 
-/datum/controller/subsystem/air/fire(resumed = FALSE, no_mc_tick = FALSE)	
+/datum/controller/subsystem/air/fire(resumed = FALSE, no_mc_tick = FALSE)
 	if (!resumed)
 		processing_edges = active_edges.Copy()
 		processing_fires = active_fire_zones.Copy()

--- a/code/game/machinery/megavend.dm
+++ b/code/game/machinery/megavend.dm
@@ -36,8 +36,8 @@
 	if(H.megavend)
 		return
 
-	var/obj/item/weapon/storage/box/gearbox = new(src)
-	gearbox.name = "\improper Personal possessions box"
+	var/obj/item/weapon/storage/box/gearbox = new(null, TRUE)
+	gearbox.name = "personal possessions box"
 	gearbox.desc = "All of the personal effects of [H.real_name], packaged neatly by the AutoDrobe."
 	for(var/obj/item/W in H.contents)
 		if(istype(W,/obj/item/organ))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -566,7 +566,7 @@
 	else
 		shrinkwrap()
 
-// Adjusts this storage object's max capacity to exactly the storage required by its contents. Will not increase max storage capacity, only decrease it.
+// Adjusts this storage object's max capacity to exactly the storage required by its contents. Will not decrease max storage capacity, only increase it.
 /obj/item/weapon/storage/proc/shrinkwrap()
 	var/total_storage_space = 0
 	for(var/obj/item/I in contents)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -521,7 +521,7 @@
 /obj/item/weapon/storage/proc/fill()
 	return
 
-/obj/item/weapon/storage/Initialize(mapload)
+/obj/item/weapon/storage/Initialize(mapload, defer_shrinkwrap = FALSE)
 	. = ..()
 
 	if (max_storage_space > STORAGE_SPACE_CAP)
@@ -561,6 +561,13 @@
 	closer.master = src
 	orient2hud(null, mapload)
 
+	if (defer_shrinkwrap)	// Caller wants to defer shrinkwrapping until after the current callstack; probably putting something in.
+		addtimer(CALLBACK(src, .proc/shrinkwrap), 0)
+	else
+		shrinkwrap()
+
+// Adjusts this storage object's max capacity to exactly the storage required by its contents. Will not increase max storage capacity, only decrease it.
+/obj/item/weapon/storage/proc/shrinkwrap()
 	var/total_storage_space = 0
 	for(var/obj/item/I in contents)
 		total_storage_space += I.get_storage_cost()

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -70,7 +70,7 @@
 		bst.equip_to_slot_or_del(new /obj/item/device/pda/captain/bst(bst.back), slot_in_backpack)
 		bst.equip_to_slot_or_del(new /obj/item/device/multitool(bst.back), slot_in_backpack)
 
-		var/obj/item/weapon/storage/box/pills = new /obj/item/weapon/storage/box
+		var/obj/item/weapon/storage/box/pills = new /obj/item/weapon/storage/box(null, TRUE)
 		pills.name = "adminordrazine"
 		for(var/i = 1, i < 12, i++)
 			new /obj/item/weapon/reagent_containers/pill/adminordrazine(pills)


### PR DESCRIPTION
changes:
- Storage objects can now defer shrinkwrapping of contents until the next stackframe if things are being put in them without using fill() (such as autodrobes & BSTs)
- SSair init properly yells at the admins when it's done.