### PR TITLE
Fix openturf starlight

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -275,6 +275,8 @@ var/list/gamemode_cache = list()
 
 	var/show_game_type_odd = 1 // If the check gamemode probability verb is enabled or not
 
+	var/openturf_starlight_permitted = FALSE
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -740,6 +742,9 @@ var/list/gamemode_cache = list()
 				if("starlight")
 					value = text2num(value)
 					config.starlight = value >= 0 ? value : 0
+
+				if("openturf_starlight")
+					openturf_starlight_permitted = TRUE
 
 				if("ert_species")
 					config.ert_species = text2list(value, ";")

--- a/code/controllers/subsystems/openturf.dm
+++ b/code/controllers/subsystems/openturf.dm
@@ -77,12 +77,12 @@
 		admin_notice("<span class='danger'>Openturf setup completed in [(t - timeofday)/10] seconds!</span>", R_DEBUG)
 
 		SSlighting.fire(FALSE, TRUE)
-		admin_notice("<span class='danger'>Secondary lighting flush completed in [(REALTIMEOFDAY - t)/10] seconds!")
+		admin_notice("<span class='danger'>Secondary lighting flush completed in [(REALTIMEOFDAY - t)/10] seconds!</span>", R_DEBUG)
 
 		t = REALTIMEOFDAY
 
 		fire(FALSE, TRUE)	// Fire /again/ to flush updates caused by the above.
-		admin_notice("<span class='danger'>Secondary openturf flush completed in [(REALTIMEOFDAY - t)/10] seconds!")
+		admin_notice("<span class='danger'>Secondary openturf flush completed in [(REALTIMEOFDAY - t)/10] seconds!</span>", R_DEBUG)
 
 	..()
 

--- a/code/controllers/subsystems/openturf.dm
+++ b/code/controllers/subsystems/openturf.dm
@@ -74,15 +74,15 @@
 	fire(FALSE, TRUE)
 	if (starlight_enabled)
 		var/t = REALTIMEOFDAY
-		admin_notice("<span class='danger'>Openturf setup completed in [(t - timeofday)/10] seconds!</span>", R_DEBUG)
+		admin_notice("<span class='danger'>[src] setup completed in [(t - timeofday)/10] seconds!</span>", R_DEBUG)
 
 		SSlighting.fire(FALSE, TRUE)
-		admin_notice("<span class='danger'>Secondary lighting flush completed in [(REALTIMEOFDAY - t)/10] seconds!</span>", R_DEBUG)
+		admin_notice("<span class='danger'>Secondary [SSlighting] flush completed in [(REALTIMEOFDAY - t)/10] seconds!</span>", R_DEBUG)
 
 		t = REALTIMEOFDAY
 
 		fire(FALSE, TRUE)	// Fire /again/ to flush updates caused by the above.
-		admin_notice("<span class='danger'>Secondary openturf flush completed in [(REALTIMEOFDAY - t)/10] seconds!</span>", R_DEBUG)
+		admin_notice("<span class='danger'>Secondary [src] flush completed in [(REALTIMEOFDAY - t)/10] seconds!</span>", R_DEBUG)
 
 	..()
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -382,6 +382,9 @@ EVENT_CUSTOM_START_MAJOR 80;100
 ## Strength of ambient star light. Set to 0 or less to turn off. A value of 1 is unlikely to have a noticeable effect in most lighting systems.
 STARLIGHT 0
 
+## If defined, starlight applies to open space turfs as well. Causes a significant number of lighting updates at round-start, may increase server's memory usage.
+#OPENTURF_STARLIGHT
+
 ## Chance, in percentage, of the merchant job slot being open at round start
 MERCHANT_CHANCE 20
 


### PR DESCRIPTION
changes:
- Openturf starlight now actually works.
- Openturf starlight is now under its own config option, so it can be toggled separately from starlight.
- OT starlight no longer re-applies to a turf that already has it set.

Seems to use a fair bit of memory unfortunately, as well as adding a good 25 seconds or so to boot time.

Screenshots:
![2017-09-05_12-07-51](https://user-images.githubusercontent.com/7097800/30075698-3409d7c4-923c-11e7-9720-3398d6cf5978.png)
![2017-09-05_12-57-15](https://user-images.githubusercontent.com/7097800/30075704-3859566a-923c-11e7-8c50-af31025ae077.png)
