### PR TITLE
Fixes Aurora3 issue 3498

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -37,7 +37,7 @@
 				S.heal_damage(15, 15, robo_repair = 1)
 				H.updatehealth()
 				use(1)
-				user.visible_message("<span class='notice'>\The [user] applies some nanite paste at[user != M ? " \the [M]'s" : " \the"][S.name] with \the [src].</span>",\
+				user.visible_message("<span class='notice'>\The [user] applies some nanite paste at[user != M ? " \the [M]'s" : " \the [user]"] [S.name] with \the [src].</span>",\
 				"<span class='notice'>You apply some nanite paste at [user == M ? "your" : "[M]'s"] [S.name].</span>")
 			else
 				user << "<span class='notice'>Nothing to fix here.</span>"


### PR DESCRIPTION
Which was a typo with the text when nanopaste is self used by an IPC and observed by another person.

There were 2 issues,
There was no space after a terniary function, causing a grammatical error.
Another grammatical error was caused due to the else block of the terniary function being defined as " \the", which was processing as \t he (tab he) and causing results such as he Hephaetus instead of the Hephaetus.

fixes #3498 
