### PR TITLE
Related grabs fixes and tweaks

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -302,6 +302,8 @@ var/list/slot_equipment_priority = list( \
 				usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Has thrown [M.name] ([M.ckey]) from [start_T_descriptor] with the target [end_T_descriptor]</font>")
 				msg_admin_attack("[usr.name] ([usr.ckey]) has thrown [M.name] ([M.ckey]) from [start_T_descriptor] with the target [end_T_descriptor] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>)",ckey=key_name(usr),ckey_target=key_name(M))
 
+			qdel(G)
+
 	if(!item) return //Grab processing has a chance of returning null
 
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -16,8 +16,12 @@
 
 ///Process_Grab()
 ///Called by client/Move()
-///Checks to see if you are grabbing anything and if moving will affect your grab.
+///Checks to see if you are grabbing or being grabbed by anything and if moving will affect your grab.
 /client/proc/Process_Grab()
+	if(isliving(mob)) //if we are being grabbed
+		var/mob/living/L = mob
+		if(!L.canmove && L.grabbed_by.len)
+			L.resist() //shortcut for resisting grabs
 	for(var/obj/item/weapon/grab/G in list(mob.l_hand, mob.r_hand))
 		G.reset_kill_state() //no wandering across the station/asteroid while choking someone
 

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -82,6 +82,8 @@
 			if(occupied)
 				user << "<span class='danger'>There's \a [occupied] in the way.</span>"
 				return
+			if(!user.Adjacent(M))
+				return
 			if (G.state < GRAB_AGGRESSIVE)
 				if(user.a_intent == I_HURT)
 					var/blocked = M.run_armor_check("head", "melee")

--- a/html/changelogs/alberyk-grab.yml
+++ b/html/changelogs/alberyk-grab.yml
@@ -1,0 +1,5 @@
+author: Alberyk
+delete-after: True
+changes: 
+  - tweak: "Trying to move, when possible, will now resist if you are grabbed."
+  - tweak: "Throwing a grab will now always break the grab, do not matter the distance."


### PR DESCRIPTION
-throwing a grab should not properly fix/delete the grab, preventing people from spamming it
-you now must be at the side of your attacker when being tabbled, no more table-stun happening accross the room
-moving away from a grab will now act as resisting, to avoid some odd situations such as neckgrabs teleporting people