### PR TITLE
Christmas map additions

### DIFF
--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -236,7 +236,7 @@
 	desc = "Flashy."
 	icon = 'icons/obj/christmas.dmi'
 	icon_state = "xmaslights"
-	layer = 5
+	layer = 4.9
 
 /obj/structure/sign/christmas/wreath
 	name = "wreath"

--- a/html/changelogs/thegreatjorge-christmas.yml
+++ b/html/changelogs/thegreatjorge-christmas.yml
@@ -1,0 +1,4 @@
+author: Santa
+delete-after: True
+changes: 
+  - rscadd: "Merry Christmas NSS Aurora!"

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -7407,12 +7407,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
 	icon_state = "rwindow";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -7584,7 +7582,6 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
 	icon_state = "rwindow";
 	dir = 4
 	},
@@ -7670,7 +7667,6 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/wallet,
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -7886,7 +7882,6 @@
 "asJ" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -8006,7 +8001,6 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
 	icon_state = "rwindow";
 	dir = 4
 	},
@@ -8034,7 +8028,6 @@
 "ata" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
 	icon_state = "rwindow";
 	dir = 4
 	},
@@ -13383,12 +13376,10 @@
 "aDM" = (
 /obj/item/modular_computer/console/preset/command,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -13465,7 +13456,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -13637,7 +13627,6 @@
 "aEr" = (
 /obj/structure/banner,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -14075,12 +14064,10 @@
 /area/centcom/ferry)
 "aFs" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -14091,7 +14078,6 @@
 /area/centcom/holding)
 "aFt" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -14102,7 +14088,6 @@
 /area/centcom/holding)
 "aFu" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -14130,7 +14115,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -14235,7 +14219,6 @@
 	pixel_y = -5
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -14339,7 +14322,6 @@
 	pixel_y = 0
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -14381,7 +14363,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -14437,7 +14418,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -14479,7 +14459,6 @@
 /area/centcom/holding)
 "aGe" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -14520,7 +14499,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -14660,7 +14638,6 @@
 "aGx" = (
 /obj/machinery/vending/coffee,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -14805,7 +14782,6 @@
 "aGL" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -16541,7 +16517,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -17196,7 +17171,6 @@
 "aLN" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -17208,7 +17182,6 @@
 	c_tag = "Surface - Arrivals Shuttle"
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -18879,7 +18852,6 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19317,7 +19289,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24501,7 +24472,6 @@
 /area/centcom/holding)
 "biU" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -24514,7 +24484,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24528,7 +24497,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24542,7 +24510,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24556,7 +24523,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24578,7 +24544,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24591,7 +24556,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24604,7 +24568,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24617,7 +24580,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24627,7 +24589,6 @@
 /area/shuttle/escape/centcom)
 "bjf" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24640,7 +24601,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24653,7 +24613,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24666,7 +24625,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24679,7 +24637,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24692,7 +24649,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24703,7 +24659,6 @@
 /area/centcom/holding)
 "bjl" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24716,7 +24671,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24729,7 +24683,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24742,7 +24695,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24755,7 +24707,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24768,7 +24719,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24779,7 +24729,6 @@
 /area/centcom/holding)
 "bjr" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24792,7 +24741,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24805,7 +24753,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24818,7 +24765,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24831,7 +24777,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24845,7 +24790,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24858,7 +24802,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24871,7 +24814,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24884,7 +24826,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24897,7 +24838,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24911,7 +24851,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24921,7 +24860,6 @@
 /area/centcom/holding)
 "bjC" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -24929,7 +24867,6 @@
 /area/shuttle/escape/centcom)
 "bjD" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -24937,7 +24874,6 @@
 /area/shuttle/escape/centcom)
 "bjE" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24951,7 +24887,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24965,7 +24900,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25023,7 +24957,6 @@
 /area/centcom/holding)
 "bjN" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25034,7 +24967,6 @@
 /area/centcom/spawning)
 "bjO" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25045,7 +24977,6 @@
 /area/centcom/spawning)
 "bjP" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25059,7 +24990,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25070,7 +25000,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25081,7 +25010,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25101,7 +25029,6 @@
 /area/shuttle/arrival/centcom)
 "bjW" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25112,7 +25039,6 @@
 /area/centcom/holding)
 "bjX" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25122,7 +25048,6 @@
 /area/centcom/holding)
 "bjY" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25133,7 +25058,6 @@
 /area/centcom/holding)
 "bjZ" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25144,7 +25068,6 @@
 /area/centcom/holding)
 "bka" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25155,7 +25078,6 @@
 /area/centcom/holding)
 "bkb" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25166,7 +25088,6 @@
 /area/centcom/holding)
 "bkc" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25177,7 +25098,6 @@
 /area/centcom/holding)
 "bkd" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25190,7 +25110,6 @@
 /obj/machinery/porta_turret/crescent,
 /obj/effect/decal/warning_stripes,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25200,7 +25119,6 @@
 /area/centcom/spawning)
 "bkf" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25211,7 +25129,6 @@
 /area/centcom/spawning)
 "bkg" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25222,7 +25139,6 @@
 /area/centcom/spawning)
 "bkh" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25233,7 +25149,6 @@
 /area/centcom/spawning)
 "bki" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25244,7 +25159,6 @@
 /area/centcom/spawning)
 "bkj" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25255,7 +25169,6 @@
 /area/centcom/spawning)
 "bkk" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25266,7 +25179,6 @@
 /area/centcom/spawning)
 "bkl" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25277,7 +25189,6 @@
 /area/centcom/spawning)
 "bkm" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25288,7 +25199,6 @@
 /area/centcom/spawning)
 "bkn" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25299,7 +25209,6 @@
 /area/centcom/spawning)
 "bko" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25310,7 +25219,6 @@
 /area/centcom/spawning)
 "bkp" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25323,7 +25231,6 @@
 /obj/machinery/porta_turret/crescent,
 /obj/effect/decal/warning_stripes,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25333,7 +25240,6 @@
 /area/centcom/spawning)
 "bkr" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25344,7 +25250,6 @@
 /area/centcom/holding)
 "bks" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25355,7 +25260,6 @@
 /area/centcom/holding)
 "bkt" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25366,7 +25270,6 @@
 /area/centcom/holding)
 "bku" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25377,7 +25280,6 @@
 /area/centcom/holding)
 "bkv" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25388,7 +25290,6 @@
 /area/centcom/spawning)
 "bkw" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25433,7 +25334,6 @@
 /area/centcom/spawning)
 "bkC" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25444,7 +25344,6 @@
 /area/centcom/spawning)
 "bkD" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25455,7 +25354,6 @@
 /area/centcom/spawning)
 "bkE" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25466,7 +25364,6 @@
 /area/centcom/spawning)
 "bkF" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25477,7 +25374,6 @@
 /area/centcom/spawning)
 "bkG" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25488,7 +25384,6 @@
 /area/centcom/spawning)
 "bkH" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25499,7 +25394,6 @@
 /area/centcom/spawning)
 "bkI" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25510,7 +25404,6 @@
 /area/centcom/spawning)
 "bkJ" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25521,7 +25414,6 @@
 /area/centcom/spawning)
 "bkK" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25532,7 +25424,6 @@
 /area/centcom/spawning)
 "bkL" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25543,7 +25434,6 @@
 /area/centcom/spawning)
 "bkM" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25554,7 +25444,6 @@
 /area/centcom/holding)
 "bkN" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25564,7 +25453,6 @@
 /area/centcom/holding)
 "bkO" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25575,7 +25463,6 @@
 /area/centcom/holding)
 "bkP" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25586,7 +25473,6 @@
 /area/centcom/holding)
 "bkQ" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25597,7 +25483,6 @@
 /area/centcom/holding)
 "bkR" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25608,7 +25493,6 @@
 /area/centcom/holding)
 "bkS" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25619,7 +25503,6 @@
 /area/centcom/holding)
 "bkT" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25630,7 +25513,6 @@
 /area/centcom/holding)
 "bkU" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25641,7 +25523,6 @@
 /area/centcom/holding)
 "bkV" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25652,7 +25533,6 @@
 /area/centcom/holding)
 "bkW" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25663,7 +25543,6 @@
 /area/centcom/holding)
 "bkX" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -13285,6 +13285,7 @@
 	opacity = 1;
 	req_access = list(101)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -13381,6 +13382,16 @@
 /area/centcom/holding)
 "aDM" = (
 /obj/item/modular_computer/console/preset/command,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -13452,6 +13463,11 @@
 /obj/machinery/camera/network/crescent{
 	c_tag = "Crescent Arrivals North";
 	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -13620,6 +13636,11 @@
 /area/centcom/holding)
 "aEr" = (
 /obj/structure/banner,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/unsimulated/floor{
 	icon_state = "green";
 	dir = 4
@@ -13630,6 +13651,7 @@
 	name = "Escape Shuttle Cockpit";
 	req_access = list(19)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape/centcom)
 "aEt" = (
@@ -14052,21 +14074,38 @@
 	},
 /area/centcom/ferry)
 "aFs" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/unsimulated/floor{
 	dir = 9;
 	icon_state = "carpetside"
 	},
 /area/centcom/holding)
 "aFt" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/unsimulated/floor{
 	dir = 1;
 	icon_state = "carpetside"
 	},
 /area/centcom/holding)
 "aFu" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/unsimulated/floor{
 	dir = 5;
 	icon_state = "carpetside"
@@ -14089,6 +14128,11 @@
 "aFx" = (
 /obj/structure/bed/chair{
 	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "greencorner";
@@ -14186,18 +14230,29 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/transport1/centcom)
 "aFI" = (
+/obj/item/weapon/xmasgift/small{
+	pixel_x = 10;
+	pixel_y = -5
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "carpetside"
 	},
 /area/centcom/holding)
 "aFJ" = (
+/obj/structure/flora/tree/pine/xmas,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "carpetsymbol"
 	},
 /area/centcom/holding)
 "aFK" = (
+/obj/item/weapon/xmasgift/medium,
 /turf/unsimulated/floor{
 	dir = 4;
 	icon_state = "carpetside"
@@ -14275,8 +14330,18 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/transport1/centcom)
 "aFR" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
+/obj/item/weapon/xmasgift/medium{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/weapon/xmasgift/small{
+	pixel_x = 16;
+	pixel_y = 0
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 10;
@@ -14284,8 +14349,9 @@
 	},
 /area/centcom/holding)
 "aFS" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
+/obj/item/weapon/xmasgift/large{
+	pixel_x = 0;
+	pixel_y = 10
 	},
 /turf/unsimulated/floor{
 	dir = 2;
@@ -14293,8 +14359,17 @@
 	},
 /area/centcom/holding)
 "aFT" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
+/obj/item/weapon/xmasgift/small{
+	pixel_x = -10;
+	pixel_y = -2
+	},
+/obj/item/weapon/xmasgift/small{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/item/weapon/xmasgift/small{
+	pixel_x = -12;
+	pixel_y = 12
 	},
 /turf/unsimulated/floor{
 	dir = 6;
@@ -14304,6 +14379,11 @@
 "aFU" = (
 /obj/structure/bed/chair{
 	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "greencorner"
@@ -14330,15 +14410,6 @@
 	},
 /area/centcom/holding)
 "aFX" = (
-/obj/structure/table/woodentable{
-	dir = 5
-	},
-/obj/item/weapon/flame/lighter/zippo,
-/obj/item/weapon/storage/fancy/cigarettes,
-/obj/item/weapon/material/ashtray/bronze{
-	pixel_x = -1;
-	pixel_y = 1
-	},
 /obj/machinery/camera/network/crescent{
 	c_tag = "Crescent Bar East";
 	dir = 4
@@ -14364,6 +14435,11 @@
 "aFZ" = (
 /obj/structure/bed/chair{
 	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "greencorner";
@@ -14442,6 +14518,11 @@
 /obj/machinery/camera/network/crescent{
 	c_tag = "Crescent Arrivals South";
 	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "green";
@@ -14578,6 +14659,11 @@
 /area/centcom/holding)
 "aGx" = (
 /obj/machinery/vending/coffee,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/unsimulated/floor{
 	icon_state = "green";
 	dir = 8
@@ -14718,6 +14804,11 @@
 /area/centcom/holding)
 "aGL" = (
 /obj/machinery/vending/cigarette,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/unsimulated/floor{
 	icon_state = "green";
 	dir = 10
@@ -14909,6 +15000,7 @@
 	name = "Escape Shuttle Infirmary";
 	req_access = list(5)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
 	},
@@ -15313,6 +15405,7 @@
 	opacity = 1;
 	req_access = list(109)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -17032,6 +17125,7 @@
 /obj/machinery/door/airlock/centcom{
 	name = "To: Arrivals Deck"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor,
 /area/centcom/spawning)
 "aLF" = (
@@ -17101,12 +17195,22 @@
 /area/shuttle/arrival/centcom)
 "aLN" = (
 /obj/structure/closet/emcloset,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/centcom)
 "aLO" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera/network/civilian_east{
 	c_tag = "Surface - Arrivals Shuttle"
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/centcom)
@@ -18066,6 +18170,7 @@
 /obj/machinery/door/airlock/centcom{
 	name = "To: NMSS Odin Hab Complex"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor,
 /area/centcom/spawning)
 "aNP" = (
@@ -18349,6 +18454,7 @@
 	opacity = 1;
 	req_access = list(109)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -18368,6 +18474,7 @@
 	opacity = 1;
 	req_access = newlist()
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -18770,6 +18877,11 @@
 "aPv" = (
 /obj/structure/flora/pottedplant/random{
 	anchored = 1
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "blue";
@@ -19204,6 +19316,11 @@
 	c_tag = "Crescent Departures";
 	dir = 8
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/unsimulated/floor{
 	icon_state = "blue";
 	dir = 4
@@ -19526,6 +19643,7 @@
 	opacity = 1;
 	req_access = list(109)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -19883,6 +20001,7 @@
 	opacity = 1;
 	req_access = list(109)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -19920,6 +20039,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Cryogenic Storage"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor";
 	dir = 2
@@ -19929,6 +20049,7 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Unisex Restroom"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor";
 	dir = 2
@@ -24365,6 +24486,1192 @@
 	dir = 8
 	},
 /area/centcom/specops)
+"biS" = (
+/obj/structure/sign/christmas/lights,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/centcom/holding)
+"biT" = (
+/obj/structure/sign/christmas/lights,
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 4
+	},
+/area/centcom/holding)
+"biU" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/centcom/holding)
+"biV" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"biW" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"biX" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"biY" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"biZ" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/shuttle/floor,
+/area/shuttle/escape/centcom)
+"bja" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/shuttle/floor,
+/area/shuttle/escape/centcom)
+"bjb" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjc" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjd" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bje" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjf" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/centcom/holding)
+"bjg" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjh" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bji" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjj" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjk" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 4
+	},
+/area/centcom/holding)
+"bjl" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/centcom/holding)
+"bjm" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjn" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjo" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjp" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjq" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "greencorner";
+	dir = 4
+	},
+/area/centcom/holding)
+"bjr" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/centcom/holding)
+"bjs" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjt" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bju" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjv" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjw" = (
+/obj/structure/bed/chair/wood/wings{
+	icon_state = "wooden_chair_wings";
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "wood"
+	},
+/area/centcom/holding)
+"bjx" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjy" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjz" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjA" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"bjB" = (
+/obj/structure/bed/chair/wood/wings{
+	icon_state = "wooden_chair_wings";
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "wood"
+	},
+/area/centcom/holding)
+"bjC" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/escape/centcom)
+"bjD" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/escape/centcom)
+"bjE" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "wood"
+	},
+/area/centcom/holding)
+"bjF" = (
+/obj/structure/bed/chair/wood/wings{
+	icon_state = "wooden_chair_wings";
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "wood"
+	},
+/area/centcom/holding)
+"bjG" = (
+/obj/structure/bed/chair/wood/wings{
+	icon_state = "wooden_chair_wings";
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "wood"
+	},
+/area/centcom/holding)
+"bjH" = (
+/obj/structure/sign/christmas/lights,
+/turf/unsimulated/floor{
+	icon_state = "wood"
+	},
+/area/centcom/holding)
+"bjI" = (
+/obj/structure/sign/christmas/lights,
+/turf/unsimulated/floor{
+	icon_state = "wood"
+	},
+/area/centcom/holding)
+"bjJ" = (
+/turf/unsimulated/floor{
+	icon_state = "wood"
+	},
+/obj/structure/sign/christmas/lights,
+/turf/unsimulated/floor{
+	name = "plating";
+	icon_state = "siding4"
+	},
+/area/centcom/holding)
+"bjK" = (
+/obj/structure/sign/christmas/lights,
+/turf/unsimulated/floor{
+	icon_state = "grimy"
+	},
+/area/centcom/holding)
+"bjL" = (
+/obj/machinery/door/airlock/glass{
+	name = "NMSS Odin Cryogenic Storage"
+	},
+/obj/structure/sign/christmas/wreath,
+/turf/unsimulated/floor{
+	dir = 4;
+	icon_state = "whitegreenfull"
+	},
+/area/centcom/holding)
+"bjM" = (
+/obj/machinery/door/airlock/glass{
+	name = "NMSS Odin Cryogenic Storage"
+	},
+/obj/structure/sign/christmas/wreath,
+/turf/unsimulated/floor{
+	dir = 4;
+	icon_state = "whitegreenfull"
+	},
+/area/centcom/holding)
+"bjN" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/spawning)
+"bjO" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/spawning)
+"bjP" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/spawning)
+"bjQ" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/centcom)
+"bjR" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/centcom)
+"bjS" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/centcom)
+"bjT" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/centcom)
+"bjU" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/centcom)
+"bjV" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/centcom)
+"bjW" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "greencorner";
+	dir = 8
+	},
+/area/centcom/holding)
+"bjX" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "greencorner"
+	},
+/area/centcom/holding)
+"bjY" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"bjZ" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 4
+	},
+/area/centcom/holding)
+"bka" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"bkb" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 4
+	},
+/area/centcom/holding)
+"bkc" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"bkd" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 4
+	},
+/area/centcom/holding)
+"bke" = (
+/obj/machinery/porta_turret/crescent,
+/obj/effect/decal/warning_stripes,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/centcom/spawning)
+"bkf" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 9
+	},
+/area/centcom/spawning)
+"bkg" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 1
+	},
+/area/centcom/spawning)
+"bkh" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 1
+	},
+/area/centcom/spawning)
+"bki" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 1
+	},
+/area/centcom/spawning)
+"bkj" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 1
+	},
+/area/centcom/spawning)
+"bkk" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 1
+	},
+/area/centcom/spawning)
+"bkl" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 1
+	},
+/area/centcom/spawning)
+"bkm" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 1
+	},
+/area/centcom/spawning)
+"bkn" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 1
+	},
+/area/centcom/spawning)
+"bko" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 1
+	},
+/area/centcom/spawning)
+"bkp" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 5
+	},
+/area/centcom/spawning)
+"bkq" = (
+/obj/machinery/porta_turret/crescent,
+/obj/effect/decal/warning_stripes,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/centcom/spawning)
+"bkr" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"bks" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 4
+	},
+/area/centcom/holding)
+"bkt" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "greencorner";
+	dir = 1
+	},
+/area/centcom/holding)
+"bku" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "greencorner";
+	dir = 4
+	},
+/area/centcom/holding)
+"bkv" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 8
+	},
+/area/centcom/spawning)
+"bkw" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 8
+	},
+/area/centcom/spawning)
+"bkx" = (
+/obj/structure/sign/christmas/lights,
+/turf/unsimulated/floor{
+	icon_state = "rampbottom";
+	dir = 4
+	},
+/area/centcom/spawning)
+"bky" = (
+/obj/structure/sign/christmas/lights,
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 10
+	},
+/area/centcom/spawning)
+"bkz" = (
+/obj/structure/sign/christmas/lights,
+/turf/unsimulated/floor{
+	icon_state = "blue"
+	},
+/area/centcom/spawning)
+"bkA" = (
+/obj/structure/sign/christmas/lights,
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 6
+	},
+/area/centcom/spawning)
+"bkB" = (
+/obj/structure/sign/christmas/lights,
+/turf/unsimulated/floor{
+	icon_state = "rampbottom";
+	dir = 4
+	},
+/area/centcom/spawning)
+"bkC" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 4
+	},
+/area/centcom/spawning)
+"bkD" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 8
+	},
+/area/centcom/spawning)
+"bkE" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 8
+	},
+/area/centcom/spawning)
+"bkF" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "rampbottom";
+	dir = 4
+	},
+/area/centcom/spawning)
+"bkG" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 9
+	},
+/area/centcom/spawning)
+"bkH" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 1
+	},
+/area/centcom/spawning)
+"bkI" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 5
+	},
+/area/centcom/spawning)
+"bkJ" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "rampbottom";
+	dir = 4
+	},
+/area/centcom/spawning)
+"bkK" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 4
+	},
+/area/centcom/spawning)
+"bkL" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "blue";
+	dir = 8
+	},
+/area/centcom/spawning)
+"bkM" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "greencorner";
+	dir = 8
+	},
+/area/centcom/holding)
+"bkN" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "greencorner"
+	},
+/area/centcom/holding)
+"bkO" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"bkP" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 4
+	},
+/area/centcom/holding)
+"bkQ" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"bkR" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 4
+	},
+/area/centcom/holding)
+"bkS" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"bkT" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 4
+	},
+/area/centcom/holding)
+"bkU" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 8
+	},
+/area/centcom/holding)
+"bkV" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "green";
+	dir = 4
+	},
+/area/centcom/holding)
+"bkW" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "greencorner";
+	dir = 1
+	},
+/area/centcom/holding)
+"bkX" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "greencorner";
+	dir = 4
+	},
+/area/centcom/holding)
 
 (1,1,1) = {"
 aaa
@@ -56166,11 +57473,11 @@ aFG
 aEQ
 aEo
 aFw
-aGr
-aGr
-aFw
-aGr
-aGr
+bjw
+bjB
+bjE
+bjF
+bjG
 aFw
 aCO
 aJw
@@ -56943,7 +58250,7 @@ aFw
 aGu
 aGu
 aFw
-aIX
+bjL
 aJx
 aHx
 aKl
@@ -57457,7 +58764,7 @@ aFw
 aGr
 aGr
 aFw
-aIX
+bjM
 aJy
 aJv
 aJb
@@ -57970,7 +59277,7 @@ aGJ
 aFw
 aHs
 aHX
-aFw
+bjH
 aDx
 aDa
 aJR
@@ -58227,7 +59534,7 @@ aGu
 aFw
 aGu
 aGu
-aFw
+bjI
 aDx
 aJz
 aCM
@@ -58240,23 +59547,23 @@ aGM
 aDj
 aMX
 aNv
-aGM
-aDj
-aDj
-aDj
-aDj
-aDb
+bjW
+bjY
+bka
+bkc
+bkr
+bkt
 aNv
 aPX
 aDj
 aDb
 aNv
-aGM
-aDj
-aDj
-aDj
-aDj
-aDb
+bkM
+bkO
+bkQ
+bkS
+bkU
+bkW
 aNv
 aPX
 aDj
@@ -58741,7 +60048,7 @@ aFw
 aHb
 aHb
 aHb
-aHb
+bjJ
 aDx
 aJz
 aCM
@@ -58754,23 +60061,23 @@ aMB
 aDk
 aMY
 aNw
-aMB
-aDk
-aDk
-aDk
-aDk
-aPq
+bjX
+bjZ
+bkb
+bkd
+bks
+bku
 aNw
 aPY
 aDk
 aPq
 aNw
-aMB
-aDk
-aDk
-aDk
-aDk
-aPq
+bkN
+bkP
+bkR
+bkT
+bkV
+bkX
 aNw
 aPY
 aDk
@@ -58998,7 +60305,7 @@ aGK
 aHc
 aHt
 aHu
-aHu
+bjK
 aDx
 aDd
 aJS
@@ -59505,7 +60812,7 @@ aEo
 aFt
 aFJ
 aFS
-aFY
+aFw
 aFw
 aFw
 aGK
@@ -59762,7 +61069,7 @@ aEo
 aFu
 aFK
 aFT
-aFY
+aFw
 aFw
 aFw
 aGK
@@ -61297,10 +62604,10 @@ aDj
 aDS
 aDx
 aEp
-aED
-aED
-aED
-aED
+biV
+biW
+biX
+biY
 aFx
 aCM
 aCM
@@ -61805,12 +63112,12 @@ aCp
 aAJ
 aCP
 aCM
-aCM
+biS
 aDx
 aDL
 aDT
 aEf
-aCM
+biU
 aCM
 aCM
 aEV
@@ -62319,7 +63626,7 @@ aCp
 aAJ
 avz
 aDd
-aDk
+biT
 aDx
 aDM
 aDV
@@ -62332,8 +63639,8 @@ aFk
 aCM
 aCM
 aFU
-aEW
-aFk
+bjk
+bjq
 aCM
 aCM
 aCO
@@ -63359,9 +64666,9 @@ aEC
 aDx
 aFz
 aCM
-aCM
-aCM
-aCM
+bjf
+bjl
+bjr
 aCM
 aCM
 aCM
@@ -63370,9 +64677,9 @@ aDx
 aII
 aJf
 aJE
-aJf
-aJf
-aJf
+bjN
+bjO
+bjP
 aJE
 aLC
 aJf
@@ -63385,11 +64692,11 @@ aOd
 aMf
 aOR
 aOb
-aOb
-aOb
-aOb
-aOb
-aOb
+bkv
+bkw
+bkD
+bkE
+bkL
 aOb
 aRq
 aIL
@@ -64414,9 +65721,9 @@ aOA
 aIL
 aPg
 aPt
-aPt
+bkx
 aMf
-aPt
+bkF
 aPt
 aQW
 aIL
@@ -64671,9 +65978,9 @@ aOB
 aIL
 aNx
 aJg
-aPH
+bky
 aMf
-aNx
+bkG
 aJg
 aPH
 aRs
@@ -64928,9 +66235,9 @@ aOC
 aIL
 aNy
 aPu
-aPI
+bkz
 aMf
-aNy
+bkH
 aPu
 aPI
 aRt
@@ -65185,9 +66492,9 @@ aOB
 aIL
 aOU
 aJg
-aPJ
+bkA
 aMf
-aOU
+bkI
 aJg
 aPJ
 aRu
@@ -65442,9 +66749,9 @@ aOD
 aIL
 aPg
 aPt
-aPt
+bkB
 aMf
-aPt
+bkJ
 aPt
 aQW
 aIL
@@ -65928,11 +67235,11 @@ aEm
 aEm
 aEm
 aDQ
-aEm
-aEm
-aEm
-aEm
-aEm
+bjb
+bjg
+bjm
+bjs
+bjx
 aGO
 aDm
 aDm
@@ -65953,7 +67260,7 @@ aKN
 aKN
 aKM
 aMf
-aOT
+bke
 aNy
 aJg
 aJg
@@ -66184,13 +67491,13 @@ aDm
 aEL
 aEL
 aEY
-aDQ
+biZ
 aFN
 aDn
 aDn
 aDn
 aDn
-aDQ
+bjC
 aHg
 aHE
 aIe
@@ -66210,7 +67517,7 @@ aLt
 aKN
 aKN
 aOE
-aNx
+bkf
 aPi
 aJg
 aJg
@@ -66442,11 +67749,11 @@ aEM
 aEM
 aDn
 aFE
-aEi
-aEi
-aEi
-aEi
-aEi
+bjc
+bjh
+bjn
+bjt
+bjy
 aDQ
 aDn
 aHF
@@ -66467,7 +67774,7 @@ aLt
 aKN
 aKN
 aMf
-aNy
+bkg
 aJg
 aJg
 aJg
@@ -66724,7 +68031,7 @@ aNF
 aMf
 aMf
 aMf
-aNy
+bkh
 aJg
 aJg
 aPK
@@ -66956,11 +68263,11 @@ aEO
 aEO
 aDn
 aDQ
-aEm
-aEm
-aEm
-aEm
-aEm
+bjd
+bji
+bjo
+bju
+bjz
 aDQ
 aDn
 aHH
@@ -67212,13 +68519,13 @@ aDm
 aEL
 aEL
 aEY
-aDQ
+bja
 aFN
 aDn
 aDn
 aDn
 aDn
-aDQ
+bjD
 aDn
 aHI
 aIg
@@ -67238,7 +68545,7 @@ aLt
 aMf
 aMf
 aMf
-aNy
+bki
 aJg
 aJg
 aPL
@@ -67470,11 +68777,11 @@ aEi
 aEi
 aEi
 aDQ
-aEi
-aEi
-aEi
-aEi
-aEi
+bje
+bjj
+bjp
+bjv
+bjA
 aGO
 aDm
 aDm
@@ -67490,12 +68797,12 @@ aLN
 aLQ
 aLQ
 aLQ
-aLQ
+bjT
 aLu
 aKN
 aKN
 aMf
-aNy
+bkj
 aJg
 aJg
 aPK
@@ -67747,12 +69054,12 @@ aLO
 aMo
 aMo
 aMo
-aLQ
+bjU
 aLu
 aKN
 aOk
 aOE
-aNy
+bkk
 aJg
 aJg
 aPK
@@ -68004,12 +69311,12 @@ aLN
 aMp
 aMp
 aMp
-aLQ
+bjV
 aLu
 aKN
 aKN
 aMf
-aNy
+bkl
 aJg
 aJg
 aPK
@@ -68266,7 +69573,7 @@ aLt
 aMf
 aMf
 aMf
-aNy
+bkm
 aJg
 aJg
 aPL
@@ -68780,7 +70087,7 @@ aNF
 aMf
 aMf
 aMf
-aNy
+bkn
 aJg
 aJg
 aPK
@@ -69029,15 +70336,15 @@ aCO
 aKN
 aLt
 aLt
-aMo
-aMo
-aMo
+bjQ
+bjR
+bjS
 aLt
 aLt
 aKN
 aKN
 aMf
-aNy
+bko
 aJg
 aJg
 aJg
@@ -69294,7 +70601,7 @@ aKN
 aKN
 aKN
 aOE
-aOU
+bkp
 aPe
 aJg
 aJg
@@ -69551,7 +70858,7 @@ aKN
 aKN
 aKN
 aMf
-aOT
+bkq
 aNy
 aJg
 aJg
@@ -69811,9 +71118,9 @@ aIL
 aIL
 aOS
 aPv
-aLD
+bkC
 aQn
-aLD
+bkK
 aPv
 aQZ
 aIL

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -879,7 +879,6 @@
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -2077,7 +2076,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
-	tag = "icon-map (WEST)";
 	icon_state = "map";
 	dir = 8
 	},
