### PR TITLE
Portable ladders can fit in bags and can be worn in the waist slot.

### DIFF
--- a/code/modules/multiz/mobile_ladders.dm
+++ b/code/modules/multiz/mobile_ladders.dm
@@ -7,8 +7,8 @@
 	contained_sprite = TRUE
 	throw_range = 3
 	force = 10
-	w_class = 4.0
-	slot_flags = SLOT_BACK
+	w_class = 3.0
+	slot_flags = SLOT_BELT | SLOT_BACK
 
 /obj/item/weapon/ladder_mobile/proc/place_ladder(atom/A, mob/user)
 

--- a/html/changelogs/chaoko99-ladderbuff.yml
+++ b/html/changelogs/chaoko99-ladderbuff.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Chaoko99
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Portable ladders now fit in bags (Size 3.0, was 4.0), can be worn in the waist slot."


### PR DESCRIPTION
Portable ladders now fit in bags (Size 3.0, was 4.0), can be worn in the waist slot.