### PR TITLE
Allow loadout species whitelists to use lists

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -60,15 +60,13 @@ var/list/gear_datums = list()
 	var/mob/preference_mob = preference_mob()
 	for(var/gear_name in gear_datums)
 		var/datum/gear/G = gear_datums[gear_name]
+		if(max_cost && G.cost > max_cost)
+			continue
 		if(G.whitelisted && preference_mob)
 			for(var/species in G.whitelisted)
 				if(is_alien_whitelisted(preference_mob, species))
 					. += gear_name
 					break
-
-		if(max_cost && G.cost > max_cost)
-			continue
-		. += gear_name
 
 /datum/category_item/player_setup_item/loadout/sanitize_character(var/sql_load = 0)
 	if (sql_load)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -67,6 +67,8 @@ var/list/gear_datums = list()
 				if(is_alien_whitelisted(preference_mob, species))
 					. += gear_name
 					break
+		else
+			+= gear_name
 
 /datum/category_item/player_setup_item/loadout/sanitize_character(var/sql_load = 0)
 	if (sql_load)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -60,8 +60,14 @@ var/list/gear_datums = list()
 	var/mob/preference_mob = preference_mob()
 	for(var/gear_name in gear_datums)
 		var/datum/gear/G = gear_datums[gear_name]
-
-		if(G.whitelisted && !is_alien_whitelisted(preference_mob, all_species[G.whitelisted]))
+		var/okay = 1
+		if(G.whitelisted && preference_mob)
+			okay = 0
+			for(var/species in G.whitelisted)
+				if(is_alien_whitelisted(preference_mob, species))
+					okay = 1
+					break
+		if(!okay)
 			continue
 		if(max_cost && G.cost > max_cost)
 			continue

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -60,15 +60,12 @@ var/list/gear_datums = list()
 	var/mob/preference_mob = preference_mob()
 	for(var/gear_name in gear_datums)
 		var/datum/gear/G = gear_datums[gear_name]
-		var/okay = 1
 		if(G.whitelisted && preference_mob)
-			okay = 0
 			for(var/species in G.whitelisted)
 				if(is_alien_whitelisted(preference_mob, species))
-					okay = 1
+					. += gear_name
 					break
-		if(!okay)
-			continue
+
 		if(max_cost && G.cost > max_cost)
 			continue
 		. += gear_name

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -68,7 +68,7 @@ var/list/gear_datums = list()
 					. += gear_name
 					break
 		else
-			+= gear_name
+			.+= gear_name
 
 /datum/category_item/player_setup_item/loadout/sanitize_character(var/sql_load = 0)
 	if (sql_load)

--- a/code/modules/client/preference_setup/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_shoes.dm
@@ -5,25 +5,13 @@
 	slot = slot_shoes
 	sort_category = "Shoes and Footwear"
 
-/datum/gear/shoes/toeless
-	display_name = "toe-less jackboots"
-	path = /obj/item/clothing/shoes/jackboots/unathi
-
 /datum/gear/shoes/workboots
 	display_name = "workboots"
 	path = /obj/item/clothing/shoes/workboots
 
-/datum/gear/shoes/workboots_toeless
-	display_name = "/obj/item/clothing/shoes/workboots/toeless"
-	path = /obj/item/clothing/shoes/workboots/toeless
-
 /datum/gear/shoes/sandals
 	display_name = "sandals"
 	path = /obj/item/clothing/shoes/sandal
-
-/datum/gear/shoes/footwraps
-	display_name = "cloth footwraps"
-	path = /obj/item/clothing/shoes/footwraps
 
 /datum/gear/shoes/color
 	display_name = "shoe selection"

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -139,11 +139,6 @@
 	path = /obj/item/clothing/under/rank/security/navyblue
 	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Security Cadet")
 
-/datum/gear/uniform/gearharness
-	display_name = "gear harness"
-	path = /obj/item/clothing/under/gearharness
-	cost = 2
-
 /datum/gear/uniform/pants
 	display_name = "pants selection"
 	path = /obj/item/clothing/under/pants

--- a/code/modules/client/preference_setup/loadout/loadout_xeno.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno.dm
@@ -4,27 +4,27 @@
 	display_name = "hide mantle (Unathi)"
 	path = /obj/item/clothing/suit/unathi/mantle
 	cost = 1
-	whitelisted = list ("Unathi")
+	whitelisted = list("Unathi")
 	sort_category = "Xenowear"
 
 /datum/gear/suit/unathi_robe
 	display_name = "roughspun robe (Unathi)"
 	path = /obj/item/clothing/suit/unathi/robe
 	cost = 1
-	whitelisted = list ("Unathi")
+	whitelisted = list("Unathi")
 	sort_category = "Xenowear"
 
 /datum/gear/suit/robe_coat
 	display_name = "tzirzi robe (Unathi)"
 	path = /obj/item/clothing/suit/unathi/robe/robe_coat
 	cost = 1
