### PR TITLE
Remove a whole bunch of in world loops and rework machinery global lists

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2165,6 +2165,7 @@
 #include "code\unit_tests\foundation_tests.dm"
 #include "code\unit_tests\map_tests.dm"
 #include "code\unit_tests\mob_tests.dm"
+#include "code\unit_tests\object_tests.dm"
 #include "code\unit_tests\observation_tests.dm"
 #include "code\unit_tests\ss_test.dm"
 #include "code\unit_tests\unit_test.dm"

--- a/code/controllers/subsystems/machinery.dm
+++ b/code/controllers/subsystems/machinery.dm
@@ -6,8 +6,11 @@
 	init_order = SS_INIT_MACHINERY
 	flags = SS_POST_FIRE_TIMING
 
-	var/tmp/list/processing_machinery = list()
-	var/tmp/list/processing_powersinks = list()
+	var/tmp/list/all_machines = list()        // A list of all machines. Including the non-processing ones.
+	var/tmp/list/processing_machines = list() // A list of machines that process.
+
+	var/tmp/list/working_machinery = list()   // A list of machinery left to process this work cycle.
+	var/tmp/list/working_powersinks = list()  // A list of machinery draining power to process this work cycle.
 	var/tmp/powernets_reset_yet
 
 	var/tmp/processes_this_tick = 0
@@ -56,8 +59,8 @@
 
 /datum/controller/subsystem/machinery/fire(resumed = 0, no_mc_tick = FALSE)
 	if (!resumed)
-		src.processing_machinery = machines.Copy()
-		src.processing_powersinks = processing_power_items.Copy()
+		src.working_machinery = processing_machines.Copy()
+		src.working_powersinks = processing_power_items.Copy()
 		powernets_reset_yet = FALSE
 
 		// Reset accounting vars.
@@ -76,8 +79,8 @@
 			sortTim(cameranet.cameras, /proc/cmp_camera)
 			cameranet.cameras_unsorted = FALSE
 
-	var/list/curr_machinery = processing_machinery
-	var/list/curr_powersinks = processing_powersinks
+	var/list/curr_machinery = working_machinery
+	var/list/curr_powersinks = working_powersinks
 
 	while (curr_machinery.len)
 		var/obj/machinery/M = curr_machinery[curr_machinery.len]
@@ -119,7 +122,7 @@
 								usage = M.idle_power_usage
 							if (2)
 								usage = M.active_power_usage
-						
+
 						A.use_power(usage, chan)
 
 		if (no_mc_tick)
@@ -138,7 +141,7 @@
 		if (QDELETED(I) || !I.pwr_drain())
 			processing_power_items -= I
 			log_debug("SSmachinery: QDELETED item [DEBUG_REF(I)] found in processing power items list.")
-		
+
 		if (no_mc_tick)
 			CHECK_TICK
 		else if (MC_TICK_CHECK)
@@ -146,7 +149,7 @@
 
 /datum/controller/subsystem/machinery/stat_entry()
 	var/list/out = list()
-	out += "M:[machines.len] PI:[processing_power_items.len]"
+	out += "AM:[all_machines.len] PM:[processing_machines.len] PI:[processing_power_items.len]"
 	out += "LT:{T:[processes_this_tick]|P:[powerusers_this_tick]}"
 	..(out.Join("\n\t"))
 
@@ -158,19 +161,34 @@
 			NewPN.add_cable(PC)
 			propagate_network(PC, PC.powernet)
 
+/**
+ * @brief Adds a machine to the SSmachinery.processing_machines and the SSmachinery.all_machines list.
+ *
+ * Must be called in every machine's Initialize(). Is called in the parent override of that proc
+ * by default.
+ *
+ * @param M The machine we want to add.
+ */
 /proc/add_machine(obj/machinery/M)
 	if (QDELETED(M))
 		crash_with("Attempted add of QDELETED machine [M ? M : "NULL"] to machines list, ignoring.")
 		return
 
 	M.machinery_processing = TRUE
-	if (machines[M])
-		crash_with("Type [M.type] was added to machines list twice! Ignoring duplicate.")
+	if (SSmachinery.processing_machines[M])
+		crash_with("Type [M.type] was added to the processing machines list twice! Ignoring duplicate.")
 
-	machines[M] = TRUE
+	SSmachinery.processing_machines[M] = TRUE
+	SSmachinery.all_machines[M] = TRUE
 
+/**
+ * @brief Removes a machine from all of the default global lists it's in.
+ *
+ * @param M The machine we want to remove.
+ */
 /proc/remove_machine(obj/machinery/M)
 	if (M)
 		M.machinery_processing = FALSE
-	machines -= M
-	SSmachinery.processing_machinery -= M
+	SSmachinery.all_machines -= M
+	SSmachinery.processing_machines -= M
+	SSmachinery.working_machinery -= M

--- a/code/controllers/subsystems/machinery.dm
+++ b/code/controllers/subsystems/machinery.dm
@@ -88,7 +88,7 @@
 
 		if (QDELETED(M))
 			log_debug("SSmachinery: QDELETED machine [DEBUG_REF(M)] found in machines list! Removing.")
-			remove_machine(M)
+			remove_machine(M, TRUE)
 			continue
 
 		var/start_tick = world.time
@@ -97,7 +97,7 @@
 			processes_this_tick++
 			switch (M.machinery_process())
 				if (PROCESS_KILL)
-					remove_machine(M)
+					remove_machine(M, FALSE)
 				if (M_NO_PROCESS)
 					M.machinery_processing = FALSE
 
@@ -185,10 +185,15 @@
  * @brief Removes a machine from all of the default global lists it's in.
  *
  * @param M The machine we want to remove.
+ * @param remove_from_global Boolean to indicate wether or not the machine should
+ * also be removed from the all_machines list. Defaults to FALSE.
  */
-/proc/remove_machine(obj/machinery/M)
+/proc/remove_machine(obj/machinery/M, remove_from_global = FALSE)
 	if (M)
 		M.machinery_processing = FALSE
-	SSmachinery.all_machines -= M
+
 	SSmachinery.processing_machines -= M
 	SSmachinery.working_machinery -= M
+
+	if (remove_from_global)
+		SSmachinery.all_machines -= M

--- a/code/controllers/subsystems/processing/pipenet.dm
+++ b/code/controllers/subsystems/processing/pipenet.dm
@@ -9,7 +9,7 @@ var/datum/controller/subsystem/processing/pipenet/SSpipenet
 	NEW_SS_GLOBAL(SSpipenet)
 
 /datum/controller/subsystem/processing/pipenet/Initialize(timeofday)
-	for (var/obj/machinery/atmospherics/machine in machines)
+	for (var/obj/machinery/atmospherics/machine in SSmachinery.processing_machines)
 		machine.build_network()
 
 		CHECK_TICK

--- a/code/controllers/subsystems/processing/shuttle.dm
+++ b/code/controllers/subsystems/processing/shuttle.dm
@@ -20,7 +20,7 @@ var/datum/controller/subsystem/processing/shuttle/shuttle_controller
 		shuttle.init_docking_controllers()
 		shuttle.dock() //makes all shuttles docked to something at round start go into the docked state
 
-	for(var/obj/machinery/embedded_controller/C in machines)
+	for(var/obj/machinery/embedded_controller/C in SSmachinery.processing_machines)
 		if(istype(C.program, /datum/computer/file/embedded_program/docking))
 			C.program.tag = null //clear the tags, 'cause we don't need 'em anymore
 

--- a/code/controllers/subsystems/statistics.dm
+++ b/code/controllers/subsystems/statistics.dm
@@ -84,7 +84,7 @@
 	src.msg_syndicate = SSfeedback.msg_syndicate
 	src.msg_cargo = SSfeedback.msg_cargo
 	src.msg_service = SSfeedback.msg_service
-	
+
 	src.feedback = SSfeedback.feedback
 
 /datum/controller/subsystem/statistics/proc/find_feedback_datum(variable)
@@ -103,7 +103,7 @@
 	var/pda_msg_amt = 0
 	var/rc_msg_amt = 0
 
-	for(var/obj/machinery/message_server/MS in machines)
+	for(var/obj/machinery/message_server/MS in SSmachinery.all_machines)
 		if(MS.pda_msgs.len > pda_msg_amt)
 			pda_msg_amt = MS.pda_msgs.len
 		if(MS.rc_msgs.len > rc_msg_amt)
@@ -159,7 +159,7 @@
 		var/DBQuery/query_insert = dbcon.NewQuery(sql)
 		query_insert.Execute()
 
-	
+
 // Sanitize inputs to avoid SQL injection attacks
 /proc/sql_sanitize_text(var/text)
 	text = replacetext(text, "'", "''")
@@ -168,7 +168,7 @@
 	return text
 
 /proc/feedback_set(var/variable,var/value)
