### PR TITLE
Adds a dispersion effect to the thermal drill.

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -185,8 +185,8 @@
 	max_shots = 4
 	fire_delay = 25
 	can_turret = 1
-	turret_is_lethal = 0		
-	turret_sprite_set = "net
+	turret_is_lethal = 0	
+	turret_sprite_set = "net"
 
 /obj/item/weapon/gun/energy/net/mounted
 	max_shots = 1

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -80,8 +80,8 @@
 	self_recharge = 1
 	recharge_time = 5 //Time it takes for shots to recharge (in ticks)
 	charge_meter = 0
-	can_turret = 1		
- 	turret_sprite_set = "meteor"
+	can_turret = 1
+	turret_sprite_set = "meteor"
 
 /obj/item/weapon/gun/energy/meteorgun/pen
 	name = "meteor pen"
@@ -100,8 +100,8 @@
 	icon_state = "xray"
 	projectile_type = /obj/item/projectile/beam/mindflayer
 	fire_sound = 'sound/weapons/Laser.ogg'
-	can_turret = 1		
- 	turret_sprite_set = "xray"
+	can_turret = 1
+	turret_sprite_set = "xray"
 
 /obj/item/weapon/gun/energy/toxgun
 	name = "phoron pistol"
@@ -184,13 +184,16 @@
 	w_class = 3
 	max_shots = 4
 	fire_delay = 25
-	can_turret = 0
+	can_turret = 1
+	turret_is_lethal = 0		
+	turret_sprite_set = "net
 
 /obj/item/weapon/gun/energy/net/mounted
 	max_shots = 1
 	self_recharge = 1
 	use_external_power = 1
 	recharge_time = 40
+	can_turret = 0
 
 /* Vaurca Weapons */
 
@@ -295,8 +298,8 @@
 	burst = 1
 	burst_delay = 1
 	fire_delay = 0
