### PR TITLE
[Bugfix] Butterfly knives now spawn in your hands instead the floor.

### DIFF
--- a/code/game/objects/items/weapons/improvised_components.dm
+++ b/code/game/objects/items/weapons/improvised_components.dm
@@ -33,9 +33,10 @@
 	if(istype(W,/obj/item/weapon/material/butterflyblade))
 		var/obj/item/weapon/material/butterflyblade/B = W
 		user << "You attach the two concealed blade parts."
-		new /obj/item/weapon/material/butterflyconstruction(user.loc, B.material.name)
+		var/finished = new /obj/item/weapon/material/butterflyconstruction(user.loc, B.material.name)
 		qdel(W)
 		qdel(src)
+		user.put_in_hands(finished)
 		return
 
 /obj/item/weapon/material/wirerod


### PR DESCRIPTION
This was always stupid and could hypothetically result in a player being robusted with their own knife.