-	whitelisted = list ("Unathi")
+	whitelisted = list("Unathi")
 	sort_category = "Xenowear"
 
 /datum/gear/gloves/unathi
 	display_name = "gloves selection (Unathi)"
 	path = /obj/item/clothing/gloves/black/unathi
-	whitelisted = list ("Unathi")
+	whitelisted = list("Unathi")
 	sort_category = "Xenowear"
 
 /datum/gear/gloves/unathi/New()
@@ -46,7 +46,7 @@
 	display_name = "headtail-wear, female (Skrell)"
 	path = /obj/item/clothing/ears/skrell/chain
 	sort_category = "Xenowear"
-	whitelisted = list ("Skrell")
+	whitelisted = list("Skrell")
 
 /datum/gear/ears/f_skrell/New()
 	..()
@@ -64,7 +64,7 @@
 	display_name = "headtail-wear, male (Skrell)"
 	path = /obj/item/clothing/ears/skrell/band
 	sort_category = "Xenowear"
-	whitelisted = list ("Skrell")
+	whitelisted = list("Skrell")
 
 /datum/gear/ears/m_skrell/New()
 	..()
@@ -85,21 +85,21 @@
 	display_name = "vaurca blindfold (Vaurca)"
 	path = /obj/item/clothing/glasses/sunglasses/blinders
 	cost = 2
-	whitelisted = list ("Vaurca Worker")
+	whitelisted = list("Vaurca Worker")
 	sort_category = "Xenowear"
 
 /datum/gear/mask/vaurca
 	display_name = "mandible garment (Vaurca)"
 	path = /obj/item/clothing/mask/breath/vaurca
 	cost = 1
-	whitelisted = list ("Vaurca Worker")
+	whitelisted = list("Vaurca Worker")
 	sort_category = "Xenowear"
 
 /datum/gear/cape
 	display_name = "tunnel cloak (Vaurca)"
 	path = /obj/item/weapon/storage/backpack/cloak
 	cost = 1
-	whitelisted = list ("Vaurca Worker")
+	whitelisted = list("Vaurca Worker")
 	sort_category = "Xenowear"
 
 //tajara items
@@ -107,7 +107,7 @@
 /datum/gear/gloves/tajara
 	display_name = "gloves selection (Tajara)"
 	path = /obj/item/clothing/gloves/black/tajara
-	whitelisted = list ("Tajara")
+	whitelisted = list("Tajara")
 	sort_category = "Xenowear"
 
 /datum/gear/gloves/tajara/New()
@@ -126,13 +126,13 @@
 /datum/gear/suit/tajara_coat
 	display_name = "tajaran naval coat (Tajara)"
 	path = /obj/item/clothing/suit/storage/tajaran
-	whitelisted = list ("Tajara")
+	whitelisted = list("Tajara")
 	sort_category = "Xenowear"
 
 /datum/gear/suit/tajaran_labcoat
 	display_name = "PRA medical coat (Tajara)"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/tajaran
-	whitelisted = list ("Tajara")
+	whitelisted = list("Tajara")
 	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Geneticist", "Paramedic", "Nursing Intern")
 	sort_category = "Xenowear"
 
@@ -142,22 +142,22 @@
 	display_name = "gear harness"
 	path = /obj/item/clothing/under/gearharness
 	sort_category = "Xenowear"
-	whitelisted = list ("Vaurca Worker", "Diona", "Baseline Frame")
+	whitelisted = list("Vaurca Worker", "Diona", "Baseline Frame")
 
 /datum/gear/shoes/footwraps
 	display_name = "cloth footwraps"
 	path = /obj/item/clothing/shoes/footwraps
 	sort_category = "Xenowear"
-	whitelisted = list ("Vaurca Worker", "Unathi", "Tajara")
+	whitelisted = list("Vaurca Worker", "Unathi", "Tajara")
 
 /datum/gear/shoes/toeless
 	display_name = "toe-less jackboots"
 	path = /obj/item/clothing/shoes/jackboots/unathi
 	sort_category = "Xenowear"
-	whitelisted = list ("Vaurca Worker", "Unathi", "Tajara")
+	whitelisted = list("Vaurca Worker", "Unathi", "Tajara")
 
 /datum/gear/shoes/workboots_toeless
 	display_name = "toeless workboots"
 	path = /obj/item/clothing/shoes/workboots/toeless
 	sort_category = "Xenowear"
-	whitelisted = list ("Vaurca Worker", "Unathi", "Tajara")
+	whitelisted = list("Vaurca Worker", "Unathi", "Tajara")

--- a/code/modules/client/preference_setup/loadout/loadout_xeno.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno.dm
@@ -4,27 +4,27 @@
 	display_name = "hide mantle (Unathi)"
 	path = /obj/item/clothing/suit/unathi/mantle
 	cost = 1
