### PR TITLE
Dionaea can now form a partial gestalt with enough biomass.

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/progression.dm
+++ b/code/modules/mob/living/carbon/alien/diona/progression.dm
@@ -25,10 +25,12 @@
 	if(stat != CONSCIOUS)
 		return
 
+	var/limbs_can_grow = (nutrition / evolve_nutrition) * 6
 
+	src << limbs_can_grow
 
-	if(nutrition < evolve_nutrition)
-		src << "<span class='warning'>You do not have enough biomass to grow yet. Currently [nutrition]/[evolve_nutrition].</span>"
+	if(limbs_can_grow >= 3) //Head, Trunk, Fork
+		src << "<span class='warning'>You do not have enough biomass to grow yet. Currently you can only grow [nutrition]/[evolve_nutrition*(3/6)] limbs ([nutrition]/[evolve_nutrition] biomass).</span>"
 		return
 
 	if(gestalt)
@@ -50,8 +52,8 @@
 	src.visible_message("<span class='warning'> [src] begins to shift and quiver.</span>",
 	"<span class='warning'> You begin to shift and quiver, feeling your awareness splinter.</span>")
 	sleep(52)
-	src.visible_message("<span class='warning'> [src] erupts in a shower of shed bark as it splits into a tangle of half a dozen new dionaea.</span>",
-	"<span class='warning'> All at once, we consume our stored nutrients to surge with growth, splitting into a tangle of half a dozen new dionaea. We have attained our gestalt form.</span>")
+	src.visible_message("<span class='warning'> [src] erupts in a shower of shed bark as it splits into a tangle of new dionaea.</span>",
+	"<span class='warning'> All at once, we consume our stored nutrients to surge with growth, splitting into a tangle of new dionaea. We have attained a new form.</span>")
 
 	var/mob/living/carbon/human/adult = new adult_form(get_turf(src))
 	adult.set_species(new_species)
@@ -88,3 +90,16 @@
 	src.loc = adult
 	src.stat = CONSCIOUS
 	src.gestalt = adult
+
+	//What do you call a person with no arms or no legs?
+	var/list/organ_removal_priorities = list("l_arm","r_arm","l_leg","r_leg")
+	var/limbs_to_remove = (6 - limbs_can_grow)
+	for(var/organ_name in organ_removal_priorities)
+		var/obj/item/organ/external/O = adult.organs_by_name[organ_name]
+		src << "<span class='warning'>You didn't have enough biomass to grow your [O.name].</warning>"
+		//adult.organs -= O
+		O.droplimb(1,DROPLIMB_EDGE)
+		limbs_to_remove -= 1
+		if(limbs_to_remove <= 0)
+			break
+	//Matt

--- a/code/modules/mob/living/carbon/alien/diona/progression.dm
+++ b/code/modules/mob/living/carbon/alien/diona/progression.dm
@@ -27,7 +27,7 @@
 
 	var/limbs_can_grow = round((nutrition / evolve_nutrition) * 6)
 	if(limbs_can_grow <= 3) //Head, Trunk, Fork
-		src << "<span class='warning'>You do not have enough biomass to grow yet. Currently you can only grow [limbs_can_grow]/6 limbs ([nutrition]/[evolve_nutrition] biomass).</span>"
+		src << "<span class='warning'>You do not have enough biomass to grow yet. Currently you can only grow [limbs_can_grow]/6 limbs. ([nutrition]/[evolve_nutrition] biomass).</span>"
 		return
 
 	if(gestalt)
@@ -93,7 +93,7 @@
 	var/limbs_to_remove = (6 - limbs_can_grow)
 	for(var/organ_name in organ_removal_priorities)
 		var/obj/item/organ/external/O = adult.organs_by_name[organ_name]
-		src << "<span class='warning'>You didn't have enough biomass to grow your [O.name].</warning>"
+		src << "<span class='warning'>You didn't have enough biomass to grow your [O.name]!</span>"
 		//adult.organs -= O
 		O.droplimb(1,DROPLIMB_EDGE)
 		qdel(O)

--- a/code/modules/mob/living/carbon/alien/diona/progression.dm
+++ b/code/modules/mob/living/carbon/alien/diona/progression.dm
@@ -25,12 +25,9 @@
 	if(stat != CONSCIOUS)
 		return
 
