### PR TITLE
Fix for disconnected turret controls

### DIFF
--- a/code/controllers/subsystems/initialization/misc_early.dm
+++ b/code/controllers/subsystems/initialization/misc_early.dm
@@ -7,6 +7,9 @@
 	flags = SS_NO_FIRE | SS_NO_DISPLAY
 
 /datum/controller/subsystem/misc_early/Initialize(timeofday)
+	// Generate the area list.
+	resort_all_areas()
+
 	// Create the data core, whatever that is.
 	data_core = new /datum/datacore()
 

--- a/code/controllers/subsystems/initialization/misc_early.dm
+++ b/code/controllers/subsystems/initialization/misc_early.dm
@@ -1,5 +1,6 @@
 // This is the first subsystem initialized by the MC.
 // Stuff that should be loaded before everything else that isn't significant enough to get its own SS goes here.
+// The area list is put together here, because some things need it early on. Turrets controls, for example.
 
 /datum/controller/subsystem/misc_early
 	name = "Early Miscellaneous Init"
@@ -50,3 +51,10 @@
 	lobby_image = new/obj/effect/lobby_image()
 
 	..()
+
+/proc/resort_all_areas()
+	all_areas = list()
+	for (var/area/A in world)
+		all_areas += A
+
+	sortTim(all_areas, /proc/cmp_name_asc)

--- a/code/controllers/subsystems/initialization/misc_late.dm
+++ b/code/controllers/subsystems/initialization/misc_late.dm
@@ -1,5 +1,4 @@
 // This subsystem loads later in the init process. Not last, but after most major things are done.
-// We sort the area list here because SSatoms needs to run first.
 
 /datum/controller/subsystem/misc_late
 	name = "Late Miscellaneous Init"
@@ -7,9 +6,6 @@
 	flags = SS_NO_FIRE | SS_NO_DISPLAY
 
 /datum/controller/subsystem/misc_late/Initialize(timeofday)
-	// Generate the area list.
-	resort_all_areas()
-
 	var/turf/picked
 	// Setup the teleport locs.
 	for (var/thing in all_areas)

--- a/code/controllers/subsystems/initialization/misc_late.dm
+++ b/code/controllers/subsystems/initialization/misc_late.dm
@@ -38,13 +38,6 @@
 
 	..(timeofday)
 
-/proc/resort_all_areas()
-	all_areas = list()
-	for (var/area/A in world)
-		all_areas += A
-
-	sortTim(all_areas, /proc/cmp_name_asc)
-
 /proc/sorted_add_area(area/A)
 	all_areas += A
 

--- a/html/changelogs/thegreatjorge-turret-fix.yml
+++ b/html/changelogs/thegreatjorge-turret-fix.yml
@@ -1,0 +1,4 @@
+author: TheGreatJorge
+delete-after: True
+changes: 
+  - bugfix: "Turret controls should now work with turrets correctly once again."


### PR DESCRIPTION
Fixes #3122 

Moved `resort_all_areas()` from `"Late Miscellaneous Init"` to `"Early Miscellaneous Init"`, so that list of all areas is filled before turret controls start checking for it.

Hopefully this doesn't break anything else.