### PR TITLE
Retuning lasers a bit.

### DIFF
--- a/code/modules/projectiles/guns/energy/rifle.dm
+++ b/code/modules/projectiles/guns/energy/rifle.dm
@@ -48,6 +48,7 @@
 	icon_state = "laser"
 	item_state = "laser"
 	fire_sound = 'sound/weapons/Laser.ogg'
+	max_shots = 15
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	projectile_type = /obj/item/projectile/beam
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -25,16 +25,17 @@
 	eyeblur = 2
 
 /obj/item/projectile/beam/pistol
-	damage = 25
+	damage = 30
 
 /obj/item/projectile/beam/midlaser
-	damage = 30
+	damage = 35
 	armor_penetration = 10
 
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	damage = 60
+	armor_penetration = 30
 
 	muzzle_type = /obj/effect/projectile/laser_heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser_heavy/tracer
@@ -44,7 +45,7 @@
 	name = "xray beam"
 	icon_state = "xray"
 	damage = 25
-	armor_penetration = 30
+	armor_penetration = 50
 
 	muzzle_type = /obj/effect/projectile/xray/muzzle
 	tracer_type = /obj/effect/projectile/xray/tracer
@@ -133,7 +134,7 @@
 	name = "sniper beam"
 	icon_state = "xray"
 	damage = 50
-	armor_penetration = 10
+	armor_penetration = 20
 	stun = 3
 	weaken = 3
 	stutter = 3
@@ -155,7 +156,7 @@
 	impact_type = /obj/effect/projectile/stun/impact
 
 /obj/item/projectile/beam/gatlinglaser
-	name = "heavy laser"
+	name = "diffused laser"
 	icon_state = "heavylaser"
 	damage = 10
 	no_attack_log = 1

--- a/html/changelogs/1138hahalaserdude.yml
+++ b/html/changelogs/1138hahalaserdude.yml
@@ -34,6 +34,6 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
- - tweak: "Tentatively buffs laser damage types across the board. Makes them more useful."
- - tweak: "Adds armor penetration to some of the more harder-hitting low-DPS beam weapons. This makes them more useful versus armored opponents."
+ - balance: "Tentatively buffs laser damage types across the board. Makes them more useful."
+ - balance: "Adds armor penetration to some of the more harder-hitting low-DPS beam weapons. This makes them more useful versus armored opponents."
  - tweak: "Also renames gatling laser beam projectiles into 'diffused lasers', from 'heavy lasers.' Trust me, it's science."

--- a/html/changelogs/1138hahalaserdude.yml
+++ b/html/changelogs/1138hahalaserdude.yml
@@ -37,3 +37,4 @@ changes:
  - balance: "Tentatively buffs laser damage types across the board. Makes them more useful."
  - balance: "Adds armor penetration to some of the more harder-hitting low-DPS beam weapons. This makes them more useful versus armored opponents."
  - tweak: "Also renames gatling laser beam projectiles into 'diffused lasers', from 'heavy lasers.' Trust me, it's science."
+ - balance: "Reduces laser rifle maximum capacity to 15 (down from 20.)"

--- a/html/changelogs/1138hahalaserdude.yml
+++ b/html/changelogs/1138hahalaserdude.yml
@@ -5,3 +5,4 @@
  +changes: 
  +  - tweak: "Tentatively buffs laser damage types across the board. Makes them more useful."
  +  - tweak: "Adds armor penetration to some of the more harder-hitting low-DPS beam weapons. This makes them more useful versus armored opponents."
+ +  - tweak: "Also renames gatling laser beam projectiles into 'diffused lasers', from 'heavy lasers.' Trust me, it's science."

--- a/html/changelogs/1138hahalaserdude.yml
+++ b/html/changelogs/1138hahalaserdude.yml
@@ -1,8 +1,39 @@
-		 +author: Scheveningen
- +
- +delete-after: True
- +
- +changes: 
- +  - tweak: "Tentatively buffs laser damage types across the board. Makes them more useful."
- +  - tweak: "Adds armor penetration to some of the more harder-hitting low-DPS beam weapons. This makes them more useful versus armored opponents."
- +  - tweak: "Also renames gatling laser beam projectiles into 'diffused lasers', from 'heavy lasers.' Trust me, it's science."
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Scheveningen
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+ - tweak: "Tentatively buffs laser damage types across the board. Makes them more useful."
+ - tweak: "Adds armor penetration to some of the more harder-hitting low-DPS beam weapons. This makes them more useful versus armored opponents."
+ - tweak: "Also renames gatling laser beam projectiles into 'diffused lasers', from 'heavy lasers.' Trust me, it's science."

