### PR TITLE
Fix space vine lag

### DIFF
--- a/code/controllers/subsystems/plants.dm
+++ b/code/controllers/subsystems/plants.dm
@@ -15,6 +15,7 @@
 	var/list/plant_product_sprites = list() // List of all growth sprites plus number of growth stages.
 
 	var/list/processing = list()
+	var/list/current = list()
 
 /datum/controller/subsystem/plants/New()
 	NEW_SS_GLOBAL(SSplants)
@@ -78,7 +79,12 @@
 		src.plant_product_sprites = SSplants.plant_product_sprites
 
 /datum/controller/subsystem/plants/fire(resumed = 0)
-	var/list/queue = processing
+	if (!resumed)
+		var/list/old = current	// This should be empty, so might as well just reuse it.
+		current = processing
+		processing = old
+
+	var/list/queue = current
 	while (queue.len)
 		var/obj/effect/plant/P = queue[queue.len]
 		queue.len--

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -17,7 +17,7 @@
 		if((locate(/obj/effect/plant) in floor.contents) || (locate(/obj/effect/dead_plant) in floor.contents) )
 			continue
 		if(floor.density)
-			if(!isnull(seed.chems["pacid"]))
+			if(seed.chems["pacid"])
 				addtimer(CALLBACK(floor, /atom/.proc/ex_act, 3), rand(5, 25))
 			continue
 		if(!Adjacent(floor) || !floor.Enter(src))
@@ -82,14 +82,15 @@
 		//spread to 1-3 adjacent turfs depending on yield trait.
 		var/max_spread = between(1, round(seed.get_trait(TRAIT_YIELD)*3/14), 3)
 		
-		addtimer(CALLBACK(src, .proc/do_spread, spread_chance, max_spread), 1)
+		do_spread(spread_chance, max_spread)
 
 	// We shouldn't have spawned if the controller doesn't exist.
 	check_health()
-	if(neighbors.len || health != max_health || buckled_mob)
+	if(neighbors.len || health != max_health || buckled_mob || !is_mature())
 		SSplants.add_plant(src)
 
 /obj/effect/plant/proc/do_spread(spread_chance, max_spread)
+	set waitfor = FALSE
 	for(var/i in 1 to max_spread)
 		if(prob(spread_chance))
 			sleep(rand(3,5))
@@ -105,8 +106,8 @@
 				neighbor.neighbors -= target_turf
 
 /obj/effect/plant/proc/do_move(turf/target, obj/effect/plant/child)
-	child.loc = target
-	child.update_icon()
+	child.forceMove(target)
+	child.queue_icon_update()
 
 /obj/effect/plant/proc/die_off()
 	// Kill off our plant.
@@ -119,6 +120,6 @@
 			neighbor.neighbors |= check_turf
 			SSplants.add_plant(neighbor)
 
-	QDEL_IN(src, 1)
+	qdel(src)
 
 #undef NEIGHBOR_REFRESH_TIME

--- a/html/changelogs/lohikar-plantlag.yml
+++ b/html/changelogs/lohikar-plantlag.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Space vines should no longer create comical amounts of lag."


### PR DESCRIPTION
Fixes lag from plants processing forever instead of obeying the subsystem's tick interval. Also fixes a glitch where plants didn't continue to grow if not mature.