### PR TITLE
Human icons performance tweaks

### DIFF
--- a/code/controllers/subsystems/icon_cache.dm
+++ b/code/controllers/subsystems/icon_cache.dm
@@ -52,6 +52,13 @@
 	var/list/human_underwear_cache = list()
 	var/list/human_undershirt_cache = list()
 	var/list/human_socks_cache = list()
+	// This is an assoc list of all icon states in `icons/mob/collar.dmi`, used by human update-icons.
+	var/list/collar_states
 
 /datum/controller/subsystem/icon_cache/New()
 	NEW_SS_GLOBAL(SSicon_cache)
+
+/datum/controller/subsystem/icon_cache/proc/setup_collar_mappings()
+	collar_states = list()
+	for (var/i in icon_states('icons/mob/collar.dmi'))
+		collar_states[i] = TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1182,7 +1182,7 @@
 		usr << "<span class='warning'>You failed to check the pulse. Try again.</span>"
 
 /mob/living/carbon/human/proc/set_species(var/new_species, var/default_colour, var/kpg=0)
-
+	cached_bodytype = null
 	if(!dna)
 		if(!new_species)
 			new_species = "Human"

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -102,3 +102,5 @@
 	var/is_noisy = FALSE		// if TRUE, movement should make sound.
 	var/last_x = 0
 	var/last_y = 0
+
+	var/cached_bodytype

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -99,19 +99,20 @@ There are several things that need to be remembered:
 #define SUIT_STORE_LAYER 13
 #define BACK_LAYER       14
 #define HAIR_LAYER       15
-#define L_EAR_LAYER      16
-#define R_EAR_LAYER      17
-#define FACEMASK_LAYER   18
-#define HEAD_LAYER       19
-#define COLLAR_LAYER     20
-#define HANDCUFF_LAYER   21
-#define LEGCUFF_LAYER    22
-#define L_HAND_LAYER     23
-#define R_HAND_LAYER     24
-#define FIRE_LAYER       25		//If you're on fire
-#define TARGETED_LAYER   26		//Layer for the target overlay from weapon targeting system
-#define TOTAL_LAYERS     26
+#define EARS_LAYER       16
+#define FACEMASK_LAYER   17
+#define HEAD_LAYER       18
+#define COLLAR_LAYER     19
+#define HANDCUFF_LAYER   20
+#define LEGCUFF_LAYER    21
+#define L_HAND_LAYER     22
+#define R_HAND_LAYER     23
+#define FIRE_LAYER       24		//If you're on fire
+#define TOTAL_LAYERS     24
 //////////////////////////////////
+
+#define UNDERSCORE_OR_NULL(target) "[target ? "[target]_" : ""]"
+#define GET_BODY_TYPE (cached_bodytype || (cached_bodytype = species.get_bodytype()))
 
 /mob/living/carbon/human
 	var/list/overlays_raw[TOTAL_LAYERS] // Our set of "raw" overlays that can be modified, but cannot be directly applied to the mob without preprocessing.
@@ -191,7 +192,7 @@ There are several things that need to be remembered:
 
 		O.update_icon()
 		if(O.damage_state == "00") continue
-		var/cache_index = "[O.damage_state]/[O.icon_name]/[species.blood_color]/[species.get_bodytype()]"
+		var/cache_index = "[O.damage_state]/[O.icon_name]/[species.blood_color]/[GET_BODY_TYPE]"
 		var/list/damage_icon_parts = SSicon_cache.damage_icon_parts
 		var/icon/DI = damage_icon_parts[cache_index]
 		if(!DI)
@@ -353,7 +354,7 @@ There are several things that need to be remembered:
 		// Beard.
 		if(f_style)
 			var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[f_style]
-			if(facial_hair_style && facial_hair_style.species_allowed && (src.species.get_bodytype() in facial_hair_style.species_allowed))
+			if(facial_hair_style && facial_hair_style.species_allowed && (GET_BODY_TYPE in facial_hair_style.species_allowed))
 				var/icon/facial_s = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
 				if(facial_hair_style.do_colouration)
 					facial_s.Blend(rgb(r_facial, g_facial, b_facial), ICON_ADD)
@@ -363,7 +364,7 @@ There are several things that need to be remembered:
 		// Hair.
 		if(hair_is_visible)
 			var/datum/sprite_accessory/hair_style = hair_styles_list[h_style]
-			if(hair_style && (src.species.get_bodytype() in hair_style.species_allowed))
+			if(hair_style && (GET_BODY_TYPE in hair_style.species_allowed))
 				var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
 				if(hair_style.do_colouration)
 					hair_s.Blend(rgb(r_hair, g_hair, b_hair), ICON_ADD)
@@ -523,8 +524,8 @@ There are several things that need to be remembered:
 
 		else if(w_uniform.icon_override)
 			under_icon = w_uniform.icon_override
-		else if(w_uniform.sprite_sheets && w_uniform.sprite_sheets[species.get_bodytype()])
-			under_icon = w_uniform.sprite_sheets[species.get_bodytype()]
+		else if(w_uniform.sprite_sheets && w_uniform.sprite_sheets[GET_BODY_TYPE])
+			under_icon = w_uniform.sprite_sheets[GET_BODY_TYPE]
 		else if(w_uniform.item_icons && w_uniform.item_icons[slot_w_uniform_str])
 			under_icon = w_uniform.item_icons[slot_w_uniform_str]
 		else
@@ -568,20 +569,14 @@ There are several things that need to be remembered:
 	if (QDELING(src))
 		return
 		
