### PR TITLE
Adds door prying power

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -428,3 +428,10 @@
 	for(var/i = 1 to l.len)
 		if(islist(.[i]))
 			.[i] = .(.[i])
+
+
+/proc/filter_list(var/list/L, var/type)
+	. = list()
+	for(var/entry in L)
+		if(istype(entry, type))
+			. += entry

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -560,3 +560,32 @@
 			G.affecting.forceMove(locate(T.x + rand(-1,1), T.y + rand(-1,1), T.z))
 		else
 			qdel(G)
+
+/mob/living/carbon/human/proc/pry_open(obj/machinery/door/A in filter_list(oview(1), /obj/machinery/door))
+	set name = "Pry Open Airlock"
+	set desc = "Pry open an airlock with your claws."
+	set category = "Abilities"
+
+	if(!istype(A) || incapacitated())
+		return
+
+	if(!A.Adjacent(src))
+		to_chat(src, "<span class='warning'>\The [A] is too far away.</span>")
+		return
+
+	if(!A.density)
+		return
+
+	src.visible_message("\The [src] begins to pry open \the [A]!")
+
+	if(!do_after(src,120,A))
+		return
+
+	if(!A.density)
+		return
+
+	A.do_animate("spark")
+	sleep(6)
+	A.stat |= BROKEN
+	var/check = A.open(1)
+	src.visible_message("\The [src] slices \the [A]'s controls[check ? ", ripping it open!" : ", breaking it!"]")

--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -84,7 +84,8 @@
 	/mob/living/carbon/human/proc/shatter_light,
 	/mob/living/carbon/human/proc/create_darkness,
 	/mob/living/carbon/human/proc/darkness_eyes,
-	/mob/living/carbon/human/proc/shadow_step
+	/mob/living/carbon/human/proc/shadow_step,
+	/mob/living/carbon/human/proc/pry_open
 	)
 
 /datum/species/shadow/handle_death(var/mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -240,7 +240,8 @@
 		/mob/living/carbon/human/proc/psychic_whisper,
 		/mob/living/proc/devour,
 		/mob/living/carbon/human/proc/regurgitate,
-		/mob/living/carbon/human/proc/darkness_eyes
+		/mob/living/carbon/human/proc/darkness_eyes,
+		/mob/living/carbon/human/proc/pry_open
 		)
 
 /datum/species/xenos/sentinel
@@ -311,7 +312,8 @@
 		/mob/living/carbon/human/proc/neurotoxin,
 		/mob/living/carbon/human/proc/resin,
 		/mob/living/carbon/human/proc/xeno_infest,
-		/mob/living/carbon/human/proc/darkness_eyes
+		/mob/living/carbon/human/proc/darkness_eyes,
+		/mob/living/carbon/human/proc/pry_open
 		)
 
 /datum/species/xenos/queen/handle_login_special(var/mob/living/carbon/human/H)


### PR DESCRIPTION
Port the drop prying power from bay, gave it to xeomorph hunters, quees and shadow poeple. It allows someone nearn an airloc to break it open if not bolted.