### PR TITLE
Devour fixes

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -125,11 +125,6 @@
 #define MOB_TINY 		4
 #define MOB_MINISCULE	1
 
-// Gluttony levels.
-#define GLUT_TINY 1       // Eat anything tiny and smaller
-#define GLUT_SMALLER 2    // Eat anything smaller than we are
-#define GLUT_ANYTHING 3   // Eat anything, ever
-
 #define BASE_MAX_NUTRITION	400
 #define HUNGER_FACTOR		0.05 // Factor of how fast mob nutrition decreases. Moved here from chemistry define
 

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -181,7 +181,7 @@
 #define TYPE_ORGANIC	1//Almost any creature under /mob/living/carbon and most simple animals
 #define	TYPE_SYNTHETIC	2//Everything under /mob/living/silicon, plus IPCs, viscerators
 #define TYPE_HUMANOID	4//Humans, skrell, unathi, tajara, vaurca, diona, IPC, vox
-#define TYPE_WIERD		8//Slimes, constructs, demons, and other creatures of a magical or bluespace nature.
+#define TYPE_WEIRD		8//Slimes, constructs, demons, and other creatures of a magical or bluespace nature.
 
 // Maximum number of chickens allowed at once.
 // If the number of chickens on the map exceeds this, laid eggs will not hatch.

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -213,7 +213,6 @@ var/global/list/cloaking_devices = list()
 
 	// Some setup work for the eat-types lists.
 	mtl_synthetic = typecacheof(mtl_synthetic) + list(
-		/mob/living/carbon/human/machine,
 		/mob/living/simple_animal/hostile/retaliate/malf_drone,
 		/mob/living/simple_animal/hostile/viscerator,
 		/mob/living/simple_animal/spiderbot

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -94,6 +94,25 @@ var/global/list/syndicate_access = list(access_maint_tunnels, access_syndicate, 
 //Cloaking devices
 var/global/list/cloaking_devices = list()
 
+// Devour types (these are typecaches). Only simple_animals check these, other types are handled specially.
+/var/list/mtl_synthetic = list(
+	/mob/living/simple_animal/hostile/hivebot
+)
+
+/var/list/mtl_weird = list(
+	/mob/living/simple_animal/construct,
+	/mob/living/simple_animal/shade,
+	/mob/living/simple_animal/slime,
+	/mob/living/simple_animal/hostile/faithless
+)
+
+// Actual human mobs are delibrately not in this list as they are handled elsewhere.
+/var/list/mtl_humanoid = list(
+	/mob/living/simple_animal/hostile/pirate,
+	/mob/living/simple_animal/hostile/russian,
+	/mob/living/simple_animal/hostile/syndicate
+)
+
 //////////////////////////
 /////Initial Building/////
 //////////////////////////
@@ -191,6 +210,18 @@ var/global/list/cloaking_devices = list()
 	for(var/T in paths)
 		var/datum/poster/P = new T
 		poster_designs += P
+
+	// Some setup work for the eat-types lists.
+	mtl_synthetic = typecacheof(mtl_synthetic) + list(
+		/mob/living/carbon/human/machine,
+		/mob/living/simple_animal/hostile/retaliate/malf_drone,
+		/mob/living/simple_animal/hostile/viscerator,
+		/mob/living/simple_animal/spiderbot
+	)
+
+	mtl_weird = typecacheof(mtl_weird) + /mob/living/simple_animal/adultslime
+
+	mtl_humanoid = typecacheof(mtl_humanoid)
 
 	return 1
 

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -236,7 +236,7 @@
 		return
 
 	var/types = victim.find_type()
-	if ((!(types & TYPE_ORGANIC)) || ((types & TYPE_WIERD)))
+	if ((!(types & TYPE_ORGANIC)) || ((types & TYPE_WEIRD)))
 		//Invalid sacrifice. Display a message and return
 		speak_to(user, "This soulless automaton cannot satisfy our hunger. We yearn for life essence, it must have a soul.")
 		return

--- a/code/modules/mob/living/carbon/alien/diona/diona_powers.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_powers.dm
@@ -222,7 +222,7 @@
 		donor.adjustBruteLoss(4)
 		nutrition += 20
 		return
-	else if (types & TYPE_WIERD)
+	else if (types & TYPE_WEIRD)
 		src.visible_message("<span class='danger'>[src] attempts to bite into [donor.name] but passes right through it!.</span>", "<span class='danger'>You attempt to sink your fangs into [donor.name] but pass right through it!</span>")
 		return
 	else if (donor.is_diona())

--- a/code/modules/mob/living/carbon/alien/diona/life.dm
+++ b/code/modules/mob/living/carbon/alien/diona/life.dm
@@ -20,7 +20,6 @@
 		nutrition = max_nutrition
 
 	//handle_trace_chems() implement this later maybe
-	handle_stomach()
 	updatehealth()
 
 	return

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -44,32 +44,17 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	h_style = "blue IPC screen"
 	. = ..(mapload, "Baseline Frame")
 
-/mob/living/carbon/human/monkey
-	mob_size = 2.6//Based on howler monkey, rough real world equivilant to on-mob sprite size
-
 /mob/living/carbon/human/monkey/Initialize(mapload)
 	. = ..(mapload, "Monkey")
-
-/mob/living/carbon/human/farwa
-	mob_size = 2.6//Roughly the same size as monkey
 
 /mob/living/carbon/human/farwa/Initialize(mapload)
 	. = ..(mapload, "Farwa")
 
-/mob/living/carbon/human/neaera
-	mob_size = 2.6//Roughly the same size as monkey
-
 /mob/living/carbon/human/neaera/Initialize(mapload)
 	. = ..(mapload, "Neaera")
 
-/mob/living/carbon/human/stok
-	mob_size = 2.6//Roughly the same size as monkey
-
 /mob/living/carbon/human/stok/Initialize(mapload)
 	. = ..(mapload, "Stok")
-
-/mob/living/carbon/human/bug
-	mob_size = 2.6//Roughly the same size as monkey
 
 /mob/living/carbon/human/bug/Initialize(mapload)
 	. = ..(mapload, "V'krexi")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -71,9 +71,6 @@
 		//Random events (vomiting etc)
 		handle_random_events()
 
-		//stuff in the stomach
-		handle_stomach()//This function is in devour.dm
-
 		handle_shock()
 
 		handle_pain()

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -36,7 +36,7 @@
 	cold_level_3 = 0
 
 	eyes = "vox_eyes_s"
-	gluttonous = GLUT_SMALLER
+	gluttonous = TRUE
 	virus_immune = 1
 
 	breath_type = "nitrogen"

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -144,6 +144,7 @@
 	var/exhaust_threshold = 50	  	// When stamina runs out, the mob takes oxyloss up til this value. Then collapses and drops to walk
 
 	var/gluttonous                // Can eat some mobs. Values can be GLUT_TINY, GLUT_SMALLER, GLUT_ANYTHING.
+	var/mouth_size
 	var/max_nutrition_factor = 1	//Multiplier on maximum nutrition
 	var/nutrition_loss_factor = 1	//Multiplier on passive nutrition losses
 
@@ -327,6 +328,7 @@
 	H.mob_push_flags = push_flags
 	H.pass_flags = pass_flags
 	H.mob_size = mob_size
+	H.mouth_size = mouth_size || 2
 	if(!kpg)
 		if(islesserform(H))
 			H.dna.SetSEState(MONKEYBLOCK,1)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -143,8 +143,8 @@
 	var/sprint_cost_factor = 0.9  	// Multiplier on stamina cost for sprinting
 	var/exhaust_threshold = 50	  	// When stamina runs out, the mob takes oxyloss up til this value. Then collapses and drops to walk
 
-	var/gluttonous                // Can eat some mobs. Values can be GLUT_TINY, GLUT_SMALLER, GLUT_ANYTHING.
-	var/mouth_size
+	var/gluttonous                // Can eat some mobs. Boolean.
+	var/mouth_size                // How big the mob's mouth is. Limits how large a mob this species can swallow. Only relevant if gluttonous is TRUE.
 	var/max_nutrition_factor = 1	//Multiplier on maximum nutrition
 	var/nutrition_loss_factor = 1	//Multiplier on passive nutrition losses
 

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -31,7 +31,7 @@
 	mob_size = MOB_SMALL
 	holder_type = /obj/item/weapon/holder/human
 	short_sighted = 1
-	gluttonous = GLUT_TINY
+	gluttonous = TRUE
 
 	spawn_flags = IS_RESTRICTED
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_EYE_COLOR

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -11,8 +11,9 @@
 
 	has_fine_manipulation = 0
 	siemens_coefficient = 0
-	gluttonous = GLUT_ANYTHING
+	gluttonous = TRUE
 	mouth_size = 15	// Should be larger than any human-type.
+	mob_size = 14
 	fall_mod = 0
 
 	eyes = "blank_eyes"

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -12,6 +12,7 @@
 	has_fine_manipulation = 0
 	siemens_coefficient = 0
 	gluttonous = GLUT_ANYTHING
+	mouth_size = 15	// Should be larger than any human-type.
 	fall_mod = 0
 
 	eyes = "blank_eyes"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1009,6 +1009,8 @@ proc/is_blind(A)
 /mob/living/carbon/human/find_type()
 	. = ..()
 	. |= isSynthetic() ? TYPE_SYNTHETIC : TYPE_ORGANIC
+	if (!islesserform(src))
+		. |= TYPE_HUMANOID
 
 /mob/living/carbon/slime/find_type()
 	. = ..()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1002,134 +1002,72 @@ proc/is_blind(A)
 //Below here is stuff related to devouring, but which is generally helpful and thus placed here
 //See Devour.dm for more info in how these are used
 
-
-
-//Blacklists of mobs that can be excluded from eating by flags in the bitfield
-
-//All of these specific human subtypes are here for a reason.
-//Using /mob/living/carbon/human as a generic type would include monkey/stok/farwa/neara.
-//We do not want those to count as humanoids, only player species
-var/list/humanoid_mobs_specific = list( /mob/living/carbon/human,
-	/mob/living/carbon/human/bst,
-	/mob/living/carbon/human/skrell,
-	/mob/living/carbon/human/unathi,
-	/mob/living/carbon/human/diona,
-	/mob/living/carbon/human/tajaran,
-	/mob/living/carbon/human/vox,
-	/mob/living/carbon/human/machine,
-	/mob/living/carbon/human/type_a,
-	/mob/living/carbon/human/type_b
-	)
-
-var/list/humanoid_mobs_inclusive = list(
-	/mob/living/simple_animal/hostile/pirate,
-	/mob/living/simple_animal/hostile/russian,
-	/mob/living/simple_animal/hostile/syndicate
-	)
-
-var/list/synthetic_mobs_specific = list(
-	/mob/living/carbon/human/machine,
-	/mob/living/simple_animal/hostile/retaliate/malf_drone,
-	/mob/living/simple_animal/hostile/viscerator,
-	/mob/living/simple_animal/spiderbot
-	)
-
-
-var/list/synthetic_mobs_inclusive = list( /mob/living/silicon,
-	/mob/living/simple_animal/hostile/hivebot,
-	/mob/living/bot
-	)
-
-var/list/wierd_mobs_specific = list(/mob/living/simple_animal/adultslime)
-
-var/list/wierd_mobs_inclusive = list( /mob/living/simple_animal/construct,
-	/mob/living/simple_animal/shade,
-	/mob/living/simple_animal/slime,
-	/mob/living/simple_animal/hostile/faithless,
-	/mob/living/carbon/slime
-	)
-
-
+// Returns a bitfield representing the mob's type as relevant to the devour system.
 /mob/proc/find_type()
-	if (istype(src, /mob/living))
-		var/mob/living/L = src
-		return L.find_type()
 	return 0
 
-/mob/living/find_type()
-	//This function returns a bitfield indicating what type(s) the passed mob is.
-	//Synthetic and wierd are exclusive from organic. We assume it's organic if it's not either of those
-	//var/mob/living/test = src
-	var/mobtypes = 0
+/mob/living/carbon/human/find_type()
+	. = ..()
+	. |= isSynthetic() ? TYPE_SYNTHETIC : TYPE_ORGANIC
 
-	if (mob_listed(src, synthetic_mobs_specific,1))
-		mobtypes |= TYPE_SYNTHETIC
-	else if (mob_listed(src, synthetic_mobs_inclusive,0))
-		mobtypes |= TYPE_SYNTHETIC
-	else
-		if (isSynthetic())
-			mobtypes |= TYPE_SYNTHETIC
+/mob/living/carbon/slime/find_type()
+	. = ..()
+	. |= TYPE_WEIRD
 
-	if (mob_listed(src, wierd_mobs_specific,1))
-		mobtypes |= TYPE_WIERD
-	else if (mob_listed(src, wierd_mobs_inclusive,0))
-		mobtypes |= TYPE_WIERD
+/mob/living/bot/find_type()
+	. = ..()
+	. |= TYPE_SYNTHETIC
 
-	if (!(mobtypes & TYPE_WIERD) && !(mobtypes & TYPE_SYNTHETIC))
-		mobtypes |= TYPE_ORGANIC
+// Yeah, I'm just going to cheat and do istype(src) checks here.
+// It's not worth adding a proc for every single one of these types.
+/mob/living/simple_animal/find_type()
+	. = ..()
+	if (is_type_in_typecache(src, global.mtl_synthetic))
+		. |= TYPE_SYNTHETIC
 
+	if (is_type_in_typecache(src, global.mtl_weird))
+		. |= TYPE_WEIRD
 
-	if (mob_listed(src, humanoid_mobs_specific,1))
-		mobtypes |= TYPE_HUMANOID
-	else if (mob_listed(src, humanoid_mobs_inclusive,0))
-		mobtypes |= TYPE_HUMANOID
+	// If it's not TYPE_SYNTHETIC or TYPE_WEIRD, we can assume it's TYPE_ORGANIC.
+	if (!(. & (TYPE_SYNTHETIC|TYPE_WEIRD)))
+		. |= TYPE_ORGANIC
 
-	return mobtypes
+	if (is_type_in_typecache(src, global.mtl_humanoid))
+		. |= TYPE_HUMANOID
 
+/mob/living/proc/get_vessel(create = FALSE)
+	if (!create)
+		return
 
-//This function attempts to find the mob's blood vessel, if it has one.
-//If it doesn't, and the create var is true, then it will create a new temporary one filled with blood that has fake DNA, and return that
-//If no vessel and no create var, then null is returned, getting blood isnt possible.
-//The fake DNA is generally useful for animals, it contains enough information to tell what kind of creature it came from
-/mob/living/proc/get_vessel(var/create = 0)
-	//Add any other creatures which have blood, here
-	if(istype(src, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = src
-		return H.vessel
-	else if (istype(src, /mob/living/carbon/alien/diona))
-		var/mob/living/carbon/alien/diona/D = src
-		return D.vessel
-	else if (create)
+	//we make a new vessel for whatever creature we're devouring. this allows blood to come from creatures that can't normally bleed
+	//We create an MD5 hash of the mob's reference to use as its DNA string.
+	//This creates unique DNA for each creature in a consistently repeatable process
+	var/datum/reagents/vessel = new/datum/reagents(600)
+	vessel.add_reagent("blood",560)
+	for(var/datum/reagent/blood/B in vessel.reagent_list)
+		if(B.id == "blood")
+			B.data = list(
+				"donor" = src,
+				"viruses" = null,
+				"species" = name,
+				"blood_DNA" = md5("\ref[src]"), 
+				"blood_colour" = "#a10808",
+				"blood_type" = null,
+				"resistances" = null,
+				"trace_chem" = null,
+				"virus2" = null,
+				"antibodies" = list()
+			)
 
-		//we make a new vessel for whatever creature we're devouring. this allows blood to come from creatures that can't normally bleed
-		//We create an MD5 hash of the mob's reference to use as its DNA string.
-		//This creates unique DNA for each creature in a consistently repeatable process
-		var/datum/reagents/vessel = new/datum/reagents(600)
-		vessel.add_reagent("blood",560)
-		for(var/datum/reagent/blood/B in vessel.reagent_list)
-			if(B.id == "blood")
-				B.data = list(	"donor"=src,"viruses"=null,"species"=src.name,"blood_DNA"=md5("\ref[src]"),"blood_colour"= "#a10808","blood_type"=null,	\
-								"resistances"=null,"trace_chem"=null, "virus2" = null, "antibodies" = list())
+			B.color = B.data["blood_colour"]
 
-				B.color = B.data["blood_colour"]
+	return vessel
 
-		return vessel
+/mob/living/carbon/human/get_vessel(create = FALSE)
+	. = vessel
 
-	else return null
-
-//This function checks against a list to see if the mob is in it.
-//Any specified types are checked against exactly, using ==, not istype
-//Any types ending in * will be tested with isType
-/proc/mob_listed(var/mob/living/test, var/list/toCheck, var/specific = 0)
-	for (var/i in toCheck)
-		if (specific)
-			if (test.type == i)
-				return 1
-		else
-			if (istype(test, i))
-				return 1
-	return 0
-
+/mob/living/carbon/alien/diona/get_vessel(create = FALSE)
+	. = vessel
 
 #define POSESSIVE_PRONOUN	0
 #define POSESSIVE_ADJECTIVE	1


### PR DESCRIPTION
Bunch of fixes and balance tweaks to the devour system. Notable changes are that xenomorphs can eat people again and that human-types no longer take ridiculous amounts of damage from devour.

changes:
- Devour type checks now actually operate on species for human-types and are all-around hopefully more sane.
- Replaced an obsolete define with a boolean.
- Fixed xenomorphs being unable to swallow human-types.
- Rebalanced digestion damage to not kill human-types in one tick.
- Digestion now deals fire+brute instead of cloneloss (bite still deals cloneloss as I didn't touch its damage function)
- Misc code tweaks.