### PR TITLE
Atmos sensors

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -439,7 +439,7 @@
 
 /obj/item/integrated_circuit/input/pressure_sensor
 	name = "integrated pressure sensor"
-	desc = "A tiny pressure sensor module similar to that found in a PDA atmosphere analyser"
+	desc = "A tiny pressure sensor module similar to that found in a PDA atmosphere analyser."
 	icon_state = "medscan_adv"
 	complexity = 3
 	inputs = list()
@@ -469,7 +469,7 @@
 
 /obj/item/integrated_circuit/input/temperature_sensor
 	name = "integrated temperature sensor"
-	desc = "A tiny temperature sensor module similar to that found in a PDA atmosphere analyser"
+	desc = "A tiny temperature sensor module similar to that found in a PDA atmosphere analyser."
 	icon_state = "medscan_adv"
 	complexity = 3
 	inputs = list()
@@ -498,7 +498,7 @@
 
 /obj/item/integrated_circuit/input/oxygen_sensor
 	name = "integrated oxygen sensor"
-	desc = "A tiny oxygen sensor module similar to that found in a PDA atmosphere analyser"
+	desc = "A tiny oxygen sensor module similar to that found in a PDA atmosphere analyser."
 	icon_state = "medscan_adv"
 	complexity = 3
 	inputs = list()
@@ -528,7 +528,7 @@
 
 /obj/item/integrated_circuit/input/co2_sensor
 	name = "integrated co2 sensor"
-	desc = "A tiny carbon dioxide sensor module similar to that found in a PDA atmosphere analyser"
+	desc = "A tiny carbon dioxide sensor module similar to that found in a PDA atmosphere analyser."
 	icon_state = "medscan_adv"
 	complexity = 3
 	inputs = list()
@@ -558,7 +558,7 @@
 
 /obj/item/integrated_circuit/input/nitrogen_sensor
 	name = "integrated nitrogen sensor"
-	desc = "A tiny nitrogen sensor module similar to that found in a PDA atmosphere analyser"
+	desc = "A tiny nitrogen sensor module similar to that found in a PDA atmosphere analyser."
 	icon_state = "medscan_adv"
 	complexity = 3
 	inputs = list()
@@ -588,7 +588,7 @@
 
 /obj/item/integrated_circuit/input/phoron_sensor
 	name = "integrated phoron sensor"
-	desc = "A tiny phoron gas sensor module similar to that found in a PDA atmosphere analyser"
+	desc = "A tiny phoron gas sensor module similar to that found in a PDA atmosphere analyser."
 	icon_state = "medscan_adv"
 	complexity = 3
 	inputs = list()

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -384,20 +384,20 @@
 	return TRUE
 
 /obj/item/integrated_circuit/input/atmo_scanner
-	name = "integrated atmospheric analyser"
-	desc = "The same atmospheric analysis module that is integrated into every PDA.  \
+	name = "atmospheric analyser"
+	desc = "The same atmospheric analysis module that is integrated into PDAs.  \
 	This allows the machine to know the composition, temperature and pressure of the surrounding atmosphere."
 	icon_state = "medscan_adv"
 	complexity = 9
 	inputs = list()
 	outputs = list(
 		"pressure"       = IC_PINTYPE_NUMBER,
-		"temperature" = IC_PINTYPE_NUMBER,
+		"temperature"    = IC_PINTYPE_NUMBER,
 		"oxygen"         = IC_PINTYPE_NUMBER,
-		"nitrogen"          = IC_PINTYPE_NUMBER,
-		"carbon dioxide"           = IC_PINTYPE_NUMBER,
-		"phoron"           = IC_PINTYPE_NUMBER,
-		"other"           = IC_PINTYPE_NUMBER
+		"nitrogen"       = IC_PINTYPE_NUMBER,
+		"carbon dioxide" = IC_PINTYPE_NUMBER,
+		"phoron"         = IC_PINTYPE_NUMBER,
+		"other"          = IC_PINTYPE_NUMBER
 	)
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
@@ -438,7 +438,7 @@
 	activate_pin(2)
 
 /obj/item/integrated_circuit/input/pressure_sensor
-	name = "integrated pressure sensor"
+	name = "pressure sensor"
 	desc = "A tiny pressure sensor module similar to that found in a PDA atmosphere analyser."
 	icon_state = "medscan_adv"
 	complexity = 3
