### PR TITLE
Fixes merchant late join

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -683,7 +683,7 @@
 			var/obj/effect/landmark/L = thing
 			if(istype(L))
 				if(L.name == "LateJoin[rank]")
-					H.loc = L.loc
+					H.forceMove(L.loc)
 					return
 
 	var/datum/spawnpoint/spawnpos

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -674,6 +674,16 @@
 	//spawn at one of the latespawn locations
 	Debug("LS/([H]): Entry; rank=[rank]")
 
+	var/datum/job/job = GetJob(rank)
+
+	H.job = rank
+
+	if(job.latejoin_at_spawnpoints)
+		var/obj/S = get_roundstart_spawnpoint(rank)
+		if(istype(S, /obj/effect/landmark/start))
+			H.forceMove(get_turf(S))
+		return
+
 	var/datum/spawnpoint/spawnpos
 
 	if(H.client.prefs.spawnpoint)

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -347,15 +347,8 @@
 
 	H.job = rank
 
-	if(!joined_late)
-		var/obj/S = null
-		for(var/obj/effect/landmark/start/sloc in landmarks_list)
-			if(sloc.name != rank)	continue
-			if(locate(/mob/living) in sloc.loc)	continue
-			S = sloc
-			break
-		if(!S)
-			S = locate("start*[rank]") // use old stype
+	if(!joined_late || job.latejoin_at_spawnpoints)
+		var/obj/S = get_roundstart_spawnpoint(rank)
 		if(istype(S, /obj/effect/landmark/start) && istype(S.loc, /turf))
 			H.loc = S.loc
 		else
@@ -847,3 +840,15 @@
 			Debug("EIS/([H]): unable to equip; no storage.")
 
 	Debug("EIS/([H]): Complete.")
+
+/datum/controller/subsystem/jobs/proc/get_roundstart_spawnpoint(var/rank)
+	var/list/loc_list = list()
+	for(var/obj/effect/landmark/start/sloc in landmarks_list)
+		if(sloc.name != rank)	continue
+		if(locate(/mob/living) in sloc.loc)	continue
+		loc_list += sloc
+	if(loc_list.len)
+		return pick(loc_list)
+	else
+		return locate("start*[rank]") // use old stype
+

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -675,16 +675,16 @@
 	Debug("LS/([H]): Entry; rank=[rank]")
 
 	var/datum/job/job = GetJob(rank)
-	world<< "the job is [rank]"
 
 	H.job = rank
 
 	if(job.latejoin_at_spawnpoints)
-		var/obj/S = get_roundstart_spawnpoint(rank)
-		if(istype(S, /obj/effect/landmark/start))
-			var/turf/spawn_turf = get_turf(S)
-			H.forceMove(spawn_turf)
-		return
+		for (var/thing in landmarks_list)
+			var/obj/effect/landmark/L = thing
+			if(istype(L))
+				if(L.name == "LateJoin[rank]")
+					H.loc = L.loc
+					return
 
 	var/datum/spawnpoint/spawnpos
 

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -675,13 +675,15 @@
 	Debug("LS/([H]): Entry; rank=[rank]")
 
 	var/datum/job/job = GetJob(rank)
+	world<< "the job is [rank]"
 
 	H.job = rank
 
 	if(job.latejoin_at_spawnpoints)
 		var/obj/S = get_roundstart_spawnpoint(rank)
 		if(istype(S, /obj/effect/landmark/start))
-			H.forceMove(get_turf(S))
+			var/turf/spawn_turf = get_turf(S)
+			H.forceMove(spawn_turf)
 		return
 
 	var/datum/spawnpoint/spawnpos

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -22,6 +22,8 @@
 	var/minimum_character_age = 17
 	var/ideal_character_age = 30
 
+	var/latejoin_at_spawnpoints = FALSE          //If this job should use roundstart spawnpoints for latejoin (offstation jobs etc)
+
 	var/account_allowed = 1				  // Does this job type come with a station account?
 	var/economic_modifier = 2			  // With how much does this job modify the initial account amount?
 	var/create_record = 1                 // Do we announce/make records for people who spawn on this job?

--- a/code/game/jobs/job/outsider/merchant.dm
+++ b/code/game/jobs/job/outsider/merchant.dm
@@ -18,6 +18,8 @@
 	access = list(access_merchant)
 	minimal_access = list(access_merchant)
 
+	latejoin_at_spawnpoints = TRUE
+
 /datum/job/merchant/equip(var/mob/living/carbon/human/H)
 	if(!H)
 		return FALSE

--- a/code/game/jobs/job/outsider/merchant.dm
+++ b/code/game/jobs/job/outsider/merchant.dm
@@ -36,3 +36,4 @@
 	..()
 	if(prob(config.merchant_chance))
 		spawn_positions = 1
+		total_positions = 1

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -49,11 +49,3 @@ var/list/spawntypes = list()
 /datum/spawnpoint/cyborg/New()
 	..()
 	turfs = latejoin_cyborg
-
-/datum/spawnpoint/merchant
-	display_name = "Merchant Station"
-	restrict_job = list("Merchant")
-
-/datum/spawnpoint/merchant/New()
-	..()
-	turfs = latejoin_merchant


### PR DESCRIPTION
Fixes merchant late spawn, and also adds frameworks for more jobs that do not spawn using the regular late join spawn points. And allows merchants to join after the round started.

Needs #3500 to work properly.