### PR TITLE
Fix MC crash handling

### DIFF
--- a/code/controllers/master/master.dm
+++ b/code/controllers/master/master.dm
@@ -110,12 +110,13 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 				else
 					msg += "\t [varname] = [varval]\n"
 	log_mc(msg)
-	
+
 	var/datum/controller/subsystem/BadBoy = Master.last_type_processed
 	var/FireHim = FALSE
 	if(istype(BadBoy))
 		msg = null
-		switch(++BadBoy.failure_strikes)
+		LAZYINITLIST(BadBoy.failure_strikes)
+		switch(++BadBoy.failure_strikes[BadBoy.type])
 			if(2)
 				msg = "The [BadBoy.name] subsystem was the last to fire for 2 controller restarts. It will be recovered now and disabled if it happens again."
 				FireHim = TRUE

--- a/code/controllers/master/subsystem.dm
+++ b/code/controllers/master/subsystem.dm
@@ -40,7 +40,7 @@
 	var/datum/controller/subsystem/queue_next
 	var/datum/controller/subsystem/queue_prev
 
-	var/static/failure_strikes = 0 //How many times we suspect this subsystem has crashed the MC, 3 strikes and you're out!
+	var/static/list/failure_strikes  //How many times we suspect a subsystem type has crashed the MC, 3 strikes and you're out!
 
 // Used to initialize the subsystem BEFORE the map has loaded
 /datum/controller/subsystem/New()


### PR DESCRIPTION
Ports a fix from /tg/ upstream - previously failure strikes did not distinguish between subsystems when they should've.