-	overlays_raw[ID_LAYER]	= null
+	overlays_raw[ID_LAYER] = null
 	if(wear_id)
 
 		wear_id.screen_loc = ui_id	//TODO
 		if(w_uniform && w_uniform:displays_id)
 			if(wear_id.contained_sprite)
 				wear_id.auto_adapt_species(src)
-				var/icon/IDIcon
-				if(wear_id.icon_override)
-					IDIcon = wear_id.icon_override
-				else
-					IDIcon = wear_id.icon
-
-				overlays_raw[ID_LAYER] = image("icon" = IDIcon, "icon_state" = "[wear_id.item_state][WORN_ID]")
+				overlays_raw[ID_LAYER] = image(wear_id.icon_override || wear_id.icon, "[wear_id.item_state][WORN_ID]")
 			else
 				overlays_raw[ID_LAYER] = image("icon" = 'icons/mob/mob.dmi', "icon_state" = "id")
 
@@ -595,47 +590,40 @@ There are several things that need to be remembered:
 	if (QDELING(src))
 		return
 		
-	overlays_raw[GLOVES_LAYER] = null
+	
 	if(check_draw_gloves())
+		var/t_state = gloves.item_state || gloves.icon_state
 
-		var/t_state = gloves.item_state
-		if(!t_state)	t_state = gloves.icon_state
-
-		var/image/standing
+		var/image/result_layer
 		if(gloves.contained_sprite)
 			gloves.auto_adapt_species(src)
-			var/state = ""
-			if (gloves.icon_species_tag)
-				state += "[gloves.icon_species_tag]_"
-			state += "[gloves.item_state][WORN_GLOVES]"
+			var/state = "[UNDERSCORE_OR_NULL(gloves.icon_species_tag)][gloves.item_state][WORN_GLOVES]"
 
-			if(gloves.icon_override)
-				standing = image("icon" = gloves.icon_override, "icon_state" = state)
-			else
-				standing = image("icon" = gloves.icon, "icon_state" = state)
+			result_layer = image(gloves.icon_override || gloves.icon, state)
+
 		else if(gloves.icon_override)
-			standing = image("icon" = gloves.icon_override, "icon_state" = "[t_state]")
-		else if(gloves.sprite_sheets && gloves.sprite_sheets[species.get_bodytype()])
-			standing = image("icon" = gloves.sprite_sheets[species.get_bodytype()], "icon_state" = "[t_state]")
+			result_layer = image(gloves.icon_override, t_state)
+		else if(gloves.sprite_sheets && gloves.sprite_sheets[GET_BODY_TYPE])
+			result_layer = image(gloves.sprite_sheets[GET_BODY_TYPE], t_state)
 		else
-			standing = image("icon" = 'icons/mob/hands.dmi', "icon_state" = "[t_state]")
+			result_layer = image('icons/mob/hands.dmi', t_state)
 
-		standing.color = gloves.color
-
-		var/list/ovr
+		if (gloves.color)
+			result_layer.color = gloves.color
 
 		if(gloves.blood_DNA)
-			var/image/bloodsies = image("icon" = species.blood_mask, "icon_state" = "bloodyhands")
+			var/image/bloodsies = image(species.blood_mask, "bloodyhands")
 			bloodsies.color = gloves.blood_color
-			ovr = list(standing, bloodsies)
+			result_layer = list(result_layer, bloodsies)
 
 		gloves.screen_loc = ui_gloves
-		overlays_raw[GLOVES_LAYER] = ovr || standing
+		overlays_raw[GLOVES_LAYER] = result_layer
+	else if(blood_DNA)
+		var/image/bloodsies	= image(species.blood_mask, "bloodyhands")
+		bloodsies.color = hand_blood_color
+		overlays_raw[GLOVES_LAYER] = bloodsies
 	else
-		if(blood_DNA)
-			var/image/bloodsies	= image("icon" = species.blood_mask, "icon_state" = "bloodyhands")
-			bloodsies.color = hand_blood_color
-			overlays_raw[GLOVES_LAYER] = bloodsies
+		overlays_raw[GLOVES_LAYER] = null
 
 	if(update_icons)
 		update_icons()
@@ -643,88 +631,71 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/update_inv_glasses(var/update_icons=1)
 	if (QDELING(src))
 		return
-		
+
 	overlays_raw[GLASSES_LAYER] = null
 	if(check_draw_glasses())
 		if(glasses.contained_sprite)
 			glasses.auto_adapt_species(src)
-			var/state = ""
-			if (glasses.icon_species_tag)
-				state += "[glasses.icon_species_tag]_"
-			state += "[glasses.item_state][WORN_EYES]"
+			var/state = "[UNDERSCORE_OR_NULL(glasses.icon_species_tag)][glasses.item_state][WORN_EYES]"
 
-			if(glasses.icon_override)
-				overlays_raw[GLASSES_LAYER] = image("icon" = glasses.icon_override, "icon_state" = state)
-			else
-				overlays_raw[GLASSES_LAYER] = image("icon" = glasses.icon, "icon_state" = state)
+			overlays_raw[GLASSES_LAYER] = image(glasses.icon_override || glasses.icon, state)
 
 		else if(glasses.icon_override)
-			overlays_raw[GLASSES_LAYER] = image("icon" = glasses.icon_override, "icon_state" = "[glasses.icon_state]")
-		else if(glasses.sprite_sheets && glasses.sprite_sheets[species.get_bodytype()])
-			overlays_raw[GLASSES_LAYER] = image("icon" = glasses.sprite_sheets[species.get_bodytype()], "icon_state" = "[glasses.icon_state]")
+			overlays_raw[GLASSES_LAYER] = image(glasses.icon_override, glasses.icon_state)
+		else if(glasses.sprite_sheets && glasses.sprite_sheets[GET_BODY_TYPE])
+			overlays_raw[GLASSES_LAYER] = image(glasses.sprite_sheets[GET_BODY_TYPE], glasses.icon_state)
 		else
