### PR TITLE
Hardsuit tweaks, tech levels fixes and pAI EAL addition

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -67,7 +67,7 @@ obj/item/weapon/circuitboard/rdserver
 	name = T_BOARD("telepad")
 	build_path = "/obj/machinery/telepad"
 	board_type = "machine"
-	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_MATERIALS = 3, TECH_BLUESPACE = 4)
+	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_MATERIAL = 3, TECH_BLUESPACE = 4)
 	req_components = list(
 							"/obj/item/bluespace_crystal" = 2,
 							"/obj/item/weapon/stock_parts/capacitor" = 1,

--- a/code/game/objects/items/weapons/circuitboards/machinery/trashcompactor.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/trashcompactor.dm
@@ -6,7 +6,7 @@
 	name = T_BOARD("crusher")
 	build_path = "/obj/machinery/crusher_base"
 	board_type = "machine"
-	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 1, TECH_MAGNET = 1, TECH_MATERIALS = 3)
+	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 1, TECH_MAGNET = 1, TECH_MATERIAL = 3)
 	req_components = list(
 							"/obj/item/weapon/stock_parts/matter_bin" = 4,
 							"/obj/item/weapon/stock_parts/manipulator" = 3,

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -111,6 +111,8 @@
 		new /obj/item/device/radio/headset/heads/cmo(src)
 		new /obj/item/device/flash(src)
 		new /obj/item/weapon/reagent_containers/hypospray(src)
+		new /obj/item/clothing/suit/storage/toggle/labcoat/cmo(src)
+		new /obj/item/clothing/suit/storage/toggle/labcoat/cmoalt(src)
 
 /obj/structure/closet/secure_closet/CMO2
 	name = "chief medical officer's attire"

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -17,6 +17,8 @@
 	helm_type = /obj/item/clothing/head/helmet/space/rig/merc
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
 
+	req_access = list(access_syndicate)
+
 	initial_modules = list(
 		/obj/item/rig_module/mounted,
 		/obj/item/rig_module/vision/thermal,

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -108,9 +108,11 @@
 	req_one_access = list()
 
 /obj/item/weapon/rig/eva/equipped
-
+	
+	req_access = list(access_engine_equip)
+	
 	initial_modules = list(
-		/obj/item/rig_module/mounted/plasmacutter,
+		/obj/item/rig_module/device/basicdrill,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/rcd,
 		/obj/item/rig_module/vision/meson
@@ -146,7 +148,7 @@
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
-		/obj/item/rig_module/mounted/plasmacutter,
+		/obj/item/rig_module/device/drill,
 		/obj/item/rig_module/device/rcd,
 		/obj/item/rig_module/vision/meson,
 		/obj/item/rig_module/actuators
@@ -231,6 +233,8 @@
 
 
 /obj/item/weapon/rig/hazard/equipped
+
+	req_access = list(access_brig)
 
 	initial_modules = list(
 		/obj/item/rig_module/vision/sechud,

--- a/code/modules/clothing/spacesuits/rig/suits/terminator.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/terminator.dm
@@ -25,7 +25,8 @@
 		/obj/item/rig_module/vision,
 		/obj/item/rig_module/voice,
 		/obj/item/rig_module/datajack,
-		/obj/item/rig_module/mounted/plasmacutter
+		/obj/item/rig_module/mounted/plasmacutter,
+		/obj/item/rig_module/actuators/combat
 		)
 
 /obj/item/clothing/head/helmet/space/rig/terminator
@@ -52,5 +53,6 @@
 		/obj/item/rig_module/vision,
 		/obj/item/rig_module/voice,
 		/obj/item/rig_module/datajack,
-		/obj/item/rig_module/mounted/plasmacutter
+		/obj/item/rig_module/mounted/plasmacutter,
+		/obj/item/rig_module/actuators/combat
 		)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -129,9 +129,10 @@
 		radio = card.radio
 
 	//Default languages without universal translator software
-	add_language("Sol Common", 1)
-	add_language("Tradeband", 1)
-	add_language("Gutter", 1)
+	add_language(LANGUAGE_SOL_COMMON, 1)
+	add_language(LANGUAGE_TRADEBAND, 1)
+	add_language(LANGUAGE_GUTTER, 1)
+	add_language(LANGUAGE_EAL, 1)
 
 	verbs += /mob/living/silicon/pai/proc/choose_chassis
 	verbs += /mob/living/silicon/pai/proc/choose_verbs

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1663,7 +1663,7 @@ CIRCUITS BELOW
 /datum/design/circuit/crusher_base
 	name = "trash compactor"
 	id = "crusher_base"
-	req_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 1, TECH_MAGNET = 1, TECH_MATERIALS = 3)
+	req_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 1, TECH_MAGNET = 1, TECH_MATERIAL = 3)
 	build_path = /obj/item/weapon/circuitboard/crusher
 	sort_string = "WAAAB"
 


### PR DESCRIPTION
-removes the plasma cutter from the ce and eva's suit, replacing it with a drill that fills the same purpose of the old plasma cutter
-adds more access restriction to the rigs as whole
-adds actuators to the terminator rig
-adds the cmo labcoats to the locker
-fixes #3097
-fixes #3098