### PR TITLE
Added pressure meters in maintenance tunnels

### DIFF
--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -8013,7 +8013,7 @@
 	dir = 4;
 	icon_state = "left";
 	name = "Atmospheric Hardsuits";
-	req_access = list(24);
+	req_access = list(24)
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -8726,7 +8726,7 @@
 	dir = 4;
 	icon_state = "left";
 	name = "Atmospheric Hardsuits";
-	req_access = list(24);
+	req_access = list(24)
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -11728,7 +11728,7 @@
 	dir = 2;
 	icon_state = "leftsecure";
 	name = "Secure Holding Cell";
-	req_access = list(2);
+	req_access = list(2)
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -12292,7 +12292,7 @@
 /obj/machinery/camera/network/engine{
 	c_tag = "Engineering - Engine Starboard";
 	dir = 8;
-	icon_state = "camera";
+	icon_state = "camera"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -22923,9 +22923,6 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -23829,8 +23826,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "aPo" = (
@@ -41699,7 +41695,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/bed/chair/comfy/teal{
 	dir = 8;
-	icon_state = "comfychair_preview";
+	icon_state = "comfychair_preview"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
@@ -48699,7 +48695,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
@@ -58919,10 +58915,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -59081,6 +59078,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "bYH" = (
@@ -59093,6 +59091,7 @@
 	dir = 1;
 	sort_tag = "Sorting Office"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "bYI" = (
@@ -59407,16 +59406,12 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j1"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "bZy" = (
@@ -59425,16 +59420,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/up{
 	icon_state = "pipe-u";
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating{
 	roof_type = null
 	},
@@ -59445,12 +59435,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "bZA" = (
@@ -59701,14 +59686,14 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
@@ -59761,10 +59746,6 @@
 /area/maintenance/disposal)
 "bZX" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
-	},
 /turf/simulated/floor/tiled,
 /area/maintenance/disposal)
 "bZY" = (
@@ -61844,6 +61825,188 @@
 "cdI" = (
 /turf/simulated/floor/asteroid/rocky,
 /area/skipjack_station/cavern)
+"cdJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"cdK" = (
+/obj/random/junk,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"cdL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/machinery/meter{
+	name = "Scrubbers"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"cdM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/meter{
+	name = "Air supply"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"cdN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"cdO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"cdP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"cdQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"cdR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"cdS" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"cdT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/machinery/meter{
+	name = "Scrubbers"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"cdU" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/meter{
+	name = "Air supply"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"cdV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"cdW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"cdX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"cdY" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"cdZ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"cea" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/machinery/meter{
+	name = "Scrubbers"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"ceb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/meter{
+	name = "Air supply"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"cec" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 
 (1,1,1) = {"
 aaa
@@ -76610,11 +76773,11 @@ aDc
 aIq
 aKn
 aLX
-aNI
-aPm
-aKp
-aKp
-aKp
+cdJ
+cdK
+cdL
+cdN
+cdO
 aVc
 aWE
 aKp
@@ -76869,9 +77032,9 @@ aKo
 aKo
 aNL
 aPn
+cdM
 aPn
-aPn
-aPn
+cdP
 aVd
 aWF
 aXO
@@ -89279,9 +89442,9 @@ bXE
 bWs
 bYp
 bYG
-bNh
+cea
 bZy
-bNh
+cec
 bJL
 bJL
 bJL
@@ -89534,9 +89697,9 @@ bWK
 bXl
 bXF
 bWs
-bNj
+cdZ
 bYH
-bOf
+ceb
 bZz
 bZT
 bJL
@@ -90310,7 +90473,7 @@ bYI
 bZd
 bZA
 bZV
-cak
+bZc
 aaa
 aaa
 aaa
@@ -90567,7 +90730,7 @@ bYJ
 bZe
 bZB
 bZW
-bYI
+bZc
 aaa
 aaa
 aaa
@@ -90824,7 +90987,7 @@ bYI
 bZf
 bZC
 bZX
-bYI
+bZc
 aaa
 aaa
 aab
@@ -91080,7 +91243,7 @@ bNf
 bYI
 bZg
 bZD
-bZY
+bZX
 bYI
 aaa
 aaa
@@ -106714,12 +106877,12 @@ bzD
 bzD
 bDi
 anS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aZf
+aZf
+aZf
+aZf
+aZf
+aZf
 aZf
 aZf
 aZf
@@ -106971,12 +107134,12 @@ bBz
 bCm
 bzD
 aZf
-aZf
-aZf
-aZf
-aZf
-aZf
-aZf
+cdQ
+cdR
+cdT
+cdV
+cdX
+aRX
 aZf
 bKB
 aRX
@@ -107229,10 +107392,10 @@ bCn
 bzD
 aZf
 bEP
-bzE
-bzE
-bzE
-bzE
+cdS
+cdU
+cdW
+cdY
 bzE
 bJZ
 bzE

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -1,5 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-//Model dictionary trimmed on: 18-11-2017 20:57 (UTC)
 "aa" = (
 /turf/unsimulated/chasm_mask,
 /area/mine/explored)
@@ -3372,7 +3371,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
-	icon_state = "map";
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
@@ -3472,7 +3471,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
-	icon_state = "map";
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -7138,8 +7137,12 @@
 /turf/simulated/floor/tiled,
 /area/tcommsat/entrance)
 "mG" = (
-/obj/machinery/light/small/emergency{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/meter{
+	name = "Scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/tcommsat/entrance)
@@ -7153,7 +7156,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/tcommsat/entrance)
 "mJ" = (
@@ -7268,10 +7274,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /turf/simulated/floor/plating,
@@ -17492,10 +17494,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/random/junk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/arrivals)
 "Ge" = (
@@ -17752,10 +17755,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/arrivals)
@@ -17767,6 +17773,10 @@
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/arrivals)
@@ -18349,7 +18359,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
-	icon_state = "map";
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
@@ -18940,6 +18950,150 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
+"IQ" = (
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
+"IR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
+"IS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
+"IT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
+"IU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
+"IV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
+"IW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/blue{
+	dir = 4
+	},
+/obj/machinery/meter{
+	name = "Air supply"
+	},
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
+"IX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tcommsat/entrance)
+"IY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"IZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"Ja" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"Jb" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/machinery/meter{
+	name = "Scrubbers"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"Jc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/meter{
+	name = "Air supply"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"Jd" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"Je" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
 
 (1,1,1) = {"
 aa
@@ -31648,9 +31802,9 @@ bv
 bg
 bg
 bg
-bc
 mi
-mR
+mi
+mQ
 mi
 ag
 ag
@@ -31905,9 +32059,9 @@ bv
 bv
 bg
 bg
-bc
-mi
-mR
+mH
+IR
+IU
 mi
 ag
 ag
@@ -32162,9 +32316,9 @@ bv
 bv
 bg
 bg
-mi
-mi
-mQ
+IQ
+IS
+IV
 mi
 ag
 ag
@@ -32421,7 +32575,7 @@ bg
 bg
 mu
 mG
-mR
+IW
 mi
 ag
 ag
@@ -32677,8 +32831,8 @@ bv
 bg
 bg
 mu
-mH
-mR
+IT
+IX
 mi
 ag
 ag
@@ -46879,10 +47033,10 @@ Fo
 Fz
 FL
 Em
-Gc
-FM
-FM
-FM
+IY
+IZ
+Jb
+Jd
 Gz
 GH
 FM
@@ -47137,9 +47291,9 @@ Em
 Em
 Em
 Gd
-sl
-sl
-sl
+Ja
+Jc
+Je
 GA
 GI
 GI


### PR DESCRIPTION
Added pressure meters to help engineers locate pipe breaks that prevent area vents from proper operation. Some areas were enlarged to make space for meters.

[Meters near cargo ladders to surface level](https://user-images.githubusercontent.com/11229891/34079345-c5a958be-e334-11e7-90df-2bf5d307208e.png)
[Meters near engine, behind CE office](https://user-images.githubusercontent.com/11229891/34079346-c5c37f32-e334-11e7-892d-18d6ae2c8b05.png)
[Meters leading to command surface section](https://user-images.githubusercontent.com/11229891/34079347-c5dc898c-e334-11e7-9737-56430e096f9e.png)
[Meters at surface level, near cargo](https://user-images.githubusercontent.com/11229891/34079348-c5f7bebe-e334-11e7-9436-5db578f16d52.png)
[Meters at tcoms](https://user-images.githubusercontent.com/11229891/34079349-c61274c0-e334-11e7-9881-1a319f20cc44.png)
