### PR TITLE
Lift light tweaks

### DIFF
--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -160,9 +160,10 @@
 
 				// Clear out contents.
 				if(clear_objects)
-					for(var/atom/movable/thing in checking.contents)
-						if(thing.simulated)
-							qdel(thing)
+					for(var/thing in checking.contents)
+						var/atom/movable/AM = thing
+						if(AM.simulated)
+							qdel(AM)
 
 				if(tx >= ux && tx <= ex && ty >= uy && ty <= ey)
 					floor_turfs += checking
@@ -196,20 +197,21 @@
 		panel_ext.set_dir(udir)
 		cfloor.ext_panel = panel_ext
 
-        // Place lights
-		var/turf/placing1 = locate(light_x1, light_y1, cz)
-		var/turf/placing2 = locate(light_x2, light_y2, cz)
-		var/obj/machinery/light/light1 = new(placing1, light)
-		var/obj/machinery/light/light2 = new(placing2, light)
-		if(udir == NORTH || udir == SOUTH)
-			light1.set_dir(WEST)
-			light2.set_dir(EAST)
-		else
-			light1.set_dir(SOUTH)
-			light2.set_dir(NORTH)
+		if (clear_objects)	// If we're clearing objects, we're going to need to place lights since they can't be mapped in.
+			// Place lights
+			var/turf/placing1 = locate(light_x1, light_y1, cz)
+			var/turf/placing2 = locate(light_x2, light_y2, cz)
+			var/obj/machinery/light/light1 = new(placing1, light)
+			var/obj/machinery/light/light2 = new(placing2, light)
+			if(udir == NORTH || udir == SOUTH)
+				light1.set_dir(WEST)
+				light2.set_dir(EAST)
+			else
+				light1.set_dir(SOUTH)
+				light2.set_dir(NORTH)
 
-		light1.no_z_overlay = 1
-		light2.no_z_overlay = 1
+			light1.no_z_overlay = 1
+			light2.no_z_overlay = 1
 
 		// Update area.
 		if(az > areas_to_use.len)

--- a/code/modules/turbolift/turbolift_turfs.dm
+++ b/code/modules/turbolift/turbolift_turfs.dm
@@ -1,2 +1,2 @@
 /turf/simulated/wall/elevator/Initialize(mapload)
-	..(mapload, "elevatorium")
+	. = ..(mapload, "elevatorium")

--- a/code/modules/turbolift/turbolift_turfs.dm
+++ b/code/modules/turbolift/turbolift_turfs.dm
@@ -1,2 +1,2 @@
-/turf/simulated/wall/elevator/New(var/newloc)
-	..(newloc,"elevatorium")
+/turf/simulated/wall/elevator/Initialize(mapload)
+	..(mapload, "elevatorium")

--- a/html/changelogs/lohikar-liftlights.yml
+++ b/html/changelogs/lohikar-liftlights.yml
@@ -1,0 +1,5 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - maptweak: "Elevators now use small lights instead of tube lights."
+  - tweak: "Lights will no longer mysteriously float in mid-air in elevator shafts."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -22348,6 +22348,62 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
+"Mo" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/turbolift/engineering_maintenance)
+"Mp" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/turbolift/engineering_maintenance)
+"Mq" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/turbolift/vault_sub)
+"Mr" = (
+/obj/machinery/light/small,
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/turbolift/ai_sub)
+"Ms" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/turbolift/medical_sub)
+"Mt" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled,
+/area/turbolift/medical_sub)
+"Mu" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/turbolift/research_maintenance)
+"Mv" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/turbolift/research_maintenance)
 
 (1,1,1) = {"
 aa
@@ -40183,7 +40239,7 @@ fg
 dc
 fG
 fG
-fG
+Mo
 fG
 fG
 dc
@@ -40954,7 +41010,7 @@ fj
 dc
 fG
 fG
-fG
+Mp
 fG
 fG
 dc
@@ -42295,7 +42351,7 @@ pL
 rq
 AW
 AW
-AW
+Mu
 AW
 AW
 rq
@@ -42809,7 +42865,7 @@ pL
 rq
 AW
 AW
-AW
+Mv
 AW
 AW
 rq
@@ -61811,9 +61867,9 @@ eZ
 qw
 eZ
 rm
+Ms
 rm
-rm
-rm
+Mt
 rm
 uf
 uO
@@ -62805,7 +62861,7 @@ ab
 ab
 fa
 fZ
-fZ
+Mq
 fZ
 fZ
 fZ
@@ -70020,7 +70076,7 @@ lz
 lH
 lH
 lH
-lH
+Mr
 lH
 fa
 ab

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -46832,6 +46832,7 @@
 /area/maintenance/medbay)
 "bCd" = (
 /obj/structure/flora/pottedplant/random,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/turbolift/command_sub)
 "bCe" = (
@@ -62865,6 +62866,36 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
+"cgg" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/turbolift/main_station)
+"cgh" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/turbolift/main_station)
+"cgi" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/turbolift/main_station_aux)
+"cgj" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/turbolift/main_station_aux)
+"cgk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/turbolift/cargo_station)
+"cgl" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/dark,
+/area/turbolift/cargo_station)
 
 (1,1,1) = {"
 aaa
@@ -84360,7 +84391,7 @@ bIM
 bKQ
 cfZ
 cgc
-bLr
+cfZ
 aLf
 bNt
 bNT
@@ -84614,10 +84645,10 @@ bHV
 bIK
 bIM
 bIM
-bKR
-bLr
-bLr
-bLr
+cfX
+cfZ
+cfZ
+cfZ
 aLf
 bep
 aLi
@@ -85645,7 +85676,7 @@ bFV
 bFV
 bFV
 bGq
-cgf
+cge
 cdW
 bep
 bNU
@@ -86946,10 +86977,10 @@ bPD
 bSy
 bSO
 bTh
+cgk
 bTh
 bTh
-bTh
-bTh
+cgl
 bTh
 bSO
 aab
@@ -91262,15 +91293,15 @@ aXD
 aYE
 aZN
 baS
+cgg
 baS
-baS
-baS
+cgh
 baS
 aZN
 bix
+cgi
 bix
-bix
-bix
+cgj
 bix
 aZN
 bpV


### PR DESCRIPTION
changes:
- Lifts no longer automatically generate lights if they're set to not clear the shaft.
- Mapped in lifts now have mapped in small lights, only in the lift cabin.

![2017-08-04_13-12-00](https://user-images.githubusercontent.com/7097800/28981215-85e50b34-7916-11e7-8dee-d0d84c206f8e.png)

