### PR TITLE
Orbit Fixes

### DIFF
--- a/code/_helpers/matrices.dm
+++ b/code/_helpers/matrices.dm
@@ -3,15 +3,24 @@
 	Turn(.) //BYOND handles cases such as -270, 360, 540 etc. DOES NOT HANDLE 180 TURNS WELL, THEY TWEEN AND LOOK LIKE SHIT
 
 
-/atom/proc/SpinAnimation(speed = 10, loops = -1)
-	var/matrix/m120 = matrix(transform)
-	m120.Turn(120)
-	var/matrix/m240 = matrix(transform)
-	m240.Turn(240)
-	var/matrix/m360 = matrix(transform)
-	speed /= 3      //Gives us 3 equal time segments for our three turns.
-	                //Why not one turn? Because byond will see that the start and finish are the same place and do nothing
-	                //Why not two turns? Because byond will do a flip instead of a turn
-	animate(src, transform = m120, time = speed, loops)
-	animate(transform = m240, time = speed)
-	animate(transform = m360, time = speed)
+/atom/proc/SpinAnimation(speed = 10, loops = -1, clockwise = 1, segments = 3)
+	if(!segments)
+		return
+	var/segment = 360/segments
+	if(!clockwise)
+		segment = -segment
+	var/list/matrices = list()
+	for(var/i in 1 to segments-1)
+		var/matrix/M = matrix(transform)
+		M.Turn(segment*i)
+		matrices += M
+	var/matrix/last = matrix(transform)
+	matrices += last
+
+	speed /= segments
+
+	animate(src, transform = matrices[1], time = speed, loops)
+	for(var/i in 2 to segments) //2 because 1 is covered above
+		animate(transform = matrices[i], time = speed)
+		//doesn't have an object argument because this is "Stacking" with the animate call above
+		//3 billion% intentional

--- a/code/datums/helper_datums/events.dm
+++ b/code/datums/helper_datums/events.dm
@@ -3,7 +3,7 @@
  */
 
 
-/datum/events
+/datum/mecha_events
 	var/list/events
 
 	New()
@@ -24,7 +24,7 @@
 			return
 		addEventType(event_type)
 		var/list/event = events[event_type]
-		var/datum/event/E = new /datum/event(proc_holder,proc_name)
+		var/datum/mecha_event/E = new /datum/mecha_event(proc_holder,proc_name)
 		event += E
 		return E
 
@@ -35,12 +35,12 @@
 		var/list/event = listgetindex(events,args[1])
 		if(istype(event))
 			spawn(-1)
-				for(var/datum/event/E in event)
+				for(var/datum/mecha_event/E in event)
 					if(!E.Fire(arglist(args.Copy(2))))
 						clearEvent(args[1],E)
 		return
 
-	// Arguments: event_type as text, E as /datum/event
+	// Arguments: event_type as text, E as /datum/mecha_event
 	// Returns: 1 if event cleared, null on error
 	proc/clearEvent(event_type as text, datum/event/E)
 		if(!event_type || !E)
@@ -50,7 +50,7 @@
 		return 1
 
 
-/datum/event
+/datum/mecha_event
 	var/listener
 	var/proc_name
 

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -213,7 +213,7 @@
 /obj/item/mecha_parts/mecha_equipment/tool/cable_layer
 	name = "Cable Layer"
 	icon_state = "mecha_wire"
-	var/datum/event/event
+	var/datum/mecha_event/event
 	var/turf/old_turf
 	var/obj/structure/cable/last_piece
 	var/obj/item/stack/cable_coil/cable

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -82,7 +82,7 @@
 	var/list/equipment = new
 	var/obj/item/mecha_parts/mecha_equipment/selected
 	var/max_equip = 3
-	var/datum/events/events
+	var/datum/mecha_events/events
 	var/lastcrash
 	var/crash_cooldown = 30
 

--- a/html/changelogs/lohikar-orbits.yml
+++ b/html/changelogs/lohikar-orbits.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Fixed a bug where orbits (such as the Tesla) didn't animate as they were intended to."


### PR DESCRIPTION
changes:
- Fixed an issue where the segment count argument of `orbit()` was ignored, leading to the Tesla not animating as it was intended to.
- Fixed an issue where `/datum/event` had two completely unrelated definitions (fixes #3192).