@@ -2190,7 +2188,6 @@
 /area/engineering/atmos)
 "eG" = (
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (NORTHEAST)";
 	icon_state = "corner_white";
 	dir = 5
 	},
@@ -2201,7 +2198,6 @@
 /area/engineering/atmos)
 "eH" = (
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (NORTHEAST)";
 	icon_state = "corner_white";
 	dir = 5
 	},
@@ -2946,7 +2942,6 @@
 	dir = 4;
 	icon_state = "map_valve0";
 	name = "Air Bypass valve";
-	tag = "icon-map_valve0 (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
@@ -3615,7 +3610,6 @@
 /area/outpost/engineering/hallway)
 "hz" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/cyan{
-	tag = "icon-up (EAST)";
 	icon_state = "up";
 	dir = 4
 	},
@@ -3903,7 +3897,6 @@
 /area/mine/unexplored)
 "ic" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/yellow{
-	tag = "icon-up (EAST)";
 	icon_state = "up";
 	dir = 4
 	},
@@ -5591,7 +5584,6 @@
 "lw" = (
 /obj/structure/table/standard,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -5790,7 +5782,6 @@
 	dir = 6
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -5805,7 +5796,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -5820,7 +5810,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -7460,7 +7449,6 @@
 /obj/item/clothing/mask/breath,
 /obj/item/weapon/tank/emergency_oxygen,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -9766,7 +9754,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (EAST)";
 	icon_state = "intact";
 	dir = 4
 	},