-			overlays_raw[GLASSES_LAYER] = image("icon" = 'icons/mob/eyes.dmi', "icon_state" = "[glasses.icon_state]")
+			overlays_raw[GLASSES_LAYER] = image('icons/mob/eyes.dmi', glasses.icon_state)
 
-	if(update_icons)   update_icons()
+	if(update_icons)
+		update_icons()
 
 /mob/living/carbon/human/update_inv_ears(var/update_icons=1)
 	if (QDELING(src))
 		return
-		
-	overlays_raw[L_EAR_LAYER] = null
-	overlays_raw[R_EAR_LAYER] = null
 
-	if (!check_draw_ears())
-		if(update_icons)   update_icons()
-		return
+	overlays_raw[EARS_LAYER] = null
 
-	else
+	if (check_draw_ears())
+		var/result_layer
 		if(l_ear)
-
 			var/t_type = l_ear.icon_state
 
 			if(l_ear.contained_sprite)
 				l_ear.auto_adapt_species(src)
-				t_type = ""
-				if (l_ear.icon_species_tag)
-					t_type += "[l_ear.icon_species_tag]_"
-				t_type += "[l_ear.item_state][WORN_LEAR]"
-				if(l_ear.icon_override)
-					overlays_raw[L_EAR_LAYER] = image("icon" = l_ear.icon_override, "icon_state" = t_type)
-				else
-					overlays_raw[L_EAR_LAYER] = image("icon" = l_ear.icon, "icon_state" = t_type)
+				t_type = "[UNDERSCORE_OR_NULL(l_ear.icon_species_tag)][l_ear.item_state][WORN_LEAR]"
+				result_layer = image(l_ear.icon_override || l_ear.icon, t_type)
 			else if(l_ear.icon_override)
-				t_type = "[t_type]_l"
-				overlays_raw[L_EAR_LAYER] = image("icon" = l_ear.icon_override, "icon_state" = "[t_type]")
-			else if(l_ear.sprite_sheets && l_ear.sprite_sheets[species.get_bodytype()])
-				t_type = "[t_type]_l"
-				overlays_raw[L_EAR_LAYER] = image("icon" = l_ear.sprite_sheets[species.get_bodytype()], "icon_state" = "[t_type]")
+				result_layer = image(l_ear.icon_override, "[t_type]_l")
+			else if(l_ear.sprite_sheets && l_ear.sprite_sheets[GET_BODY_TYPE])
+				result_layer = image(l_ear.sprite_sheets[GET_BODY_TYPE], "[t_type]_l")
 			else
-				overlays_raw[L_EAR_LAYER] = image("icon" = 'icons/mob/ears.dmi', "icon_state" = "[t_type]")
+				result_layer = image('icons/mob/ears.dmi', "[t_type]")
 
 		if(r_ear)
+			var/image/I
 			var/t_type = r_ear.icon_state
 			if(r_ear.contained_sprite)
 				r_ear.auto_adapt_species(src)
-				t_type = ""
-				if (r_ear.icon_species_tag)
-					t_type += "[r_ear.icon_species_tag]_"
-				t_type += "[r_ear.item_state][WORN_REAR]"
-				if(r_ear.icon_override)
-					overlays_raw[R_EAR_LAYER] = image("icon" = r_ear.icon_override, "icon_state" = t_type)
-				else
-					overlays_raw[R_EAR_LAYER] = image("icon" = r_ear.icon, "icon_state" = t_type)
+				t_type = "[UNDERSCORE_OR_NULL(r_ear.icon_species_tag)][r_ear.item_state][WORN_REAR]"
+				I = image(r_ear.icon_override || r_ear.icon, t_type)
 
 			else if(r_ear.icon_override)
-				t_type = "[t_type]_r"
-				overlays_raw[R_EAR_LAYER] = image("icon" = r_ear.icon_override, "icon_state" = "[t_type]")
-			else if(r_ear.sprite_sheets && r_ear.sprite_sheets[species.get_bodytype()])
-				t_type = "[t_type]_r"
-				overlays_raw[R_EAR_LAYER] = image("icon" = r_ear.sprite_sheets[species.get_bodytype()], "icon_state" = "[t_type]")
+				I = image(r_ear.icon_override, "[t_type]_r")
+			else if(r_ear.sprite_sheets && r_ear.sprite_sheets[GET_BODY_TYPE])
+				I = image(r_ear.sprite_sheets[GET_BODY_TYPE], "[t_type]_r")
 			else
-				overlays_raw[R_EAR_LAYER] = image("icon" = 'icons/mob/ears.dmi', "icon_state" = "[t_type]")
+				I = image('icons/mob/ears.dmi', "[t_type]")
 
-	if(update_icons)   update_icons()
+			if (result_layer)
+				result_layer = list(result_layer, I)
+			else
+				result_layer = I
+
+		overlays_raw[EARS_LAYER] = result_layer
+
+	if(update_icons)
+		update_icons()
 
 /mob/living/carbon/human/update_inv_shoes(var/update_icons=1)
 	if (QDELING(src))
@@ -735,20 +706,14 @@ There are several things that need to be remembered:
 		var/image/standing
 		if(shoes.contained_sprite)
 			shoes.auto_adapt_species(src)
-			var/state = ""
-			if (shoes.icon_species_tag)
-				state += "[shoes.icon_species_tag]_"
-			state += "[shoes.item_state][WORN_SHOES]"
+			var/state = "[UNDERSCORE_OR_NULL(shoes.icon_species_tag)][shoes.item_state][WORN_SHOES]"
 
