### PR TITLE
Fix a directional lighting bug

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -329,7 +329,10 @@
 			if (co_updated)
 				// We might be facing a wall now.
 				var/turf/front = get_step(source_turf, old_direction)
-				facing_opaque = (front && front.has_opaque_atom)
+				var/new_fo = (front && front.has_opaque_atom)
+				if (new_fo != facing_opaque)
+					facing_opaque = new_fo
+					regenerate_angle(ndir)
 
 				update = TRUE
 

--- a/html/changelogs/lohikar-opacity.yml
+++ b/html/changelogs/lohikar-opacity.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes:
+  - bugfix: "Fixed an issue where walking through doors with lights could screw up directional lighting."


### PR DESCRIPTION
Fixes an issue where when the tile in front of a directional light changed opacity without the dir on the light changing, the directional light would not properly transition between omnidirectional and directional lights.