### PR TITLE
Minor lighting performance tweaks

### DIFF
--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -17,9 +17,9 @@
 #define SS_INIT_ICON_UPDATE         5	// Icon update queue flush. Should run before overlays.
 #define SS_INIT_OVERLAY             4	// Overlay flush.
 #define SS_INIT_MISC                3	// Subsystems without an explicitly set initialization order start here.
-#define SS_INIT_LIGHTING            2	// Generation of lighting overlays and pre-bake.
-#define SS_INIT_OPENTURF            1	// Openturf flush. Should run after SSoverlay & SSicon_smooth so it copies the smoothed sprites. Causes lighting updates if starlight is enabled.
-#define SS_INIT_SUNLIGHT            0	// Sunlight setup. Creates lots of lighting & SSopenturf updates, but done after SSlighting inits so it doesn't delay boot.
+#define SS_INIT_SUNLIGHT            2	// Sunlight setup. Creates lots of lighting & SSopenturf updates.
+#define SS_INIT_LIGHTING            1	// Generation of lighting overlays and pre-bake. May cause openturf updates, should initialize before SSopenturf.
+#define SS_INIT_OPENTURF            0	// Openturf flush. Should run after SSoverlay & SSicon_smooth so it copies the smoothed sprites.
 #define SS_INIT_LOBBY              -1	// Lobby timer starts here.
 
 // Something to remember when setting priorities: SS_TICKER runs before Normal, which runs before SS_BACKGROUND.
@@ -49,6 +49,7 @@
 #define SS_PRIORITY_EFFECTS        35	// Effect master (Sparks)
 #define SS_PRIORITY_LIGHTING       20	// Queued lighting engine updates.
 #define SS_PRIORITY_AIRFLOW        15	// Handles object movement due to ZAS airflow.
+#define SS_PRIORITY_OPENTURF       10	// Open turf icon generation/updates.
 
 // SS_BACKGROUND
 #define SS_PRIORITY_MODIFIER      18
@@ -58,7 +59,6 @@
 #define SS_PRIORITY_EXPLOSIVES    13	// Explosion processor. Doesn't have much effect on explosion tick-checking.
 #define SS_PRIORITY_DISPOSALS     12	// Disposal holder movement.
 #define SS_PRIORITY_WIRELESS      12	// Handles pairing of wireless devices. Usually will be asleep.
-#define SS_PRIORITY_OPENTURF      10	// Open turf icon generation/updates.
 #define SS_PRIORITY_NIGHT          5	// Nightmode.
 #define SS_PRIORITY_STATISTICS     4	// Player population polling & AFK kick.
 #define SS_PRIORITY_SUN            3	// Sun movement & Solar tracking.

--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -5,7 +5,6 @@ var/datum/controller/subsystem/lighting/SSlighting
 /datum/controller/subsystem/lighting
 	name = "Lighting"
 	wait = LIGHTING_INTERVAL
-	flags = SS_FIRE_IN_LOBBY
 
 	priority = SS_PRIORITY_LIGHTING
 	init_order = SS_INIT_LIGHTING

--- a/code/controllers/subsystems/openturf.dm
+++ b/code/controllers/subsystems/openturf.dm
@@ -8,7 +8,6 @@
 
 /datum/controller/subsystem/openturf
 	name = "Open Space"
-	flags = SS_BACKGROUND | SS_FIRE_IN_LOBBY
 	wait = 1
 	init_order = SS_INIT_OPENTURF
 	priority = SS_PRIORITY_OPENTURF

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -313,8 +313,7 @@
 	var/list/Tcorners
 	var/Sx = source_turf.x
 	var/Sy = source_turf.y
-	var/use_reduced = (light_angle && facing_opaque)
-	var/actual_range = use_reduced ? light_range * LIGHTING_BLOCKED_FACTOR : light_range
+	var/actual_range = (light_angle && facing_opaque) ? light_range * LIGHTING_BLOCKED_FACTOR : light_range
 	var/test_x
 	var/test_y
 

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -46,7 +46,7 @@
 
 	var/needs_update = LIGHTING_NO_UPDATE
 
-/datum/light_source/New(var/atom/owner, var/atom/top)
+/datum/light_source/New(atom/owner, atom/top)
 	source_atom = owner // Set our new owner.
 
 	LAZYADD(source_atom.light_sources, src)
@@ -102,7 +102,7 @@
 	}
 
 // This proc will cause the light source to update the top atom, and add itself to the update queue.
-/datum/light_source/proc/update(var/atom/new_top_atom)
+/datum/light_source/proc/update(atom/new_top_atom)
 	// This top atom is different.
 	if (new_top_atom && new_top_atom != top_atom)
 		if(top_atom != source_atom) // Remove ourselves from the light sources of that top atom.
@@ -111,10 +111,7 @@
 		top_atom = new_top_atom
 
 		if (top_atom != source_atom)
-			if(!top_atom.light_sources)
-				top_atom.light_sources = list()
-
-			top_atom.light_sources += src // Add ourselves to the light sources of our new top atom.
+			LAZYADD(top_atom.light_sources, src)	// Add ourselves to the light sources of our new top atom.
 
 	//L_PROF(source_atom, "source_update")
 
@@ -156,14 +153,15 @@
 
 /datum/light_source/proc/update_angle()
 	var/turf/T = get_turf(top_atom)