-			if(shoes.icon_override)
-				standing = image("icon" = shoes.icon_override, "icon_state" = state)
-			else
-				standing = image("icon" = shoes.icon, "icon_state" = state)
+			standing = image(shoes.icon_override || shoes.icon, state)
 
 		else if(shoes.icon_override)
-			standing = image("icon" = shoes.icon_override, "icon_state" = "[shoes.icon_state]")
-		else if(shoes.sprite_sheets && shoes.sprite_sheets[species.get_bodytype()])
-			standing = image("icon" = shoes.sprite_sheets[species.get_bodytype()], "icon_state" = "[shoes.icon_state]")
+			standing = image(shoes.icon_override, "[shoes.icon_state]")
+		else if(shoes.sprite_sheets && shoes.sprite_sheets[GET_BODY_TYPE])
+			standing = image("icon" = shoes.sprite_sheets[GET_BODY_TYPE], "icon_state" = "[shoes.icon_state]")
 		else
 			standing = image("icon" = 'icons/mob/feet.dmi', "icon_state" = "[shoes.icon_state]")
 
@@ -777,9 +742,7 @@ There are several things that need to be remembered:
 		
 	if(s_store)
 		//s_store.auto_adapt_species(src)
-		var/t_state = s_store.item_state
-		if(!t_state)	t_state = s_store.icon_state
-		overlays_raw[SUIT_STORE_LAYER] = image("icon" = 'icons/mob/belt_mirror.dmi', "icon_state" = "[t_state]")
+		overlays_raw[SUIT_STORE_LAYER] = image('icons/mob/belt_mirror.dmi', s_store.item_state || s_store.icon_state)
 		s_store.screen_loc = ui_sstore1		//TODO
 	else
 		overlays_raw[SUIT_STORE_LAYER] = null
@@ -798,20 +761,13 @@ There are several things that need to be remembered:
 		var/t_icon = INV_HEAD_DEF_ICON
 		if(head.contained_sprite)
 			head.auto_adapt_species(src)
-			var/state = ""
-			if (head.icon_species_tag)
-				state += "[head.icon_species_tag]_"
-			state += "[head.item_state][WORN_HEAD]"
+			var/state = "[UNDERSCORE_OR_NULL(head.icon_species_tag)][head.item_state][WORN_HEAD]"
 
-
-			if(head.icon_override)
-				standing = image("icon" = head.icon_override, "icon_state" = state)
-			else
-				standing = image("icon" = head.icon, "icon_state" = state)
+			standing = image(head.icon_override || head.icon, state)
 		else if(head.icon_override)
 			t_icon = head.icon_override
-		else if(head.sprite_sheets && head.sprite_sheets[species.get_bodytype()])
-			t_icon = head.sprite_sheets[species.get_bodytype()]
+		else if(head.sprite_sheets && head.sprite_sheets[GET_BODY_TYPE])
+			t_icon = head.sprite_sheets[GET_BODY_TYPE]
 
 		else if(head.item_icons && (slot_head_str in head.item_icons))
 			t_icon = head.item_icons[slot_head_str]
@@ -819,11 +775,8 @@ There are several things that need to be remembered:
 			t_icon = INV_HEAD_DEF_ICON
 
 		if (!standing)
-			//Determine the state to use
-			var/t_state = head.icon_state
-
 			//Create the image
-			standing = image(icon = t_icon, icon_state = t_state)
+			standing = image(t_icon, head.icon_state)
 
 		standing.color = head.color
 
@@ -836,7 +789,7 @@ There are several things that need to be remembered:
 
 		if(istype(head,/obj/item/clothing/head))
 			var/obj/item/clothing/head/hat = head
-			var/cache_key = "[hat.light_overlay]_[species.get_bodytype()]"
+			var/cache_key = "[hat.light_overlay]_[GET_BODY_TYPE]"
 			if(hat.on && SSicon_cache.light_overlay_cache["[cache_key]"])
 				if (!ovr)
 					ovr = list(standing)
@@ -850,35 +803,31 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/update_inv_belt(var/update_icons=1)
 	if (QDELING(src))
 		return
-		
+
 	overlays_raw[BELT_LAYER] = null
 	overlays_raw[BELT_LAYER_ALT] = null
 
 	if(belt)
 		belt.screen_loc = ui_belt	//TODO
 		var/t_state = belt.item_state
-		var/t_icon = belt.icon
-		if(!t_state)	t_state = belt.icon_state
-		var/image/standing	= image("icon_state" = "[t_state]")
+		var/t_icon = belt.icon || belt.icon_state
+		var/image/standing
 
 		if(belt.contained_sprite)
 			belt.auto_adapt_species(src)
-			t_state = ""
-			if (belt.icon_species_tag)
-				t_state += "[belt.icon_species_tag]_"
-			t_state += "[belt.item_state][WORN_BELT]"
+			t_state = "[UNDERSCORE_OR_NULL(belt.icon_species_tag)][belt.item_state][WORN_BELT]"
 
 			if(belt.icon_override)
 				t_icon = belt.icon_override
 
 		else if(belt.icon_override)
 			t_icon = belt.icon_override
-		else if(belt.sprite_sheets && belt.sprite_sheets[species.get_bodytype()])
-			t_icon = belt.sprite_sheets[species.get_bodytype()]
+		else if(belt.sprite_sheets && belt.sprite_sheets[GET_BODY_TYPE])
+			t_icon = belt.sprite_sheets[GET_BODY_TYPE]
 		else
 			t_icon = 'icons/mob/belt.dmi'
 
-		standing = image("icon" = t_icon, "icon_state" = t_state)
+		standing = image(t_icon, t_state)
 		var/list/ovr
 
 		if(belt.contents.len && istype(belt, /obj/item/weapon/storage/belt))
