### PR TITLE
[Mapping] Fixes and Security Equipment redesign.

### DIFF
--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -460,7 +460,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
@@ -475,6 +475,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
+	
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
@@ -486,7 +487,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
@@ -500,7 +501,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -517,7 +518,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
@@ -538,7 +539,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
@@ -912,7 +913,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
@@ -920,7 +921,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
@@ -929,7 +930,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
@@ -937,7 +938,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -2880,6 +2881,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
+	
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
@@ -4094,6 +4096,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/power/sensor{
+	long_range = 1;
 	name = "Powernet Sensor - AI Subgrid";
 	name_tag = "AI Subgrid"
 	},
@@ -6071,7 +6074,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10;
@@ -6092,7 +6095,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
@@ -6113,7 +6116,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
@@ -6128,6 +6131,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
+	
 	},
 /turf/simulated/floor/airless{
 	icon_state = "asteroidplating"
@@ -6148,6 +6152,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
+	
 	},
 /turf/simulated/floor/airless{
 	icon_state = "asteroidplating"
@@ -6168,6 +6173,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
+	
 	},
 /turf/simulated/floor/airless{
 	icon_state = "asteroidplating"
@@ -6305,7 +6311,7 @@
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 25;
-	pixel_y = 0;
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -7576,7 +7582,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7598,7 +7604,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "asteroidplating"
@@ -7621,7 +7627,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
@@ -7638,7 +7644,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - AI Maint EVA"
@@ -7664,7 +7670,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
@@ -8919,6 +8925,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/sensor{
+	long_range = 1;
 	name = "Powernet Sensor - Medical (Sub-level)";
 	name_tag = "Medical (Sub-level)"
 	},
@@ -9627,6 +9634,9 @@
 /obj/machinery/camera/network/medbay{
 	c_tag = "Virology Starboard";
 	dir = 8
+	},
+/obj/structure/sign/deathsposal{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
@@ -11217,6 +11227,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/sensor{
+	long_range = 1;
 	name = "Powernet Sensor - Research (Sub-level)";
 	name_tag = "Research (Sub-level)"
 	},
@@ -15792,6 +15803,9 @@
 /obj/effect/decal/warning_stripes,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/structure/sign/deathsposal{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -21276,6 +21290,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/structure/sign/deathsposal{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
 "Kp" = (
@@ -22067,7 +22084,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Tesla Output";
@@ -30909,7 +30926,7 @@ ad
 ai
 af
 af
-bc
+fu
 af
 bS
 af
@@ -31680,7 +31697,7 @@ ad
 ai
 af
 af
-bc
+fu
 af
 bS
 cl
@@ -32722,7 +32739,7 @@ cm
 cm
 af
 af
-fw
+fr
 aI
 fH
 ai
@@ -45076,7 +45093,7 @@ aa
 aa
 aa
 jJ
-km
+mW
 kJ
 ab
 aa
@@ -45333,7 +45350,7 @@ aa
 aa
 ab
 jK
-kn
+mV
 kK
 ab
 aa
@@ -45590,7 +45607,7 @@ aa
 ab
 ab
 ab
-km
+mW
 ab
 ab
 ab
@@ -45847,7 +45864,7 @@ aa
 ab
 ab
 ab
-km
+mW
 ab
 ab
 ab
@@ -46104,7 +46121,7 @@ aa
 ab
 ab
 ab
-km
+mW
 ab
 bP
 ab
@@ -46361,7 +46378,7 @@ aa
 ab
 ab
 ab
-km
+mW
 ab
 ab
 ab
@@ -46618,7 +46635,7 @@ aa
 ab
 ab
 ab
-km
+mW
 ab
 ab
 ab
@@ -46875,7 +46892,7 @@ aa
 ab
 ab
 ab
-km
+mW
 ab
 ab
 aa
@@ -47132,7 +47149,7 @@ aa
 ab
 ab
 ab
-km
+mW
 ab
 ab
 aa
@@ -47389,7 +47406,7 @@ aa
 ab
 ab
 ab
-km
+mW
 ab
 ab
 aa
@@ -47646,7 +47663,7 @@ aa
 aa
 ab
 ab
-km
+mW
 ab
 ab
 aa
@@ -47903,7 +47920,7 @@ aa
 aa
 ab
 ab
-km
+mW
 ab
 ab
 aa
@@ -48160,7 +48177,7 @@ aa
 aa
 ab
 ab
-km
+mW
 ab
 ab
 aa
@@ -48417,7 +48434,7 @@ aa
 aa
 ab
 ab
-km
+mW
 ab
 aa
 aa
@@ -48674,7 +48691,7 @@ aa
 aa
 aa
 ab
-km
+mW
 ab
 aa
 aa
@@ -48931,7 +48948,7 @@ aa
 aa
 aa
 ab
-km
+mW
 ab
 aa
 aa
@@ -49188,7 +49205,7 @@ aa
 aa
 aa
 ab
-km
+mW
 ab
 aa
 aa
@@ -49445,7 +49462,7 @@ aa
 aa
 ab
 ab
-km
+mW
 ab
 ab
 aa
@@ -49702,7 +49719,7 @@ aa
 aa
 ab
 ab
-km
+mW
 ab
 ab
 aa
@@ -49959,7 +49976,7 @@ aa
 ab
 ab
 ab
-km
+mW
 ab
 ab
 ab
@@ -50216,7 +50233,7 @@ aa
 ab
 ab
 ab
-km
+mW
 ab
 ab
 ab
@@ -50473,7 +50490,7 @@ aa
 ab
 ab
 jJ
-ko
+mX
 kL
 ab
 ab

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -4040,7 +4040,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
-/area/security/main)
+/area/security/range)
 "aid" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4288,7 +4288,7 @@
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
 /obj/item/device/taperecorder,
-/turf/simulated/floor/tiled,
+/turf/simulated/wall/r_wall,
 /area/security/brig)
 "aiJ" = (
 /obj/item/device/radio/intercom{
@@ -4316,7 +4316,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/security/main)
+/area/security/range)
 "aiL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -4632,7 +4632,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/security/main)
+/area/security/range)
 "ajs" = (
 /obj/effect/floor_decal/industrial/loading,
 /turf/simulated/floor/tiled,
@@ -4878,7 +4878,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
-/area/security/main)
+/area/security/range)
 "ajV" = (
 /obj/machinery/door/window/westleft{
 	name = "Firing Range Access";
@@ -5859,69 +5859,90 @@
 /turf/simulated/floor/plating,
 /area/security/brig)
 "amh" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/table/standard,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 24
 	},
