### PR TITLE
Stacker fixes

### DIFF
--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -125,6 +125,5 @@
 	//Output amounts that are past stack_amt.
 	for(var/sheet in stack_storage)
 		if(stack_storage[sheet] >= stack_amt)
-			var/stacktype = sheet
-			var/obj/item/stack/material/S = new stacktype(get_turf(output), stack_amt)
+			new sheet(get_turf(output), stack_amt)
 			stack_storage[sheet] -= stack_amt

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -126,6 +126,5 @@
 	for(var/sheet in stack_storage)
 		if(stack_storage[sheet] >= stack_amt)
 			var/stacktype = sheet
-			var/obj/item/stack/material/S = new stacktype(get_turf(output))
-			S.amount = stack_amt
+			var/obj/item/stack/material/S = new stacktype(get_turf(output), stack_amt)
 			stack_storage[sheet] -= stack_amt

--- a/html/changelogs/lohikar-stacker.yml
+++ b/html/changelogs/lohikar-stacker.yml
@@ -1,0 +1,5 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Stacking units no longer illegally produce unlicenced cyborg glass synthesizers."
+  - rscadd: "The stacking machine's UI has been made prettier for no particular reason."

--- a/nano/templates/stacking_machine.tmpl
+++ b/nano/templates/stacking_machine.tmpl
@@ -1,20 +1,18 @@
-<div class='statusDisplay'>
-	{{if data.no_contents}}
-		<div class='notice'>No materials loaded.</div>
-	{{else}}
-		{{for data.contents}}
-			<div class='line'>
-				<div class='statusLabel'>{{:value.name}}</div>
-				<div class='statusValue'>{{:value.amount}}</div>
-				{{:helper.link('Release', 'eject', {'release_stack' : value.path})}}
-			</div>
-		{{/for}}
-	{{/if}}
+<div class='itemGroup'>
+	{{for data.contents}}
+		<div class='item'>
+			<div class='itemLabelNarrow'>{{:value.name}}</div>
+			<div class='itemContentSmall'>{{:value.amount}}</div>
+			<div class='floatRight'>{{:helper.link('Eject', 'eject', {'release_stack' : value.path})}}</div>
+		</div>
+	{{empty}}
+		No materials loaded.
+	{{/for}}
 </div>
-<div>
+<div class='statusDisplay'>
 	<div class='line'>
 		<div class='statusLabel'>Stacking:</div>
 		<div class='statusValue'>{{:data.stack_amt}}</div>
-		{{:helper.link('Change', 'wrench', {'change_stack' : 1})}}
+		<div class='floatRight'>{{:helper.link('Change', 'wrench', {'change_stack' : 1})}}</div>
 	</div>
 </div>

--- a/nano/templates/stacking_machine.tmpl
+++ b/nano/templates/stacking_machine.tmpl
@@ -1,0 +1,20 @@
+<div class='statusDisplay'>
+	{{if data.no_contents}}
+		<div class='notice'>No materials loaded.</div>
+	{{else}}
+		{{for data.contents}}
+			<div class='line'>
+				<div class='statusLabel'>{{:value.name}}</div>
+				<div class='statusValue'>{{:value.amount}}</div>
+				{{:helper.link('Release', 'eject', {'release_stack' : value.path})}}
+			</div>
+		{{/for}}
+	{{/if}}
+</div>
+<div>
+	<div class='line'>
+		<div class='statusLabel'>Stacking:</div>
+		<div class='statusValue'>{{:data.stack_amt}}</div>
+		{{:helper.link('Change', 'wrench', {'change_stack' : 1})}}
+	</div>
+</div>


### PR DESCRIPTION
Pack of general fixes, code improvements, and visual buffing for mining's stacker unit. The stacker now uses type paths to track materials instead of their names, now qdeletes the items it takes in instead of leaving them perpetually in nullspace, and now uses NanoUI for added visual fluff.

New UI:
![wkulqw](https://user-images.githubusercontent.com/7097800/33154727-10e29450-cfb0-11e7-9bf2-18dc2bd8bbb5.png)

Fixes #2999.
Fixes #3344.