### PR TITLE
Minor Performance Tweaks

### DIFF
--- a/code/datums/wires/smes.dm
+++ b/code/datums/wires/smes.dm
@@ -45,8 +45,7 @@ var/const/SMES_WIRE_FAILSAFES = 16	// Cut to disable failsafes, mend to reenable
 		if(SMES_WIRE_RCON)
 			if(S.RCon)
 				S.RCon = 0
-				spawn(10)
-					S.RCon = 1
+				addtimer(CALLBACK(S, /obj/machinery/power/smes/buildable/.proc/reset_rcon), 10)
 		if(SMES_WIRE_INPUT)
 			S.toggle_input()
 		if(SMES_WIRE_OUTPUT)
@@ -56,5 +55,10 @@ var/const/SMES_WIRE_FAILSAFES = 16	// Cut to disable failsafes, mend to reenable
 		if(SMES_WIRE_FAILSAFES)
 			if(S.safeties_enabled)
 				S.safeties_enabled = 0
-				spawn(10)
-					S.safeties_enabled = 1
+				addtimer(CALLBACK(S, /obj/machinery/power/smes/buildable/.proc/reset_safeties), 10)
+
+/obj/machinery/power/smes/buildable/proc/reset_safeties()
+	safeties_enabled = TRUE
+
+/obj/machinery/power/smes/buildable/proc/reset_rcon()
+	RCon = TRUE

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -17,8 +17,8 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 	var/wire_count = 0 // Max is 16
 	var/wires_status = 0 // BITFLAG OF WIRES
 
-	var/list/wires = list()
-	var/list/signallers = list()
+	var/list/wires
+	var/list/signallers
 
 	var/table_options = " align='center'"
 	var/row_options1 = " width='80px'"
@@ -27,7 +27,8 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 	var/window_y = 470
 
 /datum/wires/New(var/atom/holder)
-	..()
+	wires = list()
+	signallers = list()
 	src.holder = holder
 	if(!istype(holder, holder_type))
 		CRASH("Our holder is null/the wrong type!")

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -142,11 +142,11 @@
 	icon_state = "1"
 	random_icon_states = list("1","2","3","4","5")
 	amount = 0
-	var/list/drips = list()
+	var/list/drips
 
 /obj/effect/decal/cleanable/blood/drip/Initialize()
 	. = ..()
-	drips |= icon_state
+	drips = list(icon_state)
 
 /obj/effect/decal/cleanable/blood/writing
 	icon_state = "tracks"
@@ -158,9 +158,9 @@
 
 /obj/effect/decal/cleanable/blood/writing/Initialize()
 	. = ..()
-	if(random_icon_states.len)
+	if(LAZYLEN(random_icon_states))
 		for(var/obj/effect/decal/cleanable/blood/writing/W in loc)
-			random_icon_states.Remove(W.icon_state)
+			random_icon_states -= W.icon_state
 		icon_state = pick(random_icon_states)
 	else
 		icon_state = "writing1"
@@ -193,8 +193,8 @@
 	blood.Blend(basecolor,ICON_MULTIPLY)
 
 	icon = blood
-	overlays.Cut()
-	overlays += giblets
+	cut_overlays()
+	add_overlay(giblets)
 
 /obj/effect/decal/cleanable/blood/gibs/up
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6","gibup1","gibup1","gibup1")
@@ -238,7 +238,7 @@
 	layer = 2
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "mucus"
-	random_icon_states = list("mucus")
+	random_icon_states = null
 
 	var/list/datum/disease2/disease/virus2 = list()
 	var/dry = 0 // Keeps the lag down

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -1,5 +1,5 @@
 /obj/effect/decal/cleanable
-	var/list/random_icon_states = list()
+	var/list/random_icon_states
 
 /obj/effect/decal/cleanable/clean_blood(var/ignore = 0)
 	if(!ignore)
@@ -7,7 +7,7 @@
 		return
 	..()
 
-/obj/effect/decal/cleanable/New()
-	if (random_icon_states && length(src.random_icon_states) > 0)
-		src.icon_state = pick(src.random_icon_states)
-	..()
+/obj/effect/decal/cleanable/Initialize()
+	if (LAZYLEN(random_icon_states))
+		icon_state = pick(src.random_icon_states)
+	. = ..()

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -154,3 +154,6 @@
 
 /atom/movable/lighting_overlay/shuttle_move(turf/loc)
 	return
+
+/atom/movable/lighting_overlay/conveyor_act()
+	return

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -64,7 +64,6 @@
 /turf/simulated/open/Entered(atom/movable/mover)
 	..()
 	ADD_FALLING_ATOM(mover)
-	update_icon()
 
 // Override to deny a climber exit if they're set to adhere to CLIMBER_NO_EXIT
 /turf/simulated/open/Exit(atom/movable/mover, atom/newloc)
@@ -78,6 +77,7 @@
 
 // Remove from climbers just in case.
 /turf/simulated/open/Exited(atom/movable/mover, atom/newloc)
+	..()
 	LAZYREMOVE(climbers, mover)
 
 /turf/simulated/open/Destroy()
@@ -94,8 +94,7 @@
 
 	if (below)
 		below.above = null
-
-	below = null
+		below = null
 
 	LAZYCLEARLIST(climbers)
 	UNSETEMPTY(climbers)
@@ -107,7 +106,7 @@
 	return TRUE
 
 /**
- * Used to check wether or not the specific open turf eventually leads into spess.
+ * Used to check whether or not the specific open turf eventually leads into spess.
  *
  * @return	TRUE if the turfs/holes eventually lead into space. FALSE otherwise.
  */

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -119,6 +119,9 @@
 	if (!anchored && simulated && has_gravity(src))
 		step(src, move_dir)
 
+/obj/effect/conveyor_act()
+	return
+
 // attack with item, place item on conveyor
 /obj/machinery/conveyor/attackby(var/obj/item/I, mob/user)
 	if(iscrowbar(I))


### PR DESCRIPTION
changes:
- `/datum/wires` no longer has an `(init)` proc.
- SMES wires now use timers instead of spawn.
- Cleanables' `random_icon_states` list is now lazy. (eliminates ~4000 lists from dirt)
- `/obj/effect` can no longer be pushed around by conveyor belts.
- Lighting overlays are now explicitly prevented from being moved by conveyor belts.