### PR TITLE
Fixes #4164 in a really scary way

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -126,6 +126,8 @@
  *  src.product_records.
  */
 /obj/machinery/vending/proc/build_inventory()
+	sanitize_paths() // Wedge for mapped in paths. Because apparently shit happens with them?
+
 	var/list/all_products = list(
 		list(src.products, CAT_NORMAL),
 		list(src.contraband, CAT_HIDDEN),
@@ -143,6 +145,25 @@
 			product.category = category
 
 			src.product_records.Add(product)
+
+/obj/machinery/vending/proc/sanitize_paths()
+	for (var/A in products)
+		if (!ispath(A))
+			var/assoc = products[A]
+			products -= A
+			products[text2path(A)] = assoc
+
+	for (var/A in contraband)
+		if (!ispath(A))
+			var/assoc = contraband[A]
+			contraband -= A
+			contraband[text2path(A)] = assoc
+
+	for (var/A in premium)
+		if (!ispath(A))
+			var/assoc = products[A]
+			products -= A
+			products[text2path(A)] = assoc
 
 /obj/machinery/vending/Destroy()
 	qdel(wires)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -126,8 +126,6 @@
  *  src.product_records.
  */
 /obj/machinery/vending/proc/build_inventory()
-	sanitize_paths() // Wedge for mapped in paths. Because apparently shit happens with them?
-
 	var/list/all_products = list(
 		list(src.products, CAT_NORMAL),
 		list(src.contraband, CAT_HIDDEN),
@@ -145,25 +143,6 @@
 			product.category = category
 
 			src.product_records.Add(product)
-
-/obj/machinery/vending/proc/sanitize_paths()
-	for (var/A in products)
-		if (!ispath(A))
-			var/assoc = products[A]
-			products -= A
-			products[text2path(A)] = assoc
-
-	for (var/A in contraband)
-		if (!ispath(A))
-			var/assoc = contraband[A]
-			contraband -= A
-			contraband[text2path(A)] = assoc
-
-	for (var/A in premium)
-		if (!ispath(A))
-			var/assoc = products[A]
-			products -= A
-			products[text2path(A)] = assoc
 
 /obj/machinery/vending/Destroy()
 	qdel(wires)

--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -376,13 +376,15 @@ var/global/dmm_suite/preloader/_preloader = new
 
 	return next_delimiter
 
-/dmm_suite/proc/readlistitem(text as text)
+/dmm_suite/proc/readlistitem(text as text, is_key = FALSE)
 	//Check for string
 	if(findtext(text,"\"",1,2))
 		. = copytext(text,2,findtext(text,"\"",3,0))
 
 	//Check for number
-	else if(isnum(text2num(text)))
+	// Keys cannot safely be numbers. This implementation will return null if
+	// an assoc key is a number.
+	else if(!is_key && isnum(text2num(text)))
 		. = text2num(text)
 
 	//Check for null
@@ -390,7 +392,7 @@ var/global/dmm_suite/preloader/_preloader = new
 		. = null
 
 	//Check for list
-	else if(copytext(text,1,5) == "list")
+	else if(copytext(text,1,6) == "list(")
 		. = readlist(copytext(text,6,length(text)))
 
 	//Check for file
@@ -400,6 +402,11 @@ var/global/dmm_suite/preloader/_preloader = new
 	//Check for path
 	else if(ispath(text2path(text)))
 		. = text2path(text)
+
+	// Associative keys are fed in without quotation marks.
+	// So if none of the other cases apply, return simply the string that was given.
+	else if(is_key)
+		. = text
 
 //build a list from variables in text form (e.g {var1="derp"; var2; var3=7} => list(var1="derp", var2, var3=7))
 //return the filled list
@@ -420,8 +427,9 @@ var/global/dmm_suite/preloader/_preloader = new
 		var/trim_left = trim_text(copytext(text,old_position,(equal_position ? equal_position : position)),1)//the name of the variable, must trim quotes to build a BYOND compliant associatives list
 		old_position = position + 1
 
-		if(equal_position)//associative var, so do the association
+		if(equal_position) //associative var, so do the association
 			var/trim_right = trim_text(copytext(text,equal_position+1,position))//the content of the variable
+			trim_left = readlistitem(trim_left, TRUE) // Assoc vars can be anything that isn't a num!
 			to_return[trim_left] = readlistitem(trim_right)
 			list_index++
 		else if (length(trim_left))	//simple var


### PR DESCRIPTION
Map loading was to blame.

Basically. All vending machines which had custom instances defined in maps would have the associative list keys (code expects paths) loaded as strings. This traced back to DMMS casting all associate list keys into strings. The fix is to make list keys also run through the type inferring system, same as with values. The inferring system was updated with two special cases:

* Keys cannot be numbers, this will otherwise break things.
* If no valid type is given, instead of returning `null`, the original string is returned.

This will ensure that nothing that's been fine thus far breaks.