### PR TITLE
More Openturf Tweaks

### DIFF
--- a/code/controllers/subsystems/openturf.dm
+++ b/code/controllers/subsystems/openturf.dm
@@ -1,7 +1,7 @@
 #define OPENTURF_MAX_PLANE -71
 #define OPENTURF_CAP_PLANE -70      // The multiplier goes here so it'll be on top of every other overlay.
 #define OPENTURF_MAX_DEPTH 10		// The maxiumum number of planes deep we'll go before we just dump everything on the same plane.
-#define SHADOWER_DARKENING_FACTOR 0.25	// The multiplication factor for openturf shadower darkness. Lighting will be multiplied by this.
+#define SHADOWER_DARKENING_FACTOR 0.4	// The multiplication factor for openturf shadower darkness. Lighting will be multiplied by this.
 #define SHADOWER_LAYER 0
 
 /var/datum/controller/subsystem/openturf/SSopenturf

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -123,43 +123,9 @@
 			)
 
 	// If we're on an openturf, update the shadower object too.
-	// We could queue an icon update for the entire OT, but this involves less overhead.
 	var/turf/simulated/open/OT = loc:above
 	if (OT)
-		var/atom/movable/openspace/multiplier/shadower = OT.shadower
-		if (!shadower)	// The OT hasn't been initialized yet.
-			OT.update_icon()
-			return
-
-		shadower.appearance = src
-		shadower.plane = OPENTURF_CAP_PLANE
-		shadower.layer = SHADOWER_LAYER
-		shadower.invisibility = 0
-		if (shadower.icon_state == LIGHTING_BASE_ICON_STATE)
-			// We're using a color matrix, so just darken the colors.
-			var/list/c_list = shadower.color
-			c_list[CL_MATRIX_RR] *= SHADOWER_DARKENING_FACTOR
-			c_list[CL_MATRIX_RG] *= SHADOWER_DARKENING_FACTOR
-			c_list[CL_MATRIX_RB] *= SHADOWER_DARKENING_FACTOR
-			c_list[CL_MATRIX_GR] *= SHADOWER_DARKENING_FACTOR
-			c_list[CL_MATRIX_GG] *= SHADOWER_DARKENING_FACTOR
-			c_list[CL_MATRIX_GB] *= SHADOWER_DARKENING_FACTOR
-			c_list[CL_MATRIX_BR] *= SHADOWER_DARKENING_FACTOR
-			c_list[CL_MATRIX_BG] *= SHADOWER_DARKENING_FACTOR
-			c_list[CL_MATRIX_BB] *= SHADOWER_DARKENING_FACTOR
-			c_list[CL_MATRIX_AR] *= SHADOWER_DARKENING_FACTOR
-			c_list[CL_MATRIX_AG] *= SHADOWER_DARKENING_FACTOR
-			c_list[CL_MATRIX_AB] *= SHADOWER_DARKENING_FACTOR
-			shadower.color = c_list
-		else
-			shadower.color = list(
-				SHADOWER_DARKENING_FACTOR, 0, 0,
-				0, SHADOWER_DARKENING_FACTOR, 0,
-				0, 0, SHADOWER_DARKENING_FACTOR
-			)
-
-		if (shadower.bound_overlay)
-			shadower.update_above()
+		OT.update_icon()
 
 #undef ALL_EQUAL
 

--- a/code/modules/multiz/openspace.dm
+++ b/code/modules/multiz/openspace.dm
@@ -135,6 +135,9 @@
 /atom/movable/openspace/overlay/attack_generic(mob/user as mob)
 	user << span("notice", "You cannot reach \the [src] from here.")
 
+/atom/movable/openspace/overlay/examine(mob/examiner)
+	associated_atom.examine(examiner)
+
 /atom/movable/openspace/overlay/forceMove(atom/dest)
 	. = ..()
 	if (isopenturf(dest))

--- a/html/changelogs/lohikar-ot.yml
+++ b/html/changelogs/lohikar-ot.yml
@@ -1,0 +1,6 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - tweak: "Reduced openturfs' darkening factor a bit: below objects should be easier to see now."
+  - rscadd: "You can now examine human-types and other objects with complex examine behavior through openturfs."
+  - bugfix: "Fixed a bug where sometimes openturfs would look strange after a nearby lighting update."


### PR DESCRIPTION
changes:
- Openturfs now darken the lower level less (0.4 lighting multiplier vs. 0.25).
- You can now examine human-types and other objects with special examine behavior through Z-levels. (OOs proxy examine())
- Fixed a bug where shadower updates caused by LO updates caused visual inconsistencies.