### PR TITLE
Convert clothing to initialize

### DIFF
--- a/code/controllers/subsystems/icon_cache.dm
+++ b/code/controllers/subsystems/icon_cache.dm
@@ -54,6 +54,7 @@
 	var/list/human_socks_cache = list()
 	// This is an assoc list of all icon states in `icons/mob/collar.dmi`, used by human update-icons.
 	var/list/collar_states
+	var/list/uniform_states
 
 /datum/controller/subsystem/icon_cache/New()
 	NEW_SS_GLOBAL(SSicon_cache)
@@ -62,3 +63,8 @@
 	collar_states = list()
 	for (var/i in icon_states('icons/mob/collar.dmi'))
 		collar_states[i] = TRUE
+
+/datum/controller/subsystem/icon_cache/proc/setup_uniform_mappings()
+	uniform_states = list()
+	for (var/i in icon_states('icons/mob/uniform.dmi'))
+		uniform_states[i] = TRUE

--- a/code/controllers/subsystems/initialization/atoms.dm
+++ b/code/controllers/subsystems/initialization/atoms.dm
@@ -119,6 +119,17 @@ var/datum/controller/subsystem/atoms/SSatoms
 	
 	return QDELETED(A)
 
+/datum/controller/subsystem/atoms/proc/ForceInitializeContents(atom/A)
+	var/list/mload_args = list(TRUE)
+	var/loaded = 0
+	for (var/thing in A)
+		var/atom/movable/AM = thing
+		if (!AM.initialized)
+			InitAtom(AM, mload_args)
+			++loaded
+
+	log_debug("atoms: force-loaded [loaded] out of [A.contents.len] atoms in [A].")
+
 /datum/controller/subsystem/atoms/proc/InitLog()
 	. = ""
 	for(var/path in BadInitializeCalls)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -55,8 +55,8 @@
 	origin_tech = list(TECH_ILLEGAL = 3)
 	var/global/list/clothing_choices
 
-/obj/item/clothing/under/chameleon/New()
-	..()
+/obj/item/clothing/under/chameleon/Initialize()
+	. = ..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/clothing/under/gimmick, /obj/item/clothing/under/rank/centcom_officer/bst)//Prevent infinite loops and bad jumpsuits.
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/under, blocked)
@@ -92,8 +92,8 @@
 	body_parts_covered = 0
 	var/global/list/clothing_choices
 
-/obj/item/clothing/head/chameleon/New()
-	..()
+/obj/item/clothing/head/chameleon/Initialize()
+	. = ..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/clothing/head/justice,)//Prevent infinite loops and bad hats.
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/head, blocked)
@@ -128,8 +128,8 @@
 	origin_tech = list(TECH_ILLEGAL = 3)
 	var/global/list/clothing_choices
 
-/obj/item/clothing/suit/chameleon/New()
-	..()
+/obj/item/clothing/suit/chameleon/Initialize()
+	. = ..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/clothing/suit/cyborg_suit, /obj/item/clothing/suit/justice, /obj/item/clothing/suit/greatcoat)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/suit, blocked)
@@ -163,8 +163,8 @@
 	origin_tech = list(TECH_ILLEGAL = 3)
 	var/global/list/clothing_choices
 
-/obj/item/clothing/shoes/chameleon/New()
-	..()
+/obj/item/clothing/shoes/chameleon/Initialize()
+	. = ..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/clothing/shoes/syndigaloshes, /obj/item/clothing/shoes/cyborg, /obj/item/clothing/shoes/black/bst)//prevent infinite loops and bad shoes.
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/shoes, blocked)
@@ -242,8 +242,8 @@
 	origin_tech = list(TECH_ILLEGAL = 3)
 	var/global/list/clothing_choices
 	
-/obj/item/clothing/gloves/chameleon/New()
-	..()
+/obj/item/clothing/gloves/chameleon/Initialize()
+	. = ..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/clothing/gloves/swat/bst)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/gloves, blocked)
@@ -278,8 +278,8 @@
 	origin_tech = list(TECH_ILLEGAL = 3)
 	var/global/list/clothing_choices
 
-/obj/item/clothing/mask/chameleon/New()
-	..()
+/obj/item/clothing/mask/chameleon/Initialize()
+	. = ..()
 	if(!clothing_choices)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/mask, list(src.type))
 
@@ -313,8 +313,8 @@
 	origin_tech = list(TECH_ILLEGAL = 3)
 	var/list/global/clothing_choices
 
-/obj/item/clothing/glasses/chameleon/New()
-	..()
+/obj/item/clothing/glasses/chameleon/Initialize()
+	. = ..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/clothing/glasses/sunglasses/bst)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/glasses, blocked)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -542,18 +542,20 @@ BLIND     // can't see anything
 		return
 	..()
 
