### PR TITLE
Wrap walk

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -29,6 +29,8 @@
 
 	var/gfi_layer_rotation = GFI_ROTATION_DEFAULT
 
+	var/atom/movable/walking_actor = null
+
 /atom/proc/reveal_blood()
 	return
 
@@ -150,7 +152,7 @@
 /atom/proc/set_dir(new_dir)
 	. = new_dir != dir
 	dir = new_dir
-	
+
 	// Lighting
 	if (.)
 		var/datum/light_source/L

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -15,7 +15,7 @@
 		if(SSatoms.InitAtom(src, args))
 			//we were deleted
 			return
-	
+
 	var/list/created = SSatoms.created_atoms
 	if(created)
 		created += src
@@ -52,6 +52,9 @@
 	Initialize(FALSE)
 
 /atom/Destroy(force = FALSE)
+	if (walking_actor)
+		walking_actor.s_walk_stop()
+
 	if (reagents)
 		QDEL_NULL(reagents)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -20,8 +20,7 @@
 	var/list/contained_mobs
 
 	var/walking = FALSE // For the walk wrapper.
-	var/atom/movable/walking_tgt = null
-	var/atom/movable/walking_actor = null
+	var/atom/walking_tgt = null
 
 /atom/movable/Destroy()
 	. = ..()
@@ -37,9 +36,6 @@
 	// Clean up walking refs.
 	if (walking)
 		s_walk_stop()
-
-	if (walking_actor)
-		walking_actor.s_walk_stop()
 
 /atom/movable/Bump(var/atom/A, yes)
 	if(src.throwing)
@@ -329,7 +325,7 @@
 
 	walk_rand(src, lag, speed)
 
-/atom/movable/proc/s_walk_away(atom/movable/tgt, max = 5, lag = 0, speed = 0)
+/atom/movable/proc/s_walk_away(atom/tgt, max = 5, lag = 0, speed = 0)
 	RESET_VARS
 
 	ASSERT(tgt)
@@ -339,7 +335,7 @@
 
 	walk_away(src, walking_tgt, max, lag, speed)
 
-/atom/movable/proc/s_walk_to(atom/movable/tgt, min = 0, lag = 0, speed = 0)
+/atom/movable/proc/s_walk_to(atom/tgt, min = 0, lag = 0, speed = 0)
 	RESET_VARS
 
 	ASSERT(tgt)
@@ -349,7 +345,7 @@
 
 	walk_to(src, walking_tgt, min, lag, speed)
 
-/atom/movable/proc/s_walk_towards(atom/movable/tgt, lag = 0, speed = 0)
+/atom/movable/proc/s_walk_towards(atom/tgt, lag = 0, speed = 0)
 	RESET_VARS
 
 	ASSERT(tgt)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -284,13 +284,13 @@
 			pylonmode = 0
 			update_icon()
 			if (sacrifice)
-				walk_to(sacrifice,0)
+				sacrifice.s_walk_stop()
 		else
 			if (istype(sacrifice.loc, /turf) && !(sacrifice.is_ventcrawling) && !(sacrifice.buckled))
 				//Suck the creature towards the pylon if possible
-				walk_towards(sacrifice,src, 10)
+				sacrifice.s_walk_towards(src, 10)
 			else
-				walk_to(sacrifice,0) //If we're not in a valid situation, cancel walking to prevent bugginess
+				sacrifice.s_walk_stop() //If we're not in a valid situation, cancel walking to prevent bugginess
 
 /obj/structure/cult/pylon/proc/finalize_sacrifice()
 	sacrifice.visible_message(span("danger","\The [sacrifice]'s physical form unwinds as its soul is extracted from the remains, and drawn into the pylon!"))

--- a/code/game/gamemodes/events/clang.dm
+++ b/code/game/gamemodes/events/clang.dm
@@ -75,7 +75,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 //	world << "Rod in play, starting at [start.loc.x],[start.loc.y] and going to [end.loc.x],[end.loc.y]"
 	var/end = locate(endx, endy, 1)
 	spawn(0)
-		walk_towards(immrod, end,1)
+		immrod.s_walk_towards(end, 1)
 	sleep(1)
 	while (immrod)
 		if (isNotStationLevel(immrod.z))

