### PR TITLE
Area cleanup, Minor BST tweaks, Nuke Fixes, Explosion fixes

### DIFF
--- a/code/__defines/subsystem-defines.dm
+++ b/code/__defines/subsystem-defines.dm
@@ -25,6 +25,8 @@
 //number of byond ticks that are allowed to pass before the timer subsystem thinks it hung on something
 #define TIMER_NO_INVOKE_WARNING 600
 
+#define TIMER_ID_NULL -1
+
 // -- SSatoms stuff --
 // 	SSatoms Initialization state.
 #define INITIALIZATION_INSSATOMS 0	//New should not call Initialize

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -23,12 +23,17 @@ var/global/list/mechas_list = list()				//list of all mechs. Used by hostile mob
 var/global/list/joblist = list()					//list of all jobstypes, minus borg and AI
 var/global/list/brig_closets = list()				//list of all brig secure_closets. Used by brig timers. Probably should be converted to use SSwireless eventually.
 
+var/global/list/teleportlocs = list()
+var/global/list/ghostteleportlocs = list()
+var/global/list/centcom_areas = list()
+var/global/list/the_station_areas = list()
+
 var/global/list/turfs = list()						//list of all turfs
 
 //Languages/species/whitelist.
-var/global/list/all_species[0]
-var/global/list/all_languages[0]
-var/global/list/language_keys[0]					// Table of say codes for all languages
+var/global/list/all_species = list()
+var/global/list/all_languages = list()
+var/global/list/language_keys = list()					// Table of say codes for all languages
 var/global/list/whitelisted_species = list("Human") // Species that require a whitelist check.
 var/global/list/playable_species = list("Human")    // A list of ALL playable species, whitelisted, latejoin or otherwise.
 

--- a/code/controllers/subsystems/explosives.dm
+++ b/code/controllers/subsystems/explosives.dm
@@ -71,7 +71,7 @@ var/datum/controller/subsystem/explosives/SSexplosives
 	var/z_transfer = data.z_transfer
 	var/power = data.rec_pow
 
-	if(config.use_recursive_explosions)
+	if(data.is_rec)
 		explosion_rec(epicenter, power)
 		return
 
@@ -82,9 +82,9 @@ var/datum/controller/subsystem/explosives/SSexplosives
 	// Handles recursive propagation of explosions.
 	if(devastation_range > 2 || heavy_impact_range > 2)
 		if(HasAbove(epicenter.z) && z_transfer & UP)
-			global.explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, UP)
+			global.explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, UP, is_rec = FALSE)
 		if(HasBelow(epicenter.z) && z_transfer & DOWN)
-			global.explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, DOWN)
+			global.explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, DOWN, is_rec = FALSE)
 
 	var/max_range = max(devastation_range, heavy_impact_range, light_impact_range, flash_range)
 

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -8,61 +8,7 @@
 	icon_state = "NAME OF ICON" 	(defaults to "unknown" (blank))
 	requires_power = 0 				(defaults to 1)
 
-NOTE: there are two lists of areas in the end of this file: centcom and station itself. Please maintain these lists valid. --rastaf0
-
 */
-
-
-
-/area
-	var/fire = null
-	var/atmos = 1
-	var/atmosalm = 0
-	var/poweralm = 1
-	var/party = null
-	level = null
-	name = "Unknown"
-	icon = 'icons/turf/areas.dmi'
-	icon_state = "unknown"
-	layer = 10
-	luminosity = 0
-	mouse_opacity = 0
-	var/lightswitch = 1
-
-	var/eject = null
-
-	var/debug = 0
-	var/requires_power = 1
-	var/always_unpowered = 0	//this gets overriden to 1 for space in area/New()
-
-	var/power_equip = 1
-	var/power_light = 1
-	var/power_environ = 1
-	var/used_equip = 0
-	var/used_light = 0
-	var/used_environ = 0
-
-	var/has_gravity = 1
-	var/obj/machinery/power/apc/apc = null
-	var/no_air = null
-//	var/list/lights				// list of all lights on this area
-	var/list/all_doors = list()		//Added by Strumpetplaya - Alarm Change - Contains a list of doors adjacent to this area
-	var/air_doors_activated = 0
-	var/list/ambience = list('sound/ambience/ambigen1.ogg','sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg','sound/ambience/ambigen14.ogg')
-	var/list/forced_ambience = null
-	var/sound_env = STANDARD_STATION
-	var/turf/base_turf//The base turf type of the area, which can be used to override the z-level's base turf
-	var/no_light_control = 0		// if 1, lights in area cannot be toggled with light controller
-	var/allow_nightmode = 0	// if 1, lights in area will be darkened by the night mode controller
-	var/station_area = 0
-	var/centcomm_area = 0
-
-/*Adding a wizard area teleport list because motherfucking lag -- Urist*/
-/*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
-
-// Setup moved to EMI.
-var/list/teleportlocs = list()
-var/list/ghostteleportlocs = list()
 
 /*-----------------------------------------------------------------------------*/
 