-	if(!SSfeedback) 
+	if(!SSfeedback)
 		return
 
 	variable = sql_sanitize_text(variable)

--- a/code/datums/api.dm
+++ b/code/datums/api.dm
@@ -880,7 +880,7 @@ proc/api_update_command_database()
 		reportannounce = 1
 
 	//Send the message to the communications consoles
-	for (var/obj/machinery/computer/communications/C in machines)
+	for (var/obj/machinery/computer/communications/C in SSmachinery.processing_machines)
 		if(! (C.stat & (BROKEN|NOPOWER) ) )
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( C.loc )
 			P.name = "[command_name()] Update"

--- a/code/game/antagonist/alien/xenomorph.dm
+++ b/code/game/antagonist/alien/xenomorph.dm
@@ -36,7 +36,7 @@ var/datum/antagonist/xenos/xenomorphs
 
 /datum/antagonist/xenos/proc/get_vents()
 	var/list/vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in SSmachinery.processing_machines)
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in config.station_levels)
 			if(temp_vent.network.normal_members.len > 50)
 				vents += temp_vent

--- a/code/game/gamemodes/cult/hell_universe.dm
+++ b/code/game/gamemodes/cult/hell_universe.dm
@@ -86,13 +86,13 @@ In short:
 		CHECK_TICK
 
 /datum/universal_state/hell/proc/MiscSet()
-	for (var/obj/machinery/firealarm/alm in machines)
+	for (var/obj/machinery/firealarm/alm in SSmachinery.processing_machines)
 		if (!(alm.stat & BROKEN))
 			alm.ex_act(2)
 		CHECK_TICK
 
 /datum/universal_state/hell/proc/APCSet()
-	for (var/obj/machinery/power/apc/APC in machines)
+	for (var/obj/machinery/power/apc/APC in SSmachinery.processing_machines)
 		if (!(APC.stat & BROKEN) && !APC.is_critical)
 			APC.chargemode = 0
 			if(APC.cell)

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -37,7 +37,7 @@ var/global/universe_has_ended = 0
 // Apply changes when entering state
 /datum/universal_state/supermatter_cascade/OnEnter()
 	set background = 1
-	
+
 	world << "<span class='sinister' style='font-size:22pt'>You are blinded by a brilliant flash of energy.</span>"
 
 	world << sound('sound/effects/cascade.ogg')
@@ -101,7 +101,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 
 /datum/universal_state/supermatter_cascade/OverlayAndAmbientSet()
 	set waitfor = FALSE
-	for(var/turf/T in world)
+	for(var/turf/T in turfs)
 		if(istype(T, /turf/space))
 			T.add_overlay("end01")
 		else

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -82,7 +82,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 	"}
 	priority_announcement.Announce(txt,"SUPERMATTER CASCADE DETECTED")
 
-	for(var/obj/machinery/computer/shuttle_control/C in machines)
+	for(var/obj/machinery/computer/shuttle_control/C in SSmachinery.processing_machines)
 		if(istype(C, /obj/machinery/computer/shuttle_control/research) || istype(C, /obj/machinery/computer/shuttle_control/mining))
 			C.req_access = list()
 			C.req_one_access = list()
@@ -118,13 +118,13 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 		CHECK_TICK
 
 /datum/universal_state/supermatter_cascade/proc/MiscSet()
-	for (var/obj/machinery/firealarm/alm in machines)
+	for (var/obj/machinery/firealarm/alm in SSmachinery.processing_machines)
 		if (!(alm.stat & BROKEN))
 			alm.ex_act(2)
 		CHECK_TICK
 
 /datum/universal_state/supermatter_cascade/proc/APCSet()
-	for (var/obj/machinery/power/apc/APC in machines)
+	for (var/obj/machinery/power/apc/APC in SSmachinery.processing_machines)
 		if (!(APC.stat & BROKEN) && !APC.is_critical)
 			APC.chargemode = 0
 			if(APC.cell)

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -245,7 +245,7 @@ var/hadevent    = 0
 
 
 	var/list/area/areas = list()
-	for(var/area/A in world)
+	for(var/area/A in the_station_areas)
 		if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
 			areas += A
 

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -186,7 +186,7 @@ var/hadevent    = 0
 	//command_alert("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert")
 	//world << sound('sound/AI/aliens.ogg')
 	var/list/vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in SSmachinery.processing_machines)
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in config.station_levels)
 			if(temp_vent.network.normal_members.len > 50) // Stops Aliens getting stuck in small networks. See: Security, Virology
 				vents += temp_vent
@@ -312,7 +312,7 @@ var/hadevent    = 0
 				apc.overload_lighting()
 
 	else
-		for(var/obj/machinery/power/apc/apc in machines)
+		for(var/obj/machinery/power/apc/apc in SSmachinery.processing_machines)
 			apc.overload_lighting()
 
 	return
@@ -423,7 +423,7 @@ Would like to add a law like "Law x is _______" where x = a number, and _____ is
 					M.add_ion_law("THE STATION IS [who2pref] [who2]")
 
 	if(botEmagChance)
-		for(var/obj/machinery/bot/bot in machines)
+		for(var/obj/machinery/bot/bot in SSmachinery.processing_machines)
 			if(prob(botEmagChance))
 				bot.emag_act(1)
 

--- a/code/game/gamemodes/events/PortalStorm.dm
+++ b/code/game/gamemodes/events/PortalStorm.dm
@@ -7,11 +7,11 @@
 		var/list/turfs = list(	)
 		var/turf/picked
 
-		for(var/turf/T in world)
+		for(var/turf/T in turfs)
 			if(T.z < 5 && istype(T,/turf/simulated/floor))
 				turfs += T
 
-		for(var/turf/T in world)
+		for(var/turf/T in turfs)
 			if(prob(10) && T.z < 5 && istype(T,/turf/simulated/floor))
 				spawn(50+rand(0,3000))
 					picked = pick(turfs)

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -7,7 +7,7 @@
 		S.energy_fail(rand(15 * severity,30 * severity))
 
 
-	for(var/obj/machinery/power/apc/C in machines)
+	for(var/obj/machinery/power/apc/C in SSmachinery.processing_machines)
 		if(!C.is_critical)
 			C.energy_fail(rand(40 * severity,150 * severity))
 
@@ -16,7 +16,7 @@
 
 	if(announce)
 		command_announcement.Announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
-	for(var/obj/machinery/power/apc/C in machines)
+	for(var/obj/machinery/power/apc/C in SSmachinery.processing_machines)
 		if(C.cell && (C.z in config.station_levels))
 			C.cell.charge = C.cell.maxcharge
 	for(var/obj/machinery/power/smes/S in SSpower.smes_units)

--- a/code/game/gamemodes/malfunction/malf_hardware.dm
+++ b/code/game/gamemodes/malfunction/malf_hardware.dm
@@ -60,7 +60,7 @@
 
 /datum/malf_hardware/strong_turrets/install()
 	..()
-	for(var/obj/machinery/porta_turret/T in machines)
+	for(var/obj/machinery/porta_turret/T in SSmachinery.processing_machines)
 		T.maxhealth = round(initial(T.maxhealth) * 2)
 		T.shot_delay = round(initial(T.shot_delay) / 2)
 		T.auto_repair = 1

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
@@ -170,7 +170,7 @@
 // Description: Returns a list of all unhacked APCs
 /proc/get_unhacked_apcs(var/mob/living/silicon/ai/user)
 	var/list/H = list()
-	for(var/obj/machinery/power/apc/A in machines)
+	for(var/obj/machinery/power/apc/A in SSmachinery.processing_machines)
 		if(A.hacker && A.hacker == user)
 			continue
 		H.Add(A)
@@ -181,7 +181,7 @@
 // Description: Returns a list of all hacked APCs
 /proc/get_hacked_apcs()
 	var/list/H = list()
-	for(var/obj/machinery/power/apc/A in machines)
+	for(var/obj/machinery/power/apc/A in SSmachinery.processing_machines)
 		if(!A.hacker)
 			continue
 		H.Add(A)
@@ -192,13 +192,13 @@
 // Description: Returns a list of all APCs
 /proc/get_apcs()
 	var/list/H = list()
-	for(var/obj/machinery/power/apc/A in machines)
+	for(var/obj/machinery/power/apc/A in SSmachinery.processing_machines)
 		H.Add(A)
 	return H
 
 /proc/get_unhacked_holopads()
 	var/list/H = list()
-	for(var/obj/machinery/hologram/holopad/HP in machines)
+	for(var/obj/machinery/hologram/holopad/HP in SSmachinery.processing_machines)
 		if(!HP.hacked)
 			H.Add(HP)
 	return H

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
@@ -138,7 +138,7 @@
 	user.hacking = 0
 
 
