### PR TITLE
Make chemmasters default to transfer-to-beaker

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -22,7 +22,7 @@
 	layer = 2.9
 	var/beaker = null
 	var/obj/item/weapon/storage/pill_bottle/loaded_pill_bottle = null
-	var/mode = 0
+	var/mode = TRUE
 	var/condi = 0
 	var/useramount = 30 // Last used amount
 	var/pillamount = 10
@@ -33,9 +33,7 @@
 
 /obj/machinery/chem_master/Initialize()
 	. = ..()
-	var/datum/reagents/R = new/datum/reagents(120)
-	reagents = R
-	R.my_atom = src
+	create_reagents(120)
 
 /obj/machinery/chem_master/ex_act(severity)
 	switch(severity)

--- a/html/changelogs/lohikar-beaker.yml
+++ b/html/changelogs/lohikar-beaker.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - tweak: "ChemMasters will now default to transfer-to-beaker instead of transfer-to-disposal."


### PR DESCRIPTION
changes:
- ChemMasters will now default to transferring buffer back into the beaker instead of into the disposal.