### PR TITLE
Added toggleable Autohiss for Dionaea

### DIFF
--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -39,6 +39,7 @@
 	var/list/autohiss_basic_map = null
 	var/list/autohiss_extra_map = null
 	var/list/autohiss_exempt = null
+	var/list/autohiss_basic_extend = null
 
 /datum/species/unathi
 	autohiss_basic_map = list(
@@ -83,6 +84,9 @@
 	autohiss_exempt = list(LANGUAGE_VAURCA)
 
 /datum/species/diona
+
+	autohiss_basic_extend = list("who","what","when","where","why","how","i'm","i","am","this","they","are","they're","their","his","her","their","the","he","she")
+
 	autohiss_basic_map = list(
 			"s" = list("ss","sss"),
 			"z" = list("zz","zzz"),
@@ -98,27 +102,7 @@
 			LANGUAGE_ROOTSONG
 		)
 
-/datum/species/proc/handle_autoslow(message)
-
-	var/returning = ""
-	var/longwords = list(
-		"who","what","when","where","why","how",
-		"i'm","i","am","this",
-		"they","are","they're","their","his","her","their","the","he","she",
-		)
-
-	for(var/word in text2list(message," ")) // For each word in a message
-		var/addum = word + " "
-		if (lowertext(word) in longwords)
-			addum = word + "... "
-		returning += addum
-
-	return trim(returning)
-
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
-
-	if ( (mode && mode > 0) && (name && name == "Diona") && (lang && lang.name && lang.name != LANGUAGE_ROOTSONG) )
-		message =  handle_autoslow(message)
 
 	if(!autohiss_basic_map)
 		return message
@@ -127,6 +111,15 @@
 	// No reason to auto-hiss in sign-language.
 	if (lang.flags && (lang.flags & SIGNLANG))
 		return message
+
+	if(autohiss_basic_extend)
+		var/longwords = autohiss_basic_extend.Copy()
+		var/list/returninglist = list()
+		for(var/word in text2list(message," ")) // For each word in a message
+			if (lowertext(word) in longwords)
+				word += "..."
+			returninglist += word
+		message = returninglist.Join(" ")
 
 	var/map = autohiss_basic_map.Copy()
 	if(mode == AUTOHISS_FULL && autohiss_extra_map)

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -82,8 +82,44 @@
 		)
 	autohiss_exempt = list(LANGUAGE_VAURCA)
 
+/datum/species/diona
+	autohiss_basic_map = list(
+			"s" = list("ss","sss"),
+			"z" = list("zz","zzz"),
+			"e" = list("ee", "eee")
+		)
+	autohiss_extra_map = list(
+			"a" = list("aa", "aaa"),
+			"i" = list("ii", "iii"),
+			"o" = list("oo", "ooo"),
+			"u" = list("uu", "uuu")
+		)
+	autohiss_exempt = list(
+			LANGUAGE_ROOTSONG
+		)
+
+/datum/species/proc/handle_autoslow(message)
+
+	var/returning = ""
+	var/longwords = list(
+		"who","what","when","where","why","how",
+		"i'm","i","am","this",
+		"they","are","they're","their","his","her","their","the","he","she",
+		)
+
+	for(var/word in text2list(message," ")) // For each word in a message
+		var/addum = word + " "
+		if (lowertext(word) in longwords)
+			addum = word + "... "
+		returning += addum
+
+	return trim(returning)
 
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
+
+	if ( (mode && mode > 0) && (name && name == "Diona") && (lang && lang.name && lang.name != LANGUAGE_ROOTSONG) )
+		message =  handle_autoslow(message)
+
 	if(!autohiss_basic_map)
 		return message
 	if(autohiss_exempt && (lang.name in autohiss_exempt))


### PR DESCRIPTION
The intent is to provide Dionaea players authentic sounding speech according to the currently existing lore. This PR does this by using the already existing autohiss plugin as well as a small custom sentence checker to change the sentence of whatever the player types. This only applies to non-rootsong languages and by default this is disabled.

When on basic or full, ellipses are added after the following words:
"who","what","when","where","why","how","i'm","i","am","this","they","are","they're","their","his","her","their","the","he","she"

When on basic or full, these letters are elongated:
"s","z","e"

When on full, these letters are elongated:
"a","i","o","u"

This was made with sleepy wolf's, the dionaea head loremaster, blessing.

Example of it in action (old screenshot):
![image](https://user-images.githubusercontent.com/8602857/32991419-392dc212-ccf0-11e7-987f-0c1699def21a.png)