### PR TITLE
[WIP] Added Annoying Messages Telling You You're Slow + Movement Speed Calculation Edits

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -1,6 +1,8 @@
 /mob/living/carbon/human/movement_delay()
 
 	var/tally = 0
+	var/messagechance = 5 // Base chance for a message to appear when you move. Decreases by half every time a message appears to prevent 10 messages from showing up at once.
+
 	if(species.slowdown)
 		tally = species.slowdown
 
@@ -14,21 +16,29 @@
 		handle_embedded_objects() //Moving with objects stuck in you can cause bad times.
 
 	var/health_deficiency = (100 - health)
-	if(health_deficiency >= 40) tally += (health_deficiency / 25)
+	if(health_deficiency >= 40)
+		tally += (health_deficiency / 25)
+		if(prob(messagechance + health_deficiency*0.1))
+			messagechance = messagechance*0.5
+			src << "<span class='warning'>You limp as your low vitality makes movement difficult...</span>"
 
 	if (!(species && (species.flags & NO_PAIN)))
-		if(halloss >= 10) tally += (halloss / 10) //halloss shouldn't slow you down if you can't even feel it
+		if(halloss >= 10)
+			tally += (halloss / 10) //halloss shouldn't slow you down if you can't even feel it
+			if(prob(messagechance + halloss))
+				messagechance = messagechance*0.5
+				src << "<span class='warning'>The pain hinders your movement...</span>"
 
-
-//Simpler hunger slowdown calculations, this should be a little faster due to no division, and more scaleable
-	if (nutrition < (max_nutrition * 0.4))
-		tally++
-		if (nutrition < (max_nutrition * 0.1))
-			tally++
+	// Hunger edits used to be here.
 
 	if(wear_suit)
 		tally += wear_suit.slowdown
+		if(prob(messagechance*0.1*wear_suit.slowdown)) //This is more obvious and should happen less, with modifiers to the suit movement.
+			messagechance = messagechance*0.5
+			src << "<span class='average'>Your [wear_suit.name] restricts your movement.</span>"
 
+	// People in wheelchairs don't need reminders.
+	// Possible TODO: Implement some sort of memory system where users are reminded of their missing limb if the limb was removed during the round.
 	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
 		for(var/organ_name in list("l_hand","r_hand","l_arm","r_arm"))
 			var/obj/item/organ/external/E = get_organ(organ_name)
@@ -41,7 +51,10 @@
 	else
 		if(shoes)
 			tally += shoes.slowdown
-
+			if(prob(messagechance*0.1*shoes.slowdown)) //This is more obvious and should happen less, with modifiers to the shoe movement.
+				messagechance = messagechance*0.5
+				src << "<span class='average'>Your [shoes.name] makes walking tedious.</span>"
+		//See wheelchair message. People like roleplaying as characters with missing legs and I don't think that they require constant reminders.
 		for(var/organ_name in list("l_foot","r_foot","l_leg","r_leg"))
 			var/obj/item/organ/external/E = get_organ(organ_name)
 			if(!E || E.is_stump())
@@ -51,30 +64,63 @@
 			else if(E.status & ORGAN_BROKEN)
 				tally += 1.5
 
-	if(shock_stage >= 10) tally += 3
+	if(shock_stage >= 10)
+		tally += 3
+		if(prob(messagechance*5)) //Higher chance because it's important
+			messagechance = messagechance*0.5
+			src << "<span class='warning'>Your leg muscle spasms from your recent shock!</span>"
 
-
+	//No message required. See message below.
 	if(aiming && aiming.aiming_at) tally += 5 // Iron sights make you slower, it's a well-known fact.
 
-	if (drowsyness) tally += 6
+	if (drowsyness)
+		tally += 6
+		if(prob(messagechance))
+			messagechance = messagechance*0.5
+			src << "<span class='average'>Your fatigue slows you down.</span>"
 
 	if(FAT in src.mutations)
 		tally += 1.5
+		if(prob(messagechance*0.5)) // Being fat is more obvious so less the chance.
+			messagechance = messagechance*0.5
+			src << "<span class='average'>Your fat thighs chaff together, restricting your movement.</span>"
+
 	if (bodytemperature < 283.222)
 		tally += (283.222 - bodytemperature) / 10 * 1.75
+		if(prob(messagechance*0.5)) // Being hot is more obvious so less the chance.
+			messagechance = messagechance*0.5
+			src << "<span class='average'>You break out into a sweat and slow yourself down.</span>"
 
+	// Players don't need to be reminded of missing feat.
 	tally += max(2 * stance_damage, 0) //damaged/missing feet or legs is slow