--- a/code/game/gamemodes/events/dust.dm
+++ b/code/game/gamemodes/events/dust.dm
@@ -87,7 +87,7 @@ The "dust" will damage the hull of the station causin minor hull breaches.
 		src.y = starty
 		src.z = z_level
 		spawn(0)
-			walk_towards(src, goal, 1)
+			s_walk_towards(goal, 1)
 		return
 
 	touch_map_edge()
@@ -109,7 +109,6 @@ The "dust" will damage the hull of the station causin minor hull breaches.
 
 				life--
 				if(life <= 0)
-					walk(src,0)
 					qdel(src)
 					return 0
 		return

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -77,7 +77,7 @@
 
 	M.dest = pickedgoal
 	spawn(1)
-		walk_towards(M, M.dest, 2)
+		M.s_walk_towards(M.dest, 2)
 
 	return
 
@@ -108,10 +108,6 @@
 	detonation_chance = 30
 	shieldsoundrange = 160
 	dropamt = 1
-
-/obj/effect/meteor/Destroy()
-	walk(src,0) //this cancels the walk_towards() proc
-	return ..()
 
 /obj/effect/meteor/Bump(atom/A)
 	if (!done)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -153,7 +153,6 @@ datum/track/New(var/title_name, var/audio)
 	interact(user)
 
 /obj/machinery/media/jukebox/proc/explode()
-	walk_to(src,0)
 	src.visible_message("<span class='danger'>\the [src] blows apart!</span>", 1)
 
 	explosion(src.loc, 0, 0, 1, rand(1,2), 1)

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -27,11 +27,7 @@
 	//float over to our destination, if we have one
 	destination = dest_turf
 	if(destination)
-		walk_to(src, destination)
-
-/obj/effect/effect/smoke/chem/Destroy()
-	walk(src, 0)
-	return ..()
+		s_walk_to(destination)
 
 /obj/effect/effect/smoke/chem/Move()
 	var/list/oldlocs = view(1, src)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -210,7 +210,7 @@
 		var/list/nearby = oview(5, src)
 		if(nearby.len)
 			var/target_atom = pick(nearby)
-			walk_to(src, target_atom, 5)
+			s_walk_to(target_atom, 5)
 			if(prob(25))
 				src.visible_message(span("notice", "\the [src] skitters[pick(" away"," around","")]."))
 	else if(prob(5))
@@ -218,7 +218,7 @@
 		for(var/obj/machinery/atmospherics/unary/vent_pump/v in view(7,src))
 			if(!v.welded)
 				entry_vent = v
-				walk_to(src, entry_vent, 5)
+				s_walk_to(entry_vent, 5)
 				break
 
 	if(isturf(loc) && amount_grown >= 100)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -158,7 +158,7 @@
 	banglet = 1
 	var/stepdist = rand(1,4)//How far to step
 	var/temploc = src.loc//Saves the current location to know where to step away from
-	walk_away(src,temploc,stepdist)//I must go, my people need me
+	s_walk_away(temploc, stepdist)//I must go, my people need me
 	var/dettime = rand(15,60)
 	addtimer(CALLBACK(src, .proc/prime), dettime)
 	..()
@@ -183,7 +183,7 @@
 	banglet = 1
 	var/stepdist = rand(1,3)
 	var/temploc = src.loc
-	walk_away(src,temploc,stepdist)
+	s_walk_away(temploc, stepdist)
 	var/dettime = rand(15,60)
 	addtimer(CALLBACK(src, .proc/prime), dettime)
 	..()

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -23,25 +23,6 @@
 		return 0
 	return 1
 
-
-/*/obj/item/weapon/grenade/afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
-	if (istype(target, /obj/item/weapon/storage)) return ..() // Trying to put it in a full container
-	if (istype(target, /obj/item/weapon/gun/grenadelauncher)) return ..()
-	if((user.get_active_hand() == src) && (!active) && (clown_check(user)) && target.loc != src.loc)
-		user << "<span class='warning'>You prime the [name]! [det_time/10] seconds!</span>"
-		active = 1
-		icon_state = initial(icon_state) + "_active"
-		playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
-		spawn(det_time)
-			prime()
-			return
-		user.set_dir(get_dir(user, target))
-		user.drop_item()
-		var/t = (isturf(target) ? target : target.loc)
-		walk_towards(src, t, 3)
-	return*/
-
-
 /obj/item/weapon/grenade/examine(mob/user)
 	if(..(user, 0))
 		if(det_time > 1)
