### PR TITLE
Gives Dionaea an Eyewear and Mask Slot

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -182,7 +182,7 @@
 	else
 		//blindness
 		if(!(sdisabilities & BLIND))
-			if(equipment_tint_total >= TINT_BLIND)	// Covered eyes, heal faster
+			if(!src.is_diona() && equipment_tint_total >= TINT_BLIND)	// Covered eyes, heal faster
 				eye_blurry = max(eye_blurry-2, 0)
 			else
 				eye_blurry = max(eye_blurry-1, 0)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -133,7 +133,7 @@
 	if(silent || (sdisabilities & MUTE))
 		message = ""
 		speech_problem_flag = 1
-	else if(istype(wear_mask, /obj/item/clothing/mask))
+	else if(!src.is_diona() && istype(wear_mask, /obj/item/clothing/mask))
 		var/obj/item/clothing/mask/M = wear_mask
 		if(M.voicechange)
 			message = pick(M.say_messages)

--- a/code/modules/mob/living/carbon/human/species/species_hud.dm
+++ b/code/modules/mob/living/carbon/human/species/species_hud.dm
@@ -59,16 +59,14 @@
 		"i_clothing" =   list("loc" = ui_iclothing, "name" = "Uniform",      "slot" = slot_w_uniform, "state" = "center", "toggle" = 1),
 		"o_clothing" =   list("loc" = ui_shoes,     "name" = "Suit",         "slot" = slot_wear_suit, "state" = "suit",   "toggle" = 1),
 		"l_ear" =        list("loc" = ui_glasses,   "name" = "Left Ear",     "slot" = slot_l_ear,     "state" = "ears",   "toggle" = 1),
-		"r_ear" =        list("loc" = ui_l_ear,    "name" = "Right Ear",    "slot" = slot_r_ear,     "state" = "ears",   "toggle" = 1),
-		"head" =         list("loc" = ui_mask, 		"name" = "Hat",          "slot" = slot_head,      "state" = "hair",   "toggle" = 1),
+		"r_ear" =        list("loc" = ui_gloves,    "name" = "Right Ear",    "slot" = slot_r_ear,     "state" = "ears",   "toggle" = 1),
+		"head" =         list("loc" = ui_oclothing, "name" = "Hat",          "slot" = slot_head,      "state" = "hair",   "toggle" = 1),
 		"suit storage" = list("loc" = ui_sstore1,   "name" = "Suit Storage", "slot" = slot_s_store,   "state" = "suitstore"),
 		"back" =         list("loc" = ui_back,      "name" = "Back",         "slot" = slot_back,      "state" = "back"),
 		"id" =           list("loc" = ui_id,        "name" = "ID",           "slot" = slot_wear_id,   "state" = "id"),
 		"storage1" =     list("loc" = ui_storage1,  "name" = "Left Pocket",  "slot" = slot_l_store,   "state" = "pocket"),
 		"storage2" =     list("loc" = ui_storage2,  "name" = "Right Pocket", "slot" = slot_r_store,   "state" = "pocket"),
-		"belt" =         list("loc" = ui_belt,      "name" = "Belt",         "slot" = slot_belt,      "state" = "belt"),
-		"mask" =         list("loc" = ui_oclothing,	"name" = "Mask",         "slot" = slot_wear_mask, "state" = "mask",   "toggle" = 1),
-		"eyes" =         list("loc" = ui_gloves,   "name" = "Glasses",      "slot" = slot_glasses,   "state" = "glasses","toggle" = 1)
+		"belt" =         list("loc" = ui_belt,      "name" = "Belt",         "slot" = slot_belt,      "state" = "belt")
 		)
 
 /datum/hud_data/monkey

--- a/code/modules/mob/living/carbon/human/species/species_hud.dm
+++ b/code/modules/mob/living/carbon/human/species/species_hud.dm
@@ -59,7 +59,7 @@
 		"i_clothing" =   list("loc" = ui_iclothing, "name" = "Uniform",      "slot" = slot_w_uniform, "state" = "center", "toggle" = 1),
 		"o_clothing" =   list("loc" = ui_shoes,     "name" = "Suit",         "slot" = slot_wear_suit, "state" = "suit",   "toggle" = 1),
 		"l_ear" =        list("loc" = ui_glasses,   "name" = "Left Ear",     "slot" = slot_l_ear,     "state" = "ears",   "toggle" = 1),
-		"r_ear" =        list("loc" = ui_l_ear,    "name" = "Right Ear",    "slot" = slot_r_ear,     "state" = "ears",   "toggle" = 1),
+		"r_ear" =        list("loc" = ui_l_ear,		"name" = "Right Ear",    "slot" = slot_r_ear,     "state" = "ears",   "toggle" = 1),
 		"head" =         list("loc" = ui_mask, 		"name" = "Hat",          "slot" = slot_head,      "state" = "hair",   "toggle" = 1),
 		"suit storage" = list("loc" = ui_sstore1,   "name" = "Suit Storage", "slot" = slot_s_store,   "state" = "suitstore"),
 		"back" =         list("loc" = ui_back,      "name" = "Back",         "slot" = slot_back,      "state" = "back"),
