### PR TITLE
CCIAA can see round type

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -377,7 +377,8 @@ var/list/admin_verbs_cciaa = list(
 	/client/proc/view_duty_log,
 	/datum/admins/proc/create_admin_fax,
 	/client/proc/check_fax_history,
-	/client/proc/aooc
+	/client/proc/aooc,
+	/client/proc/check_antagonists
 )
 
 /client/proc/add_admin_verbs()
@@ -1123,7 +1124,7 @@ var/list/admin_verbs_cciaa = list(
 
 	SSsunlight.apply_sun_state(S)
 	log_and_message_admins("has set the sun state to '[S]'.")
-#else 
+#else
 /client/proc/apply_sunstate()
 	set hidden = TRUE
 

--- a/html/changelogs/skull132-buff_cciaa.yml
+++ b/html/changelogs/skull132-buff_cciaa.yml
@@ -1,0 +1,6 @@
+author: Skull132
+
+delete-after: True
+
+changes:
+  - bugfix: "CCIAA can now see the round type."


### PR DESCRIPTION
Authorized by head admins.

I looked, the Topic() links from check-antagonists are flag checked properly, so this should be fine.

~~Need to clarify one thing first, so DNM until then.~~ Cleared.