@@ -108,6 +89,5 @@
 	return
 
 /obj/item/weapon/grenade/attack_hand()
-	walk(src, null, null)
+	s_walk_stop()
 	..()
-	return

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -269,7 +269,6 @@ proc/check_panel(mob/M)
 		if (my_target)
 			my_target.hallucinations -= src
 
-		walk(src, 0)
 		qdel(src)
 
 	proc/updateimage()

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -53,6 +53,8 @@
 	if(stat == DEAD)
 		return 0
 
+	s_walk_stop()
+
 	facing_dir = null
 
 	if(!gibbed && deathmessage != "no message") // This is gross, but reliable. Only brains use it.

--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -350,7 +350,6 @@
 	return 1
 
 /mob/living/carbon/alien/diona/Destroy()
-	walk_to(src,0)
 	cleanupTransfer()
 	. = ..()
 

--- a/code/modules/mob/living/carbon/alien/diona/life.dm
+++ b/code/modules/mob/living/carbon/alien/diona/life.dm
@@ -35,9 +35,9 @@
 
 	if (!gestalt)
 		if(master_nymph && !client && master_nymph != src)
-			walk_to(src,master_nymph,1,movement_delay())
+			s_walk_to(master_nymph, 1, movement_delay())
 		else
-			walk_to(src,0)
+			s_walk_stop()
 		..()
 
 

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -52,7 +52,7 @@
 
 		if(!buckled)
 			if (turns_since_move > 5 || (flee_target || mousetarget))
-				walk_to(src,0)
+				s_walk_stop()
 				turns_since_move = 0
 
 				if (flee_target) //fleeing takes precendence
@@ -61,7 +61,7 @@
 					handle_movement_target()
 
 		if (!movement_target)
-			walk_to(src,0)
+			s_walk_stop()
 
 		addtimer(CALLBACK(src, .proc/attack_mice), 2)
 
@@ -89,7 +89,7 @@
 
 	if(movement_target)
 		stop_automated_movement = 1
-		walk_to(src,movement_target,0,seek_move_delay)
+		s_walk_to(movement_target, 0, seek_move_delay)
 
 /mob/living/simple_animal/cat/proc/attack_mice()
 	if((src.loc) && isturf(src.loc))
@@ -126,7 +126,7 @@
 	if (flee_target)
 		if(prob(25)) say("HSSSSS")
 		stop_automated_movement = 1
-		walk_away(src, flee_target, 7, 2)
+		s_walk_away(flee_target, 7, 2)
 
 /mob/living/simple_animal/cat/proc/set_flee_target(atom/A)
 	if(A)
@@ -177,17 +177,17 @@
 		if (movement_target != friend)
 			if (current_dist > follow_dist && !istype(movement_target, /mob/living/simple_animal/mouse) && (friend in oview(src)))
 				//stop existing movement
-				walk_to(src,0)
+				s_walk_stop()
 				turns_since_scan = 0
 
 				//walk to friend
 				stop_automated_movement = 1
 				movement_target = friend
-				walk_to(src, movement_target, near_dist, seek_move_delay)
+				s_walk_to(movement_target, near_dist, seek_move_delay)
 
 		//already following and close enough, stop
 		else if (current_dist <= near_dist)
-			walk_to(src,0)
+			s_walk_stop()
 			movement_target = null
 			stop_automated_movement = 0
 			if (prob(10))

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -60,7 +60,7 @@
 	if(..())
 
 		if(client)
-			walk_to(src,0)
+			s_walk_stop()
 
 			//Player-animals don't do random speech normally, so this is here
 			//Player-controlled mice will still squeak, but less often than NPC mice
@@ -182,7 +182,7 @@
 	if (stat == CONSCIOUS)
 		if (squeakcooldown > world.time) return
 		squeakcooldown = world.time + 4 SECONDS
