### PR TITLE
Fix camera lag

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -142,7 +142,17 @@
 		jump_to = locate() in A
 	else if(isturf(A))
 		var/best_dist = INFINITY
-		for(var/obj/machinery/camera/camera in get_area(A))
+		var/check_area = get_area(A)
+
+		if (!check_area)
+			return
+
+		for(var/cc in SSmachinery.all_cameras)
+			var/obj/machinery/camera/camera = cc
+			if(!camera.loc)
+				continue
+			if (camera.loc.loc != check_area)
+				continue
 			if(!camera.can_use())
 				continue
 			if(!can_access_camera(camera))

--- a/html/changelogs/skull132-kill_camera_lag.yml
+++ b/html/changelogs/skull132-kill_camera_lag.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: true
+
+changes:
+  - bugfix: "Cameras will no longer lag the server to death whenever you click to jump to a turf that's outside the station."


### PR DESCRIPTION
Edge case where the turf you click is the outside station area, and it has to crawl that fucking massive area.

Also makes the loop generally more efficient.