### PR TITLE
Assorted tweaks & fixes

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -24,6 +24,7 @@
 #define IS_TAJARA  5
 #define IS_XENOS   6
 #define IS_MACHINE 7
+#define IS_VAURCA  8
 
 #define CE_STABLE "stable" // Inaprovaline
 #define CE_ANTIBIOTIC "antibiotic" // Spaceacilin

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -337,7 +337,7 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define SOFTREF(A) "\ref[A]"
 
 // This only works on 511 because it relies on 511's `var/something = foo = bar` syntax.
-#define WEAKREF(D) (istype(D, /datum) && !D:gcDestroyed ? (D:weakref ? D:weakref : (D:weakref = new(D))) : null)
+#define WEAKREF(D) (istype(D, /datum) && !D:gcDestroyed ? (D:weakref || (D:weakref = new(D))) : null)
 
 #define ADD_VERB_IN(the_atom,time,verb) addtimer(CALLBACK(the_atom, /atom/.proc/add_verb, verb), time, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_NO_HASH_WAIT)
 #define ADD_VERB_IN_IF(the_atom,time,verb,callback) addtimer(CALLBACK(the_atom, /atom/.proc/add_verb, verb, callback), time, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_NO_HASH_WAIT)

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -99,14 +99,6 @@
 	//turfs += centerturf
 	return atoms
 
-/proc/trange(rad = 0, turf/centre = null) //alternative to range (ONLY processes turfs and thus less intensive)
-	if(!centre)
-		return
-
-	var/turf/x1y1 = locate(((centre.x-rad)<1 ? 1 : centre.x-rad),((centre.y-rad)<1 ? 1 : centre.y-rad),centre.z)
-	var/turf/x2y2 = locate(((centre.x+rad)>world.maxx ? world.maxx : centre.x+rad),((centre.y+rad)>world.maxy ? world.maxy : centre.y+rad),centre.z)
-	return block(x1y1,x2y2)
-
 /proc/get_dist_euclidian(atom/Loc1 as turf|mob|obj,atom/Loc2 as turf|mob|obj)
 	var/dx = Loc1.x - Loc2.x
 	var/dy = Loc1.y - Loc2.y

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -44,32 +44,6 @@
 			return 1
 	return 0
 
-/proc/is_type_in_oview(var/type, var/dist = 0, var/center = src)
-	if (!ispath(type))
-		CRASH("Not a valid type in 'is_type_in_oview()'")
-	if (!isnum(dist))
-		CRASH("Not a valid dist in 'is_type_in_oview()'")
-	if (!isloc(center))
-		CRASH("Not a valid center in 'is_type_in_oview()'")
-	var/list/atoms = oview(dist, center)
-	for (var/A in atoms)
-		if (istype(A, type))
-			return 1
-	return 0
-
-/proc/is_type_in_view(var/type, var/dist = 0, var/center = src)
-	if (!ispath(type))
-		CRASH("Not a valid type in 'is_type_in_view()'")
-	if (!isnum(dist))
-		CRASH("Not a valid dist in 'is_type_in_view()'")
-	if (!isloc(center))
-		CRASH("Not a valid center in 'is_type_in_view()'")
-	var/list/atoms = view(dist, center)
-	for (var/A in atoms)
-		if (istype(A, type))
-			return 1
-	return 0
-
 /proc/instances_of_type_in_list(var/atom/A, var/list/L)
 	var/instances = 0
 	for(var/type in L)

--- a/code/controllers/subsystems/explosives.dm
+++ b/code/controllers/subsystems/explosives.dm
@@ -174,7 +174,12 @@ var/datum/controller/subsystem/explosives/SSexplosives
 	var/y0 = epicenter.y
 	var/z0 = epicenter.z
 
-	for(var/turf/T in RANGE_TURFS(max_range, epicenter))
+	for(var/thing in RANGE_TURFS(max_range, epicenter))
+		var/turf/T = thing
+		if (!T)
+			CHECK_TICK
+			continue
+
 		var/dist = sqrt((T.x - x0)**2 + (T.y - y0)**2)
 
 		if (dist < devastation_range)
@@ -184,6 +189,7 @@ var/datum/controller/subsystem/explosives/SSexplosives
 		else if (dist < light_impact_range)
 			dist = 3
 		else
+			CHECK_TICK
 			continue
 
 		T.ex_act(dist)
@@ -232,9 +238,8 @@ var/datum/controller/subsystem/explosives/SSexplosives
 
 	//This step applies the ex_act effects for the explosion, as planned in the previous step.
 	for(var/turf/T in explosion_turfs)
-		if(explosion_turfs[T] <= 0)
-			continue
-		if(!T)
+		if(!T || explosion_turfs[T] <= 0)
+			CHECK_TICK
 			continue
 
 		//Wow severity looks confusing to calculate... Fret not, I didn't leave you with any additional instructions or help. (just kidding, see the line under the calculation)

