### PR TITLE
Misc tweaks

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -123,5 +123,8 @@
 #define AO_UPDATE_OVERLAY 1
 #define AO_UPDATE_REBUILD 2
 
+// If ao_neighbors equals this, no AO shadows are present.
+#define AO_ALL_NEIGHBORS 1910
+
 // If defined, integrate with the lighting engine and use its opacity value. Otherwise a simple turf opacity check is used. This may cause visual artifacts with opaque non-square movables.
 //#define AO_USE_LIGHTING_OPACITY

--- a/code/controllers/subsystems/effects.dm
+++ b/code/controllers/subsystems/effects.dm
@@ -7,7 +7,7 @@ var/datum/controller/subsystem/effects/SSeffects
 	priority = SS_PRIORITY_EFFECTS
 
 	var/list/datum/effect_system/effect_systems = list()	// The effect-spawning objects. Shouldn't be many of these.
-	var/list/obj/visual_effect/visuals	= list()	// The visible component of an effect. May be created without an effect object.
+	var/list/obj/effect/visual/visuals	= list()	// The visible component of an effect. May be created without an effect object.
 
 	var/tmp/list/processing_effects = list()
 	var/tmp/list/processing_visuals = list()
@@ -49,7 +49,7 @@ var/datum/controller/subsystem/effects/SSeffects
 
 	// Most often these will be continuing to tick, so assume that we're going to keep poking the effect.
 	while (current_visuals.len)
-		var/obj/visual_effect/V = current_visuals[current_visuals.len]
+		var/obj/effect/visual/V = current_visuals[current_visuals.len]
 		current_visuals.len--
 
 		if (QDELETED(V) || !V.isprocessing)

--- a/code/controllers/subsystems/openturf.dm
+++ b/code/controllers/subsystems/openturf.dm
@@ -122,15 +122,16 @@
 		if (depth > OPENTURF_MAX_DEPTH)
 			depth = OPENTURF_MAX_DEPTH
 
-		var/target_plane
+		var/oo_target = OPENTURF_MAX_PLANE - depth
+		var/t_target
 
 		// Handle space parallax & starlight.
 		if (T.is_above_space())
-			target_plane = PLANE_SPACE_BACKGROUND
+			t_target = PLANE_SPACE_BACKGROUND
 			if (starlight_enabled && !T.light_range)
 				T.set_light(config.starlight, 0.5)
 		else
-			target_plane = OPENTURF_MAX_PLANE - depth
+			t_target = oo_target
 			if (starlight_enabled && T.light_range)
 				T.set_light(0)
 
@@ -142,7 +143,7 @@
 			TO.appearance = T.below
 			TO.name = T.name
 			T.desc = TO.desc = "Below seems to be \a [T.below]."
-			TO.plane = target_plane
+			TO.plane = t_target
 		else
 			// This openturf doesn't care about its icon, so we can just overwrite it.
 			if (T.below.bound_overlay)
@@ -150,7 +151,7 @@
 			T.appearance = T.below
 			T.name = initial(T.name)
 			T.opacity = FALSE
-			T.plane = target_plane
+			T.plane = t_target
 
 		T.desc = "Below seems to be \a [T.below]."
 		T.queue_ao()	// No need to recalculate ajacencies, shouldn't have changed.
@@ -162,7 +163,7 @@
 				// Don't queue deleted stuff or stuff that doesn't need an overlay.
 				continue
 
-			if (istype(object, /atom/movable/lighting_overlay))	// Special case.
+			if (object.type == /atom/movable/lighting_overlay)	// Special case.
 				T.shadower.copy_lighting(object)
 			else
 				if (!object.bound_overlay)	// Generate a new overlay if the atom doesn't already have one.
@@ -172,7 +173,7 @@
 				var/atom/movable/openspace/overlay/OO = object.bound_overlay
 
 				// Cache our already-calculated depth so we don't need to re-calculate it a bunch of times.
-				OO.depth = target_plane
+				OO.depth = oo_target
 
 				queued_overlays += OO
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -150,6 +150,14 @@
 /atom/proc/set_dir(new_dir)
 	. = new_dir != dir
 	dir = new_dir
+	
+	// Lighting
+	if (.)
+		var/datum/light_source/L
+		for (var/thing in light_sources)
+			L = thing
+			if (L.light_angle)
+				L.source_atom.update_light()
 
 /atom/proc/ex_act()
 	return

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -58,9 +58,10 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "greenglow"
 
