### PR TITLE
Improved directional lighting fallback when facing opaque objects

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -10,6 +10,7 @@
 #define LIGHTING_TRANSPARENT_ICON_STATE "blank"
 
 #define LIGHTING_SOFT_THRESHOLD 0.001 // If the max of the lighting lumcounts of each spectrum drops below this, disable luminosity on the lighting overlays.
+#define LIGHTING_BLOCKED_FACTOR 0.5	// How much the range of a directional light will be reduced while facing a wall.
 
 // If I were you I'd leave this alone.
 #define LIGHTING_BASE_MATRIX \

--- a/code/modules/lighting/_lighting_defs.dm
+++ b/code/modules/lighting/_lighting_defs.dm
@@ -1,6 +1,6 @@
 // This is the define used to calculate falloff.
-#define LUM_FALLOFF(C, T) (1 - CLAMP01(sqrt((C.x - T.x) ** 2 + (C.y - T.y) ** 2 + LIGHTING_HEIGHT) / max(1, light_range)))
-#define LUM_FALLOFF_XY(Cx,Cy,Tx,Ty) (1 - CLAMP01(sqrt(((Cx) - (Tx)) ** 2 + ((Cy) - (Ty)) ** 2 + LIGHTING_HEIGHT) / max(1, light_range)))
+#define LUM_FALLOFF(C, T) (1 - CLAMP01(sqrt((C.x - T.x) ** 2 + (C.y - T.y) ** 2 + LIGHTING_HEIGHT) / max(1, actual_range)))
+#define LUM_FALLOFF_XY(Cx,Cy,Tx,Ty) (1 - CLAMP01(sqrt(((Cx) - (Tx)) ** 2 + ((Cy) - (Ty)) ** 2 + LIGHTING_HEIGHT) / max(1, actual_range)))
 
 // Macro that applies light to a new corner.
 // It is a macro in the interest of speed, yet not having to copy paste it.

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -179,22 +179,22 @@
 		if (NORTH)
 			limit_a_t = angle + 90
 			limit_b_t = -(angle) + 90
-			test_y_offset += 1
+			++test_y_offset
 
 		if (SOUTH)
 			limit_a_t = (angle) - 90
 			limit_b_t = -(angle) - 90
-			test_y_offset -= 1
+			--test_y_offset
 
 		if (EAST)
 			limit_a_t = angle
 			limit_b_t = -(angle)
-			test_x_offset += 1
+			++test_x_offset
 
 		if (WEST)
 			limit_a_t = angle + 180
 			limit_b_t = -(angle) - 180
-			test_x_offset -= 1
+			--test_x_offset
 
 	// Convert our angle + range into a vector.
 	limit_a_x = POLAR_TO_CART_X(light_range + ARBITRARY_NUMBER, limit_a_t)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -37,6 +37,7 @@
 	var/tmp/targ_sign       // The sign to test the point against.
 	var/tmp/test_x_offset   // How much the X coord should be offset due to direction.
 	var/tmp/test_y_offset   // How much the Y coord should be offset due to direction.
+	var/tmp/facing_opaque = FALSE
 
 	var/list/datum/lighting_corner/effect_str     // List used to store how much we're affecting corners.
 	var/list/turf/affecting_turfs
@@ -159,46 +160,41 @@
 	if (T.x == cached_origin_x && T.y == cached_origin_y && old_direction == top_atom.dir)
 		return
 
-	var/do_offset = TRUE
-	var/turf/front = get_step(T, top_atom.dir)
-	if (front && front.has_opaque_atom)
-		do_offset = FALSE
-
-	cached_origin_x = T.x
-	test_x_offset = cached_origin_x
-	cached_origin_y = T.y
-	test_y_offset = cached_origin_y
-
 	if (istype(top_atom, /mob) && top_atom:facing_dir)
 		old_direction = top_atom:facing_dir
 	else
 		old_direction = top_atom.dir
+
+	var/turf/front = get_step(T, old_direction)
+	facing_opaque = (front && front.has_opaque_atom)
+
+	cached_origin_x = test_x_offset = T.x
+	cached_origin_y = test_y_offset = T.y
+
+	if (facing_opaque)
+		return
 
 	var/angle = light_angle / 2
 	switch (old_direction)
 		if (NORTH)
 			limit_a_t = angle + 90
 			limit_b_t = -(angle) + 90
-			if (do_offset)
-				test_y_offset += 1
+			test_y_offset += 1
 
 		if (SOUTH)
 			limit_a_t = (angle) - 90
 			limit_b_t = -(angle) - 90
-			if (do_offset)
-				test_y_offset -= 1
+			test_y_offset -= 1
 
 		if (EAST)
 			limit_a_t = angle
 			limit_b_t = -(angle)
-			if (do_offset)
-				test_x_offset += 1
+			test_x_offset += 1
 
 		if (WEST)
 			limit_a_t = angle + 180
 			limit_b_t = -(angle) - 180
-			if (do_offset)
-				test_x_offset -= 1
+			test_x_offset -= 1
 
 	// Convert our angle + range into a vector.
 	limit_a_x = POLAR_TO_CART_X(light_range + ARBITRARY_NUMBER, limit_a_t)
@@ -254,6 +250,8 @@
 	if (effect_str[C]) // Already have one.
 		REMOVE_CORNER(C,now)
 		effect_str[C] = 0
+
+	var/actual_range = light_range
 
 	APPLY_CORNER(C,now)
 	UNSETEMPTY(effect_str)
@@ -331,10 +329,12 @@
 	var/list/Tcorners
 	var/Sx = source_turf.x
 	var/Sy = source_turf.y
+	var/use_reduced = (light_angle && facing_opaque)
+	var/actual_range = use_reduced ? light_range * LIGHTING_BLOCKED_FACTOR : light_range
 
-	FOR_DVIEW(T, Ceiling(light_range), source_turf, 0)
+	FOR_DVIEW(T, Ceiling(actual_range), source_turf, 0)
 		check_t:
-		if (light_angle && check_light_cone(T.x, T.y))
+		if (light_angle && !facing_opaque && check_light_cone(T.x, T.y))
 			continue
 
 		if (T.dynamic_lighting || T.light_sources)

--- a/code/modules/lighting/lighting_source_novis.dm
+++ b/code/modules/lighting/lighting_source_novis.dm
@@ -64,6 +64,7 @@
 	var/list/Tcorners
 	var/Sx = source_turf.x
 	var/Sy = source_turf.y
+	var/actual_range = light_range	// novis sources don't support directional lighting.
 
 	// We don't need no damn vis checks!
 	for (Tthing in RANGE_TURFS(Ceiling(light_range), source_turf))


### PR DESCRIPTION
Facing an opaque object with a directional light source will now temporarily change the light to `LIGHT_OMNI` and halve the range instead of slightly tweaking where the light cone is drawn.
Old behavior:
![2017-08-01_21-03-03](https://user-images.githubusercontent.com/7097800/28854460-d5d7fb36-76fc-11e7-9a7e-1474fc596dcc.png)
New behavior:
![2017-08-01_20-44-05](https://user-images.githubusercontent.com/7097800/28854464-db3e00a2-76fc-11e7-805e-5c2e97a45761.png)