--- a/html/changelogs/1138hahalaserdude.yml
+++ b/html/changelogs/1138hahalaserdude.yml
@@ -1,0 +1,7 @@
+		 +author: Scheveningen
+ +
+ +delete-after: True
+ +
+ +changes: 
+ +  - tweak: "Tentatively buffs laser damage types across the board. Makes them more useful."
+ +  - tweak: "Adds armor penetration to some of the more harder-hitting low-DPS beam weapons. This makes them more useful versus armored opponents."

--- a/html/changelogs/1138hahalaserdude.yml
+++ b/html/changelogs/1138hahalaserdude.yml
@@ -34,7 +34,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
- - balance: "Tentatively buffs laser damage types across the board. Makes them more useful."
- - balance: "Adds armor penetration to some of the more harder-hitting low-DPS beam weapons. This makes them more useful versus armored opponents."
- - tweak: "Also renames gatling laser beam projectiles into 'diffused lasers', from 'heavy lasers.' Trust me, it's science."
- - balance: "Reduces laser rifle maximum capacity to 15 (down from 20.)"
+ - balance: "Tentatively buffs laser damage types across the board and makes other adjustments to their overall impact."
+ - balance: "Reduces laser rifle maximum capacity to 15 (down from 20). It is a change to make it less oppressive."


### PR DESCRIPTION
Quick explanation (haha just kidding), for whatever reason Nanako decided to nerf several beam-type projectiles across the board and make them almost inferior to non-hitscan weapons. Laser guns have low capacity (excluding the laser rifle, which I may review and nerf in a separate discussion) so missing your shots is utterly devastating as you cannot reload energy weapons on the spot, they must be recharged at certain select stations that are inconvenient to travel back to during a serious conflict. There is justification to keep them powerful as is, and people going up against lasers whether antag or not should respect and analyze whenever someone has a hitscan weapon that can easily sink them into pain crit.

The problem was that these weapons were slashed by 25%. That's not an insignificant percentage, considering the existence of armor, which nanako also considered and decided... for some reason, to slash armor penetration effects from rarer, more exotic variants of lasers such as laser cannons and x-ray guns. Remember that laser cannon that would consistently do half its damage regardless if your armor soaked it or not? It had its armor penetration effect slashed entirely. Remember the x-ray guns that would always do its full damage to a greater effect than a laser cannon, making it an anti-armor solution to ERT, nuke ops and those in hardsuits? Almost halved its effect making it less relevant as an exotic weapon.

This makes antags suffer as well from having to choose more consistent options such as revolvers, smgs, double-barrel shotguns and other weapons that kill more reliably and hit their targets much more often in close combat. Lasers are tweaked (thanks to bay in previous revisions) to be less consistently accurate than projectile-based bullets and shrapnel. Don't believe me? Take a laser rifle and shoot it at someone 7 tiles away from you, count how many times you hit them versus using an SMG or an assault rifle at the same range. If you've played shooters before, it's harder to precisely track someone with your ironsights versus shooting and leading where they're gonna go. Lasers require precision to use, projectiles require player sense in movement patterns and etc. Pacman also dunked on the aimbot thing so now lasers require more skill to use, mildly justifying the buff here.

So anyway. What it was before:
40 burn per midlaser, meaning 5 shots that hit without taking into consideration of armor or miss frequency, would cause someone to pretty much die.

Now:
30 burn per midlaser, meaning it takes 7 shots to kill. Not including the inaccuracy and armor which will normally soak lasers even if the armor value is very low, some jumpsuits, labcoats and voidsuits have energy and laser resistance, so they can outright factor into an absorption check. That means 15 damage minimum provided the armor doesn't soak the entire blow.

My suggestion:
35 burn per laser. 17.5 as a damage minimum is fair in my mind. 6 shots to kill isn't bad either on an unarmored target, that is more than  half than the capacity of an energy carbine, but still allows you to use the rest of it to put another person into crit if you didn't miss before don't and miss again. Unlikely, but still allows for some use to the weapon without making it a "i can only shoot one person with this and then its useless" weapon.

Speaking of which, the topic of personal defense. An energy pistol at close range should be able to deal enough lethal damage to crit someone with all of their shots. 30x6 = 180 without accounting for armor, the minimum being 90 or even less depending on hit rate or armor absorption, which is still enough to make someone fall into pain after a few minutes of the agony building up by itself. Compare with 25x5 = 125, or the minimum being 62.5 or even less depending on miss rate or armor absorption, which more often than not will make the weapon totally useless as a personal defense weapon if it won't do enough damage to crit someone. Burn damage factors into agony x2, do note, with higher values making the agonyrate needed to make someone go into paincrit even faster. Anyway that should be enough of my autism math.

Haven't done a PR in a bit so if I mess something up please let me know.

Oh, and gatling lasers are called "diffused lasers" because rapid-fire lasering works by a process called diffusion. They aren't "heavy lasers" if they're individually weak by themselves.