### PR TITLE
Adjusting SSD Timers

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -239,7 +239,7 @@
 			msg += "<span class='deadsay'>[T.He] [T.is] [species.show_ssd].</span>\n"
 		if(client && ((client.inactivity / 600) > 10)) // inactivity/10/60 > 10 MINUTES
 			msg += "<span class='deadsay'>\[Inactive for [round(client.inactivity / 600)] minutes.\]\n</span>"
-		else if((client && (world.realtime - disconnect_time) >= 5 MINUTES))
+		else if((!client && (world.realtime - disconnect_time) >= 5 MINUTES))
 			msg += "<span class='deadsay'>\[Disconnected/ghosted [(world.realtime - disconnect_time)/600] minutes ago.\]\n</span>"
 
 	var/list/wound_flavor_text = list()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -239,7 +239,7 @@
 			msg += "<span class='deadsay'>[T.He] [T.is] [species.show_ssd].</span>\n"
 		if(client && ((client.inactivity / 600) > 10)) // inactivity/10/60 > 10 MINUTES
 			msg += "<span class='deadsay'>\[Inactive for [round(client.inactivity / 600)] minutes.\]\n</span>"
-		else if((world.realtime - disconnect_time) >= 5 MINUTES)
+		else if((client && (world.realtime - disconnect_time) >= 5 MINUTES))
 			msg += "<span class='deadsay'>\[Disconnected/ghosted [(world.realtime - disconnect_time)/600] minutes ago.\]\n</span>"
 
 	var/list/wound_flavor_text = list()


### PR DESCRIPTION
Fixes a slight oversight in SSD timers where a check was not made for seeing if a client was actually in an allegedly disconnected mob. Only became apparent after adminbus and shenaniganry which bypadded Login() and Logout().