@@ -468,7 +468,7 @@
 	activate_pin(2)
 
 /obj/item/integrated_circuit/input/temperature_sensor
-	name = "integrated temperature sensor"
+	name = "temperature sensor"
 	desc = "A tiny temperature sensor module similar to that found in a PDA atmosphere analyser."
 	icon_state = "medscan_adv"
 	complexity = 3
@@ -496,21 +496,29 @@
 	push_data()
 	activate_pin(2)
 
-/obj/item/integrated_circuit/input/oxygen_sensor
-	name = "integrated oxygen sensor"
+/obj/item/integrated_circuit/input/gas_sensor
+	name = "oxygen sensor"
 	desc = "A tiny oxygen sensor module similar to that found in a PDA atmosphere analyser."
 	icon_state = "medscan_adv"
 	complexity = 3
-	inputs = list()
-	outputs = list(
-		"oxygen"       = IC_PINTYPE_NUMBER
-	)
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
 	power_draw_per_use = 20
 
-/obj/item/integrated_circuit/input/oxygen_sensor/do_work()
+	var/gas_name = "oxygen"
+	var/gas_display_name = "oxygen"
+
+/obj/item/integrated_circuit/input/gas_sensor/Initialize()
+	name = "[gas_display_name] sensor"
+	displayed_name = "[gas_display_name] sensor"
+	desc = "A tiny [gas_display_name] sensor module similar to that found in a PDA atmosphere analyser."
+	outputs = list(
+		gas_name = IC_PINTYPE_NUMBER
+	)
+	. = ..()
+
+/obj/item/integrated_circuit/input/gas_sensor/do_work()
 	var/turf/T = get_turf(src)
 	if(!istype(T)) //Invalid input
 		return
@@ -519,99 +527,21 @@
 	var/total_moles = environment.total_moles
 
 	if (total_moles)
-		var/o2_level = environment.gas["oxygen"]/total_moles
-		set_pin_data(IC_OUTPUT, 1, round(o2_level*100,0.1))
+		var/gas_level = environment.gas[gas_name]/total_moles
+		set_pin_data(IC_OUTPUT, 1, round(gas_level*100,0.1))
 	else
 		set_pin_data(IC_OUTPUT, 1, 0)
 	push_data()
 	activate_pin(2)
 
-/obj/item/integrated_circuit/input/co2_sensor
-	name = "integrated co2 sensor"
-	desc = "A tiny carbon dioxide sensor module similar to that found in a PDA atmosphere analyser."
-	icon_state = "medscan_adv"
-	complexity = 3
-	inputs = list()
-	outputs = list(
-		"co2"       = IC_PINTYPE_NUMBER
-	)
-	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
-	spawn_flags = IC_SPAWN_RESEARCH
-	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
-	power_draw_per_use = 20
+/obj/item/integrated_circuit/input/gas_sensor/co2
+	gas_name = "carbon_dioxide"
+	gas_display_name = "carbon dioxide"
 
-/obj/item/integrated_circuit/input/co2_sensor/do_work()
-	var/turf/T = get_turf(src)
-	if(!istype(T)) //Invalid input
-		return
-	var/datum/gas_mixture/environment = T.return_air()
+/obj/item/integrated_circuit/input/gas_sensor/nitrogen
+	gas_name = "nitrogen"
+	gas_display_name = "nitrogen"
 
