### PR TITLE
New map bugfixes

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1175,7 +1175,7 @@ CIRCUITS BELOW
 /datum/design/circuit/sentencing
 	name = "criminal sentencing console"
 	id = "sentencing"
-	build_path = /obj/machinery/computer/sentencing
+	build_path = /obj/item/weapon/circuitboard/sentencing
 	sort_string = "DADAA"
 
 

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -82,7 +82,7 @@
 			if(occupied)
 				user << "<span class='danger'>There's \a [occupied] in the way.</span>"
 				return
-			if (G.state >= GRAB_AGGRESSIVE)
+			if (G.state < GRAB_AGGRESSIVE)
 				if(user.a_intent == I_HURT)
 					var/blocked = M.run_armor_check("head", "melee")
 					if (prob(30 * BLOCKED_MULT(blocked)))

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -20226,12 +20226,12 @@
 "Ir" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/syringegun,
-/obj/item/mecha_parts/mecha_equipment/tool/syringe_gun,
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
+/obj/item/weapon/gun/launcher/syringe,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
 "Is" = (
@@ -40321,15 +40321,15 @@ aa
 aa
 aa
 aa
-Lp
-Lp
-Lp
-Lp
-Lp
 aa
 aa
 aa
 aa
+Lp
+Lp
+Lp
+Lp
+Lp
 aa
 aa
 aa
@@ -40577,6 +40577,10 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 Lp
 Lp
 Lw
@@ -40584,10 +40588,6 @@ LI
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -40833,6 +40833,10 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 Lp
 Lp
 Lw
@@ -40842,10 +40846,6 @@ Lw
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -41089,6 +41089,10 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 Lp
 Lp
 Lw
@@ -41100,10 +41104,6 @@ Lw
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -41345,6 +41345,10 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 Lp
 Lp
 Lw
@@ -41358,10 +41362,6 @@ Lw
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -41599,6 +41599,10 @@ aa
 aa
 aa
 aa
+ab
+ab
+aa
+aa
 aa
 aa
 Lp
@@ -41616,10 +41620,6 @@ Lw
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -41856,6 +41856,10 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
 aa
 Lp
 Lp
@@ -41874,10 +41878,6 @@ Lw
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -42114,6 +42114,10 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
 Lp
 Ls
 Lw
@@ -42131,10 +42135,6 @@ Lw
 Lw
 Lw
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -42370,6 +42370,10 @@ Ln
 Ln
 Ln
 Ln
+Ln
+Ln
+Ln
+Ln
 Lm
 Lq
 Ls
@@ -42388,10 +42392,6 @@ Lw
 LM
 LI
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -42627,6 +42627,10 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
 Lo
 Lp
 Ls
@@ -42645,10 +42649,6 @@ Lw
 Lw
 Lw
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -42883,6 +42883,10 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
 aa
 aa
 Lp
@@ -42902,10 +42906,6 @@ Lw
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -43140,6 +43140,10 @@ aa
 aa
 ab
 ab
+ab
+ab
+ab
+aa
 aa
 aa
 aa
@@ -43158,10 +43162,6 @@ Lw
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -43401,6 +43401,10 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 Lp
 Lp
 Lw
@@ -43414,10 +43418,6 @@ Lw
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -43659,6 +43659,10 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 Lp
 Lp
 Lw
@@ -43670,10 +43674,6 @@ Lw
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -43917,6 +43917,10 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 Lp
 Lp
 Lw
@@ -43926,10 +43930,6 @@ Lw
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -44175,6 +44175,10 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 Lp
 Lp
 Lw
@@ -44182,10 +44186,6 @@ LI
 Lw
 Lp
 Lp
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -44433,15 +44433,15 @@ aa
 aa
 aa
 aa
-Lp
-Lp
-Lp
-Lp
-Lp
 aa
 aa
 aa
 aa
+Lp
+Lp
+Lp
+Lp
+Lp
 aa
 aa
 aa

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -6823,7 +6823,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Corridor Camera 9";
-	dir = 9;
+	dir = 8;
 	icon_state = "camera"
 	},
 /obj/effect/floor_decal/corner/blue{
@@ -7319,7 +7319,6 @@
 	name = "Weaponry (Ion Rifle)";
 	req_access = list(3)
 	},
-/obj/item/weapon/gun/energy/ionrifle,
 /obj/item/weapon/gun/energy/ionrifle,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -15041,14 +15040,11 @@
 /area/security/armoury)
 "aBU" = (
 /obj/structure/table/rack,
-/obj/item/weapon/storage/box/emps{
-	pixel_x = -2;
-	pixel_y = 2
-	},
 /obj/item/weapon/storage/box/flashbangs{
 	pixel_x = 2;
 	pixel_y = -2
 	},
+/obj/item/weapon/storage/box/teargas,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "aBV" = (
@@ -25944,7 +25940,7 @@
 /area/security/detectives_office)
 "aUb" = (
 /obj/machinery/camera/network/security{
-	c_tag = "Security - Firing Range Starboard";
+	c_tag = "Security - Detective's Office";
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -82949,7 +82945,7 @@ afw
 ahg
 ahb
 afw
-ceS
+ceR
 ajK
 aeE
 als
@@ -91450,7 +91446,7 @@ aAA
 aCa
 aDq
 aEW
-ceY
+aGH
 aIw
 aJW
 aLM
@@ -108144,7 +108140,7 @@ aab
 aab
 aab
 aqi
-ceX
+ceU
 asw
 asw
 auS

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -5590,7 +5590,7 @@
 	master_tag = "nuke_shuttle_dock_airlock";
 	name = "exterior access button";
 	pixel_x = -5;
-	pixel_y = -26;
+	pixel_y = 26;
 	req_one_access = list(13)
 	},
 /turf/simulated/floor/plating,


### PR DESCRIPTION
Fixes #3108
Fixes #2953
Fixes #3091
Fixes #3102
Fixes the syringe gun at medical being the wrong type
Place the bomb range a bit more away from the launching room, to avoid damage to it
Fix a bug with table grabs
Remove the extra ion rifle from the armory and the emp grenades, because, it seems those are really excessive, as seen in the HK event rounds