-/datum/game_mode/malfunction/verb/machine_overload(obj/machinery/M in machines)
+/datum/game_mode/malfunction/verb/machine_overload(obj/machinery/M in SSmachinery.processing_machines)
 	set name = "Machine Overload"
 	set desc = "400 CPU - Causes cyclic short-circuit in machine, resulting in weak explosion after some time."
 	set category = "Software"

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -217,7 +217,7 @@
 		return
 	log_ability_use(user, "system override (STARTED)")
 	var/list/remaining_apcs = list()
-	for(var/obj/machinery/power/apc/A in machines)
+	for(var/obj/machinery/power/apc/A in SSmachinery.processing_machines)
 		if(!(A.z in config.station_levels)) 		// Only station APCs
 			continue
 		if(A.hacker == user || A.aidisabled) 		// This one is already hacked, or AI control is disabled on it.
@@ -263,7 +263,7 @@
 	user << "## REACHABLE APC SYSTEMS OVERTAKEN. BYPASSING PRIMARY FIREWALL."
 	sleep(300)
 	// Hack all APCs, including those built during hack sequence.
-	for(var/obj/machinery/power/apc/A in machines)
+	for(var/obj/machinery/power/apc/A in SSmachinery.processing_machines)
 		if((!A.hacker || A.hacker != src) && !A.aidisabled && A.z in config.station_levels)
 			A.ai_hack(src)
 

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_synthetic.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_synthetic.dm
@@ -365,10 +365,10 @@
 	ntnet_global.intrusion_detection_alarm = 1
 	ntnet_global.add_log("IDS WARNING - Excess traffic flood targeting NTNet relays detected from @!*x&!#*ERS*")
 	//lower the dos capacity of the relay
-	for(var/obj/machinery/ntnet_relay/T in machines)
+	for(var/obj/machinery/ntnet_relay/T in SSmachinery.processing_machines)
 		T.dos_capacity = 200
 	//And give all computers EMAGGED status so they can all have evil programs on them
-	for(var/obj/item/modular_computer/console/C in machines)
+	for(var/obj/item/modular_computer/console/C in SSmachinery.processing_machines)
 		C.computer_emagged = 1
 		user <<"New hacked files available on all current computers hooked to NTNet."
 	sleep(50) // give the AI some time to read they can download evil files

--- a/code/game/gamemodes/newobjective.dm
+++ b/code/game/gamemodes/newobjective.dm
@@ -1070,7 +1070,7 @@ datum
 							for(var/mob/living/silicon/ai/M in C)
 								if(istype(M, /mob/living/silicon/ai) && M.stat != 2)
 									return 1
-						for(var/mob/living/silicon/ai/M in world)
+						for(var/mob/living/silicon/ai/M in silicon_mob_list)
 							if(istype(M.loc, /turf))
 								if(istype(get_area(M), /area/shuttle/escape))
 									return 1
@@ -1236,7 +1236,7 @@ datum
 					return 0
 				var/area/shuttle = locate(/area/shuttle/escape/centcom)
 				var/protected_mobs[] = list(/mob/living/silicon/ai, /mob/living/silicon/pai, /mob/living/silicon/robot)
-				for(var/mob/living/player in world)
+				for(var/mob/living/player in mob_list)
 					if(player.type in protected_mobs)	continue
 					if (player.mind)
 						if (player.stat != 2)
@@ -1286,11 +1286,11 @@ datum
 				if (ticker)
 					var/n_p = 1 //autowin
 					if (ticker.current_state == GAME_STATE_SETTING_UP)
-						for(var/mob/new_player/P in world)
+						for(var/mob/new_player/P in mob_list)
 							if(P.client && P.ready && P.mind!=owner)
 								n_p ++
 					else if (ticker.current_state == GAME_STATE_PLAYING)
-						for(var/mob/living/carbon/human/P in world)
+						for(var/mob/living/carbon/human/P in human_mob_list)
 							if(P.client && !(P.mind in ticker.mode.changelings) && P.mind!=owner)
 								n_p ++
 					target_amount = min(target_amount, n_p)
@@ -1464,7 +1464,7 @@ datum/objective/silence
 		var/area/pod3 =    locate(/area/shuttle/escape_pod3/centcom)
 		var/area/pod4 =    locate(/area/shuttle/escape_pod5/centcom)
 
-		for(var/mob/living/player in world)
+		for(var/mob/living/player in player_list)
 			if (player == owner.current)
 				continue
 			if (player.mind)

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -49,7 +49,7 @@
 
 /obj/item/weapon/pinpointer/examine(mob/user)
 	..(user)
-	for(var/obj/machinery/nuclearbomb/bomb in machines)
+	for(var/obj/machinery/nuclearbomb/bomb in SSmachinery.all_machines)
 		if(bomb.timing)
 			user << "Extreme danger.  Arming signal detected.   Time remaining: [bomb.timeleft]"
 

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -49,7 +49,7 @@
 
 /obj/item/weapon/pinpointer/examine(mob/user)
 	..(user)
-	for(var/obj/machinery/nuclearbomb/bomb in world)
+	for(var/obj/machinery/nuclearbomb/bomb in machines)
 		if(bomb.timing)
 			user << "Extreme danger.  Arming signal detected.   Time remaining: [bomb.timeleft]"
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -863,7 +863,7 @@ datum/objective/heist/salvage
 	explanation_text = "Summon Nar-Sie via the use of the appropriate rune (Hell join self). It will only work if nine cultists stand on and around it. The convert rune is join blood self."
 
 /datum/objective/cult/eldergod/check_completion()
-	return (locate(/obj/singularity/narsie/large) in machines)
+	return (locate(/obj/singularity/narsie/large) in SSmachinery.all_machines)
 
 /datum/objective/cult/sacrifice
 	explanation_text = "Conduct a ritual sacrifice for the glory of Nar-Sie."

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -530,7 +530,7 @@ datum/objective/steal
 						if(istype(M, /mob/living/silicon/ai) && M.stat != 2) //See if any AI's are alive inside that card.
 							return 1
 
-				for(var/mob/living/silicon/ai/ai in world)
+				for(var/mob/living/silicon/ai/ai in silicon_mob_list)
 					var/turf/T = get_turf(ai)
 					if(istype(T))
 						var/area/check_area = get_area(ai)

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -82,7 +82,7 @@
 					if("Koran")
 						B.icon_state = "koran"
 						B.item_state = "koran"
-						for(var/area/chapel/main/A in world)
+						for(var/area/chapel/main/A in the_station_areas)
 							for(var/turf/T in A.contents)
 								if(T.icon_state == "carpetsymbol")
 									T.set_dir(4)
@@ -101,7 +101,7 @@
 					if("Athiest")
 						B.icon_state = "athiest"
 						B.item_state = "syringe_kit"
-						for(var/area/chapel/main/A in world)
+						for(var/area/chapel/main/A in the_station_areas)
 							for(var/turf/T in A.contents)
 								if(T.icon_state == "carpetsymbol")
 									T.set_dir(10)
@@ -117,7 +117,7 @@
 					if("Scientology")
 						B.icon_state = "scientology"
 						B.item_state = "scientology"
-						for(var/area/chapel/main/A in world)
+						for(var/area/chapel/main/A in the_station_areas)
 							for(var/turf/T in A.contents)
 								if(T.icon_state == "carpetsymbol")
 									T.set_dir(8)
@@ -131,7 +131,7 @@
 						// if christian bible, revert to default
 						B.icon_state = "bible"
 						B.item_state = "bible"
