### PR TITLE
Removes the movecooldown when clicking turfs near you

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -126,7 +126,6 @@
 	sdepth = A.storage_depth_turf()
 	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
 		if(A.Adjacent(src) || (W && W.attack_can_reach(src, A, W.reach)) ) // see adjacent.dm
-			setMoveCooldown(5)
 
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)


### PR DESCRIPTION
This is really annoying, and this change should make clicking and running around more fluid.