--- a/code/controllers/subsystems/explosives.dm
+++ b/code/controllers/subsystems/explosives.dm
@@ -174,7 +174,7 @@ var/datum/controller/subsystem/explosives/SSexplosives
 	var/y0 = epicenter.y
 	var/z0 = epicenter.z
 
-	for(var/turf/T in trange(max_range, epicenter))
+	for(var/turf/T in RANGE_TURFS(max_range, epicenter))
 		var/dist = sqrt((T.x - x0)**2 + (T.y - y0)**2)
 
 		if (dist < devastation_range)
@@ -226,8 +226,9 @@ var/datum/controller/subsystem/explosives/SSexplosives
 	//This steap handles the gathering of turfs which will be ex_act() -ed in the next step. It also ensures each turf gets the maximum possible amount of power dealt to it.
 	for(var/direction in cardinal)
 		var/turf/T = get_step(epicenter, direction)
-		explosion_spread(T, power - epicenter.explosion_resistance, direction)
-		CHECK_TICK
+		if (T)
+			explosion_spread(T, power - epicenter.explosion_resistance, direction)
+			CHECK_TICK
 
 	//This step applies the ex_act effects for the explosion, as planned in the previous step.
 	for(var/turf/T in explosion_turfs)
@@ -270,11 +271,14 @@ var/datum/controller/subsystem/explosives/SSexplosives
 			spread_power -= O.explosion_resistance
 
 	var/turf/T = get_step(s, direction)
-	explosion_spread(T, spread_power, direction)
+	if (T)
+		explosion_spread(T, spread_power, direction)
 	T = get_step(s, turn(direction,90))
-	explosion_spread(T, spread_power, turn(direction,90))
+	if (T)
+		explosion_spread(T, spread_power, turn(direction,90))
 	T = get_step(s, turn(direction,-90))
-	explosion_spread(T, spread_power, turn(direction,90))
+	if (T)
+		explosion_spread(T, spread_power, turn(direction,90))
 
 // Add an explosion to the queue for processing.
 /datum/controller/subsystem/explosives/proc/queue(var/datum/explosiondata/data)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -305,3 +305,4 @@ var/list/accessible_z_levels = list("8" = 5, "9" = 10, "7" = 15, "2" = 60)
 		if (bound_overlay)
 			// The overlay will handle cleaning itself up on non-openspace turfs.
 			bound_overlay.forceMove(get_step(src, UP))
+			bound_overlay.set_dir(dir)

--- a/code/game/gamemodes/cult/narsie.dm
+++ b/code/game/gamemodes/cult/narsie.dm
@@ -379,7 +379,7 @@ var/global/list/narsie_list = list()
 	grav_pull = 0
 
 /obj/singularity/narsie/wizard/eat()
-	for (var/turf/T in trange(consume_range, src))
+	for (var/turf/T in RANGE_TURFS(consume_range, src))
 		consume(T)
 
 /obj/singularity/narsie/proc/narsie_spawn_animation()

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -73,7 +73,7 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
 		if(istajara(H))
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/botanic_leather/tajara(H), slot_gloves)
-		if(isunathi(H))
+		else if(isunathi(H))
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/botanic_leather/unathi(H), slot_gloves)
 		else
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/botanic_leather(H), slot_gloves)

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -40,7 +40,12 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/workboots(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat/white(H), slot_head)
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/utility/full(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
+		if(istajara(H))
+			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/tajara(H), slot_gloves)
+		else if(isunathi(H))
+			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/unathi(H), slot_gloves)
+		else
+			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
 		return 1
 
 	equip_survival(var/mob/living/carbon/human/H)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -37,7 +37,7 @@
 		H.equip_to_slot_or_del(new /obj/item/device/pda/heads/hos(H), slot_belt)
 		if(istajara(H))
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/tajara(H), slot_gloves)
-		if(isunathi(H))
+		else if(isunathi(H))
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/unathi(H), slot_gloves)
 		else
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
@@ -78,7 +78,7 @@
 		H.equip_to_slot_or_del(new /obj/item/device/pda/warden(H), slot_belt)
 		if(istajara(H))
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/tajara(H), slot_gloves)
-		if(isunathi(H))
+		else if(isunathi(H))
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/unathi(H), slot_gloves)
 		else
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
@@ -119,7 +119,7 @@
 		H.equip_to_slot_or_del(new /obj/item/device/pda/detective(H), slot_belt)
 		if(istajara(H))
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/tajara(H), slot_gloves)
-		if(isunathi(H))
+		else if(isunathi(H))
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/unathi(H), slot_gloves)
 		else
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
@@ -155,7 +155,7 @@
 		H.equip_to_slot_or_del(new /obj/item/device/pda/detective(H), slot_belt)
 		if(istajara(H))
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/tajara(H), slot_gloves)
-		if(isunathi(H))
+		else if(isunathi(H))
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/unathi(H), slot_gloves)
 		else
 			H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -436,7 +436,7 @@ var/bomb_set
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/nuclearbomb/station/LateInitialize()
-	for(var/turf/simulated/floor/T in trange(1, src))
+	for(var/turf/simulated/floor/T in RANGE_TURFS(1, src))
 		T.set_flooring(get_flooring_data(/decl/flooring/reinforced/circuit/red))
 		flash_tiles += T
 	update_icon()

