### PR TITLE
Fixes ccia actions not clearing when the char is changed

### DIFF
--- a/code/modules/client/preference_setup/other/01_incidents.dm
+++ b/code/modules/client/preference_setup/other/01_incidents.dm
@@ -4,6 +4,7 @@
 
 /datum/category_item/player_setup_item/other/incidents/load_special(var/savefile/S)
 	pref.incidents = list()
+	pref.ccia_actions = list()
 
 	//Special Aurora Snowflake to load in the ccia actions and persistant incidents
 	if (config.sql_saves) // Doesnt work without db


### PR DESCRIPTION
Fixes the following issue:
Char A joins with ccia actions
Char A cryos
Char B is loaded and joins
CCIA Actions from A show up at B

Its caused by not clearing the previous list of ccia actions before loading in the actions for Char B