-						for(var/area/chapel/main/A in world)
+						for(var/area/chapel/main/A in the_station_areas)
 							for(var/turf/T in A.contents)
 								if(T.icon_state == "carpetsymbol")
 									T.set_dir(2)

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -175,7 +175,7 @@ var/global/list/engineering_networks = list(
 /obj/machinery/camera/proc/upgradeMotion()
 	assembly.upgrades.Add(new /obj/item/device/assembly/prox_sensor(assembly))
 	setPowerUsage()
-	if(!(machines[src]))
+	if(!(SSmachinery.processing_machines[src]))
 		add_machine(src)
 	update_coverage()
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -526,7 +526,7 @@
 
 
 /proc/is_relay_online()
-    for(var/obj/machinery/bluespacerelay/M in machines)
+    for(var/obj/machinery/bluespacerelay/M in SSmachinery.all_machines)
         if(M.stat == 0)
             return 1
     return 0

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -17,7 +17,7 @@
 	. = INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/computer/pod/LateInitialize()
-	for(var/obj/machinery/mass_driver/M in machines)
+	for(var/obj/machinery/mass_driver/M in SSmachinery.processing_machines)
 		if(M.id == id)
 			connected = M
 			return
@@ -30,22 +30,25 @@
 		viewers(null, null) << "Cannot locate mass driver connector. Cancelling firing sequence!"
 		return
 
-	for(var/obj/machinery/door/blast/M in machines)
+	var/list/same_id = list()
+
+	for(var/obj/machinery/door/blast/M in SSmachinery.processing_machines)
 		if(M.id == id)
+			same_id += M
 			M.open()
 
 	sleep(20)
 
-	for(var/obj/machinery/mass_driver/M in machines)
+	for(var/obj/machinery/mass_driver/M in SSmachinery.processing_machines)
 		if(M.id == id)
 			M.power = connected.power
 			M.drive()
 
 	sleep(50)
-	for(var/obj/machinery/door/blast/M in machines)
-		if(M.id == id)
-			M.close()
-			return
+	for(var/mm in same_id)
+		var/obj/machinery/door/blast/M = mm
+		M.close()
+		return
 	return
 
 /*
@@ -168,7 +171,7 @@
 		if(href_list["alarm"])
 			alarm()
 		if(href_list["drive"])
-			for(var/obj/machinery/mass_driver/M in machines)
+			for(var/obj/machinery/mass_driver/M in SSmachinery.processing_machines)
 				if(M.id == id)
 					M.power = connected.power
 					M.drive()
@@ -180,7 +183,7 @@
 			time += tp
 			time = min(max(round(time), 0), 120)
 		if(href_list["door"])
-			for(var/obj/machinery/door/blast/M in machines)
+			for(var/obj/machinery/door/blast/M in SSmachinery.processing_machines)
 				if(M.id == id)
 					if(M.density)
 						M.open()

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -180,7 +180,7 @@
 			time += tp
 			time = min(max(round(time), 0), 120)
 		if(href_list["door"])
-			for(var/obj/machinery/door/blast/M in world)
+			for(var/obj/machinery/door/blast/M in machines)
 				if(M.id == id)
 					if(M.density)
 						M.open()

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -91,7 +91,7 @@
 	*/
 
 /obj/machinery/button/remote/airlock/trigger()
-	for(var/obj/machinery/door/airlock/D in machines)
+	for(var/obj/machinery/door/airlock/D in SSmachinery.processing_machines)
 		if(D.id_tag == src.id)
 			if(specialfunctions & OPEN)
 				if (D.density)
@@ -135,7 +135,7 @@
 	desc = "It controls blast doors, remotely."
 
 /obj/machinery/button/remote/blast_door/trigger()
-	for(var/obj/machinery/door/blast/M in machines)
+	for(var/obj/machinery/door/blast/M in SSmachinery.all_machines)
 		if(M.id == src.id)
 			if(M.density)
 				spawn(0)
@@ -154,7 +154,7 @@
 	desc = "It controls emitters, remotely."
 
 /obj/machinery/button/remote/emitter/trigger(mob/user as mob)
-	for(var/obj/machinery/power/emitter/E in machines)
+	for(var/obj/machinery/power/emitter/E in SSmachinery.all_machines)
 		if(E.id == src.id)
 			spawn(0)
 				E.activate(user)
@@ -173,25 +173,23 @@
 	active = 1
 	update_icon()
 
-	for(var/obj/machinery/door/blast/M in machines)
+	var/list/same_id = list()
+
+	for(var/obj/machinery/door/blast/M in SSmachinery.all_machines)
 		if (M.id == src.id)
-			spawn( 0 )
-				M.open()
-				return
+			same_id += M
+			INVOKE_ASYNC(M, /obj/machinery/door/blast/open)
 
 	sleep(20)
 
-	for(var/obj/machinery/mass_driver/M in machines)
+	for(var/obj/machinery/mass_driver/M in SSmachinery.all_machines)
 		if(M.id == src.id)
 			M.drive()
 
 	sleep(50)
 
-	for(var/obj/machinery/door/blast/M in machines)
-		if (M.id == src.id)
-			spawn(0)
-				M.close()
-				return
+	for(var/mm in same_id)
+		INVOKE_ASYNC(mm, /obj/machinery/door/blast/close)
 
 	icon_state = "launcherbtt"
 	active = 0

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -91,7 +91,7 @@
 	*/
 
 /obj/machinery/button/remote/airlock/trigger()
-	for(var/obj/machinery/door/airlock/D in world)
+	for(var/obj/machinery/door/airlock/D in machines)
 		if(D.id_tag == src.id)
 			if(specialfunctions & OPEN)
 				if (D.density)
@@ -135,7 +135,7 @@
 	desc = "It controls blast doors, remotely."
 
 /obj/machinery/button/remote/blast_door/trigger()
-	for(var/obj/machinery/door/blast/M in world)
+	for(var/obj/machinery/door/blast/M in machines)
 		if(M.id == src.id)
 			if(M.density)
 				spawn(0)
@@ -154,7 +154,7 @@
 	desc = "It controls emitters, remotely."
 
 /obj/machinery/button/remote/emitter/trigger(mob/user as mob)
-	for(var/obj/machinery/power/emitter/E in world)
+	for(var/obj/machinery/power/emitter/E in machines)
 		if(E.id == src.id)
 			spawn(0)
 				E.activate(user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1173,7 +1173,7 @@ About the new airlock wires panel:
 		wires = new/datum/wires/airlock(src)
 
 	if(mapload && src.closeOtherId != null)
-		for (var/obj/machinery/door/airlock/A in world)
+		for (var/obj/machinery/door/airlock/A in machines)
 			if(A.closeOtherId == src.closeOtherId && A != src)
 				src.closeOther = A
 				break

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1173,7 +1173,7 @@ About the new airlock wires panel:
 		wires = new/datum/wires/airlock(src)
 
 	if(mapload && src.closeOtherId != null)
-		for (var/obj/machinery/door/airlock/A in machines)
+		for (var/obj/machinery/door/airlock/A in SSmachinery.processing_machines)
 			if(A.closeOtherId == src.closeOtherId && A != src)
 				src.closeOther = A
 				break

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -40,11 +40,11 @@
 /obj/machinery/door_timer/Initialize()
 	. = ..()
 
-	for(var/obj/machinery/door/window/brigdoor/M in machines)
+	for(var/obj/machinery/door/window/brigdoor/M in SSmachinery.all_machines)
 		if (M.id == src.id)
 			targets += M
 
-	for(var/obj/machinery/flasher/F in machines)
+	for(var/obj/machinery/flasher/F in SSmachinery.all_machines)
 		if(F.id == src.id)
 			targets += F
 
@@ -145,7 +145,7 @@
 
 	qdel( incident )
 	incident = null
-	
+
 	src.updateUsrDialog()
 
 	return 1

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -138,7 +138,7 @@
 	active = 1
 	icon_state = "launcheract"
 
-	for(var/obj/machinery/flasher/M in machines)
+	for(var/obj/machinery/flasher/M in SSmachinery.all_machines)
 		if(M.id == src.id)
 			spawn()
 				M.flash()

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -66,10 +66,8 @@
 	active = !active
 	icon_state = "light[active]"
 
-	for(var/obj/machinery/holosign/M in machines)
+	for(var/obj/machinery/holosign/M in SSmachinery.all_machines)
 		if (M.id == src.id)
-			spawn( 0 )
-				M.toggle()
-				return
+			INVOKE_ASYNC(M, /obj/machinery/holosign/proc/toggle)
 
 	return

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -151,12 +151,11 @@
 	active = 1
 	icon_state = "launcheract"
 
-	for(var/obj/machinery/sparker/M in machines)
+	for(var/obj/machinery/sparker/M in SSmachinery.all_machines)
 		if (M.id == id)
-			spawn( 0 )
-				M.ignite()
+			INVOKE_ASYNC(M, /obj/machinery/sparker/proc/ignite)
 
-	for(var/obj/machinery/igniter/M in machines)
+	for(var/obj/machinery/igniter/M in SSmachinery.all_machines)
 		if(M.id == id)
 			M.ignite()
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -124,7 +124,7 @@ Class Procs:
 	add_machine(src)
 
 /obj/machinery/Destroy()
-	remove_machine(src)
+	remove_machine(src, TRUE)
 	if(component_parts)
 		for(var/atom/A in component_parts)
 			if(A.loc == src) // If the components are inside the machine, delete them.
@@ -377,7 +377,7 @@ Class Procs:
 
 	if (play_sound)
 		playsound(src.loc, print_sfx, 50, 1)
-	
+
 	visible_message("<span class='notice'>[src] rattles to life and spits out a paper titled [paper].</span>")
 
 	addtimer(CALLBACK(src, .proc/print_move_paper, paper), print_delay)

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -237,7 +237,7 @@
 
 	process()
 		if(magnets.len == 0 && autolink)
-			for(var/obj/machinery/magnetic_module/M in world)
+			for(var/obj/machinery/magnetic_module/M in machines)
 				if(M.freq == frequency && M.code == code)
 					magnets += M
 

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -231,13 +231,13 @@
 			filter_path() // renders rpath
 
 	LateInitialize()
-		for(var/obj/machinery/magnetic_module/M in machines)
+		for(var/obj/machinery/magnetic_module/M in SSmachinery.all_machines)
 			if(M.freq == frequency && M.code == code)
 				magnets += M
 
 	process()
 		if(magnets.len == 0 && autolink)
-			for(var/obj/machinery/magnetic_module/M in machines)
+			for(var/obj/machinery/magnetic_module/M in SSmachinery.all_machines)
 				if(M.freq == frequency && M.code == code)
 					magnets += M
 

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -205,7 +205,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 		var/log_msg = message
 		var/pass = 0
 		screen = RCS_SENTFAIL
-		for (var/obj/machinery/message_server/MS in machines)
+		for (var/obj/machinery/message_server/MS in SSmachinery.processing_machines)
 			if(!MS.active) continue
 			MS.send_rc_message(ckey(href_list["department"]),department,log_msg,msgStamped,msgVerified,priority)
 			pass = 1
@@ -366,7 +366,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 		else if(screen == 0)	//Faxing them papers
 			var/pass = 0
 			var/sendto = input("Select department.", "Send Fax", null, null) in allConsoles
-			for (var/obj/machinery/message_server/MS in machines)
+			for (var/obj/machinery/message_server/MS in SSmachinery.processing_machines)
 				if(!MS.active) continue
 				pass = 1
 			if(pass)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -100,7 +100,7 @@
 			singulo.target = src
 	icon_state = "[icontype]1"
 	active = 1
-	machines |= src
+	SSmachinery.processing_machines |= src
 	if(user)
 		user << "<span class='notice'>You activate the beacon.</span>"
 

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -49,7 +49,7 @@
 	if(!control_area)
 		control_area = get_area(src)
 	else if(istext(control_area))
-		for(var/area/A in world)
+		for(var/area/A in all_areas)
 			if(A.name && A.name==control_area)
 				control_area = A
 				break

--- a/code/game/machinery/wishgranter.dm
+++ b/code/game/machinery/wishgranter.dm
@@ -91,7 +91,7 @@
 				for(var/datum/objective/OBJ in user.mind.objectives)
 					user << "<B>Objective #[obj_count]</B>: [OBJ.explanation_text]"
 					obj_count++
-				for(var/obj/machinery/nuclearbomb/station/N in world)
+				for(var/obj/machinery/nuclearbomb/station/N in machines)
 					user << "<span class='warning'>[N.r_code]...!</span>"
 					user.mind.store_memory("<B>Nuclear Bomb Code</B>: [N.r_code]", 0, 0)
 			if("I want peace")

--- a/code/game/machinery/wishgranter.dm
+++ b/code/game/machinery/wishgranter.dm
@@ -91,7 +91,7 @@
 				for(var/datum/objective/OBJ in user.mind.objectives)
 					user << "<B>Objective #[obj_count]</B>: [OBJ.explanation_text]"
 					obj_count++
-				for(var/obj/machinery/nuclearbomb/station/N in machines)
+				for(var/obj/machinery/nuclearbomb/station/N in SSmachinery.all_machines)
 					user << "<span class='warning'>[N.r_code]...!</span>"
 					user.mind.store_memory("<B>Nuclear Bomb Code</B>: [N.r_code]", 0, 0)
 			if("I want peace")

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -807,7 +807,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		if("Toggle Door")
 			if(cartridge && cartridge.access_remote_door)
-				for(var/obj/machinery/door/blast/M in machines)
+				for(var/obj/machinery/door/blast/M in SSmachinery.all_machines)
 					if(M.id == cartridge.remote_door_id)
 						if(M.density)
 							M.open()

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -807,7 +807,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		if("Toggle Door")
 			if(cartridge && cartridge.access_remote_door)
-				for(var/obj/machinery/door/blast/M in world)
+				for(var/obj/machinery/door/blast/M in machines)
 					if(M.id == cartridge.remote_door_id)
 						if(M.density)
 							M.open()

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -141,7 +141,7 @@ Frequency:
 		user << "<span class='notice'>\The [src] is malfunctioning.</span>"
 		return
 	var/list/L = list(  )
-	for(var/obj/machinery/teleport/hub/R in machines)
+	for(var/obj/machinery/teleport/hub/R in SSmachinery.all_machines)
 		var/obj/machinery/computer/teleporter/com = locate(/obj/machinery/computer/teleporter, locate(R.x - 2, R.y, R.z))
 		if (istype(com, /obj/machinery/computer/teleporter) && com.locked && !com.one_time_use)
 			if(R.icon_state == "tele1")

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -141,7 +141,7 @@ Frequency:
 		user << "<span class='notice'>\The [src] is malfunctioning.</span>"
 		return
 	var/list/L = list(  )
-	for(var/obj/machinery/teleport/hub/R in world)
+	for(var/obj/machinery/teleport/hub/R in machines)
 		var/obj/machinery/computer/teleporter/com = locate(/obj/machinery/computer/teleporter, locate(R.x - 2, R.y, R.z))
 		if (istype(com, /obj/machinery/computer/teleporter) && com.locked && !com.one_time_use)
 			if(R.icon_state == "tele1")

--- a/code/global.dm
+++ b/code/global.dm
@@ -7,7 +7,6 @@
 // Items that ask to be called every cycle.
 var/global/datum/datacore/data_core = null
 var/global/list/all_areas                = list()
-var/global/list/machines                 = list()
 var/global/list/processing_objects       = list()
 var/global/list/processing_power_items   = list()
 var/global/list/med_hud_users            = list() // List of all entities using a medical HUD.

--- a/code/modules/admin/secrets/fun_secrets/fix_all_lights.dm
+++ b/code/modules/admin/secrets/fun_secrets/fix_all_lights.dm
@@ -6,5 +6,5 @@
 	if(!.)
 		return
 
-	for(var/obj/machinery/light/L in machines)
+	for(var/obj/machinery/light/L in SSmachinery.all_machines)
 		L.fix()

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -12,23 +12,23 @@
 
 	usr << "Checking for disconnected pipes..."
 	//all plumbing - yes, some things might get stated twice, doesn't matter.
-	for (var/obj/machinery/atmospherics/plumbing in world)
+	for (var/obj/machinery/atmospherics/plumbing in machines)
 		if (plumbing.nodealert)
 			usr << "Unconnected [plumbing.name] located at [plumbing.x],[plumbing.y],[plumbing.z] ([get_area(plumbing.loc)])"
 
 	//Manifolds
-	for (var/obj/machinery/atmospherics/pipe/manifold/pipe in world)
+	for (var/obj/machinery/atmospherics/pipe/manifold/pipe in machines)
 		if (!pipe.node1 || !pipe.node2 || !pipe.node3)
 			usr << "Unconnected [pipe.name] located at [pipe.x],[pipe.y],[pipe.z] ([get_area(pipe.loc)])"
 
 	//Pipes
-	for (var/obj/machinery/atmospherics/pipe/simple/pipe in world)
+	for (var/obj/machinery/atmospherics/pipe/simple/pipe in machines)
 		if (!pipe.node1 || !pipe.node2)
 			usr << "Unconnected [pipe.name] located at [pipe.x],[pipe.y],[pipe.z] ([get_area(pipe.loc)])"
 
 	usr << "Checking for overlapping pipes..."
 	next_turf:
-		for(var/turf/T in world)
+		for(var/turf/T in turfs)
 			for(var/dir in cardinal)
 				var/list/connect_types = list(1 = 0, 2 = 0, 3 = 0)
 				for(var/obj/machinery/atmospherics/pipe in T)

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -12,17 +12,17 @@
 
 	usr << "Checking for disconnected pipes..."
 	//all plumbing - yes, some things might get stated twice, doesn't matter.
-	for (var/obj/machinery/atmospherics/plumbing in machines)
+	for (var/obj/machinery/atmospherics/plumbing in world)
 		if (plumbing.nodealert)
 			usr << "Unconnected [plumbing.name] located at [plumbing.x],[plumbing.y],[plumbing.z] ([get_area(plumbing.loc)])"
 
 	//Manifolds
-	for (var/obj/machinery/atmospherics/pipe/manifold/pipe in machines)
+	for (var/obj/machinery/atmospherics/pipe/manifold/pipe in world)
 		if (!pipe.node1 || !pipe.node2 || !pipe.node3)
 			usr << "Unconnected [pipe.name] located at [pipe.x],[pipe.y],[pipe.z] ([get_area(pipe.loc)])"
 
 	//Pipes
-	for (var/obj/machinery/atmospherics/pipe/simple/pipe in machines)
+	for (var/obj/machinery/atmospherics/pipe/simple/pipe in world)
 		if (!pipe.node1 || !pipe.node2)
 			usr << "Unconnected [pipe.name] located at [pipe.x],[pipe.y],[pipe.z] ([get_area(pipe.loc)])"
 

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -423,7 +423,7 @@ var/global/movement_disabled_exception //This is the client that calls the proc,
 	set category = "Mapping"
 	set name = "Find Bad Doors"
 
-	for(var/obj/machinery/door/airlock/A in machines)
+	for(var/obj/machinery/door/airlock/A in world)
 		var/turf/T = get_turf(A)
 		if(istype(T, /turf/space) || istype(T, /turf/simulated/floor/asteroid) || isopenturf(T) || T.density)
 			usr << "Airlock [A] with bad turf at ([A.x],[A.y],[A.z]) in [T.loc]."
@@ -432,7 +432,7 @@ var/global/movement_disabled_exception //This is the client that calls the proc,
 	set category = "Mapping"
 	set name = "Find Bad Fire Doors"
 
-	for(var/obj/machinery/door/firedoor/F in machines)
+	for(var/obj/machinery/door/firedoor/F in world)
 		var/turf/T = get_turf(F)
 		var/firelock_increment = 0
 		for(var/obj/machinery/door/firedoor/FD in T)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -12,7 +12,7 @@
 
 
 /datum/event/brand_intelligence/start()
-	for(var/obj/machinery/vending/V in machines)
+	for(var/obj/machinery/vending/V in SSmachinery.processing_machines)
 		if(isNotStationLevel(V.z))	continue
 		vendingMachines.Add(V)
 

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -12,7 +12,7 @@
 			continue
 		players += player.real_name
 
-	for (var/mob/living/silicon/ai/target in world)
+	for (var/mob/living/silicon/ai/target in silicon_mob_list)
 		var/random_player = "The Captain"
 		if(players.len)
 			random_player = pick(players)		//Random player's name, to be used in laws.
@@ -88,7 +88,7 @@
 
 /datum/event/ionstorm/tick()
 	if(botEmagChance)
-		for(var/obj/machinery/bot/bot in world)
+		for(var/obj/machinery/bot/bot in machines)
 			if(prob(botEmagChance))
 				bot.emag_act(1)
 

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -88,7 +88,7 @@
 
 /datum/event/ionstorm/tick()
 	if(botEmagChance)
-		for(var/obj/machinery/bot/bot in machines)
+		for(var/obj/machinery/bot/bot in SSmachinery.all_machines)
 			if(prob(botEmagChance))
 				bot.emag_act(1)
 

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -20,7 +20,7 @@
 	Notifications will be sent as updates occur.<br>"
 	var/my_department = "[station_name()] firewall subroutines"
 
-	for(var/obj/machinery/message_server/MS in machines)
+	for(var/obj/machinery/message_server/MS in SSmachinery.processing_machines)
 		if(!MS.active) continue
 		MS.send_rc_message("Head of Personnel's Desk", my_department, message, "", "", 2)
 
@@ -62,6 +62,6 @@
 
 	var/my_department = "[station_name()] firewall subroutines"
 
-	for(var/obj/machinery/message_server/MS in machines)
+	for(var/obj/machinery/message_server/MS in SSmachinery.processing_machines)
 		if(!MS.active) continue
 		MS.send_rc_message("Head of Personnel's Desk", my_department, message, "", "", 2)

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -19,11 +19,11 @@
 	without intervention this attack will succeed in approximately 10 minutes. Required intervention: temporary suspension of affected accounts until the attack has ceased. \
 	Notifications will be sent as updates occur.<br>"
 	var/my_department = "[station_name()] firewall subroutines"
-	
-	for(var/obj/machinery/message_server/MS in world)
+
+	for(var/obj/machinery/message_server/MS in machines)
 		if(!MS.active) continue
 		MS.send_rc_message("Head of Personnel's Desk", my_department, message, "", "", 2)
-		
+
 
 /datum/event/money_hacker/tick()
 	if(world.time >= end_time)
@@ -62,6 +62,6 @@
 
 	var/my_department = "[station_name()] firewall subroutines"
 
-	for(var/obj/machinery/message_server/MS in world)
+	for(var/obj/machinery/message_server/MS in machines)
 		if(!MS.active) continue
 		MS.send_rc_message("Head of Personnel's Desk", my_department, message, "", "", 2)

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -6,7 +6,7 @@
 	var/list/area/areas = list()		//List of areas to affect. Filled by start()
 	ic_name = "an imprisonment system virus"
 	no_fake = 1
-	
+
 	var/eventDept = "Security"			//Department name in announcement
 	var/list/areaName = list("Brig")	//Names of areas mentioned in AI and Engineering announcements
 	var/list/areaType = list(/area/security/prison, /area/security/brig)	//Area types to include.
@@ -43,7 +43,7 @@
 
 
 /datum/event/prison_break/start()
-	for(var/area/A in world)
+	for(var/area/A in the_station_areas)
 		if(is_type_in_list(A,areaType) && !is_type_in_list(A,areaNotType))
 			areas += A
 

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -50,7 +50,7 @@
 	if(areas && areas.len > 0)
 		var/my_department = "[station_name()] firewall subroutines"
 		var/rc_message = "An unknown malicious program has been detected in the [english_list(areaName)] lighting and airlock control systems at [worldtime2text()]. Systems will be fully compromised within approximately three minutes. Direct intervention is required immediately.<br>"
-		for(var/obj/machinery/message_server/MS in machines)
+		for(var/obj/machinery/message_server/MS in SSmachinery.processing_machines)
 			MS.send_rc_message("Engineering", my_department, rc_message, "", "", 2)
 		for(var/mob/living/silicon/ai/A in player_list)
 			A << "<span class='danger'>Malicious program detected in the [english_list(areaName)] lighting and airlock control systems by [my_department].</span>"

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -17,7 +17,7 @@
 
 /datum/event/spider_infestation/start()
 	var/list/vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in SSmachinery.processing_machines)
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in config.station_levels)
 			if(temp_vent.network.normal_members.len > 50)
 				vents += temp_vent

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -17,7 +17,7 @@
 
 /datum/event/spider_infestation/start()
 	var/list/vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in world)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in config.station_levels)
 			if(temp_vent.network.normal_members.len > 50)
 				vents += temp_vent

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -13,7 +13,7 @@
 
 /datum/event/vent_clog/setup()
 	endWhen = rand(25, 100)