--- a/code/game/objects/items/devices/magnetic_lock.dm
+++ b/code/game/objects/items/devices/magnetic_lock.dm
@@ -285,7 +285,7 @@
 					user << "<span class='warning'>There is something in the way of \the [newtarget]!</span>"
 					return
 
-		if (is_type_in_oview(/obj/machinery/door/airlock, 1, newtarget))
+		if (locate(/obj/machinery/door/airlock) in oview(1, newtarget))
 			if (alert("Brace adjacent airlocks?",,"Yes", "No") == "Yes")
 				if (!check_target(newtarget, user)) return
 				for (var/obj/machinery/door/airlock/A in get_step(newtarget.loc, turn(direction, -90)))

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -3,12 +3,20 @@
 	endWhen 		= 900
 
 	var/list/spawned_carp = list()
-	var/list/spawned_dweller = list()
+
+	var/list/despawn_turfs = list(
+		/turf/space,
+		/turf/simulated/floor/asteroid,
+		/turf/simulated/open,
+		/turf/simulated/floor/reinforced/airless	// Station roof.
+	)
+
 	ic_name = "biological entities"
 
 /datum/event/carp_migration/setup()
 	announceWhen = rand(40, 60)
 	endWhen = rand(600,1200)
+	despawn_turfs = typecacheof(despawn_turfs)
 
 /datum/event/carp_migration/announce()
 	var/announcement = ""
@@ -30,6 +38,7 @@
 		spawn_fish(rand(1, 3), 1, 2)	//1 to 6 carp, alone or in pairs
 
 /datum/event/carp_migration/proc/spawn_fish(var/num_groups, var/group_size_min=3, var/group_size_max=5)
+	set waitfor = FALSE
 	var/list/spawn_locations = list()
 
 	for(var/obj/effect/landmark/C in landmarks_list)
@@ -44,13 +53,16 @@
 		for (var/j = 1, j <= group_size, j++)
 			if(prob(99))
 				var/mob/living/simple_animal/hostile/carp/carp = new(spawn_locations[i])
-				spawned_carp += SOFTREF(carp)
+				spawned_carp += WEAKREF(carp)
 			else
 				var/mob/living/simple_animal/hostile/carp/shark/carp = new(spawn_locations[i])
-				spawned_carp += SOFTREF(carp)
+				spawned_carp += WEAKREF(carp)
+
+			CHECK_TICK
 		i++
 
 /datum/event/carp_migration/proc/spawn_caverndweller(var/num_groups, var/group_size_min=2, var/group_size_max=3)
+	set waitfor = FALSE
 	var/list/spawn_locations = list()
 
 	for(var/obj/effect/landmark/C in landmarks_list)
@@ -62,13 +74,14 @@
 	var/i = 1
 	while (i <= num_groups)
 		var/group_size = rand(group_size_min, group_size_max)
-		for (var/j = 1, j <= group_size, j++)
-			var/mob/living/simple_animal/hostile/retaliate/cavern_dweller/dweller = new(spawn_locations[i])
-			spawned_dweller += SOFTREF(dweller)
+		for (var/j in 1 to group_size)
+			new /mob/living/simple_animal/hostile/retaliate/cavern_dweller(spawn_locations[i])
+			CHECK_TICK
 		i++
 
 /datum/event/carp_migration/end()
 	for (var/carp_ref in spawned_carp)
-		var/mob/living/simple_animal/hostile/carp/fish = locate(carp_ref)
-		if (fish && istype(fish.loc, /turf/space) && prob(50))
+		var/datum/weakref/carp_weakref = carp_ref
+		var/mob/living/simple_animal/hostile/carp/fish = carp_weakref.resolve()
+		if (fish && prob(50) && is_type_in_typecache(fish.loc, despawn_turfs))
 			qdel(fish)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -622,6 +622,7 @@ datum/species/machine/handle_post_spawn(var/mob/living/carbon/human/H)
 	hazard_low_pressure = 0
 	ethanol_resistance = 2
 	taste_sensitivity = TASTE_SENSITIVE
