### PR TITLE
Reduce SSgarbage's tickrate

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -3,7 +3,7 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 /datum/controller/subsystem/garbage_collector
 	name = "Garbage"
 	priority = SS_PRIORITY_GARBAGE
-	wait = 5
+	wait = 2 SECONDS
 	flags = SS_FIRE_IN_LOBBY|SS_POST_FIRE_TIMING|SS_BACKGROUND|SS_NO_INIT
 
 	var/collection_timeout = 3000// deciseconds to wait to let running procs finish before we just say fuck it and force del() the object


### PR DESCRIPTION
Reduces the garbage collector's tick rate to 2 seconds vs. 0.5 seconds - it doesn't need to tick this fast and this should in theory reduce GC lag.