@@ -9790,7 +9777,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (EAST)";
 	icon_state = "intact";
 	dir = 4
 	},
@@ -9811,7 +9797,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (EAST)";
 	icon_state = "intact";
 	dir = 4
 	},
@@ -9838,7 +9823,6 @@
 	req_access = list(19)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (EAST)";
 	icon_state = "intact";
 	dir = 4
 	},
@@ -9851,7 +9835,6 @@
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (EAST)";
 	icon_state = "intact";
 	dir = 4
 	},
@@ -17840,7 +17823,6 @@
 /area/medical/patient_wing)
 "FF" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -17849,7 +17831,6 @@
 "FG" = (
 /obj/structure/bed/roller,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -17858,7 +17839,6 @@
 "FH" = (
 /obj/machinery/iv_drip,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -18928,7 +18908,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -18942,7 +18921,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19267,7 +19245,6 @@
 /obj/structure/bed/chair/comfy/teal,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -19284,7 +19261,6 @@
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -19321,7 +19297,6 @@
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -20007,7 +19982,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -20020,7 +19994,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -20035,7 +20008,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -21086,7 +21058,6 @@
 "La" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -21127,7 +21098,6 @@
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -21387,7 +21357,6 @@
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -22628,7 +22597,6 @@
 	pixel_y = -32
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -23958,7 +23926,6 @@
 /area/rnd/mixing)
 "Qg" = (
 /obj/structure/toilet{
-	tag = "icon-toilet00 (NORTH)";
 	icon_state = "toilet00";
 	dir = 1
 	},
@@ -25351,7 +25318,6 @@
 "Ts" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25360,7 +25326,6 @@
 "Tt" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25369,7 +25334,6 @@
 "Tu" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25382,7 +25346,6 @@
 /area/outpost/engineering/meeting)
 "Tw" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25394,7 +25357,6 @@
 "Tx" = (
 /obj/structure/table/standard,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25417,7 +25379,6 @@
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -25426,7 +25387,6 @@
 "TA" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -878,6 +878,11 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/meeting)
 "cc" = (
@@ -2279,6 +2284,7 @@
 "eO" = (
 /obj/machinery/floodlight,
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/meeting)
 "eP" = (
@@ -2296,11 +2302,13 @@
 "eQ" = (
 /obj/structure/flora/pottedplant/random,
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/meeting)
 "eR" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/meeting)
 "eS" = (
@@ -2405,9 +2413,6 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "fe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	icon_state = "map";
 	dir = 1
@@ -2593,6 +2598,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "fw" = (
@@ -4074,7 +4080,7 @@
 "iu" = (
 /obj/machinery/camera/network/engineering_outpost{
 	c_tag = "Engineering Sublevel -Tesla Parts Storage";
-	dir = 5;
+	dir = 2;
 	icon_state = "camera"
 	},
 /turf/simulated/floor{
@@ -5584,6 +5590,11 @@
 /area/turret_protected/ai)
 "lw" = (
 /obj/structure/table/standard,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
@@ -5778,6 +5789,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
@@ -5788,6 +5804,11 @@
 	icon_state = "intact";
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
@@ -5797,6 +5818,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
 	},
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
@@ -6865,6 +6891,7 @@
 	name = "AI Core Door";
 	req_access = list(16)
 	},
+/obj/item/weapon/xmasgift/small,
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
@@ -6917,6 +6944,7 @@
 /obj/effect/landmark/start{
 	name = "AI"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
@@ -7081,6 +7109,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
 "ny" = (
@@ -7430,6 +7459,11 @@
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
 /obj/item/weapon/tank/emergency_oxygen,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
@@ -7735,6 +7769,7 @@
 	dir = 5;
 	icon_state = "intact"
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
@@ -7744,6 +7779,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
@@ -7757,6 +7793,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
@@ -7948,6 +7985,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
 "oP" = (
@@ -8017,6 +8055,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
 "oT" = (
@@ -8081,6 +8120,7 @@
 "oX" = (
 /obj/machinery/computer/robotics,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
@@ -8951,6 +8991,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
 "qs" = (
@@ -17459,6 +17500,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
 "Fc" = (
@@ -17513,6 +17555,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
 "Ff" = (
@@ -17796,14 +17839,29 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "FF" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "FG" = (
 /obj/structure/bed/roller,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "FH" = (
 /obj/machinery/iv_drip,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "FI" = (
@@ -18869,6 +18927,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "Hl" = (
@@ -18878,6 +18941,11 @@
 "Hm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "Hn" = (
@@ -19198,6 +19266,11 @@
 "HR" = (
 /obj/structure/bed/chair/comfy/teal,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "HS" = (
@@ -19210,6 +19283,11 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "HT" = (
@@ -19242,6 +19320,11 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "HX" = (
@@ -19923,6 +20006,11 @@
 	icon_state = "rwindow";
 	dir = 8
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
@@ -19931,6 +20019,11 @@
 "Jk" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
@@ -19940,6 +20033,11 @@
 /obj/machinery/vending/snack,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
@@ -20987,6 +21085,11 @@
 /area/crew_quarters/medbreak)
 "La" = (
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
 "Lb" = (
@@ -21023,6 +21126,11 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
 "Lg" = (
@@ -21278,6 +21386,11 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
 "LH" = (
@@ -21386,6 +21499,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
 "LN" = (
@@ -22422,6 +22536,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
 "NC" = (
@@ -22511,6 +22626,11 @@
 /obj/item/weapon/tape_roll,
 /obj/machinery/status_display{
 	pixel_y = -32
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
@@ -22778,6 +22898,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
 "Ok" = (
@@ -23653,6 +23774,7 @@
 	name = "Briefing Room";
 	req_access = list(5)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
 "PN" = (
@@ -25226,6 +25348,90 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
+"Ts" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/meeting)
+"Tt" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/meeting)
+"Tu" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/meeting)
+"Tv" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/meeting)
+"Tw" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"Tx" = (
+/obj/structure/table/standard,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"Ty" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"Tz" = (
+/obj/structure/bed/chair/comfy/teal{
+	dir = 8;
+	icon_state = "comfychair_preview"
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_wing)
+"TA" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
 
 (1,1,1) = {"
 aa
@@ -38679,7 +38885,7 @@ bY
 cC
 dt
 ca
-bw
+Tv
 fu
 fU
 gB
@@ -39445,10 +39651,10 @@ af
 am
 aD
 aZ
-bw
+Ts
 cb
-bw
-bw
+Tt
+Tu
 ef
 eR
 fu
@@ -63941,7 +64147,7 @@ Ko
 Lf
 LL
 Ms
-La
+TA
 NH
 Ko
 OM
@@ -68558,7 +68764,7 @@ Fd
 FJ
 GI
 Ho
-HX
+Tz
 IH
 Jm
 HX
@@ -75193,7 +75399,7 @@ lb
 lb
 lv
 lL
-lw
+Tx
 mE
 nb
 nC
@@ -76991,13 +77197,13 @@ kj
 lb
 lb
 lb
-ly
+Tw
 ly
 mJ
 ni
 nH
 ly
-ly
+Ty
 lb
 lb
 lb

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -4769,7 +4769,6 @@
 /area/engineering/atmos)
 "ajK" = (
 /obj/machinery/atmospherics/pipe/zpipe/down/cyan{
-	tag = "icon-down (WEST)";
 	icon_state = "down";
 	dir = 8
 	},
@@ -5544,7 +5543,6 @@
 /area/engineering/atmos)
 "als" = (
 /obj/machinery/atmospherics/pipe/zpipe/down/red{
-	tag = "icon-down (WEST)";
 	icon_state = "down";
 	dir = 8
 	},
@@ -5897,12 +5895,10 @@
 /obj/item/device/radio,
 /obj/item/device/radio,
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHEAST)";
 	icon_state = "corner_white";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHWEST)";
 	icon_state = "corner_white";
 	dir = 9
 	},
@@ -5918,7 +5914,6 @@
 /obj/item/weapon/crowbar,
 /obj/item/weapon/crowbar,
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHEAST)";
 	icon_state = "corner_white";
 	dir = 5
 	},
@@ -5931,7 +5926,6 @@
 /obj/item/device/flashlight/maglight,
 /obj/item/device/flashlight/maglight,
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHEAST)";
 	icon_state = "corner_white";
 	dir = 5
 	},
@@ -6443,7 +6437,6 @@
 /area/security/main)
 "anc" = (
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHWEST)";
 	icon_state = "corner_white";
 	dir = 9
 	},
@@ -6898,7 +6891,6 @@
 /area/security/brig)
 "anX" = (
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHWEST)";
 	icon_state = "corner_white";
 	dir = 9
 	},
@@ -7391,7 +7383,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHWEST)";
 	icon_state = "corner_white";
 	dir = 9
 	},
@@ -7743,7 +7734,6 @@
 /obj/structure/table/standard,
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHWEST)";
 	icon_state = "corner_white";
 	dir = 9
 	},
@@ -8519,7 +8509,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHWEST)";
 	icon_state = "corner_white";
 	dir = 9
 	},
@@ -8929,7 +8918,6 @@
 	icon_state = "left";
 	name = "Atmospheric Hardsuits";
 	req_access = list(24);
-	tag = "icon-left (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -9145,7 +9133,6 @@
 "asf" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHWEST)";
 	icon_state = "corner_white";
 	dir = 9
 	},
@@ -9170,7 +9157,6 @@
 /area/security/main)
 "asi" = (
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (SOUTHWEST)";
 	icon_state = "corner_white";
 	dir = 10
 	},
@@ -9188,7 +9174,6 @@
 "asj" = (
 /obj/structure/flora/pottedplant/random,
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (SOUTHWEST)";
 	icon_state = "corner_white";
 	dir = 10
 	},
@@ -9596,7 +9581,6 @@
 	icon_state = "left";
 	name = "Atmospheric Hardsuits";
 	req_access = list(24);
-	tag = "icon-left (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -12181,7 +12165,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (EAST)";
 	icon_state = "intact";
 	dir = 4
 	},
@@ -12342,7 +12325,6 @@
 	icon_state = "leftsecure";
 	name = "Secure Holding Cell";
 	req_access = list(2);
-	tag = "icon-leftsecure"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -12652,7 +12634,6 @@
 "axJ" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -12898,7 +12879,6 @@
 	c_tag = "Engineering - Engine Starboard";
 	dir = 8;
 	icon_state = "camera";
-	tag = "icon-camera (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -13232,7 +13212,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
 	dir = 5
 	},
@@ -13246,7 +13225,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
 	icon_state = "intact";
 	dir = 4
 	},
@@ -13267,7 +13245,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
 	icon_state = "intact";
 	dir = 4
 	},
@@ -13557,7 +13534,6 @@
 /area/security/brig)
 "aza" = (
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHEAST)";
 	icon_state = "corner_white";
 	dir = 5
 	},
@@ -13575,7 +13551,6 @@
 /area/security/brig)
 "azb" = (
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHEAST)";
 	icon_state = "corner_white";
 	dir = 5
 	},
