### PR TITLE
Lowers the Heist gamemode readied-player requirement from 15 to 12, lowers minimum antags to 3

### DIFF
--- a/heist.dm
+++ b/heist.dm
@@ -1,0 +1,22 @@
+/*
+VOX HEIST ROUNDTYPE
+*/
+
+
+/datum/game_mode/heist
+	name = "heist"
+	config_tag = "heist"
+	required_players = 12
+	required_enemies = 3
+	round_description = "An unidentified bluespace signature has slipped past the Icarus and is approaching the station!"
+	extended_round_description = "The galaxy is a place full of dangers, even the inner colonies are not free of such scourges. \
+	Raiders and pirates are a well-know threat in the inhabited space, and places such as space stations are easy targets \
+	for their greedy plans."
+	end_on_antag_death = 1
+	antag_tags = list(MODE_RAIDER)
+
+/datum/game_mode/heist/check_finished()
+	var/datum/shuttle/multi_shuttle/skipjack = shuttle_controller.shuttles["Skipjack"]
+	if (skipjack && skipjack.returned_home)
+		return 1
+	return ..()


### PR DESCRIPTION
Followup to this - https://forums.aurorastation.org/viewtopic.php?p=89854#p89854

Basically as the title says. Heist can now be rolled if there are 12 players ready instead of 15, and the minimum raiders are 3 instead of 4, so it should even out as 9 crew vs 3 raiders, which seems fair.