@@ -71,7 +17,7 @@ var/list/ghostteleportlocs = list()
 /////////
 
 /area/space
-	name = "\improper Space"
+	name = "Space"
 	icon_state = "space"
 	requires_power = 1
 	always_unpowered = 1
@@ -98,8 +44,6 @@ area/space/atmosalert()
 /area/space/partyalert()
 	return
 
-/area/turret_protected/
-
 /area/arrival
 	requires_power = 0
 	no_light_control = 1
@@ -113,17 +57,12 @@ area/space/atmosalert()
 	icon_state = "start"
 
 
-
 ////////////
 //SHUTTLES//
 ////////////
 //shuttle areas must contain at least two areas in a subgroup if you want to move a shuttle from one
 //place to another. Look at escape shuttle for example.
 //All shuttles should now be under shuttle since we have smooth-wall code.
-
-/area/shuttle/lifts/placeholder //placeholder until lift code is done.
-	name = "\improper Placeholder!1!!"
-	icon_state = "unknown"
 
 /area/shuttle
 	requires_power = 0
@@ -2111,18 +2050,6 @@ area/space/atmosalert()
 /area/tcommsat/mainlvl_tcomms__relay
 	name = "\improper Telecommucations Main Level Relay"
 	icon_state = "tcomsatcham"
-
-/////////////////////////////////////////////////////////////////////
-/*
- Lists of areas to be used with is_type_in_list.
- Used in gamemodes code at the moment. --rastaf0
-*/
-
-// CENTCOM
-var/list/centcom_areas = list()
-
-//SPACE STATION 13
-var/list/the_station_areas = list()
 
 /area/beach
 	name = "Keelin's private beach"

--- a/code/game/gamemodes/cult/hell_universe.dm
+++ b/code/game/gamemodes/cult/hell_universe.dm
@@ -60,7 +60,7 @@ In short:
 		if(!istype(A,/area) || istype(A, /area/space))
 			continue
 
-		A.updateicon()
+		A.queue_icon_update()
 		CHECK_TICK
 
 /datum/universal_state/hell/OverlayAndAmbientSet()

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -88,7 +88,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 			C.req_one_access = list()
 
 /datum/universal_state/supermatter_cascade/proc/end_universe()
-	SSticker.station_explosion_cinematic(0,null) // TODO: Custom cinematic
+	SSticker.station_explosion_cinematic(0, null, config.player_levels) // TODO: Custom cinematic
 	universe_has_ended = 1
 
 /datum/universal_state/supermatter_cascade/proc/AreaSet()
@@ -96,7 +96,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 		if(!istype(A,/area) || istype(A, /area/space) || istype(A,/area/beach))
 			continue
 
-		A.updateicon()
+		A.queue_icon_update()
 		CHECK_TICK
 
 /datum/universal_state/supermatter_cascade/OverlayAndAmbientSet()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -26,7 +26,6 @@
 
 //all air alarms in area are connected via magic
 /area
-	var/obj/machinery/alarm/master_air_alarm
 	var/list/air_vent_names = list()
 	var/list/air_scrub_names = list()
 	var/list/air_vent_info = list()
@@ -157,8 +156,6 @@
 	first_run()
 
 	set_frequency(frequency)
-	if (!master_is_operating())
-		elect_master()
 
 	return INITIALIZE_HINT_LATELOAD
 