-/obj/structure/closet/secure_closet/security,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/effect/floor_decal/corner/blue{
+	tag = "icon-corner_white (NORTHEAST)";
+	icon_state = "corner_white";
+	dir = 5
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/blue{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "ami" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/table/standard,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 24
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/security_cadet,
+/obj/item/weapon/crowbar,
+/obj/item/weapon/crowbar,
+/obj/item/weapon/crowbar,
+/obj/item/weapon/crowbar,
+/obj/effect/floor_decal/corner/blue{
+	tag = "icon-corner_white (NORTHEAST)";
+	icon_state = "corner_white";
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "amj" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/standard,
+/obj/item/device/flashlight/maglight,
+/obj/item/device/flashlight/maglight,
+/obj/item/device/flashlight/maglight,
+/obj/item/device/flashlight/maglight,
+/obj/effect/floor_decal/corner/blue{
+	tag = "icon-corner_white (NORTHEAST)";
+	icon_state = "corner_white";
+	dir = 5
 	},
-/obj/structure/window/reinforced{
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/security_cadet,
 /turf/simulated/floor/tiled,
 /area/security/main)
 "amk" = (
 /obj/machinery/vending/security,
-/obj/structure/sign/nosmoking_2{
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/security/main)
 "aml" = (
-/obj/machinery/vending/coffee,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/obj/structure/closet/secure_closet/security,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/security/main)
 "amm" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/obj/structure/closet/secure_closet/security,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/status_display{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/main)
 "amn" = (
-/obj/structure/table/standard,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/weapon/crowbar,
-/obj/item/weapon/crowbar,
-/obj/item/weapon/crowbar,
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 24
-	},
-/obj/item/device/flashlight/maglight,
-/obj/item/device/flashlight/maglight,
-/obj/item/device/flashlight/maglight,
-/turf/simulated/floor/tiled,
+/obj/structure/closet/secure_closet/security,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/security/main)
 "amo" = (
 /obj/structure/table/standard,
@@ -6374,49 +6395,87 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "anb" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass_security{
 	name = "Equipment Storage";
 	req_access = list(1)
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "anc" = (
+/obj/effect/floor_decal/corner/blue{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "and" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "ane" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "anf" = (
-/obj/effect/floor_decal/corner/blue,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "ang" = (
 /obj/effect/floor_decal/corner/blue{
-	dir = 10
+	icon_state = "corner_white";
+	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/main)
 "anh" = (
 /obj/machinery/light{
@@ -6527,6 +6586,7 @@
 	dir = 1;
 	icon_state = "leftsecure";
 	name = "Engine Waste";
+	req_access = null;
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/plating,
@@ -6540,6 +6600,7 @@
 	dir = 1;
 	icon_state = "leftsecure";
 	name = "Engine Waste";
+	req_access = null;
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/plating,
@@ -6548,16 +6609,17 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/door/window/brigdoor/westleft{
-	dir = 1;
-	icon_state = "leftsecure";
-	name = "Engine Waste";
-	req_one_access = list(11,24)
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/door/window/brigdoor/westleft{
+	dir = 1;
+	icon_state = "leftsecure";
+	name = "Engine Waste";
+	req_access = null;
+	req_one_access = list(11,24)
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "any" = (
@@ -6802,18 +6864,10 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "anX" = (
-/obj/item/weapon/stool/padded,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
@@ -6832,16 +6886,13 @@
 /turf/simulated/floor/tiled,
 /area/security/main)
 "anZ" = (
-/obj/item/weapon/stool/padded,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/security/main)
 "aoa" = (
@@ -6855,28 +6906,35 @@
 /turf/simulated/floor/tiled,
 /area/security/main)
 "aob" = (
-/obj/effect/floor_decal/corner/blue/full{
-	dir = 8
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/main)
 "aoc" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/security/main)
 "aod" = (
 /obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
-	dir = 5
+	dir = 6
 	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 0
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/security/main)
 "aoe" = (
 /obj/structure/filingcabinet/security{
@@ -7294,25 +7352,20 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/security_starboard)
 "aoX" = (
-/obj/structure/noticeboard{
-	desc = "A board for pinning important notices upon. This board seems a little chipped around the corners. Maybe it just needs to be noticed.";
-	pixel_x = -32
-	},
-/obj/machinery/newscaster{
-	pixel_x = -27;
-	pixel_y = -27
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Equipment Storage";
-	dir = 4
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
-	dir = 10
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/device/radio/intercom{
+	pixel_x = -28
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
@@ -7332,27 +7385,29 @@
 /turf/simulated/floor/tiled,
 /area/security/main)
 "apa" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 9
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/window/reinforced,
+/obj/structure/closet/wardrobe/red,
+/obj/item/clothing/accessory/holster/waist,
+/obj/item/clothing/accessory/holster/waist,
+/obj/item/clothing/accessory/holster/waist,
+/turf/simulated/floor/tiled/dark,
 /area/security/main)
 "apb" = (
 /turf/simulated/floor/tiled,
 /area/security/main)
 "apc" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+/obj/structure/window/reinforced,
+/obj/structure/closet/secure_closet/security_cadet,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/nosmoking_2{
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/security/main)
 "apd" = (
 /obj/structure/grille,
@@ -7650,25 +7705,49 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "apM" = (
+/obj/structure/table/standard,
 /obj/structure/window/reinforced,
-/obj/structure/closet/secure_closet/security,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/blue{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/item/weapon/folder/blue,
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Equipment Storage";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "apN" = (
-/obj/structure/window/reinforced,
-/obj/structure/closet/secure_closet/security,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "apO" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced,
-/obj/structure/closet/secure_closet/security,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "apP" = (
@@ -7701,9 +7780,10 @@
 /turf/simulated/floor/tiled,
 /area/security/main)
 "apT" = (
-/obj/structure/bed/chair,
-/obj/item/device/radio/intercom{
-	pixel_x = 28
+/obj/structure/table/standard,
+/obj/machinery/newscaster{
+	pixel_x = 28;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
@@ -8394,26 +8474,17 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aqZ" = (
-/obj/structure/closet/wardrobe/red,
-/obj/item/clothing/accessory/armband,
-/obj/item/clothing/accessory/armband,
-/obj/item/clothing/accessory/armband,
-/obj/item/clothing/accessory/armband,
-/obj/item/clothing/accessory/armband,
-/obj/item/clothing/accessory/armband,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/effect/floor_decal/corner/blue{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/clothing/accessory/holster/waist,
-/obj/item/clothing/accessory/holster/waist,
-/obj/item/clothing/accessory/holster/waist,
+/obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled,
 /area/security/main)
 "ara" = (
@@ -8427,23 +8498,35 @@
 /area/security/main)
 "arb" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "arc" = (
 /obj/structure/cable/green{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 6
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
@@ -8454,7 +8537,17 @@
 /turf/simulated/floor/tiled,
 /area/security/main)
 "are" = (
-/obj/structure/table/standard,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/security/main)
 "arf" = (
@@ -8859,11 +8952,12 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -9007,40 +9101,55 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "asf" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/blue{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
 	},
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/pen,
 /turf/simulated/floor/tiled,
 /area/security/main)
 "asg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "ash" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled,
+/area/security/main)
+"asi" = (
+/obj/effect/floor_decal/corner/blue{
+	tag = "icon-corner_white (SOUTHWEST)";
+	icon_state = "corner_white";
+	dir = 10
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/security/main)
-"asi" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/main)
 "asj" = (
 /obj/structure/flora/pottedplant/random,
+/obj/effect/floor_decal/corner/blue{
+	tag = "icon-corner_white (SOUTHWEST)";
+	icon_state = "corner_white";
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "ask" = (
@@ -9533,8 +9642,8 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/device/gps/engineering,
 /obj/item/weapon/storage/belt/utility,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -9698,31 +9807,65 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
+	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
+	icon_state = "rwindow";
 	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
 "atp" = (
 /obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass_security{
+	name = "Equipment Storage";
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled,
 /area/security/main)
 "atq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 4
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -9958,7 +10101,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/table/reinforced,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "atJ" = (
@@ -11177,11 +11320,10 @@
 /obj/item/device/flashlight,
 /obj/item/device/gps/engineering,
 /obj/item/weapon/storage/belt/utility,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "avC" = (
@@ -12185,15 +12327,6 @@
 "axo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 9
@@ -12206,11 +12339,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/device/radio/intercom{
@@ -12679,6 +12807,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 5
+	},
+/obj/machinery/camera/network/engine{
+	c_tag = "Engineering - Engine Starboard";
+	dir = 8;
+	icon_state = "camera";
+	tag = "icon-camera (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -22030,15 +22164,6 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 9
@@ -22083,11 +22208,6 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aNy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/blue{
@@ -23988,6 +24108,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aQL" = (
@@ -25382,6 +25507,11 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aTe" = (
@@ -25397,6 +25527,11 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aTf" = (
@@ -25404,6 +25539,11 @@
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -25417,6 +25557,11 @@
 /obj/effect/floor_decal/corner/yellow/full{
 	icon_state = "corner_white_full";
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -25638,6 +25783,11 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aTC" = (
@@ -25649,6 +25799,11 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
@@ -26388,23 +26543,15 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/foyer)
 "aUO" = (
@@ -26442,18 +26589,11 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/engineering/foyer)
 "aUR" = (
@@ -26625,6 +26765,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/security/lobby)
 "aVf" = (
@@ -28251,12 +28392,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
 "aXV" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
+/obj/machinery/recharger,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
 "aXW" = (
@@ -29480,8 +29622,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop)
 "bal" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop)
 "bam" = (
@@ -30191,6 +30332,7 @@
 /area/crew_quarters/heads/hop)
 "bbC" = (
 /obj/structure/table/woodentable,
+/obj/item/weapon/folder/blue,
 /obj/item/weapon/stamp/hop,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -30381,6 +30523,11 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -31138,6 +31285,11 @@
 "bdl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -34968,6 +35120,11 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 23;
+	pixel_y = -11
+	},
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	pixel_x = 30;
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
@@ -35124,14 +35281,14 @@
 /turf/simulated/floor/tiled/freezer,
 /area/medical/medbay3)
 "bjO" = (
-/obj/structure/sink{
-	pixel_y = 26
-	},
 /obj/structure/mirror{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/sink{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/medbay3)
@@ -38602,6 +38759,9 @@
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 1
+	},
+/obj/structure/sink{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
@@ -55304,7 +55464,6 @@
 	c_tag = "Hydroponics - Animal Pen";
 	dir = 1
 	},
-/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -56992,8 +57151,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bVF" = (
-/obj/item/device/radio/intercom{
-	pixel_y = -32
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
@@ -58714,14 +58874,27 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/disposal)
 "bYW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 102;
+	external_pressure_bound_default = 102;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 0;
+	internal_pressure_bound_default = 0;
+	pressure_checks = 1;
+	pressure_checks_default = 1;
+	pump_direction = 0;
+	use_power = 1
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/disposal)
@@ -58957,6 +59130,9 @@
 	icon_state = "warning";
 	dir = 10
 	},
+/obj/structure/sign/deathsposal{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled,
 /area/maintenance/disposal)
 "bZq" = (
@@ -58970,6 +59146,9 @@
 /area/maintenance/disposal)
 "bZr" = (
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/maintenance/disposal)
 "bZs" = (
@@ -59579,7 +59758,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/closet/crate,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
 "cat" = (
@@ -59850,7 +60028,7 @@
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
 "caR" = (
 /obj/machinery/mineral/stacking_unit_console{
@@ -59929,23 +60107,17 @@
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "cba" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
 /obj/machinery/door/window/southright,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "cbb" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 6
 	},
+/obj/structure/closet/crate,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "cbc" = (
@@ -60235,8 +60407,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
@@ -60396,8 +60568,9 @@
 	pixel_x = -27;
 	pixel_y = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1;
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
@@ -60413,6 +60586,7 @@
 	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "cbS" = (
@@ -60538,17 +60712,31 @@
 /area/outpost/mining_main/eva)
 "ccd" = (
 /obj/effect/floor_decal/corner/brown/full,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/meter,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "cce" = (
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8;
+	name = "Distro to Canisters";
+	target_pressure = 150
+	},
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/outpost/mining_main/eva)
 "ccf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "ccg" = (
@@ -61078,6 +61266,9 @@
 	icon_state = "warningcorner";
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/maintenance/disposal)
 "cdi" = (
@@ -61115,8 +61306,9 @@
 /area/crew_quarters/bar)
 "cdm" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/disposal)
@@ -61667,13 +61859,17 @@
 /area/security/brig)
 "cej" = (
 /obj/effect/floor_decal/corner/blue{
-	dir = 10
+	dir = 5
 	},
-/obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/noticeboard{
+	desc = "A board for pinning important notices upon. This board seems a little chipped around the corners. Maybe it just needs to be noticed.";
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/main)
 "cek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -62147,6 +62343,414 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
+"cfm" = (
+/turf/simulated/wall/r_wall,
+/area/security/range)
+"cfn" = (
+/obj/structure/sign/nosmoking_2{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/security/range)
+"cfo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"cfp" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/security/main)
+"cfq" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/main)
+"cfr" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/main)
+"cfs" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/security/main)
+"cft" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/standard,
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/tiled/dark,
+/area/security/main)
+"cfu" = (
+/obj/structure/window/reinforced,
+/obj/structure/closet/secure_closet/security_cadet,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/security/main)
+"cfv" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/main)
+"cfw" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled,
+/area/security/main)
+"cfx" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/security/main)
+"cfy" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/security/main)
+"cfz" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/main)
+"cfA" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/security/main)
+"cfB" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/security/main)
+"cfC" = (
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled,
+/area/security/main)
+"cfD" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue{
+	tag = "icon-corner_white (SOUTHWEST)";
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/security/main)
+"cfE" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/security/main)
+"cfF" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"cfG" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"cfH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"cfI" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/lobby)
+"cfJ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"cfK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/storage/tech)
+"cfL" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"cfM" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/machinery/light{
+	dir = 4;
+	status = 2
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"cfN" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
+"cfO" = (
+/obj/structure/sign/double/barsign{
+	tag = "icon-empty (WEST)";
+	icon_state = "empty";
+	dir = 8
+	},
+/turf/simulated/wall,
+/area/crew_quarters/bar)
+"cfP" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"cfQ" = (
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
+"cfR" = (
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"cfS" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/eva)
 
 (1,1,1) = {"
 aaa
@@ -79752,7 +80356,7 @@ aZA
 baB
 bbR
 bdk
-bdk
+cfJ
 bdk
 bgT
 bih
@@ -80009,7 +80613,7 @@ aEJ
 baB
 bbS
 bdl
-bdk
+cfK
 bdk
 bgU
 bih
@@ -86513,7 +87117,7 @@ caZ
 caw
 cbC
 cbQ
-cbr
+cfS
 cbr
 ccw
 cbr
@@ -86739,7 +87343,7 @@ bRa
 bRu
 bRx
 bRu
-bRx
+cfP
 bSO
 bTh
 bTh
@@ -86765,7 +87369,7 @@ cad
 cal
 caq
 cbM
-cbM
+cbl
 cba
 cbl
 cbD
@@ -87022,7 +87626,7 @@ cad
 cal
 car
 cay
-cay
+cfQ
 cbb
 cbm
 cbE
@@ -87507,7 +88111,7 @@ bPH
 bQg
 bQD
 bRd
-bRx
+cfM
 bRx
 bSl
 bRx
@@ -87537,7 +88141,7 @@ cam
 cas
 caA
 caN
-cbd
+cfR
 cbd
 cbG
 cbT
@@ -89500,8 +90104,8 @@ ayT
 axh
 axh
 ame
-aES
-aGB
+cfG
+cfH
 aIs
 aJP
 aLI
@@ -89564,7 +90168,7 @@ bQi
 bQJ
 bRg
 bQi
-bQi
+cfN
 bQi
 bQi
 bSS
@@ -89762,7 +90366,7 @@ aGD
 aIs
 aJQ
 aLJ
-aNv
+aLJ
 aPe
 aLJ
 aLJ
@@ -90019,7 +90623,7 @@ aGE
 aIt
 aJR
 aJR
-aNw
+aJR
 aPf
 aJR
 aJR
@@ -90276,7 +90880,7 @@ aGF
 aIu
 aJS
 aLK
-aNx
+aLK
 aPg
 aLK
 aLK
@@ -90590,9 +91194,9 @@ bJa
 bMI
 bJa
 bIl
-bJa
-bRE
 ceF
+bRE
+bJa
 bOf
 bSG
 bSV
@@ -90792,7 +91396,7 @@ aJU
 aLJ
 aLJ
 aLJ
-aLJ
+cfI
 aSi
 aTD
 aIs
@@ -90849,7 +91453,7 @@ bQm
 bMJ
 bRi
 bRi
-bRi
+cfO
 bSr
 bSH
 bRi
@@ -93340,7 +93944,7 @@ ajp
 agE
 akH
 afH
-agE
+cfo
 agE
 anV
 agE
@@ -93603,7 +94207,7 @@ anW
 agF
 agF
 aqY
-ase
+agF
 atn
 aut
 avX
@@ -93846,21 +94450,21 @@ adI
 aeo
 aeQ
 afJ
-agG
-ahs
+cfm
+aiN
 aic
 aiK
 ajr
 ajU
-ahs
+aiN
 alC
-alC
+cfp
 anb
+cfs
 alC
-alC
-alC
-alC
-alC
+cfv
+cfx
+cfB
 alC
 auu
 avN
@@ -94110,7 +94714,7 @@ aiL
 ahy
 ahy
 akJ
-agH
+alC
 amh
 anc
 anX
@@ -94118,7 +94722,7 @@ aoX
 apM
 aqZ
 asf
-ato
+alC
 aeP
 avN
 axt
@@ -94367,15 +94971,15 @@ ahy
 ahy
 ahy
 akK
-agH
+alC
 ami
 and
-anY
-aoY
+apb
+apb
 apN
-ara
+apb
 asg
-atp
+alC
 aeS
 avY
 axu
@@ -94624,15 +95228,15 @@ agH
 aiN
 ajV
 aiN
-agH
+alC
 amj
 ane
 anZ
-ang
+anZ
 apO
 arb
-apb
-atq
+cfC
+alC
 auv
 anV
 axv
@@ -94881,16 +95485,16 @@ aiM
 ajs
 ahy
 akL
-agH
+alC
 amk
 anf
-aoa
-aoZ
-apP
+apb
+apR
+apb
 arc
 ash
-atr
-auw
+alC
+aeX
 avZ
 axu
 axu
@@ -95138,15 +95742,15 @@ aiN
 ahy
 ahy
 akM
-agH
+alC
 aml
 ang
 aob
 apa
-apQ
-apa
-apa
-ats
+apb
+arc
+arf
+alC
 aux
 awa
 axw
@@ -95394,15 +95998,15 @@ ahy
 aiM
 ajs
 ahy
-akN
-agH
+akL
+alC
 amm
-ang
+cfq
 aoc
-apb
-apR
-ard
-ard
+cft
+cfw
+cfy
+cfD
 ato
 auy
 awb
@@ -95651,17 +96255,17 @@ aig
 aiN
 ahy
 ahy
-ahy
-agH
+cfn
+alC
 amn
-ang
+cfr
 aoc
-apb
-apS
+cfu
+ard
 are
 asi
 atp
-auz
+cfF
 awa
 axw
 azl
@@ -95909,13 +96513,13 @@ aiM
 ajs
 ahy
 akL
-agH
-amo
+alC
+amn
 cej
 aod
 apc
 apT
-arf
+cfz
 asj
 atq
 auA
@@ -96159,21 +96763,21 @@ aah
 aaV
 aeZ
 afS
-agI
-agI
-agI
-agI
-agI
-agI
-agI
 agJ
 agJ
-agI
-agI
-agI
+agJ
+agJ
+agJ
+agJ
+agJ
+agG
+agG
 alC
 alC
 alC
+alC
+cfA
+cfE
 alC
 auz
 awa
@@ -97754,7 +98358,7 @@ bpc
 bqp
 brL
 btb
-bua
+cfL
 buZ
 bua
 cdd

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -1322,12 +1322,15 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/library)
 "cz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
 	icon_state = "door_locked";
 	id_tag = "fuckyou3_inner";
 	locked = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
@@ -1610,7 +1613,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -757,8 +757,7 @@
 	name = "Arrivals Airlock";
 	req_access = list(13)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/dock)
 "bt" = (
@@ -774,11 +773,8 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/dock)
 "bu" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/machinery/meter,
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bv" = (
@@ -804,8 +800,7 @@
 	name = "Arrivals Airlock";
 	req_access = list(13)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/dock)
 "by" = (
@@ -937,6 +932,9 @@
 	id_tag = "arrival_dock";
 	pixel_y = 25
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bP" = (
@@ -946,50 +944,48 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/floor_decal/corner/blue{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1;
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
 	icon_state = "intact"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
@@ -1144,8 +1140,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "cq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 1;
+	name = "Distro to Canister";
+	target_pressure = 200
+	},
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/hallway/secondary/entry/dock)
 "cr" = (
 /obj/structure/bed/chair{
@@ -2001,7 +2005,7 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/structure/closet/emcloset,
+/obj/structure/bed/chair,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "dQ" = (
@@ -2011,7 +2015,7 @@
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 1
 	},
-/obj/structure/closet/emcloset,
+/obj/structure/bed/chair,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "dR" = (
@@ -2573,6 +2577,9 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "eS" = (
@@ -2583,7 +2590,20 @@
 	icon_state = "corner_white_full";
 	dir = 1
 	},
-/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/machinery/door/window/eastright{
+	tag = "icon-right (WEST)";
+	icon_state = "right";
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "eT" = (
@@ -2717,7 +2737,16 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
-/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/eastright,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "fe" = (
@@ -2733,6 +2762,10 @@
 	pixel_x = 25;
 	pixel_y = 0;
 	req_one_access = list(13)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -2934,7 +2967,6 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "fB" = (
@@ -3082,7 +3114,9 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/closet/emcloset,
+/obj/structure/bed/chair{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "fQ" = (
@@ -3090,6 +3124,7 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "fR" = (
@@ -3328,6 +3363,7 @@
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "admin_shuttle_dock_sensor";
+	master_tag = "admin_shuttle_bay";
 	pixel_x = 0;
 	pixel_y = 26
 	},
@@ -3379,12 +3415,14 @@
 	pixel_y = 26;
 	req_one_access = list(13)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map";
+	tag = "icon-manifold-f (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
@@ -3469,9 +3507,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "gz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
 	dir = 6
@@ -3484,6 +3519,11 @@
 	pixel_x = 30;
 	pixel_y = 26;
 	req_one_access = list(13)
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map";
+	tag = "icon-manifold-f (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -3528,6 +3568,7 @@
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "escape_dock_north_sensor";
+	master_tag = "escape_dock_north_airlock";
 	pixel_x = 0;
 	pixel_y = -25
 	},
@@ -3703,7 +3744,8 @@
 	},
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
-	target_pressure = 200
+	name = "Distro to Canisters";
+	target_pressure = 150
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
@@ -4296,33 +4338,16 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/port)
 "hX" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/eastright,
-/obj/effect/floor_decal/corner/yellow/full{
-	icon_state = "corner_white_full";
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "hY" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4;
-	icon_state = "map"
-	},
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
-	dir = 1
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "hZ" = (
@@ -4355,7 +4380,7 @@
 	dir = 4;
 	icon_state = "direction_evac";
 	pixel_x = 0;
-	pixel_y = 36;
+	pixel_y = 36
 	},
 /obj/structure/sign/directions/all{
 	pixel_x = 0;
@@ -4431,7 +4456,7 @@
 	dir = 4;
 	icon_state = "direction_evac";
 	pixel_x = 0;
-	pixel_y = 36;
+	pixel_y = 36
 	},
 /obj/structure/sign/directions/all{
 	pixel_x = 0;
@@ -4458,24 +4483,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "ip" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/door/window/westleft,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/full{
-	icon_state = "corner_white_full";
-	dir = 1
-	},
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "iq" = (
@@ -4624,12 +4633,12 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
@@ -5033,12 +5042,12 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
 	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -5611,6 +5620,7 @@
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
 	id_tag = "nuke_shuttle_dock_sensor";
+	master_tag = "nuke_shuttle_dock_airlock";
 	pixel_x = 0;
 	pixel_y = -25
 	},
@@ -5812,7 +5822,7 @@
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1380;
-	master_tag = "escape_dock_south_inner";
+	master_tag = "escape_dock_south_airlock";
 	name = "interior access button";
 	pixel_x = 30;
 	pixel_y = 26;
@@ -5867,6 +5877,7 @@
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "escape_dock_south_sensor";
+	master_tag = "escape_dock_south_airlock";
 	pixel_x = 0;
 	pixel_y = 25
 	},
@@ -6579,7 +6590,7 @@
 	dir = 8;
 	icon_state = "leftsecure";
 	name = "Arrivals Processing Desk";
-	req_access = list(1);
+	req_access = list(1)
 	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
@@ -7138,9 +7149,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -7155,6 +7163,10 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/plaque,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mE" = (
@@ -7206,13 +7218,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mL" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mM" = (
@@ -7275,6 +7285,7 @@
 	pixel_x = -24
 	},
 /obj/effect/floor_decal/corner/lime/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mU" = (
@@ -7289,7 +7300,7 @@
 	dir = 4;
 	icon_state = "direction_evac";
 	pixel_x = 0;
-	pixel_y = -28;
+	pixel_y = -28
 	},
 /obj/structure/sign/directions/all{
 	pixel_x = 0;
@@ -7298,7 +7309,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7410,7 +7420,6 @@
 	name = "NSS Aurora"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9131,12 +9140,12 @@
 	dir = 1;
 	icon_state = "direction_evac";
 	pixel_x = 0;
-	pixel_y = 4;
+	pixel_y = 4
 	},
 /obj/structure/sign/directions/engineering{
 	dir = 4;
 	icon_state = "direction_eng";
-	pixel_y = -4;
+	pixel_y = -4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/fore)
@@ -9243,23 +9252,23 @@
 	dir = 4;
 	icon_state = "direction_med";
 	pixel_x = 0;
-	pixel_y = 4;
+	pixel_y = 4
 	},
 /obj/structure/sign/directions/science{
 	dir = 4;
 	icon_state = "direction_sci";
-	pixel_y = -4;
+	pixel_y = -4
 	},
 /obj/structure/sign/directions/security{
 	dir = 4;
 	icon_state = "direction_sec";
 	pixel_x = 0;
-	pixel_y = -12;
+	pixel_y = -12
 	},
 /obj/structure/sign/directions/com{
 	dir = 4;
 	icon_state = "direction_com";
-	pixel_y = 12;
+	pixel_y = 12
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/fore)
@@ -9423,7 +9432,7 @@
 /obj/structure/sign/directions/civ{
 	dir = 4;
 	icon_state = "direction_civ";
-	pixel_y = 4;
+	pixel_y = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/fore)
@@ -11151,7 +11160,7 @@
 	dir = 4;
 	icon_state = "direction_cryo";
 	pixel_x = 32;
-	pixel_y = 36;
+	pixel_y = 36
 	},
 /obj/structure/sign/directions/all{
 	pixel_x = 32;
@@ -13917,12 +13926,12 @@
 	dir = 1;
 	icon_state = "direction_cryo";
 	pixel_x = 32;
-	pixel_y = 8;
+	pixel_y = 8
 	},
 /obj/structure/sign/directions/all{
 	dir = 8;
 	icon_state = "direction_all";
-	pixel_x = 32;
+	pixel_x = 32
 	},
 /obj/structure/sign/directions/evac{
 	dir = 8;
@@ -14117,19 +14126,19 @@
 	dir = 1;
 	icon_state = "direction_evac";
 	pixel_x = 0;
-	pixel_y = -24;
+	pixel_y = -24
 	},
 /obj/structure/sign/directions/all{
 	dir = 1;
 	icon_state = "direction_all";
 	pixel_x = 0;
-	pixel_y = -32;
+	pixel_y = -32
 	},
 /obj/structure/sign/directions/cryo{
 	dir = 4;
 	icon_state = "direction_cryo";
 	pixel_x = 0;
-	pixel_y = -40;
+	pixel_y = -40
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
@@ -15498,13 +15507,13 @@
 	dir = 1;
 	icon_state = "direction_evac";
 	pixel_x = 32;
-	pixel_y = 4;
+	pixel_y = 4
 	},
 /obj/structure/sign/directions/all{
 	dir = 1;
 	icon_state = "direction_all";
 	pixel_x = 32;
-	pixel_y = -4;
+	pixel_y = -4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
@@ -17364,6 +17373,7 @@
 /area/maintenance/substation/civilian_east)
 "Gb" = (
 /obj/machinery/power/sensor{
+	long_range = 1;
 	name = "Powernet Sensor - Civilian (Surface Level)  Subgrid";
 	name_tag = "Civilian (Surface Level) Subgrid"
 	},
@@ -18769,7 +18779,7 @@
 	dir = 1;
 	icon_state = "leftsecure";
 	name = "Holding Cell";
-	req_access = list(2);
+	req_access = list(2)
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -18783,6 +18793,392 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
+"IB" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/dock)
+"IC" = (
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/corner/blue/full,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "interior door";
+	req_access = null
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/dock)
+"ID" = (
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/dock)
+"IE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/floor_decal/industrial/warning/cee,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/dock)
+"IF" = (
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/port)
+"IG" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/exit)
+"IH" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
+"II" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	tag = "icon-warningcee (EAST)";
+	icon_state = "warningcee";
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 4;
+	name = "Distro to Canisters";
+	target_pressure = 200
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
+"IJ" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/exit)
+"IK" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map";
+	tag = "icon-manifold-f (WEST)"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/port)
+"IL" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 8
+	},
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8;
+	name = "Distro to Canisters";
+	target_pressure = 200
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/port)
+"IM" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/port)
+"IN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/port)
+"IO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"IP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"IQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"IR" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"IS" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"IT" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"IU" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"IV" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/door/airlock/atmos{
+	name = "Docks Air Bypass";
+	req_one_access = list(11,24)
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"IW" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"IX" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"IY" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"IZ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Ja" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Jb" = (
+/obj/machinery/atmospherics/tvalve/bypass{
+	icon_state = "map_tvalve0";
+	name = "Distro to Docks Bypass";
+	state = 0
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Jc" = (
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Jd" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Je" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Jf" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Jg" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Jh" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Ji" = (
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Jj" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	tag = "icon-intact (NORTHEAST)";
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Jk" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	icon_state = "map_universal";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Jl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Docks Air Bypass";
+	req_one_access = list(11,24)
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/fore)
+"Jm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
 
 (1,1,1) = {"
 aa
@@ -41502,8 +41898,8 @@ fy
 go
 hl
 hX
-iA
-jp
+hX
+hX
 jK
 kf
 kL
@@ -41755,13 +42151,13 @@ aa
 aa
 ex
 eR
-fz
+IF
 gp
 hm
 hY
-iB
-jq
-hm
+hY
+hY
+IK
 kg
 fz
 lg
@@ -42018,7 +42414,7 @@ hn
 fD
 iC
 fD
-fC
+IL
 fC
 fD
 lh
@@ -42275,7 +42671,7 @@ ho
 hZ
 iD
 fB
-fC
+IM
 fC
 fB
 li
@@ -42532,7 +42928,7 @@ fC
 fC
 iE
 jr
-jr
+IN
 kh
 fC
 lj
@@ -43313,10 +43709,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+gs
+IS
+IX
+Jf
 gs
 mg
 mw
@@ -43571,10 +43967,10 @@ mw
 mw
 mI
 gs
-aa
-aa
-aa
-nH
+IT
+IY
+Jg
+gs
 nU
 oj
 oA
@@ -43828,10 +44224,10 @@ ju
 ju
 mJ
 gs
-aa
-aa
-aa
-nI
+IU
+IZ
+Jh
+gs
 nV
 oj
 oB
@@ -44060,7 +44456,7 @@ aa
 aa
 bq
 bO
-cm
+IC
 cE
 cY
 cm
@@ -44086,9 +44482,9 @@ mC
 mK
 gs
 gs
-aa
-aa
-nI
+Ja
+Ji
+gs
 nW
 oj
 oC
@@ -44316,8 +44712,8 @@ aW
 bd
 bi
 br
-bP
-cn
+IB
+ID
 cF
 co
 cn
@@ -44339,13 +44735,13 @@ lG
 lP
 mj
 jA
-iT
+IO
 mL
 mT
-gt
-aa
-aa
-nI
+IV
+Jb
+Jj
+gs
 nX
 ok
 oD
@@ -44596,13 +44992,13 @@ lH
 jR
 jT
 mx
-iL
-jA
+IP
+jz
 mK
-gu
-aa
-aa
-nJ
+IW
+Jc
+Jk
+gs
 nY
 ol
 oE
@@ -44857,8 +45253,8 @@ iL
 jA
 mU
 gs
-nv
-nE
+Jd
+Jl
 gs
 nZ
 nZ
@@ -45110,12 +45506,12 @@ kS
 lS
 jQ
 mx
-iL
+IQ
 jA
 mK
 ng
 jA
-jA
+pS
 nK
 oa
 om
@@ -45343,7 +45739,7 @@ az
 aw
 aa
 bl
-bv
+bu
 bR
 cp
 cG
@@ -45368,11 +45764,11 @@ lT
 ml
 mz
 mD
-jv
+IR
 mV
 nh
-kO
-kO
+Je
+Jm
 kO
 ob
 on
@@ -45600,7 +45996,7 @@ az
 aw
 aa
 bl
-bw
+bu
 bR
 cn
 cF
@@ -45860,7 +46256,7 @@ bm
 br
 bT
 cq
-cq
+IE
 db
 co
 co
@@ -48182,7 +48578,7 @@ eI
 fc
 fO
 gy
-hx
+IG
 hx
 iZ
 hx
@@ -48439,7 +48835,7 @@ eI
 fa
 fM
 fO
-fO
+IH
 fM
 ja
 fM
@@ -48696,7 +49092,7 @@ eI
 fd
 fP
 fO
-fO
+II
 fN
 jb
 fN
@@ -48953,10 +49349,10 @@ eJ
 fe
 fQ
 gz
-hy
-io
-jc
-io
+IJ
+fQ
+fQ
+fQ
 hy
 ks
 Iz
@@ -49212,8 +49608,8 @@ fR
 gA
 hz
 ip
-jd
-jD
+ip
+ip
 jZ
 kt
 kY

--- a/maps/aurora/aurora-7_roof.dmm
+++ b/maps/aurora/aurora-7_roof.dmm
@@ -310,7 +310,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/blue{
 	dir = 2;
-	icon_state = "11-1";
+	icon_state = "11-1"
 	},
 /turf/simulated/open,
 /area/mine/explored)
@@ -2033,7 +2033,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
@@ -2258,9 +2258,6 @@
 	pixel_y = -25;
 	req_access = list(11,13)
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -2272,6 +2269,10 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/solarmaint)
 "eG" = (
@@ -2572,7 +2573,7 @@
 "fb" = (
 /obj/structure/cable{
 	dir = 2;
-	icon_state = "11-1";
+	icon_state = "11-1"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -3629,6 +3630,41 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
 	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/mine/explored)
+"ih" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 9
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/mine/explored)
+"ii" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/mine/explored)
+"ij" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/mine/explored)
+"ik" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/mine/explored)
+"il" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/mine/explored)
@@ -8872,9 +8908,9 @@ aa
 aa
 aa
 ad
-fN
+fk
 ah
-fY
+fq
 aw
 ab
 ab
@@ -9899,11 +9935,11 @@ ag
 ag
 ag
 ag
-fK
+fk
 ah
 ah
 ah
-fZ
+fq
 ag
 ag
 ag
@@ -11175,7 +11211,7 @@ ah
 ah
 ah
 ah
-fu
+fo
 ai
 ai
 ai
@@ -11197,7 +11233,7 @@ ai
 ai
 ai
 ai
-go
+fl
 ah
 ah
 ah
@@ -11431,7 +11467,7 @@ ah
 ah
 ah
 ah
-fp
+fo
 am
 aa
 aa
@@ -11455,7 +11491,7 @@ aa
 aa
 aa
 af
-gs
+fl
 ah
 ah
 ah
@@ -13254,7 +13290,7 @@ aa
 aa
 aa
 ad
-gt
+fk
 ah
 ah
 ah
@@ -13488,7 +13524,7 @@ ah
 ah
 ah
 ah
-fv
+fo
 ai
 am
 aa
@@ -13510,14 +13546,14 @@ cV
 aa
 ad
 ag
-gp
+fk
 ah
 ah
 ah
 ah
 ah
 ah
-gC
+fq
 ag
 ag
 ag
@@ -13763,9 +13799,9 @@ aU
 cv
 ap
 ag
-gh
+fR
 ag
-gm
+fk
 ah
 ah
 ah
@@ -14253,7 +14289,7 @@ ad
 ag
 ag
 ag
-fm
+fk
 ah
 ah
 ah
@@ -14292,7 +14328,7 @@ ah
 ah
 ah
 ah
-gG
+fq
 ag
 ag
 ag
@@ -14553,7 +14589,7 @@ ah
 ah
 ah
 ah
-gI
+fq
 ag
 aw
 aa
@@ -15067,7 +15103,7 @@ ah
 ah
 ah
 ah
-gJ
+fo
 ai
 am
 aa
@@ -15281,7 +15317,7 @@ af
 ai
 ai
 ai
-fn
+fl
 ah
 ah
 ah
@@ -15318,7 +15354,7 @@ ah
 ah
 ah
 ah
-gF
+fo
 ai
 ai
 ai
@@ -15572,7 +15608,7 @@ ah
 ah
 ah
 ah
-gB
+fo
 ai
 ai
 am
@@ -15821,7 +15857,7 @@ ap
 ai
 gi
 ai
-gn
+fl
 ah
 ah
 ah
@@ -16080,7 +16116,7 @@ cU
 aa
 af
 ai
-gq
+fl
 ah
 ah
 ah
@@ -16338,7 +16374,7 @@ aa
 aa
 aa
 af
-gu
+fl
 ah
 ah
 ah
@@ -16577,7 +16613,7 @@ ah
 ah
 ah
 ah
-fz
+fo
 ap
 bl
 bz
@@ -17091,7 +17127,7 @@ ah
 ah
 ah
 ah
-fA
+fw
 bb
 bb
 bb
@@ -18113,7 +18149,7 @@ ah
 ah
 fo
 ai
-fr
+fl
 ah
 ah
 ah
@@ -18137,10 +18173,10 @@ aa
 aa
 aa
 ad
-gv
+gr
 ai
 ai
-gy
+ft
 ah
 al
 ab
@@ -18379,13 +18415,13 @@ ai
 fB
 ag
 ag
-fI
+fk
 ah
 ah
 ah
 ah
 ah
-ga
+fq
 ag
 ag
 ag
@@ -18636,13 +18672,13 @@ ab
 af
 ai
 ai
-fJ
+fl
 ah
 ah
 ah
 ah
 ah
-gb
+fo
 ai
 ai
 ai
@@ -26092,11 +26128,11 @@ aa
 aa
 ae
 ah
-fS
+fq
 ag
 ag
 ag
-gc
+fk
 ah
 bm
 aa
@@ -26347,7 +26383,7 @@ aa
 aa
 ad
 ao
-fL
+fk
 ah
 ah
 ah
@@ -26355,7 +26391,7 @@ ah
 ah
 ah
 ah
-ge
+fq
 ao
 aw
 aa
@@ -26420,7 +26456,7 @@ aa
 ad
 ag
 ao
-hY
+fk
 ah
 ah
 ah
@@ -26683,7 +26719,7 @@ ah
 ah
 ah
 ah
-ib
+fq
 ag
 ag
 ag
@@ -27188,7 +27224,7 @@ eo
 eo
 eo
 eo
-hV
+fk
 ah
 ah
 ah
@@ -27416,10 +27452,10 @@ ab
 ae
 ah
 ah
-hc
+fq
 ag
 ag
-hj
+fk
 ah
 ah
 ah
@@ -27427,7 +27463,7 @@ ah
 ah
 ah
 ah
-hC
+fq
 aw
 ab
 ab
@@ -28162,11 +28198,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-ad
+ih
+ii
+ij
+ik
+il
 ag
 ag
 ag
@@ -28197,7 +28233,7 @@ ai
 ai
 ai
 ai
-hA
+fl
 ah
 al
 ab
@@ -28405,7 +28441,7 @@ fC
 ai
 ai
 ai
-fT
+fl
 ah
 ah
 ah
@@ -28413,17 +28449,17 @@ ah
 ah
 ah
 ah
-gk
+fq
 ag
 ag
 ag
 ag
 ag
-aw
-aa
-aa
-aa
-ae
+fk
+ah
+ah
+ah
+ah
 an
 ah
 ah
@@ -28676,11 +28712,11 @@ ah
 ah
 ah
 ah
-al
-aa
-aa
-aa
-ae
+ah
+ah
+ah
+ah
+ah
 bX
 ah
 ah
@@ -28713,7 +28749,7 @@ ed
 ee
 ae
 ah
-hD
+fq
 ag
 aw
 ab
@@ -28919,7 +28955,7 @@ al
 aa
 aa
 ad
-fU
+fk
 ah
 ah
 ah
@@ -28933,11 +28969,11 @@ ah
 ah
 ah
 ah
-gw
-aw
-aa
-aa
-ae
+ah
+ah
+ah
+ah
+ah
 ah
 ah
 ah
@@ -29164,7 +29200,7 @@ aa
 ad
 ag
 ag
-fs
+fk
 ah
 ah
 ah
@@ -29191,10 +29227,10 @@ ah
 ah
 ah
 ah
-al
-aa
-aa
-ae
+ah
+ah
+ah
+ah
 ah
 ah
 ah
@@ -29229,7 +29265,7 @@ ae
 ah
 ah
 ah
-hG
+fq
 ag
 ag
 bG
@@ -29448,10 +29484,10 @@ ah
 ah
 ah
 ah
-al
-aa
-aa
-ae
+ah
+ah
+ah
+ah
 ah
 ah
 ah
@@ -29517,7 +29553,7 @@ ah
 ah
 ah
 ah
-ie
+fq
 bG
 ag
 ag
@@ -29686,10 +29722,10 @@ ah
 ah
 ah
 ah
-fE
+fq
 ag
 bG
-fO
+fk
 ah
 ah
 ah
@@ -29705,10 +29741,10 @@ ah
 ah
 ah
 ah
-gz
-ag
-ag
-gD
+ah
+ah
+ah
+ah
 ah
 ah
 ah
@@ -30714,10 +30750,10 @@ ah
 ah
 ah
 ah
-fF
+fo
 ai
 ai
-fP
+fl
 ah
 ah
 ah
@@ -30733,10 +30769,10 @@ an
 ah
 ah
 ah
-gA
+fo
 ai
 ai
-gE
+ft
 ah
 ah
 ah
@@ -30775,9 +30811,9 @@ ah
 ah
 ah
 eg
-hM
+fo
 ai
-hQ
+ft
 ah
 al
 aa
@@ -31043,7 +31079,7 @@ ad
 ag
 ag
 ag
-hW
+fk
 eU
 ah
 ah
@@ -31063,11 +31099,11 @@ ah
 ah
 ah
 ah
-if
+fq
 ag
 ag
 ag
-ig
+fk
 ah
 ah
 ah
@@ -31271,7 +31307,7 @@ al
 ag
 ag
 ag
-hd
+gU
 aP
 eb
 dU
@@ -31489,7 +31525,7 @@ al
 aa
 aa
 ak
-fV
+fl
 ah
 ah
 ah
@@ -31503,7 +31539,7 @@ ah
 ah
 ah
 ah
-gx
+fo
 am
 aa
 aa
@@ -31829,7 +31865,7 @@ ah
 ah
 ah
 ah
-id
+fo
 ai
 ai
 ai
@@ -32003,7 +32039,7 @@ fH
 ag
 ag
 ag
-fW
+fk
 ah
 ah
 ah
@@ -32011,7 +32047,7 @@ ah
 ah
 ah
 ah
-gl
+fo
 ai
 ai
 ai
@@ -32060,14 +32096,14 @@ ah
 ah
 ah
 ah
-hN
+fq
 ag
-hR
+fk
 ah
-al
-aa
-aa
-ae
+fq
+ag
+ag
+fk
 ah
 ah
 ah
@@ -32321,10 +32357,6 @@ ah
 ah
 ah
 ah
-hS
-ag
-ag
-hU
 ah
 ah
 ah
@@ -32340,7 +32372,11 @@ ah
 ah
 ah
 ah
-ic
+ah
+ah
+ah
+ah
+fo
 ai
 ai
 am
@@ -32591,9 +32627,9 @@ ah
 ah
 ah
 ah
-hZ
+fo
 ai
-ia
+fl
 ah
 ah
 ah
@@ -32798,13 +32834,13 @@ ah
 ah
 ah
 ah
-gH
+fo
 ai
 ai
 ai
 ai
 ai
-gK
+fl
 ah
 ah
 ah
@@ -32835,14 +32871,14 @@ ah
 ah
 ah
 ah
-hT
-ai
-ai
-ai
-ai
-ai
-ai
-hX
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
 ah
 ah
 ah
@@ -33092,14 +33128,14 @@ ah
 ah
 ah
 ah
-al
-aa
-aa
-aa
-aa
-aa
-aa
-af
+fo
+ai
+ai
+ai
+ai
+ai
+ai
+ai
 ai
 ai
 ai
@@ -33320,7 +33356,7 @@ ab
 ab
 af
 ai
-gL
+fl
 ah
 ah
 al
@@ -33835,7 +33871,7 @@ ab
 ab
 ab
 af
-gS
+fl
 ah
 al
 ah
@@ -34057,7 +34093,7 @@ aa
 aa
 af
 ao
-fM
+fl
 ah
 ah
 ah
@@ -34065,7 +34101,7 @@ ah
 ah
 ah
 ah
-gf
+fo
 ao
 am
 aa
@@ -34316,11 +34352,11 @@ aa
 aa
 ae
 ah
-fX
+fo
 ai
 ai
 ai
-gd
+fl
 ah
 al
 aa
@@ -34865,7 +34901,7 @@ ab
 ab
 ae
 ah
-gV
+fq
 ag
 ag
 ag
@@ -34879,7 +34915,7 @@ ag
 ag
 ag
 ag
-hB
+fk
 ah
 ah
 ah
@@ -35135,7 +35171,7 @@ ah
 ah
 ah
 ah
-hx
+fo
 ai
 ai
 ai
@@ -35390,7 +35426,7 @@ ah
 ah
 ah
 ah
-hu
+fo
 ai
 am
 ab
@@ -35643,8 +35679,8 @@ ai
 ai
 ai
 ai
-hk
-hp
+ft
+fo
 ai
 ai
 am
@@ -35912,7 +35948,7 @@ ag
 ag
 ag
 ag
-hI
+fk
 ah
 al
 ab
@@ -36163,7 +36199,7 @@ aa
 ad
 ag
 ag
-hy
+fk
 ah
 ah
 ah
@@ -36672,7 +36708,7 @@ aa
 aa
 aa
 ae
-hq
+fw
 bb
 hs
 ah
@@ -36683,7 +36719,7 @@ ah
 ah
 ah
 ah
-hJ
+fo
 ai
 am
 ab
@@ -36934,7 +36970,7 @@ aa
 ae
 ah
 ah
-hz
+fo
 ai
 ai
 ai
@@ -37185,10 +37221,10 @@ ag
 ag
 ag
 ag
-hl
-hr
+fk
+fq
 ag
-ht
+fk
 ah
 ah
 al
@@ -47983,7 +48019,7 @@ ah
 ah
 ah
 ah
-hv
+fq
 ag
 ag
 ag
@@ -48234,7 +48270,7 @@ ab
 ab
 dP
 ag
-hf
+fk
 ah
 ah
 ah
@@ -48489,7 +48525,7 @@ ac
 ab
 ab
 ad
-gY
+fk
 ah
 ah
 ah
@@ -48759,13 +48795,13 @@ ah
 ah
 ah
 ah
-hE
+fq
 ag
 ag
 ag
 ag
 ag
-hO
+fk
 ah
 ah
 al
@@ -49273,13 +49309,13 @@ ah
 ah
 ah
 ah
-hF
+fo
 aq
 aq
 aq
 aq
 aq
-hP
+ft
 ah
 ah
 al
@@ -49517,7 +49553,7 @@ ac
 ac
 ab
 af
-gZ
+fl
 ah
 ah
 ah
@@ -50031,7 +50067,7 @@ ag
 ag
 ag
 ag
-ha
+fk
 ah
 ah
 ah
@@ -50039,7 +50075,7 @@ ah
 ah
 ah
 ah
-hw
+fo
 aq
 aq
 aq
@@ -50796,7 +50832,7 @@ aa
 aa
 aa
 af
-gN
+ft
 ah
 ah
 ah
@@ -51310,7 +51346,7 @@ aa
 aa
 aa
 ad
-gO
+fk
 ah
 ah
 ah
@@ -51824,7 +51860,7 @@ aa
 aa
 aa
 af
-gP
+ft
 ah
 ah
 ah
@@ -52089,7 +52125,7 @@ ah
 ah
 ah
 ah
-hg
+fo
 ai
 dW
 aq
@@ -52338,7 +52374,7 @@ aa
 aa
 aa
 ad
-gQ
+fk
 ah
 ah
 ah
@@ -52852,7 +52888,7 @@ aa
 aa
 aa
 af
-gR
+ft
 ah
 ah
 ah
@@ -53111,7 +53147,7 @@ aa
 aa
 af
 ai
-gT
+fl
 ah
 ah
 ah
@@ -53374,7 +53410,7 @@ ah
 ah
 ah
 ah
-hh
+fq
 bG
 aw
 ab
@@ -54398,13 +54434,13 @@ aa
 aa
 ao
 ah
-gX
+fo
 ai
 hb
 ai
-hi
+ft
 ah
-hm
+fw
 eb
 aa
 aa
@@ -55432,7 +55468,7 @@ cU
 aa
 ae
 ah
-hn
+fq
 ag
 aw
 aa
@@ -55946,7 +55982,7 @@ cU
 aa
 ae
 ah
-ho
+fo
 ai
 am
 aa


### PR DESCRIPTION
- Remap: Security Office has been redesigned to make it more intuitive
and with a bit more of basic equipment.
- Addition: A new camera has been added to the Engine Bay, as AIs did
not have full view of the room (SMES and Emitter) when the shutters were
down.
- Fix: All docks and the mining airlock are now connected to Distro and
have a slightly different design. A small atmospheric substation has
been included, as well as a bypass, in case the Distro line is destroyed
and the docks don't have enough air to fill. Manually operated.
- Fix: Hopefully the issue causing the Departures shuttle not to dock
has been resolved.
- Fix: A suction vent has been installed in the Trash Compactor, to deal
with the increase of the pressure caused because of the disposals'
pneumatics.
- Fix: All powernet sensors have been toggled the long_range variable,
so they show up in the power screen.
- Fix: Access to the engine windoors has been fixed. Atmospheric
Technicians and Engineers have access.
- A revision of piping and wiring has been done, fixing improperly
connected pipes and power networks which mostly supplied electrified
windows.
