### PR TITLE
Add get_listeners_by_type

### DIFF
--- a/code/controllers/subsystems/global_listener.dm
+++ b/code/controllers/subsystems/global_listener.dm
@@ -25,3 +25,16 @@ var/datum/controller/subsystem/listener/SSlistener
 	
 	if (!LAZYLEN(listeners[L.channel]))
 		listeners -= L.channel
+
+/proc/get_listeners_by_type(id, type)
+	if (!type)
+		CRASH("Cannot get listeners of type null.")
+
+	. = list()
+	var/listener/L
+	var/datum/D
+	for (var/thing in GET_LISTENERS(id))
+		L = thing
+		D = L.target
+		if (istype(D, type) && !QDELETED(D))
+			. += D


### PR DESCRIPTION
Adds a small helper proc that should reduce boilerplate code required for working with global listeners.
Old:
```dm
for (var/thing in GET_LISTENERS("foo"))
    var/listener/L = thing
    var/obj/foo/bar = L.target
    if (istype(bar))
        do_the_thing(bar)
```
New:
```dm
for (var/thing in get_listeners_by_type("foo", /obj/foo))
    var/obj/foo/bar = thing
    do_the_thing(bar)
```