@@ -314,18 +311,6 @@
 		if (!(mode == AALARM_MODE_PANIC || mode == AALARM_MODE_CYCLE))
 			return 1
 
-	return 0
-
-
-/obj/machinery/alarm/proc/master_is_operating()
-	return alarm_area.master_air_alarm && !(alarm_area.master_air_alarm.stat & (NOPOWER|BROKEN))
-
-
-/obj/machinery/alarm/proc/elect_master()
-	for (var/obj/machinery/alarm/AA in alarm_area)
-		if (!(AA.stat & (NOPOWER|BROKEN)))
-			alarm_area.master_air_alarm = AA
-			return 1
 	return 0
 
 /obj/machinery/alarm/proc/get_danger_level(var/current_value, var/list/danger_levels)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -42,7 +42,7 @@
 	//Then look for a free one in the area
 	if(!scannerf)
 		var/area/A = get_area(src)
-		for(var/obj/machinery/dna_scannernew/S in A.get_contents())
+		for(var/obj/machinery/dna_scannernew/S in A)
 			return S
 
 	return
@@ -83,7 +83,7 @@
 /obj/machinery/computer/cloning/proc/findcloner()
 	var/num = 1
 	var/area/A = get_area(src)
-	for(var/obj/machinery/clonepod/P in A.get_contents())
+	for(var/obj/machinery/clonepod/P in A)
 		if(!P.connected)
 			pods += P
 			P.connected = src

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -40,7 +40,7 @@
 	on = !on
 
 	area.lightswitch = on
-	area.updateicon()
+	area.update_icon()
 
 	for(var/obj/machinery/light_switch/L in area)
 		L.on = on

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -360,7 +360,7 @@ var/bomb_set
 	if(SSticker.mode && SSticker.mode.name == "Mercenary")
 		var/obj/machinery/computer/shuttle_control/multi/syndicate/syndie_location = locate(/obj/machinery/computer/shuttle_control/multi/syndicate)
 		if(syndie_location)
-			SSticker.mode:syndies_didnt_escape = (syndie_location.z in config.admin_levels)	//muskets will make me change this, but it will do for now
+			SSticker.mode:syndies_didnt_escape = !(syndie_location.z in config.admin_levels)	//muskets will make me change this, but it will do for now
 		SSticker.mode:nuke_off_station = off_station
 
 	SSticker.station_explosion_cinematic(off_station, null, GetConnectedZlevels(z))

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -360,7 +360,7 @@ var/bomb_set
 	if(SSticker.mode && SSticker.mode.name == "Mercenary")
 		var/obj/machinery/computer/shuttle_control/multi/syndicate/syndie_location = locate(/obj/machinery/computer/shuttle_control/multi/syndicate)
 		if(syndie_location)
-			SSticker.mode:syndies_didnt_escape = !(syndie_location.z in config.admin_levels)	//muskets will make me change this, but it will do for now
+			SSticker.mode:syndies_didnt_escape = !(syndie_location.z in config.admin_levels)
 		SSticker.mode:nuke_off_station = off_station
 
 	SSticker.station_explosion_cinematic(off_station, null, GetConnectedZlevels(z))

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -360,9 +360,10 @@ var/bomb_set
 	if(SSticker.mode && SSticker.mode.name == "Mercenary")
 		var/obj/machinery/computer/shuttle_control/multi/syndicate/syndie_location = locate(/obj/machinery/computer/shuttle_control/multi/syndicate)
 		if(syndie_location)
-			SSticker.mode:syndies_didnt_escape = (syndie_location.z > 1 ? 0 : 1)	//muskets will make me change this, but it will do for now
+			SSticker.mode:syndies_didnt_escape = (syndie_location.z in config.admin_levels)	//muskets will make me change this, but it will do for now
 		SSticker.mode:nuke_off_station = off_station
-	SSticker.station_explosion_cinematic(off_station,null)
+
+	SSticker.station_explosion_cinematic(off_station, null, GetConnectedZlevels(z))
 	if(SSticker.mode)
 		SSticker.mode.explosion_in_progress = 0
 		if(off_station == 1)

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -58,7 +58,7 @@
 		return
 	A.use_power(EQUIP, 5000)
 	var/light = A.power_light
