### PR TITLE
parallax_togs and AO fix

### DIFF
--- a/code/modules/ambient_occlusion/ao_turf.dm
+++ b/code/modules/ambient_occlusion/ao_turf.dm
@@ -1,7 +1,7 @@
 #ifdef AO_USE_LIGHTING_OPACITY
-#define AO_TURF_CHECK(T) (!T.has_opaque_atom)
+#define AO_TURF_CHECK(T) (!T.has_opaque_atom || !T.permit_ao)
 #else
-#define AO_TURF_CHECK(T) (!T.density || !T.opacity)
+#define AO_TURF_CHECK(T) (!T.density || !T.opacity || !T.permit_ao)
 #endif
 
 /turf

--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -32,7 +32,8 @@
 				"asfx_togs",
 				"lastmotd" = "motd_hash",
 				"lastmemo" = "memo_hash",
-				"parallax_toggles" = "parallax_togs"
+				"parallax_toggles" = "parallax_togs",
+				"parallax_speed"
 			), 
 			"args" = list("ckey")
 		)

--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -31,7 +31,8 @@
 				"toggles",
 				"asfx_togs",
 				"lastmotd" = "motd_hash",
-				"lastmemo" = "memo_hash"
+				"lastmemo" = "memo_hash",
+				"parallax_toggles" = "parallax_togs"
 			), 
 			"args" = list("ckey")
 		)

--- a/html/changelogs/lohikar-fixes.yml
+++ b/html/changelogs/lohikar-fixes.yml
@@ -1,0 +1,5 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Parallax preferences now actually get loaded, because apparently that's important or something."
+  - bugfix: "Shuttles should now longer get mysterious square shadows."


### PR DESCRIPTION
changes:
- `parallax_togs` now actually gets read from the database instead of just written. Whoops.
- AO on turfs adjacent to AO-deny turfs should no longer consider those turfs as AO neighbors. 