### PR TITLE
More granular Atlas logs & Holomap Init Tweaks

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -466,3 +466,5 @@ Define for getting a bitfield of adjacent turfs that meet a condition.
 #define SOUND_Z_FACTOR 100
 // Maximum number of Zs away you can be from a sound before it stops being audible.
 #define MAX_SOUND_Z_TRAVERSAL 2
+
+#define Z_ALL_TURFS(Z) block(locate(1, 1, Z), locate(world.maxx, world.maxy, Z))

--- a/code/_helpers/icon_smoothing.dm
+++ b/code/_helpers/icon_smoothing.dm
@@ -428,8 +428,7 @@
 
 //Icon smoothing helpers
 /proc/smooth_zlevel(var/zlevel, now = FALSE)
-	var/list/away_turfs = block(locate(1, 1, zlevel), locate(world.maxx, world.maxy, zlevel))
-	for(var/V in away_turfs)
+	for(var/V in Z_ALL_TURFS(zlevel))
 		var/turf/T = V
 		if(T.smooth)
 			if(now)

--- a/code/controllers/subsystems/initialization/atlas.dm
+++ b/code/controllers/subsystems/initialization/atlas.dm
@@ -79,12 +79,14 @@ var/datum/controller/subsystem/atlas/SSatlas
 	sortTim(files, /proc/cmp_text_asc)
 	var/mfile
 	var/first_dmm = TRUE
+	var/time
 	for (var/i in 1 to files.len)
 		mfile = files[i]
 		if (!mapregex.Find(mfile))
 			continue
 
 		log_ss("atlas", "Loading '[mfile]'.")
+		time = world.time
 
 		mfile = "[directory][mfile]"
 
@@ -92,10 +94,12 @@ var/datum/controller/subsystem/atlas/SSatlas
 		if (overwrite_default_z && first_dmm)
 			target_z = 1
 			first_dmm = FALSE
-			log_ss("atlas", "Overwriting Z[target_z].")
+			log_ss("atlas", "Overwriting first Z.")
 
 		if (!maploader.load_map(file(mfile), 0, 0, target_z, no_changeturf = TRUE))
 			log_ss("atlas", "Failed to load '[mfile]'!")
+		else
+			log_ss("atlas", "Loaded level in [(world.time - time)/10] seconds.")
 
 		.++
 		CHECK_TICK
@@ -131,6 +135,7 @@ var/datum/controller/subsystem/atlas/SSatlas
 	priority_announcement = new(do_log = 0)
 	command_announcement = new(do_log = 0, do_newscast = 1)
 
+	log_debug("atlas: running [LAZYLEN(mapload_callbacks)] mapload callbacks.")
 	for (var/thing in mapload_callbacks)
 		var/datum/callback/cb = thing
 		cb.InvokeAsync()

--- a/code/controllers/subsystems/initialization/map_finalization.dm
+++ b/code/controllers/subsystems/initialization/map_finalization.dm
@@ -9,10 +9,14 @@
 	// Setup the global antag uplink. This needs to be done after SSatlas as it requires current_map.
 	global.uplink = new
 
+	var/time = world.time
 	current_map.finalize_load()
+	log_ss("map_finalization", "Finalized map in [(world.time - time)/10] seconds.")
 
 	if(config.generate_asteroid)
+		time = world.time
 		current_map.generate_asteroid()
+		log_ss("map_finalization", "Generated asteroid in [(world.time - time)/10] seconds.")
 
 	// Generate the area list.
 	resort_all_areas()

--- a/code/controllers/subsystems/initialization/minimap.dm
+++ b/code/controllers/subsystems/initialization/minimap.dm
@@ -1,21 +1,6 @@
 // Minimap generation system adapted from vorestation, adapted from /vg/.
 // Seems to be much simpler/saner than /vg/'s implementation.
 
-// Turfs that will be colored as HOLOMAP_ROCK
-#define IS_ROCK(tile) (istype(tile, /turf/simulated/mineral) || istype(tile, /turf/simulated/floor/asteroid) || isopenturf(tile))
-
-// Turfs that will be colored as HOLOMAP_OBSTACLE
-#define IS_OBSTACLE(tile) ((!istype(tile, /turf/space) && istype(tile.loc, /area/mine/unexplored)) \
-					|| istype(tile, /turf/simulated/wall) \
-					|| istype(tile, /turf/unsimulated/mineral) \
-					|| (istype(tile, /turf/unsimulated/wall)) \
-					|| (locate(/obj/structure/grille) in tile))
-
-// Turfs that will be colored as HOLOMAP_PATH
-#define IS_PATH(tile) ((istype(tile, /turf/simulated/floor) && !istype(tile, /turf/simulated/floor/asteroid)) \
-					|| istype(tile, /turf/unsimulated/floor) \
-					|| (locate(/obj/structure/lattice/catwalk) in tile))
-
 /var/datum/controller/subsystem/minimap/SSminimap
 
 /datum/controller/subsystem/minimap
@@ -52,26 +37,44 @@
 	// Sanity checks - Better to generate a helpful error message now than have DrawBox() runtime
 	var/icon/canvas = icon(HOLOMAP_ICON, "blank")
 	if(world.maxx + offset_x > canvas.Width())
