### PR TITLE
Brings back cyborg module examining from old code

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -3,6 +3,11 @@
 	..(user, infix = custom_infix)
 
 	var/msg = ""
+
+	msg += "\n"
+	msg += describe_all_modules() // describe modules
+	msg += "\n"
+
 	msg += "<span class='warning'>"
 	if (src.getBruteLoss())
 		if (src.getBruteLoss() < 75)

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -297,7 +297,7 @@
 
 
 /mob/living/silicon/robot/proc/describe_module(var/slot)
-	var/list/index_module=list(module_state_1,module_state_2,module_state_3)
+	var/list/index_module = list(module_state_1,module_state_2,module_state_3)
 	var/result = "   Hardpoint [slot] holds "
 	result += (index_module[slot]) ? "\icon[index_module[slot]] [index_module[slot]]." : "nothing."
 	result += "\n"
@@ -306,8 +306,8 @@
 /mob/living/silicon/robot/proc/describe_all_modules()
 	var/result="It has three tool hardpoints.\n"
 	for (var/x = 1; x <=3; x++)
-		result+=describe_module(x)
-	var/selected=get_selected_module()
+		result += describe_module(x)
+	var/selected = get_selected_module()
 	if (selected)
-		result+="\nThe activity light on hardpoint [selected] is on.\n"
+		result += "\nThe activity light on hardpoint [selected] is on.\n"
 	return result

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -21,6 +21,7 @@
 /mob/living/silicon/robot/proc/uneq_active()
 	if(isnull(module_active))
 		return
+
 	if(module_state_1 == module_active)
 		if(istype(module_state_1,/obj/item/borg/sight))
 			sight_mode &= ~module_state_1:sight_mode
@@ -293,3 +294,20 @@
 	if (I.loc != src)
 		return 1//Allows objects inside grippers
 	return 0//don't allow dropping our modules
+
+
+/mob/living/silicon/robot/proc/describe_module(var/slot)
+	var/list/index_module=list(module_state_1,module_state_2,module_state_3)
+	var/result = "   Hardpoint [slot] holds "
+	result += (index_module[slot]) ? "\icon[index_module[slot]] [index_module[slot]]." : "nothing."
+	result += "\n"
+	return result
+
+/mob/living/silicon/robot/proc/describe_all_modules()
+	var/result="It has three tool hardpoints.\n"
+	for (var/x = 1; x <=3; x++)
+		result+=describe_module(x)
+	var/selected=get_selected_module()
+	if (selected)
+		result+="\nThe activity light on hardpoint [selected] is on.\n"
+	return result

--- a/html/changelogs/albery-borgexamine.yml
+++ b/html/changelogs/albery-borgexamine.yml
@@ -1,0 +1,4 @@
+author: Alberyk
+delete-after: True
+changes: 
+  - rscadd: "Examining a cyborg will now reveal what modules they are holding and each module is active."


### PR DESCRIPTION
You can now examine a cyborg to see what they are holding now:

![memetron](https://user-images.githubusercontent.com/11579997/35202201-62211dc8-ff08-11e7-945b-edd9dfa134b0.png)
