### PR TITLE
Fix merchants spawning without their gear when joining late

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -503,10 +503,12 @@
 		if("AI")
 			Debug("EP/([H]): Abort, H is AI.")
 			return EquipRank(H, rank, 1)
-	if(spawning_at != "Arrivals Shuttle")
-		return EquipRank(H, rank, 1)
 
 	var/datum/job/job = GetJob(rank)
+
+	if(spawning_at != "Arrivals Shuttle" || job.latejoin_at_spawnpoints)
+		return EquipRank(H, rank, 1)
+
 	var/list/spawn_in_storage = list()
 	H <<"<span class='notice'>You have ten minutes to reach the station before you will be forced there.</span>"
 

--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -454,7 +454,7 @@
 /datum/access/merchant
 	id = access_merchant
 	desc = "Merchant Access"
-	access_type = ACCESS_TYPE_NONE
+	access_type = ACCESS_TYPE_CENTCOM
 
 /***************
 * Antag access *


### PR DESCRIPTION
If a merchant character has cryo as their spawn point and join late, they do not get their gear, this should fix said issue. And also fixes all access ids not getting merchant access.