@@ -68,7 +68,7 @@
 		"storage2" =     list("loc" = ui_storage2,  "name" = "Right Pocket", "slot" = slot_r_store,   "state" = "pocket"),
 		"belt" =         list("loc" = ui_belt,      "name" = "Belt",         "slot" = slot_belt,      "state" = "belt"),
 		"mask" =         list("loc" = ui_oclothing,	"name" = "Mask",         "slot" = slot_wear_mask, "state" = "mask",   "toggle" = 1),
-		"eyes" =         list("loc" = ui_gloves,   "name" = "Glasses",      "slot" = slot_glasses,   "state" = "glasses","toggle" = 1)
+		"eyes" =         list("loc" = ui_gloves,   	"name" = "Glasses",      "slot" = slot_glasses,   "state" = "glasses","toggle" = 1)
 		)
 
 /datum/hud_data/monkey

--- a/code/modules/mob/living/carbon/human/species/species_hud.dm
+++ b/code/modules/mob/living/carbon/human/species/species_hud.dm
@@ -59,14 +59,16 @@
 		"i_clothing" =   list("loc" = ui_iclothing, "name" = "Uniform",      "slot" = slot_w_uniform, "state" = "center", "toggle" = 1),
 		"o_clothing" =   list("loc" = ui_shoes,     "name" = "Suit",         "slot" = slot_wear_suit, "state" = "suit",   "toggle" = 1),
 		"l_ear" =        list("loc" = ui_glasses,   "name" = "Left Ear",     "slot" = slot_l_ear,     "state" = "ears",   "toggle" = 1),
-		"r_ear" =        list("loc" = ui_gloves,    "name" = "Right Ear",    "slot" = slot_r_ear,     "state" = "ears",   "toggle" = 1),
-		"head" =         list("loc" = ui_oclothing, "name" = "Hat",          "slot" = slot_head,      "state" = "hair",   "toggle" = 1),
+		"r_ear" =        list("loc" = ui_l_ear,    "name" = "Right Ear",    "slot" = slot_r_ear,     "state" = "ears",   "toggle" = 1),
+		"head" =         list("loc" = ui_mask, 		"name" = "Hat",          "slot" = slot_head,      "state" = "hair",   "toggle" = 1),
 		"suit storage" = list("loc" = ui_sstore1,   "name" = "Suit Storage", "slot" = slot_s_store,   "state" = "suitstore"),
 		"back" =         list("loc" = ui_back,      "name" = "Back",         "slot" = slot_back,      "state" = "back"),
 		"id" =           list("loc" = ui_id,        "name" = "ID",           "slot" = slot_wear_id,   "state" = "id"),
 		"storage1" =     list("loc" = ui_storage1,  "name" = "Left Pocket",  "slot" = slot_l_store,   "state" = "pocket"),
 		"storage2" =     list("loc" = ui_storage2,  "name" = "Right Pocket", "slot" = slot_r_store,   "state" = "pocket"),
-		"belt" =         list("loc" = ui_belt,      "name" = "Belt",         "slot" = slot_belt,      "state" = "belt")
+		"belt" =         list("loc" = ui_belt,      "name" = "Belt",         "slot" = slot_belt,      "state" = "belt"),
+		"mask" =         list("loc" = ui_oclothing,	"name" = "Mask",         "slot" = slot_wear_mask, "state" = "mask",   "toggle" = 1),
+		"eyes" =         list("loc" = ui_gloves,   "name" = "Glasses",      "slot" = slot_glasses,   "state" = "glasses","toggle" = 1)
 		)
 
 /datum/hud_data/monkey

--- a/html/changelogs/burgerbb-dionaea_equipment.yml
+++ b/html/changelogs/burgerbb-dionaea_equipment.yml
@@ -1,0 +1,8 @@
+author: BurgerBB
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added a mask and eyewear slot for dionaea."
+  - tweak: "Made Dionaea immune to the effects of blindfolds and muzzles."
+  - balance: "Dionaea recieve only 25% arousal per second from blindfolds and muzzles."


### PR DESCRIPTION
# Overview
![Cool Cat](https://i.imgur.com/UareXPQ.png)

## Eyewear and Mask Slots
Dionaea eye and mask slots are now enabled, while feet and hands slots are rightfully restricted still. The inventory is rearranged to reflect this.
![Inventory](https://i.imgur.com/iX2Fdy8.png)

## Balance
Dionaea can now wear special eyewear, including HUDs and meson goggles. They can still be flashed and knocked down while wearing sunglasses, thanks to code that already exists in the system. Pepper spray is useless against Dionaea even without a mask, so that's unaffected.

They can also disguise themselves with masks now like anyone else. Greytide pride worldwide. Given how Dionaea don't have lungs, they don't need to use internals. 

Dionaea can receive reagents smoked from a pipe, despite not having lungs, however this makes sense given how Dionaea can already consume reagents via digestion, and this would be similar to disgusting smoke or fine particles.