-	var/total_moles = environment.total_moles
-
-	if (total_moles)
-		var/co2_level = environment.gas["carbon_dioxide"]/total_moles
-		set_pin_data(IC_OUTPUT, 1, round(co2_level*100,0.1))
-	else
-		set_pin_data(IC_OUTPUT, 1, 0)
-	push_data()
-	activate_pin(2)
-
-/obj/item/integrated_circuit/input/nitrogen_sensor
-	name = "integrated nitrogen sensor"
-	desc = "A tiny nitrogen sensor module similar to that found in a PDA atmosphere analyser."
-	icon_state = "medscan_adv"
-	complexity = 3
-	inputs = list()
-	outputs = list(
-		"nitrogen"       = IC_PINTYPE_NUMBER
-	)
-	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
-	spawn_flags = IC_SPAWN_RESEARCH
-	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
-	power_draw_per_use = 20
-
-/obj/item/integrated_circuit/input/nitrogen_sensor/do_work()
-	var/turf/T = get_turf(src)
-	if(!istype(T)) //Invalid input
-		return
-	var/datum/gas_mixture/environment = T.return_air()
-
-	var/total_moles = environment.total_moles
-
-	if (total_moles)
-		var/n2_level = environment.gas["nitrogen"]/total_moles
-		set_pin_data(IC_OUTPUT, 1, round(n2_level*100,0.1))
-	else
-		set_pin_data(IC_OUTPUT, 1, 0)
-	push_data()
-	activate_pin(2)
-
-/obj/item/integrated_circuit/input/phoron_sensor
-	name = "integrated phoron sensor"
-	desc = "A tiny phoron gas sensor module similar to that found in a PDA atmosphere analyser."
-	icon_state = "medscan_adv"
-	complexity = 3
-	inputs = list()
-	outputs = list(
-		"phoron"       = IC_PINTYPE_NUMBER
-	)
-	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
-	spawn_flags = IC_SPAWN_RESEARCH
-	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
-	power_draw_per_use = 20
-
-/obj/item/integrated_circuit/input/phoron_sensor/do_work()
-	var/turf/T = get_turf(src)
-	if(!istype(T)) //Invalid input
-		return
-	var/datum/gas_mixture/environment = T.return_air()
-
-	var/total_moles = environment.total_moles
-
-	if (total_moles)
-		var/phoron_level = environment.gas["phoron"]/total_moles
-		set_pin_data(IC_OUTPUT, 1, round(phoron_level*100,0.1))
-	else
-		set_pin_data(IC_OUTPUT, 1, 0)
-	push_data()
-	activate_pin(2)
+/obj/item/integrated_circuit/input/gas_sensor/phoron
+	gas_name = "phoron"
+	gas_display_name = "phoron"

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -397,7 +397,7 @@
 		"nitrogen"          = IC_PINTYPE_NUMBER,
 		"carbon dioxide"           = IC_PINTYPE_NUMBER,
 		"phoron"           = IC_PINTYPE_NUMBER,
-		"other"           = IC_PINTYPE_NUMBER,
+		"other"           = IC_PINTYPE_NUMBER
 	)
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
@@ -444,7 +444,7 @@
 	complexity = 3
 	inputs = list()
 	outputs = list(
-		"pressure"       = IC_PINTYPE_NUMBER,
+		"pressure"       = IC_PINTYPE_NUMBER
 	)
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
@@ -474,7 +474,7 @@
 	complexity = 3
 	inputs = list()
 	outputs = list(
-		"temperature"       = IC_PINTYPE_NUMBER,
+		"temperature"       = IC_PINTYPE_NUMBER
 	)
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
@@ -503,7 +503,7 @@
 	complexity = 3
 	inputs = list()
 	outputs = list(
-		"oxygen"       = IC_PINTYPE_NUMBER,
+		"oxygen"       = IC_PINTYPE_NUMBER
 	)
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
@@ -533,7 +533,7 @@
 	complexity = 3
 	inputs = list()
 	outputs = list(
-		"co2"       = IC_PINTYPE_NUMBER,
+		"co2"       = IC_PINTYPE_NUMBER
 	)
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
@@ -563,7 +563,7 @@
 	complexity = 3
 	inputs = list()
 	outputs = list(
-		"nitrogen"       = IC_PINTYPE_NUMBER,
+		"nitrogen"       = IC_PINTYPE_NUMBER
 	)
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
@@ -593,7 +593,7 @@
 	complexity = 3
 	inputs = list()
 	outputs = list(
-		"phoron"       = IC_PINTYPE_NUMBER,
+		"phoron"       = IC_PINTYPE_NUMBER
 	)
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -382,3 +382,236 @@
 	push_data()
 	activate_pin(1)
 	return TRUE
