### PR TITLE
Fix infinite while loop in chemistry

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -175,7 +175,7 @@
 
 			if(reagents.total_volume/count < 1) //Sanity checking.
 				return
-			while (count--)
+			while (count-- && count >= 0)
 				var/obj/item/weapon/reagent_containers/pill/P = new/obj/item/weapon/reagent_containers/pill(src.loc)
 				if(!name) name = reagents.get_master_reagent_name()
 				P.name = "[name] pill"


### PR DESCRIPTION
PR stolen from [here.](https://github.com/Baystation12/Baystation12/pull/20280)

This fixes a terrible bug that can crash dream daemon without any hassle.