-	for(var/obj/machinery/atmospherics/unary/vent_scrubber/temp_vent in machines)
+	for(var/obj/machinery/atmospherics/unary/vent_scrubber/temp_vent in SSmachinery.processing_machines)
 		if(!temp_vent)
 			continue
 		if(temp_vent.z in config.station_levels)//STATION ZLEVEL

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -505,7 +505,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	//If we hit the limit without finding a valid one, then the best one we found is selected
 
 	var/list/found_vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/v in machines)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/v in SSmachinery.processing_machines)
 		if(!v.welded && v.z == ZLevel)
 			found_vents.Add(v)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -938,7 +938,7 @@
 		src.verbs -= /mob/living/carbon/human/proc/remotesay
 		return
 	var/list/creatures = list()
-	for(var/mob/living/carbon/h in world)
+	for(var/mob/living/carbon/h in human_mob_list)
 		creatures += h
 	var/mob/target = input("Who do you want to project your mind to ?") as null|anything in creatures
 	if (isnull(target))
@@ -951,7 +951,7 @@
 		target.show_message("<span class='notice'>You hear a voice that seems to echo around the room: [say]</span>")
 	usr.show_message("<span class='notice'>You project your mind into [target.real_name]: [say]</span>")
 	log_say("[key_name(usr)] sent a telepathic message to [key_name(target)]: [say]",ckey=key_name(usr))
