### PR TITLE
Make get_smooth_underlay_icon work properly with space parallax

### DIFF
--- a/code/_helpers/icon_smoothing.dm
+++ b/code/_helpers/icon_smoothing.dm
@@ -181,6 +181,7 @@
 				var/istate = "[((x + y) ^ ~(x * y) + z) % 25]"
 				underlay_appearance.icon = 'icons/turf/space.dmi'
 				underlay_appearance.icon_state = istate
+				underlay_appearance.plane = PLANE_SPACE_BACKGROUND
 
 				var/image/dust = image('icons/turf/space_parallax1.dmi', istate)
 				dust.plane = PLANE_SPACE_DUST

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -92,8 +92,7 @@
 	return QDEL_HINT_IWILLGC
 
 /turf/proc/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	underlay_appearance.icon = icon
-	underlay_appearance.icon_state = icon_state
+	underlay_appearance.appearance = src
 	underlay_appearance.dir = adjacency_dir
 	return TRUE
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -549,11 +549,6 @@
 
 	return INITIALIZE_HINT_NORMAL
 
-/turf/simulated/floor/asteroid/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	. = ..()
-	underlay_appearance.pixel_x = pixel_x
-	underlay_appearance.pixel_y = pixel_y
-
 /turf/simulated/floor/asteroid/ex_act(severity)
 	switch(severity)
 		if(3.0)

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -105,10 +105,6 @@
 
 	return ..()
 
-/turf/simulated/open/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	underlay_appearance.appearance = src
-	return TRUE
-
 /**
  * Used to check whether or not the specific open turf eventually leads into spess.
  *


### PR DESCRIPTION
Fixes an issue where space underlays on diagonally smoothed turfs would not work properly with space parallax.