### PR TITLE
Deletable mirrors and indexing for faster searching

### DIFF
--- a/SQL/migrate/V012__Deleteable_mirrors.sql
+++ b/SQL/migrate/V012__Deleteable_mirrors.sql
@@ -1,5 +1,5 @@
 --
--- Implemented in PR #.
+-- Implemented in PR #4026.
 -- Adds a deleted_at column for mirrors.
 -- Also adds indexes for speeding up search queries around the ban database.
 --

--- a/SQL/migrate/V012__Deleteable_mirrors.sql
+++ b/SQL/migrate/V012__Deleteable_mirrors.sql
@@ -1,0 +1,29 @@
+--
+-- Implemented in PR #.
+-- Adds a deleted_at column for mirrors.
+-- Also adds indexes for speeding up search queries around the ban database.
+--
+
+ALTER TABLE `ss13_ban_mirrors`
+  ADD `deleted_at` DATETIME NULL DEFAULT NULL AFTER `extra_info`;
+
+CREATE INDEX `idx_mirrors_isbanned` ON `ss13_ban_mirrors` (
+  `deleted_at`,
+  `ckey`,
+  `ip`,
+  `computerid`
+);
+
+CREATE INDEX `idx_mirrors_select` ON `ss13_ban_mirrors` (
+  `deleted_at`,
+  `ban_id`
+);
+
+CREATE INDEX `idx_ban_isbanned` ON `ss13_ban` (
+  `unbanned`,
+  `bantype`,
+  `expiration_time`,
+  `ckey`,
+  `computerid`,
+  `ip`
+);

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -133,7 +133,7 @@
 	else
 		bantype_sql = "bantype = '[bantype_str]'"
 
-	var/sql = "SELECT id FROM ss13_ban WHERE ckey = '[ckey]' AND [bantype_sql] AND (unbanned is null OR unbanned = false)"
+	var/sql = "SELECT id FROM ss13_ban WHERE isnull(unbanned) AND [bantype_sql] AND ckey = '[ckey]'"
 	if(job)
 		sql += " AND job = '[job]'"
 
@@ -437,7 +437,7 @@
 			if (!match)
 				var/DBQuery/mirror_query = dbcon.NewQuery({"SELECT DISTINCT(mirrors.ban_id), bans.ckey FROM ss13_ban_mirrors mirrors
 					JOIN ss13_ban bans ON mirrors.ban_id = bans.id
-					WHERE (1 [mirror_player] [mirror_ip] [mirror_cid])
+					WHERE (isnull(mirrors.deleted_at) AND (1 [mirror_player] [mirror_ip] [mirror_cid]))
 					AND (
 						ISNULL(bans.unbanned) AND (
 							(bans.bantype = 'PERMABAN')

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -44,10 +44,10 @@ world/IsBanned(key,address,computer_id)
 		var/params[] = list()
 		var/query_content = ""
 		if (pulled_ban_id)
-			query_content = "SELECT id, ckey, ip, computerid, a_ckey, reason, expiration_time, duration, bantime, bantype FROM ss13_ban WHERE id = :ban_id: AND (bantype = 'PERMABAN' OR (bantype = 'TEMPBAN' AND expiration_time > Now())) AND isnull(unbanned)"
+			query_content = "SELECT id, ckey, ip, computerid, a_ckey, reason, expiration_time, duration, bantime, bantype FROM ss13_ban WHERE id = :ban_id: AND isnull(unbanned) AND (bantype = 'PERMABAN' OR (bantype = 'TEMPBAN' AND expiration_time > Now()))"
 			params["ban_id"] = pulled_ban_id
 		else
-			query_content = "SELECT id, ckey, ip, computerid, a_ckey, reason, expiration_time, duration, bantime, bantype FROM ss13_ban WHERE (ckey = :ckey: OR computerid = :computerid: OR ip = :address:) AND (bantype = 'PERMABAN' OR (bantype = 'TEMPBAN' AND expiration_time > Now())) AND isnull(unbanned)"
+			query_content = "SELECT id, ckey, ip, computerid, a_ckey, reason, expiration_time, duration, bantime, bantype FROM ss13_ban WHERE isnull(unbanned) AND (bantype = 'PERMABAN' OR (bantype = 'TEMPBAN' AND expiration_time > Now())) AND (ckey = :ckey: OR computerid = :computerid: OR ip = :address:)"
 			params["ckey"] = ckey
 			params["computerid"] = computer_id
 			params["address"] = address

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -97,8 +97,13 @@
 		display_mirrors_panel(usr, text2num(href_list["dbbanmirrors"]))
 		return
 
-	else if(href_list["dbbanmirrorckeys"])
-		display_mirrors_ckeys(usr, text2num(href_list["dbbanmirrorckeys"]))
+	else if(href_list["dbbanmirroract"])
+		// Mirror act contains the ID of the mirror being acted upon.
+		var/mirror_id = text2num(href_list["dbbanmirroract"])
+		if (href_list["mirrorckeys"])
+			display_mirrors_ckeys(usr, mirror_id)
+		else if (href_list["mirrorstatus"])
+			toggle_mirror_status(usr, mirror_id, text2num(href_list["mirrorstatus"]))
 		return
 
 	else if(href_list["editrights"])


### PR DESCRIPTION
Makes individual mirrors deletable as per admin request.
Adds indexes for queries in isbanned() to make them roll faster.