### PR TITLE
Fixes brig timers, medboots and titanium

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -40,6 +40,9 @@
 /obj/machinery/door_timer/Initialize()
 	. = ..()
 
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/door_timer/LateInitialize()
 	for(var/obj/machinery/door/window/brigdoor/M in SSmachinery.all_machines)
 		if (M.id == src.id)
 			targets += M

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -38,7 +38,7 @@
 	var/datum/browser/menu = new( null, "brig_timer", "Brig Timer", 400, 300 )
 
 /obj/machinery/door_timer/Initialize()
-	. = ..()
+	..()
 
 	return INITIALIZE_HINT_LATELOAD
 

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -408,7 +408,11 @@ var/list/name_to_material
 /material/plasteel/titanium
 	name = "titanium"
 	stack_type = /obj/item/stack/material/titanium
+	integrity = 600
 	conductivity = 2.38
+	hardness = 90
+	weight = 25
+	protectiveness = 25
 	icon_base = "metal"
 	door_icon_base = "metal"
 	icon_colour = "#D1E6E3"

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -303,7 +303,7 @@
 	if((H.getToxLoss() >= heal_threshold) && (!H.reagents.has_reagent(treatment_tox)))
 		return treatment_tox
 
-	for(var/datum/disease/D in H.viruses)
+	for(var/datum/disease2/disease/D in H.virus2)
 		if (!H.reagents.has_reagent(treatment_virus))
 			return treatment_virus // STOP DISEASE FOREVER
 

--- a/code/modules/random_map/drop/droppod.dm
+++ b/code/modules/random_map/drop/droppod.dm
@@ -210,10 +210,7 @@
 	// Chuck them into the pod.
 	var/automatic_pod
 	if(spawned_mob && selected_player)
-		if(selected_player.mob.mind)
-			selected_player.mob.mind.transfer_to(spawned_mob)
-		else
-			spawned_mob.ckey = selected_player.mob.ckey
+		spawned_mob.ckey = selected_player.mob.ckey
 		spawned_mobs = list(spawned_mob)
 		message_admins("[key_name_admin(usr)] dropped a pod containing \the [spawned_mob] ([spawned_mob.key]) at ([usr.x],[usr.y],[usr.z])")
 		log_admin("[key_name(usr)] dropped a pod containing \the [spawned_mob] ([spawned_mob.key]) at ([usr.x],[usr.y],[usr.z])",admin_key=key_name(usr),ckey=key_name(spawned_mob))


### PR DESCRIPTION
-fixes #4216
-fixes #4239
-fixes titanium being the same thing as plasteel
-fixes drop pods not working when you select a ghost