### PR TITLE
Overdose Tweaks

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -61,7 +61,7 @@
 	if(!dose && volume)//If dose is currently zero, we do the first effect
 		initial_effect(M, alien)
 
-	if(overdose && (volume > overdose) && (location != CHEM_TOUCH))
+	if(overdose && (dose > overdose) && (location != CHEM_TOUCH))
 		overdose(M, alien)
 	var/removed = metabolism
 	if(ingest_met && (location == CHEM_INGEST))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -1429,9 +1429,6 @@
 /datum/reagent/ethanol/coffee/overdose(var/mob/living/carbon/M, var/alien)
 	if(alien == IS_DIONA)
 		return
-	if(alien == IS_TAJARA)
-		M.adjustToxLoss(4 * REM)
-		M.apply_effect(3, STUTTER)
 	M.make_jittery(5)
 
 /datum/reagent/ethanol/coffee/kahlua

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -51,7 +51,7 @@
 					healpower = W.heal_damage(healpower,1)
 					if (healpower <= 0)
 						return
-		M.adjustBruteLoss(7) //but not without a price, of course
+		M.adjustBruteLoss(5) //but not without a price, of course
 
 /datum/reagent/kelotane
 	name = "Kelotane"
@@ -69,7 +69,7 @@
 
 /datum/reagent/kelotane/overdose(var/mob/living/carbon/M, var/alien)
 	if(alien != IS_DIONA)
-		M.adjustFireLoss(8)
+		M.adjustFireLoss(4)
 
 /datum/reagent/dermaline
 	name = "Dermaline"
@@ -88,7 +88,7 @@
 
 /datum/reagent/dermaline/overdose(var/mob/living/carbon/M, var/alien)
 	if(alien != IS_DIONA)
-		M.adjustFireLoss(15)
+		M.adjustFireLoss(7)
 
 /datum/reagent/dylovene
 	name = "Dylovene"
@@ -106,7 +106,7 @@
 		M.hallucination = max(0, M.hallucination - 9 * removed)
 		M.adjustToxLoss(-4 * removed)
 
-/datum/reagent/kelotane/overdose(var/mob/living/carbon/M, var/alien)
+/datum/reagent/dylovene/overdose(var/mob/living/carbon/M, var/alien)
 	if(alien != IS_DIONA)
 		M.adjustToxLoss(6)
 
@@ -129,16 +129,17 @@
 	holder.remove_reagent("lexorin", 2 * removed)
 
 /datum/reagent/dexalin/overdose(var/mob/living/carbon/M, var/alien)