-	
+
 		if (squeals > 0 || !manual)
 			playsound(src, 'sound/effects/creatures/mouse_squeak_loud.ogg', 50, 1)
 			squeals --

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -262,7 +262,7 @@
 	set_stance(HOSTILE_STANCE_TIRED)
 	speak_audio()
 	stance_step = 0
-	walk(src, 0) //This stops the bear's walking
+	s_walk_stop() //This stops the bear's walking
 
 /mob/living/simple_animal/hostile/bear/spatial/tire_out()
 	..()
@@ -335,7 +335,7 @@
 		if (stance > HOSTILE_STANCE_ALERT)//If we're currently above alert
 			set_stance(HOSTILE_STANCE_ALERT)//Drop to alert and cease attacking
 		target_mob = null
-		walk(src, 0)
+		s_walk_stop()
 
 /mob/living/simple_animal/hostile/bear/AttackingTarget()
 	var/targetname = target_mob.name

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -77,7 +77,7 @@
 	if(!target_mob)
 		return
 	if(target_mob in ListTargets(10))
-		walk_to(src,target_mob,1,move_to_delay)
+		s_walk_to(target_mob, 1, move_to_delay)
 
 /mob/living/simple_animal/hostile/commanded/proc/commanded_stop() //basically a proc that runs whenever we are asked to stay put. Probably going to remain unused.
 	return
@@ -127,7 +127,7 @@
 
 /mob/living/simple_animal/hostile/commanded/proc/attack_command(var/mob/speaker,var/text)
 	target_mob = null //want me to attack something? Well I better forget my old target.
-	walk_to(src,0)
+	s_walk_stop()
 	stance = HOSTILE_STANCE_IDLE
 	if(text == "attack" || findtext(text,"everyone") || findtext(text,"anybody") || findtext(text, "somebody") || findtext(text, "someone")) //if its just 'attack' then just attack anybody, same for if they say 'everyone', somebody, anybody. Assuming non-pickiness.
 		allowed_targets = list("everyone")//everyone? EVERYONE
@@ -143,14 +143,14 @@
 	target_mob = null
 	stance = COMMANDED_STOP
 	stop_automated_movement = 1
-	walk_to(src,0)
+	s_walk_stop()
 	if(emote_hear && emote_hear.len)
 		audible_emote("[pick(emote_hear)].",0)
 	return 1
 
 /mob/living/simple_animal/hostile/commanded/proc/stop_command(var/mob/speaker,var/text)
 	allowed_targets = list()
-	walk_to(src,0)
+	s_walk_stop()
 	target_mob = null //gotta stop SOMETHIN
 	stance = HOSTILE_STANCE_IDLE
 	stop_automated_movement = 0

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -99,12 +99,12 @@
 				for(var/turf/T in orange(20, src))
 					move_targets.Add(T)*/
 				stop_automated_movement = 1
-				walk_to(src, pick(orange(20, src)), 1, move_to_delay)
+				s_walk_to(pick(orange(20, src)), 1, move_to_delay)
 				addtimer(CALLBACK(src, .proc/stop_walking), 50, TIMER_UNIQUE)
 
 /mob/living/simple_animal/hostile/giant_spider/proc/stop_walking()
 	stop_automated_movement = 0
-	walk(src, 0)
+	s_walk_stop()
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/Life()
 	..()
@@ -118,7 +118,7 @@
 					if(C.stat)
 						cocoon_target = C
 						busy = MOVING_TO_TARGET
-						walk_to(src, C, 1, move_to_delay)
+						s_walk_to(C, 1, move_to_delay)
 						//give up if we can't reach them after 10 seconds
 						addtimer(CALLBACK(src, .proc/GiveUp, C), 100, TIMER_UNIQUE)
 						return
@@ -149,7 +149,7 @@
 								cocoon_target = O
 								busy = MOVING_TO_TARGET
 								stop_automated_movement = 1
-								walk_to(src, O, 1, move_to_delay)
+								s_walk_to(O, 1, move_to_delay)
 								//give up if we can't reach them after 10 seconds
 								GiveUp(O)
 
