### PR TITLE
Fix constant runtimes on runtime station

### DIFF
--- a/code/controllers/subsystems/processing/shuttle.dm
+++ b/code/controllers/subsystems/processing/shuttle.dm
@@ -45,6 +45,8 @@ var/datum/controller/subsystem/processing/shuttle/shuttle_controller
 	START_PROCESSING(shuttle_controller, shuttle)
 	if(!shuttle)
 		log_debug("Escape shuttle does not exist!")
+	else
+		emergency_shuttle.shuttle = shuttle
 
 	// Supply shuttle
 	shuttle = new/datum/shuttle/ferry/supply()

--- a/maps/aurora/code/aurora_shuttles.dm
+++ b/maps/aurora/code/aurora_shuttles.dm
@@ -45,7 +45,6 @@
 	START_PROCESSING(shuttle_controller, shuttle)
 
 	//give the emergency shuttle controller it's shuttles
-	emergency_shuttle.shuttle = shuttles["Escape"]
 	emergency_shuttle.escape_pods = list(
 		shuttles["Escape Pod 1"],
 		shuttles["Escape Pod 2"],

--- a/maps/exodus/code/exodus_shuttles.dm
+++ b/maps/exodus/code/exodus_shuttles.dm
@@ -61,7 +61,6 @@
 	shuttles["Escape Pod 5"] = shuttle
 
 	//give the emergency shuttle controller it's shuttles
-	emergency_shuttle.shuttle = shuttles["Escape"]
 	emergency_shuttle.escape_pods = list(
 		shuttles["Escape Pod 1"],
 		shuttles["Escape Pod 2"],


### PR DESCRIPTION
Probably we shouldn't be getting literally constant runtimes if the emergency shuttle doesn't exist for whatever reason, but this fix is fine for now.