-	if(alien != IS_DIONA)
-		M.adjustOxyLoss(20)
+	if (alien != IS_DIONA && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.vessel.remove_reagent("blood", 2)
 
 /datum/reagent/dexalinp
 	name = "Dexalin Plus"
 	id = "dexalinp"
-	description = "Dexalin Plus is used in the treatment of oxygen deprivation. It is highly effective."
+	description = "Dexalin Plus is used in the treatment of oxygen deprivation. It is highly effective, but much harsher on the patient's circulatory system."
 	reagent_state = LIQUID
 	color = "#0040FF"
-	overdose = REAGENTS_OVERDOSE * 0.5
+	overdose = 5
 	scannable = 1
 	taste_description = "bitterness"
 
@@ -149,6 +150,11 @@
 		M.adjustOxyLoss(-300 * removed)
 
 	holder.remove_reagent("lexorin", 3 * removed)
+
+/datum/reagent/dexalinp/overdose(mob/living/carbon/M, alien)
+	if (alien != IS_DIONA && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.vessel.remove_reagent("blood", 4)
 
 /datum/reagent/tricordrazine
 	name = "Tricordrazine"
@@ -168,8 +174,8 @@
 
 /datum/reagent/tricordrazine/overdose(var/mob/living/carbon/M, var/alien)
 	if(alien != IS_DIONA)
-		M.adjustToxLoss(6)
-		M.adjustOxyLoss(8)
+		M.adjustToxLoss(3)
+		M.adjustOxyLoss(4)
 
 /datum/reagent/cryoxadone
 	name = "Cryoxadone"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -121,7 +121,7 @@
 /datum/reagent/dexalinp
 	name = "Dexalin Plus"
 	id = "dexalinp"
-	description = "Dexalin Plus is used in the treatment of oxygen deprivation. It is highly effective, but much harsher on the patient's circulatory system."
+	description = "Dexalin Plus is used in the treatment of oxygen deprivation. It is highly effective."
 	reagent_state = LIQUID
 	color = "#0040FF"
 	overdose = 5

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -51,7 +51,6 @@
 					healpower = W.heal_damage(healpower,1)
 					if (healpower <= 0)
 						return
-		M.adjustBruteLoss(5) //but not without a price, of course
 
 /datum/reagent/kelotane
 	name = "Kelotane"
@@ -69,7 +68,7 @@
 
 /datum/reagent/kelotane/overdose(var/mob/living/carbon/M, var/alien)
 	if(alien != IS_DIONA)
-		M.adjustFireLoss(4)
+		M.adjustToxLoss(4)
 
 /datum/reagent/dermaline
 	name = "Dermaline"
@@ -86,10 +85,6 @@
 	if(alien != IS_DIONA)
 		M.heal_organ_damage(0, 12 * removed)
 
-/datum/reagent/dermaline/overdose(var/mob/living/carbon/M, var/alien)
-	if(alien != IS_DIONA)
-		M.adjustFireLoss(7)
-
 /datum/reagent/dylovene
 	name = "Dylovene"
 	id = "anti_toxin"
@@ -97,7 +92,6 @@
 	reagent_state = LIQUID
 	color = "#00A000"
 	scannable = 1
-	overdose = REAGENTS_OVERDOSE
 	taste_description = "a roll of gauze"
 
 /datum/reagent/dylovene/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -105,10 +99,6 @@
 		M.drowsyness = max(0, M.drowsyness - 6 * removed)
 		M.hallucination = max(0, M.hallucination - 9 * removed)
 		M.adjustToxLoss(-4 * removed)
-
-/datum/reagent/dylovene/overdose(var/mob/living/carbon/M, var/alien)
-	if(alien != IS_DIONA)
-		M.adjustToxLoss(6)
 
 /datum/reagent/dexalin
 	name = "Dexalin"
@@ -128,11 +118,6 @@
 
 	holder.remove_reagent("lexorin", 2 * removed)
 
-/datum/reagent/dexalin/overdose(var/mob/living/carbon/M, var/alien)
-	if (alien != IS_DIONA && ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.vessel.remove_reagent("blood", 2)
-
 /datum/reagent/dexalinp
 	name = "Dexalin Plus"
 	id = "dexalinp"
@@ -151,11 +136,6 @@
 
 	holder.remove_reagent("lexorin", 3 * removed)
 
-/datum/reagent/dexalinp/overdose(mob/living/carbon/M, alien)
-	if (alien != IS_DIONA && ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.vessel.remove_reagent("blood", 4)
-
 /datum/reagent/tricordrazine
 	name = "Tricordrazine"
 	id = "tricordrazine"
@@ -163,7 +143,6 @@
 	reagent_state = LIQUID
 	color = "#8040FF"
 	scannable = 1
-	overdose = REAGENTS_OVERDOSE
 	taste_description = "bitterness"
 
 /datum/reagent/tricordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -171,11 +150,6 @@
 		M.adjustOxyLoss(-6 * removed)
 		M.heal_organ_damage(3 * removed, 3 * removed)
 		M.adjustToxLoss(-3 * removed)
-
-/datum/reagent/tricordrazine/overdose(var/mob/living/carbon/M, var/alien)
-	if(alien != IS_DIONA)
-		M.adjustToxLoss(3)
-		M.adjustOxyLoss(4)
 
 /datum/reagent/cryoxadone
 	name = "Cryoxadone"

--- a/html/changelogs/lohikar-ods.yml
+++ b/html/changelogs/lohikar-ods.yml
@@ -1,0 +1,5 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - balance: "Reverted most overdoses more or less to their pre-buff behavior."
+  - balance: "Kelotane, dexalin, and dermaline now deal Toxin damage instead of their respective heal types."


### PR DESCRIPTION
Partially reverts OD changes, as per skull's request:
> Let's do this:
>
>    Remove OD from chemicals where they already fix toxins damage. So dylovene, tricord, etc. Also from Bicard, because of point two.
>    Flip the odd damage types for kelotane, dexalin, dermaline to toxins and raise them to higher counts. Like 40 units (as is already the case with spaceacillin).
>
>That should be a workable solution until we actually implement something deeper.