@@ -887,20 +836,12 @@ There are several things that need to be remembered:
 				var/c_state
 				var/c_icon
 				if(i.contained_sprite)
-					c_state = ""
-					if (i.icon_species_tag)
-						c_state += "[i.icon_species_tag]_"
-					c_state += "[i.item_state][WORN_BELT]"
-
-					c_icon = belt.icon
-					if(belt.icon_override)
-						c_icon = belt.icon_override
-
+					c_state = "[UNDERSCORE_OR_NULL(i.icon_species_tag)][i.item_state][WORN_BELT]"
+					c_icon = belt.icon_override || belt.icon
 				else
 					c_icon = 'icons/mob/belt.dmi'
-					c_state = i.item_state
-					if(!c_state) c_state = i.icon_state
-				ovr += image("icon" = c_icon, "icon_state" = c_state)
+					c_state = i.item_state || i.icon_state
+				ovr += image(c_icon, c_state)
 
 		var/beltlayer = BELT_LAYER
 		if(istype(belt, /obj/item/weapon/storage/belt))
@@ -924,29 +865,25 @@ There are several things that need to be remembered:
 
 		if(wear_suit.contained_sprite)
 			wear_suit.auto_adapt_species(src)
-			var/state = ""
-			if (wear_suit.icon_species_tag)
-				state += "[wear_suit.icon_species_tag]_"
-			state += "[wear_suit.item_state][WORN_SUIT]"
+			var/state = "[UNDERSCORE_OR_NULL(wear_suit.icon_species_tag)][wear_suit.item_state][WORN_SUIT]"
 
-			if(wear_suit.icon_override)
-				standing = image("icon" = wear_suit.icon_override, "icon_state" = state)
-			else
-				standing = image("icon" = wear_suit.icon, "icon_state" = state)
+			standing = image(wear_suit.icon_override || wear_suit.icon, state)
 
 		else if(wear_suit.icon_override)
-			standing = image("icon" = wear_suit.icon_override, "icon_state" = "[wear_suit.icon_state]")
-		else if(wear_suit.sprite_sheets && wear_suit.sprite_sheets[species.get_bodytype()])
-			standing = image("icon" = wear_suit.sprite_sheets[species.get_bodytype()], "icon_state" = "[wear_suit.icon_state]")
+			standing = image(wear_suit.icon_override, wear_suit.icon_state)
+		else if(wear_suit.sprite_sheets && wear_suit.sprite_sheets[GET_BODY_TYPE])
+			standing = image(wear_suit.sprite_sheets[GET_BODY_TYPE], wear_suit.icon_state)
 		else
-			standing = image("icon" = 'icons/mob/suit.dmi', "icon_state" = "[wear_suit.icon_state]")
+			standing = image('icons/mob/suit.dmi', wear_suit.icon_state)
 
-		standing.color = wear_suit.color
+		if (wear_suit.color)
+			standing.color = wear_suit.color
+
 		var/list/ovr
 
 		if(wear_suit.blood_DNA)
 			var/obj/item/clothing/suit/S = wear_suit
-			var/image/bloodsies = image("icon" = species.blood_mask, "icon_state" = "[S.blood_overlay_type]blood")
+			var/image/bloodsies = image(species.blood_mask, "[S.blood_overlay_type]blood")
 			bloodsies.color = wear_suit.blood_color
 			ovr = list(standing, bloodsies)
 
@@ -960,7 +897,6 @@ There are several things that need to be remembered:
 
 		overlays_raw[SUIT_LAYER] = ovr || standing
 		update_tail_showing(0)
-
 	else
 		overlays_raw[SUIT_LAYER] = null
 		update_tail_showing(0)
@@ -975,15 +911,19 @@ There are several things that need to be remembered:
 	if (QDELING(src))
 		return
 		
-	if(l_store)			l_store.screen_loc = ui_storage1	//TODO
-	if(r_store)			r_store.screen_loc = ui_storage2	//TODO
-	if(update_icons)	update_icons()
+	if(l_store)
+		l_store.screen_loc = ui_storage1	//TODO
+	if(r_store)
+		r_store.screen_loc = ui_storage2	//TODO
+
+	if(update_icons)
+		update_icons()
 
 
 /mob/living/carbon/human/update_inv_wear_mask(var/update_icons=1)
 	if (QDELING(src))
 		return
-		
+
 	overlays_raw[FACEMASK_LAYER] = null
 	if(check_draw_mask())
 		wear_mask.screen_loc = ui_mask	//TODO
@@ -991,27 +931,24 @@ There are several things that need to be remembered:
 
 		if(wear_mask.contained_sprite)
 			wear_mask.auto_adapt_species(src)
-			var/state = ""
-			if (wear_mask.icon_species_tag)
-				state += "[wear_mask.icon_species_tag]_"
-			state += "[wear_mask.item_state][WORN_MASK]"
+			var/state = "[UNDERSCORE_OR_NULL(wear_mask.icon_species_tag)][wear_mask.item_state][WORN_MASK]"
 
-			if(wear_mask.icon_override)
-				standing = image("icon" = wear_mask.icon_override, "icon_state" = state)
-			else
-				standing = image("icon" = wear_mask.icon, "icon_state" = state)
+			standing = image(wear_mask.icon_override || wear_mask.icon, state)
+
 		else if(wear_mask.icon_override)