-/obj/effect/decal/cleanable/greenglow/New()
-	..()
-	QDEL_IN(src, 2 MINUTES)
+/obj/effect/decal/cleanable/greenglow/Initialize(mapload)
+	. = ..()
+	if (!ROUND_IS_STARTED)	// Round-start goo should stick around.
+		QDEL_IN(src, 2 MINUTES)
 
 /obj/effect/decal/cleanable/cobweb
 	name = "cobweb"

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -66,7 +66,7 @@
 		add_overlay(stool_cache[cache_key])
 
 /obj/structure/bed/chair/set_dir()
-	..()
+	. = ..()
 	if(buckled_mob)
 		buckled_mob.set_dir(dir)
 

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -14,7 +14,7 @@
 	add_overlay(image(icon = 'icons/obj/furniture.dmi', icon_state = "w_overlay", layer = FLY_LAYER))
 
 /obj/structure/bed/chair/wheelchair/set_dir()
-	..()
+	. = ..()
 	if(buckled_mob)
 		buckled_mob.set_dir(dir)
 

--- a/code/modules/ambient_occlusion/ao_openspace.dm
+++ b/code/modules/ambient_occlusion/ao_openspace.dm
@@ -12,6 +12,9 @@
 		shadower.cut_overlay(ao_overlays)
 		ao_overlays.Cut()
 
+	if (ao_neighbors == AO_ALL_NEIGHBORS)
+		return
+
 	var/list/cache = SSicon_cache.ao_cache
 
 	for(var/i = 1 to 4)

--- a/code/modules/ambient_occlusion/ao_turf.dm
+++ b/code/modules/ambient_occlusion/ao_turf.dm
@@ -53,7 +53,7 @@
 		cut_overlay(ao_overlays, TRUE)
 		ao_overlays.Cut()
 
-	if (!permit_ao)
+	if (!permit_ao || ao_neighbors == AO_ALL_NEIGHBORS)	// If all corners are going to be transparent anyways, bail early.
 		return
 
 	var/list/cache = SSicon_cache.ao_cache

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -217,13 +217,6 @@ All custom items with worn sprites must follow the contained sprite system: http
 /obj/structure/bed/chair/wheelchair/fluff/nomak_scooter/update_icon()
 	return
 
-/obj/structure/bed/chair/wheelchair/fluff/nomak_scooter/set_dir()
-	..()
-	overlays = null
-	if(buckled_mob)
-		buckled_mob.set_dir(dir)
-
-
 /obj/item/weapon/coin/fluff/yoiko_coin //Sobriety Chip - Yurick Ali - raineko
 	name = "sobriety chip"
 	desc = "A red coin, made from plastic. A triangle is engraved, surrounding it is the words: \"TO THINE OWN SELF BE TRUE\"."

--- a/code/modules/effects/sparks/spawner.dm
+++ b/code/modules/effects/sparks/spawner.dm
@@ -25,7 +25,7 @@
 
 	var/total_sparks = 1
 	if (location)
-		var/obj/visual_effect/sparks/S = new(location, src, 0) //Trigger one on the tile it's on
+		var/obj/effect/visual/sparks/S = new(location, src, 0) //Trigger one on the tile it's on
 		S.start()
 		playsound(location, "sparks", 100, 1)
 		QUEUE_VISUAL(S)	// Queue it.
@@ -39,7 +39,7 @@
 			else
 				direction = 0
 
-			S = new /obj/visual_effect/sparks(location, src)
+			S = new /obj/effect/visual/sparks(location, src)
 			S.start(direction)	
 			QUEUE_VISUAL(S)
 			total_sparks++

--- a/code/modules/effects/sparks/visuals.dm
+++ b/code/modules/effects/sparks/visuals.dm
@@ -1,15 +1,15 @@
-// -- Spark visual_effect --
-/obj/visual_effect/sparks
+// -- Spark visual effect --
+/obj/effect/visual/sparks
 	name = "sparks"
 	icon_state = "sparks"
 	anchored = 1
 	mouse_opacity = 0
 
-/obj/visual_effect/sparks/New(var/turf/loc)
-	..(loc)
+/obj/effect/visual/sparks/Initialize(mapload)
+	. = ..(mapload)
 	life_ticks = rand(5,10)
 
-/obj/visual_effect/sparks/tick()
+/obj/effect/visual/sparks/tick()
 	. = ..()
 
 	var/turf/T = get_turf(src)
@@ -19,9 +19,9 @@
 	if (life_ticks < 2)
 		animate(src, alpha = 0, time = 2, easing = SINE_EASING | EASE_IN)
 
