### PR TITLE
More Openturf fixes

### DIFF
--- a/code/controllers/subsystems/openturf.dm
+++ b/code/controllers/subsystems/openturf.dm
@@ -100,7 +100,11 @@
 			T.shadower = new(T)
 
 		// Figure out how many z-levels down we are.
-		var/depth = calculate_depth(T)
+		var/depth = 0
+		var/turf/simulated/open/Td = T
+		while (Td && isopenturf(Td.below))
+			Td = Td.below
+			depth++
 		if (depth > OPENTURF_MAX_DEPTH)
 			depth = OPENTURF_MAX_DEPTH
 
@@ -178,7 +182,7 @@
 		else if (MC_TICK_CHECK)
 			break
 
-	if (qt_idex > 1 && qo_idex <= curr_turfs.len)
+	if (qt_idex > 1 && qt_idex <= curr_turfs.len)
 		curr_turfs.Cut(1, qt_idex)
 		qt_idex = 1
 
@@ -227,9 +231,3 @@
 		if (qo_idex > 1 && qo_idex <= curr_ov.len)
 			curr_ov.Cut(1, qo_idex)
 			qo_idex = 1
-
-/datum/controller/subsystem/openturf/proc/calculate_depth(turf/simulated/open/T)
-	. = 0
-	while (T && isopenturf(T.below))
-		T = T.below
-		.++

--- a/code/modules/multiz/openspace.dm
+++ b/code/modules/multiz/openspace.dm
@@ -24,7 +24,8 @@
 
 /atom/movable/Destroy()
 	. = ..()
-	QDEL_NULL(bound_overlay)
+	if (bound_overlay)
+		QDEL_NULL(bound_overlay)
 
 /atom/movable/forceMove(atom/dest)
 	. = ..(dest)
@@ -39,10 +40,10 @@
 	if (!bound_overlay)
 		return
 
-	// check_existence returns TRUE if the overlay is valid.
-	if (isopenturf(bound_overlay.loc) && !bound_overlay.queued)
-		SSopenturf.queued_overlays += bound_overlay
-		bound_overlay.queued = TRUE
+	if (isopenturf(bound_overlay.loc))
+		if (!bound_overlay.queued)
+			SSopenturf.queued_overlays += bound_overlay
+			bound_overlay.queued = TRUE
 	else
 		qdel(bound_overlay)
 

--- a/html/changelogs/lohikar-oo.yml
+++ b/html/changelogs/lohikar-oo.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Fixed an issue where objects could not be seen in holes in some rare cases."


### PR DESCRIPTION
Fixes a bug where openturf would unexpectedly delete an overlay if it was updated via. `update_above()` when it was already queued for update. Also fixes #3191 and includes some minor performance optimizations.