### PR TITLE
Better stamina meter

### DIFF
--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -8,13 +8,10 @@
 
 	var/obj/screen/using
 
-	using = new /obj/screen()
-	using.name = "mov_intent"
+	using = new /obj/screen/movement_intent()
 	using.set_dir(SOUTHWEST)
 	using.icon = 'icons/mob/screen1_alien.dmi'
 	using.icon_state = (mymob.m_intent == "run" ? "running" : "walking")
-	using.screen_loc = ui_acti
-	using.layer = 20
 	src.adding += using
 	move_intent = using
 

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -132,7 +132,7 @@ var/list/global_huds
 	var/obj/screen/r_hand_hud_object
 	var/obj/screen/l_hand_hud_object
 	var/obj/screen/action_intent
-	var/obj/screen/move_intent
+	var/obj/screen/movement_intent/move_intent
 
 	var/list/adding
 	var/list/other

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -124,12 +124,9 @@
 		//end intent small hud objects
 
 	if(hud_data.has_m_intent)
-		using = new /obj/screen()
-		using.name = "mov_intent"
+		using = new /obj/screen/movement_intent()
 		using.icon = ui_style
 		using.icon_state = (mymob.m_intent == "run" ? "running" : "walking")
-		using.screen_loc = ui_movi
-		using.layer = 20
 		using.color = ui_color
 		using.alpha = ui_alpha
 		src.adding += using

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -194,29 +194,6 @@
 				var/mob/living/L = usr
 				L.resist()
 
-		if("mov_intent")
-
-			var/list/modifiers = params2list(params)
-			//This is here instead of outside the switch to save adding overhead. its not used for any other UI icons right now
-			//If its needed in future for other UI icons, then move it up to above the switch
-
-			if(iscarbon(usr))
-				var/mob/living/carbon/C = usr
-				if (modifiers["alt"])
-					C.set_walk_speed()
-					return
-
-				if(C.legcuffed)
-					C << "<span class='notice'>You are legcuffed! You cannot run until you get [C.legcuffed] removed!</span>"
-					C.m_intent = "walk"	//Just incase
-					C.hud_used.move_intent.icon_state = "walking"
-					return 1
-				switch(usr.m_intent)
-					if("run")
-						usr.m_intent = "walk"
-					if("walk")
-						usr.m_intent = "run"
-			update_move_icon(usr)
 		if("m_intent")
 			if(!usr.m_int)
 				switch(usr.m_intent)
@@ -562,23 +539,50 @@
 	return 1
 
 
-
-
+/obj/screen/movement_intent
+	name = "mov_intent"
+	screen_loc = ui_movi
+	layer = 20
 
 //This updates the run/walk button on the hud
-/obj/screen/proc/update_move_icon(var/mob/living/user)
-	switch(name)
-		if("mov_intent")
-			overlays.Cut()
-			switch(user.m_intent)
-				if("run")//When in run mode, the button will have a flashing coloured overlay which gives a visual indicator of stamina
-					icon_state = "running"
-					if (user.max_stamina != -1)//If max stamina is -1, this species doesnt use stamina. no overlay for them
-						var/image/holder = image('icons/mob/screen1.dmi', src, "run_overlay")
-						var/staminaportion = user.stamina / user.max_stamina
-						holder.color = percentage_to_colour(staminaportion)
-						holder.blend_mode = BLEND_MULTIPLY
-						overlays += holder
+/obj/screen/movement_intent/proc/update_move_icon(var/mob/living/user)
+	if (!user.client)
+		return
 
-				if("walk")
-					icon_state = "walking"
+	if (user.max_stamina == -1 || user.stamina == user.max_stamina)
+		if (user.stamina_bar)
+			QDEL_NULL(user.stamina_bar)
+		return
+
+	if (!user.stamina_bar)
+		user.stamina_bar = new(user, user.max_stamina, src)
+
+	user.stamina_bar.update(user.stamina)
+	if (user.m_intent == "run")
+		icon_state = "running"
+	else
+		icon_state = "walking"
+
+/obj/screen/movement_intent/Click(location, control, params)
+	if(!usr)
+		return 1
+	var/list/modifiers = params2list(params)
+
+	if(iscarbon(usr))
+		var/mob/living/carbon/C = usr
+		if (modifiers["alt"])
+			C.set_walk_speed()
+			return
+
+		if(C.legcuffed)
+			C << "<span class='notice'>You are legcuffed! You cannot run until you get [C.legcuffed] removed!</span>"
+			C.m_intent = "walk"	//Just incase
+			C.hud_used.move_intent.icon_state = "walking"
+			return 1
+		switch(usr.m_intent)
+			if("run")
+				usr.m_intent = "walk"
+			if("walk")
+				usr.m_intent = "run"
+
+		update_move_icon(usr)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -65,6 +65,7 @@
 	var/stamina_recovery = 1
 	var/min_walk_delay = 0//When move intent is walk, movedelay is clamped to this value as a lower bound
 	var/exhaust_threshold = 50
+	var/datum/progressbar/stamina_bar	// Progress bar shown when stamina is not at full, and the mob supports stamina. Deleted on Logout or when stamina is full.
 
 	var/move_delay_mod = 0//Added to move delay, used for calculating movement speeds. Provides a centralised value for modifiers to alter
 

--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -1,4 +1,6 @@
 /mob/living/Logout()
+	if (stamina_bar)
+		QDEL_NULL(stamina_bar)
 	..()
 	if (mind)	
 		//Per BYOND docs key remains set if the player DCs, becomes null if switching bodies.

--- a/html/changelogs/lohikar-staminabar.yml
+++ b/html/changelogs/lohikar-staminabar.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - rscadd: "Sprinting stamina now has a bar showing your remaining stamina instead of coloring the sprint button."


### PR DESCRIPTION
Changes the sprinting stamina meter to a progress bar instead of coloring the sprint button. Bar is only visible on mobs that actually have stamina & aren't already at max stamina.

Fixes #2300.
Fixes #1912.

![wesh2i](https://user-images.githubusercontent.com/7097800/31050166-622a3150-a608-11e7-944d-2f9bc4593620.gif)
![otiecq](https://user-images.githubusercontent.com/7097800/31050167-64b32102-a608-11e7-9418-5f0647f53559.gif)
