### PR TITLE
More human icons tweaks/fixes

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -54,14 +54,7 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 		T = get_turf(body)				//Where is the body located?
 		attack_log = body.attack_log	//preserve our attack logs by copying them to our ghost
 
-		if (ishuman(body))
-			var/mob/living/carbon/human/H = body
-			icon = H.stand_icon
-			overlays = H.overlays_standing
-		else
-			icon = body.icon
-			icon_state = body.icon_state
-			overlays = body.overlays
+		appearance = body
 
 		alpha = 127
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -59,6 +59,7 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 		desc = originaldesc
 
 		alpha = 127
+		invisibility = initial(invisibility)
 
 		gender = body.gender
 		if(body.mind && body.mind.name)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -54,7 +54,9 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 		T = get_turf(body)				//Where is the body located?
 		attack_log = body.attack_log	//preserve our attack logs by copying them to our ghost
 
+		var/originaldesc = desc
 		appearance = body
+		desc = originaldesc
 
 		alpha = 127
 

--- a/html/changelogs/lohikar-ghostfix.yml
+++ b/html/changelogs/lohikar-ghostfix.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Fixed a bug where ghosts would find their inner nudist upon death."


### PR DESCRIPTION
changes:
- Updated the documentation in human update_icons a bit.
- Renamed `overlays_standing` to `overlays_raw` to better describe what it is.
- Nuked more compound overlays.
- Ghosts now use appearance copy to copy their old mob (Fixes #3135)
- Layer defines are now space-aligned instead of tab-aligned.
- Renamed `SURGERY_LEVEL` to `SURGERY_LAYER` like the other layer defines.
- Fixed a potential bug where belt overlays may have not cleared in certain cases.