### PR TITLE
Fixes #3817.

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/alien_attacks.dm
@@ -15,7 +15,7 @@
 		if (I_GRAB)
 			if (M == src)
 				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab( M, M, src )
+			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab( M, src )
 
 			M.put_in_active_hand(G)
 


### PR DESCRIPTION
(fixes #3817)
Identical to an issue on Polaris, may be an issue resulting from Bay. Had to replace `M, M, src` with `M, src`.

Originally, `M, M, src` resulted in the third argument being ignored, and making a player aggressively grab themselves.

Changelog coming soon(tm).