@@ -158,7 +158,7 @@
 					busy = SPINNING_COCOON
 					src.visible_message("<span class='notice'>\The [src] begins to secrete a sticky substance around \the [cocoon_target].</span>")
 					stop_automated_movement = 1
-					walk(src,0)
+					s_walk_stop()
 					addtimer(CALLBACK(src, .proc/finalize_cocoon), 50, TIMER_UNIQUE)
 
 		else

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -89,10 +89,10 @@
 			if(get_dist(src, target_mob) <= 6)
 				OpenFire(target_mob)
 			else
-				walk_to(src, target_mob, 1, move_to_delay)
+				s_walk_to(target_mob, 1, move_to_delay)
 		else
 			stance = HOSTILE_STANCE_ATTACKING
-			walk_to(src, target_mob, 1, move_to_delay)
+			s_walk_to(target_mob, 1, move_to_delay)
 
 /mob/living/simple_animal/hostile/proc/AttackTarget()
 
@@ -129,7 +129,7 @@
 /mob/living/simple_animal/hostile/proc/LoseTarget()
 	stance = HOSTILE_STANCE_IDLE
 	target_mob = null
-	walk(src, 0)
+	s_walk_stop()
 	LostTarget()
 
 /mob/living/simple_animal/hostile/proc/LostTarget()
@@ -147,13 +147,12 @@
 
 /mob/living/simple_animal/hostile/death()
 	..()
-	walk(src, 0)
 
 /mob/living/simple_animal/hostile/Life()
 
 	. = ..()
 	if(!.)
-		walk(src, 0)
+		s_walk_stop()
 		return 0
 	if(client)
 		return 0

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -125,7 +125,7 @@
 			else
 				src.visible_message(span("notice", "\The [src] suddenly lies still and quiet."))
 			disabled = rand(150, 600)
-			walk(src,0)
+			s_walk_stop()
 
 	if(exploding && prob(20))
 		if(prob(50))
@@ -139,7 +139,7 @@
 		exploding = 1
 		stat = UNCONSCIOUS
 		wander = 1
-		walk(src,0)
+		s_walk_stop()
 		spawn(rand(50,150))
 			if(!disabled && exploding)
 				explosion(get_turf(src), 0, 1, 4, 7)
@@ -151,7 +151,7 @@
 	health -= rand(3,15) * (severity + 1)
 	disabled = rand(150, 600)
 	hostile_drone = 0
-	walk(src,0)
+	s_walk_stop()
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/death()
 	..(null,"suddenly breaks apart.")

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -110,7 +110,6 @@
 	if(held_item)
 		held_item.loc = src.loc
 		held_item = null
-	walk(src,0)
 	..()
 
 /mob/living/simple_animal/parrot/Stat()
@@ -352,7 +351,7 @@
 //-----WANDERING - This is basically a 'I dont know what to do yet' state
 	else if(parrot_state == PARROT_WANDER)
 		//Stop movement, we'll set it later
-		walk(src, 0)
+		s_walk_stop()
 		parrot_interest = null
 
 		//Wander around aimlessly. This will help keep the loops from searches down
@@ -390,7 +389,7 @@
 				return
 //-----STEALING
 	else if(parrot_state == (PARROT_SWOOP | PARROT_STEAL))
-		walk(src,0)
+		s_walk_stop()
 		if(!parrot_interest || held_item)
 			parrot_state = PARROT_SWOOP | PARROT_RETURN
 			return
@@ -414,12 +413,12 @@
 			parrot_state = PARROT_SWOOP | PARROT_RETURN
 			return
 
-		walk_to(src, parrot_interest, 1, parrot_speed)
+		s_walk_to(parrot_interest, 1, parrot_speed)
 		return
 
 //-----RETURNING TO PERCH
 	else if(parrot_state == (PARROT_SWOOP | PARROT_RETURN))
-		walk(src, 0)
+		s_walk_stop()
 		if(!parrot_perch || !isturf(parrot_perch.loc)) //Make sure the perch exists and somehow isnt inside of something else.
 			parrot_perch = null
 			parrot_state = PARROT_WANDER
@@ -432,16 +431,16 @@
 			icon_state = "parrot_sit"
 			return
 
