### PR TITLE
Fix some mapping issues

### DIFF
--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -18686,13 +18686,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "GS" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	opacity = 0
-	},
 /obj/machinery/door/window/westright{
 	name = "Containment Pen";
 	req_access = list(47)

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -57545,10 +57545,6 @@
 /obj/machinery/atm{
 	pixel_y = -32
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWw" = (
@@ -96727,7 +96723,7 @@ bRk
 bRk
 bVr
 bRH
-ckb
+bWa
 bWv
 bRi
 bVN
@@ -98525,7 +98521,7 @@ bUl
 bRH
 bRH
 bRi
-cjY
+cjX
 bJp
 bNO
 bML
@@ -98782,7 +98778,7 @@ bUm
 bUI
 bVd
 bRi
-cjZ
+cjX
 bWd
 bML
 bML
@@ -99039,7 +99035,7 @@ bRi
 bRi
 bRi
 bRi
-cka
+cjX
 bML
 bJp
 bNo


### PR DESCRIPTION
(prepare for terrible quick MS paint jobs)
Fixes #3671 (by removing the blast doors outlined in red, it makes them more consistent with the three southern xenobiology pins)
Fixes #3680 (by removing the disposal unit outlined in green, there is already a disposal unit at the northern side of the bar)
![xenoinmybio](https://user-images.githubusercontent.com/7574664/31744015-b7274290-b44c-11e7-923a-b5be06cb05e4.png)
![byebyedisposal](https://user-images.githubusercontent.com/7574664/31744214-81df656c-b44d-11e7-9960-372b017769d0.png)