-	// Don't do anything if nothing is different, trig ain't free.
-	if (T.x == cached_origin_x && T.y == cached_origin_y && old_direction == top_atom.dir)
-		return
 
 	if (istype(top_atom, /mob) && top_atom:facing_dir)
 		old_direction = top_atom:facing_dir
 	else
 		old_direction = top_atom.dir
+
+	// Don't do anything if nothing is different, trig ain't free.
+	if (T.x == cached_origin_x && T.y == cached_origin_y && old_direction == top_atom.dir)
+		return
 
 	var/turf/front = get_step(T, old_direction)
 	facing_opaque = (front && front.has_opaque_atom)
@@ -209,25 +207,11 @@
 	targ_sign = PSEUDO_WEDGE(limit_a_x, limit_a_y, limit_b_x, limit_b_y) > 0
 
 #undef ARBITRARY_NUMBER
-
-// I know this is 2D, calling it a cone anyways. Fuck the system.
-// Returns true if the test point is NOT inside the cone.
-// Make sure update_angle() is called first if the light's loc or dir have changed.
-/datum/light_source/proc/check_light_cone(var/test_x, var/test_y)
-	test_x -= test_x_offset
-	test_y -= test_y_offset
-	var/at = PSEUDO_WEDGE(limit_a_x, limit_a_y, test_x, test_y)
-	var/tb = PSEUDO_WEDGE(test_x, test_y, limit_b_x, limit_b_y)
-
-	// if the signs of both at and tb are NOT the same, the point is NOT within the cone.
-	return (((at > 0) != targ_sign) || ((tb > 0) != targ_sign))
-
 #undef POLAR_TO_CART_X
 #undef POLAR_TO_CART_Y
-#undef PSEUDO_WEDGE
 #undef MINMAX
 
-/datum/light_source/proc/remove_lum(var/now = FALSE)
+/datum/light_source/proc/remove_lum(now = FALSE)
 	applied = FALSE
 
 	var/thing
@@ -245,7 +229,7 @@
 
 	effect_str = null
 
-/datum/light_source/proc/recalc_corner(var/datum/lighting_corner/C, var/now = FALSE)
+/datum/light_source/proc/recalc_corner(datum/lighting_corner/C, now = FALSE)
 	LAZYINITLIST(effect_str)
 	if (effect_str[C]) // Already have one.
 		REMOVE_CORNER(C,now)
@@ -331,11 +315,19 @@
 	var/Sy = source_turf.y
 	var/use_reduced = (light_angle && facing_opaque)
 	var/actual_range = use_reduced ? light_range * LIGHTING_BLOCKED_FACTOR : light_range
+	var/test_x
+	var/test_y
 
 	FOR_DVIEW(T, Ceiling(actual_range), source_turf, 0)
 		check_t:
-		if (light_angle && !facing_opaque && check_light_cone(T.x, T.y))
-			continue
+
+		if (light_angle && !facing_opaque)	// Directional lighting coordinate filter.
+			test_x = T.x - test_x_offset
+			test_y = T.y - test_y_offset
+
+			// if the signs of both of these are NOT the same, the point is NOT within the cone.
+			if (((PSEUDO_WEDGE(limit_a_x, limit_a_y, test_x, test_y) > 0) != targ_sign) || ((PSEUDO_WEDGE(test_x, test_y, limit_b_x, limit_b_y) > 0) != targ_sign))
+				continue
 
 		if (T.dynamic_lighting || T.light_sources)
 			Tcorners = T.corners
@@ -427,3 +419,4 @@
 #undef QUEUE_UPDATE
 #undef DO_UPDATE
 #undef INTELLIGENT_UPDATE
+#undef PSEUDO_WEDGE

--- a/code/modules/lighting/lighting_source_novis.dm
+++ b/code/modules/lighting/lighting_source_novis.dm
@@ -1,7 +1,6 @@
 /datum/light_source/novis
 
 /datum/light_source/novis/update_corners()
-	set waitfor = FALSE
 	var/update = FALSE
 
 	if (QDELETED(source_atom))
@@ -158,9 +157,6 @@
 	UNSETEMPTY(effect_str)
 	UNSETEMPTY(affecting_turfs)
 
-/datum/light_source/novis/check_light_cone()
-	return FALSE
-
 /datum/light_source/novis/update_angle()
 	return
 
@@ -182,10 +178,7 @@
 		top_atom = new_top_atom
 
 		if (top_atom != source_atom)
-			if(!top_atom.light_sources)
-				top_atom.light_sources = list()
-
-			top_atom.light_sources += src // Add ourselves to the light sources of our new top atom.
+			LAZYADD(top_atom.light_sources, src)	// Add ourselves to the light sources of our new top atom.
 
 	//L_PROF(source_atom, "source_update")
 
@@ -196,6 +189,5 @@
 
 /datum/light_source/novis/vis_update()
 	QUEUE_UPDATE(LIGHTING_VIS_UPDATE)
-
 
 #undef QUEUE_UPDATE


### PR DESCRIPTION
changes:
- Sunlight prebake now happens during MC Initialize instead of in the lobby.
- Openturf no longer ticks in the lobby.
- Openturf has been promoted to a normal SS, from `SS_BACKGROUND`.
- Lighting no longer ticks in the lobby.
- Inlined directional lighting's coordinate filter.
- Directional lighting wedge caching now properly works with face-direction.