### PR TITLE
Atmos GC lag bandaid

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -42,6 +42,10 @@ Pipelines + Other Objects -> Pipe network
 		pipe_color = null
 	..()
 
+/obj/machinery/atmospherics/Destroy()
+	..()
+	return QDEL_HINT_HARDDEL	// fuck it
+
 /obj/machinery/atmospherics/proc/atmos_init()
 
 

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -255,3 +255,7 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 /client/Destroy()
 	..()
 	return QDEL_HINT_HARDDEL_NOW
+
+/image/Destroy()
+	..()
+	return QDEL_HINT_HARDDEL

--- a/html/changelogs/lohikar-pipedel.yml
+++ b/html/changelogs/lohikar-pipedel.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - experiment: "Made some changes to how the server deletes pipes; explosions will probably be laggier, but there should no longer be crushing lag 5 minutes later."


### PR DESCRIPTION
changes:
- Atmospherics devices and images now always hard-delete; this should address issues with crushing lag 5 minutes after explosions at the cost of slowing down explosions a bit.