### PR TITLE
Clean up some legacy code

### DIFF
--- a/code/controllers/subsystems/icon_cache.dm
+++ b/code/controllers/subsystems/icon_cache.dm
@@ -24,6 +24,8 @@
 	var/list/floor_light_cache = list()
 	var/list/ashtray_cache = list()
 
+	var/list/uristrunes = list()
+
 /*
 	Global associative list for caching humanoid icons.
 	Index format m or f, followed by a string of 0 and 1 to represent bodyparts followed by husk fat hulk skeleton 1 or 0.

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -155,26 +155,10 @@ var/global/ManifestJSON
 	var/damage = 0.0
 	var/range = 10.0
 
-
-/obj/effect/list_container
-	name = "list container"
-
-/obj/effect/list_container/mobl
-	name = "mobl"
-	var/master = null
-
-	var/list/container = list(  )
-
 /obj/effect/projection
 	name = "Projection"
 	desc = "This looks like a projection of something."
 	anchored = 1.0
-
-
-/obj/effect/shut_controller
-	name = "shut controller"
-	var/moving = null
-	var/list/parts = list(  )
 
 /obj/structure/showcase
 	name = "Showcase"
@@ -204,13 +188,6 @@ var/global/ManifestJSON
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 		user.drop_item()
 		src.throw_at(target, throw_range, throw_speed, user)
-
-/obj/effect/stop
-	var/victim = null
-	icon_state = "empty"
-	name = "Geas"
-	desc = "You can't resist."
-	// name = ""
 
 /obj/effect/spawner
 	name = "object spawner"

--- a/code/game/magic/Uristrunes.dm
+++ b/code/game/magic/Uristrunes.dm
@@ -56,21 +56,18 @@ var/list/word_to_uristrune_table = null
 
 	return get_uristrune(bits, animated)
 
-
-var/list/uristrune_cache = list()
-
 /proc/get_uristrune(symbol_bits, animated = 0)
 	var/lookup = "[symbol_bits]-[animated]"
 
-	if(lookup in uristrune_cache)
-		return uristrune_cache[lookup]
+	var/icon/result = SSicon_cache.uristrunes[lookup]
+	if (result)
+		return result
 
 	var/icon/I = icon('icons/effects/uristrunes.dmi', "blank")
 
 	for(var/i = 0, i < 10, i++)
 		if(BITTEST(symbol_bits, i))
 			I.Blend(icon('icons/effects/uristrunes.dmi', "rune-[1 << i]"), ICON_OVERLAY)
-
 
 	I.SwapColor(rgb(0, 0, 0, 100), rgb(100, 0, 0, 200))
 	I.SwapColor(rgb(0, 0, 0, 50), rgb(150, 0, 0, 200))
@@ -97,7 +94,7 @@ var/list/uristrune_cache = list()
 					if(ne == "#000000" || se == "#000000" || nw == "#000000" || sw == "#000000")
 						I.DrawBox(rgb(200, 0, 0, 100), x, y)
 
-	var/icon/result = icon(I, "")
+	result = icon(I, "")
 
 	result.Insert(I,  "", frame = 1, delay = 10)
 
@@ -126,6 +123,6 @@ var/list/uristrune_cache = list()
 		result.Insert(I3, "", frame = 7, delay = 2)
 		result.Insert(I2, "", frame = 8, delay = 2)
 
-	uristrune_cache[lookup] = result
+	SSicon_cache.uristrunes[lookup] = result
 
 	return result

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -838,11 +838,6 @@
 	if(wearer.transforming || !wearer.canmove)
 		return
 
-	if(locate(/obj/effect/stop/, wearer.loc))
-		for(var/obj/effect/stop/S in wearer.loc)
-			if(S.victim == wearer)
-				return
-
 	if(!wearer.lastarea)
 		wearer.lastarea = get_area(wearer.loc)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -319,7 +319,11 @@
 /mob/proc/clear_point()
 	QDEL_NULL(pointing_effect)
 
-/mob/proc/ret_grab(obj/effect/list_container/mobl/L as obj, flag)
+/datum/mobl	// I have no idea what the fuck this is, but it's better for it to be a datum than an /obj/effect.
+	var/list/container = list()
+	var/master
+
+/mob/proc/ret_grab(datum/mobl/L, flag)
 	if ((!( istype(l_hand, /obj/item/weapon/grab) ) && !( istype(r_hand, /obj/item/weapon/grab) )))
 		if (!( L ))
 			return null
@@ -327,26 +331,24 @@
 			return L.container
 	else
 		if (!( L ))
-			L = new /obj/effect/list_container/mobl( null )
+			L = new /datum/mobl
 			L.container += src
 			L.master = src
 		if (istype(l_hand, /obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = l_hand
-			if (!( L.container.Find(G.affecting) ))
+			if (!(L.container.Find(G.affecting)))
 				L.container += G.affecting
 				if (G.affecting)
 					G.affecting.ret_grab(L, 1)
 		if (istype(r_hand, /obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = r_hand
-			if (!( L.container.Find(G.affecting) ))
+			if (!(L.container.Find(G.affecting)))
 				L.container += G.affecting
 				if (G.affecting)
 					G.affecting.ret_grab(L, 1)
 		if (!( flag ))
 			if (L.master == src)
-				var/list/temp = list(  )
-				temp += L.container
-				//L = null
+				var/list/temp = L.container.Copy()
 				qdel(L)
 				return temp
 			else


### PR DESCRIPTION
changes:
- `/obj/effect/list_container/mobl` has been replaced with `/datum/mobl`.
- `/obj/effect/stop` has been removed as it is unused.
- `/obj/effect/shut_controller` has been removed as it is unused.
- Uristrunes now cache in SSicon_cache.