### PR TITLE
Fix airlock construction

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1139,7 +1139,7 @@ About the new airlock wires panel:
 	. = ..()
 
 	//if assembly is given, create the new door from the assembly
-	if (assembly && istype(assembly))
+	if (istype(assembly))
 		assembly_type = assembly.type
 
 		electronics = assembly.electronics
@@ -1148,11 +1148,11 @@ About the new airlock wires panel:
 		//update the door's access to match the electronics'
 		secured_wires = electronics.secure
 		if(electronics.one_access)
-			req_access.Cut()
-			req_one_access = src.electronics.conf_access
+			req_access = null
+			req_one_access = electronics.conf_access
 		else
-			req_one_access.Cut()
-			req_access = src.electronics.conf_access
+			req_one_access = null
+			req_access = electronics.conf_access
 
 		//get the name from the assembly
 		if(assembly.created_name)
@@ -1164,9 +1164,9 @@ About the new airlock wires panel:
 		set_dir(assembly.dir)
 
 	//wires
-	var/turf/T = get_turf(src)
-	if(T && (T.z in config.admin_levels))
+	if(loc && (z in config.admin_levels))
 		secured_wires = 1
+
 	if (secured_wires)
 		wires = new/datum/wires/airlock/secure(src)
 	else

--- a/html/changelogs/lohikar-permfix.yml
+++ b/html/changelogs/lohikar-permfix.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "A manufacturing defect has been identified in airlock control mainboards that caused field-programmed boards to ignore configured access restrictions. NanoTrasen is not responsible for any loss of property caused by defective airlocks."


### PR DESCRIPTION
changes:
- Fixed a runtime in `airlock/Initialize()` that resulted from `req_access` or `req_one_access` being null. (Fixes #2802)
- Minor `airlock/Initialize()` efficiency tweaks.
