### PR TITLE
Door visual glitch fix

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -632,6 +632,7 @@ About the new airlock wires panel:
 	switch(animation)
 		if("opening")
 			cut_overlays()
+			compile_overlays()	// Flick will prevent SSoverlays from changing the overlay list mid-flick, so we force it.
 			if(p_open)
 				flick("o_door_opening", src)
 				update_icon()
@@ -641,6 +642,7 @@ About the new airlock wires panel:
 		if("closing")
 			if(overlays)
 				cut_overlays()
+				compile_overlays()
 			if(p_open)
 				flick("o_door_closing", src)
 				update_icon()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -85,7 +85,6 @@
 	update_nearby_tiles(need_rebuild=1)
 	if (hashatch)
 		setup_hatch()
-	return
 
 /obj/machinery/door/proc/setup_hatch()
 	hatch_image = image('icons/obj/doors/hatches.dmi', src, hatchstyle, closed_layer+0.1)
@@ -94,7 +93,6 @@
 	hatch_image.pixel_y = hatch_offset_y
 	hatch_image.dir = dir
 
-	add_overlay(hatch_image)
 	update_icon()
 
 /obj/machinery/door/proc/open_hatch(var/atom/mover = null)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -374,6 +374,7 @@
 	return ..()
 
 /obj/machinery/door/firedoor/do_animate(animation)
+	compile_overlays()
 	switch(animation)
 		if("opening")
 			flick("door_opening", src)

--- a/html/changelogs/lohikar-doors.yml
+++ b/html/changelogs/lohikar-doors.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Fixed a visual inconsistency where airlock hatches & maint panel overlays would draw over the opening animation when they shouldn't have."


### PR DESCRIPTION
Fixes hatches & maint overlays not properly being cleared during the door open animation.

Thanks go to TheGreatJorge for figuring out why this was happening.

![aaa](https://i.lohikar.io/12LQfU.gif)