### PR TITLE
Fix a rogue get_map_cell call.

### DIFF
--- a/code/modules/random_map/noise/noise.dm
+++ b/code/modules/random_map/noise/noise.dm
@@ -78,7 +78,7 @@
 		map[TRANSLATE_COORD(x+isize,y)]   \
 		)/2)
 
-	map[get_map_cell(x,y+hsize)] = round((  \
+	map[TRANSLATE_COORD(x,y+hsize)] = round((  \
 		map[TRANSLATE_COORD(x,y+isize)] + \
 		map[TRANSLATE_COORD(x,y)]              \
 		)/2)


### PR DESCRIPTION
Replaces a rogue `get_map_cell()` with `TRANSLATE_COORD`. Seems to slightly speed up asteroid gen?