### PR TITLE
Reworks the telebaton's stun

### DIFF
--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -110,7 +110,7 @@
 					if(T.species.flags & NO_SLIP)
 						stun_chance -= 5
 
-					if(H.species.brute_mod<0.8)
+					if(T.species.brute_mod<0.8)
 						stun_chance -= 5
 
 					if(T.wear_suit && istype(T.wear_suit,/obj/item/clothing/suit/space))

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -94,5 +94,30 @@
 			else
 				user.take_organ_damage(2*force)
 			return
+		if(..() == 1)
+			playsound(src.loc, "swing_hit", 50, 1, -1)
+			if (target_zone == "r_leg" || target_zone == "l_leg")
+				var/stun_chance = 25
+				if(ishuman(target))
+					var/mob/living/carbon/human/T = target
+					var/armor = T.run_armor_check(T, "melee")
+					if(armor < 100)
+						stun_chance -= 5
+
+					if(T.shoes && T.shoes.item_flags & NOSLIP)
+						stun_chance -= 5
+
+					if(T.species.flags & NO_SLIP)
+						stun_chance -= 5
+
+					if(H.species.brute_mod<0.8)
+						stun_chance -= 5
+
+					if(T.wear_suit && istype(T.wear_suit,/obj/item/clothing/suit/space))
+						stun_chance -= 5
+
+					if(prob(stun_chance))
+						T.Weaken(5) //nerfed, because yes.
+			return
 	else
 		return ..()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -100,11 +100,10 @@
 				var/stun_chance = 100
 				if(ishuman(target))
 					var/mob/living/carbon/human/T = target
-					var/obj/item/organ/external/organ = T.get_organ(target_zone)
-					var/armor = T.getarmor_organ(organ,"melee")
+					var/armor = T.run_armor_check(target_zone,"melee")
 					stun_chance -= armor
 
-					if(T.shoes && (T.shoes.item_flags & NOSLIP) && istype(T.shoes, /obj/item/clothing/shoes/magboots))
+					if(T.shoes && (T.shoes.item_flags & NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots))
 						stun_chance -= 10
 
 					if(T.species.brute_mod<0.8)

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -100,22 +100,18 @@
 				var/stun_chance = 100
 				if(ishuman(target))
 					var/mob/living/carbon/human/T = target
-					var/armor = T.run_armor_check(T, "melee")
-					if(armor < 100)
-						stun_chance -= 30
+					var/obj/item/organ/external/organ = T.get_organ(target_zone)
+					var/armor = T.getarmor_organ(organ,"melee")
+					world << "armor reduction chance is [armor]"
+					stun_chance -= armor
 
-					if(T.shoes && T.shoes.item_flags & NOSLIP)
-						stun_chance -= 25
-
-					if(T.species.flags & NO_SLIP)
+					if(T.shoes && (T.shoes.item_flags & NOSLIP) && istype(T.shoes, /obj/item/clothing/shoes/magboots))
 						stun_chance -= 25
 
 					if(T.species.brute_mod<0.8)
 						stun_chance -= 25
 
-					if(T.wear_suit && istype(T.wear_suit,/obj/item/clothing/suit/space))
-						stun_chance -= 30
-
+					world << "stun chance is [stun_chance]"
 					if(prob(stun_chance))
 						T.Weaken(5) //nerfed, because yes.
 			return

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -94,4 +94,5 @@
 			else
 				user.take_organ_damage(2*force)
 			return
+	else
 		return ..()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -103,7 +103,7 @@
 					var/armor = T.run_armor_check(target_zone,"melee")
 					stun_chance -= armor
 
-					if(T.shoes && (T.shoes.item_flags & NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots))
+					if(T.shoes && (T.shoes.item_flags & NOSLIP) && istype(T.shoes, /obj/item/clothing/shoes/magboots))
 						stun_chance -= 10
 
 					if(T.species.brute_mod<0.8)

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -102,16 +102,14 @@
 					var/mob/living/carbon/human/T = target
 					var/obj/item/organ/external/organ = T.get_organ(target_zone)
 					var/armor = T.getarmor_organ(organ,"melee")
-					world << "armor reduction chance is [armor]"
 					stun_chance -= armor
 
 					if(T.shoes && (T.shoes.item_flags & NOSLIP) && istype(T.shoes, /obj/item/clothing/shoes/magboots))
-						stun_chance -= 25
+						stun_chance -= 10
 
 					if(T.species.brute_mod<0.8)
-						stun_chance -= 25
+						stun_chance -= 10
 
-					world << "stun chance is [stun_chance]"
 					if(prob(stun_chance))
 						T.Weaken(5) //nerfed, because yes.
 			return

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -94,14 +94,4 @@
 			else
 				user.take_organ_damage(2*force)
 			return
-		if(..() == 1)
-			playsound(src.loc, "swing_hit", 50, 1, -1)
-			if (target_zone == "r_leg" || target_zone == "l_leg")
-				if(ishuman(target))
-					var/mob/living/carbon/human/T = target
-					var/armor = T.run_armor_check(T, "melee")
-					if(armor < 100)
-						T.Weaken(5) //nerfed, because yes.
-			return
-	else
 		return ..()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -97,24 +97,24 @@
 		if(..() == 1)
 			playsound(src.loc, "swing_hit", 50, 1, -1)
 			if (target_zone == "r_leg" || target_zone == "l_leg")
-				var/stun_chance = 25
+				var/stun_chance = 100
 				if(ishuman(target))
 					var/mob/living/carbon/human/T = target
 					var/armor = T.run_armor_check(T, "melee")
 					if(armor < 100)
-						stun_chance -= 5
+						stun_chance -= 30
 
 					if(T.shoes && T.shoes.item_flags & NOSLIP)
-						stun_chance -= 5
+						stun_chance -= 25
 
 					if(T.species.flags & NO_SLIP)
-						stun_chance -= 5
+						stun_chance -= 25
 
 					if(T.species.brute_mod<0.8)
-						stun_chance -= 5
+						stun_chance -= 25
 
 					if(T.wear_suit && istype(T.wear_suit,/obj/item/clothing/suit/space))
-						stun_chance -= 5
+						stun_chance -= 30
 
 					if(prob(stun_chance))
 						T.Weaken(5) //nerfed, because yes.

--- a/html/changelogs/alberyk_telebaton.yml
+++ b/html/changelogs/alberyk_telebaton.yml
@@ -1,0 +1,5 @@
+
+author: Alberyk
+delete-after: True
+changes: 
+  - balance: "Changed how the telebaton's stun works, it should now take in consideration things like spacesuits, armor and species related variables when stunning a target."


### PR DESCRIPTION
Reworks how the telebaton stun is calculated, now it has a base chance of 100% of stunning the target, being reduced by things like having magboots on, melee armor, having natural brute resist and etc.