-/obj/item/clothing/under/New()
-	..()
+/obj/item/clothing/under/Initialize()
+	. = ..()
 	if(worn_state)
-		if(!item_state_slots)
-			item_state_slots = list()
+		LAZYINITLIST(item_state_slots)
 		item_state_slots[slot_w_uniform_str] = worn_state
 	else
 		worn_state = icon_state
 
 	//autodetect rollability
 	if(rolled_down < 0)
-		if((worn_state + "_d_s") in icon_states('icons/mob/uniform.dmi'))
+		if (!SSicon_cache.uniform_states)
+			SSicon_cache.setup_uniform_mappings()
+
+		if (SSicon_cache.uniform_states["[worn_state]_d_s"])
 			rolled_down = 0
 
 /obj/item/clothing/under/proc/update_rolldown_status()
@@ -720,6 +722,6 @@ BLIND     // can't see anything
 		usr << "<span class='notice'>You roll down your [src]'s sleeves.</span>"
 	update_clothing_icon()
 
-/obj/item/clothing/under/rank/New()
+/obj/item/clothing/under/rank/Initialize()
 	sensor_mode = pick(0,1,2,3)
-	..()
+	. = ..()

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -152,13 +152,13 @@
 	var/hat_color
 	contained_sprite = 1
 
-/obj/item/clothing/head/det/technicolor/New()
+/obj/item/clothing/head/det/technicolor/Initialize()
 	if(prob(5))
 		var/list/colors = list("yellow"=2,"red"=1,"white"=1,"orange"=1,"purple"=1,"green"=1,"blue"=1 )
 		var/color = pickweight(colors)
 		icon_state = "hat_detective_[color]"
 		item_state = "hat_detective_[color]"
-	..()
+	. = ..()
 
 /obj/item/clothing/head/det/technicolor/attackby(obj/item/weapon/O as obj, mob/user as mob)
 	if(istype(O, /obj/item/weapon/reagent_containers/glass/paint))

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -16,10 +16,10 @@
 	item_state = null
 	w_class = 1
 
-/obj/item/clothing/mask/muzzle/New()
-    ..()
-    say_messages = list("Mmfph!", "Mmmf mrrfff!", "Mmmf mnnf!")
-    say_verbs = list("mumbles", "says")
+/obj/item/clothing/mask/muzzle/Initialize()
+	. = ..()
+	say_messages = list("Mmfph!", "Mmmf mrrfff!", "Mmmf mnnf!")
+	say_verbs = list("mumbles", "says")
 
 // Clumsy folks can't take the mask off themselves.
 /obj/item/clothing/mask/muzzle/attack_hand(mob/user as mob)
@@ -116,11 +116,11 @@
 	w_class = 2
 	siemens_coefficient = 0.9
 
-/obj/item/clothing/mask/horsehead/New()
-    ..()
-    // The horse mask doesn't cause voice changes by default, the wizard spell changes the flag as necessary
-    say_messages = list("NEEIIGGGHHHH!", "NEEEIIIIGHH!", "NEIIIGGHH!", "HAAWWWWW!", "HAAAWWW!")
-    say_verbs = list("whinnies", "neighs", "says")
+/obj/item/clothing/mask/horsehead/Initialize()
+	. = ..()
+	// The horse mask doesn't cause voice changes by default, the wizard spell changes the flag as necessary
+	say_messages = list("NEEIIGGGHHHH!", "NEEEIIIIGHH!", "NEIIIGGHH!", "HAAWWWWW!", "HAAAWWW!")
+	say_verbs = list("whinnies", "neighs", "says")
 
 /obj/item/clothing/mask/ai
 	name = "camera MIU"
@@ -131,7 +131,8 @@
 	body_parts_covered = 0
 	var/mob/eye/aiEye/eye
 
-/obj/item/clothing/mask/ai/New()
+/obj/item/clothing/mask/ai/Initialize()
+	. = ..()
 	eye = new(src)
 
 /obj/item/clothing/mask/ai/equipped(var/mob/user, var/slot)

--- a/code/modules/clothing/masks/voice.dm
+++ b/code/modules/clothing/masks/voice.dm
@@ -26,6 +26,6 @@
 	changer.voice = voice
 	usr << "<span class='notice'>You are now mimicking <B>[changer.voice]</B>.</span>"
 
-/obj/item/clothing/mask/gas/voice/New()
-	..()
+/obj/item/clothing/mask/gas/voice/Initialize()
+	. = ..()
 	changer = new(src)

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -19,9 +19,9 @@
 	var/burn_damage = 0                     // Specifically burn damage.
 	var/base_name                           // Used to keep the original name safe while we apply modifiers.
 
