### PR TITLE
APC placement lag and blueprint lag

### DIFF
--- a/code/_helpers/area_movement.dm
+++ b/code/_helpers/area_movement.dm
@@ -50,8 +50,6 @@
 	var/list/source_turfs = src.build_ordered_turf_list(turf_to_leave)
 	var/list/target_turfs = A.build_ordered_turf_list()
 
-	//log_debug("move_contents_to: source_turfs.len=[source_turfs.len],target_turfs.len=[target_turfs.len]")
-
 	ASSERT(source_turfs.len == target_turfs.len)
 
 	for (var/i = 1 to source_turfs.len)
@@ -81,8 +79,6 @@
 	var/list/target_turfs = A.build_ordered_turf_list()
 
 	. = list()
-
-	log_debug("copy_contents_to: source_turfs.len=[source_turfs.len],target_turfs.len=[target_turfs.len]")
 
 	ASSERT(source_turfs.len == target_turfs.len)
 

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -24,7 +24,7 @@
 	if (!istype(loc, /turf/simulated/floor))
 		usr << "<span class='warning'>APC cannot be placed on this spot.</span>"
 		return
-	if (A.requires_power == 0 || istype(A, /area/space))
+	if (A.requires_power == 0 || istype(A, /area/space) || istype(A, /area/mine/unexplored))
 		usr << "<span class='warning'>APC cannot be placed in this area.</span>"
 		return
 	if (A.get_apc())

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -80,7 +80,7 @@ move an amendment</a> to the drawing.</p>
 	return A
 
 /obj/item/blueprints/proc/get_area_type(var/area/A = get_area())
-	if(istype(A, /area/space))
+	if(istype(A, /area/space) || istype(A, /area/mine/unexplored))
 		return AREA_SPACE
 	var/list/SPECIALS = list(
 		/area/shuttle,
@@ -133,10 +133,7 @@ move an amendment</a> to the drawing.</p>
 
 	sorted_add_area(A)
 
-	spawn(5)
-		//ma = A.master ? "[A.master]" : "(null)"
-		//world << "DEBUG: create_area(5): <br>A.name=[A.name]<br>A.tag=[A.tag]<br>A.master=[ma]"
-		interact()
+	addtimer(CALLBACK(src, .proc/interact), 5)
 	return
 
 
@@ -156,7 +153,7 @@ move an amendment</a> to the drawing.</p>
 	if(length(str) > 50)
 		usr << "<span class='warning'>Text too long.</span>"
 		return
-	set_area_machinery_title(A,str,prevname)
+	INVOKE_ASYNC(src, .proc/set_area_machinery_title, A, str, prevname)
 	A.name = str
 	sortTim(all_areas, /proc/cmp_text_asc)
 	usr << "<span class='notice'>You set the area '[prevname]' title to '[str]'.</span>"
@@ -169,17 +166,19 @@ move an amendment</a> to the drawing.</p>
 	if (!oldtitle) // or replacetext goes to infinite loop
 		return
 
-	for(var/obj/machinery/alarm/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/power/apc/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/atmospherics/unary/vent_scrubber/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/atmospherics/unary/vent_pump/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/door/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	//TODO: much much more. Unnamed airlocks, cameras, etc.
+	var/static/list/types_to_rename = list(
+		/obj/machinery/alarm,
+		/obj/machinery/power/apc,
+		/obj/machinery/atmospherics/unary/vent_scrubber,
+		/obj/machinery/atmospherics/unary/vent_pump,
+		/obj/machinery/door
+	)
+
+	for(var/obj/machinery/M in A)
+		if (is_type_in_list(M, types_to_rename))
+			M.name = replacetext(M.name, oldtitle, title)
+
+		CHECK_TICK
 
 /obj/item/blueprints/proc/check_tile_is_border(var/turf/T2,var/dir)
 	if (istype(T2, /turf/space))

--- a/html/changelogs/skull132-construction_woes.yml
+++ b/html/changelogs/skull132-construction_woes.yml
@@ -1,0 +1,6 @@
+author: Skull132
+delete-after: true
+
+changes:
+  - bugfix: "Blueprints now work on the asteroid as they would work in space. They also no longer megalag the server to death."
+  - bugfix: "Attempting to power the entirety of the asteroid, and thus lagging the server to death, is no longer possible."


### PR DESCRIPTION
Fixes #3063 
Fixes #3064 

Makes the asteroid area equivalent to the space area: cannot be powered with an APC, an APC cannot be placed there, and blueprints will allow you to create new areas there. Also tick checks a blueprint proc which caused the lag in the first place, just for future reference.