-	for(var/mob/dead/observer/G in world)
+	for(var/mob/dead/observer/G in dead_mob_list)
 		G.show_message("<i>Telepathic message from <b>[src]</b> to <b>[target]</b>: [say]</i>")
 
 /mob/living/carbon/human/proc/remoteobserve()
@@ -976,7 +976,7 @@
 
 	var/list/mob/creatures = list()
 
-	for(var/mob/living/carbon/h in world)
+	for(var/mob/living/carbon/h in human_mob_list)
 		var/turf/temp_turf = get_turf(h)
 		if((temp_turf.z != 1 && temp_turf.z != 5) || h.stat!=CONSCIOUS) //Not on mining or the station. Or dead
 			continue

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -941,7 +941,7 @@
 	for(var/hh in human_mob_list)
 		var/mob/living/carbon/human/H = hh
 		if (H.client)
-			creatures += h
+			creatures += hh
 
 	var/mob/target = input("Who do you want to project your mind to ?") as null|anything in creatures
 	if (isnull(target))
@@ -984,8 +984,8 @@
 		if (!H.client)
 			continue
 
-		var/turf/temp_turf = get_turf(h)
-		if((temp_turf.z != 1 && temp_turf.z != 5) || h.stat!=CONSCIOUS) //Not on mining or the station. Or dead
+		var/turf/temp_turf = get_turf(H)
+		if((temp_turf.z != 1 && temp_turf.z != 5) || H.stat!=CONSCIOUS) //Not on mining or the station. Or dead
 			continue
 		creatures += h
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -938,8 +938,11 @@
 		src.verbs -= /mob/living/carbon/human/proc/remotesay
 		return
 	var/list/creatures = list()
