### PR TITLE
Move sunlight to compile-time option

### DIFF
--- a/code/__defines/_compile_options.dm
+++ b/code/__defines/_compile_options.dm
@@ -1,2 +1,5 @@
 #define BACKGROUND_ENABLED 0    // The default value for all uses of set background. Set background can cause gradual lag and is recommended you only turn this on if necessary.
 								// 1 will enable set background. 0 will disable set background.
+
+// If defined, the sunlight system is enabled. Caution: this uses a LOT of memory.
+//#define ENABLE_SUNLIGHT

--- a/code/controllers/subsystems/sunlight.dm
+++ b/code/controllers/subsystems/sunlight.dm
@@ -1,3 +1,5 @@
+#ifdef ENABLE_SUNLIGHT
+
 /var/datum/controller/subsystem/sunlight/SSsunlight
 
 /datum/controller/subsystem/sunlight
@@ -96,3 +98,5 @@
 /datum/sun_state/blue
 	name = "Blue"
 	color = LIGHT_COLOR_BLUE
+
+#endif

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1108,6 +1108,7 @@ var/list/admin_verbs_cciaa = list(
 
 	SSopenturf.hard_reset()
 
+#ifdef ENABLE_SUNLIGHT
 /client/proc/apply_sunstate()
 	set category = "Fun"
 	set name = "Apply Sun Preset"
@@ -1122,3 +1123,9 @@ var/list/admin_verbs_cciaa = list(
 
 	SSsunlight.apply_sun_state(S)
 	log_and_message_admins("has set the sun state to '[S]'.")
+#else 
+/client/proc/apply_sunstate()
+	set hidden = TRUE
+
+	usr << "The sunlight system is disabled."
+#endif

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -6,7 +6,9 @@
 	var/light_color     // Hexadecimal RGB string representing the colour of the light.
 	var/uv_intensity = 255	// How much UV light is being emitted by this object. Valid range: 0-255.
 	var/light_wedge		// The angle that the light's emission should be restricted to. null for omnidirectional.
+#ifdef ENABLE_SUNLIGHT
 	var/light_novis     // If TRUE, visibility checks will be skipped when calculating this light.
+#endif
 
 	var/tmp/datum/light_source/light // Our light source. Don't fuck with this directly unless you have a good reason!
 	var/tmp/list/light_sources       // Any light sources that are "inside" of us, for example, if src here was a mob that's carrying a flashlight, that flashlight's light source would be part of this list.
@@ -70,12 +72,19 @@
 		else
 			. = loc
 
+#ifdef ENABLE_SUNLIGHT
 		if (light) // Update the light or create it if it does not exist.
 			light.update(.)
 		else if (light_novis)
 			light = new/datum/light_source/sunlight(src, .)
 		else
 			light = new/datum/light_source(src, .)
+#else 
+		if (light)
+			light.update(.)
+		else
+			light = new /datum/light_source(src, .)
+#endif
 
 // If we have opacity, make sure to tell (potentially) affected light sources.
 /atom/movable/Destroy()

--- a/code/modules/lighting/lighting_source_sunlight.dm
+++ b/code/modules/lighting/lighting_source_sunlight.dm
@@ -1,3 +1,5 @@
+#ifdef ENABLE_SUNLIGHT
+
 /datum/light_source/sunlight
 	skip_falloff = TRUE
 
@@ -191,3 +193,5 @@
 	QUEUE_UPDATE(LIGHTING_VIS_UPDATE)
 
 #undef QUEUE_UPDATE
+
+#endif 


### PR DESCRIPTION
Turns out sunlight is a little memory hungry/slow. This disables sunlight via. compile-time define instead of removing it so it can be re-enabled if suitable later.