@@ -13595,7 +13570,6 @@
 /area/security/brig)
 "azc" = (
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHEAST)";
 	icon_state = "corner_white";
 	dir = 5
 	},
@@ -13831,7 +13805,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -14402,7 +14375,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHWEST)";
 	icon_state = "corner_white";
 	dir = 9
 	},
@@ -15288,7 +15260,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHWEST)";
 	icon_state = "corner_white";
 	dir = 9
 	},
@@ -15872,7 +15843,6 @@
 	pixel_y = 0
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -15912,7 +15882,6 @@
 	},
 /obj/item/modular_computer/console/preset/engineering,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -15921,7 +15890,6 @@
 "aCX" = (
 /obj/machinery/papershredder,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -16316,7 +16284,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -20332,7 +20299,6 @@
 	pixel_y = 32
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -21392,7 +21358,6 @@
 	pixel_x = -32
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -22403,7 +22368,6 @@
 	dir = 9
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -23023,7 +22987,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -23397,7 +23360,6 @@
 	dir = 9
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -23597,7 +23559,6 @@
 	pixel_x = 27
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -24121,7 +24082,6 @@
 	dir = 9
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24358,7 +24318,6 @@
 	},
 /obj/machinery/firealarm/west,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -24761,7 +24720,6 @@
 /area/bridge/meeting_room)
 "aRu" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (EAST)";
 	icon_state = "spline_fancy";
 	dir = 4
 	},
@@ -25566,7 +25524,6 @@
 	pixel_y = 0
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -25592,7 +25549,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -25805,7 +25761,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/corner/yellow/full,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -26438,7 +26393,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -26457,7 +26411,6 @@
 "aUg" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -26538,7 +26491,6 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/blue,
 /obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (EAST)";
 	icon_state = "spline_fancy";
 	dir = 4
 	},
@@ -26938,7 +26890,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -26957,7 +26908,6 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -27190,7 +27140,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -27244,7 +27193,6 @@
 	},
 /obj/item/weapon/pen,
 /obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (EAST)";
 	icon_state = "spline_fancy";
 	dir = 4
 	},
@@ -27368,7 +27316,6 @@
 "aVJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -27394,7 +27341,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -27429,7 +27375,6 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -27631,7 +27576,6 @@
 	pixel_y = 24
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -27894,7 +27838,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -27987,7 +27930,6 @@
 "aWT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/orange{
-	tag = "icon-corner_white (SOUTHEAST)";
 	icon_state = "corner_white";
 	dir = 6
 	},
@@ -31045,7 +30987,6 @@
 	dir = 6
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -31087,7 +31028,6 @@
 "bcj" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -32575,7 +32515,6 @@
 	dir = 6
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -36003,7 +35942,6 @@
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -36869,7 +36807,6 @@
 /obj/machinery/vending/dinnerware,
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -38493,7 +38430,6 @@
 	pixel_y = 23
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -38653,7 +38589,6 @@
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -38966,7 +38901,6 @@
 	id = "medbay_ringer"
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -38984,12 +38918,10 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -39470,7 +39402,6 @@
 /obj/machinery/smartfridge/drinks,
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -40078,7 +40009,6 @@
 	icon_state = "comfychair_preview"
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -40949,13 +40879,11 @@
 /area/medical/medbay2)
 "bsc" = (
 /obj/effect/floor_decal/corner/grey{
-	tag = "icon-corner_white (WEST)";
 	icon_state = "corner_white";
 	dir = 8
 	},
 /obj/structure/table/standard,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -40984,7 +40912,6 @@
 /area/crew_quarters/heads/cmo)
 "bsf" = (
 /obj/effect/floor_decal/corner/paleblue{
-	tag = "icon-corner_white (WEST)";
 	icon_state = "corner_white";
 	dir = 8
 	},
@@ -41563,7 +41490,6 @@
 /obj/structure/bed/chair/comfy/teal{
 	dir = 8;
 	icon_state = "comfychair_preview";
-	tag = "icon-comfychair (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
@@ -41986,7 +41912,6 @@
 /obj/item/weapon/storage/box/cups,
 /obj/item/weapon/storage/box/cups,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -42541,7 +42466,6 @@
 "buL" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -43948,7 +43872,6 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -45119,7 +45042,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -45275,7 +45197,6 @@
 	},
 /obj/machinery/firealarm/south,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -47200,7 +47121,6 @@
 "bCi" = (
 /obj/effect/floor_decal/corner/mauve,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -51198,7 +51118,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -55247,7 +55166,6 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -55993,7 +55911,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -56013,7 +55930,6 @@
 "bSW" = (
 /obj/machinery/firealarm/west,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -56347,7 +56263,6 @@
 	},
 /obj/machinery/firealarm/north,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -56753,7 +56668,6 @@
 "bUs" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -56881,7 +56795,6 @@
 	},
 /obj/item/weapon/material/kitchen/utensil/fork,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -57060,7 +56973,6 @@
 	},
 /obj/item/weapon/material/kitchen/utensil/knife/plastic,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -57255,7 +57167,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -57287,7 +57198,6 @@
 	},
 /obj/item/weapon/material/kitchen/utensil/spoon,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -57460,7 +57370,6 @@
 	pixel_y = -28
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -57526,7 +57435,6 @@
 "bVL" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -57538,12 +57446,10 @@
 	c_tag = "Bar - Smoking Lounge"
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -57955,7 +57861,6 @@
 	},
 /obj/structure/sign/christmas/lights,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -62423,7 +62328,6 @@
 	pixel_y = -32
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -62637,7 +62541,6 @@
 "cfd" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (EAST)";
 	icon_state = "spline_fancy";
 	dir = 4
 	},
@@ -62667,7 +62570,6 @@
 /area/bridge/meeting_room)
 "cfh" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (EAST)";
 	icon_state = "spline_fancy";
 	dir = 4
 	},
@@ -62938,7 +62840,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (SOUTHWEST)";
 	icon_state = "corner_white";
 	dir = 10
 	},
@@ -63093,7 +62994,6 @@
 /area/hydroponics)
 "cfO" = (
 /obj/structure/sign/double/barsign{
-	tag = "icon-empty (WEST)";
 	icon_state = "empty";
 	dir = 8
 	},
@@ -63882,7 +63782,6 @@
 /area/security/brig)
 "chm" = (
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (NORTHEAST)";
 	icon_state = "corner_white";
 	dir = 5
 	},
@@ -63906,7 +63805,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -64557,7 +64455,6 @@
 	pixel_y = 32
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -64930,7 +64827,6 @@
 "ciR" = (
 /obj/structure/flora/pottedplant/random,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65303,7 +65199,6 @@
 /area/bridge)
 "cjv" = (
 /obj/structure/toilet{
-	tag = "icon-toilet00 (WEST)";
 	icon_state = "toilet00";
 	dir = 8
 	},
@@ -65476,7 +65371,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65647,7 +65541,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -65701,7 +65594,6 @@
 	dir = 6
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65709,7 +65601,6 @@
 /area/security/brig)
 "ckl" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -65733,7 +65624,6 @@
 /area/hallway/primary/starboard)
 "ckq" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -65741,7 +65631,6 @@
 /area/engineering/foyer)
 "ckr" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65749,7 +65638,6 @@
 /area/security/lobby)
 "cks" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65757,7 +65645,6 @@
 /area/hallway/primary/starboard)
 "ckt" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65765,7 +65652,6 @@
 /area/hallway/primary/starboard)
 "cku" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65777,7 +65663,6 @@
 	dir = 5
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -65789,7 +65674,6 @@
 	dir = 5
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -65798,7 +65682,6 @@
 "ckx" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -65806,7 +65689,6 @@
 /area/hallway/primary/starboard)
 "cky" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -65814,7 +65696,6 @@
 /area/engineering/foyer)
 "ckz" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -65822,7 +65703,6 @@
 /area/engineering/foyer)
 "ckA" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -65830,7 +65710,6 @@
 /area/hallway/primary/port)
 "ckB" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -65838,7 +65717,6 @@
 /area/hallway/primary/port)
 "ckC" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65846,7 +65724,6 @@
 /area/hallway/primary/starboard)
 "ckD" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -65854,7 +65731,6 @@
 /area/hallway/primary/central_one)
 "ckE" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -65862,7 +65738,6 @@
 /area/hallway/primary/central_one)
 "ckF" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -65870,7 +65745,6 @@
 /area/hallway/primary/central_one)
 "ckG" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65878,7 +65752,6 @@
 /area/hallway/primary/central_one)
 "ckH" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65886,7 +65759,6 @@
 /area/hallway/primary/central_one)
 "ckI" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65894,7 +65766,6 @@
 /area/hallway/primary/central_one)
 "ckJ" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65902,7 +65773,6 @@
 /area/hallway/primary/central_one)
 "ckK" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65911,7 +65781,6 @@
 "ckL" = (
 /obj/effect/floor_decal/corner/lime,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65929,7 +65798,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65940,7 +65808,6 @@
 	dir = 6
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65948,7 +65815,6 @@
 /area/medical/reception)
 "ckQ" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65956,7 +65822,6 @@
 /area/hallway/primary/central_one)
 "ckR" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -65964,7 +65829,6 @@
 /area/hallway/primary/central_one)
 "ckS" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -65976,7 +65840,6 @@
 	dir = 9
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -65984,7 +65847,6 @@
 /area/hallway/primary/central_one)
 "ckU" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -65992,7 +65854,6 @@
 /area/hallway/primary/central_one)
 "ckV" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66004,7 +65865,6 @@
 	dir = 9
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66012,7 +65872,6 @@
 /area/hallway/primary/central_one)
 "ckX" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -66020,7 +65879,6 @@
 /area/hallway/primary/central_one)
 "ckY" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66028,7 +65886,6 @@
 /area/hallway/primary/central_one)
 "ckZ" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -66036,7 +65893,6 @@
 /area/hallway/primary/central_one)
 "cla" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66048,7 +65904,6 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66056,7 +65911,6 @@
 /area/hallway/primary/central_one)
 "clc" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66064,7 +65918,6 @@
 /area/rnd/research)
 "cld" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66072,7 +65925,6 @@
 /area/hallway/primary/central_one)
 "cle" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -66098,7 +65950,6 @@
 /area/hallway/primary/central_one)
 "clh" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -66106,7 +65957,6 @@
 /area/hallway/primary/central_one)
 "cli" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -66114,7 +65964,6 @@
 /area/hallway/primary/central_one)
 "clj" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -66122,7 +65971,6 @@
 /area/hallway/primary/central_one)
 "clk" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -66130,7 +65978,6 @@
 /area/library)
 "cll" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -66138,7 +65985,6 @@
 /area/library)
 "clm" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -66146,7 +65992,6 @@
 /area/library)
 "cln" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -66154,7 +65999,6 @@
 /area/library)
 "clo" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -66165,7 +66009,6 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -66174,7 +66017,6 @@
 "clq" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -66187,7 +66029,6 @@
 	pixel_y = 5
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -66195,7 +66036,6 @@
 /area/library)
 "cls" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66203,7 +66043,6 @@
 /area/hallway/primary/aft)
 "clt" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66211,7 +66050,6 @@
 /area/hallway/primary/aft)
 "clu" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66219,7 +66057,6 @@
 /area/hallway/primary/aft)
 "clv" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -66227,7 +66064,6 @@
 /area/crew_quarters/bar)
 "clw" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -66236,7 +66072,6 @@
 "clx" = (
 /obj/structure/table/marble,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -66244,7 +66079,6 @@
 /area/crew_quarters/bar)
 "cly" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66252,7 +66086,6 @@
 /area/hallway/primary/aft)
 "clz" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66260,7 +66093,6 @@
 /area/hallway/primary/aft)
 "clA" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -66273,7 +66105,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -66306,7 +66137,6 @@
 /area/crew_quarters/bar)
 "clI" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -66354,7 +66184,6 @@
 "clM" = (
 /obj/structure/sign/christmas/lights,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -17204,9 +17204,6 @@
 	dir = 8
 	},
 /obj/structure/table/standard,
-/obj/item/weapon/stamp{
-	name = "warden's rubber stamp"
-	},
 /obj/item/weapon/folder/sec,
 /obj/item/weapon/stamp{
 	name = "warden's rubber stamp"
@@ -23369,6 +23366,7 @@
 "aPa" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/skills,
+/obj/item/weapon/xmasgift/medium,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
 "aPb" = (
@@ -24055,6 +24053,7 @@
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
+/obj/item/weapon/xmasgift/medium,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/chief)
 "aQj" = (
@@ -27211,6 +27210,7 @@
 "aVo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/skills,
+/obj/item/weapon/xmasgift/medium,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
 "aVp" = (
@@ -37622,7 +37622,7 @@
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
 /obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Phychiatrist Office";
+	c_tag = "Medical - Psychiatrist's Office";
 	dir = 1;
 	icon_state = "camera"
 	},
@@ -41013,6 +41013,7 @@
 	pixel_y = 6
 	},
 /obj/item/weapon/pen,
+/obj/item/weapon/xmasgift/medium,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "bsj" = (
@@ -43903,7 +43904,6 @@
 	pixel_x = 3;
 	pixel_y = -2
 	},
-/obj/item/weapon/paper/monitorkey,
 /obj/item/device/megaphone,
 /obj/item/weapon/paper_bin{
 	pixel_x = 1;
@@ -43911,11 +43911,13 @@
 	},
 /obj/item/weapon/pen,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/weapon/xmasgift/medium,
 /turf/simulated/floor/tiled/white,
 /area/rnd/rdoffice)
 "bwS" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/weapon/paper/monitorkey,
 /turf/simulated/floor/tiled/white,
 /area/rnd/rdoffice)
 "bwT" = (
@@ -56010,6 +56012,11 @@
 /area/hallway/primary/aft)
 "bSW" = (
 /obj/machinery/firealarm/west,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bSX" = (
@@ -57877,9 +57884,14 @@
 	},
 /obj/structure/table/woodentable,
 /obj/item/weapon/toy/xmas_cracker,