-	whitelisted = "Unathi"
+	whitelisted = list ("Unathi")
 	sort_category = "Xenowear"
 
 /datum/gear/suit/unathi_robe
 	display_name = "roughspun robe (Unathi)"
 	path = /obj/item/clothing/suit/unathi/robe
 	cost = 1
-	whitelisted = "Unathi"
+	whitelisted = list ("Unathi")
 	sort_category = "Xenowear"
 
 /datum/gear/suit/robe_coat
 	display_name = "tzirzi robe (Unathi)"
 	path = /obj/item/clothing/suit/unathi/robe/robe_coat
 	cost = 1
-	whitelisted = "Unathi"
+	whitelisted = list ("Unathi")
 	sort_category = "Xenowear"
-	
+
 /datum/gear/gloves/unathi
 	display_name = "gloves selection (Unathi)"
 	path = /obj/item/clothing/gloves/black/unathi
-	whitelisted = "Unathi"
+	whitelisted = list ("Unathi")
 	sort_category = "Xenowear"
 
 /datum/gear/gloves/unathi/New()
@@ -46,7 +46,7 @@
 	display_name = "headtail-wear, female (Skrell)"
 	path = /obj/item/clothing/ears/skrell/chain
 	sort_category = "Xenowear"
-	whitelisted = "Skrell"
+	whitelisted = list ("Skrell")
 
 /datum/gear/ears/f_skrell/New()
 	..()
@@ -64,7 +64,7 @@
 	display_name = "headtail-wear, male (Skrell)"
 	path = /obj/item/clothing/ears/skrell/band
 	sort_category = "Xenowear"
-	whitelisted = "Skrell"
+	whitelisted = list ("Skrell")
 
 /datum/gear/ears/m_skrell/New()
 	..()
@@ -85,21 +85,21 @@
 	display_name = "vaurca blindfold (Vaurca)"
 	path = /obj/item/clothing/glasses/sunglasses/blinders
 	cost = 2
-	whitelisted = "Vaurca Worker"
+	whitelisted = list ("Vaurca Worker")
 	sort_category = "Xenowear"
 
 /datum/gear/mask/vaurca
 	display_name = "mandible garment (Vaurca)"
 	path = /obj/item/clothing/mask/breath/vaurca
 	cost = 1
-	whitelisted = "Vaurca Worker"
+	whitelisted = list ("Vaurca Worker")
 	sort_category = "Xenowear"
 
 /datum/gear/cape
 	display_name = "tunnel cloak (Vaurca)"
 	path = /obj/item/weapon/storage/backpack/cloak
 	cost = 1
-	whitelisted = "Vaurca Worker"
+	whitelisted = list ("Vaurca Worker")
 	sort_category = "Xenowear"
 
 //tajara items
@@ -107,7 +107,7 @@
 /datum/gear/gloves/tajara
 	display_name = "gloves selection (Tajara)"
 	path = /obj/item/clothing/gloves/black/tajara
-	whitelisted = "Tajara"
+	whitelisted = list ("Tajara")
 	sort_category = "Xenowear"
 
 /datum/gear/gloves/tajara/New()
@@ -126,12 +126,38 @@
 /datum/gear/suit/tajara_coat
 	display_name = "tajaran naval coat (Tajara)"
 	path = /obj/item/clothing/suit/storage/tajaran
-	whitelisted = "Tajara"
+	whitelisted = list ("Tajara")
 	sort_category = "Xenowear"
-	
+
 /datum/gear/suit/tajaran_labcoat
 	display_name = "PRA medical coat (Tajara)"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/tajaran
-	whitelisted = "Tajara"
+	whitelisted = list ("Tajara")
 	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Geneticist", "Paramedic", "Nursing Intern")
 	sort_category = "Xenowear"
+
+//other things
+
+/datum/gear/uniform/gearharness
+	display_name = "gear harness"
+	path = /obj/item/clothing/under/gearharness
+	sort_category = "Xenowear"
+	whitelisted = list ("Vaurca Worker", "Diona", "Baseline Frame")
+
+/datum/gear/shoes/footwraps
+	display_name = "cloth footwraps"
+	path = /obj/item/clothing/shoes/footwraps
+	sort_category = "Xenowear"
+	whitelisted = list ("Vaurca Worker", "Unathi", "Tajara")
+
+/datum/gear/shoes/toeless
+	display_name = "toe-less jackboots"
+	path = /obj/item/clothing/shoes/jackboots/unathi
+	sort_category = "Xenowear"
+	whitelisted = list ("Vaurca Worker", "Unathi", "Tajara")
+
+/datum/gear/shoes/workboots_toeless
+	display_name = "toeless workboots"
+	path = /obj/item/clothing/shoes/workboots/toeless
+	sort_category = "Xenowear"
+	whitelisted = list ("Vaurca Worker", "Unathi", "Tajara")


### PR DESCRIPTION
With this change, ported from baystation, whitelist loadouts can use lists now, so, you can have one xeno item that is allowed to two different species, like the gear harness.