+
+/obj/item/integrated_circuit/input/atmo_scanner
+	name = "integrated atmospheric analyser"
+	desc = "The same atmospheric analysis module that is integrate into every pda.  \
+	This allows the machine to know the composition, temperature and pressure of the surrounding atmosphere."
+	icon_state = "medscan_adv"
+	complexity = 9
+	inputs = list()
+	outputs = list(
+		"pressure"       = IC_PINTYPE_NUMBER,
+		"temperature" = IC_PINTYPE_NUMBER,
+		"oxygen"         = IC_PINTYPE_NUMBER,
+		"nitrogen"          = IC_PINTYPE_NUMBER,
+		"carbon dioxide"           = IC_PINTYPE_NUMBER,
+		"phoron"           = IC_PINTYPE_NUMBER,
+		"other"           = IC_PINTYPE_NUMBER,
+	)
+	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_RESEARCH
+	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
+	power_draw_per_use = 60
+
+/obj/item/integrated_circuit/input/atmo_scanner/do_work()
+	var/turf/T = get_turf(src)
+	if(!istype(T)) //Invalid input
+		return
+	var/datum/gas_mixture/environment = T.return_air()
+
+	var/pressure = environment.return_pressure()
+	var/total_moles = environment.total_moles
+
+	if (total_moles)
+		var/o2_level = environment.gas["oxygen"]/total_moles
+		var/n2_level = environment.gas["nitrogen"]/total_moles
+		var/co2_level = environment.gas["carbon_dioxide"]/total_moles
+		var/phoron_level = environment.gas["phoron"]/total_moles
+		var/unknown_level =  1-(o2_level+n2_level+co2_level+phoron_level)
+		set_pin_data(IC_OUTPUT, 1, pressure)
+		set_pin_data(IC_OUTPUT, 2, round(environment.temperature-T0C,0.1))
+		set_pin_data(IC_OUTPUT, 3, round(o2_level*100,0.1))
+		set_pin_data(IC_OUTPUT, 4, round(n2_level*100,0.1))
+		set_pin_data(IC_OUTPUT, 5, round(co2_level*100,0.1))
+		set_pin_data(IC_OUTPUT, 6, round(phoron_level*100,0.01))
+		set_pin_data(IC_OUTPUT, 7, round(unknown_level, 0.01))
+	else
+		set_pin_data(IC_OUTPUT, 1, 0)
+		set_pin_data(IC_OUTPUT, 2, -273.15)
+		set_pin_data(IC_OUTPUT, 3, 0)
+		set_pin_data(IC_OUTPUT, 4, 0)
+		set_pin_data(IC_OUTPUT, 5, 0)
+		set_pin_data(IC_OUTPUT, 6, 0)
+		set_pin_data(IC_OUTPUT, 7, 0)
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/input/pressure_sensor
+	name = "integrated pressure sensor"
+	desc = "A tiny pressure sensor module similar to that found in a PDA atmosphere analyser"
+	icon_state = "medscan_adv"
+	complexity = 3
+	inputs = list()
+	outputs = list(
+		"pressure"       = IC_PINTYPE_NUMBER,
+	)
+	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_RESEARCH
+	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
+	power_draw_per_use = 20
+
+/obj/item/integrated_circuit/input/pressure_sensor/do_work()
+	var/turf/T = get_turf(src)
+	if(!istype(T)) //Invalid input
+		return
+	var/datum/gas_mixture/environment = T.return_air()
+
+	var/pressure = environment.return_pressure()
+	var/total_moles = environment.total_moles
+
+	if (total_moles)
+		set_pin_data(IC_OUTPUT, 1, pressure)
+	else
+		set_pin_data(IC_OUTPUT, 1, 0)
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/input/temperature_sensor
+	name = "integrated temperature sensor"
+	desc = "A tiny temperature sensor module similar to that found in a PDA atmosphere analyser"
+	icon_state = "medscan_adv"
+	complexity = 3
+	inputs = list()
+	outputs = list(
+		"temperature"       = IC_PINTYPE_NUMBER,
+	)
+	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_RESEARCH
+	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
+	power_draw_per_use = 20
+
+/obj/item/integrated_circuit/input/temperature_sensor/do_work()
+	var/turf/T = get_turf(src)
+	if(!istype(T)) //Invalid input
+		return
+	var/datum/gas_mixture/environment = T.return_air()
+
+	var/total_moles = environment.total_moles
+
+	if (total_moles)
+		set_pin_data(IC_OUTPUT, 1, round(environment.temperature-T0C,0.1))
+	else
+		set_pin_data(IC_OUTPUT, 1, -273.15)
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/input/oxygen_sensor
+	name = "integrated oxygen sensor"
+	desc = "A tiny oxygen sensor module similar to that found in a PDA atmosphere analyser"
+	icon_state = "medscan_adv"
+	complexity = 3
+	inputs = list()
+	outputs = list(
+		"oxygen"       = IC_PINTYPE_NUMBER,
+	)
+	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_RESEARCH
+	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
+	power_draw_per_use = 20
+
+/obj/item/integrated_circuit/input/oxygen_sensor/do_work()
+	var/turf/T = get_turf(src)
+	if(!istype(T)) //Invalid input
+		return
+	var/datum/gas_mixture/environment = T.return_air()
+
+	var/total_moles = environment.total_moles
+
+	if (total_moles)
+		var/o2_level = environment.gas["oxygen"]/total_moles
+		set_pin_data(IC_OUTPUT, 1, round(o2_level*100,0.1))
+	else
+		set_pin_data(IC_OUTPUT, 1, 0)
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/input/co2_sensor
+	name = "integrated co2 sensor"
+	desc = "A tiny carbon dioxide sensor module similar to that found in a PDA atmosphere analyser"
+	icon_state = "medscan_adv"
+	complexity = 3
+	inputs = list()
+	outputs = list(
+		"co2"       = IC_PINTYPE_NUMBER,
+	)
+	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_RESEARCH
+	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
+	power_draw_per_use = 20
+
+/obj/item/integrated_circuit/input/co2_sensor/do_work()
+	var/turf/T = get_turf(src)
+	if(!istype(T)) //Invalid input
+		return
+	var/datum/gas_mixture/environment = T.return_air()
+
+	var/total_moles = environment.total_moles
+
+	if (total_moles)
+		var/co2_level = environment.gas["carbon_dioxide"]/total_moles
+		set_pin_data(IC_OUTPUT, 1, round(co2_level*100,0.1))
+	else
+		set_pin_data(IC_OUTPUT, 1, 0)
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/input/nitrogen_sensor
+	name = "integrated nitrogen sensor"
+	desc = "A tiny nitrogen sensor module similar to that found in a PDA atmosphere analyser"
+	icon_state = "medscan_adv"
+	complexity = 3
+	inputs = list()
+	outputs = list(
+		"nitrogen"       = IC_PINTYPE_NUMBER,
+	)
+	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_RESEARCH
+	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
+	power_draw_per_use = 20
+
+/obj/item/integrated_circuit/input/nitrogen_sensor/do_work()
+	var/turf/T = get_turf(src)
+	if(!istype(T)) //Invalid input
+		return
+	var/datum/gas_mixture/environment = T.return_air()
+
+	var/total_moles = environment.total_moles
+
+	if (total_moles)
+		var/n2_level = environment.gas["nitrogen"]/total_moles
+		set_pin_data(IC_OUTPUT, 1, round(n2_level*100,0.1))
+	else
+		set_pin_data(IC_OUTPUT, 1, 0)
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/input/phoron_sensor
+	name = "integrated phoron sensor"
+	desc = "A tiny phoron gas sensor module similar to that found in a PDA atmosphere analyser"
+	icon_state = "medscan_adv"
+	complexity = 3
+	inputs = list()
+	outputs = list(
+		"phoron"       = IC_PINTYPE_NUMBER,
+	)
+	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_RESEARCH
+	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
+	power_draw_per_use = 20
+
+/obj/item/integrated_circuit/input/phoron_sensor/do_work()
+	var/turf/T = get_turf(src)
+	if(!istype(T)) //Invalid input
+		return
+	var/datum/gas_mixture/environment = T.return_air()
+
+	var/total_moles = environment.total_moles
+
+	if (total_moles)
+		var/phoron_level = environment.gas["phoron"]/total_moles
+		set_pin_data(IC_OUTPUT, 1, round(phoron_level*100,0.1))
+	else
+		set_pin_data(IC_OUTPUT, 1, 0)
+	push_data()
+	activate_pin(2)

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -385,7 +385,7 @@
 
 /obj/item/integrated_circuit/input/atmo_scanner
 	name = "integrated atmospheric analyser"
-	desc = "The same atmospheric analysis module that is integrate into every pda.  \
+	desc = "The same atmospheric analysis module that is integrated into every PDA.  \
 	This allows the machine to know the composition, temperature and pressure of the surrounding atmosphere."
 	icon_state = "medscan_adv"
 	complexity = 9


### PR DESCRIPTION
Added a set of atmospheric analysis sensors to the integrated electronics module

Consists of 7 new input parts. Pressure, temperature, o2 n2 co2 and phoron levels. The last part is a general atmospheric analyser which has all 6 of those functions in one unit. The multi-purpose part uses triple the complexity and power so it is only worthwhile if you need more than 2 of the output pins.

Please note: There are no changes to the icons, all parts use an existing icon - the one from the advanced medical sensor. I did not feel that this was important to change but someone will probably want to at some point.