-			standing = image("icon" = wear_mask.icon_override, "icon_state" = "[wear_mask.icon_state]")
-		else if(wear_mask.sprite_sheets && wear_mask.sprite_sheets[species.get_bodytype()])
-			standing = image("icon" = wear_mask.sprite_sheets[species.get_bodytype()], "icon_state" = "[wear_mask.icon_state]")
+			standing = image(wear_mask.icon_override, wear_mask.icon_state)
+		else if(wear_mask.sprite_sheets && wear_mask.sprite_sheets[GET_BODY_TYPE])
+			standing = image(wear_mask.sprite_sheets[GET_BODY_TYPE], wear_mask.icon_state)
 		else
-			standing = image("icon" = 'icons/mob/mask.dmi', "icon_state" = "[wear_mask.icon_state]")
+			standing = image('icons/mob/mask.dmi', wear_mask.icon_state)
 
-		standing.color = wear_mask.color
+		if (wear_mask.color)
+			standing.color = wear_mask.color
+
 		var/list/ovr
 
 		if( !istype(wear_mask, /obj/item/clothing/mask/smokable/cigarette) && wear_mask.blood_DNA )
-			var/image/bloodsies = image("icon" = species.blood_mask, "icon_state" = "maskblood")
+			var/image/bloodsies = image(species.blood_mask, "maskblood")
 			bloodsies.color = wear_mask.blood_color
 			ovr = list(standing, bloodsies)
 
@@ -1024,11 +961,9 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/update_inv_back(var/update_icons=1)
 	if (QDELING(src))
 		return
-		
 
 	overlays_raw[BACK_LAYER] = null
 	if(back)
-
 		back.screen_loc = ui_back	//TODO
 
 		//determine the icon to use
@@ -1037,22 +972,17 @@ There are several things that need to be remembered:
 
 		if(back.contained_sprite)
 			back.auto_adapt_species(src)
-			if (back.icon_species_tag)
-				overlay_state += "[back.icon_species_tag]_"
-			overlay_state += "[back.item_state][WORN_BACK]"
+			overlay_state = "[UNDERSCORE_OR_NULL(back.icon_species_tag)][back.item_state][WORN_BACK]"
 
-			if(back.icon_override)
-				overlay_icon = back.icon_override
-			else
-				overlay_icon = back.icon
+			overlay_icon = back.icon_override || back.icon
 		else if(back.icon_override)
 			overlay_icon = back.icon_override
 		else if(istype(back, /obj/item/weapon/rig))
 			//If this is a rig and a mob_icon is set, it will take species into account in the rig update_icon() proc.
 			var/obj/item/weapon/rig/rig = back
 			overlay_icon = rig.mob_icon
-		else if(back.sprite_sheets && back.sprite_sheets[species.get_bodytype()])
-			overlay_icon = back.sprite_sheets[species.get_bodytype()]
+		else if(back.sprite_sheets && back.sprite_sheets[GET_BODY_TYPE])
+			overlay_icon = back.sprite_sheets[GET_BODY_TYPE]
 		else if(back.item_icons && (slot_back_str in back.item_icons))
 			overlay_icon = back.item_icons[slot_back_str]
 		else
@@ -1065,16 +995,16 @@ There are several things that need to be remembered:
 			else if(back.item_state)
 				overlay_state = back.item_state
 			else if(back.contained_sprite)
-				overlay_icon = image("icon" = back.icon, "icon_state" = "[back.icon_state]_w")
+				overlay_icon = back.icon
+				overlay_state = "[back.icon_state]_w"
 			else
 				overlay_state = back.icon_state
 
-		//apply color
-		var/image/standing = image(icon = overlay_icon, icon_state = overlay_state)
-		standing.color = back.color
+		var/image/standing = image(overlay_icon, overlay_state)
+		if (back.color)
+			standing.color = back.color
 
-		//create the image
-		overlays_raw[BACK_LAYER] = image(icon = overlay_icon, icon_state = overlay_state)
+		overlays_raw[BACK_LAYER] = standing
 
 	if(update_icons)
 		update_icons()
@@ -1098,13 +1028,12 @@ There are several things that need to be remembered:
 
 		var/image/standing
 		if(handcuffed.icon_override)
-			standing = image("icon" = handcuffed.icon_override, "icon_state" = "handcuff1")
-		else if(handcuffed.sprite_sheets && handcuffed.sprite_sheets[species.get_bodytype()])
-			standing = image("icon" = handcuffed.sprite_sheets[species.get_bodytype()], "icon_state" = "handcuff1")
+			standing = image(handcuffed.icon_override, "handcuff1")
+		else if(handcuffed.sprite_sheets && handcuffed.sprite_sheets[GET_BODY_TYPE])
+			standing = image(handcuffed.sprite_sheets[GET_BODY_TYPE], "handcuff1")
 		else
-			standing = image("icon" = 'icons/mob/mob.dmi', "icon_state" = "handcuff1")
+			standing = image('icons/mob/mob.dmi', "handcuff1")
 		overlays_raw[HANDCUFF_LAYER] = standing
-
 	else
 		overlays_raw[HANDCUFF_LAYER] = null
 
@@ -1116,20 +1045,19 @@ There are several things that need to be remembered:
 		return
 		
 	if(legcuffed)
-
 		var/image/standing
 		if(legcuffed.icon_override)
-			standing = image("icon" = legcuffed.icon_override, "icon_state" = "legcuff1")
-		else if(legcuffed.sprite_sheets && legcuffed.sprite_sheets[species.get_bodytype()])
-			standing = image("icon" = legcuffed.sprite_sheets[species.get_bodytype()], "icon_state" = "legcuff1")
+			standing = image(legcuffed.icon_override, "legcuff1")
+		else if(legcuffed.sprite_sheets && legcuffed.sprite_sheets[GET_BODY_TYPE])
+			standing = image(legcuffed.sprite_sheets[GET_BODY_TYPE], "legcuff1")
 		else