-/obj/item/clothing/suit/space/New()
-	..()
-	base_name = "[name]"
+/obj/item/clothing/suit/space/Initialize()
+	. = ..()
+	base_name = name
 
 //Some simple descriptors for breaches. Global because lazy, TODO: work out a better way to do this.
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -13,9 +13,9 @@
 	var/pocket_size = 2
 	var/pocket_total = null//This will be calculated, unless specifically overidden
 
-/obj/item/clothing/suit/armor/New()
-	..()
-	pockets = new/obj/item/weapon/storage/internal(src)
+/obj/item/clothing/suit/armor/Initialize()
+	. = ..()
+	pockets = new /obj/item/weapon/storage/internal(src)
 	pockets.storage_slots = pocket_slots	//two slots
 	pockets.max_w_class = pocket_size		//fit only pocket sized items
 	if (pocket_total)
@@ -25,8 +25,7 @@
 
 /obj/item/clothing/suit/armor/Destroy()
 	if (pockets)
-		qdel(pockets)
-		pockets = null
+		QDEL_NULL(pockets)
 	return ..()
 
 /obj/item/clothing/suit/armor/attack_hand(mob/user as mob)
@@ -253,12 +252,12 @@
 	siemens_coefficient = 0.5
 	var/obj/item/clothing/accessory/holster/holster
 
-/obj/item/clothing/suit/armor/tactical/New()
-	..()
+/obj/item/clothing/suit/armor/tactical/Initialize()
+	. = ..()
 	holster = new()
 	holster.on_attached(src)	//its inside a suit, we set  this so it can be drawn from
 	QDEL_NULL(pockets)	//Tactical armour has internal holster instead of pockets, so we null this out
-	overlays.Cut()	// Remove the holster's overlay.
+	cut_overlays()	// Remove the holster's overlay.
 
 /obj/item/clothing/suit/armor/tactical/attackby(obj/item/W as obj, mob/user as mob)
 	..()
@@ -336,8 +335,8 @@
 	allowed = list(/obj/item/weapon/gun,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/device/flashlight)
 	siemens_coefficient = 0.5
 
-/obj/item/clothing/suit/storage/vest/New()
-	..()
+/obj/item/clothing/suit/storage/vest/Initialize()
+	. = ..()
 	pockets.storage_slots = 2	//two slots
 
 /obj/item/clothing/suit/storage/vest/officer

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -131,13 +131,13 @@
 	var/suit_color
 	contained_sprite = 1
 
-/obj/item/clothing/suit/storage/det_trench/technicolor/New()
+/obj/item/clothing/suit/storage/det_trench/technicolor/Initialize()
 	if(prob(5))
 		var/list/colors = list("yellow"=2,"red"=1,"white"=1,"orange"=1,"purple"=1,"green"=1,"blue"=1 )
 		var/color = pickweight(colors)
 		icon_state = "suit_detective_[color]"
 		item_state = "suit_detective_[color]"
-	..()
+	. = ..()
 
 /obj/item/clothing/suit/storage/det_trench/technicolor/attackby(obj/item/weapon/O as obj, mob/user as mob)
 	if(istype(O, /obj/item/weapon/reagent_containers/glass/paint))

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -1,8 +1,8 @@
 /obj/item/clothing/suit/storage
 	var/obj/item/weapon/storage/internal/pockets
 
-/obj/item/clothing/suit/storage/New()
-	..()
+/obj/item/clothing/suit/storage/Initialize()
+	. = ..()
 	pockets = new/obj/item/weapon/storage/internal(src)
 	pockets.storage_slots = 2	//two slots
 	pockets.max_w_class = 2		//fit only pocket sized items
@@ -58,15 +58,15 @@
 		update_clothing_icon()	//so our overlays update
 
 
-/obj/item/clothing/suit/storage/vest/merc/New()
-	..()
+/obj/item/clothing/suit/storage/vest/merc/Initialize()
+	. = ..()
 	pockets = new/obj/item/weapon/storage/internal(src)
 	pockets.storage_slots = 4
 	pockets.max_w_class = 2
 	pockets.max_storage_space = 8
 
-/obj/item/clothing/suit/storage/vest/hos/New()
-	..()
+/obj/item/clothing/suit/storage/vest/hos/Initialize()
+	. = ..()
 	pockets = new/obj/item/weapon/storage/internal(src)
 	pockets.storage_slots = 4
 	pockets.max_w_class = 2

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -7,8 +7,8 @@
 	var/obj/item/weapon/storage/internal/hold
 	w_class = 3.0
 
-/obj/item/clothing/accessory/storage/New()
-	..()
+/obj/item/clothing/accessory/storage/Initialize()
+	. = ..()
 	hold = new/obj/item/weapon/storage/internal(src)
 	hold.storage_slots = slots
 	hold.max_storage_space = 12