-	A.updateicon()
+	A.update_icon()
 
 	flick("echair1", src)
 	spark(src, 12, alldirs)
@@ -71,5 +71,5 @@
 	visible_message("<span class='danger'>The electric chair goes off!</span>", "<span class='danger'>You hear a deep sharp shock!</span>")
 
 	A.power_light = light
-	A.updateicon()
+	A.update_icon()
 	return

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -450,7 +450,7 @@
 			vision_flags = 0
 			see_invisible = -1
 
-	usr << "<span class='notice'>\The [src]'s vision mode is now <b>[mode]</b>."
+	usr << "<span class='notice'>\The [src]'s vision mode is now <b>[mode]</b>.</span>"
 
 /*	New()
 		..()

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -156,7 +156,7 @@
 				bsu()
 			if("Skrell")
 				bss()
-			if("Vaurca")
+			if("Vaurca Worker")
 				bsv()
 		return
 
@@ -289,10 +289,6 @@
 		ghostize(0)
 		key = null
 		suicide()
-
-/mob/living/carbon/human/bst/say(var/message)
-	var/verb = "says in a subdued tone"
-	..(message, verb)
 
 /mob/living/carbon/human/bst/verb/bstwalk()
 	set name = "Ruin Everything"
@@ -436,6 +432,26 @@
 	vision_flags = (SEE_TURFS|SEE_OBJS|SEE_MOBS)
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	canremove = 0
+
+/obj/item/clothing/glasses/sunglasses/bst/verb/toggle_xray(mode in list("X-Ray without Lighting", "X-Ray with Lighting", "Normal"))
+	set name = "Change Vision Mode"
+	set desc = "Changes your glasses' vision mode."
+	set category = "BST"
+	set src in usr
+
+	switch (mode)
+		if ("X-Ray without Lighting")
+			vision_flags = (SEE_TURFS|SEE_OBJS|SEE_MOBS)
+			see_invisible = SEE_INVISIBLE_NOLIGHTING
+		if ("X-Ray with Lighting")
+			vision_flags = (SEE_TURFS|SEE_OBJS|SEE_MOBS)
+			see_invisible = -1
+		if ("Normal")
+			vision_flags = 0
+			see_invisible = -1
+
+	usr << "<span class='notice'>\The [src]'s vision mode is now <b>[mode]</b>."
+
 /*	New()
 		..()
 		src.hud += new/obj/item/clothing/glasses/hud/security(src)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -112,12 +112,12 @@
 
 /mob/living/carbon/human/Move()
 	. = ..()
-	if (is_noisy)
-		var/turf/T = get_turf(src)
-		if ((T.x == last_x && T.y == last_y) || !T.footstep_sound)
+	if (is_noisy && !stat && !lying)
+		var/turf/T = loc
+		if ((x == last_x && y == last_y) || !T.footstep_sound)
 			return
-		last_x = T.x
-		last_y = T.y
+		last_x = x
+		last_y = y
 		if (m_intent == "run")
 			playsound(src, T.footstep_sound, 70, 1)
 		else

--- a/html/changelogs/lohikar-misc.yml
+++ b/html/changelogs/lohikar-misc.yml
@@ -1,0 +1,5 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "The nuke no longer destroys CC if detonated on the station."
+  - bugfix: "You should no longer make footstep sounds when being dragged around or when dead."


### PR DESCRIPTION
changes:
- Ported some timer fixes from /tg/ (timerid overflow fix, invalid deltimer logging)
- Removed pointless air alarm elections.
- Cleaned up some area code and moved area var definitions into `areas.dm`.
- The nuke now only destroys Zs connected to the Z it detonates on. (Fixes #2552)
- The nuke no longer destroys CC.
- Nukes now dust mobs.
- Cascades now dust all mobs on all non-admin levels.
- Fixed a bug where SSexplosives would not honor the `is_rec` var.
- Improved the efficiency of `/proc/random_station_area()`.
- Bluespace Bugs can now teleport out again.
- Bluespace Technicians can now turn off their x-ray vision without needing to remove their glasses.
- Human-types no longer make footstep sounds when lying down, unconscious, or dead.