### PR TITLE
Fix an error in DMMS

### DIFF
--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -3,7 +3,7 @@
 
 /atom/New(loc, ...)
 	// For the (currently unused) DMM Suite.
-	if(_preloader && (src.type == _preloader.target_path))//in case the instanciated atom is creating other atoms in New()
+	if(use_preloader && (src.type == _preloader.target_path))//in case the instanciated atom is creating other atoms in New()
 		_preloader.load(src)
 
 	//. = ..() //uncomment if you are dumb enough to add a /datum/New() proc


### PR DESCRIPTION
Fixes a mistake in `/atom/New()` that breaks DMMS loading & has a minor performance impact.