### PR TITLE
Allows species with strong claws to pry open closed airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -763,22 +763,7 @@ About the new airlock wires panel:
 				return
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.species.can_shred(H))
-
-			if(!src.density)
-				return
-
-			H.visible_message("\The [H] begins to pry open \the [src]!", "You being to pry open \the [src]!", "You hear the sound of an airlock being forced open.")
-
-			if(!do_after(H, 120, 1, act_target = src))
-				return
-
-			src.do_animate("spark")
-			src.stat |= BROKEN
-			var/check = src.open(1)
-			src.visible_message("\The [H] slices \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]", "You slice \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]", "You hear something sparking.")
-			return
-
+		
 		if(H.getBrainLoss() >= 50)
 			if(prob(40) && src.density)
 				playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
@@ -792,6 +777,22 @@ About the new airlock wires panel:
 				else
 					user.visible_message("<span class='warning'>[user] headbutts the airlock. Good thing they're wearing a helmet.</span>")
 				return
+		
+		if(H.species.can_shred(H))
+
+			if(!src.density)
+				return
+
+			H.visible_message("\The [H] begins to pry open \the [src]!", "You begin to pry open \the [src]!", "You hear the sound of an airlock being forced open.")
+
+			if(!do_after(H, 120, 1, act_target = src))
+				return
+
+			src.do_animate("spark")
+			src.stat |= BROKEN
+			var/check = src.open(1)
+			src.visible_message("\The [H] slices \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]", "You slice \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]", "You hear something sparking.")
+			return
 	if(src.p_open)
 		user.set_machine(src)
 		wires.Interact(user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -761,22 +761,37 @@ About the new airlock wires panel:
 		if(src.isElectrified())
 			if(src.shock(user, 100))
 				return
-
-	if(ishuman(user) && prob(40) && src.density)
+	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.getBrainLoss() >= 50)
-			playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
-			if(!istype(H.head, /obj/item/clothing/head/helmet))
-				user.visible_message("<span class='warning'>[user] headbutts the airlock.</span>")
-				var/obj/item/organ/external/affecting = H.get_organ("head")
-				H.Stun(8)
-				H.Weaken(5)
-				if(affecting.take_damage(10, 0))
-					H.UpdateDamageIcon()
-			else
-				user.visible_message("<span class='warning'>[user] headbutts the airlock. Good thing they're wearing a helmet.</span>")
+		if(H.species.can_shred(H))
+
+			if(!src.density)
+				return
+
+			H.visible_message("\The [H] begins to pry open \the [src]!")
+
+			if(!do_after(H,120,src))
+				return
+
+			src.do_animate("spark")
+			src.stat |= BROKEN
+			var/check = src.open(1)
+			src.visible_message("\The [H] slices \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]")
 			return
 
+		if(prob(40) && src.density)
+			if(H.getBrainLoss() >= 50)
+				playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
+				if(!istype(H.head, /obj/item/clothing/head/helmet))
+					user.visible_message("<span class='warning'>[user] headbutts the airlock.</span>")
+					var/obj/item/organ/external/affecting = H.get_organ("head")
+					H.Stun(8)
+					H.Weaken(5)
+					if(affecting.take_damage(10, 0))
+						H.UpdateDamageIcon()
+				else
+					user.visible_message("<span class='warning'>[user] headbutts the airlock. Good thing they're wearing a helmet.</span>")
+				return
 	if(src.p_open)
 		user.set_machine(src)
 		wires.Interact(user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -768,7 +768,7 @@ About the new airlock wires panel:
 			if(!src.density)
 				return
 
-			H.visible_message("\The [H] begins to pry open \the [src]!")
+			H.visible_message("\The [H] begins to pry open \the [src]!", "You being to pry open \the [src]!", "You hear the sound of an airlock being forced open.")
 
 			if(!do_after(H, 120, 1, act_target = src))
 				return
@@ -776,11 +776,11 @@ About the new airlock wires panel:
 			src.do_animate("spark")
 			src.stat |= BROKEN
 			var/check = src.open(1)
-			src.visible_message("\The [H] slices \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]")
+			src.visible_message("\The [H] slices \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]", "You slice \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]", "You hear something sparking.")
 			return
 
-		if(prob(40) && src.density)
-			if(H.getBrainLoss() >= 50)
+		if(H.getBrainLoss() >= 50)
+			if(prob(40) && src.density)
 				playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
 				if(!istype(H.head, /obj/item/clothing/head/helmet))
 					user.visible_message("<span class='warning'>[user] headbutts the airlock.</span>")

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -770,7 +770,7 @@ About the new airlock wires panel:
 
 			H.visible_message("\The [H] begins to pry open \the [src]!")
 
-			if(!do_after(H,120,src))
+			if(!do_after(H, 120, 1, src))
 				return
 
 			src.do_animate("spark")

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -770,7 +770,7 @@ About the new airlock wires panel:
 
 			H.visible_message("\The [H] begins to pry open \the [src]!")
 
-			if(!do_after(H, 120, 1, src))
+			if(!do_after(H, 120, 1, act_target = src))
 				return
 
 			src.do_animate("spark")

--- a/html/changelogs/alberyk-airlock.yml
+++ b/html/changelogs/alberyk-airlock.yml
@@ -1,0 +1,4 @@
+author: Alberyk
+delete-after: True
+changes: 
+  - rscadd: "Antag related species, such as vox, xenomorphs and skeletons, can now pry open airlocks by clicking on them with harm intent."


### PR DESCRIPTION
If any mob with strong claws, like xenos, vox, skeletons, shadow people and etc, hit an airlock with harm intent, it will pry the airlock open after some seconds.