### PR TITLE
Actually check-tick unit tests

### DIFF
--- a/code/unit_tests/ss_test.dm
+++ b/code/unit_tests/ss_test.dm
@@ -63,6 +63,9 @@
 
 		total_unit_tests++
 
+		if (MC_TICK_CHECK)
+			return
+
 	if (!curr.len)
 		stage++
 


### PR DESCRIPTION
Adds a missing MC_TICK_CHECK in the main unit test loop.