-		walk_to(src, parrot_perch, 1, parrot_speed)
+		s_walk_to(parrot_perch, 1, parrot_speed)
 		return
 
 //-----FLEEING
 	else if(parrot_state == (PARROT_SWOOP | PARROT_FLEE))
-		walk(src,0)
+		s_walk_stop()
 		if(!parrot_interest || !isliving(parrot_interest)) //Sanity
 			parrot_state = PARROT_WANDER
 
-		walk_away(src, parrot_interest, 1, parrot_speed-parrot_been_shot)
+		s_walk_away(parrot_interest, 1, parrot_speed-parrot_been_shot)
 		parrot_been_shot--
 		return
 
@@ -489,11 +488,11 @@
 
 		//Otherwise, fly towards the mob!
 		else
-			walk_to(src, parrot_interest, 1, parrot_speed)
+			s_walk_to(parrot_interest, 1, parrot_speed)
 		return
 //-----STATE MISHAP
 	else //This should not happen. If it does lets reset everything and try again
-		walk(src,0)
+		s_walk_stop()
 		parrot_interest = null
 		parrot_perch = null
 		drop_held_item()
@@ -760,9 +759,9 @@
 
 /mob/living/simple_animal/parrot/can_fall()
 	return FALSE
-	
+
 /mob/living/simple_animal/parrot/can_ztravel()
 	return TRUE
-	
+
 /mob/living/simple_animal/parrot/CanAvoidGravity()
 	return TRUE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -470,7 +470,6 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 		death()
 
 /mob/living/simple_animal/death(gibbed, deathmessage = "dies!")
-	walk_to(src,0)
 	movement_target = null
 	icon_state = icon_dead
 	density = 0
@@ -559,7 +558,7 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 				foodtarget = 0
 				stop_automated_movement = 0
 			if( !movement_target || !(movement_target.loc in oview(src, 7)) )
-				walk_to(src,0)
+				s_walk_stop()
 				movement_target = null
 				foodtarget = 0
 				stop_automated_movement = 0
@@ -590,9 +589,9 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 				stop_automated_movement = 1
 
 				if (istype(movement_target.loc, /turf))
-					walk_to(src,movement_target,0, seek_move_delay)//Stand ontop of food
+					s_walk_to(movement_target, 0, seek_move_delay) //Stand ontop of food
 				else
-					walk_to(src,movement_target.loc,1, seek_move_delay)//Don't stand ontop of people
+					s_walk_to(movement_target.loc, 1, seek_move_delay) //Don't stand ontop of people
 
 
 
@@ -656,7 +655,7 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 		stat = UNCONSCIOUS
 		canmove = 0
 		wander = 0
-		walk_to(src,0)
+		s_walk_stop()
 		movement_target = null
 		foodtarget = 0
 		update_icons()


### PR DESCRIPTION
Because walk is an ass that keeps hidden references to the subject and actor, thus preventing soft GC, it's easier to wrap them.

New procs added, to be used as drop-in replacements for `walk` and Co.:
* `atom/movable/proc/s_walk_stop()` - Stops all walking and cleans up local refs. Called in `atom/movable/Destroy` and `mob/living/death`. Replaces all iterations of `walk(src, null)`.
* `atom/movable/proc/s_walk_dir(dir, lag = 0, speed = 0)` - Replacement for `walk(src, dir, lag, speed)`.
* `atom/movable/proc/s_walk_rand(lag = 0, speed = 0)` - Repalcement for `walk_rand(src, lag, speed)`.
* `atom/movable/proc/s_walk_away(atom/tgt, max = 5, lag = 0, speed = 0)` - Replacement for `walk_away(src, tgt, max, lag, speed)`.
* `atom/movable/proc/s_walk_to(atom/tgt, min = 0, lag = 0, speed = 0)` - Replacement for `walk_to(src, tgt, min, lag, speed)`.
* `atom/movable/proc/s_walk_towards(atom/tgt, lag = 0, speed = 0)` - Replacement for `walk_towards(src, tgt, lag, speed)`.

Cleanup of the walk happens both in `atom/movable/Destroy` and `atom/Destroy`, as the subject _can_ be an `atom`. Turfs, for example.

REGEX used to find all the walk calls: `walk(_(to|away|towards|rands))?(`