### PR TITLE
Fixing spelling of the word "Appropriate"

### DIFF
--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -3,7 +3,7 @@
 	name = "NTNet Quantum Relay"
 	desc = "A very complex router and transmitter capable of connecting electronic devices together. Looks fragile."
 	use_power = 2
-	active_power_usage = 20000 //20kW, apropriate for machine that keeps massive cross-Zlevel wireless network operational.
+	active_power_usage = 20000 //20kW, aporopriate for machine that keeps massive cross-Zlevel wireless network operational.
 	idle_power_usage = 100
 	icon_state = "ntnet"
 	icon = 'icons/obj/machines/telecomms.dmi'

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -3,7 +3,7 @@
 	name = "NTNet Quantum Relay"
 	desc = "A very complex router and transmitter capable of connecting electronic devices together. Looks fragile."
 	use_power = 2
-	active_power_usage = 20000 //20kW, aporopriate for machine that keeps massive cross-Zlevel wireless network operational.
+	active_power_usage = 20000 //20kW, appropriate for machine that keeps massive cross-Zlevel wireless network operational.
 	idle_power_usage = 100
 	icon_state = "ntnet"
 	icon = 'icons/obj/machines/telecomms.dmi'

--- a/code/modules/modular_computers/_description.dm
+++ b/code/modules/modular_computers/_description.dm
@@ -4,7 +4,7 @@ Program-based computers, designed to replace computer3 project and eventually mo
 
 1. Basic information
 Program based computers will allow you to do multiple things from single computer. Each computer will have programs, with more being downloadable from NTNet (stationwide network with wireless coverage)
-if user has apropriate ID card access. It will be possible to hack the computer by using an emag on it - the emag will have to be completely new and will be consumed on use, but it will
+if user has appropriate ID card access. It will be possible to hack the computer by using an emag on it - the emag will have to be completely new and will be consumed on use, but it will
 lift ALL locks on ALL installed programs, and allow download of programs even if your ID doesn't have access to them. Computers will have hard drives that can store files.
 Files can be programs (datum/computer_file/program/ subtype) or data files (datum/computer_file/data/ subtypes). Program for sending files will be available that will allow transfer via NTNet.
 NTNet coverage will be limited to station's Z level, but better network card (=more expensive and higher power use) will allow usage everywhere. Hard drives will have limited capacity for files

--- a/code/modules/modular_computers/computers/modular_computer/hardware.dm
+++ b/code/modules/modular_computers/computers/modular_computer/hardware.dm
@@ -1,4 +1,4 @@
-// Attempts to install the hardware into apropriate slot.
+// Attempts to install the hardware into appropriate slot.
 /obj/item/modular_computer/proc/try_install_component(var/mob/living/user, var/obj/item/weapon/computer_hardware/H, var/found = 0)
 	// "USB" flash drive.
 	if(istype(H, /obj/item/weapon/computer_hardware/hard_drive/portable))

--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -75,7 +75,7 @@ var/warrant_uid = 0
 		return
 	var/obj/item/weapon/card/id/I = user.GetIdCard()
 	if(!istype(I) || !I.registered_name || !(access_armory in I.access) || issilicon(user))
-		to_chat(user, "Authentication error: Unable to locate ID with apropriate access to allow this operation.")
+		to_chat(user, "Authentication error: Unable to locate ID with appropriate access to allow this operation.")
 		return
 
 	if(href_list["addwarrant"])

--- a/code/modules/supermatter/setup_supermatter.dm
+++ b/code/modules/supermatter/setup_supermatter.dm
@@ -233,7 +233,7 @@
 				P.mode = ATM_CO2
 				break
 			else
-				log_and_message_admins("## WARNING: Inapropriate filter coolant type set at [x] [y] [z]!")
+				log_and_message_admins("## WARNING: Inappropriate filter coolant type set at [x] [y] [z]!")
 				return SETUP_WARNING
 		F.rebuild_filtering_list()
 


### PR DESCRIPTION
Changes multiple misspellings of the word "appropriate" in messages sent to admins and players as seen (partially) here https://github.com/Aurorastation/Aurora.3/issues/3150  as well as some commented out explanatory text in the files on the off chance that it's useful (it was easy to change).