### PR TITLE
Fixes #3333

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -35,6 +35,9 @@
 	if (eyeobj)
 		return eyeobj.zMove(direction)
 
+	if (istype(src.loc,/obj/mecha))
+		return FALSE
+
 	// Check if we can actually travel a Z-level.
 	if (!can_ztravel(direction))
 		to_chat(src, "<span class='warning'>You lack means of travel in that direction.</span>")


### PR DESCRIPTION
Should stop people from teleporting out of exosuits using the multi z movement verbs.