-	for(var/mob/living/carbon/h in human_mob_list)
-		creatures += h
+	for(var/hh in human_mob_list)
+		var/mob/living/carbon/human/H = hh
+		if (H.client)
+			creatures += h
+
 	var/mob/target = input("Who do you want to project your mind to ?") as null|anything in creatures
 	if (isnull(target))
 		return
@@ -976,7 +979,11 @@
 
 	var/list/mob/creatures = list()
 
-	for(var/mob/living/carbon/h in human_mob_list)
+	for(var/h in human_mob_list)
+		var/mob/living/carbon/human/H = h
+		if (!H.client)
+			continue
+
 		var/turf/temp_turf = get_turf(h)
 		if((temp_turf.z != 1 && temp_turf.z != 5) || h.stat!=CONSCIOUS) //Not on mining or the station. Or dead
 			continue

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -393,7 +393,7 @@ var/list/ai_verbs_default = list(
 
 	// hack to display shuttle timer
 	if(emergency_shuttle.online())
-		var/obj/machinery/computer/communications/C = locate() in machines
+		var/obj/machinery/computer/communications/C = locate() in SSmachinery.processing_machines
 		if(C)
 			C.post_status("shuttle")
 

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -17,7 +17,7 @@
 	client.screen.Add( blind, flash )
 
 	if(stat != DEAD)
-		for(var/obj/machinery/ai_status_display/O in machines) //change status
+		for(var/obj/machinery/ai_status_display/O in SSmachinery.all_status_displays) //change status
 			O.mode = 1
 			O.emotion = "Neutral"
 	src.view_core()

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -28,7 +28,7 @@
 	var/dat
 	dat += "<B>Maintenance Units</B><BR>"
 
-	for(var/mob/living/silicon/robot/drone/D in world)
+	for(var/mob/living/silicon/robot/drone/D in silicon_mob_list)
 		if(D.z != src.z)
 			continue
 		dat += "<BR>[D.real_name] ([D.stat == 2 ? "<font color='red'>INACTIVE</FONT>" : "<font color='green'>ACTIVE</FONT>"])"
@@ -70,7 +70,7 @@
 	else if (href_list["ping"])
 
 		usr << "<span class='notice'>You issue a maintenance request for all active drones, highlighting [drone_call_area].</span>"
-		for(var/mob/living/silicon/robot/drone/D in world)
+		for(var/mob/living/silicon/robot/drone/D in silicon_mob_list)
 			if(D.client && D.stat == 0)
 				D << "-- Maintenance drone presence requested in: [drone_call_area]."
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -110,7 +110,7 @@
 	if(!fabricator)
 
 		var/list/all_fabricators = list()
-		for(var/obj/machinery/drone_fabricator/DF in machines)
+		for(var/obj/machinery/drone_fabricator/DF in SSmachinery.all_machines)
 			if((DF.stat & NOPOWER) || !DF.produce_drones || DF.drone_progress < 100)
 				continue
 			all_fabricators[DF.fabricator_tag] = DF

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -1,6 +1,6 @@
 /proc/count_drones()
 	var/drones = 0
-	for(var/mob/living/silicon/robot/drone/D in world)
+	for(var/mob/living/silicon/robot/drone/D in silicon_mob_list)
 		if(D.key && D.client)
 			drones++
 	return drones
@@ -75,9 +75,9 @@
 	flick("h_lathe_leave",src)
 
 	time_last_drone = world.time
-	if(player.mob && player.mob.mind) 
+	if(player.mob && player.mob.mind)
 		player.mob.mind.reset()
-		
+
 	var/mob/living/silicon/robot/drone/new_drone = new drone_type(get_turf(src))
 	new_drone.transfer_personality(player)
 	new_drone.master_fabricator = src

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -54,7 +54,7 @@
 			user << "The [src] is empty.  Put something inside it first."
 	if(response == "Sync")
 		var/success = 0
-		for(var/obj/machinery/r_n_d/server/S in machines)
+		for(var/obj/machinery/r_n_d/server/S in SSmachinery.all_machines)
 			for(var/datum/tech/T in files.known_tech) //Uploading
 				S.files.AddTech2Known(T)
 			for(var/datum/tech/T in S.files.known_tech) //Downloading

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -31,7 +31,7 @@ var/global/datum/ntnet/ntnet_global = new()
 /datum/ntnet/New()
 	if(ntnet_global && (ntnet_global != src))
 		ntnet_global = src // There can be only one.
-	for(var/obj/machinery/ntnet_relay/R in machines)
+	for(var/obj/machinery/ntnet_relay/R in SSmachinery.all_machines)
 		relays.Add(R)
 		R.NTNet = src
 	build_software_lists()

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -290,7 +290,7 @@ var/last_message_id = 0
 		l.Add(message)
 
 	//Old console support
-	for (var/obj/machinery/computer/communications/comm in machines)
+	for (var/obj/machinery/computer/communications/comm in SSmachinery.processing_machines)
 		if (!(comm.stat & (BROKEN | NOPOWER)) && comm.prints_intercept)
 			var/obj/item/weapon/paper/intercept = new /obj/item/weapon/paper( comm.loc )
 			intercept.name = message_title

--- a/code/modules/nano/modules/atmos_control.dm
+++ b/code/modules/nano/modules/atmos_control.dm
@@ -19,7 +19,7 @@
 		log_debug("\The [src] given an unepxected req_one_access: [req_one_access]")
 
 	if(monitored_alarm_ids)
-		for(var/obj/machinery/alarm/alarm in machines)
+		for(var/obj/machinery/alarm/alarm in SSmachinery.processing_machines)
 			if(alarm.alarm_id && alarm.alarm_id in monitored_alarm_ids)
 				monitored_alarms += alarm
 		// machines may not yet be ordered at this point
@@ -31,7 +31,7 @@
 
 	if(href_list["alarm"])
 		if(ui_ref)
-			var/obj/machinery/alarm/alarm = locate(href_list["alarm"]) in (monitored_alarms.len ? monitored_alarms : machines)
+			var/obj/machinery/alarm/alarm = locate(href_list["alarm"]) in (monitored_alarms.len ? monitored_alarms : SSmachinery.processing_machines)
 			if(alarm)
 				var/datum/topic_state/TS = generate_state(alarm)
 				alarm.ui_interact(usr, master_ui = ui_ref, state = TS)
@@ -42,7 +42,7 @@
 	var/alarms[0]
 
 	// TODO: Move these to a cache, similar to cameras
-	for(var/obj/machinery/alarm/alarm in (monitored_alarms.len ? monitored_alarms : machines))
+	for(var/obj/machinery/alarm/alarm in (monitored_alarms.len ? monitored_alarms : SSmachinery.processing_machines))
 		alarms[++alarms.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = max(alarm.danger_level, alarm.alarm_area.atmosalm))
 	data["alarms"] = alarms
 

--- a/code/modules/overmap/ships/engines/engine.dm
+++ b/code/modules/overmap/ships/engines/engine.dm
@@ -9,7 +9,7 @@ var/list/ship_engines = list()
 /datum/ship_engine/New(var/obj/machinery/holder)
 	engine = holder
 	zlevel = holder.z
-	for(var/obj/machinery/computer/engines/E in machines)
+	for(var/obj/machinery/computer/engines/E in SSmachinery.processing_machines)
 		if (E.z == zlevel && !(src in E.engines))
 			E.engines += src
 			break
@@ -53,7 +53,7 @@ var/list/ship_engines = list()
 	return 1
 
 /datum/ship_engine/proc/die()
-	for(var/obj/machinery/computer/engines/E in machines)
+	for(var/obj/machinery/computer/engines/E in SSmachinery.processing_machines)
 		if (E.z == zlevel)
 			E.engines -= src
 			break

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -16,11 +16,11 @@
 
 /obj/effect/map/ship/Initialize()
 	. = ..()
-	for(var/obj/machinery/computer/engines/E in machines)
+	for(var/obj/machinery/computer/engines/E in SSmachinery.processing_machines)
 		if (E.z == map_z)
 			eng_control = E
 			break
-	for(var/obj/machinery/computer/helm/H in machines)
+	for(var/obj/machinery/computer/helm/H in SSmachinery.processing_machines)
 		if (H.z == map_z)
 			nav_control = H
 			break
@@ -112,5 +112,5 @@
 		var/turf/newloc = locate(x + deltas[1], y + deltas[2], z)
 		if(newloc)
 			Move(newloc)
-		if(rotate)	
+		if(rotate)
 			rotate(get_heading())

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -44,7 +44,7 @@ proc/cardinalrange(var/center)
 		controllerscan()
 		return
 	link_control(AMC)
-	remove_machine(src)
+	remove_machine(src, FALSE)
 	if (mapload)
 		. = INITIALIZE_HINT_LATELOAD
 	else

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -124,7 +124,7 @@
 
 			for(var/area/A in gravity_generator:localareas)
 				var/obj/machinery/gravity_generator/G
-				for(G in machines)
+				for(G in SSmachinery.processing_machines)
 					if((A in G.localareas) && (G.on))
 						break
 				if(!G)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -312,7 +312,7 @@ field_generator power level display
 	//I want to avoid using global variables.
 	spawn(1)
 		var/temp = 1 //stops spam
-		for(var/obj/singularity/O in machines)
+		for(var/obj/singularity/O in SSmachinery.processing_machines)
 			if(O.last_warning && temp)
 				if((world.time - O.last_warning) > 50) //to stop message-spam
 					temp = 0

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -39,7 +39,7 @@
 
 	..()
 	START_PROCESSING(SScalamity, src)
-	for(var/obj/machinery/power/singularity_beacon/singubeacon in machines)
+	for(var/obj/machinery/power/singularity_beacon/singubeacon in SSmachinery.processing_machines)
 		if(singubeacon.active)
 			target = singubeacon
 			break

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -219,11 +219,11 @@
 /obj/machinery/computer/turbine_computer/New()
 	..()
 	spawn(5)
-		for(var/obj/machinery/compressor/C in machines)
+		for(var/obj/machinery/compressor/C in SSmachinery.all_machines)
 			if(id == C.comp_id)
 				compressor = C
 		doors = new /list()
-		for(var/obj/machinery/door/blast/P in machines)
+		for(var/obj/machinery/door/blast/P in SSmachinery.all_machines)
 			if(P.id == id)
 				doors += P
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -98,7 +98,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	return
 
 /obj/machinery/computer/rdconsole/proc/griefProtection() //Have it automatically push research to the centcomm server so wild griffins can't fuck up R&D's work
-	for(var/obj/machinery/r_n_d/server/centcom/C in machines)
+	for(var/obj/machinery/r_n_d/server/centcom/C in SSmachinery.all_machines)
 		for(var/datum/tech/T in files.known_tech)
 			C.files.AddTech2Known(T)
 		for(var/datum/design/D in files.known_designs)
@@ -109,7 +109,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	. = ..()
 	files = new /datum/research(src) //Setup the research data holder.
 	if(!id)
-		for(var/obj/machinery/r_n_d/server/centcom/S in machines)
+		for(var/obj/machinery/r_n_d/server/centcom/S in SSmachinery.all_machines)
 			S.setup()
 			break
 	SyncRDevices()
@@ -278,7 +278,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			griefProtection() //Putting this here because I dont trust the sync process
 			spawn(30)
 				if(src)
-					for(var/obj/machinery/r_n_d/server/S in machines)
+					for(var/obj/machinery/r_n_d/server/S in SSmachinery.all_machines)
 						var/server_processed = 0
 						if((id in S.id_with_upload) || istype(S, /obj/machinery/r_n_d/server/centcom))
 							for(var/datum/tech/T in files.known_tech)
@@ -411,7 +411,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				info += GetResearchListInfo()
 			else
 				info += GetResearchLevelsInfo()
-			
+
 			PR.set_content_unsafe(pname, info)
 			print(PR)
 			spawn(10)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -82,7 +82,7 @@
 
 //Backup files to centcomm to help admins recover data after greifer attacks
 /obj/machinery/r_n_d/server/proc/griefProtection()
-	for(var/obj/machinery/r_n_d/server/centcom/C in machines)
+	for(var/obj/machinery/r_n_d/server/centcom/C in SSmachinery.all_machines)
 		for(var/datum/tech/T in files.known_tech)
 			C.files.AddTech2Known(T)
 		for(var/datum/design/D in files.known_designs)
@@ -128,7 +128,7 @@
 	..()
 	var/list/no_id_servers = list()
 	var/list/server_ids = list()
-	for(var/obj/machinery/r_n_d/server/S in machines)
+	for(var/obj/machinery/r_n_d/server/S in SSmachinery.all_machines)
 		switch(S.server_id)
 			if(-1)
 				continue
@@ -179,20 +179,20 @@
 		temp_server = null
 		consoles = list()
 		servers = list()
-		for(var/obj/machinery/r_n_d/server/S in machines)
+		for(var/obj/machinery/r_n_d/server/S in SSmachinery.all_machines)
 			if(S.server_id == text2num(href_list["access"]) || S.server_id == text2num(href_list["data"]) || S.server_id == text2num(href_list["transfer"]))
 				temp_server = S
 				break
 		if(href_list["access"])
 			screen = 1
-			for(var/obj/machinery/computer/rdconsole/C in machines)
+			for(var/obj/machinery/computer/rdconsole/C in SSmachinery.all_machines)
 				if(C.sync)
 					consoles += C
 		else if(href_list["data"])
 			screen = 2
 		else if(href_list["transfer"])
 			screen = 3
-			for(var/obj/machinery/r_n_d/server/S in machines)
+			for(var/obj/machinery/r_n_d/server/S in SSmachinery.all_machines)
 				if(S == src)
 					continue
 				servers += S
@@ -242,7 +242,7 @@
 		if(0) //Main Menu
 			dat += "Connected Servers:<BR><BR>"
 
-			for(var/obj/machinery/r_n_d/server/S in machines)
+			for(var/obj/machinery/r_n_d/server/S in SSmachinery.all_machines)
 				if(istype(S, /obj/machinery/r_n_d/server/centcom) && !badmin)
 					continue
 				dat += "[S.name] || "

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -111,7 +111,7 @@
 
 /obj/machinery/keycard_auth/proc/broadcast_request()
 	icon_state = "auth_on"
-	for(var/obj/machinery/keycard_auth/KA in world)
+	for(var/obj/machinery/keycard_auth/KA in machines)
 		if(KA == src) continue
 		KA.reset()
 		spawn()

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -111,7 +111,7 @@
 
 /obj/machinery/keycard_auth/proc/broadcast_request()
 	icon_state = "auth_on"
-	for(var/obj/machinery/keycard_auth/KA in machines)
+	for(var/obj/machinery/keycard_auth/KA in SSmachinery.all_machines)
 		if(KA == src) continue
 		KA.reset()
 		spawn()

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -50,7 +50,7 @@
 				SSnightlight.temp_disable()
 
 		var/newlevel = get_security_level()
-		for(var/obj/machinery/firealarm/FA in machines)
+		for(var/obj/machinery/firealarm/FA in SSmachinery.processing_machines)
 			if(FA.z in config.contact_levels)
 				FA.set_security_level(newlevel)
 

--- a/code/unit_tests/object_tests.dm
+++ b/code/unit_tests/object_tests.dm
@@ -1,0 +1,33 @@
+/**
+ * Tests whether or not all mapped in machinery appear in the SSmachinery.all_machines
+ * list after round start.
+ *
+ * It's not exactly the most robust, but it'll catch basic faults in new machinery
+ * design.
+ */
+/datum/unit_test/machinery_global_test
+	name = "OBJECTS: Machinery Global List Test"
+
+/datum/unit_test/machinery_global_test/start_test()
+	var/list/all_types = list()
+	var/list/unfound_types = list()
+
+	for (var/obj/machinery/M in world)
+		if (!SSmachinery.all_machines[M] && !QDELETED(M))
+			if (!unfound_types[M.type])
+				unfound_types[M.type] = 1
+			else
+				unfound_types[M.type]++
+
+			if (!all_types[M.type])
+				all_types[M.type] = 1
+
+	if (unfound_types.len)
+		for (var/t in unfound_types)
+			log_unit_test("[ascii_red]--------------- [unfound_types[t]] instances of [t] not found in SSmachinery.all_machines.")
+
+		fail("\[[unfound_types.len] / [all_types.len]\] mapped in machinery types were not found in SSmachinery.all_machines.")
+	else
+		pass("All \[[all_types.len]\] mapped in machinery types were found in SSmachinery.all_machines.")
+
+	return 1

--- a/code/unit_tests/object_tests.dm
+++ b/code/unit_tests/object_tests.dm
@@ -19,8 +19,8 @@
 			else
 				unfound_types[M.type]++
 
-			if (!all_types[M.type])
-				all_types[M.type] = 1
+		if (!all_types[M.type])
+			all_types[M.type] = 1
 
 	if (unfound_types.len)
 		for (var/t in unfound_types)


### PR DESCRIPTION
Removes a whole bunch of in world loops.
Reworks SSmachinery to hold two lists: all_machines and processing_machines. all_machines contains all machines 5ever. All of them. Literally. Forever. And ever. processing_machines only contains machines that process with the SSmachinery controller.

I checked most types at runtime on the live server to see whether they're in processing_machines or in all_machines, and did debug to ensure that most machinery ends up and stays in all_machines.

Includes a basic UT to make sure all mapped in machinery types remain within the all_machines list post-init.