-			standing = image("icon" = 'icons/mob/mob.dmi', "icon_state" = "legcuff1")
+			standing = image('icons/mob/mob.dmi', "legcuff1")
 		overlays_raw[LEGCUFF_LAYER] = standing
 
-		if(src.m_intent != "walk")
-			src.m_intent = "walk"
-			if(src.hud_used && src.hud_used.move_intent)
-				src.hud_used.move_intent.icon_state = "walking"
+		if(m_intent != "walk")
+			m_intent = "walk"
+			if(hud_used && hud_used.move_intent)
+				hud_used.move_intent.icon_state = "walking"
 
 	else
 		overlays_raw[LEGCUFF_LAYER] = null
@@ -1141,7 +1069,7 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/update_inv_r_hand(var/update_icons=1)
 	if (QDELING(src))
 		return
-		
+
 	overlays_raw[R_HAND_LAYER] = null
 	if(r_hand)
 		r_hand.screen_loc = ui_rhand	//TODO
@@ -1150,22 +1078,14 @@ There are several things that need to be remembered:
 		var/t_state
 		if(r_hand.contained_sprite)
 			r_hand.auto_adapt_species(src)
-			if (r_hand.icon_species_tag && r_hand.icon_species_in_hand)
-				t_state += "[r_hand.icon_species_tag]_"
-			t_state += "[r_hand.item_state][WORN_RHAND]"
+			t_state = "[UNDERSCORE_OR_NULL(r_hand.icon_species_tag)][r_hand.item_state][WORN_RHAND]"
 
-			if(r_hand.icon_override)
-				overlays_raw[R_HAND_LAYER] = image(icon = r_hand.icon_override, icon_state = t_state)
-			else
-				overlays_raw[R_HAND_LAYER] = image(icon = r_hand.icon, icon_state = t_state)
-
+			overlays_raw[R_HAND_LAYER] = image(r_hand.icon_override || r_hand.icon, t_state)
 		else
 			if(r_hand.item_state_slots && r_hand.item_state_slots[slot_r_hand_str])
 				t_state = r_hand.item_state_slots[slot_r_hand_str]
-			else if(r_hand.item_state)
-				t_state = r_hand.item_state
 			else
-				t_state = r_hand.icon_state
+				t_state = r_hand.item_state || r_hand.icon_state
 
 			//determine icon to use
 			var/icon/t_icon
@@ -1177,8 +1097,7 @@ There are several things that need to be remembered:
 			else
 				t_icon = INV_R_HAND_DEF_ICON
 
-			overlays_raw[R_HAND_LAYER] = image(icon = t_icon, icon_state = t_state)
-
+			overlays_raw[R_HAND_LAYER] = image(t_icon, t_state)
 
 	if(update_icons) 
 		update_icons()
@@ -1187,7 +1106,7 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/update_inv_l_hand(var/update_icons=1)
 	if (QDELING(src))
 		return
-		
+
 	overlays_raw[L_HAND_LAYER] = null
 	if(l_hand)
 		l_hand.screen_loc = ui_lhand	//TODO
@@ -1196,22 +1115,14 @@ There are several things that need to be remembered:
 		var/t_state
 		if(l_hand.contained_sprite)
 			l_hand.auto_adapt_species(src)
-			if (l_hand.icon_species_tag && l_hand.icon_species_in_hand)
-				t_state += "[l_hand.icon_species_tag]_"
-			t_state += "[l_hand.item_state][WORN_LHAND]"
+			t_state = "[UNDERSCORE_OR_NULL(l_hand.icon_species_tag)][l_hand.item_state][WORN_LHAND]"
 
-			if(l_hand.icon_override)
-				overlays_raw[L_HAND_LAYER] = image(icon = l_hand.icon_override, icon_state = t_state)
-			else
-				overlays_raw[L_HAND_LAYER] = image(icon = l_hand.icon, icon_state = t_state)
-
+			overlays_raw[L_HAND_LAYER] = image(l_hand.icon_override || l_hand.icon, t_state)
 		else
 			if(l_hand.item_state_slots && l_hand.item_state_slots[slot_l_hand_str])
 				t_state = l_hand.item_state_slots[slot_l_hand_str]
-			else if(l_hand.item_state)
-				t_state = l_hand.item_state
 			else
-				t_state = l_hand.icon_state
+				t_state = l_hand.item_state || l_hand.icon_state
 
 			//determine icon to use
 			var/icon/t_icon
@@ -1223,15 +1134,15 @@ There are several things that need to be remembered:
 			else
 				t_icon = INV_L_HAND_DEF_ICON
 
-			overlays_raw[L_HAND_LAYER] = image(icon = t_icon, icon_state = t_state)
+			overlays_raw[L_HAND_LAYER] = image(t_icon, t_state)
 
-
-	if(update_icons) update_icons()
+	if(update_icons)
+		update_icons()
 
 /mob/living/carbon/human/proc/update_tail_showing(var/update_icons=1)
 	if (QDELING(src))
 		return
-		
+
 	overlays_raw[TAIL_LAYER] = null
 
 	if(species.tail && !(wear_suit && wear_suit.flags_inv & HIDETAIL))
@@ -1245,7 +1156,7 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/proc/get_tail_icon()
 	if (QDELING(src))
 		return
-		
+
 	var/icon_key = "[species.race_key][r_skin][g_skin][b_skin][r_hair][g_hair][b_hair]"
 	var/icon/tail_icon = SSicon_cache.tail_icon_cache[icon_key]
 	if(!tail_icon)
@@ -1260,7 +1171,6 @@ There are several things that need to be remembered:
 		SSicon_cache.tail_icon_cache[icon_key] = tail_icon
 
 	return tail_icon
