### PR TITLE
Closet & use_check() tweaks

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1122,27 +1122,40 @@ var/list/wall_items = typecacheof(list(
 // Checks if user can use this object. Set use_flags to customize what checks are done.
 // Returns 0 if they can use it, a value representing why they can't if not.
 // Flags are in `code/__defines/misc.dm`
-/atom/proc/use_check(mob/user, use_flags = 0)
+/atom/proc/use_check(mob/user, use_flags = 0, show_messages = FALSE)
 	. = 0
 	if (NOT_FLAG(USE_ALLOW_NONLIVING) && !isliving(user))
+		// No message for ghosts.
 		return USE_FAIL_NONLIVING
 
 	if (NOT_FLAG(USE_ALLOW_NON_ADJACENT) && !Adjacent(user))
+		if (show_messages)
+			user << "<span class='notice'>You're too far away from [src] to do that.</span>"
 		return USE_FAIL_NON_ADJACENT
 
 	if (NOT_FLAG(USE_ALLOW_DEAD) && user.stat == DEAD)
+		if (show_messages)
+			user << "<span class='notice'>How do you expect to do that when you're dead?</span>"
 		return USE_FAIL_DEAD
 
 	if (NOT_FLAG(USE_ALLOW_INCAPACITATED) && (user.incapacitated()))
+		if (show_messages)
+			user << "<span class='notice'>You cannot do that in your current state.</span>"
 		return USE_FAIL_INCAPACITATED
 
 	if (NOT_FLAG(USE_ALLOW_NON_ADV_TOOL_USR) && !user.IsAdvancedToolUser())
+		if (show_messages)
+			user << "<span class='notice'>You don't know how to operate [src].</span>"
 		return USE_FAIL_NON_ADV_TOOL_USR
 
 	if (HAS_FLAG(USE_DISALLOW_SILICONS) && issilicon(user))
+		if (show_messages)
+			user << "<span class='notice'>How do you propose doing that without hands?</span>"
 		return USE_FAIL_IS_SILICON
 
 	if (HAS_FLAG(USE_FORCE_SRC_IN_USER) && !(src in user))
+		if (show_messages)
+			user << "<span class='notice'>You need to be holding [src] to do that.</span>"
 		return USE_FAIL_NOT_IN_USER
 
 #undef NOT_FLAG

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -20,8 +20,7 @@
 	var/const/ROOM_ERR_TOOLARGE = -2
 
 /obj/item/blueprints/attack_self(mob/user as mob)
-	if (use_check(user))
-		user << "This stack of blue paper means nothing to you."
+	if (use_check(user, USE_DISALLOW_SILICONS))
 		return
 	add_fingerprint(user)
 	interact()

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -987,7 +987,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		user << "<span class='notice'>[src] does not have a pen slot.</span>"
 		return
 
-	switch (use_check(user, USE_DISALLOW_SILICONS))
+	switch (use_check(user, USE_DISALLOW_SILICONS, show_messages = FALSE))
 		if (USE_FAIL_NON_ADJACENT)
 			user << "<span class='notice'>You are too far away from [src].</span>"
 

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -81,7 +81,6 @@
 	set name = "Print Data"
 
 	if(use_check(usr))
-		usr << "No."
 		return
 
 	var/scan_data = ""

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -222,14 +222,24 @@
 			return 0
 		if(iswelder(W))
 			var/obj/item/weapon/weldingtool/WT = W
+			user.visible_message(
+				"<span class='warning'>[user] begins cutting [src] apart.</span>",
+				"<span class='notice'>You begin welding [src] apart.</span>",
+				"You hear a welding torch on metal."
+			)
+			playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
+			if (!do_after(user, 2 SECONDS, act_target = src, extra_checks = CALLBACK(src, .proc/is_open)))
+				return
 			if(!WT.remove_fuel(0,user))
 				if(WT.isOn())
 					user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 					return
 			else
 				new /obj/item/stack/material/steel(src.loc)
-				for(var/mob/M in viewers(src))
-					M.show_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", 3, "You hear welding.", 2)
+				user.visible_message(
+					"<span class='notice'>[src] has been cut apart by [user] with [WT].",
+					"<span class='notice'>You cut apart [src] with [WT].</span>"
+				)
 				qdel(src)
 				return
 		if(istype(W, /obj/item/weapon/storage/laundry_basket) && W.contents.len)
@@ -237,9 +247,11 @@
 			var/turf/T = get_turf(src)
 			for(var/obj/item/I in LB.contents)
 				LB.remove_from_storage(I, T)
-			user.visible_message("<span class='notice'>[user] empties \the [LB] into \the [src].</span>", \
-								 "<span class='notice'>You empty \the [LB] into \the [src].</span>", \
-								 "<span class='notice'>You hear rustling of clothes.</span>")
+			user.visible_message(
+				"<span class='notice'>[user] empties \the [LB] into \the [src].</span>",
+				"<span class='notice'>You empty \the [LB] into \the [src].</span>",
+				"<span class='notice'>You hear rustling of clothes.</span>"
+			)
 			return
 		if(!dropsafety(W))
 			return
@@ -250,6 +262,14 @@
 		return
 	else if(iswelder(W))
 		var/obj/item/weapon/weldingtool/WT = W
+		user.visible_message(
+			"<span class='warning'>[user] begins welding [src] [welded ? "open" : "shut"].</span>",
+			"<span class='notice'>You begin welding [src] [welded ? "open" : "shut"].</span>",
+			"You hear a welding torch on metal."
+		)
+		playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
+		if (!do_after(user, 2 SECONDS, act_target = src, extra_checks = CALLBACK(src, .proc/is_closed)))
+			return
 		if(!WT.remove_fuel(0,user))
 			if(!WT.isOn())
 				return
@@ -258,11 +278,21 @@
 				return
 		src.welded = !src.welded
 		src.update_icon()
-		for(var/mob/M in viewers(src))
-			M.show_message("<span class='warning'>[src] has been [welded?"welded shut":"unwelded"] by [user.name].</span>", 3, "You hear welding.", 2)
+		user.visible_message(
+			"<span class='warning'>[src] has been [welded ? "welded shut" : "unwelded"] by [user].</span>",
+			"<span class='notice'>You weld [src] [!welded ? "open" : "shut"].</span>"
+		)
 	else
 		src.attack_hand(user)
 	return
+
+
+// helper procs for callbacks
+/obj/structure/closet/proc/is_closed()
+	. = !opened
+
+/obj/structure/closet/proc/is_open()
+	. = opened
 
 /obj/structure/closet/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 	if(istype(O, /obj/screen))	//fix for HUD elements making their way into the world	-Pete
@@ -369,22 +399,36 @@
 	escapee.next_move = world.time + 100
 	escapee.last_special = world.time + 100
 	escapee << "<span class='warning'>You lean on the back of \the [src] and start pushing the door open. (this will take about [breakout_time] minutes)</span>"
-	visible_message("<span class='danger'>The [src] begins to shake violently!</span>")
+	visible_message("<span class='danger'>\The [src] begins to shake violently!</span>")
+
+	var/time = 6 * breakout_time * 2
+
+	var/datum/progressbar/bar
+	if (escapee.client && escapee.client.prefs.parallax_togs & PROGRESS_BARS)
+		bar = new(escapee, time, src)
 
 	breakout = 1
-	for(var/i in 1 to (6*breakout_time * 2)) //minutes * 6 * 5seconds * 2
+	for(var/i in 1 to time) //minutes * 6 * 5seconds * 2
 		playsound(src.loc, 'sound/effects/grillehit.ogg', 100, 1)
 		animate_shake()
 
-		if(!do_after(escapee, 50)) //5 seconds
+		if (bar)
+			bar.update(i)
+
+		if(!do_after(escapee, 50, display_progress = FALSE)) //5 seconds
 			breakout = 0
+			qdel(bar)
 			return
+
 		if(!escapee || escapee.stat || escapee.loc != src)
 			breakout = 0
+			qdel(bar)
 			return //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
+
 		//Perform the same set of checks as above for weld and lock status to determine if there is even still a point in 'resisting'...
 		if(!req_breakout())
 			breakout = 0
+			qdel(bar)
 			return
 
 	//Well then break it!
@@ -394,6 +438,7 @@
 	playsound(src.loc, 'sound/effects/grillehit.ogg', 100, 1)
 	break_open()
 	animate_shake()
+	qdel(bar)
 
 /obj/structure/closet/proc/break_open()
 	welded = 0

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -224,7 +224,7 @@
 			var/obj/item/weapon/weldingtool/WT = W
 			user.visible_message(
 				"<span class='warning'>[user] begins cutting [src] apart.</span>",
-				"<span class='notice'>You begin welding [src] apart.</span>",
+				"<span class='notice'>You begin cutting [src] apart.</span>",
 				"You hear a welding torch on metal."
 			)
 			playsound(loc, 'sound/items/Welder2.ogg', 50, 1)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -237,7 +237,7 @@
 			else
 				new /obj/item/stack/material/steel(src.loc)
 				user.visible_message(
-					"<span class='notice'>[src] has been cut apart by [user] with [WT].",
+					"<span class='notice'>[src] has been cut apart by [user] with [WT].</span>",
 					"<span class='notice'>You cut apart [src] with [WT].</span>"
 				)
 				qdel(src)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1085,7 +1085,6 @@ var/list/total_extraction_beacons = list()
 
 /obj/item/weapon/oremagnet/attack_self(mob/user)
 	if (use_check(user))
-		to_chat(user, "<span class='warning'>You cannot do that right now.</span>")
 		return
 
 	toggle_on(user)

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -28,17 +28,7 @@
 	return // no, bad
 
 /obj/effect/hoist_hook/MouseDrop_T(atom/movable/AM,mob/user)
-	var/canuse = use_check(user, USE_DISALLOW_SILICONS)
-	if(canuse) // to cut it down from 4+ return statements to just 1
-		switch(canuse)
-			if(USE_FAIL_INCAPACITATED)
-				to_chat(user, span("warning", "You can't do that while incapacitated!"))
-			if(USE_FAIL_NONLIVING)
-				to_chat(user, span("warning", "You can't do that while dead."))
-			if(USE_FAIL_IS_SILICON)
-				to_chat(user, span("notice", "You need hands for that."))
-			if(USE_FAIL_NON_ADV_TOOL_USR)
-				to_chat(user, span("warning", "You stare cluelessly at \the [src]."))
+	if (use_check(user, USE_DISALLOW_SILICONS))
 		return
 
 	if (!AM.simulated || AM.anchored)

--- a/html/changelogs/lohikar-closets.yml
+++ b/html/changelogs/lohikar-closets.yml
@@ -1,0 +1,6 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - balance: "Welding and disassembling lockers now takes 2 seconds instead of being instantaneous."
+  - rscadd: "Escaping welded lockers now shows a progress bar to the escapee if Progress Bars are enabled in your global preferences."
+  - spellcheck: "Made some sanity check messages more clear as to why an object cannot be interacted with."


### PR DESCRIPTION
changes:
- `use_check()` will now show failure messages to the affected mob by default. It still returns the failure reason & permits disabling of messages via. the `show_messages` parameter.
- Lockers now take 2 seconds to weld or disassemble.
- A progress bar is now shown to mobs with the progress bars pref enabled while attempting to break out of welded lockers.

![rtj7yp](https://user-images.githubusercontent.com/7097800/29685150-2c352208-88da-11e7-9d3b-7e5d3b9acb8c.gif)