@@ -96,14 +96,16 @@
 	icon_state = "unathiharness2"
 	slots = 2
 
-/obj/item/clothing/accessory/storage/knifeharness/New()
-	..()
+/obj/item/clothing/accessory/storage/knifeharness/Initialize()
+	. = ..()
 	hold.max_storage_space = 4
-	hold.can_hold = list(/obj/item/weapon/material/hatchet/unathiknife,\
-	/obj/item/weapon/material/kitchen/utensil/knife,\
-	/obj/item/weapon/material/kitchen/utensil/knife/plastic,\
-	/obj/item/weapon/material/knife,\
-	/obj/item/weapon/material/knife/ritual)
+	hold.can_hold = list(
+		/obj/item/weapon/material/hatchet/unathiknife,
+		/obj/item/weapon/material/kitchen/utensil/knife,
+		/obj/item/weapon/material/kitchen/utensil/knife/plastic,
+		/obj/item/weapon/material/knife,
+		/obj/item/weapon/material/knife/ritual
+	)
 
 	new /obj/item/weapon/material/hatchet/unathiknife(hold)
 	new /obj/item/weapon/material/hatchet/unathiknife(hold)

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -67,9 +67,13 @@ All custom items with worn sprites must follow the contained sprite system: http
 	contained_sprite = TRUE
 	var/obj/item/weapon/disk/chip
 
-/obj/item/clothing/glasses/fluff/nebula_glasses/New()
+/obj/item/clothing/glasses/fluff/nebula_glasses/Initialize()
+	. = ..()
 	chip = new /obj/item/weapon/disk/fluff/nebula_chip()
-	..()
+
+/obj/item/clothing/glasses/fluff/nebula_glasses/Destroy()
+	QDEL_NULL(chip)
+	return ..()
 
 /obj/item/clothing/glasses/fluff/nebula_glasses/attack_self(mob/user as mob)
 	if(chip)
@@ -847,13 +851,16 @@ All custom items with worn sprites must follow the contained sprite system: http
 	icon_state = "ikrad_beret"
 	item_state = "ikrad_beret"
 	contained_sprite = TRUE
-	var/letter
+	var/obj/item/fluff/ikrad_letter/letter
 
-/obj/item/clothing/head/beret/engineering/fluff/ikrad_beret/New()
-	..()
-	var/obj/item/fluff/ikrad_letter/hat_letter = new(src)
-	letter = hat_letter
-	hat_letter.attack_self()
+/obj/item/clothing/head/beret/engineering/fluff/ikrad_beret/Initialize()
+	. = ..()
+	letter = new(src)
+	letter.attack_self()
+
+/obj/item/clothing/head/beret/engineering/fluff/ikrad_beret/Destroy()
+	QDEL_NULL(letter)
+	return ..()
 
 /obj/item/clothing/head/beret/engineering/fluff/ikrad_beret/attack_self(var/mob/user)
 	if(letter)

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_facehugger.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_facehugger.dm
@@ -38,11 +38,11 @@ var/const/MAX_ACTIVE_TIME = 400
 	if(hit_zone == "head")
 		Attach(target)
 
-/obj/item/clothing/mask/facehugger/New()
+/obj/item/clothing/mask/facehugger/Initialize()
 	if(config.aliens_allowed)
-		..()
+		. = ..()
 	else
-		qdel(src)
+		. = INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/mask/facehugger/examine(mob/user)
 	..(user)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -226,7 +226,11 @@ datum/preferences
 
 		SSjobs.EquipCustomDeferred(mannequin, src, leftovers, used_slots)
 
-		mannequin.update_icons()
+		if (!SSATOMS_IS_PROBABLY_DONE)
+			SSatoms.ForceInitializeContents(mannequin)
+			mannequin.regenerate_icons()
+		else
+			mannequin.update_icons()
 
 /datum/preferences/proc/update_preview_icon()
 	var/mob/living/carbon/human/dummy/mannequin/mannequin = SSmob.get_mannequin(client.ckey)

--- a/code/modules/research/xenoarchaeology/finds/finds_special.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_special.dm
@@ -24,7 +24,8 @@
 	var/last_twitch = 0
 	var/max_stored_messages = 100
 
-/obj/item/clothing/mask/gas/poltergeist/New()
+/obj/item/clothing/mask/gas/poltergeist/Initialize()
+	. = ..()
 	START_PROCESSING(SSprocessing, src)
 	listening_objects += src
 


### PR DESCRIPTION
changes:
- Converted all clothing types to Initialize.
- Added some missing destroys to some custom items.
- Char setup now forcibly initializes the mannequin's contents if SSatoms has not finished yet.
- `/obj/item/clothing/under` no longer does `in icon_states()` in New().
