### PR TITLE
Movement smoothing

### DIFF
--- a/html/changelogs/lohikar-smoothmove.yml
+++ b/html/changelogs/lohikar-smoothmove.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - experiment: "Movement should be generally smoother now, with less rubber banding on faster mobs."

--- a/html/changelogs/lohikar-smoothmove.yml
+++ b/html/changelogs/lohikar-smoothmove.yml
@@ -1,4 +1,4 @@
 author: Lohikar
 delete-after: True
 changes: 
-  - experiment: "Movement should be generally smoother now, with less rubber banding on faster mobs."
+  - experiment: "Movement should be generally smoother now with less rubber banding on faster mobs."

--- a/html/changelogs/lohikar-smoothmove.yml
+++ b/html/changelogs/lohikar-smoothmove.yml
@@ -1,4 +1,4 @@
 author: Lohikar
 delete-after: True
 changes: 
-  - experiment: "Movement should be generally smoother now with less rubber banding on faster mobs."
+  - experiment: "Movement should be generally smoother now, with less rubber banding on faster mobs."


### PR DESCRIPTION
Replaces BYOND's crappy default glide speed calcs with manual ones. Results in much smoother movement, especially of faster-moving mobs like Tajara. Slows down movement speed a bit, so config should probably be updated.