### PR TITLE
Removes Goebbles

### DIFF
--- a/config/names/last.txt
+++ b/config/names/last.txt
@@ -502,7 +502,6 @@ Stamos
 Sagan
 Hawking
 Dawkins
-Goebbles
 McShain
 McDonohugh
 Power


### PR DESCRIPTION
We dont need 3rd Reich references in our name list (with just two letters switched)