-		crash_with("Minimap for z=[zlevel] : world.maxx ([world.maxx]) + holomap_offset_x ([offset_x]) must be <= [canvas.Width()]")
+		CRASH("Minimap for z=[zlevel] : world.maxx ([world.maxx]) + holomap_offset_x ([offset_x]) must be <= [canvas.Width()]")
 	if(world.maxy + offset_y > canvas.Height())
-		crash_with("Minimap for z=[zlevel] : world.maxy ([world.maxy]) + holomap_offset_y ([offset_y]) must be <= [canvas.Height()]")
+		CRASH("Minimap for z=[zlevel] : world.maxy ([world.maxy]) + holomap_offset_y ([offset_y]) must be <= [canvas.Height()]")
 
-	for(var/x = 1 to world.maxx)
-		for(var/y = 1 to world.maxy)
-			var/turf/tile = locate(x, y, zlevel)
-			var/area/A
-			if(tile)
-				A = tile.loc
-				if (A.flags & HIDE_FROM_HOLOMAP)
-					continue
-				if(IS_ROCK(tile))
-					continue
-				if(IS_OBSTACLE(tile))
-					canvas.DrawBox(HOLOMAP_OBSTACLE, x + offset_x, y + offset_y)
-				else if(IS_PATH(tile))
-					canvas.DrawBox(HOLOMAP_PATH, x + offset_x, y + offset_y)
+	var/list/rock_tcache = typecacheof(list(
+		/turf/simulated/mineral,
+		/turf/simulated/floor/asteroid,
+		/turf/simulated/open
+	))
+	var/list/obstacle_tcache = typecacheof(list(
+		/turf/simulated/wall,
+		/turf/unsimulated/mineral,
+		/turf/unsimulated/wall
+	))
+	var/list/path_tcache = typecacheof(list(
+		/turf/simulated/floor,
+		/turf/unsimulated/floor
+	)) - typecacheof(/turf/simulated/floor/asteroid)
+
+	var/turf/T
+	var/area/A
+	var/Ttype
+	for (var/thing in Z_ALL_TURFS(zlevel))
+		T = thing
+		A = T.loc
+		Ttype = T.type
+
+		if (A.flags & HIDE_FROM_HOLOMAP)
+			continue
+		if (rock_tcache[Ttype])
+			continue
+		if (obstacle_tcache[Ttype] || (T.contents.len && locate(/obj/structure/grille, T)))
+			canvas.DrawBox(HOLOMAP_OBSTACLE, T.x + offset_x, T.y + offset_y)
+		else if(path_tcache[Ttype] || (T.contents.len && locate(/obj/structure/lattice/catwalk, T)))
+			canvas.DrawBox(HOLOMAP_PATH, T.x + offset_x, T.y + offset_y)
 
 		CHECK_TICK
+
 	return canvas
 
 /datum/controller/subsystem/minimap/proc/generateStationMinimap(zlevel)
@@ -86,13 +89,13 @@
 	if(world.maxy + offset_y > canvas.Height())
 		crash_with("Minimap for z=[zlevel] : world.maxy ([world.maxy]) + holomap_offset_y ([offset_y]) must be <= [canvas.Height()]")
 
-	for(var/x = 1 to world.maxx)
-		for(var/y = 1 to world.maxy)
-			var/turf/tile = locate(x, y, zlevel)
-			if(tile && tile.loc)
-				var/area/areaToPaint = tile.loc
-				if(areaToPaint.holomap_color)
-					canvas.DrawBox(areaToPaint.holomap_color, x + offset_x, y + offset_y)
+	var/turf/T
+	var/area/A
+	for (var/thing in Z_ALL_TURFS(zlevel))
+		T = thing
+		A = T.loc
+		if (A.holomap_color)
+			canvas.DrawBox(A.holomap_color, T.x + offset_x, T.y + offset_y)
 
 	// Save this nice area-colored canvas in case we want to layer it or something I guess
 	extra_minimaps["[HOLOMAP_EXTRA_STATIONMAPAREAS]_[zlevel]"] = canvas

--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -71,7 +71,7 @@ var/datum/controller/subsystem/lighting/SSlighting
 	var/turf/T
 	var/thing
 	for (var/zlevel = 1 to world.maxz)
-		for (thing in block(locate(1, 1, zlevel), locate(world.maxx, world.maxy, zlevel)))
+		for (thing in Z_ALL_TURFS(zlevel))
 			T = thing
 			if (!T.dynamic_lighting)
 				continue

--- a/code/controllers/subsystems/sunlight.dm
+++ b/code/controllers/subsystems/sunlight.dm
@@ -31,7 +31,7 @@
 
 	var/thing
 	var/turf/T
-	for (thing in block(locate(1, 1, config.sun_target_z), locate(world.maxx, world.maxy, config.sun_target_z)))
+	for (thing in Z_ALL_TURFS(config.sun_target_z))
 		T = thing
 		if (!(T.x % config.sun_accuracy) && !(T.y % config.sun_accuracy))
 			light_points += new /atom/movable/sunobj(thing)


### PR DESCRIPTION
changes:
- Atlas now logs init time per DMM.
- Map Finalization now separately logs finalize & asteroid generation time.
- Added `Z_ALL_TURFS()` macro to get a list of all turfs in a Z-level.
- Misc. performance optimizations for SSminimap init.