### PR TITLE
[WIP] Messages are now displayed when equipping items.

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -370,10 +370,11 @@
 			user.visible_message(\
 				"<span class='notice'>[user] places \the [W] in \the [src].</span>",\
 				"<span class='notice'>You put \the [W] in \the [src].</span>",\
-				"<span class='notice'>You hear shuffling nearby...</span>",\
+				"<span class='notice'>You hear shuffling (DIR).</span>",\
 				"<span class='notice'>You see [user] put something in \the [src].</span>",\
 				max(1,W.w_class*0.5),\
-				max(2,W.w_class)\
+				max(2,W.w_class),
+				1\
 			)
 		orient2hud(user)
 		if(user.s_active)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -367,14 +367,14 @@
 		add_fingerprint(user)
 
 		if(!prevent_warning)
-			for(var/mob/M in viewers(user, null))
-				if (M == usr)
-					usr << "<span class='notice'>You put \the [W] into [src].</span>"
-				else if (M in range(1)) //If someone is standing close enough, they can tell what it is...
-					M.show_message("<span class='notice'>\The [user] puts [W] into [src].</span>")
-				else if (W && W.w_class >= 3) //Otherwise they can only see large or normal items from a distance...
-					M.show_message("<span class='notice'>\The [user] puts [W] into [src].</span>")
-
+			user.visible_message_stealth(\
+				"<span class='notice'>[user] tucks \the [W] in \the [src].",\
+				"<span class='notice'>You place \the [W] in \the [src].",\
+				"<span class='notice'>You see [user] put something in \the [src].",\
+				"<span class='notice'>You hear shuffling nearby...",\
+				max(1,W.w_class*0.5),\
+				max(2,W.w_class)\
+			)
 		orient2hud(user)
 		if(user.s_active)
 			user.s_active.show_to(user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -367,11 +367,11 @@
 		add_fingerprint(user)
 
 		if(!prevent_warning)
-			user.visible_message_stealth(\
-				"<span class='notice'>[user] tucks \the [W] in \the [src].",\
-				"<span class='notice'>You place \the [W] in \the [src].",\
-				"<span class='notice'>You see [user] put something in \the [src].",\
-				"<span class='notice'>You hear shuffling nearby...",\
+			user.visible_message(\
+				"<span class='notice'>[user] places \the [W] in \the [src].</span>",\
+				"<span class='notice'>You put \the [W] in \the [src].</span>",\
+				"<span class='notice'>You hear shuffling nearby...</span>",\
+				"<span class='notice'>You see [user] put something in \the [src].</span>",\
 				max(1,W.w_class*0.5),\
 				max(2,W.w_class)\
 			)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -27,22 +27,16 @@
 	switch(slot)
 		if(slot_l_store)
 			selfverb = "You place \the [W] in your left pocket."
-			otherverb = "[src] stuffs the [W] in their left pocket."
+			otherverb = "[src] stuffs \the [W] in their left pocket."
 		if(slot_r_store)
 			selfverb = "You place \the [W] in your right pocket."
-			otherverb = "[src] stuffs the [W] in their right pocket."
+			otherverb = "[src] stuffs \the [W] in their right pocket."
 		if(slot_back)
 			selfverb = "You hoist \the [W] onto your back."
 			otherverb = "[src] hoists the [W] onto their back."
 		if(slot_wear_id)
-			selfverb = "You place and adjust \the [W] on your uniform."
-			otherverb = "[src] places and adjusts the [W] on your uniform."
-		if(slot_w_uniform)
-			selfverb = "You dress yourself into \the [W]."
-			otherverb = "[src] dresses themself into the [W]."
-		if(slot_wear_suit)
-			selfverb = "You dress yourself into \the [W]."
-			otherverb = "[src] dresses themself into the [W]."
+			selfverb = "You place \the [W] on your uniform."
+			otherverb = "[src] places \the [W] on your uniform."
 		if(slot_head)
 			selfverb = "You place \the [W] on your head."
 			otherverb = "[src] places \the [W] on their head."
@@ -91,11 +85,11 @@
 		var/person3rd = returninglist[2]
 		var/personstealth = replacetext(person3rd,"the [W]","something")
 
-		src.visible_message_stealth(\
-			"<span class='notice'>[person3rd].",\
-			"<span class='notice'>[person1st]",\
-			"<span class='notice'>[personstealth].",\
-			"<span class='notice'>You hear rustling nearby...",\
+		src.visible_message(\
+			"<span class='notice'>[person3rd].</span>",\
+			"<span class='notice'>[person1st].</span>",\
+			"<span class='notice'>You hear rustling nearby...</span>",\
+			"<span class='notice'>[personstealth].</span>",\
 			max(1,W.w_class*0.5),\
 			max(2,W.w_class)\
 		)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -17,6 +17,57 @@
 		return 1
 	return 0
 
+
+/mob/proc/get_proper_equip_name(obj/item/W as obj,slot)
+
+	var/selfverb = "You equip the [W]."
+	var/otherverb = "[src] equips the [W]."
+	var/mob/living/carbon/human/srchuman = src
+
+	switch(slot)
+		if(slot_l_store)
+			selfverb = "You place \the [W] in your left pocket."
+			otherverb = "[src] stuffs the [W] in their left pocket."
+		if(slot_r_store)
+			selfverb = "You place \the [W] in your right pocket."
+			otherverb = "[src] stuffs the [W] in their right pocket."
+		if(slot_back)
+			selfverb = "You hoist \the [W] onto your back."
+			otherverb = "[src] hoists the [W] onto their back."
+		if(slot_wear_id)
+			selfverb = "You place and adjust \the [W] on your uniform."
+			otherverb = "[src] places and adjusts the [W] on your uniform."
+		if(slot_w_uniform)
+			selfverb = "You dress yourself into \the [W]."
+			otherverb = "[src] dresses themself into the [W]."
+		if(slot_wear_suit)
+			selfverb = "You dress yourself into \the [W]."
+			otherverb = "[src] dresses themself into the [W]."
+		if(slot_head)
+			selfverb = "You place \the [W] on your head."
+			otherverb = "[src] places \the [W] on their head."
+		if(slot_shoes)
+			selfverb = "You slip on \the [W]."
+			otherverb = "[src] slips on \the [W]."
+		if(slot_gloves)
+			if(istype(srchuman) && (!srchuman.l_hand || srchuman.r_hand))
+				selfverb = "You slide your hand into \the [W]."
+				otherverb = "[src] slides their hand into \the [W]."
+			else
+				selfverb = "You slide your hands into \the [W]."
+				otherverb = "[src] slides their hands into \the [W]."
+		if(slot_belt)
+			selfverb = "You put \the [W] around your waist."
+			otherverb = "[src] places \the [W] around their waist."
+		if(slot_s_store || slot_l_store || slot_r_store)
+			selfverb = "You tuck \the [W] in your pocket."
+			otherverb = "[src] tucks \the [W] in their pocket."
+
+
+	var/list/returninglist = list(selfverb,otherverb)
+
+	return returninglist
+
 //This is a SAFE proc. Use this instead of equip_to_slot()!
 //set del_on_fail to have it delete W if it fails to equip
 //set disable_warning to disable the 'you are unable to equip that' warning.
@@ -33,6 +84,22 @@
 		return 0
 
 	equip_to_slot(W, slot, redraw_mob) //This proc should not ever fail.
+	if(!disable_warning)
+
+		var/list/returninglist = get_proper_equip_name(W,slot)
+		var/person1st = returninglist[1]
+		var/person3rd = returninglist[2]
+		var/personstealth = replacetext(person3rd,"the [W]","something")
+
+		src.visible_message_stealth(\
+			"<span class='notice'>[person3rd].",\
+			"<span class='notice'>[person1st]",\
+			"<span class='notice'>[personstealth].",\
+			"<span class='notice'>You hear rustling nearby...",\
+			max(1,W.w_class*0.5),\
+			max(2,W.w_class)\
+		)
+
 	return 1
 
 //This is an UNSAFE proc. It merely handles the actual job of equipping. All the checks on whether you can or can't eqip need to be done before! Use mob_can_equip() for that task.
@@ -84,9 +151,8 @@ var/list/slot_equipment_priority = list( \
 	if(istype(src.back,/obj/item/weapon/storage))
 		var/obj/item/weapon/storage/backpack = src.back
 		if(backpack.can_be_inserted(newitem, 1))
-			newitem.forceMove(src.back)
+			newitem.forceMove(backpack)
 			return 1
-
 	// Try to place it in any item that can store stuff, on the mob.
 	for(var/obj/item/weapon/storage/S in src.contents)
 		if(S.can_be_inserted(newitem, 1))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -41,8 +41,8 @@
 			selfverb = "You place \the [W] on your head."
 			otherverb = "[src] places \the [W] on their head."
 		if(slot_shoes)
-			selfverb = "You slip on \the [W]."
-			otherverb = "[src] slips on \the [W]."
+			selfverb = "You put on \the [W]."
+			otherverb = "[src] puts on \the [W]."
 		if(slot_gloves)
 			if(istype(srchuman) && (!srchuman.l_hand || srchuman.r_hand))
 				selfverb = "You slide your hand into \the [W]."
@@ -51,11 +51,11 @@
 				selfverb = "You slide your hands into \the [W]."
 				otherverb = "[src] slides their hands into \the [W]."
 		if(slot_belt)
-			selfverb = "You put \the [W] around your waist."
-			otherverb = "[src] places \the [W] around their waist."
+			selfverb = "You attach \the [W] around your waist."
+			otherverb = "[src] attaches \the [W] around their waist."
 		if(slot_s_store || slot_l_store || slot_r_store)
-			selfverb = "You tuck \the [W] in your pocket."
-			otherverb = "[src] tucks \the [W] in their pocket."
+			selfverb = "You place \the [W] in your pocket."
+			otherverb = "[src] places \the [W] in their pocket."
 
 
 	var/list/returninglist = list(selfverb,otherverb)
@@ -85,14 +85,16 @@
 		var/person3rd = returninglist[2]
 		var/personstealth = replacetext(person3rd,"the [W]","something")
 
-		src.visible_message(\
-			"<span class='notice'>[person3rd].</span>",\
-			"<span class='notice'>[person1st].</span>",\
-			"<span class='notice'>You hear rustling nearby...</span>",\
-			"<span class='notice'>[personstealth].</span>",\
-			max(1,W.w_class*0.5),\
-			max(2,W.w_class)\
-		)
+		if(person1st && person3rd && personstealth)
+			src.visible_message(\
+				"<span class='notice'>[person3rd]</span>",\
+				"<span class='notice'>[person1st]</span>",\
+				"<span class='notice'>You hear rustling nearby...</span>",\
+				"<span class='notice'>[personstealth]</span>",\
+				W.w_class*0.5,\
+				W.w_class,
+				1\
+			)
 
 	return 1
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -105,40 +105,14 @@
 // message is the message output to anyone who can see e.g. "[src] does something!"
 // self_message (optional) is what the src mob sees  e.g. "You do something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
-
-/mob/visible_message(var/message, var/self_message, var/blind_message)
+// distance_message (optional): message it displays when people are at a distance,
+// distance: maximum distance for when message variable is displayed to that user, and minimum variable for when a distance_message variable is displayed to that user
+/mob/visible_message(var/message, var/self_message, var/blind_message, var/distance_message, var/minrange = -1,var/maxrange = -1)
 	var/list/messageturfs = list()//List of turfs we broadcast to.
 	var/list/messagemobs = list()//List of living mobs nearby who can hear it, and distant ghosts who've chosen to hear it
-	for (var/turf in view(world.view, get_turf(src)))
-		messageturfs += turf
 
-	for(var/A in player_list)
-		var/mob/M = A
-		if (QDELETED(M))
-			warning("Null or QDELETED object [DEBUG_REF(M)] found in player list! Removing.")
-			player_list -= M
-			continue
-		if (!M.client || istype(M, /mob/abstract/new_player))
-			continue
-		if(get_turf(M) in messageturfs)
-			messagemobs += M
-
-	for(var/A in messagemobs)
-		var/mob/M = A
-		if(self_message && M==src)
-			M.show_message(self_message, 1, blind_message, 2)
-		else if(M.see_invisible < invisibility)  // Cannot view the invisible, but you can hear it.
-			if(blind_message)
-				M.show_message(blind_message, 2)
-		else
-			M.show_message(message, 1, blind_message, 2)
-
-//Same as contained_visible_message, except it takes two additional variables
-//distance_message: message it displays when people are at a distance,
-//distance: maximum distance for when message variable is displayed to that user, and minimum variable for when a distance_message variable is displayed to that user
-/mob/proc/visible_message_stealth(var/message, var/self_message, var/distance_message, var/blind_message, var/minrange = 2,var/maxrange = 4)
-	var/list/messageturfs = list()//List of turfs we broadcast to.
-	var/list/messagemobs = list()//List of living mobs nearby who can hear it, and distant ghosts who've chosen to hear it
+	if(maxrange == -1)
+		maxrange = world.view
 
 	for (var/turf in view(maxrange, get_turf(src)))
 		messageturfs += turf
@@ -162,9 +136,9 @@
 		else if(M.see_invisible < invisibility)  // Cannot view the invisible, but you can hear it.
 			if(blind_message && distance < maxrange)
 				M.show_message(blind_message, 2)
-		else if(distance < minrange)
+		else if(distance < minrange || minrange == -1 || !distance_message)
 			M.show_message(message, 1, blind_message, 2)
-		else if(distance < maxrange)
+		else if(distance_message && distance < maxrange)
 			M.show_message(distance_message, 1, blind_message, 2)
 
 // Designed for mobs contained inside things, where a normal visible message wont actually be visible

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -107,7 +107,7 @@
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 // distance_message (optional): message it displays when people are at a distance,
 // distance: maximum distance for when message variable is displayed to that user, and minimum variable for when a distance_message variable is displayed to that user
-/mob/visible_message(var/message, var/self_message, var/blind_message, var/distance_message, var/minrange = -1,var/maxrange = -1)
+/mob/visible_message(var/message, var/self_message, var/blind_message, var/distance_message, var/minrange = -1,var/maxrange = -1, var/usedir = 0)
 	var/list/messageturfs = list()//List of turfs we broadcast to.
 	var/list/messagemobs = list()//List of living mobs nearby who can hear it, and distant ghosts who've chosen to hear it
 
@@ -131,15 +131,18 @@
 	for(var/A in messagemobs)
 		var/mob/M = A
 		var/distance = get_dist(M,src)
-		if(self_message && M==src)
+		var/isfacing = M.dir & get_dir(M, src)
+		if(usedir && blind_message && !isfacing && distance*1.5 <= maxrange )
+			M.show_message(blind_message, 2)
+		else if(self_message && M==src)
 			M.show_message(self_message, 1, blind_message, 2)
-		else if(M.see_invisible < invisibility)  // Cannot view the invisible, but you can hear it.
-			if(blind_message && distance < maxrange)
-				M.show_message(blind_message, 2)
-		else if(distance < minrange || minrange == -1 || !distance_message)
+		else if(message && distance < minrange || minrange == -1)
 			M.show_message(message, 1, blind_message, 2)
-		else if(distance_message && distance < maxrange)
+		else if(distance_message)
 			M.show_message(distance_message, 1, blind_message, 2)
+		else if(blind_message && M.see_invisible < invisibility)
+			M.show_message(blind_message, 2)
+
 
 // Designed for mobs contained inside things, where a normal visible message wont actually be visible
 // Useful for visible actions by pAIs, and held mobs

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -133,6 +133,40 @@
 		else
 			M.show_message(message, 1, blind_message, 2)
 
+//Same as contained_visible_message, except it takes two additional variables
+//distance_message: message it displays when people are at a distance,
+//distance: maximum distance for when message variable is displayed to that user, and minimum variable for when a distance_message variable is displayed to that user
+/mob/proc/visible_message_stealth(var/message, var/self_message, var/distance_message, var/blind_message, var/minrange = 2,var/maxrange = 4)
+	var/list/messageturfs = list()//List of turfs we broadcast to.
+	var/list/messagemobs = list()//List of living mobs nearby who can hear it, and distant ghosts who've chosen to hear it
+
+	for (var/turf in view(maxrange, get_turf(src)))
+		messageturfs += turf
+
+	for(var/A in player_list)
+		var/mob/M = A
+		if (QDELETED(M))
+			warning("Null or QDELETED object [DEBUG_REF(M)] found in player list! Removing.")
+			player_list -= M
+			continue
+		if (!M.client || istype(M, /mob/abstract/new_player))
+			continue
+		if(get_turf(M) in messageturfs)
+			messagemobs += M
+
+	for(var/A in messagemobs)
+		var/mob/M = A
+		var/distance = get_dist(M,src)
+		if(self_message && M==src)
+			M.show_message(self_message, 1, blind_message, 2)
+		else if(M.see_invisible < invisibility)  // Cannot view the invisible, but you can hear it.
+			if(blind_message && distance < maxrange)
+				M.show_message(blind_message, 2)
+		else if(distance < minrange)
+			M.show_message(message, 1, blind_message, 2)
+		else if(distance < maxrange)
+			M.show_message(distance_message, 1, blind_message, 2)
+
 // Designed for mobs contained inside things, where a normal visible message wont actually be visible
 // Useful for visible actions by pAIs, and held mobs
 // Broadcaster is the place the action will be seen/heard from, mobs in sight of THAT will see the message. This is generally the object or mob that src is contained in


### PR DESCRIPTION
# Overview
Much like putting things into a backpack, messages are now displayed to people around you when equipping items like belts and clothing on your character, as well as putting items in your pocket.

Full messages are only displayed when close to someone. Partial messages are displayed when you are somewhat close to someone. This closeness check is influenced by the size of the object.

A full message would be something like: Grey Tide stuffs the insulated gloves intp their right pocket.
A partial message would be: Grey Tide stuffs something into their right pocket.

## Other Additions
Added a new proc "visible_message_stealth" which has the same function of a visible message except you can control the distance of what the message displays as well as whether or not it should show a less descriptive message at a certain distance.

### Will this spam?
Yes, but much like someone spamming a zippo locker or a medical android who shall not be named spamming emotes, it can be managed by not being a dick. The only time it would ever get super spammy is when you're in a locker room as sec and you're next to people.

### WIP
People might not like this change or some aspects of it. Feedback is appreciated. I'm thinking of just making it so that pockets display a notification, as opposed to everything else.