### PR TITLE
Fixes simple animals taking in consideration the hp of their victims when selecting targets

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -489,7 +489,7 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 /mob/living/simple_animal/proc/SA_attackable(target_mob)
 	if (isliving(target_mob))
 		var/mob/living/L = target_mob
-		if(!L.stat && L.health >= 0)
+		if(!L.stat)
 			return (0)
 	if (istype(target_mob,/obj/mecha))
 		var/obj/mecha/M = target_mob


### PR DESCRIPTION
Now simples animals should not take someone's hp in consideration, only if they are awake or not when attacking. This should fix simple animals stopping attacking when someone has 100 of total damage.