-	can_turret = 1		
- 	turret_sprite_set = "laser"
+	can_turret = 1
+	turret_sprite_set = "laser"
 
 	firemodes = list(
 		list(mode_name="single shot", burst=1, burst_delay = 1, fire_delay = 0),

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -430,7 +430,7 @@
 	firemodes = list(
 		list(mode_name="2 second burst", burst=10, burst_delay = 1, fire_delay = 20, dispersion = list(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)),
 		list(mode_name="4 second burst", burst=20, burst_delay = 1, fire_delay = 40, dispersion = list(0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 0.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8)),
-		list(mode_name="6 second burst", burst=30, burst_delay = 1, fire_delay = 60, dispersion = list(0.0, 0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.1, 2.4, 2.7, 3.0, 3.3, 3.6, 3.9, 4.2, 4.5, 4.8, 5.1, 5.4, 5.7, 6.0, 6.3, 6.6, 6.9, 7.2, 7.5, 7.8, 8.1, 8.4, 8.7)),
+		list(mode_name="6 second burst", burst=30, burst_delay = 1, fire_delay = 60, dispersion = list(0.0, 0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.1, 2.4, 2.7, 3.0, 3.3, 3.6, 3.9, 4.2, 4.5, 4.8, 5.1, 5.4, 5.7, 6.0, 6.3, 6.6, 6.9, 7.2, 7.5, 7.8, 8.1, 8.4, 8.7))
 		)
 
 	action_button_name = "Wield thermal drill"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -12,6 +12,8 @@
 	charge_cost = 300
 	max_shots = 10
 	projectile_type = /obj/item/projectile/ion
+	can_turret = 1
+	turret_sprite_set = "ion"
 
 /obj/item/weapon/gun/energy/ionrifle/emp_act(severity)
 	..(max(severity, 2)) //so it doesn't EMP itself, I guess
@@ -28,6 +30,7 @@
 	self_recharge = 1
 	use_external_power = 1
 	recharge_time = 10
+	can_turret = 0
 
 /obj/item/weapon/gun/energy/decloner
 	name = "biological demolecularisor"
@@ -77,6 +80,8 @@
 	self_recharge = 1
 	recharge_time = 5 //Time it takes for shots to recharge (in ticks)
 	charge_meter = 0
+	can_turret = 1		
+ 	turret_sprite_set = "meteor"
 
 /obj/item/weapon/gun/energy/meteorgun/pen
 	name = "meteor pen"
@@ -86,6 +91,7 @@
 	item_state = "pen"
 	w_class = 1
 	slot_flags = SLOT_BELT
+	can_turret = 0
 
 
 /obj/item/weapon/gun/energy/mindflayer
@@ -94,6 +100,8 @@
 	icon_state = "xray"
 	projectile_type = /obj/item/projectile/beam/mindflayer
 	fire_sound = 'sound/weapons/Laser.ogg'
+	can_turret = 1		
+ 	turret_sprite_set = "xray"
 
 /obj/item/weapon/gun/energy/toxgun
 	name = "phoron pistol"
@@ -103,6 +111,9 @@
 	w_class = 3.0
 	origin_tech = list(TECH_COMBAT = 5, TECH_PHORON = 4)
 	projectile_type = /obj/item/projectile/energy/phoron
+	can_turret = 1		
+	turret_is_lethal = 0		
+	turret_sprite_set = "net"
 
 /obj/item/weapon/gun/energy/beegun
 	name = "\improper NanoTrasen Portable Apiary"
@@ -173,6 +184,7 @@
 	w_class = 3
 	max_shots = 4
 	fire_delay = 25
+	can_turret = 0
 
 /obj/item/weapon/gun/energy/net/mounted
 	max_shots = 1
@@ -283,6 +295,8 @@
 	burst = 1
 	burst_delay = 1
 	fire_delay = 0
+	can_turret = 1		
+ 	turret_sprite_set = "laser"
 
 	firemodes = list(
 		list(mode_name="single shot", burst=1, burst_delay = 1, fire_delay = 0),
@@ -407,6 +421,8 @@
 	charge_meter = 1
 	charge_cost = 50
 	dispersion = list(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
+	can_turret = 1		 
+	turret_sprite_set = "thermaldrill"
 
 	firemodes = list(
 		list(mode_name="2 second burst", burst=10, burst_delay = 1, fire_delay = 20, dispersion = list(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)),

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -12,8 +12,6 @@
 	charge_cost = 300
 	max_shots = 10
 	projectile_type = /obj/item/projectile/ion
-	can_turret = 1
-	turret_sprite_set = "ion"
 
 /obj/item/weapon/gun/energy/ionrifle/emp_act(severity)
 	..(max(severity, 2)) //so it doesn't EMP itself, I guess
@@ -30,7 +28,6 @@
 	self_recharge = 1
 	use_external_power = 1
 	recharge_time = 10
-	can_turret = 0
 
 /obj/item/weapon/gun/energy/decloner
 	name = "biological demolecularisor"
@@ -80,8 +77,6 @@
 	self_recharge = 1
 	recharge_time = 5 //Time it takes for shots to recharge (in ticks)
 	charge_meter = 0
-	can_turret = 1
-	turret_sprite_set = "meteor"
 
 /obj/item/weapon/gun/energy/meteorgun/pen
 	name = "meteor pen"
@@ -91,7 +86,6 @@
 	item_state = "pen"
 	w_class = 1
 	slot_flags = SLOT_BELT
-	can_turret = 0
 
 
 /obj/item/weapon/gun/energy/mindflayer
@@ -100,8 +94,6 @@
 	icon_state = "xray"
 	projectile_type = /obj/item/projectile/beam/mindflayer
 	fire_sound = 'sound/weapons/Laser.ogg'
-	can_turret = 1
-	turret_sprite_set = "xray"
 
 /obj/item/weapon/gun/energy/toxgun
 	name = "phoron pistol"
@@ -181,16 +173,12 @@
 	w_class = 3
 	max_shots = 4
 	fire_delay = 25
-	can_turret = 1
-	turret_is_lethal = 0
-	turret_sprite_set = "net"
 
 /obj/item/weapon/gun/energy/net/mounted
 	max_shots = 1
 	self_recharge = 1
 	use_external_power = 1
 	recharge_time = 40
-	can_turret = 0
 
 /* Vaurca Weapons */
 
@@ -295,8 +283,6 @@
 	burst = 1
 	burst_delay = 1
 	fire_delay = 0
-	can_turret = 1
-	turret_sprite_set = "laser"
 
 	firemodes = list(
 		list(mode_name="single shot", burst=1, burst_delay = 1, fire_delay = 0),
@@ -420,13 +406,12 @@
 	recharge_time = 1
 	charge_meter = 1
 	charge_cost = 50
-	can_turret = 1
-	turret_sprite_set = "thermaldrill"
+	dispersion = list(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
 
 	firemodes = list(
-		list(mode_name="2 second burst", burst=10, burst_delay = 1, fire_delay = 20),
-		list(mode_name="4 second burst", burst=20, burst_delay = 1, fire_delay = 40),
-		list(mode_name="6 second burst", burst=30, burst_delay = 1, fire_delay = 60)
+		list(mode_name="2 second burst", burst=10, burst_delay = 1, fire_delay = 20, dispersion = list(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)),
+		list(mode_name="4 second burst", burst=20, burst_delay = 1, fire_delay = 40, dispersion = list(0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 0.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8)),
+		list(mode_name="6 second burst", burst=30, burst_delay = 1, fire_delay = 60, dispersion = list(0.0, 0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.1, 2.4, 2.7, 3.0, 3.3, 3.6, 3.9, 4.2, 4.5, 4.8, 5.1, 5.4, 5.7, 6.0, 6.3, 6.6, 6.9, 7.2, 7.5, 7.8, 8.1, 8.4, 8.7)),
 		)
 
 	action_button_name = "Wield thermal drill"
@@ -489,6 +474,7 @@
 	charge_meter = 1
 	use_external_power = 1
 	charge_cost = 25
+	dispersion = list(0.0, 0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.1, 2.4, 2.7, 3.0, 3.3, 3.6, 3.9, 4.2, 4.5, 4.8, 5.1, 5.4, 5.7, 6.0, 6.3, 6.6, 6.9, 7.2, 7.5, 7.8, 8.1, 8.4, 8.7)
 
 /obj/item/weapon/gun/energy/vaurca/mountedthermaldrill/special_check(var/mob/user)
 	..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -185,7 +185,7 @@
 	max_shots = 4
 	fire_delay = 25
 	can_turret = 1
-	turret_is_lethal = 0	
+	turret_is_lethal = 0
 	turret_sprite_set = "net"
 
 /obj/item/weapon/gun/energy/net/mounted

--- a/html/changelogs/1138-thermaldrills.yml
+++ b/html/changelogs/1138-thermaldrills.yml
@@ -1,0 +1,5 @@
+author: Scheveningen
+ 
+ delete-after: True
+ changes:
+   - balance: "Adds dispersion effects to the thermal drill and mounted thermal drill."

--- a/html/changelogs/1138-thermaldrills.yml
+++ b/html/changelogs/1138-thermaldrills.yml
@@ -1,5 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
 author: Scheveningen
- 
- delete-after: True
- changes:
-   - balance: "Adds dispersion effects to the thermal drill and mounted thermal drill."
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+ - balance: "Adds a dispersion effect to the thermal drill."

--- a/html/changelogs/1138-thermaldrills.yml
+++ b/html/changelogs/1138-thermaldrills.yml
@@ -34,4 +34,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
- - balance: "Adds a dispersion effect to the thermal drill."
+  - balance: "Adds a dispersion effect to the thermal drill."


### PR DESCRIPTION
The thermal drill is a bit too niche right now to be an effective mining tool. Unfortunately, at the same time it is far too effective **as a weapon** given how burst fire weapons behave due to how guncode handles what I refer to as 'target acquisition'. 

Simply, when you click directly on a mob, you fire exactly at the location of the person you are shooting at. This is effectively called either "proper aim tracking" in other games or 'target acquisition' in this particular case, where the game handles shooting for you if you're able to directly click on someone's sprite, thus being generous enough to favor the shooter and grant them the hits.

Visualization: imagine you have a C-20r. If you fire 1 tile behind the person you're shooting at, the three bullets will fire in the general direction of that tile. If the individual moves from that firing line, those bullets will definitely miss since he's not in the way of the bullets. However, if you shoot directly at them by clicking on their sprite, even if they move in the split second after your first shot, the next two shots will trail after them. That's how burst fire weapons usually behave and I think it's somewhat fair, since the same methodology is applied to games where tracking is important to hit projectile shots on a moving target. Those burst fire weapons are also normally projectile bullets, and ballistic weapons have less-than-manageable recoil that can disorient a user pretty quickly.

But since the thermal drill is also a burst fire weapon with high burst counts, it behaves similarly, but with the unfortunate consequence in that because it is a beam type weapon, it has hitscan, thus causing it to hit with incredible amounts of accuracy and adding a lot of burn damaged caused by the high concentration of beam hits in addition to the overwhelming amount of firestacks it applies to carbon mobs that it hits. Some miners have taken to using this against bears, spiders, other people that earn their ire in the round. 

This is unfortunately, too reliable as a weapon and strangely not reliable enough as a mining tool that it is supposed to be. The various burst fire modes will have proportionally higher dispersion rates. The mounted thermal drill itself will remain having 30 shots fired in its 12 second burst but will have the dispersion value similar to the non-mounted thermal drill on its highest burst setting.

The 10-shot burst will be still effective at carving tunnels until a certain range, allowing it to still have its utility in creating tunnels very easily. At 20-shot bursts, it will pave through rock very easily while suffering a bit from inaccuracy. At the 30-shot burst, it will soften a lot of rock up in order to blast chunks with high width but much lower length. I've done more testing with 10 shots and 20 shots, not so much the 30 shot burst, since the 30 shot dispersion values are a bit funny and I'm not sure if it's that good. It's worth changing later when before the merge to master, since this is a development branch request.

Although I have tested this and this seems fine, I'd like to see some feedback from the maintainers first.