### PR TITLE
Removes Engine Room Access from the Apprentice

### DIFF
--- a/code/modules/intern/intern.dm
+++ b/code/modules/intern/intern.dm
@@ -81,7 +81,7 @@
 	supervisors = "the Chief Engineer"
 	selection_color = "#fff5cc"
 	access = list(access_maint_tunnels, access_construction, access_engine_equip, access_engine)
-	minimal_access = list(access_maint_tunnels, access_construction, access_engine_equip, access_engine)
+	minimal_access = list(access_maint_tunnels, access_construction, access_engine)
 
 	bag_type = /obj/item/weapon/storage/backpack/industrial
 	satchel_type = /obj/item/weapon/storage/backpack/satchel_eng


### PR DESCRIPTION
Removes the engine room access from the engineering apprentice.

It regularly happens that they walk into the engine room and attempt to setup the engine with little to no knowledge of how to do so.
And you cant really blame them for doing so, because they have access to it.

According to the access_datums.dm access_engine_equip is supposed to be the engine room:

> /var/const/access_engine_equip = 11
> /datum/access/engine_equip
>	id = access_engine_equip
>	desc = "Engine Room"
>	region = ACCESS_REGION_ENGINEERING

But a quick search revealed that this covers much more than just the engine room.

Therefore DNM until I figured out if the engine apprentice can work with the reduced access or if a engineering access overhaul is needed.