### PR TITLE
Fix security consoles' light color

### DIFF
--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/computer.dmi'
 
 	icon_screen = "explosive"
-	light_color = "#a91515"
+	light_color = LIGHT_COLOR_ORANGE
 	req_access = list(access_armory)
 	circuit = /obj/item/weapon/circuitboard/prisoner
 	var/id = 0.0

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -5,7 +5,7 @@
 	desc = "Used to view, edit and maintain security records"
 
 	icon_screen = "security"
-	light_color = "#a91515"
+	light_color = LIGHT_COLOR_ORANGE
 	req_one_access = list(access_security, access_forensics_lockers, access_lawyer)
 	circuit = /obj/item/weapon/circuitboard/secure_data
 	var/obj/item/weapon/card/id/scan = null

--- a/html/changelogs/lohikar-colors.yml
+++ b/html/changelogs/lohikar-colors.yml
@@ -1,0 +1,5 @@
+author: Lohikar
+delete-after: True
+
+changes: 
+  - bugfix: "Orange security consoles have had their red lights swapped out for orange ones. No longer will your orange holoconsole mysteriously glow red."


### PR DESCRIPTION
Orange consoles shouldn't really be emitting red light.