### PR TITLE
Vaurca organ fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -592,7 +592,12 @@ datum/species/machine/handle_post_spawn(var/mob/living/carbon/human/H)
 	icobase = 'icons/mob/human_races/r_vaurca.dmi'
 	deform = 'icons/mob/human_races/r_vaurca.dmi'
 	name_language = LANGUAGE_VAURCA
-	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
+	unarmed_types = list(
+		/datum/unarmed_attack/stomp,
+		/datum/unarmed_attack/kick,
+		/datum/unarmed_attack/claws,
+		/datum/unarmed_attack/bite/sharp
+	)
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/bug
 	rarity_value = 4
 	slowdown = 1
@@ -636,37 +641,35 @@ datum/species/machine/handle_post_spawn(var/mob/living/carbon/human/H)
 	death_message = "chitters faintly before crumbling to the ground, their eyes dead and lifeless..."
 	halloss_message = "crumbles to the ground, too weak to continue fighting."
 
-	list/heat_discomfort_strings = list(
+	heat_discomfort_strings = list(
 		"Your blood feels like its boiling in the heat.",
 		"You feel uncomfortably warm.",
 		"Your carapace feels hot as the sun."
-		)
-	list/cold_discomfort_strings = list(
+	)
+
+	cold_discomfort_strings = list(
 		"You chitter in the cold.",
 		"You shiver suddenly.",
 		"Your carapace is ice to the touch."
-		)
+	)
 
-	stamina	=	100			  // Long period of sprinting, but relatively low speed gain
+	stamina = 100			  // Long period of sprinting, but relatively low speed gain
 	sprint_speed_factor = 0.7
 	sprint_cost_factor = 0.30
-	stamina_recovery = 2//slow recovery
-
+	stamina_recovery = 2	//slow recovery
 
 	has_organ = list(
-		"neural socket" =  /obj/item/organ/vaurca/neuralsocket,
-		"lungs" =    /obj/item/organ/lungs,
-		"filtration bit" = /obj/item/organ/vaurca/filtrationbit,
-		"lungs" =    /obj/item/organ/lungs,
-		"heart" =    /obj/item/organ/heart,
+		"neural socket"       = /obj/item/organ/vaurca/neuralsocket,
+		"lungs"               = /obj/item/organ/lungs,
+		"filtration bit"      = /obj/item/organ/vaurca/filtrationbit,
+		"right heart"         = /obj/item/organ/heart/right,
+		"left heart"          = /obj/item/organ/heart/left,
 		"phoron reserve tank" = /obj/item/organ/vaurca/preserve,
-		"second heart" =    /obj/item/organ/heart,
-		"left heart" =    /obj/item/organ/heart/left,
-		"liver" =    /obj/item/organ/liver,
-		"kidneys" =  /obj/item/organ/kidneys,
-		"brain" =    /obj/item/organ/brain,
-		"eyes" =     /obj/item/organ/eyes
-		)
+		"liver"               = /obj/item/organ/liver,
+		"kidneys"             = /obj/item/organ/kidneys,
+		"brain"               = /obj/item/organ/brain,
+		"eyes"                = /obj/item/organ/eyes
+	)
 
 /datum/species/bug/equip_survival_gear(var/mob/living/carbon/human/H)
 	..()

--- a/html/changelogs/lohikar-vaurcaorgans.yml
+++ b/html/changelogs/lohikar-vaurcaorgans.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Vaurca now have two hearts and one set of lungs as was originally intended instead of three hearts and two sets of lungs."


### PR DESCRIPTION
Fixes some errors in Vaurca organ definitions causing them to get more organs than seems to have originally been intended.

changes:
- Vaurca now have two hearts ("left heart" and "right heart") instead of three ("left heart", "heart", and "second heart").
- Vaurca now have only one set of lungs.