-
 
 /mob/living/carbon/human/proc/set_tail_state(var/t_state)
 	if (!species.tail)
@@ -1286,7 +1196,7 @@ There are several things that need to be remembered:
 
 	tail_overlay = set_tail_state(t_state)
 	if(tail_overlay)
-		addtimer(CALLBACK(src, .proc/end_animate_tail_once, tail_overlay), 20)
+		addtimer(CALLBACK(src, .proc/end_animate_tail_once, tail_overlay), 20, TIMER_CLIENT_TIME)
 
 /mob/living/carbon/human/proc/end_animate_tail_once(image/tail_overlay)
 	//check that the animation hasn't changed in the meantime
@@ -1296,11 +1206,8 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/proc/animate_tail_start()
 	set_tail_state("[species.tail]_slow[rand(0,9)]")
 
-
 /mob/living/carbon/human/proc/animate_tail_fast()
 	set_tail_state("[species.tail]_loop[rand(0,9)]")
-
-	//if(update_icons)
 
 /mob/living/carbon/human/proc/animate_tail_reset()
 	if(stat != DEAD && !lying)
@@ -1308,12 +1215,8 @@ There are several things that need to be remembered:
 	else
 		set_tail_state("[species.tail]_static")
 
-
-
 /mob/living/carbon/human/proc/animate_tail_stop(var/update_icons=1)
 	set_tail_state("[species.tail]_static")
-
-
 
 //Adds a collar overlay above the helmet layer if the suit has one
 //	Suit needs an identically named sprite in icons/mob/collar.dmi
@@ -1321,25 +1224,23 @@ There are several things that need to be remembered:
 	if (QDELING(src))
 		return
 
-	var/icon/C = new('icons/mob/collar.dmi')
-	var/image/standing = null
+	var/list/collar_mapping	= SSicon_cache.collar_states
+	if (!collar_mapping)
+		SSicon_cache.setup_collar_mappings()
 
-	if(wear_suit)
-		if(wear_suit.icon_state in C.IconStates())
-			standing = image("icon" = C, "icon_state" = "[wear_suit.icon_state]")
+	if(wear_suit && collar_mapping[wear_suit.icon_state])
+		overlays_raw[COLLAR_LAYER] = image('icons/mob/collar.dmi', wear_suit.icon_state)
+	else
+		overlays_raw[COLLAR_LAYER] = null
 
-	overlays_raw[COLLAR_LAYER] = standing
-
-	if(update_icons)   update_icons()
-
+	if(update_icons)
+		update_icons()
 
 /mob/living/carbon/human/update_fire(var/update_icons=1)
 	if (QDELING(src))
 		return
 
-	overlays_raw[FIRE_LAYER] = null
-	if(on_fire)
-		overlays_raw[FIRE_LAYER] = image("icon"='icons/mob/OnFire.dmi', "icon_state"="Standing", "layer"=FIRE_LAYER)
+	overlays_raw[FIRE_LAYER] = on_fire ? image('icons/mob/OnFire.dmi', "Standing", layer = FIRE_LAYER) : null
 
 	if(update_icons)
 		update_icons()
@@ -1349,8 +1250,9 @@ There are several things that need to be remembered:
 	var/list/ovr
 	for(var/obj/item/organ/external/E in organs)
 		if(E.open)
-			var/image/I = image("icon"='icons/mob/surgery.dmi', "icon_state"="[E.name][round(E.open)]", "layer"=-SURGERY_LAYER)
+			var/image/I = image("icon"='icons/mob/surgery.dmi', "icon_state"="[E.name][round(E.open)]", "layer" = -SURGERY_LAYER)
 			LAZYADD(ovr, I)
+
 	overlays_raw[SURGERY_LAYER] = ovr
 
 	if(update_icons)
@@ -1420,9 +1322,6 @@ There are several things that need to be remembered:
 	else
 		return 1
 
-
-
-
 //Human Overlays Indexes/////////
 #undef MUTATIONS_LAYER
 #undef DAMAGE_LAYER
@@ -1431,22 +1330,24 @@ There are several things that need to be remembered:
 #undef ID_LAYER
 #undef SHOES_LAYER
 #undef GLOVES_LAYER
-#undef EARS_LAYER
+#undef BELT_LAYER
 #undef SUIT_LAYER
 #undef TAIL_LAYER
 #undef GLASSES_LAYER
-#undef FACEMASK_LAYER
-#undef BELT_LAYER
+#undef BELT_LAYER_ALT
 #undef SUIT_STORE_LAYER
 #undef BACK_LAYER
 #undef HAIR_LAYER
+#undef EARS_LAYER
+#undef FACEMASK_LAYER
 #undef HEAD_LAYER
 #undef COLLAR_LAYER
 #undef HANDCUFF_LAYER
 #undef LEGCUFF_LAYER
 #undef L_HAND_LAYER
 #undef R_HAND_LAYER
-#undef TARGETED_LAYER
 #undef FIRE_LAYER
 #undef TOTAL_LAYERS
 
+#undef UNDERSCORE_OR_NULL
+#undef GET_BODY_TYPE


### PR DESCRIPTION
A collection of misc. micro-optimizations to the various human update-icons procs.

changes to human update icons:
- Removed some unused human layers.
- Merged the l_ear and r_ear layers into one layer.
- Minor optimizations to update_ears (optimized for only one ear in use)
- `update_collar()` no longer creates an icon each time it runs just to check icon_states.
- `update_collar()` now uses a cached assoc list of icon_states for comparison instead of `in IconStates()`.
- Human body types are now cached on first access so the proc doesn't need to be called all the time.
- Contained icons now involve less temporary strings.
- Manual tail swish now uses client-time timers instead of server-time timers.