### PR TITLE
Gutter language lore changes

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -37,7 +37,7 @@
 #define LANGUAGE_RESOMI "Resomi"
 #define LANGUAGE_ROOTSONG "Rootsong"
 #define LANGUAGE_TRADEBAND "Tradeband"
-#define LANGUAGE_GUTTER "Gutter"
+#define LANGUAGE_GUTTER "Freespeak"
 #define LANGUAGE_VAURCA "Hivenet"
 #define LANGUAGE_AZAZIBA "Sinta'azaziba"
 #define LANGUAGE_SIGN "Sign Language"

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -57,7 +57,7 @@
 // Criminal language.
 /datum/language/gutter
 	name = LANGUAGE_GUTTER
-	desc = "A language of renegades and frontiersmen descending from various languages from Earth. This language is the only common cultural identity for humans in the frontier. Speaking this language in itself boldly declares the speaker a free spirit."
+	desc = "A language of renegades and frontiersmen descending from various languages from Earth. This language is the only common cultural identity for humans in the frontier. Speaking this language in itself boldly declares the speaker a free spirit. Often called 'Gutter' by Alliance citizens."
 	speech_verb = "growls"
 	colour = "rough"
 	key = "3"

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -57,11 +57,11 @@
 // Criminal language.
 /datum/language/gutter
 	name = LANGUAGE_GUTTER
-	desc = "Much like Standard, this crude pidgin tongue descended from numerous languages and serves as Tradeband for criminal elements."
+	desc = "A language of renegades and frontiersmen descending from various languages from Earth. This language is the only common cultural identity for humans in the frontier. Speaking this language in itself boldly declares the speaker a free spirit."
 	speech_verb = "growls"
 	colour = "rough"
 	key = "3"
-	syllables = list ("slo","nik","ko","zels","het","zlo","nis","iv","da","ati","yib","ban","dup","sha","ansh","nou","nec","zby", "ci")
+	syllables = list("slo","nik","ko","zels","het","zlo","nis","iv","da","ati","yib","ban","dup","sha","ansh","nou","nec","zby", "ci")
 
 // Sign language
 /datum/language/sign

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -152,7 +152,7 @@ var/list/ai_verbs_default = list(
 	add_language(LANGUAGE_SIIK_MAAS, 0)
 	add_language(LANGUAGE_SKRELLIAN, 0)
 	add_language("Tradeband", 1)
-	add_language("Gutter", 0)
+	add_language(LANGUAGE_GUTTER, 0)
 	add_language(LANGUAGE_VAURCA, 0)
 	add_language("Rootsong", 0)
 	add_language(LANGUAGE_EAL, 1)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -131,7 +131,7 @@
 	//Default languages without universal translator software
 	add_language("Sol Common", 1)
 	add_language("Tradeband", 1)
-	add_language("Gutter", 1)
+	add_language(LANGUAGE_GUTTER, 1)
 
 	verbs += /mob/living/silicon/pai/proc/choose_chassis
 	verbs += /mob/living/silicon/pai/proc/choose_verbs

--- a/html/changelogs/lohikar-gutter.yml
+++ b/html/changelogs/lohikar-gutter.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - tweak: "The 'Gutter' language has been renamed to 'Freespeak' for lore reasons."


### PR DESCRIPTION
Changes made by loredev request.

changes:
- Gutter has been renamed to "Freespeak" via. define. Define name is unchanged.
- The description of Gutter has been replaced with one supplied by Jackboot.
- Replaced remaining references to gutter in the code with the define.