-	var/limbs_can_grow = (nutrition / evolve_nutrition) * 6
-
-	src << limbs_can_grow
-
-	if(limbs_can_grow >= 3) //Head, Trunk, Fork
-		src << "<span class='warning'>You do not have enough biomass to grow yet. Currently you can only grow [nutrition]/[evolve_nutrition*(3/6)] limbs ([nutrition]/[evolve_nutrition] biomass).</span>"
+	var/limbs_can_grow = round((nutrition / evolve_nutrition) * 6)
+	if(limbs_can_grow <= 3) //Head, Trunk, Fork
+		src << "<span class='warning'>You do not have enough biomass to grow yet. Currently you can only grow [limbs_can_grow]/6 limbs ([nutrition]/[evolve_nutrition] biomass).</span>"
 		return
 
 	if(gestalt)
@@ -99,6 +96,7 @@
 		src << "<span class='warning'>You didn't have enough biomass to grow your [O.name].</warning>"
 		//adult.organs -= O
 		O.droplimb(1,DROPLIMB_EDGE)
+		qdel(O)
 		limbs_to_remove -= 1
 		if(limbs_to_remove <= 0)
 			break

--- a/code/modules/mob/living/carbon/human/diona_gestalt.dm
+++ b/code/modules/mob/living/carbon/human/diona_gestalt.dm
@@ -217,6 +217,11 @@
 	var/mob/living/carbon/alien/diona/bestNymph = null
 	var/bestHealth = 0
 
+
+	var/nymphs_to_kill_off = 0
+
+
+
 	//We iterate through all the nymphs and find which one is healthiest and not controlled
 	//The gestalt's player will control that nymph
 
@@ -224,7 +229,19 @@
 	playsound(src.loc, 'sound/species/diona/gestalt_split.ogg', 100, 1)
 	sleep(20)
 	var/list/nymphos = list()
+
+	var/list/organ_removal_priorities = list("l_arm","r_arm","l_leg","r_leg")
+	for(var/organ_name in organ_removal_priorities)
+		var/obj/item/organ/external/O = organs_by_name[organ_name]
+		if(O.is_stump())
+			nymphs_to_kill_off += 1
+
 	for(var/mob/living/carbon/alien/diona/D in src)
+		if(nymphs_to_kill_off > 0)
+			D.stat = DEAD
+			nymphs_to_kill_off -= 1
+			qdel(D)
+			continue
 		if ((!D.key) && bestNymph == null)
 			//As a safety, we choose the first unkeyed one to begin with, even if its dead.
 			//We'll replace this choice when/if we find a better one

--- a/code/modules/mob/living/carbon/human/diona_gestalt.dm
+++ b/code/modules/mob/living/carbon/human/diona_gestalt.dm
@@ -233,7 +233,7 @@
 	var/list/organ_removal_priorities = list("l_arm","r_arm","l_leg","r_leg")
 	for(var/organ_name in organ_removal_priorities)
 		var/obj/item/organ/external/O = organs_by_name[organ_name]
-		if(O.is_stump())
+		if(!O || O.is_stump())
 			nymphs_to_kill_off += 1
 
 	for(var/mob/living/carbon/alien/diona/D in src)

--- a/html/changelogs/burgerbb-dionaeagestalt.yml
+++ b/html/changelogs/burgerbb-dionaeagestalt.yml
@@ -1,0 +1,6 @@
+author: BurgerBB
+
+delete-after: True
+
+changes: 
+  - balance: "Diona nymphs can perform partial merges at half biomass, with the consequence of missing limbs. The more biomass, the less missing limbs."


### PR DESCRIPTION
# Overview
I'm a filthy dionaea main.

## Logical Forming
For some strange reason, if you did not have enough biomass (The maximum amount), you couldn't form a gestalt. It was either you had enough biomass, or you didn't. This felt incredibly arbitrary as you can survive as a gestalt with only 3 nymphs (Head, body, lower body) and there are no lore reasons why you couldn't have a gestalt with only 4 nymphs, just minus the arm.

Limbs are removed or added based on usefulness. If you don't have enough biomass, the order of limb removal is the following: Remove left arm, remove right arm, remove left leg, remove right leg.

Currently, in order to merge, you need 3 or more biomass worth of nymphs. Having less prevents you from merging.

## Logical Splitting
Before, when a dionaea broke off, it would spawn 6 nymphs every time it died unless the internal nymph was damaged heavily due to an explosion. This makes it so that one nymph is removed for every major missing limb the dionaea has, such as a full arm or a leg.

## Balance
If you're a gestalt at full health, and you split, you spawn 6 nymphs.
If you try to reform again as 6 nymphs, you will only have enough biomass for 4 nymphs and you'll form as an armless gestalt. Split again, and you will split into 4 nymphs. 4 nymphs is not enough biomass to form a gestalt as they have the equivalent of 2 biomass worth of nymphs.