+
+	//  Players don't need to be reminded of mutations as it is probably handled elsewhere.
 	if(mRun in mutations)
 		tally = 0
 
 	tally += move_delay_mod
 
+	//  Players don't need to be reminded of chem effects as messages are handled elsewhere.
 	if(tally > 0 && (CE_SPEEDBOOST in chem_effects))
 		tally = max(0, tally-3)
 
+	// Messaging should be handled elsewhere as tiles have different reasons as to why you're being slowed down.
 	var/turf/T = get_turf(src)
 	if(T)
 		tally += T.movement_cost
+
+	// Putting the hunger system here so being starving is MUCH more noticable as it now considers movement speed penalties
+	//Simpler hunger slowdown calculations, this should be a little faster due to no division, and more scaleable
+	if (nutrition < (max_nutrition * 0.4))
+		tally++
+		if(prob(messagechance))
+			messagechance = messagechance*0.5
+			src << "<span class='warning'>Your lack of nutrition makes movement difficult...</span>"
+	else if (nutrition < (max_nutrition * 0.1))
+		tally+= tally*2 //Yell at me if there is a *= function or something
+		if(prob(messagechance*4)) // Multiplying this by two because im a biased piece of shit who hates seeing malnourished kids who don't eat.
+			messagechance = messagechance*0.5
+			src << "<span class='bad'>Walking becomes next to impossible as malnourshment weakens your muscles...</span>"
 
 	return (tally+config.human_delay)
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -64,11 +64,7 @@
 			else if(E.status & ORGAN_BROKEN)
 				tally += 1.5
 
-	if(shock_stage >= 10)
-		tally += 3
-		if(prob(messagechance*5)) //Higher chance because it's important
-			messagechance = messagechance*0.5
-			src << "<span class='warning'>Your leg muscle spasms from your recent shock!</span>"
+	if(shock_stage >= 10) tally += 3
 
 	//No message required. See message below.
 	if(aiming && aiming.aiming_at) tally += 5 // Iron sights make you slower, it's a well-known fact.

--- a/html/changelogs/burgerlua-movementedits.yml
+++ b/html/changelogs/burgerlua-movementedits.yml
@@ -1,0 +1,5 @@
+author: BurgerBB
+delete-after: True
+changes:
+  - tweak: "Hunger move penalties are now calculated after all movement speed penalties, instead of before. Players will be generally slower when hungry when affected by other things."
+  - rscadd: "Adding annoying messages when you're being slowed down by certain things, such as wearing heavy equipement, being tired, and being unhealthy."


### PR DESCRIPTION
I'm tired of seeing people walking around while they're full on starving, especially when they walk past the kitchen with all this food. People just don't like eating for whatever reason, so I decided to make a thing that punishes users with annoying text almost every time they take a step as well as calculate movement penalties differently by moving the hunger multiplication at the bottom of the code.

# Movement Speed
Currently, if you wore a hardsuit and were starving, the movement speed penalty would be insignificant as the calculation would be (species movement penalty * hunger move penalty) + hardsuit move penalty. This push makes it so the calculation is actually (species movement penalty + hardsuit move penalty) * hunger move penalty. It would make sense that moving in a hardsuit would be twice as hard when you're starving as your muscles would be weak.

# Messages
There's a chance for an annoying message to pop up every time you move without gravity, and this applies to most movement modifications. The base message chance is rare (5% per step) and gets lower or higher depending on how significant the penalty is. I did a lap around the center of the halls with a hardsuit and magboots on and I got at most 1 annoying message per lap. If you're starving, there's a 20% of an annoying message popping up telling you that you're starving each time you take a step.

# Further Justification
Under Roleplaying Characters: Take into account your character's comfort. Wearing hardsuits or internals for a prolonged period of time would be very tiring or uncomfortable. Do not wear these items without good reason. People just don't seem to take into character their character's comfort. Maybe they don't know that they're starving or maybe they just don't care, I think this sort of thing would make them care as it's incredibly distracting, just like being starving in real life is.

# Things that send you notification
(Percentage is based on per step.)
- Low health (5% - 15%, 0 Health Loss to 100 Health Loss)
- Pain (5% - 105%, 0 Pain to 100 Pain)
- Shoes (6% - ~20%, Depends on the shoe's slowdown. Prisoner Legcuffs is 20% per tile.)
- Suit (6% - 10%, Depends on the suit's slowdown. Hardsuits are like 1 to 5.)
- Drowsiness (5%)
- Being Fat (2.5%)
- High Body Temperature (2.5%)
- Hungry (5%)
- Starving (20%)

Everything else that slows you down, such as having a missing limb, I feel does not need a notification.