### PR TITLE
Announcement Fixes

### DIFF
--- a/code/datums/uplink/announcements.dm
+++ b/code/datums/uplink/announcements.dm
@@ -25,7 +25,7 @@
 	return list("title" = title, "message" = message)
 
 /datum/uplink_item/abstract/announcements/fake_centcom/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/user, var/list/args)
-	command_announcement.Announce(args["message"], args["title"])
+	command_announcement.Announce(args["message"], args["title"], do_newscast=1, do_print=1)
 	return 1
 
 /datum/uplink_item/abstract/announcements/fake_crew_arrival

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -7,30 +7,32 @@
 	var/log = 0
 	var/sound
 	var/newscast = 0
+	var/print = 0
 	var/channel_name = "Station Announcements"
 	var/announcement_type = "Announcement"
 
-/datum/announcement/New(var/do_log = 0, var/new_sound = null, var/do_newscast = 0)
+/datum/announcement/New(var/do_log = 0, var/new_sound = null, var/do_newscast = 0, var/do_print = 0)
 	sound = new_sound
 	log = do_log
 	newscast = do_newscast
+	print = do_print
 
-/datum/announcement/priority/New(var/do_log = 1, var/new_sound = 'sound/misc/notice2.ogg', var/do_newscast = 0)
-	..(do_log, new_sound, do_newscast)
+/datum/announcement/priority/New(var/do_log = 1, var/new_sound = 'sound/misc/notice2.ogg', var/do_newscast = 0, var/do_print = 0)
+	..(do_log, new_sound, do_newscast, do_print)
 	title = "Priority Announcement"
 	announcement_type = "Priority Announcement"
 
-/datum/announcement/priority/command/New(var/do_log = 1, var/new_sound = 'sound/misc/notice2.ogg', var/do_newscast = 0)
-	..(do_log, new_sound, do_newscast)
+/datum/announcement/priority/command/New(var/do_log = 1, var/new_sound = 'sound/misc/notice2.ogg', var/do_newscast = 0, var/do_print = 0)
+	..(do_log, new_sound, do_newscast, do_print)
 	title = "[command_name()] Update"
 	announcement_type = "[command_name()] Update"
 
-/datum/announcement/priority/security/New(var/do_log = 1, var/new_sound = 'sound/misc/notice2.ogg', var/do_newscast = 0)
-	..(do_log, new_sound, do_newscast)
+/datum/announcement/priority/security/New(var/do_log = 1, var/new_sound = 'sound/misc/notice2.ogg', var/do_newscast = 0, var/do_print = 0)
+	..(do_log, new_sound, do_newscast, do_print)
 	title = "Security Announcement"
 	announcement_type = "Security Announcement"
 
-/datum/announcement/proc/Announce(var/message as text, var/new_title = "", var/new_sound = null, var/do_newscast = newscast, var/msg_sanitized = 0)
+/datum/announcement/proc/Announce(var/message as text, var/new_title = "", var/new_sound = null, var/do_newscast = newscast, var/msg_sanitized = 0, var/do_print = 0)
 	if(!message)
 		return
 	var/message_title = new_title ? new_title : title
@@ -43,6 +45,8 @@
 	Message(message, message_title)
 	if(do_newscast)
 		NewsCast(message, message_title)
+	if(do_print)
+		post_comm_message(message_title, message)
 	Sound(message_sound)
 	Log(message, message_title)
 

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -153,7 +153,7 @@
 				log_ability_use(user, "advanced encryption hack (FAIL - title: [reporttitle])")
 				return
 			log_ability_use(user, "advanced encryption hack (SUCCESS - title: [reporttitle])")
-			command_announcement.Announce("[reportbody]", reporttitle, new_sound = 'sound/AI/commandreport.ogg', msg_sanitized = 1);
+			command_announcement.Announce("[reportbody]", reporttitle, new_sound = 'sound/AI/commandreport.ogg', msg_sanitized = 1, do_newscast=1, do_print=1)
 
 		if("No")
 			if(!reporttitle || !reportbody || !ability_pay(user, price))

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -384,5 +384,5 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	if(!message)
 		return
 
-	command_announcement.Announce("[message]", title, new_sound = 'sound/AI/commandreport.ogg', msg_sanitized = 1);
+	command_announcement.Announce("[message]", title, new_sound = 'sound/AI/commandreport.ogg', msg_sanitized = 1, do_newscast=1, do_print=1);
 	qdel(src)

--- a/code/modules/events/ccia_general_notice.dm
+++ b/code/modules/events/ccia_general_notice.dm
@@ -19,4 +19,4 @@
 
 /datum/event/ccia_general_notice/announce()
 	if(announce)
-		command_announcement.Announce("[reportbody]", reporttitle, new_sound = 'sound/AI/commandreport.ogg', msg_sanitized = 1);
+		command_announcement.Announce("[reportbody]", reporttitle, new_sound = 'sound/AI/commandreport.ogg', msg_sanitized = 1, do_newscast=1, do_print=1);


### PR DESCRIPTION
Makes printing announcments a parameter of .Announce() and changes a few announcements to use that.
Should fix #3841