### PR TITLE
Faster (?) Garbage SS

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -70,9 +70,10 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 	while((tobequeued.len - (idex - 1)) && starttime == world.time && starttimeofday == world.timeofday)
 		if (MC_TICK_CHECK)
 			break
-		var/ref = tobequeued[idex++]
+		var/ref = tobequeued[idex]
+		tobequeued[idex++] = null	// Clear this ref to assist hard deletes in Queue().
 		Queue(ref)
-	
+
 	if (idex > 1)
 		tobequeued.Cut(1, idex)
 

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -38,7 +38,7 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 	NEW_SS_GLOBAL(SSgarbage)
 
 /datum/controller/subsystem/garbage_collector/stat_entry(msg)
-	msg += "Q:[queue.len]|D:[delslasttick]|G:[gcedlasttick]|"
+	msg += "W:[tobequeued.len]|Q:[queue.len]|D:[delslasttick]|G:[gcedlasttick]|"
 	msg += "GR:"
 	if (!(delslasttick+gcedlasttick))
 		msg += "n/a|"
@@ -66,12 +66,15 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 	var/list/tobequeued = src.tobequeued
 	var/starttime = world.time
 	var/starttimeofday = world.timeofday
-	while(tobequeued.len && starttime == world.time && starttimeofday == world.timeofday)
+	var/idex = 1
+	while((tobequeued.len - (idex - 1)) && starttime == world.time && starttimeofday == world.timeofday)
 		if (MC_TICK_CHECK)
 			break
-		var/ref = tobequeued[1]
+		var/ref = tobequeued[idex++]
 		Queue(ref)
-		tobequeued.Cut(1, 2)
+	
+	if (idex > 1)
+		tobequeued.Cut(1, idex)
 
 /datum/controller/subsystem/garbage_collector/proc/HandleQueue()
 	delslasttick = 0
@@ -80,18 +83,19 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 	var/list/queue = src.queue
 	var/starttime = world.time
 	var/starttimeofday = world.timeofday
-	while(queue.len && starttime == world.time && starttimeofday == world.timeofday)
+	var/idex = 1
+	while((queue.len - (idex - 1)) && starttime == world.time && starttimeofday == world.timeofday)
 		if (MC_TICK_CHECK)
 			break
-		var/refID = queue[1]
+		var/refID = queue[idex]
 		if (!refID)
-			queue.Cut(1, 2)
+			idex++
 			continue
 
 		var/GCd_at_time = queue[refID]
 		if(GCd_at_time > time_to_kill)
 			break // Everything else is newer, skip them
-		queue.Cut(1, 2)
+		idex++
 		var/datum/A
 		A = locate(refID)
 		if (A && A.gcDestroyed == GCd_at_time) // So if something else coincidently gets the same ref, it's not deleted by mistake
@@ -111,6 +115,9 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 		else
 			++gcedlasttick
 			++totalgcs
+
+	if (idex > 1)
+		queue.Cut(1, idex)
 
 /datum/controller/subsystem/garbage_collector/proc/QueueForQueuing(datum/A)
 	if (istype(A) && A.gcDestroyed == GC_CURRENTLY_BEING_QDELETED)

--- a/code/game/gamemodes/cult/hell_universe.dm
+++ b/code/game/gamemodes/cult/hell_universe.dm
@@ -41,7 +41,7 @@ In short:
 
 // Apply changes when entering state
 /datum/universal_state/hell/OnEnter()
-	set background = 1
+	SSgarbage.disable()	// Yeah, fuck it. No point hard-deleting stuff now.
 
 	escape_list = get_area_turfs(locate(/area/hallway/secondary/exit))
 

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -36,7 +36,7 @@ var/global/universe_has_ended = 0
 
 // Apply changes when entering state
 /datum/universal_state/supermatter_cascade/OnEnter()
-	set background = 1
+	SSgarbage.disable()
 
 	world << "<span class='sinister' style='font-size:22pt'>You are blinded by a brilliant flash of energy.</span>"
 
@@ -56,8 +56,6 @@ var/global/universe_has_ended = 0
 
 	// Disable Nar-Sie.
 	cult.allow_narsie = 0
-
-	SSgarbage.collection_timeout = 20 MINUTES	// Yeah, no point trying to hard-del stuff at this point.
 
 	PlayerSet()
 


### PR DESCRIPTION
changes:
- The GC now truncates its lists using a single Cut() call per run instead of one cut call per item removed.
- Nar-sie and Supermatter Cascades now disable the GC to reduce lag during these events - round is ending in 5 minutes anyways, so enforcing deletes is not important.
- Garbage's MC status panel now displays how many objects are awaiting queueing.