-/obj/visual_effect/sparks/start(var/direction)
+/obj/effect/visual/sparks/start(var/direction)
 	if (direction)
 		addtimer(CALLBACK(src, .proc/do_step, direction), 5)
 
-/obj/visual_effect/sparks/proc/do_step(direction)
+/obj/effect/visual/sparks/proc/do_step(direction)
 	step(src, direction)

--- a/code/modules/effects/visual_effect.dm
+++ b/code/modules/effects/visual_effect.dm
@@ -1,4 +1,4 @@
-/obj/visual_effect
+/obj/effect/visual
 	name = "effect"
 	icon = 'icons/effects/effects.dmi'
 	anchored = 1
@@ -10,24 +10,24 @@
 	var/life_ticks_max		// The high limit for the random tick picker.
 	var/life_ticks_min		// The low limit for the random tick picker.
 
-/obj/visual_effect/New(var/life_min = 3 SECONDS, var/life_max = 5 SECONDS)
-	..()
+/obj/effect/visual/Initialize(var/life_min = 3 SECONDS, var/life_max = 5 SECONDS)
+	. = ..()
 	life_ticks_min = life_min
 	life_ticks_max = life_max
 	if (!life_ticks)
 		life_ticks = rand(life_ticks_min, life_ticks_max)
 
 // Called when the visual_effect is manifested.
-/obj/visual_effect/proc/start()
+/obj/effect/visual/proc/start()
 
 // Called every effects processor tick. Return value determines what the process does to this object.
-/obj/visual_effect/proc/tick()
+/obj/effect/visual/proc/tick()
 	if (!life_ticks)	
 		return EFFECT_DESTROY
 
 	life_ticks--
 	return EFFECT_CONTINUE
 
-/obj/visual_effect/Destroy()
+/obj/effect/visual/Destroy()
 	STOP_VISUAL(src)
 	return ..()

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -130,11 +130,3 @@
 	for (thing in light_sources)
 		L = thing
 		L.source_atom.update_light()
-
-
-/atom/set_dir(new_dir)
-	. = ..()
-
-	for (var/datum/light_source/L in src.light_sources)
-		if (L.light_angle)
-			L.source_atom.update_light()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1173,14 +1173,14 @@ mob/proc/yank_out_object()
 		set_dir(dir)
 		facing_dir = dir
 
-/mob/set_dir()
+/mob/set_dir(ndir)
 	if(facing_dir)
 		if(!canface() || lying || buckled || restrained())
 			facing_dir = null
 		else if(dir != facing_dir)
 			return ..(facing_dir)
 	else
-		return ..()
+		return ..(ndir)
 
 /mob/forceMove(atom/dest)
 	var/atom/movable/AM

--- a/code/modules/multiz/openspace.dm
+++ b/code/modules/multiz/openspace.dm
@@ -53,7 +53,7 @@ Most openspace appearance code is in code/controllers/subsystems/openturf.dm.
 /atom/movable/set_dir(ndir)
 	. = ..()
 	if (. && bound_overlay)
-		bound_overlay.set_dir(dir)
+		bound_overlay.set_dir(ndir)
 
 /atom/movable/update_above()
 	if (!bound_overlay)
@@ -125,6 +125,7 @@ Most openspace appearance code is in code/controllers/subsystems/openturf.dm.
 
 /atom/movable/openspace/multiplier/proc/copy_lighting(atom/movable/lighting_overlay/LO)
 	appearance = LO
+	layer = LIGHTING_LAYER + 0.001
 	plane = OPENTURF_CAP_PLANE
 	invisibility = 0
 	if (icon_state == LIGHTING_BASE_ICON_STATE)
@@ -153,7 +154,7 @@ Most openspace appearance code is in code/controllers/subsystems/openturf.dm.
 
 	if (our_overlays || priority_overlays)
 		compile_overlays()
-	else
+	else if (bound_overlay)
 		// compile_overlays() calls update_above().
 		update_above()
 


### PR DESCRIPTION
changes:
- `/obj/visual_effect` has been repathed to `/obj/effect/visual`.
- Openspace movables will no longer use the space plane when on an openturf mimicing a space turf.
- Lights now only update on direction change if your direction actually changed.
- Fixed some bad `set_dir()` procs that were either pointless or that didn't return parent.
- Mapped-in or maint dirtier-spawned glowing goo no longer self-deletes after 2 minutes.
- Fixed an issue that may have caused some openspace movables to not properly handle direction changes.