+/obj/item/clothing/head/festive/santa,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bWr" = (
+/obj/item/weapon/xmasgift/medium{
+	pixel_x = -5;
+	pixel_y = -5
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bWs" = (
@@ -58104,7 +58116,7 @@
 	c_tag = "Bar - Diner Seating";
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWQ" = (
 /obj/item/weapon/xmasgift/small{
@@ -66191,22 +66203,21 @@
 /area/hallway/primary/aft)
 "clt" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
+	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
-	dir = 1
+	dir = 8
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
 "clu" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
+	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
-	dir = 1
+	dir = 8
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
 "clv" = (
-/obj/structure/table/marble,
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
@@ -66216,20 +66227,21 @@
 /area/crew_quarters/bar)
 "clw" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
+	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
-	dir = 8
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "clx" = (
+/obj/structure/table/marble,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
+	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
-	dir = 8
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "cly" = (
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (WEST)";
@@ -66239,6 +66251,22 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "clz" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"clA" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"clB" = (
 /obj/effect/floor_decal/corner/grey,
 /obj/effect/floor_decal/corner/white{
 	icon_state = "corner_white";
@@ -66251,26 +66279,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"clA" = (
+"clC" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/toy/xmas_cracker,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"clB" = (
+"clD" = (
 /obj/structure/table/woodentable,
 /obj/item/clothing/head/festive/santa,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"clC" = (
+"clE" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/xmasgift/small,
 /turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"clD" = (
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
-"clE" = (
-/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "clF" = (
 /turf/simulated/floor/carpet,
@@ -66279,37 +66301,28 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "clH" = (
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
-"clI" = (
 /obj/structure/flora/tree/pine/xmas,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
-"clJ" = (
-/obj/item/weapon/xmasgift/medium{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
-"clK" = (
+"clI" = (
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"clL" = (
+"clJ" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights,
 /obj/structure/table/woodentable,
+/obj/item/weapon/toy/xmas_cracker,
 /obj/item/weapon/xmasgift/small,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
-"clM" = (
+"clK" = (
 /obj/item/weapon/xmasgift/medium{
 	pixel_x = 8;
 	pixel_y = 8
@@ -66321,7 +66334,7 @@
 /obj/structure/sign/christmas/lights,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
-"clN" = (
+"clL" = (
 /obj/item/weapon/xmasgift/large{
 	pixel_x = 0;
 	pixel_y = 10
@@ -66338,14 +66351,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
-"clO" = (
+"clM" = (
 /obj/structure/sign/christmas/lights,
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 
 (1,1,1) = {"
@@ -94266,9 +94279,9 @@ bJR
 bKz
 bOd
 bLD
-bJa
+cls
 bMG
-bJa
+clt
 bNC
 bKZ
 bOH
@@ -94276,11 +94289,11 @@ bPg
 bPO
 bQl
 bIl
-cls
-clw
-bRZ
-clx
+clu
 cly
+bRZ
+clz
+clA
 bSU
 bTl
 bJa
@@ -94795,7 +94808,7 @@ bMI
 bJa
 bOf
 bSG
-clz
+clB
 bOf
 bOf
 bTY
@@ -95561,7 +95574,7 @@ bNF
 bNF
 bQn
 bQL
-clt
+clv
 bRF
 bSa
 bRH
@@ -95831,9 +95844,9 @@ bUB
 bUW
 bUW
 bVI
-clD
+bRH
 bWq
-clL
+clJ
 bRi
 bTe
 bMM
@@ -96075,21 +96088,21 @@ bPi
 bPQ
 bQp
 bQN
-clu
+clw
 bRl
 bSb
 bRH
 bSJ
 bSX
-clA
+clC
 bTG
 bUb
 bSX
-clC
+clE
 bTG
 bRH
-clE
-bWr
+bRH
+bRH
 bWP
 bRi
 bMQ
@@ -96332,7 +96345,7 @@ bPj
 bPR
 bQp
 bQO
-clv
+clx
 bRG
 bSb
 bRH
@@ -96347,7 +96360,7 @@ bTG
 bRH
 clF
 bWs
-clM
+clK
 bRi
 cdZ
 bMN
@@ -96595,7 +96608,7 @@ bSc
 bRm
 bSL
 bSX
-clB
+clD
 bTG
 bUb
 bSX
@@ -96603,8 +96616,8 @@ bTm
 bTG
 bRH
 clG
-clI
-clN
+clH
+clL
 bRi
 bMQ
 bMN
@@ -96860,7 +96873,7 @@ bUC
 bUC
 bUC
 bVY
-clJ
+bWr
 bWQ
 bRi
 bMQ
@@ -97116,9 +97129,9 @@ bRH
 bRH
 bRH
 bRH
-clH
-clK
-clO
+bRH
+clI
+clM
 bRi
 bMQ
 bXM

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -6438,6 +6438,7 @@
 	name = "Equipment Storage";
 	req_access = list(1)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/main)
 "anc" = (
@@ -9886,6 +9887,7 @@
 	name = "Equipment Storage";
 	req_access = list(1)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/main)
 "atq" = (
@@ -12122,11 +12124,11 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/item/device/pipe_painter,
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
 	dir = 1
 	},
+/obj/item/device/floor_painter,
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "awS" = (
@@ -12649,6 +12651,11 @@
 /area/lawoffice)
 "axJ" = (
 /obj/structure/closet/emcloset,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "axK" = (
@@ -13822,6 +13829,11 @@
 	},
 /obj/structure/bed/chair{
 	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -15665,6 +15677,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "aCC" = (
@@ -15858,6 +15871,11 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aCU" = (
@@ -15893,10 +15911,20 @@
 	dir = 5
 	},
 /obj/item/modular_computer/console/preset/engineering,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aCX" = (
 /obj/machinery/papershredder,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aCY" = (
@@ -16287,6 +16315,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "aDA" = (
@@ -16479,6 +16512,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "aDS" = (
@@ -18039,6 +18073,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aGz" = (
@@ -18054,6 +18089,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aGA" = (
@@ -19233,6 +19269,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/hos)
 "aIp" = (
@@ -19528,6 +19565,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/warden)
 "aIH" = (
@@ -19757,6 +19795,7 @@
 	name = "Bridge";
 	req_access = list(19)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/bridge)
 "aJa" = (
@@ -20295,6 +20334,11 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aJV" = (
@@ -20583,6 +20627,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aKs" = (
@@ -20647,6 +20692,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "aKA" = (
@@ -21348,6 +21394,11 @@
 /obj/machinery/computer/cryopod{
 	pixel_x = -32
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "aLS" = (
@@ -21910,6 +21961,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/weapon/xmasgift/large,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "aMC" = (
@@ -22353,6 +22405,11 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aNv" = (
@@ -22621,6 +22678,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aNS" = (
@@ -22765,6 +22823,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "aOf" = (
@@ -22965,6 +23024,11 @@
 "aOr" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
@@ -23334,6 +23398,11 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aPe" = (
@@ -23529,6 +23598,11 @@
 /obj/machinery/newscaster{
 	pixel_x = 27
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "aPx" = (
@@ -23700,6 +23774,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
 "aPM" = (
@@ -23824,6 +23899,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "aPV" = (
@@ -24044,6 +24120,11 @@
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 9
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -24277,6 +24358,11 @@
 	dir = 9
 	},
 /obj/machinery/firealarm/west,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aQK" = (
@@ -24833,6 +24919,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "aRG" = (
@@ -24847,6 +24934,7 @@
 	pixel_y = -27
 	},
 /obj/machinery/firealarm/south,
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "aRH" = (
@@ -24871,6 +24959,7 @@
 	icon_state = "intact-scrubbers";
 	dir = 5
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "aRI" = (
@@ -25036,6 +25125,7 @@
 	name = "Chief Engineer";
 	req_access = list(56)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "aRS" = (
@@ -25476,6 +25566,11 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aSH" = (
@@ -25497,6 +25592,11 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aSJ" = (
@@ -25705,6 +25805,11 @@
 "aTc" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/corner/yellow/full,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aTd" = (
@@ -26333,6 +26438,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aUf" = (
@@ -26347,6 +26457,11 @@
 /area/hallway/primary/starboard)
 "aUg" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aUh" = (
@@ -26784,6 +26899,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aUP" = (
@@ -26793,6 +26909,7 @@
 	req_one_access = list(10)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aUQ" = (
@@ -26821,6 +26938,11 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aUT" = (
@@ -26833,6 +26955,11 @@
 "aUU" = (
 /obj/effect/floor_decal/corner/yellow/full{
 	icon_state = "corner_white_full";
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -26990,6 +27117,7 @@
 	desc = "It opens and closes. Hazardous lifeforms ahead. Caution advised!";
 	name = "Security Lobby"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aVg" = (
@@ -27008,6 +27136,7 @@
 	name = "Security Aft Entrance";
 	req_access = list(63)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aVh" = (
@@ -27061,6 +27190,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aVn" = (
@@ -27233,6 +27367,11 @@
 /area/engineering/foyer)
 "aVJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aVK" = (
@@ -27253,6 +27392,11 @@
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -27282,6 +27426,11 @@
 "aVO" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -27480,6 +27629,11 @@
 	icon_state = "direction_evac";
 	pixel_x = 0;
 	pixel_y = 24
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -27739,6 +27893,11 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aWM" = (
@@ -28532,6 +28691,7 @@
 	name = "Bridge Blast Doors";
 	opacity = 0
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
 "aXS" = (
@@ -29514,6 +29674,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aZH" = (
@@ -29523,6 +29684,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aZI" = (
@@ -30882,6 +31044,11 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bci" = (
@@ -30919,6 +31086,11 @@
 /area/hallway/primary/central_one)
 "bcj" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bck" = (
@@ -31404,6 +31576,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/bridge)
 "bda" = (
@@ -32400,6 +32573,11 @@
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 6
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -34655,6 +34833,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
 "biw" = (
@@ -35823,6 +36002,11 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
 "bkq" = (
@@ -36684,6 +36868,11 @@
 "blJ" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
 "blK" = (
@@ -37635,6 +37824,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "bna" = (
@@ -38302,6 +38492,11 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bog" = (
@@ -38457,6 +38652,11 @@
 	req_access = list(19)
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
 "bos" = (
@@ -38765,6 +38965,11 @@
 /obj/machinery/ringer_button{
 	id = "medbay_ringer"
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "boS" = (
@@ -38776,6 +38981,16 @@
 	},
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -39097,6 +39312,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "bpw" = (
@@ -39253,6 +39469,11 @@
 "bpI" = (
 /obj/machinery/smartfridge/drinks,
 /obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
 "bpJ" = (
@@ -39855,6 +40076,11 @@
 /obj/structure/bed/chair/comfy/teal{
 	dir = 8;
 	icon_state = "comfychair_preview"
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
@@ -40728,6 +40954,11 @@
 	dir = 8
 	},
 /obj/structure/table/standard,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bsd" = (
@@ -41085,6 +41316,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "bsE" = (
@@ -41752,6 +41984,11 @@
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/cups,
 /obj/item/weapon/storage/box/cups,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "btM" = (
@@ -41765,6 +42002,7 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "btO" = (
@@ -41775,6 +42013,7 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "btP" = (
@@ -42300,6 +42539,11 @@
 /area/medical/reception)
 "buL" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "buM" = (
@@ -42967,6 +43211,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "bvL" = (
@@ -43204,6 +43449,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/rnd/lab)
 "bwb" = (
@@ -43699,6 +43945,11 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 1
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "bwV" = (
@@ -43909,6 +44160,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "bxn" = (
@@ -44864,6 +45116,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "byM" = (
@@ -45015,6 +45272,11 @@
 	dir = 6
 	},
 /obj/machinery/firealarm/south,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "byZ" = (
@@ -46450,6 +46712,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "bBw" = (
@@ -46934,6 +47197,11 @@
 /area/crew_quarters/sleep/research)
 "bCi" = (
 /obj/effect/floor_decal/corner/mauve,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/research)
 "bCj" = (
@@ -48543,6 +48811,7 @@
 	name = "Conference Room and Lift";
 	req_access = list(47)
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/research)
 "bEP" = (
@@ -49711,6 +49980,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/main)
 "bGJ" = (
@@ -49740,6 +50010,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/locker/locker_toilet)
 "bGM" = (
@@ -50924,6 +51195,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "bJm" = (
@@ -51514,6 +51790,7 @@
 	name = "Unisex Restrooms"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/locker/locker_toilet)
 "bKB" = (
@@ -54722,6 +54999,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bQN" = (
@@ -54762,6 +55040,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bQQ" = (
@@ -54965,6 +55244,11 @@
 	pixel_y = 0
 	},
 /obj/structure/closet/emcloset,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bRo" = (
@@ -55105,6 +55389,7 @@
 "bRF" = (
 /obj/structure/table/marble,
 /obj/machinery/firealarm/west,
+/obj/item/weapon/toy/xmas_cracker,
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bRG" = (
@@ -55705,6 +55990,11 @@
 	c_tag = "Aft Corridor - Camera 1";
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bSV" = (
@@ -56049,6 +56339,11 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/north,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "bTF" = (
@@ -56179,6 +56474,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "bTT" = (
@@ -56336,6 +56632,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "bUi" = (
@@ -56448,6 +56745,11 @@
 /area/quartermaster/office)
 "bUs" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "bUt" = (
@@ -56571,6 +56873,11 @@
 	pixel_x = 4
 	},
 /obj/item/weapon/material/kitchen/utensil/fork,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bUB" = (
@@ -56745,6 +57052,11 @@
 	pixel_x = 4
 	},
 /obj/item/weapon/material/kitchen/utensil/knife/plastic,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bUW" = (
@@ -56912,6 +57224,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "bVm" = (
@@ -56933,6 +57246,11 @@
 "bVn" = (
 /obj/structure/bed/chair{
 	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -56961,6 +57279,11 @@
 	pixel_x = 4
 	},
 /obj/item/weapon/material/kitchen/utensil/spoon,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bVq" = (
@@ -57129,6 +57452,11 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "bVE" = (
@@ -57190,12 +57518,27 @@
 /area/crew_quarters/bar)
 "bVL" = (
 /obj/structure/bed/chair/comfy/black,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bVM" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/camera/network/civilian_west{
 	c_tag = "Bar - Smoking Lounge"
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -57335,7 +57678,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bVZ" = (
 /obj/structure/disposalpipe/segment{
@@ -57529,24 +57872,25 @@
 	},
 /area/janitor)
 "bWq" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/toy/xmas_cracker,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bWr" = (
-/obj/structure/table/woodentable,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bWs" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
+/obj/item/weapon/xmasgift/small{
+	pixel_x = 10;
+	pixel_y = -5
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/weapon/xmasgift/medium{
+	layer = 2.9;
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
@@ -57580,6 +57924,7 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWx" = (
@@ -57589,11 +57934,18 @@
 	pixel_x = 0;
 	pixel_y = -32
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWy" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
+	},
+/obj/structure/sign/christmas/lights,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -57747,7 +58099,6 @@
 	},
 /area/janitor)
 "bWP" = (
-/obj/structure/table/woodentable,
 /obj/machinery/light/small,
 /obj/machinery/camera/network/civilian_west{
 	c_tag = "Bar - Diner Seating";
@@ -57756,8 +58107,21 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bWQ" = (
-/obj/structure/table/woodentable,
+/obj/item/weapon/xmasgift/small{
+	pixel_x = -10;
+	pixel_y = -2
+	},
+/obj/item/weapon/xmasgift/small{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/item/weapon/xmasgift/small,
 /obj/machinery/light/small,
+/obj/item/weapon/xmasgift/medium{
+	layer = 2.9;
+	pixel_x = -8;
+	pixel_y = 8
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bWR" = (
@@ -58263,6 +58627,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "bXI" = (
@@ -59414,6 +59779,7 @@
 	req_access = list(50)
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "bZY" = (
@@ -62044,6 +62410,11 @@
 	pixel_x = 0;
 	pixel_y = -32
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "ceH" = (
@@ -63522,6 +63893,11 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "chp" = (
@@ -64168,6 +64544,11 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/bridge)
 "cip" = (
@@ -64536,6 +64917,11 @@
 /area/bridge/meeting_room)
 "ciR" = (
 /obj/structure/flora/pottedplant/random,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/bridge)
 "ciS" = (
@@ -65077,6 +65463,11 @@
 	icon_state = "corner_white";
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "cjP" = (
@@ -65237,6 +65628,725 @@
 /obj/structure/sign/greencross,
 /turf/simulated/wall,
 /area/medical/reception)
+"ckh" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"cki" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"ckj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"ckk" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"ckl" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"ckm" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"ckn" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"cko" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"ckp" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"ckq" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"ckr" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/lobby)
+"cks" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"ckt" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"cku" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"ckv" = (
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"ckw" = (
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"ckx" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"cky" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"ckz" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"ckA" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/port)
+"ckB" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/port)
+"ckC" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"ckD" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckE" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckF" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckG" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckH" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckI" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckJ" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckK" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckL" = (
+/obj/effect/floor_decal/corner/lime,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckM" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckN" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"ckP" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"ckQ" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckR" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckS" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
+"ckT" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckU" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckV" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckW" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckX" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckY" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"ckZ" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"cla" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
+"clb" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"clc" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
+"cld" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"cle" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/research)
+"clf" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"clg" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"clh" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"cli" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"clj" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"clk" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"cll" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/library)
+"clm" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/library)
+"cln" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"clo" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"clp" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"clq" = (
+/obj/structure/bed/chair/comfy/black,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"clr" = (
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"cls" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"clt" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
+"clu" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
+"clv" = (
+/obj/structure/table/marble,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
+"clw" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"clx" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"cly" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"clz" = (
+/obj/effect/floor_decal/corner/grey,
+/obj/effect/floor_decal/corner/white{
+	icon_state = "corner_white";
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"clA" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/toy/xmas_cracker,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"clB" = (
+/obj/structure/table/woodentable,
+/obj/item/clothing/head/festive/santa,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"clC" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/xmasgift/small,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"clD" = (
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"clE" = (
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"clF" = (
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"clG" = (
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"clH" = (
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"clI" = (
+/obj/structure/flora/tree/pine/xmas,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"clJ" = (
+/obj/item/weapon/xmasgift/medium{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"clK" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"clL" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights,
+/obj/structure/table/woodentable,
+/obj/item/weapon/xmasgift/small,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"clM" = (
+/obj/item/weapon/xmasgift/medium{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/weapon/xmasgift/small{
+	pixel_x = 14;
+	pixel_y = 0
+	},
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"clN" = (
+/obj/item/weapon/xmasgift/large{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/obj/structure/sign/christmas/lights,
+/obj/item/weapon/xmasgift/small{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/weapon/xmasgift/small,
+/obj/item/weapon/xmasgift/small{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"clO" = (
+/obj/structure/sign/christmas/lights,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aaa
@@ -82321,7 +83431,7 @@ aQj
 aRN
 aSY
 aUI
-aEJ
+cky
 aXg
 aEJ
 aZz
@@ -82578,7 +83688,7 @@ aQg
 aRO
 aSZ
 aUJ
-aEJ
+ckz
 aXg
 aYn
 aQs
@@ -83600,8 +84710,8 @@ aGd
 aHS
 aJy
 aLj
-aEJ
-aEJ
+ckl
+ckq
 aQn
 aRS
 aTc
@@ -84662,7 +85772,7 @@ byE
 cdL
 bAz
 bBu
-bCh
+cle
 bCX
 bDP
 bEG
@@ -85404,7 +86514,7 @@ aOP
 aQu
 aRX
 aTi
-aUT
+ckv
 aEJ
 aXm
 aDa
@@ -85918,7 +87028,7 @@ aOT
 aQv
 aRZ
 aTk
-aUT
+ckw
 aEJ
 aXm
 aDa
@@ -86164,7 +87274,7 @@ awY
 ayD
 aAm
 aBI
-aDa
+ckh
 aEJ
 aEJ
 aHZ
@@ -86970,10 +88080,10 @@ bqZ
 buB
 bvL
 bwU
-bqZ
+ckS
 byL
-bqZ
-bqZ
+cla
+clc
 bBx
 bCp
 bDe
@@ -87975,7 +89085,7 @@ aGu
 aGu
 aTo
 aUW
-aVT
+ckA
 aXs
 aVT
 aVa
@@ -88489,7 +89599,7 @@ aIg
 aIg
 aTq
 aUY
-aVT
+ckB
 aXu
 aYx
 aZJ
@@ -91339,10 +92449,10 @@ brh
 buG
 bwb
 bkL
-bkL
-bkL
-bwc
-aWn
+ckT
+ckW
+clb
+cld
 bBL
 buG
 bDn
@@ -91563,7 +92673,7 @@ aAw
 aBU
 ame
 aES
-aGB
+cki
 aIp
 aJM
 aLF
@@ -91578,9 +92688,9 @@ aXB
 aWn
 aWc
 baP
-aWn
-aWn
-aWn
+ckD
+ckE
+ckF
 bfR
 baT
 aWn
@@ -91820,7 +92930,7 @@ aoT
 aoT
 aDm
 aEQ
-aGB
+ckj
 aIq
 aJN
 aLG
@@ -92109,9 +93219,9 @@ bsE
 aWn
 bdA
 bwd
-aWn
-aWn
-aWn
+ckQ
+ckU
+ckX
 bzV
 bdA
 aWn
@@ -92618,7 +93728,7 @@ bcj
 bny
 aVc
 aWn
-aWn
+ckM
 bsF
 btJ
 btJ
@@ -92631,7 +93741,7 @@ btJ
 btJ
 btJ
 bsF
-aWn
+clh
 bFh
 bGb
 bGH
@@ -93166,11 +94276,11 @@ bPg
 bPO
 bQl
 bIl
-bJa
-bJa
+cls
+clw
 bRZ
-bJa
-bJa
+clx
+cly
 bSU
 bTl
 bJa
@@ -93402,7 +94512,7 @@ btJ
 btJ
 btJ
 ceB
-aWn
+cli
 bFj
 bDx
 bGJ
@@ -93452,9 +94562,9 @@ aaa
 aaa
 aab
 aab
-aab
-aab
-aab
+aSV
+aSV
+aSV
 aab
 aab
 aab
@@ -93685,7 +94795,7 @@ bMI
 bJa
 bOf
 bSG
-bOf
+clz
 bOf
 bOf
 bTY
@@ -93709,9 +94819,9 @@ aaa
 aaa
 aab
 aab
-aab
-aab
-aab
+aSV
+aSV
+aSV
 aab
 aab
 aab
@@ -93881,7 +94991,7 @@ aIs
 aJU
 aLJ
 aLJ
-aLJ
+ckr
 cfI
 aSi
 aTD
@@ -93966,9 +95076,9 @@ aaa
 aaa
 aab
 aab
-aab
-aab
-aab
+aSV
+aSV
+aSV
 aab
 aab
 aab
@@ -94160,7 +95270,7 @@ bix
 bix
 aZN
 aWn
-aWn
+ckN
 bsF
 btJ
 btJ
@@ -94173,7 +95283,7 @@ btJ
 btJ
 btJ
 ceB
-aWn
+clj
 bFk
 aWn
 bGK
@@ -94451,7 +95561,7 @@ bNF
 bNF
 bQn
 bQL
-bRk
+clt
 bRF
 bSa
 bRH
@@ -94679,9 +95789,9 @@ bsH
 aWn
 bdD
 bwe
-aWn
-aWn
-aWn
+ckR
+ckV
+ckY
 aWc
 bdD
 aWn
@@ -94721,9 +95831,9 @@ bUB
 bUW
 bUW
 bVI
-bRH
+clD
 bWq
-bWq
+clL
 bRi
 bTe
 bMM
@@ -94965,20 +96075,20 @@ bPi
 bPQ
 bQp
 bQN
-bRk
+clu
 bRl
 bSb
 bRH
 bSJ
 bSX
-bTm
+clA
 bTG
 bUb
 bSX
-bTm
+clC
 bTG
 bRH
-bRH
+clE
 bWr
 bWP
 bRi
@@ -95179,15 +96289,15 @@ baV
 aWn
 bdE
 beG
+ckG
+ckH
+aWn
+ckI
+ckJ
 aWn
 aWn
-aWn
-aWn
-aWn
-aWn
-aWn
-aWn
-bpW
+ckK
+ckL
 brp
 bsJ
 btK
@@ -95195,7 +96305,7 @@ bpW
 bwf
 brp
 cjO
-aWn
+ckZ
 aWc
 aWn
 aXD
@@ -95222,7 +96332,7 @@ bPj
 bPR
 bQp
 bQO
-bRl
+clv
 bRG
 bSb
 bRH
@@ -95235,9 +96345,9 @@ bSX
 bTn
 bTG
 bRH
-bRH
+clF
 bWs
-bWs
+clM
 bRi
 cdZ
 bMN
@@ -95485,16 +96595,16 @@ bSc
 bRm
 bSL
 bSX
-bTm
+clB
 bTG
 bUb
 bSX
 bTm
 bTG
 bRH
-bRH
-bWq
-bWq
+clG
+clI
+clN
 bRi
 bMQ
 bMN
@@ -95713,7 +96823,7 @@ byW
 btQ
 bAR
 bBN
-bCD
+clf
 bDz
 bEl
 bFo
@@ -95750,7 +96860,7 @@ bUC
 bUC
 bUC
 bVY
-bWr
+clJ
 bWQ
 bRi
 bMQ
@@ -95970,7 +97080,7 @@ byX
 btQ
 bAS
 aXD
-bCD
+clg
 bDA
 bEm
 bFp
@@ -96006,9 +97116,9 @@ bRH
 bRH
 bRH
 bRH
-bRH
-bWs
-bWs
+clH
+clK
+clO
 bRi
 bMQ
 bXM
@@ -96219,7 +97329,7 @@ bqa
 brt
 brr
 btM
-buM
+ckP
 buM
 bxi
 buM
@@ -96988,7 +98098,7 @@ bnA
 boS
 bqc
 brw
-bsN
+ckO
 btP
 buP
 bsN
@@ -97257,10 +98367,10 @@ bAW
 bBS
 bly
 bDD
-bEr
+clk
 bEp
-bEp
-bEp
+cll
+clm
 bEp
 bIt
 bEp
@@ -97518,7 +98628,7 @@ bEs
 bFr
 bGh
 bGP
-bEr
+cln
 bIt
 bEp
 bEp
@@ -97775,7 +98885,7 @@ bEt
 bFs
 bEr
 bGQ
-bEr
+clo
 bIt
 bJj
 bEp
@@ -98806,9 +99916,9 @@ bDy
 bHI
 bGf
 bJl
-bGM
-bGf
-bGN
+clp
+clq
+clr
 bLT
 bDy
 bMQ
@@ -101332,7 +102442,7 @@ aFq
 aHc
 aIP
 abH
-abI
+ckk
 aNQ
 aPy
 aQZ
@@ -102363,11 +103473,11 @@ azz
 aLZ
 cdu
 aAY
-azz
-azz
-azz
+cks
+ckt
+cku
 aVh
-azz
+ckC
 cfj
 aZa
 bac
@@ -103646,7 +104756,7 @@ azz
 aIQ
 azz
 aMc
-azz
+ckm
 aPE
 aRe
 aSz
@@ -103903,7 +105013,7 @@ axK
 aIR
 axK
 aMd
-azz
+ckn
 aPF
 aRf
 aSA
@@ -104160,7 +105270,7 @@ aHk
 aIQ
 azz
 aMe
-azz
+cko
 aPF
 aRg
 aSB
@@ -104417,7 +105527,7 @@ awj
 awj
 cfa
 aMe
-azz
+ckp
 aPG
 aRh
 aSC
@@ -106735,7 +107845,7 @@ aPJ
 aRn
 aSI
 aUg
-aRn
+ckx
 aWM
 aXR
 aZk

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -2615,6 +2615,11 @@
 	icon_state = "corner_white_full";
 	dir = 1
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "eW" = (
@@ -4304,6 +4309,11 @@
 "hX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "hZ" = (
@@ -5266,6 +5276,11 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "jP" = (
@@ -5362,6 +5377,11 @@
 /area/security/checkpoint2)
 "jV" = (
 /obj/effect/floor_decal/corner/blue/full,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "jW" = (
@@ -6780,6 +6800,11 @@
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 1
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mk" = (
@@ -6817,6 +6842,11 @@
 /area/security/checkpoint2)
 "mm" = (
 /obj/effect/floor_decal/corner/blue/full{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -7265,6 +7295,7 @@
 	name = "NSS Aurora"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "nh" = (
@@ -7278,6 +7309,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "ni" = (
@@ -10502,6 +10534,11 @@
 	icon_state = "corner_white_full";
 	dir = 1
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "tv" = (
@@ -11195,6 +11232,11 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "uP" = (
@@ -11556,6 +11598,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "vz" = (
@@ -12000,6 +12043,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "wm" = (
@@ -17048,6 +17092,7 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
+/obj/item/weapon/xmasgift/small,
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
 "FW" = (
@@ -17163,6 +17208,11 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "Gh" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/ramp{
 	icon_state = "ramptop";
 	dir = 8
@@ -17285,6 +17335,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/ramp{
 	icon_state = "ramptop";
 	dir = 8
@@ -19668,6 +19719,24 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "ML" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/full{
+	icon_state = "corner_white_full";
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/port)
+"MM" = (
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 9
@@ -19679,7 +19748,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
-"MM" = (
+"MN" = (
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 6
@@ -19691,7 +19760,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
-"MN" = (
+"MO" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
@@ -19709,7 +19778,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
-"MO" = (
+"MP" = (
 /obj/effect/floor_decal/corner/blue/full{
 	icon_state = "corner_white_full";
 	dir = 4
@@ -19721,18 +19790,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
-"MP" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "MQ" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -19746,10 +19803,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "MR" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
 	},
-/obj/structure/sign/christmas/lights,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "MS" = (
@@ -19760,6 +19822,38 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "MT" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"MU" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/full,
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/port)
+"MV" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/full{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/port)
+"MW" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (EAST)";
@@ -19768,7 +19862,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
-"MU" = (
+"MX" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
@@ -19782,53 +19876,53 @@
 /obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
-"MV" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
-"MW" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
-"MX" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "MY" = (
 /obj/effect/floor_decal/corner/lime{
-	dir = 6
+	icon_state = "corner_white";
+	dir = 9
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
+	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "MZ" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Na" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nb" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19839,7 +19933,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
-"Na" = (
+"Nd" = (
 /obj/structure/bed/chair/comfy/beige,
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (WEST)";
@@ -19848,7 +19942,7 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/fore)
-"Nb" = (
+"Ne" = (
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
@@ -19856,7 +19950,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
-"Nc" = (
+"Nf" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 1;
 	icon_state = "comfychair_preview"
@@ -19869,11 +19963,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/fore)
-"Nd" = (
+"Ng" = (
 /obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
-"Ne" = (
+"Nh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -19888,7 +19982,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
-"Nf" = (
+"Ni" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -19903,7 +19997,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
-"Ng" = (
+"Nj" = (
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
@@ -19911,7 +20005,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
-"Nh" = (
+"Nk" = (
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
@@ -19919,42 +20013,34 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
-"Ni" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
-"Nj" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
-"Nk" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "Nl" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/crew_quarters/sleep/cryo)
+/area/hallway/secondary/entry/fore)
 "Nm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nn" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"No" = (
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
@@ -19962,7 +20048,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/cryo)
-"Nn" = (
+"Np" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/sleep/cryo)
+"Nq" = (
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
@@ -19970,30 +20064,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/cryo)
-"No" = (
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
-"Np" = (
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
-"Nq" = (
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "Nr" = (
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (NORTH)";
@@ -20020,41 +20090,40 @@
 /area/hallway/secondary/entry/fore)
 "Nu" = (
 /obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nv" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nw" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nx" = (
+/obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
-"Nv" = (
+"Ny" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/aft)
-"Nw" = (
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/aft)
-"Nx" = (
-/obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/aft)
-"Ny" = (
-/obj/machinery/door/firedoor,
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
@@ -20063,6 +20132,31 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "Nz" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/aft)
+"NA" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/aft)
+"NB" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/aft)
+"NC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -20073,7 +20167,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
-"NA" = (
+"ND" = (
 /obj/structure/sign/christmas/lights{
 	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
@@ -43566,7 +43660,7 @@ aa
 aa
 aa
 ey
-eT
+ML
 fB
 fC
 ho
@@ -43576,7 +43670,7 @@ fB
 IM
 fC
 fB
-li
+MU
 jI
 aa
 aa
@@ -44090,7 +44184,7 @@ fD
 fC
 fC
 fD
-lh
+MV
 jI
 aa
 aa
@@ -44644,7 +44738,7 @@ xD
 yi
 yI
 vK
-Nu
+Nx
 vK
 Ar
 sP
@@ -44876,10 +44970,10 @@ gs
 nU
 oj
 oA
-Na
+Nd
 pd
 pr
-Nc
+Nf
 pP
 pW
 qg
@@ -45122,8 +45216,8 @@ ll
 lF
 lP
 mh
-MV
-MX
+MY
+Na
 mJ
 gs
 IU
@@ -45632,7 +45726,7 @@ jw
 jO
 kj
 kP
-MT
+MW
 lG
 lP
 mj
@@ -45882,10 +45976,10 @@ eC
 aa
 aa
 gu
-MP
+MQ
 ie
 iM
-MR
+MS
 jP
 jR
 kQ
@@ -45916,7 +46010,7 @@ qy
 qO
 re
 rm
-Nh
+Nk
 rX
 sw
 pP
@@ -46393,7 +46487,7 @@ ds
 dM
 ee
 eD
-ML
+MM
 fI
 gv
 hr
@@ -46436,10 +46530,10 @@ ph
 sS
 tE
 Ih
-Ni
-Nj
+Nl
+Nm
 wL
-Nk
+Nn
 ph
 yM
 zn
@@ -46682,9 +46776,9 @@ kO
 pR
 kO
 ql
-Ne
+Nh
 qA
-Nf
+Ni
 kO
 kO
 rB
@@ -46907,8 +47001,8 @@ cn
 dO
 eg
 eF
-MM
-MO
+MN
+MP
 gv
 hr
 ii
@@ -46930,19 +47024,19 @@ jA
 jA
 nL
 jA
-MZ
+Nc
 iL
-Nb
+Ne
 jw
 nZ
 jA
 pS
 jA
-Nd
+Ng
 qr
 qB
 qP
-Ng
+Nj
 jA
 mM
 jA
@@ -47424,10 +47518,10 @@ eA
 aa
 aa
 gt
-MQ
+MR
 ik
 iS
-MS
+MT
 jU
 jR
 kQ
@@ -47469,7 +47563,7 @@ vN
 wP
 xG
 yn
-No
+Nr
 iL
 oo
 Ai
@@ -47726,7 +47820,7 @@ tK
 wQ
 ta
 yo
-Np
+Ns
 zp
 on
 Aj
@@ -47983,7 +48077,7 @@ tJ
 wR
 um
 yp
-Nq
+Nt
 iL
 zL
 Ai
@@ -48206,8 +48300,8 @@ ls
 lN
 lW
 mo
-MW
-MY
+MZ
+Nb
 mP
 gs
 ag
@@ -48497,7 +48591,7 @@ tJ
 vO
 um
 yq
-Nr
+Nu
 iL
 zN
 Ai
@@ -48754,7 +48848,7 @@ tK
 vO
 tK
 yo
-Ns
+Nv
 iL
 zO
 pu
@@ -49011,7 +49105,7 @@ vO
 vO
 um
 yn
-Nt
+Nw
 zr
 on
 pv
@@ -49278,18 +49372,18 @@ Bi
 BB
 BB
 BB
-Nv
+Ny
 BB
 BB
-Nw
+Nz
 CG
 BB
 BB
 BB
-Nx
-Ny
-Nz
 NA
+NB
+NC
+ND
 BB
 JK
 BB
@@ -49734,7 +49828,7 @@ aa
 aa
 aa
 eI
-MN
+MO
 fM
 fO
 IH
@@ -49744,7 +49838,7 @@ fM
 fO
 Iw
 fM
-MU
+MX
 eI
 aa
 aa
@@ -50551,8 +50645,8 @@ us
 vg
 vS
 wV
-Nl
-Nm
+No
+Np
 yP
 rr
 zT
@@ -51837,7 +51931,7 @@ vk
 vU
 wZ
 vg
-Nn
+Nq
 yT
 rr
 sr

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -772,7 +772,6 @@
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -1102,7 +1101,6 @@
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/blue/full,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -1308,7 +1306,6 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -2572,7 +2569,6 @@
 	dir = 1
 	},
 /obj/machinery/door/window/eastright{
-	tag = "icon-right (WEST)";
 	icon_state = "right";
 	dir = 8
 	},
@@ -2616,7 +2612,6 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -2689,7 +2684,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -3029,7 +3023,6 @@
 "fI" = (
 /obj/effect/floor_decal/corner/blue/full,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -3411,7 +3404,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
 	icon_state = "map";
-	tag = "icon-manifold-f (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
@@ -3512,7 +3504,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
 	icon_state = "map";
-	tag = "icon-manifold-f (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -4021,7 +4012,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -4310,7 +4300,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -4441,7 +4430,6 @@
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -5277,7 +5265,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -5378,7 +5365,6 @@
 "jV" = (
 /obj/effect/floor_decal/corner/blue/full,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -5947,7 +5933,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -6005,7 +5990,6 @@
 "kV" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -6776,7 +6760,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -6801,7 +6784,6 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -6845,7 +6827,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -6864,7 +6845,6 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -6966,7 +6946,6 @@
 	dir = 5
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -7091,7 +7070,6 @@
 	pixel_y = -22
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -7142,7 +7120,6 @@
 	pixel_y = -32
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -8011,7 +7988,6 @@
 /area/maintenance/solarmaint)
 "oA" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -8324,7 +8300,6 @@
 	spawn_object = /obj/item/weapon/flame/lighter
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -8447,7 +8422,6 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/chips,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -8945,7 +8919,6 @@
 "qp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -9000,7 +8973,6 @@
 	icon_state = "comfychair_preview"
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -9059,7 +9031,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -9089,7 +9060,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -9139,7 +9109,6 @@
 	},
 /obj/structure/flora/pottedplant/random,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -9276,7 +9245,6 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -9312,7 +9280,6 @@
 	icon_state = "comfychair_preview"
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -9421,7 +9388,6 @@
 	pixel_y = 0
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -9527,7 +9493,6 @@
 "rm" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -10535,7 +10500,6 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -11063,7 +11027,6 @@
 "uw" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -11233,7 +11196,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -11455,7 +11417,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -11843,7 +11804,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -13408,7 +13368,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -13466,7 +13425,6 @@
 /obj/structure/flora/pottedplant/random,
 /obj/structure/sign/christmas/lights,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -13491,7 +13449,6 @@
 	pixel_y = -32
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -15756,7 +15713,6 @@
 "Dz" = (
 /obj/machinery/vending/coffee,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -15906,7 +15862,6 @@
 "DQ" = (
 /obj/machinery/vending/cola,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -16024,7 +15979,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -16562,7 +16516,6 @@
 "ET" = (
 /obj/structure/closet/crate/trashcart,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -17209,7 +17162,6 @@
 /area/quartermaster/loading)
 "Gh" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -18535,7 +18487,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (EAST)";
 	icon_state = "intact";
 	dir = 4
 	},
@@ -18600,7 +18551,6 @@
 /area/hallway/secondary/exit)
 "II" = (
 /obj/effect/floor_decal/industrial/warning/cee{
-	tag = "icon-warningcee (EAST)";
 	icon_state = "warningcee";
 	dir = 4
 	},
@@ -18637,7 +18587,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
 	icon_state = "map";
-	tag = "icon-manifold-f (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
@@ -18854,7 +18803,6 @@
 "Jj" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
 	dir = 5
 	},
@@ -18931,7 +18879,6 @@
 	},
 /obj/machinery/firealarm/east,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -19696,7 +19643,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -19712,7 +19658,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19730,7 +19675,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -19742,7 +19686,6 @@
 	dir = 9
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -19754,7 +19697,6 @@
 	dir = 6
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19772,7 +19714,6 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -19784,7 +19725,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19796,7 +19736,6 @@
 	dir = 5
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -19808,7 +19747,6 @@
 	dir = 5
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -19856,7 +19794,6 @@
 "MW" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19882,7 +19819,6 @@
 	dir = 9
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -19893,7 +19829,6 @@
 	dir = 6
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19905,7 +19840,6 @@
 	dir = 9
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -19916,7 +19850,6 @@
 	dir = 6
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19927,7 +19860,6 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19936,7 +19868,6 @@
 "Nd" = (
 /obj/structure/bed/chair/comfy/beige,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -19944,7 +19875,6 @@
 /area/hallway/secondary/entry/fore)
 "Ne" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19957,7 +19887,6 @@
 	},
 /obj/machinery/light,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -19976,7 +19905,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19991,7 +19919,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -19999,7 +19926,6 @@
 /area/hallway/secondary/entry/fore)
 "Nj" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -20007,7 +19933,6 @@
 /area/hallway/secondary/entry/fore)
 "Nk" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -20016,7 +19941,6 @@
 "Nl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -20025,7 +19949,6 @@
 "Nm" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -20034,7 +19957,6 @@
 "Nn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -20042,7 +19964,6 @@
 /area/hallway/secondary/entry/fore)
 "No" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -20050,7 +19971,6 @@
 /area/crew_quarters/sleep/cryo)
 "Np" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -20058,7 +19978,6 @@
 /area/crew_quarters/sleep/cryo)
 "Nq" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -20066,7 +19985,6 @@
 /area/crew_quarters/sleep/cryo)
 "Nr" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -20074,7 +19992,6 @@
 /area/hallway/secondary/entry/fore)
 "Ns" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -20082,7 +19999,6 @@
 /area/hallway/secondary/entry/fore)
 "Nt" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -20090,7 +20006,6 @@
 /area/hallway/secondary/entry/fore)
 "Nu" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -20098,7 +20013,6 @@
 /area/hallway/secondary/entry/fore)
 "Nv" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -20106,7 +20020,6 @@
 /area/hallway/secondary/entry/fore)
 "Nw" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (NORTH)";
 	icon_state = "xmaslights";
 	dir = 1
 	},
@@ -20114,7 +20027,6 @@
 /area/hallway/secondary/entry/fore)
 "Nx" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (WEST)";
 	icon_state = "xmaslights";
 	dir = 8
 	},
@@ -20125,7 +20037,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -20133,7 +20044,6 @@
 /area/hallway/secondary/entry/aft)
 "Nz" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -20141,7 +20051,6 @@
 /area/hallway/secondary/entry/aft)
 "NA" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -20150,7 +20059,6 @@
 "NB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -20161,7 +20069,6 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},
@@ -20169,7 +20076,6 @@
 /area/hallway/secondary/entry/aft)
 "ND" = (
 /obj/structure/sign/christmas/lights{
-	tag = "icon-xmaslights (EAST)";
 	icon_state = "xmaslights";
 	dir = 4
 	},

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -771,6 +771,11 @@
 "bu" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bx" = (
@@ -1096,6 +1101,11 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/blue/full,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "cn" = (
@@ -1296,6 +1306,11 @@
 	},
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
@@ -2668,6 +2683,11 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "fc" = (
@@ -3003,6 +3023,11 @@
 /area/hallway/secondary/entry/dock)
 "fI" = (
 /obj/effect/floor_decal/corner/blue/full,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "fJ" = (
@@ -3990,6 +4015,11 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "hr" = (
@@ -4400,6 +4430,11 @@
 "ip" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "iq" = (
@@ -5282,6 +5317,7 @@
 	req_access = list(1)
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "jT" = (
@@ -5890,6 +5926,11 @@
 "kP" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "kQ" = (
@@ -5943,6 +5984,11 @@
 /area/security/checkpoint2)
 "kV" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "kW" = (
@@ -6260,6 +6306,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/full,
+/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "lw" = (
@@ -6708,6 +6755,11 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mi" = (
@@ -6760,6 +6812,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "mm" = (
@@ -6779,6 +6832,11 @@
 /obj/effect/floor_decal/corner/lime/full{
 	icon_state = "corner_white_full";
 	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
@@ -6876,6 +6934,11 @@
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 5
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
@@ -6997,6 +7060,11 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mK" = (
@@ -7042,6 +7110,11 @@
 	},
 /obj/machinery/newscaster{
 	pixel_y = -32
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
@@ -7905,6 +7978,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/solarmaint)
 "oA" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/fore)
 "oB" = (
@@ -7995,6 +8073,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice)
 "oJ" = (
@@ -8212,6 +8291,11 @@
 	spawn_nothing_percentage = 50;
 	spawn_object = /obj/item/weapon/flame/lighter
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/fore)
 "pe" = (
@@ -8330,6 +8414,11 @@
 "pr" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/chips,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/fore)
 "ps" = (
@@ -8823,6 +8912,11 @@
 /area/storage/primary)
 "qp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "qq" = (
@@ -8872,6 +8966,11 @@
 /obj/structure/bed/chair/comfy/teal{
 	dir = 4;
 	icon_state = "comfychair_preview"
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
@@ -8927,6 +9026,11 @@
 "qy" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "qz" = (
@@ -8951,6 +9055,11 @@
 /obj/machinery/camera/network/civilian_east{
 	c_tag = "Surface - Corridor Camera 10";
 	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
@@ -8997,6 +9106,11 @@
 	dir = 8
 	},
 /obj/structure/flora/pottedplant/random,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "qD" = (
@@ -9129,6 +9243,11 @@
 /obj/structure/table/standard,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "qP" = (
@@ -9159,6 +9278,11 @@
 /obj/structure/bed/chair/comfy/teal{
 	dir = 4;
 	icon_state = "comfychair_preview"
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
@@ -9264,6 +9388,11 @@
 /obj/machinery/recharger{
 	pixel_y = 0
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "rf" = (
@@ -9365,6 +9494,11 @@
 /area/storage/primary)
 "rm" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "rn" = (
@@ -10891,6 +11025,11 @@
 /area/crew_quarters/sleep/cryo)
 "uw" = (
 /obj/structure/closet/emcloset,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/cryo)
 "ux" = (
@@ -11273,6 +11412,11 @@
 "vk" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/cryo)
 "vl" = (
@@ -11654,6 +11798,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/cryo)
@@ -13214,6 +13363,11 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
 "yJ" = (
@@ -13266,6 +13420,12 @@
 /area/hallway/secondary/entry/fore)
 "yP" = (
 /obj/structure/flora/pottedplant/random,
+/obj/structure/sign/christmas/lights,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/cryo)
 "yQ" = (
@@ -13285,6 +13445,11 @@
 /obj/machinery/light_switch{
 	pixel_x = 0;
 	pixel_y = -32
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/cryo)
@@ -14035,6 +14200,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/sleep/bedrooms)
 "Ai" = (
@@ -14052,6 +14218,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
 "Ak" = (
@@ -15544,6 +15711,11 @@
 /area/quartermaster/loading)
 "Dz" = (
 /obj/machinery/vending/coffee,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "DA" = (
@@ -15689,6 +15861,11 @@
 /area/quartermaster/loading)
 "DQ" = (
 /obj/machinery/vending/cola,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "DR" = (
@@ -15801,6 +15978,11 @@
 /obj/machinery/camera/network/civilian_east{
 	c_tag = "Cargo - Auxilliary Entrance";
 	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
@@ -16076,6 +16258,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "EA" = (
@@ -16334,6 +16517,11 @@
 /area/quartermaster/loading)
 "ET" = (
 /obj/structure/closet/crate/trashcart,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "EU" = (
@@ -18691,6 +18879,11 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/east,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "Jr" = (
@@ -19443,6 +19636,451 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
+"MJ" = (
+/obj/structure/bed/chair,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/full{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/dock)
+"MK" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/corner/blue/full{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/dock)
+"ML" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/dock)
+"MM" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/dock)
+"MN" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/exit)
+"MO" = (
+/obj/effect/floor_decal/corner/blue/full{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/dock)
+"MP" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"MQ" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"MR" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"MS" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"MT" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"MU" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/full{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/exit)
+"MV" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"MW" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"MX" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"MY" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"MZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Na" = (
+/obj/structure/bed/chair/comfy/beige,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/entry/fore)
+"Nb" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nc" = (
+/obj/structure/bed/chair/comfy/beige{
+	dir = 1;
+	icon_state = "comfychair_preview"
+	},
+/obj/machinery/light,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/secondary/entry/fore)
+"Nd" = (
+/obj/structure/sign/christmas/lights,
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Ne" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Ng" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nh" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/storage/primary)
+"Ni" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nj" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nk" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nl" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/sleep/cryo)
+"Nm" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/sleep/cryo)
+"Nn" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/sleep/cryo)
+"No" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Np" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nq" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nr" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Ns" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nt" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (NORTH)";
+	icon_state = "xmaslights";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/fore)
+"Nu" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (WEST)";
+	icon_state = "xmaslights";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/locker)
+"Nv" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/aft)
+"Nw" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/aft)
+"Nx" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/aft)
+"Ny" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/aft)
+"Nz" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/aft)
+"NA" = (
+/obj/structure/sign/christmas/lights{
+	tag = "icon-xmaslights (EAST)";
+	icon_state = "xmaslights";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/aft)
 
 (1,1,1) = {"
 aa
@@ -44006,7 +44644,7 @@ xD
 yi
 yI
 vK
-vK
+Nu
 vK
 Ar
 sP
@@ -44238,10 +44876,10 @@ gs
 nU
 oj
 oA
-oS
+Na
 pd
 pr
-pB
+Nc
 pP
 pW
 qg
@@ -44484,8 +45122,8 @@ ll
 lF
 lP
 mh
-ju
-ju
+MV
+MX
 mJ
 gs
 IU
@@ -44721,7 +45359,7 @@ aa
 bq
 bO
 IC
-cE
+MJ
 cY
 cm
 cE
@@ -44994,7 +45632,7 @@ jw
 jO
 kj
 kP
-kV
+MT
 lG
 lP
 mj
@@ -45244,10 +45882,10 @@ eC
 aa
 aa
 gu
-hr
+MP
 ie
 iM
-jx
+MR
 jP
 jR
 kQ
@@ -45278,7 +45916,7 @@ qy
 qO
 re
 rm
-rz
+Nh
 rX
 sw
 pP
@@ -45755,7 +46393,7 @@ ds
 dM
 ee
 eD
-eD
+ML
 fI
 gv
 hr
@@ -45798,10 +46436,10 @@ ph
 sS
 tE
 Ih
-ph
-ph
+Ni
+Nj
 wL
-ph
+Nk
 ph
 yM
 zn
@@ -46044,9 +46682,9 @@ kO
 pR
 kO
 ql
-kO
+Ne
 qA
-kO
+Nf
 kO
 kO
 rB
@@ -46269,8 +46907,8 @@ cn
 dO
 eg
 eF
-eF
-ej
+MM
+MO
 gv
 hr
 ii
@@ -46292,19 +46930,19 @@ jA
 jA
 nL
 jA
-oo
+MZ
 iL
-jA
+Nb
 jw
 nZ
 jA
 pS
 jA
-jA
+Nd
 qr
 qB
 qP
-jA
+Ng
 jA
 mM
 jA
@@ -46786,10 +47424,10 @@ eA
 aa
 aa
 gt
-hr
+MQ
 ik
 iS
-jx
+MS
 jU
 jR
 kQ
@@ -46831,7 +47469,7 @@ vN
 wP
 xG
 yn
-jA
+No
 iL
 oo
 Ai
@@ -47088,7 +47726,7 @@ tK
 wQ
 ta
 yo
-jA
+Np
 zp
 on
 Aj
@@ -47293,7 +47931,7 @@ bV
 cr
 cH
 dc
-cr
+MK
 dQ
 ej
 eC
@@ -47345,7 +47983,7 @@ tJ
 wR
 um
 yp
-jA
+Nq
 iL
 zL
 Ai
@@ -47568,8 +48206,8 @@ ls
 lN
 lW
 mo
-jB
-jB
+MW
+MY
 mP
 gs
 ag
@@ -47859,7 +48497,7 @@ tJ
 vO
 um
 yq
-jA
+Nr
 iL
 zN
 Ai
@@ -48116,7 +48754,7 @@ tK
 vO
 tK
 yo
-jA
+Ns
 iL
 zO
 pu
@@ -48373,7 +49011,7 @@ vO
 vO
 um
 yn
-jA
+Nt
 zr
 on
 pv
@@ -48640,18 +49278,18 @@ Bi
 BB
 BB
 BB
-Cj
+Nv
 BB
 BB
-BB
+Nw
 CG
 BB
 BB
 BB
-BB
-AR
-Cj
-BB
+Nx
+Ny
+Nz
+NA
 BB
 JK
 BB
@@ -49096,7 +49734,7 @@ aa
 aa
 aa
 eI
-fa
+MN
 fM
 fO
 IH
@@ -49106,7 +49744,7 @@ fM
 fO
 Iw
 fM
-lu
+MU
 eI
 aa
 aa
@@ -49913,8 +50551,8 @@ us
 vg
 vS
 wV
-wZ
-wZ
+Nl
+Nm
 yP
 rr
 zT
@@ -51199,7 +51837,7 @@ vk
 vU
 wZ
 vg
-wZ
+Nn
 yT
 rr
 sr


### PR DESCRIPTION
Fixes #3910 
Fixes #3909 
Fixes #3781 
Fixes #3772 
Also replaces pipe painter with floor painter next to the engineering elevator.

Adds a tree with some presents to both station and CC bar.
Adds wreaths to doors and christmas lights to hallways and rooms around the station. Almost all public areas have some. All head offices have some. All departmental break-rooms have some. Bridge has some. AI core has some. CC has quite a lot.

Also adds large present to Captain's office. Medium present to every other Head of Staff office. And small present to QM's office and AI core.

Based heavily on last years Christmas PR #1203 by LordFowl.

Example of station changes:
![43bb65ccc5870eb9e611248e850eb23c](https://user-images.githubusercontent.com/23423301/33514798-58ab7c28-d75a-11e7-8ee1-34acdd623532.png)
![66692448a61f05ea2c01823eabde2d79](https://user-images.githubusercontent.com/23423301/33509633-812edee4-d703-11e7-948e-97865eec23d0.png)
![6fd00bb28b202ae190e687cb29371689](https://user-images.githubusercontent.com/23423301/33509634-832b7b80-d703-11e7-8861-d0384811196a.png)

Example of Central changes:
![b49b6582b4fda8ad61384e45a1387576](https://user-images.githubusercontent.com/23423301/33509636-8734d582-d703-11e7-84d4-e0ba2d7847c9.png)
![778a71ed6502cd0fd6e8c2bedfc1cd48](https://user-images.githubusercontent.com/23423301/33509637-89378bea-d703-11e7-8732-56a9c8b3eab6.png)

There are many more changes than that, of course.
If there is something that needs to or should be changed or adjusted, of course, let me know.