+	reagent_tag = IS_VAURCA
 	siemens_coefficient = 1 //setting it to 0 would be redundant due to LordLag's snowflake checks, plus batons/tasers use siemens now too.
 	breath_type = "phoron"
 	poison_type = "nitrogen" //a species that breathes plasma shouldn't be poisoned by it.

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -446,7 +446,7 @@
 
 	var/shoegrip = Check_Shoegrip()
 
-	for(var/turf/simulated/T in trange(1,src)) //we only care for non-space turfs
+	for(var/turf/simulated/T in RANGE_TURFS(1,src)) //we only care for non-space turfs
 		if(T.density)	//walls work
 			return 1
 		else

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -16,8 +16,10 @@
 	anchored = 1	//  don't get pushed around
 	simulated = FALSE
 
-/mob/new_player/New()
-	..()
+INITIALIZE_IMMEDIATE(/mob/new_player)
+
+/mob/new_player/Initialize()
+	. = ..()
 	dead_mob_list -= src
 
 /mob/new_player/verb/new_player_panel()

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -124,7 +124,7 @@
 		return TRUE
 
 	if(Check_Shoegrip())	//scaling hull with magboots
-		for(var/turf/simulated/T in trange(1,src))
+		for(var/turf/simulated/T in RANGE_TURFS(1,src))
 			if(T.density)
 				return TRUE
 
@@ -135,7 +135,7 @@
 	if(Allow_Spacemove()) //Checks for active jetpack
 		return TRUE
 
-	for(var/turf/simulated/T in trange(1,src)) //Robots get "magboots"
+	for(var/turf/simulated/T in RANGE_TURFS(1,src)) //Robots get "magboots"
 		if(T.density)
 			return TRUE
 

--- a/code/modules/multiz/openspace.dm
+++ b/code/modules/multiz/openspace.dm
@@ -33,8 +33,14 @@
 		// The overlay will handle cleaning itself up on non-openspace turfs.
 		if (isturf(dest))
 			bound_overlay.forceMove(get_step(src, UP))
+			bound_overlay.set_dir(dir)
 		else	// Not a turf, so we need to destroy immediately instead of waiting for the destruction timer to proc.
 			qdel(bound_overlay)
+
+/atom/movable/set_dir(ndir)
+	. = ..()
+	if (. && bound_overlay)
+		bound_overlay.set_dir(dir)
 
 /atom/movable/update_above()
 	if (!bound_overlay)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -197,16 +197,16 @@
 	return
 
 /datum/reagent/butanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	if(isvaurca(M))//Vaurca are damaged instead of getting nutrients, but they can still get drunk
+	if (alien == IS_VAURCA)
 		M.adjustToxLoss(removed * (strength / 100))
 	else
 		M.nutrition += nutriment_factor * removed
 
-	if(alien == IS_DIONA)
-		return //Diona can gain nutrients, but don't get drunk or suffer other effects
-
-	if(isunathi(M))
-		ingest_met = initial(ingest_met)*3 //Unathi digest butanol much faster
+	switch (alien)
+		if (IS_DIONA)
+			return
+		if (IS_UNATHI)
+			ingest_met = initial(ingest_met)*3
 
 	var/quantity = (strength / 100) * removed
 	M.intoxication += quantity

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
@@ -12,7 +12,7 @@
 
 		spark(get_turf(user), 3)
 
-		user.Move(pick(trange(50, get_turf(holder))))
+		user.Move(pick(RANGE_TURFS(50, holder)))
 
 		spark(get_turf(user), 3)
 
@@ -28,7 +28,7 @@
 
 				spark(get_turf(M), 3)
 
-				M.Move(pick(trange(50, T)))
+				M.Move(pick(RANGE_TURFS(50, T)))
 				
 				spark(get_turf(M), 3)
 
@@ -44,6 +44,6 @@
 
 				spark(get_turf(M), 3)
 
-				M.Move(pick(trange(50, T)))
+				M.Move(pick(RANGE_TURFS(50, T)))
 				
 				spark(get_turf(M), 3)


### PR DESCRIPTION
changes:
- Fixed #3203.
- Tajara or Unathi CEs now get gloves that actually fit them.
- OOs now respect direction changes from their mimicked object.
- Replaced all references to `trange()` with `RANGE_TURFS()`.
- Replaced all references to `is_type_in_oview()` with `locate() in oview()`.
- Fixed a runtime caused by recursive explosions falling off the edges of the map.
- Carp despawn now works properly with the new asteroid turfs.
- Carp despawn now uses `WEAKREF` instead of `SOFTREF`.
- Added tick-checks to the carp migration event.
- Vaurca now have the `IS_VAURCA` `reagent_tag`.
- Cleaned up butanol alien handling a bit.