### PR TITLE
Job-Specific antag uplink item framework.

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -283,6 +283,7 @@
 #include "code\datums\uplink\highly visible and dangerous weapons.dm"
 #include "code\datums\uplink\implants.dm"
 #include "code\datums\uplink\medical.dm"
+#include "code\datums\uplink\specialty.dm"
 #include "code\datums\uplink\stealth and camouflage items.dm"
 #include "code\datums\uplink\stealthy and inconspicuous weapons.dm"
 #include "code\datums\uplink\telecrystals.dm"

--- a/code/datums/uplink/specialty.dm
+++ b/code/datums/uplink/specialty.dm
@@ -49,7 +49,8 @@ Quick and easy list of all the occupations for farther expansion and addition.
 	item_cost = 6
 	path = /obj/item/weapon/gun/energy/crossbow
 	antag_job = "assistant"
-/*
+*/
+
 
 
 

--- a/code/datums/uplink/specialty.dm
+++ b/code/datums/uplink/specialty.dm
@@ -1,0 +1,56 @@
+/*
+Quick and easy list of all the occupations for farther expansion and addition.
+
+/datum/job/assistant
+/datum/job/captain
+/datum/job/hop
+/datum/job/bartender
+/datum/job/chef
+/datum/job/hydro
+/datum/job/qm
+/datum/job/cargo_tech
+/datum/job/mining
+/datum/job/janitor
+/datum/job/librarian
+/datum/job/lawyer
+/datum/job/chaplain
+/datum/job/chief_engineer
+/datum/job/engineer
+/datum/job/atmos
+/datum/job/cmo
+/datum/job/doctor
+/datum/job/chemist
+/datum/job/psychiatrist
+/datum/job/paramedic
+/datum/job/rd
+/datum/job/scientist
+/datum/job/xenobiologist
+/datum/job/roboticist
+/datum/job/geneticist
+/datum/job/hos
+/datum/job/warden
+/datum/job/detective
+/datum/job/forensics
+/datum/job/officer
+/datum/job/ai
+/datum/job/cyborg
+/datum/job/intern_sec
+/datum/job/intern_med
+/datum/job/intern_sci
+/datum/job/intern_eng
+*/
+
+/datum/uplink_item/item/specialty
+	category = /datum/uplink_category/specialty
+
+/* //An example of how to set it up.
+/datum/uplink_item/item/specialty/crossbow
+	name = "Eneree Crossbow"
+	item_cost = 6
+	path = /obj/item/weapon/gun/energy/crossbow
+	antag_job = "assistant"
+/*
+
+
+
+

--- a/code/datums/uplink/uplink_categories.dm
+++ b/code/datums/uplink/uplink_categories.dm
@@ -47,3 +47,8 @@
 
 /datum/uplink_category/telecrystals
 	name = "Telecrystals"
+
+/datum/uplink_category/specialty //snowflake antag items - a brave new frontier!
+	name = "Specialised Items"
+
+

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -86,11 +86,8 @@ var/datum/uplink/uplink = new()
 		if(antag.is_antagonist(U.uplink_owner))
 			return 1
 
-	if (antag_job = U.uplink_owner.assigned_role) //for a quick and easy list of the assigned_role, look in specialty.dm
+	if (antag_job == U.uplink_owner.assigned_role) //for a quick and easy list of the assigned_role, look in specialty.dm
 		return 1
-	else
-		return 0
-
 	return 0
 
 /datum/uplink_item/proc/cost(var/telecrystals)

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -31,6 +31,7 @@ var/datum/uplink/uplink = new()
 	var/item_cost = 0
 	var/datum/uplink_category/category		// Item category
 	var/list/datum/antagonist/antag_roles	// Antag roles this item is displayed to. If empty, display to all.
+	var/list/datum/antagonist/antag_job     // Antag job this item is displayed to, if empty, display to all.
 
 /datum/uplink_item/item
 	var/path = null
@@ -73,7 +74,7 @@ var/datum/uplink/uplink = new()
 
 /datum/uplink_item/proc/can_view(obj/item/device/uplink/U)
 	// Making the assumption that if no uplink was supplied, then we don't care about antag roles
-	if(!U || !antag_roles.len)
+	if(!U || (!antag_roles.len && !antag_job))
 		return 1
 
 	// With no owner, there's no need to check antag status.
@@ -84,6 +85,12 @@ var/datum/uplink/uplink = new()
 		var/datum/antagonist/antag = all_antag_types[antag_role]
 		if(antag.is_antagonist(U.uplink_owner))
 			return 1
+
+	if (antag_job = U.uplink_owner.assigned_role) //for a quick and easy list of the assigned_role, look in specialty.dm
+		return 1
+	else
+		return 0
+
 	return 0
 
 /datum/uplink_item/proc/cost(var/telecrystals)


### PR DESCRIPTION
This is the basic framework for as the title suggests: Job specific antag items. it also adds a "Specialist" category, just for ease of finding said items once they're added.

currently none are implemented, though it'll be relatively easy to do so in the future - Once I get ideas for them.

The whole idea for this is "Antag items that only a trained person of X profession would be able to use effectively"

Whether it be viro samples for a virologist, a bluespace toolbox for an assistant, or other gimmicky items.