### PR TITLE
Turns the AI Common intercom off by default.

### DIFF
--- a/html/changelogs/Changelog-IntercomAI.yml
+++ b/html/changelogs/Changelog-IntercomAI.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "The AI's Common Channel intercom will no longer betray Traitor or Malf AIs. Unless they want it to."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -2067,6 +2067,17 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"ew" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	icon_state = "map";
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
 "ex" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	icon_state = "intact";
@@ -2165,6 +2176,27 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "eF" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	icon_state = "map";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
+"eG" = (
+/obj/effect/floor_decal/corner/black{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
+"eH" = (
+/obj/effect/floor_decal/corner/black{
+	icon_state = "corner_white";
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	icon_state = "map";
 	dir = 1
@@ -2462,6 +2494,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
+"fp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	dir = 2;
+	name = "light switch ";
+	pixel_x = 0;
+	pixel_y = 36
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	is_critical = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/simulated/floor/plating,
+/area/outpost/engineering/power)
 "fq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2491,7 +2548,7 @@
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
 "fs" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/outpost/engineering/hallway)
 "ft" = (
 /obj/structure/grille,
@@ -2517,6 +2574,23 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/engineering/hallway)
+"fv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Break Room";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/hallway)
 "fw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -2530,7 +2604,17 @@
 /turf/simulated/floor/plating,
 /area/outpost/engineering/hallway)
 "fx" = (
-/turf/simulated/wall,
+/obj/machinery/door/airlock/engineering{
+	name = "Restrooms";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/freezer,
+/area/outpost/engineering/meeting)
+"fy" = (
+/turf/simulated/wall/r_wall,
 /area/outpost/engineering/hallway)
 "fz" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2710,24 +2794,17 @@
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "fW" = (
-/obj/machinery/door/firedoor{
-	dir = 4;
-	name = "Firelock"
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/engineering/hallway)
-"fX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"fY" = (
+"fX" = (
 /obj/machinery/newscaster{
 	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"fZ" = (
+"fY" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -2741,15 +2818,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"ga" = (
+"fZ" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"gb" = (
+"ga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/hallway)
+"gb" = (
+/obj/machinery/door/firedoor{
+	dir = 4;
+	name = "Firelock"
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "gc" = (
@@ -2842,6 +2926,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"gp" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/valve/digital{
+	dir = 4;
+	icon_state = "map_valve0";
+	name = "Air Bypass valve"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
 "gq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	icon_state = "intact";
@@ -2927,6 +3023,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
+"gA" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Tesla Bay";
+	req_access = list(11)
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/power)
 "gB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2992,7 +3101,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"gG" = (
+"gF" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3004,7 +3113,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"gH" = (
+"gG" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3028,7 +3137,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"gI" = (
+"gH" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3042,7 +3151,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"gJ" = (
+"gI" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3061,7 +3170,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"gK" = (
+"gJ" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3069,6 +3178,24 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/hallway)
+"gK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4;
+	name = "Firelock"
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "gL" = (
@@ -3388,10 +3515,6 @@
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "hp" = (
-/obj/machinery/firealarm/south,
-/turf/simulated/floor/tiled,
-/area/outpost/engineering/hallway)
-"hq" = (
 /obj/machinery/light,
 /obj/machinery/camera/network/engineering_outpost{
 	c_tag = "Engineering Sublevel - Corridor Camera 1";
@@ -3400,7 +3523,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"hr" = (
+"hq" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -3411,11 +3534,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"hs" = (
+"hr" = (
 /obj/machinery/station_map{
 	dir = 1;
 	pixel_y = -32
 	},
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/hallway)
+"hs" = (
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "ht" = (
@@ -3473,6 +3600,13 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/hallway)
+"hz" = (
+/obj/machinery/atmospherics/pipe/zpipe/up/cyan{
+	icon_state = "up";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "hA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4;
@@ -3650,6 +3784,34 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
+"hU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Storage";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/outpost/engineering/hallway)
+"hV" = (
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Storage";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/outpost/engineering/hallway)
 "hW" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/gravity_gen)
@@ -3723,6 +3885,13 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
+"ic" = (
+/obj/machinery/atmospherics/pipe/zpipe/up/yellow{
+	icon_state = "up";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "id" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -3750,6 +3919,9 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "ig" = (
+/turf/simulated/wall,
+/area/engineering/atmos)
+"ih" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_atmos{
 	name = "Distribution and Waste";
@@ -3757,7 +3929,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"ih" = (
+"ii" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced,
@@ -3775,7 +3947,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"ii" = (
+"ij" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced,
@@ -3785,7 +3957,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"ij" = (
+"ik" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced,
@@ -3802,27 +3974,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"ik" = (
+"il" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"il" = (
+"im" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"im" = (
+"in" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"in" = (
+"io" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"io" = (
+"ip" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/visible/black,
@@ -3844,14 +4016,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"ip" = (
+"iq" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"iq" = (
+"ir" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -3867,12 +4039,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"ir" = (
+"is" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"is" = (
+"it" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -3882,7 +4054,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"it" = (
+"iu" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 1
@@ -3891,7 +4063,7 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"iu" = (
+"iv" = (
 /obj/machinery/camera/network/engineering_outpost{
 	c_tag = "Engineering Sublevel -Tesla Parts Storage";
 	dir = 5;
@@ -3901,7 +4073,7 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"iv" = (
+"iw" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -3916,7 +4088,7 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"iw" = (
+"ix" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -3928,12 +4100,12 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"ix" = (
+"iy" = (
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"iy" = (
+"iz" = (
 /obj/machinery/power/tesla_coil,
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -3943,10 +4115,10 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"iz" = (
+"iA" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/engineering/storage)
-"iA" = (
+"iB" = (
 /obj/structure/table/standard,
 /obj/item/stack/material/plasteel{
 	amount = 10
@@ -3958,17 +4130,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iB" = (
+"iC" = (
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iC" = (
+"iD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iD" = (
+"iE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -3982,7 +4154,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iE" = (
+"iF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -3994,7 +4166,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iF" = (
+"iG" = (
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -4005,13 +4177,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iG" = (
+"iH" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iH" = (
+"iI" = (
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
@@ -5094,12 +5266,22 @@
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
 "kS" = (
-/obj/machinery/gravity_generator/main/station,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/engineering/gravity_gen)
 "kT" = (
+/obj/machinery/gravity_generator/main/station,
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/engineering/gravity_gen)
+"kU" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering Sublevel - Engine Camera 1";
 	dir = 1;
@@ -5113,7 +5295,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"kU" = (
+"kV" = (
 /obj/machinery/light,
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -5122,7 +5304,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"kV" = (
+"kW" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -5134,7 +5316,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"kW" = (
+"kX" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering Sublevel - Engine Camera 2";
 	dir = 1;
@@ -5153,13 +5335,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"kX" = (
+"kY" = (
 /obj/machinery/light,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/engineering/gravity_gen)
-"kY" = (
+"kZ" = (
+/obj/machinery/camera/network/engineering_outpost{
+	c_tag = "Engineering Sublevel - Gravity Chamber";
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/engineering/gravity_gen)
+"la" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -5167,7 +5359,7 @@
 	icon_state = "plating"
 	},
 /area/turbolift/engineering_maintenance)
-"kZ" = (
+"lb" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -5175,7 +5367,7 @@
 	icon_state = "plating"
 	},
 /area/turbolift/engineering_maintenance)
-"la" = (
+"lc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -5189,33 +5381,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"lb" = (
+"ld" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"lc" = (
+"le" = (
 /obj/turbolift_map_holder/aurora/engineering,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/engineering_maintenance)
-"ld" = (
+"lf" = (
 /obj/structure/sign/drop,
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored)
-"le" = (
+"lg" = (
 /obj/structure/sign/securearea{
 	name = "\improper DANGER: REACTOR VENT SHAFT"
 	},
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored)
-"lf" = (
+"lh" = (
 /turf/simulated/open,
 /area/mine/unexplored)
-"lg" = (
+"li" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"lh" = (
+"lj" = (
 /obj/machinery/door/window{
 	base_state = "right";
 	dir = 2;
@@ -5232,7 +5424,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"li" = (
+"lk" = (
 /obj/machinery/door/window{
 	base_state = "right";
 	dir = 2;
@@ -5249,23 +5441,23 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lj" = (
+"ll" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/open,
 /area/mine/unexplored)
-"lk" = (
+"lm" = (
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"ll" = (
+"ln" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"lm" = (
+"lo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -5279,7 +5471,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"lo" = (
+"lp" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access = list(11,24)
+	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -5294,7 +5490,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"lp" = (
+"lq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/sublevel)
+"lr" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -5308,7 +5519,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"lr" = (
+"ls" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/sublevel)
+"lt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 9
@@ -5319,25 +5542,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"ls" = (
+"lu" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 4
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"lt" = (
+"lv" = (
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/vault_sub)
-"lu" = (
+"lw" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"lv" = (
+"lx" = (
 /obj/machinery/computer/aiupload,
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
@@ -5354,27 +5577,27 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lw" = (
+"ly" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lx" = (
+"lz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ly" = (
+"lA" = (
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lz" = (
+"lB" = (
 /obj/machinery/ai_status_display{
 	pixel_x = 32
 	},
@@ -5384,7 +5607,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lA" = (
+"lC" = (
 /obj/effect/decal/warning_stripes,
 /obj/machinery/porta_turret{
 	dir = 4
@@ -5394,20 +5617,20 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lB" = (
+"lD" = (
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lC" = (
+"lE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lD" = (
+"lF" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -5416,7 +5639,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lE" = (
+"lG" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -5424,7 +5647,7 @@
 	icon_state = "plating"
 	},
 /area/turbolift/vault_sub)
-"lF" = (
+"lH" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 4;
@@ -5432,7 +5655,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_cyborg_station)
-"lG" = (
+"lI" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -5440,7 +5663,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_cyborg_station)
-"lH" = (
+"lJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -5460,7 +5683,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"lI" = (
+"lK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -5479,13 +5702,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"lJ" = (
+"lL" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_cyborg_station)
-"lK" = (
+"lM" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload_foyer)
-"lL" = (
+"lN" = (
 /obj/structure/table/standard,
 /obj/item/weapon/aiModule/nanotrasen,
 /obj/item/weapon/aiModule/reset,
@@ -5498,7 +5721,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lM" = (
+"lO" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
@@ -5510,7 +5733,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lN" = (
+"lP" = (
 /obj/machinery/porta_turret{
 	dir = 4
 	},
@@ -5520,7 +5743,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lO" = (
+"lQ" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -5546,7 +5769,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"lP" = (
+"lR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
@@ -5555,7 +5778,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lQ" = (
+"lS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 4
@@ -5565,7 +5788,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lR" = (
+"lT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 4
@@ -5575,7 +5798,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lS" = (
+"lU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 4
@@ -5588,7 +5811,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lT" = (
+"lV" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - Beta Core 2";
 	dir = 1
@@ -5606,7 +5829,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lU" = (
+"lW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 4
@@ -5617,7 +5840,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lV" = (
+"lX" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
@@ -5631,7 +5854,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lW" = (
+"lY" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI SMES";
 	req_access = list(16)
@@ -5656,7 +5879,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lX" = (
+"lZ" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
@@ -5670,7 +5893,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lY" = (
+"ma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
 	icon_state = "intact"
@@ -5683,11 +5906,11 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lZ" = (
+"mb" = (
 /obj/structure/sign/vacuum,
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored)
-"ma" = (
+"mc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
@@ -5697,13 +5920,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"mb" = (
+"md" = (
 /obj/effect/landmark{
 	name = "cavernspawn"
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"mc" = (
+"me" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5722,18 +5945,18 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"md" = (
+"mf" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_cyborg_station)
-"me" = (
+"mg" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mf" = (
+"mh" = (
 /obj/structure/closet/crate{
 	name = "Camera Assembly Crate"
 	},
@@ -5759,14 +5982,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mg" = (
+"mi" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mh" = (
+"mj" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5784,14 +6007,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"mi" = (
+"mk" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mj" = (
+"ml" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -5808,7 +6031,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mk" = (
+"mm" = (
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
@@ -5817,7 +6040,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ml" = (
+"mn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark{
@@ -5825,7 +6048,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mm" = (
+"mo" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -5849,7 +6072,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"mn" = (
+"mp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/porta_turret{
 	dir = 4
@@ -5860,7 +6083,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mo" = (
+"mq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -5869,7 +6092,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mp" = (
+"mr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -5878,7 +6101,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mq" = (
+"ms" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 9
@@ -5888,7 +6111,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mr" = (
+"mt" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	frequency = 1343;
@@ -5922,7 +6145,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ms" = (
+"mu" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI SMES";
 	req_access = list(16)
@@ -5933,7 +6156,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mt" = (
+"mv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5954,7 +6177,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"mu" = (
+"mw" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -5968,7 +6191,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mv" = (
+"mx" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -5982,7 +6205,7 @@
 	dir = 8
 	},
 /area/turret_protected/ai_cyborg_station)
-"mw" = (
+"my" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -6002,7 +6225,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mx" = (
+"mz" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6016,7 +6239,7 @@
 	dir = 4
 	},
 /area/turret_protected/ai_cyborg_station)
-"my" = (
+"mA" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6031,7 +6254,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mz" = (
+"mB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6057,7 +6280,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"mA" = (
+"mC" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 4;
@@ -6077,7 +6300,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mB" = (
+"mD" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6098,7 +6321,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mC" = (
+"mE" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 8;
@@ -6112,7 +6335,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mD" = (
+"mF" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload";
 	req_access = list(16)
@@ -6127,7 +6350,7 @@
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mE" = (
+"mG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6139,7 +6362,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mF" = (
+"mH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -6151,7 +6374,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mG" = (
+"mI" = (
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
@@ -6169,7 +6392,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"mH" = (
+"mJ" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6183,7 +6406,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"mI" = (
+"mK" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6210,7 +6433,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"mJ" = (
+"mL" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 8;
@@ -6221,21 +6444,21 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mK" = (
+"mM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mL" = (
+"mN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mM" = (
+"mO" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -6250,7 +6473,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mN" = (
+"mP" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 4;
@@ -6258,7 +6481,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"mO" = (
+"mQ" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -6276,7 +6499,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"mP" = (
+"mR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/spiderling_remains,
@@ -6285,7 +6508,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mQ" = (
+"mS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6294,13 +6517,13 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mR" = (
+"mT" = (
 /obj/turbolift_map_holder/aurora/vault,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/vault_sub)
-"mS" = (
+"mU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -6313,12 +6536,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"mT" = (
+"mV" = (
 /obj/machinery/cryopod/robot,
 /obj/item/toy/figure/borg,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_cyborg_station)
-"mU" = (
+"mW" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -6327,7 +6550,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mV" = (
+"mX" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/blood/oil/streak{
 	amount = 0
@@ -6336,7 +6559,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mW" = (
+"mY" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -6345,14 +6568,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mX" = (
+"mZ" = (
 /obj/machinery/cryopod/robot,
 /obj/machinery/computer/cryopod/robot{
 	pixel_y = -32
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_cyborg_station)
-"mY" = (
+"na" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -6364,13 +6587,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mZ" = (
+"nb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"na" = (
+"nc" = (
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
 	locked_frequency = 1343;
@@ -6389,7 +6612,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nb" = (
+"nd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/motion{
 	c_tag = "AI Core - Upload Room";
@@ -6403,7 +6626,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nc" = (
+"ne" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -6413,7 +6636,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nd" = (
+"nf" = (
 /obj/machinery/hologram/holopad,
 /obj/item/weapon/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6427,7 +6650,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ne" = (
+"ng" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;
@@ -6455,7 +6678,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nf" = (
+"nh" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "door_locked";
@@ -6474,7 +6697,7 @@
 	temperature = 273.15
 	},
 /area/turret_protected/ai)
-"ng" = (
+"ni" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "ai_core_airlock";
@@ -6516,7 +6739,7 @@
 	temperature = 273.15
 	},
 /area/turret_protected/ai)
-"nh" = (
+"nj" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "door_locked";
@@ -6550,7 +6773,7 @@
 	temperature = 273.15
 	},
 /area/turret_protected/ai)
-"ni" = (
+"nk" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -6587,7 +6810,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nj" = (
+"nl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
 	icon_state = "map"
@@ -6606,7 +6829,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nk" = (
+"nm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -6618,7 +6841,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nl" = (
+"nn" = (
 /obj/machinery/flasher{
 	id = "AI";
 	pixel_x = 22;
@@ -6642,7 +6865,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nm" = (
+"no" = (
 /obj/item/device/radio/intercom{
 	listening = 0;
 	name = "Custom Channel";
@@ -6657,7 +6880,7 @@
 	pixel_y = -26
 	},
 /obj/item/device/radio/intercom{
-	broadcasting = 1;
+	broadcasting = 0;
 	listening = 1;
 	name = "Common Channel";
 	pixel_x = 27;
@@ -6694,7 +6917,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nn" = (
+"np" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 8;
@@ -6707,7 +6930,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"no" = (
+"nq" = (
 /obj/effect/decal/warning_stripes,
 /obj/machinery/light/small{
 	dir = 8
@@ -6732,7 +6955,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"np" = (
+"nr" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI SMES";
 	req_access = list(16)
@@ -6757,7 +6980,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nq" = (
+"ns" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -6770,7 +6993,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nr" = (
+"nt" = (
 /obj/effect/decal/warning_stripes,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6787,7 +7010,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ns" = (
+"nu" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - SMES Room 1";
 	dir = 8
@@ -6820,7 +7043,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nt" = (
+"nv" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -6828,7 +7051,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"nu" = (
+"nw" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -6836,13 +7059,13 @@
 	},
 /turf/simulated/wall,
 /area/turret_protected/ai)
-"nv" = (
+"nx" = (
 /turf/simulated/wall/r_wall,
 /area/security/nuke_storage)
-"nw" = (
+"ny" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"nx" = (
+"nz" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Cyborg Station";
 	req_access = list(16)
@@ -6855,7 +7078,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ny" = (
+"nA" = (
 /obj/machinery/door/window/northleft{
 	req_access = list(16)
 	},
@@ -6872,14 +7095,14 @@
 	dir = 1
 	},
 /area/turret_protected/ai_upload_foyer)
-"nz" = (
+"nB" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nA" = (
+"nC" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -6887,7 +7110,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nB" = (
+"nD" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload";
 	req_access = list(16)
@@ -6901,7 +7124,7 @@
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nC" = (
+"nE" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6912,7 +7135,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nD" = (
+"nF" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6924,7 +7147,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nE" = (
+"nG" = (
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
@@ -6943,7 +7166,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"nF" = (
+"nH" = (
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
@@ -6959,7 +7182,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"nG" = (
+"nI" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6988,7 +7211,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"nH" = (
+"nJ" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -7004,7 +7227,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nI" = (
+"nK" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 8;
@@ -7016,14 +7239,14 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nJ" = (
+"nL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nK" = (
+"nM" = (
 /obj/machinery/power/apc/super/critical{
 	dir = 4;
 	name = "east bump";
@@ -7049,7 +7272,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nL" = (
+"nN" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -7062,7 +7285,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"nM" = (
+"nO" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 8;
@@ -7070,7 +7293,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"nN" = (
+"nP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7082,7 +7305,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nO" = (
+"nQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7093,7 +7316,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nP" = (
+"nR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -7108,7 +7331,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nQ" = (
+"nS" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -7116,17 +7339,17 @@
 	},
 /turf/simulated/wall,
 /area/turret_protected/ai)
-"nR" = (
+"nT" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Command - Vault Sublevel Elevator Access";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"nS" = (
+"nU" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_server_room)
-"nT" = (
+"nV" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -7134,7 +7357,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nU" = (
+"nW" = (
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
 	locked_frequency = 1343;
@@ -7147,14 +7370,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nV" = (
+"nX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nW" = (
+"nY" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -7163,7 +7386,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nX" = (
+"nZ" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -7177,7 +7400,7 @@
 	dir = 1
 	},
 /area/turret_protected/ai_upload_foyer)
-"nY" = (
+"oa" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -7187,7 +7410,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nZ" = (
+"ob" = (
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
@@ -7196,7 +7419,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oa" = (
+"oc" = (
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/structure/table/rack,
@@ -7207,7 +7430,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ob" = (
+"od" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -7231,7 +7454,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"oc" = (
+"oe" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -7247,7 +7470,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"od" = (
+"of" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -7261,7 +7484,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oe" = (
+"og" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -7280,7 +7503,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"of" = (
+"oh" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 8;
@@ -7294,7 +7517,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"og" = (
+"oi" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	frequency = 1343;
@@ -7325,7 +7548,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oh" = (
+"oj" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI SMES";
 	req_access = list(16)
@@ -7336,14 +7559,14 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oi" = (
+"ok" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 1
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"oj" = (
+"ol" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 1
@@ -7353,14 +7576,14 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"ok" = (
+"om" = (
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"ol" = (
+"on" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -7369,18 +7592,18 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"om" = (
+"oo" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"on" = (
+"op" = (
 /obj/machinery/computer/message_monitor,
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_server_room)
-"oo" = (
+"oq" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -7401,7 +7624,7 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_server_room)
-"op" = (
+"or" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -7409,15 +7632,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oq" = (
+"os" = (
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"or" = (
+"ot" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"os" = (
+"ou" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -7428,7 +7651,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ot" = (
+"ov" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -7443,12 +7666,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ou" = (
+"ow" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ov" = (
+"ox" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -7459,7 +7682,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ow" = (
+"oy" = (
 /obj/structure/table/standard,
 /obj/item/weapon/aiModule/freeform,
 /obj/item/weapon/aiModule/protectStation,
@@ -7473,7 +7696,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ox" = (
+"oz" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark{
@@ -7481,7 +7704,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oy" = (
+"oA" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -7502,7 +7725,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"oz" = (
+"oB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
 	icon_state = "intact"
@@ -7512,7 +7735,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oA" = (
+"oC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -7521,7 +7744,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oB" = (
+"oD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -7534,7 +7757,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oC" = (
+"oE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -7546,7 +7769,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oD" = (
+"oF" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -7561,7 +7784,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oE" = (
+"oG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -7573,7 +7796,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oF" = (
+"oH" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - Beta Core 1"
 	},
@@ -7591,7 +7814,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oG" = (
+"oI" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI SMES";
 	req_access = list(16)
@@ -7615,7 +7838,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oH" = (
+"oJ" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -7630,7 +7853,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oI" = (
+"oK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
 	icon_state = "intact"
@@ -7643,7 +7866,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oJ" = (
+"oL" = (
 /obj/structure/cable{
 	icon_state = "12-0"
 	},
@@ -7658,7 +7881,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"oK" = (
+"oM" = (
 /obj/effect/decal/warning_stripes,
 /obj/structure/ladder/up{
 	pixel_y = 16
@@ -7667,13 +7890,13 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"oL" = (
+"oN" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"oM" = (
+"oO" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -7687,7 +7910,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_server_room)
-"oN" = (
+"oP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7703,7 +7926,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_server_room)
-"oO" = (
+"oQ" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Messaging Server";
 	req_access = list(16)
@@ -7722,7 +7945,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oP" = (
+"oR" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -7746,7 +7969,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oQ" = (
+"oS" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -7760,7 +7983,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oR" = (
+"oT" = (
 /obj/machinery/porta_turret,
 /obj/effect/decal/warning_stripes,
 /obj/structure/cable/cyan{
@@ -7772,7 +7995,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oS" = (
+"oU" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
 	req_access = list(16)
@@ -7791,7 +8014,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oT" = (
+"oV" = (
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
 	locked_frequency = 1343;
@@ -7815,7 +8038,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oU" = (
+"oW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -7830,13 +8053,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oV" = (
+"oX" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oW" = (
+"oY" = (
 /obj/machinery/computer/borgupload,
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
@@ -7850,7 +8073,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oX" = (
+"oZ" = (
 /obj/machinery/computer/robotics,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark{
@@ -7858,7 +8081,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oY" = (
+"pa" = (
 /obj/machinery/alarm/cold{
 	dir = 1;
 	pixel_y = -22
@@ -7871,7 +8094,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oZ" = (
+"pb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -7880,7 +8103,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"pa" = (
+"pc" = (
 /obj/machinery/door/window/northright,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -7891,7 +8114,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"pb" = (
+"pd" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -7904,14 +8127,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pc" = (
+"pe" = (
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pd" = (
+"pf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
@@ -7928,7 +8151,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pe" = (
+"pg" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 9
@@ -7937,7 +8160,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pf" = (
+"ph" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 5
@@ -7946,7 +8169,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pg" = (
+"pi" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 1
@@ -7955,13 +8178,13 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"ph" = (
+"pj" = (
 /obj/item/weapon/hand_tele,
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"pi" = (
+"pk" = (
 /obj/item/weapon/aiModule/freeformcore{
 	pixel_x = -4;
 	pixel_y = -8
@@ -7975,29 +8198,29 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"pj" = (
+"pl" = (
 /obj/item/weapon/rig/hazmat,
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"pk" = (
+"pm" = (
 /obj/item/rig_module/device/rcd,
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"pl" = (
+"pn" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"pm" = (
+"po" = (
 /obj/machinery/message_server,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_server_room)
-"pn" = (
+"pp" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - Messaging Server";
 	dir = 1
@@ -8008,16 +8231,16 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_server_room)
-"po" = (
+"pq" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"pp" = (
+"pr" = (
 /turf/simulated/wall/r_wall,
 /area/tcommsat/mainlvl_tcomms__relay)
-"pq" = (
+"ps" = (
 /obj/structure/plasticflaps/airtight,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8033,7 +8256,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/mainlvl_tcomms__relay)
-"pr" = (
+"pt" = (
 /obj/machinery/door/window{
 	base_state = "left";
 	dir = 1;
@@ -8050,7 +8273,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ps" = (
+"pu" = (
 /obj/machinery/door/window{
 	base_state = "left";
 	dir = 1;
@@ -8067,7 +8290,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"pt" = (
+"pv" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -8077,7 +8300,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"pu" = (
+"pw" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8088,7 +8311,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"pv" = (
+"px" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -8102,7 +8325,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"pw" = (
+"py" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Supermatter Cooling Access";
 	req_access = list(11)
@@ -8117,7 +8340,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"px" = (
+"pz" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -8137,7 +8360,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"py" = (
+"pA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8151,7 +8374,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pz" = (
+"pB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8169,7 +8392,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pA" = (
+"pC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8187,7 +8410,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pB" = (
+"pD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8204,7 +8427,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pC" = (
+"pE" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -8236,7 +8459,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pD" = (
+"pF" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8261,7 +8484,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pE" = (
+"pG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8288,7 +8511,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pF" = (
+"pH" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -8305,7 +8528,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pG" = (
+"pI" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
 	icon_state = "door_locked";
@@ -8326,7 +8549,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pH" = (
+"pJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8342,7 +8565,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pI" = (
+"pK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8362,7 +8585,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pJ" = (
+"pL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8382,7 +8605,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pK" = (
+"pM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -8398,7 +8621,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pL" = (
+"pN" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 4
@@ -8407,7 +8630,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pM" = (
+"pO" = (
 /obj/structure/closet/secure_closet/freezer/money,
 /obj/item/weapon/storage/belt/champion,
 /obj/item/stack/material/gold,
@@ -8421,7 +8644,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"pN" = (
+"pP" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 9
@@ -8435,18 +8658,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"pO" = (
+"pQ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"pP" = (
+"pR" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/cable/cyan,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"pQ" = (
+"pS" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - Lobby";
 	dir = 1
@@ -8457,20 +8680,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"pR" = (
+"pT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"pS" = (
+"pU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"pT" = (
+"pV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -8484,7 +8707,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"pU" = (
+"pW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -8502,7 +8725,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"pV" = (
+"pX" = (
 /obj/machinery/alarm/cold{
 	dir = 8;
 	icon_state = "alarm0";
@@ -8517,7 +8740,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"pW" = (
+"pY" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -8525,7 +8748,7 @@
 	},
 /turf/simulated/wall,
 /area/mine/unexplored)
-"pX" = (
+"pZ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -8533,19 +8756,19 @@
 	},
 /turf/simulated/wall,
 /area/mine/unexplored)
-"pY" = (
+"qa" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/black,
 /turf/simulated/floor/plating{
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"pZ" = (
+"qb" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/green,
 /turf/simulated/floor/plating{
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"qa" = (
+"qc" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -8556,21 +8779,24 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"qb" = (
+"qd" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"qc" = (
+"qe" = (
+/turf/simulated/wall,
+/area/maintenance/sublevel)
+"qf" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"qd" = (
+"qg" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1379;
@@ -8583,7 +8809,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"qe" = (
+"qh" = (
 /obj/machinery/camera/network/engineering_outpost{
 	c_tag = "Engineering Sublevel - Cavern Entrance";
 	dir = 4;
@@ -8604,7 +8830,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/sublevel)
-"qf" = (
+"qi" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 6
@@ -8613,7 +8839,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"qg" = (
+"qj" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 10
@@ -8622,7 +8848,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"qh" = (
+"qk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -8636,26 +8862,26 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"qi" = (
+"ql" = (
 /obj/effect/decal/warning_stripes,
 /obj/machinery/nuclearbomb/station,
 /turf/simulated/floor/reinforced,
 /area/security/nuke_storage)
-"qj" = (
+"qm" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qk" = (
+"qn" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"ql" = (
+"qo" = (
 /obj/machinery/porta_turret/stationary,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qm" = (
+"qp" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -8663,7 +8889,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qn" = (
+"qq" = (
 /obj/machinery/door/airlock/vault/bolted{
 	req_access = list(20)
 	},
@@ -8674,7 +8900,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qo" = (
+"qr" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8695,7 +8921,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qp" = (
+"qs" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -8703,7 +8929,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qq" = (
+"qt" = (
 /obj/machinery/light/small/emergency,
 /obj/structure/sign/securearea{
 	pixel_y = -32
@@ -8715,7 +8941,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qr" = (
+"qu" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
 	req_access = list(16)
@@ -8725,7 +8951,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"qs" = (
+"qv" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Command - Telecomms Main Level Relay";
 	dir = 1
@@ -8744,7 +8970,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"qt" = (
+"qw" = (
 /obj/machinery/telecomms/relay/preset/station,
 /obj/structure/sign/nosmoking_1{
 	pixel_x = 0;
@@ -8755,7 +8981,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"qu" = (
+"qx" = (
 /obj/item/device/radio/intercom{
 	pixel_y = -26
 	},
@@ -8764,7 +8990,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"qv" = (
+"qy" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8772,13 +8998,13 @@
 	},
 /turf/simulated/wall,
 /area/mine/unexplored)
-"qw" = (
+"qz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor/plating{
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"qx" = (
+"qA" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -8789,7 +9015,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"qy" = (
+"qB" = (
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
 	dir = 4
@@ -8803,13 +9029,13 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"qz" = (
+"qC" = (
 /obj/effect/landmark{
 	name = "carpspawn"
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"qA" = (
+"qD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -8822,7 +9048,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"qB" = (
+"qE" = (
 /obj/structure/safe/station,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -8832,7 +9058,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"qC" = (
+"qF" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 10
@@ -8846,11 +9072,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qD" = (
+"qG" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qE" = (
+"qH" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -8859,7 +9085,7 @@
 /obj/structure/cable,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qF" = (
+"qI" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -8876,7 +9102,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"qG" = (
+"qJ" = (
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
 	locked_frequency = 1343;
@@ -8898,14 +9124,14 @@
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"qH" = (
+"qK" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/zpipe/down/black{
 	dir = 1
 	},
 /turf/simulated/open,
 /area/maintenance/sublevel)
-"qI" = (
+"qL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "11-1"
@@ -8915,11 +9141,19 @@
 	},
 /turf/simulated/open,
 /area/maintenance/sublevel)
-"qJ" = (
+"qM" = (
 /obj/structure/ladder,
 /turf/simulated/open,
 /area/maintenance/sublevel)
-"qL" = (
+"qN" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/rig_module/vision/nvg,
+/turf/simulated/floor/plating,
+/area/security/nuke_storage)
+"qO" = (
 /obj/item/rig_module/mounted/egun{
 	pixel_x = 4;
 	pixel_y = 4
@@ -8934,7 +9168,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"qM" = (
+"qP" = (
 /obj/item/weapon/rig/hazard{
 	pixel_x = -8;
 	pixel_y = 0
@@ -8952,7 +9186,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"qO" = (
+"qQ" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/rig_module/chem_dispenser/injector,
+/turf/simulated/floor/plating,
+/area/security/nuke_storage)
+"qR" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -8963,7 +9205,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qP" = (
+"qS" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -8971,14 +9213,14 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"qQ" = (
+"qT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"qR" = (
+"qU" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -8988,7 +9230,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"qS" = (
+"qV" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -8996,20 +9238,20 @@
 	},
 /turf/simulated/wall,
 /area/mine/unexplored)
-"qT" = (
+"qW" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/turret_protected/ai_upload_foyer)
-"qU" = (
+"qX" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"qV" = (
+"qY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9020,19 +9262,19 @@
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"qW" = (
+"qZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"qX" = (
+"ra" = (
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"qY" = (
+"rb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -9045,7 +9287,7 @@
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"qZ" = (
+"rc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9056,7 +9298,7 @@
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"ra" = (
+"rd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9068,7 +9310,7 @@
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"rb" = (
+"re" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9079,7 +9321,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rc" = (
+"rf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -9090,7 +9332,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rd" = (
+"rg" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -9102,19 +9344,19 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"re" = (
+"rh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rf" = (
+"ri" = (
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/ai_sub)
-"rg" = (
+"rj" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -9123,10 +9365,10 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"rh" = (
+"rk" = (
 /turf/simulated/wall/r_wall,
 /area/bridge/aibunker)
-"ri" = (
+"rl" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9134,10 +9376,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/bridge/aibunker)
-"rj" = (
+"rm" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/analysis)
-"rk" = (
+"rn" = (
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/structure/table/standard,
 /obj/machinery/light_switch{
@@ -9145,21 +9387,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rl" = (
+"ro" = (
 /obj/structure/reagent_dispensers/coolanttank,
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rm" = (
+"rp" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rn" = (
+"rq" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9174,22 +9416,25 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"ro" = (
+"rr" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rp" = (
+"rs" = (
+/turf/simulated/wall,
+/area/bridge/aibunker)
+"rt" = (
 /obj/item/modular_computer/console/preset/security,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rq" = (
+"ru" = (
 /obj/item/modular_computer/console/preset/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rr" = (
+"rv" = (
 /obj/structure/bed/chair,
 /obj/machinery/computer/security/telescreen{
 	name = "Access Monitor";
@@ -9200,7 +9445,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rs" = (
+"rw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/airlock{
 	id = "bunker1";
@@ -9213,10 +9458,10 @@
 /obj/item/bodybag,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rt" = (
+"rx" = (
 /turf/simulated/wall,
 /area/mine/unexplored)
-"ru" = (
+"ry" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -9229,12 +9474,12 @@
 	dir = 5
 	},
 /area/outpost/research/analysis)
-"rv" = (
+"rz" = (
 /obj/item/weapon/stool/padded,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rw" = (
+"rA" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
@@ -9245,13 +9490,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rx" = (
+"rB" = (
 /obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/ai_sub)
-"ry" = (
+"rC" = (
 /obj/structure/closet/crate{
 	name = "Emergency Fuel"
 	},
@@ -9263,7 +9508,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rz" = (
+"rD" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -9274,7 +9519,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rA" = (
+"rE" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -9296,7 +9541,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rB" = (
+"rF" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -9308,14 +9553,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rC" = (
+"rG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rD" = (
+"rH" = (
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rE" = (
+"rI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
@@ -9331,22 +9576,22 @@
 /obj/item/device/radio,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rF" = (
+"rJ" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"rG" = (
+"rK" = (
 /obj/machinery/radiocarbon_spectrometer,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/outpost/research/analysis)
-"rH" = (
+"rL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rI" = (
+"rM" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -9365,13 +9610,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rJ" = (
+"rN" = (
 /obj/turbolift_map_holder/aurora/aiaccess,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/ai_sub)
-"rK" = (
+"rO" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access = list(56)
 	},
@@ -9386,7 +9631,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rL" = (
+"rP" = (
 /obj/machinery/newscaster{
 	pixel_x = -32;
 	pixel_y = 0
@@ -9395,18 +9640,18 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rM" = (
+"rQ" = (
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rN" = (
+"rR" = (
 /obj/item/modular_computer/console/preset/medical,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rO" = (
+"rS" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/anomaly_analysis)
-"rP" = (
+"rT" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -9414,7 +9659,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rQ" = (
+"rU" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
@@ -9431,7 +9676,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rR" = (
+"rV" = (
 /obj/structure/table/rack{
 	dir = 1
 	},
@@ -9443,20 +9688,20 @@
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rS" = (
+"rW" = (
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rT" = (
+"rX" = (
 /obj/effect/decal/warning_stripes,
 /obj/structure/ladder/up{
 	pixel_y = 16
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rU" = (
+"rY" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -9474,7 +9719,63 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rY" = (
+"rZ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	desc = "It opens and closes. It has a small sign engraved: Bunker capacity: 6. Only facility's Command Staff is permitted.";
+	icon_state = "door_locked";
+	id_tag = "bunker3";
+	locked = 1;
+	name = "Command Bunker";
+	req_access = list(19);
+	secured_wires = 1
+	},
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/bridge/aibunker)
+"sa" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/item/device/radio/intercom/locked{
+	frequency = 1347;
+	locked_frequency = 1347;
+	name = "Bunker Entrance Intercom";
+	pixel_x = 0;
+	pixel_y = 22
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"sb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"sc" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -9487,7 +9788,31 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sb" = (
+"sd" = (
+/obj/machinery/door/airlock/highsecurity{
+	id_tag = null;
+	name = "Auxiliary Commanding Post";
+	req_access = list(19)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"se" = (
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"sf" = (
 /obj/machinery/firealarm/south,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -9495,7 +9820,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sc" = (
+"sg" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
@@ -9504,15 +9829,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sd" = (
+"sh" = (
 /obj/item/modular_computer/console/preset/command,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"se" = (
+"si" = (
 /obj/structure/closet,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"sf" = (
+"sj" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9535,17 +9860,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/anomaly_analysis)
-"sg" = (
+"sk" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sh" = (
+"sl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"si" = (
+"sm" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/bio_suit/anomaly,
 /obj/item/clothing/head/bio_hood/anomaly,
@@ -9561,12 +9886,15 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"sj" = (
+"sn" = (
+/turf/simulated/wall,
+/area/outpost/research/anomaly_analysis)
+"so" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/mauve,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sk" = (
+"sp" = (
 /obj/machinery/alarm{
 	dir = 2;
 	pixel_y = 25
@@ -9580,7 +9908,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sl" = (
+"sq" = (
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -9597,7 +9925,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sm" = (
+"sr" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 0;
 	pixel_y = 32
@@ -9608,7 +9936,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sn" = (
+"ss" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 4
@@ -9618,7 +9946,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"so" = (
+"st" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "anolaser"
@@ -9628,7 +9956,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"sp" = (
+"su" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -9637,7 +9965,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"sq" = (
+"sv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 1
@@ -9655,7 +9983,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"sr" = (
+"sw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -9672,7 +10000,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"ss" = (
+"sx" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 1
@@ -9687,7 +10015,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"st" = (
+"sy" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 5
@@ -9703,11 +10031,11 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"su" = (
+"sz" = (
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/turret_protected/ai_upload_foyer)
-"sv" = (
+"sA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -9719,7 +10047,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"sw" = (
+"sB" = (
 /obj/machinery/light/small/emergency,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9731,7 +10059,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"sx" = (
+"sC" = (
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "bunker1";
 	name = "Command Bunker Access";
@@ -9746,7 +10074,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sy" = (
+"sD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9755,7 +10083,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sz" = (
+"sE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -9768,7 +10096,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sA" = (
+"sF" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9787,7 +10115,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"sB" = (
+"sG" = (
 /obj/machinery/button/remote/airlock{
 	id = "bunker3";
 	name = "Bunker Inner Airlock Bolt Control";
@@ -9797,35 +10125,35 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sC" = (
+"sH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/vending/wallmed2{
 	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sD" = (
+"sI" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"sE" = (
+"sJ" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"sF" = (
+"sK" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"sG" = (
+"sL" = (
 /obj/structure/table/rack,
 /obj/item/weapon/ladder_mobile,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"sH" = (
+"sM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9845,17 +10173,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/anomaly_analysis)
-"sI" = (
+"sN" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sJ" = (
+"sO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sK" = (
+"sP" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/bio_suit/anomaly,
 /obj/item/clothing/head/bio_hood/anomaly,
@@ -9874,7 +10202,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"sL" = (
+"sQ" = (
 /obj/item/device/radio/intercom{
 	frequency = 1459;
 	name = "Station Intercom (General)";
@@ -9887,13 +10215,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sM" = (
+"sR" = (
 /obj/structure/table/standard,
 /obj/item/weapon/flame/lighter/random,
 /obj/item/weapon/crowbar,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sN" = (
+"sS" = (
 /obj/machinery/artifact_analyser,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9902,17 +10230,17 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/anomaly_analysis)
-"sO" = (
+"sT" = (
 /obj/machinery/artifact_scanpad,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/anomaly_analysis)
-"sP" = (
+"sU" = (
 /obj/machinery/conveyor_switch{
 	id = "anolaser"
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sQ" = (
+"sV" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "anolaser"
@@ -9923,7 +10251,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"sR" = (
+"sW" = (
+/turf/simulated/wall,
+/area/outpost/research/analysis)
+"sX" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
@@ -9941,10 +10272,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"sS" = (
+"sY" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/emergency_storage)
-"sT" = (
+"sZ" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 8
@@ -9953,7 +10284,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"sU" = (
+"ta" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -9975,7 +10306,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"sV" = (
+"tb" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -10001,7 +10332,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"sW" = (
+"tc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10017,7 +10348,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"sX" = (
+"td" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10038,7 +10369,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"sY" = (
+"te" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -10058,7 +10389,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"sZ" = (
+"tf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10081,7 +10412,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"ta" = (
+"tg" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10103,7 +10434,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tb" = (
+"th" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -10121,14 +10452,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tc" = (
+"ti" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"td" = (
+"tj" = (
 /obj/structure/table/rack{
 	dir = 1
 	},
@@ -10138,7 +10469,7 @@
 /obj/item/clothing/head/helmet/space/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"te" = (
+"tk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera/network/command{
@@ -10156,7 +10487,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tf" = (
+"tl" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10180,7 +10511,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"tg" = (
+"tm" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -26;
 	pixel_y = 0
@@ -10191,14 +10522,14 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"th" = (
+"tn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"ti" = (
+"to" = (
 /obj/structure/closet,
 /obj/item/weapon/reagent_containers/food/snacks/liquidfood,
 /obj/item/weapon/reagent_containers/food/snacks/liquidfood,
@@ -10213,11 +10544,16 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tj" = (
+"tp" = (
+/obj/structure/table/rack,
+/obj/item/hoist_kit,
+/turf/simulated/floor/asteroid/ash/rocky,
+/area/mine/unexplored)
+"tq" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tk" = (
+"tr" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/bio_suit/anomaly,
 /obj/item/clothing/head/bio_hood/anomaly,
@@ -10234,7 +10570,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"tl" = (
+"ts" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -10249,11 +10585,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tm" = (
+"tt" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tn" = (
+"tu" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/dropper{
 	pixel_y = -4
@@ -10265,10 +10601,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"to" = (
+"tv" = (
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tp" = (
+"tw" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
 	dir = 4;
@@ -10285,7 +10621,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tq" = (
+"tx" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "anolaser"
@@ -10301,7 +10637,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"tr" = (
+"ty" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -10316,7 +10652,7 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"ts" = (
+"tz" = (
 /obj/machinery/door/window/westleft{
 	dir = 4;
 	name = "Monkey Pen";
@@ -10339,7 +10675,7 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"tt" = (
+"tA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -10357,7 +10693,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"tu" = (
+"tB" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Corridor Camera 6"
 	},
@@ -10368,7 +10704,7 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"tv" = (
+"tC" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
 	dir = 1
@@ -10376,17 +10712,20 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"tw" = (
+"tD" = (
+/turf/simulated/wall,
+/area/outpost/research/emergency_storage)
+"tE" = (
 /obj/machinery/power/emitter{
 	anchored = 0
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"tx" = (
+"tF" = (
 /obj/machinery/suspension_gen,
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"ty" = (
+"tG" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/gloves{
 	pixel_x = 4;
@@ -10402,7 +10741,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"tz" = (
+"tH" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/structure/cable{
 	d1 = 1;
@@ -10414,7 +10753,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"tA" = (
+"tI" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
 	icon_state = "door_locked";
@@ -10424,7 +10763,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tB" = (
+"tJ" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "sl3s";
 	pixel_y = -26
@@ -10436,13 +10775,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tC" = (
+"tK" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tD" = (
+"tL" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -10455,7 +10794,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tE" = (
+"tM" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10471,7 +10810,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tF" = (
+"tN" = (
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -10479,7 +10818,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tG" = (
+"tO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -10489,7 +10828,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tH" = (
+"tP" = (
 /obj/machinery/door/airlock/hatch{
 	desc = "It opens and closes. It has a small sign engraved: Bunker capacity: 6. Only facility's Command Staff is permitted.";
 	icon_state = "door_closed";
@@ -10508,7 +10847,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"tI" = (
+"tQ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -10524,7 +10863,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"tJ" = (
+"tR" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
@@ -10533,14 +10872,14 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tK" = (
+"tS" = (
 /obj/effect/decal/cleanable/cobweb2{
 	icon_state = "spiderling";
 	name = "dead spider"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tL" = (
+"tT" = (
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
@@ -10550,22 +10889,22 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tM" = (
+"tU" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"tN" = (
+"tV" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"tO" = (
+"tW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tP" = (
+"tX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10575,7 +10914,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tQ" = (
+"tY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10585,14 +10924,10 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tR" = (
+"tZ" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
-	},
-/obj/machinery/door/airlock/research{
-	name = "Anomalous Materials";
-	req_access = list(65)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10600,9 +10935,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/airlock/research{
+	name = "Anomalous Materials Locker Room";
+	req_access = list(65)
+	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tS" = (
+"ua" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -10620,7 +10959,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tT" = (
+"ub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10635,7 +10974,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tU" = (
+"uc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -10655,7 +10994,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tV" = (
+"ud" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -10667,7 +11006,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tW" = (
+"ue" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -10679,14 +11018,31 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tX" = (
+"uf" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tZ" = (
+"ug" = (
+/obj/machinery/door/firedoor{
+	dir = 4;
+	name = "Firelock"
+	},
+/obj/machinery/door/airlock/research{
+	name = "Anomalous Materials";
+	req_access = list(65)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/outpost/research/anomaly_analysis)
+"uh" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -10698,7 +11054,7 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"ua" = (
+"ui" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -10714,7 +11070,7 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"ub" = (
+"uj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 1
@@ -10736,7 +11092,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uc" = (
+"uk" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -10744,7 +11100,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"ud" = (
+"ul" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -10756,7 +11112,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"ue" = (
+"um" = (
 /obj/machinery/door/airlock/research{
 	name = "Supply Closet";
 	req_access = list(65)
@@ -10769,7 +11125,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/emergency_storage)
-"uf" = (
+"un" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -10777,10 +11133,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"ug" = (
+"uo" = (
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"uh" = (
+"up" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/lights/bulbs{
 	pixel_x = 5;
@@ -10796,7 +11152,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"ui" = (
+"uq" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10807,7 +11163,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"uj" = (
+"ur" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -10828,7 +11184,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uk" = (
+"us" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10843,7 +11199,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"ul" = (
+"ut" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10858,7 +11214,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"um" = (
+"uu" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10874,7 +11230,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"un" = (
+"uv" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -10888,7 +11244,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uo" = (
+"uw" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10905,14 +11261,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"up" = (
+"ux" = (
 /obj/machinery/computer/cryopod{
 	pixel_x = 32;
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"uq" = (
+"uy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -10933,7 +11289,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/anomaly_analysis)
-"ur" = (
+"uz" = (
 /obj/structure/closet/secure_closet/xenoarchaeologist{
 	req_access = list(47)
 	},
@@ -10942,14 +11298,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"ut" = (
+"uA" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"uu" = (
+"uB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -10959,11 +11315,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uv" = (
+"uC" = (
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uw" = (
+"uD" = (
 /obj/structure/table/rack,
 /obj/item/clothing/head/welding,
 /obj/item/weapon/weldingtool,
@@ -10973,7 +11329,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"ux" = (
+"uE" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
 /obj/item/weapon/screwdriver{
@@ -10982,19 +11338,19 @@
 /obj/item/weapon/melee/baton/loaded,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uy" = (
+"uF" = (
 /obj/machinery/light/small,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uz" = (
+"uG" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Anomalous Materials Lab";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uA" = (
+"uH" = (
 /obj/machinery/door/window/westleft{
 	dir = 2;
 	name = "Monkey Pen";
@@ -11015,7 +11371,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uB" = (
+"uI" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -11033,7 +11389,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uC" = (
+"uJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 1
@@ -11050,17 +11406,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uD" = (
+"uK" = (
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uE" = (
+"uL" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uF" = (
+"uM" = (
 /obj/structure/closet/hydrant{
 	pixel_x = -32
 	},
@@ -11072,7 +11428,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"uG" = (
+"uN" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/item/weapon/storage/box/monkeycubes,
@@ -11080,18 +11436,18 @@
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"uH" = (
+"uO" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uI" = (
+"uP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uJ" = (
+"uQ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -11102,7 +11458,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uK" = (
+"uR" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -11115,16 +11471,30 @@
 	icon_state = "plating"
 	},
 /area/maintenance/sublevel)
-"uN" = (
+"uS" = (
+/obj/structure/table/reinforced/steel,
+/obj/machinery/cell_charger,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"uT" = (
+/obj/structure/table/reinforced/steel,
+/obj/item/weapon/storage/firstaid/regular,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"uU" = (
 /obj/machinery/cryopod,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"uO" = (
+"uV" = (
 /obj/structure/cryofeed,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"uP" = (
+"uW" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
@@ -11142,7 +11512,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uQ" = (
+"uX" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
@@ -11153,7 +11523,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uR" = (
+"uY" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -11168,7 +11538,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uS" = (
+"uZ" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 5
@@ -11179,7 +11549,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uT" = (
+"va" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 1
@@ -11196,7 +11566,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uU" = (
+"vb" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -11207,13 +11577,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uV" = (
+"vc" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/anomaly_storage)
-"uW" = (
+"vd" = (
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
-"uX" = (
+"ve" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Medbay Substation";
 	req_one_access = list(11,24)
@@ -11221,7 +11591,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uY" = (
+"vf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance{
@@ -11229,7 +11599,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uZ" = (
+"vg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11252,28 +11622,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/hallway)
-"va" = (
+"vh" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vb" = (
+"vi" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vc" = (
+"vj" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vd" = (
+"vk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -11287,7 +11657,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"ve" = (
+"vl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
@@ -11298,7 +11668,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vf" = (
+"vm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 1
@@ -11315,7 +11685,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vg" = (
+"vn" = (
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -11331,31 +11701,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_storage)
-"vh" = (
+"vo" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"vi" = (
+"vp" = (
 /obj/machinery/artifact_scanpad,
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/anomaly_storage)
-"vj" = (
+"vq" = (
 /obj/machinery/artifact_harvester,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/anomaly_storage)
-"vk" = (
+"vr" = (
 /obj/structure/crematorium{
 	id = "patientmurder"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"vl" = (
+"vs" = (
 /obj/machinery/button/crematorium{
 	id = "patientmurder";
 	pixel_x = -4;
@@ -11368,13 +11738,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"vm" = (
+"vt" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "\[F.4] Medical Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vn" = (
+"vu" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - \[F.4] Medical"
 	},
@@ -11388,7 +11758,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vo" = (
+"vv" = (
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
@@ -11404,24 +11774,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vp" = (
+"vw" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"vq" = (
+"vx" = (
 /obj/structure/table/rack,
 /obj/item/weapon/pickaxe,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"vr" = (
+"vy" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/steel{
 	amount = 10
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"vs" = (
+"vz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11441,14 +11811,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/hallway)
-"vt" = (
+"vA" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vu" = (
+"vB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -11462,7 +11832,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vv" = (
+"vC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -11476,7 +11846,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vw" = (
+"vD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
@@ -11491,7 +11861,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vx" = (
+"vE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -11503,7 +11873,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vy" = (
+"vF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -11522,7 +11892,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vz" = (
+"vG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -11536,7 +11906,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vA" = (
+"vH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -11550,7 +11920,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vB" = (
+"vI" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -11569,7 +11939,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vC" = (
+"vJ" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -11584,7 +11954,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vD" = (
+"vK" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
@@ -11603,7 +11973,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_storage)
-"vE" = (
+"vL" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -11617,17 +11987,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_storage)
-"vF" = (
+"vM" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	icon_state = "map";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"vG" = (
+"vN" = (
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"vH" = (
+"vO" = (
 /obj/item/weapon/anodevice{
 	pixel_x = 3;
 	pixel_y = 3
@@ -11636,10 +12006,10 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"vI" = (
+"vP" = (
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"vJ" = (
+"vQ" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 1
@@ -11653,7 +12023,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"vK" = (
+"vR" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 5
@@ -11667,7 +12037,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"vL" = (
+"vS" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11677,7 +12047,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"vM" = (
+"vT" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11697,7 +12067,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vN" = (
+"vU" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -11710,7 +12080,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vO" = (
+"vV" = (
 /obj/machinery/power/terminal{
 	icon_state = "term";
 	dir = 1
@@ -11722,7 +12092,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vP" = (
+"vW" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -11730,14 +12100,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vQ" = (
+"vX" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vR" = (
+"vY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -11747,25 +12117,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vS" = (
+"vZ" = (
 /obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vT" = (
+"wa" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vU" = (
+"wb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vV" = (
+"wc" = (
 /obj/machinery/light,
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Corridor Camera 5";
@@ -11777,7 +12147,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vW" = (
+"wd" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -11789,7 +12159,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vX" = (
+"we" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/mauve{
@@ -11798,7 +12168,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vY" = (
+"wf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -11808,7 +12178,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vZ" = (
+"wg" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
 	dir = 4
@@ -11819,7 +12189,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"wa" = (
+"wh" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
@@ -11832,11 +12202,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_storage)
-"wb" = (
+"wi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"wc" = (
+"wj" = (
 /obj/item/weapon/anobattery{
 	pixel_x = -6;
 	pixel_y = 2
@@ -11859,19 +12229,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"wd" = (
+"wk" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"we" = (
+"wl" = (
 /obj/effect/decal/cleanable/blood,
 /obj/random/junk,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"wf" = (
+"wm" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -11888,32 +12258,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wg" = (
+"wn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wh" = (
+"wo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wi" = (
+"wp" = (
 /obj/structure/morgue{
 	icon_state = "morgue1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wj" = (
+"wq" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/airless{
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"wk" = (
+"wr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
 	name = "Medbay Substation";
@@ -11926,7 +12296,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"wl" = (
+"ws" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(19)
 	},
@@ -11943,17 +12313,17 @@
 	icon_state = "plating"
 	},
 /area/maintenance/sublevel)
-"wm" = (
+"wt" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"wn" = (
+"wu" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/isolation_monitoring)
-"wo" = (
+"wv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -11968,7 +12338,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_monitoring)
-"wp" = (
+"ww" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -11983,7 +12353,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_monitoring)
-"wq" = (
+"wx" = (
 /obj/machinery/door/airlock/research{
 	name = "Anomaly Isolation";
 	req_access = list(65)
@@ -11999,7 +12369,7 @@
 	},
 /turf/simulated/floor,
 /area/outpost/research/isolation_monitoring)
-"wr" = (
+"wy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12016,7 +12386,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_monitoring)
-"ws" = (
+"wz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12028,7 +12398,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_monitoring)
-"wt" = (
+"wA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12044,7 +12414,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_monitoring)
-"wu" = (
+"wB" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
@@ -12057,7 +12427,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_storage)
-"wv" = (
+"wC" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -12068,16 +12438,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"ww" = (
+"wD" = (
 /obj/machinery/artifact_scanpad,
 /obj/machinery/light/small,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/anomaly_storage)
-"wx" = (
+"wE" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"wy" = (
+"wF" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/bodybags,
 /obj/machinery/alarm{
@@ -12087,7 +12457,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wz" = (
+"wG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -12095,13 +12465,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wA" = (
+"wH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wB" = (
+"wI" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes,
 /obj/structure/disposalpipe/trunk{
@@ -12112,7 +12482,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wC" = (
+"wJ" = (
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
 	dir = 4
@@ -12121,7 +12491,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/sublevel)
-"wD" = (
+"wK" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -12136,7 +12506,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"wE" = (
+"wL" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -12144,7 +12514,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"wF" = (
+"wM" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -12152,7 +12522,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"wG" = (
+"wN" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -12166,7 +12536,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"wH" = (
+"wO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -12180,15 +12550,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"wI" = (
+"wP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wJ" = (
+"wQ" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wK" = (
+"wR" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -12198,7 +12568,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wL" = (
+"wS" = (
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
@@ -12211,7 +12581,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wM" = (
+"wT" = (
 /obj/structure/cable/blue{
 	d2 = 8;
 	icon_state = "0-8"
@@ -12224,29 +12594,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wN" = (
+"wU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wO" = (
+"wV" = (
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/tape_roll,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wP" = (
+"wW" = (
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wQ" = (
+"wX" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wR" = (
+"wY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wS" = (
+"wZ" = (
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
@@ -12254,20 +12624,20 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"wT" = (
+"xa" = (
 /obj/structure/table/standard,
 /obj/item/weapon/scalpel,
 /obj/item/weapon/autopsy_scanner,
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wU" = (
+"xb" = (
 /obj/machinery/optable,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wV" = (
+"xc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12275,7 +12645,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wW" = (
+"xd" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -12287,7 +12657,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"wX" = (
+"xe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -12296,7 +12666,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"wY" = (
+"xf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -12308,7 +12678,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"wZ" = (
+"xg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -12318,7 +12688,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"xa" = (
+"xh" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -12333,7 +12703,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"xb" = (
+"xi" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 9
@@ -12342,7 +12712,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/mine/unexplored)
-"xc" = (
+"xj" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1379;
@@ -12360,7 +12730,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/mine/unexplored)
-"xd" = (
+"xk" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 5
@@ -12369,7 +12739,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/mine/unexplored)
-"xe" = (
+"xl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12390,22 +12760,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/hallway)
-"xf" = (
+"xm" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xg" = (
+"xn" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xh" = (
+"xo" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xi" = (
+"xp" = (
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
@@ -12413,20 +12783,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xj" = (
+"xq" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/firstaid/regular,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xk" = (
+"xr" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xl" = (
+"xs" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xm" = (
+"xt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/light_switch{
 	pixel_x = 27;
@@ -12434,11 +12804,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xn" = (
+"xu" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
-"xo" = (
+"xv" = (
+/turf/simulated/wall,
+/area/medical/virology)
+"xw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -12457,7 +12830,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xp" = (
+"xx" = (
 /obj/structure/sign/biohazard{
 	pixel_x = -32
 	},
@@ -12473,7 +12846,7 @@
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xq" = (
+"xy" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -12481,7 +12854,7 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xr" = (
+"xz" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -12493,7 +12866,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xs" = (
+"xA" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -12501,7 +12874,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xt" = (
+"xB" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -12509,13 +12882,13 @@
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xu" = (
+"xC" = (
 /turf/simulated/floor/tiled,
 /area/turbolift/medical_sub)
-"xv" = (
+"xD" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/eva)
-"xw" = (
+"xE" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -12540,7 +12913,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"xx" = (
+"xF" = (
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
@@ -12561,10 +12934,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"xy" = (
+"xG" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/hallway)
-"xz" = (
+"xH" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -12579,26 +12952,26 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"xA" = (
+"xI" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xB" = (
+"xJ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xC" = (
+"xK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	icon_state = "map";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xD" = (
+"xL" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
@@ -12609,18 +12982,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xE" = (
+"xM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xF" = (
+"xN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/visible/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xG" = (
+"xO" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -12628,12 +13001,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xH" = (
+"xP" = (
 /obj/structure/table/standard,
 /obj/item/clothing/gloves/latex,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xI" = (
+"xQ" = (
 /obj/structure/table/standard,
 /obj/machinery/computer/atmoscontrol/laptop{
 	monitored_alarm_ids = list("isolation_one","isolation_two","isolation_three");
@@ -12641,14 +13014,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xJ" = (
+"xR" = (
 /obj/structure/table/standard,
 /obj/item/weapon/folder,
 /obj/item/device/camera,
 /obj/item/weapon/pen,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xK" = (
+"xS" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/beakers,
 /obj/item/weapon/storage/box/syringes{
@@ -12662,7 +13035,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xL" = (
+"xT" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -12670,7 +13043,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xM" = (
+"xU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -12681,7 +13054,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xO" = (
+"xV" = (
+/obj/machinery/firealarm/north,
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"xW" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -12704,7 +13085,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xP" = (
+"xX" = (
 /obj/effect/floor_decal/corner/lime/full{
 	icon_state = "corner_white_full";
 	dir = 8
@@ -12714,7 +13095,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xQ" = (
+"xY" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -12727,7 +13108,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xR" = (
+"xZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -12739,7 +13120,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xS" = (
+"ya" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/clothing/mask/gas,
 /obj/effect/floor_decal/corner/lime/full{
@@ -12756,7 +13137,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xT" = (
+"yb" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/clothing/mask/gas,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -12771,7 +13152,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xU" = (
+"yc" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/clothing/mask/gas,
 /obj/machinery/alarm{
@@ -12785,14 +13166,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xV" = (
+"yd" = (
 /obj/structure/closet/wardrobe/virology_white,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xW" = (
+"ye" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 9
@@ -12800,20 +13181,20 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xX" = (
+"yf" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xY" = (
+"yg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xZ" = (
+"yh" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/turbolift/medical_sub)
-"ya" = (
+"yi" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -12833,7 +13214,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"yb" = (
+"yj" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12849,7 +13230,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"yc" = (
+"yk" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -12864,7 +13245,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"yd" = (
+"yl" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -12889,14 +13270,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"ye" = (
+"ym" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1;
 	icon_state = "map"
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"yf" = (
+"yn" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1379;
@@ -12905,7 +13286,7 @@
 /obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"yg" = (
+"yo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -12917,7 +13298,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"yh" = (
+"yp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -12927,7 +13308,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"yi" = (
+"yq" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
@@ -12941,17 +13322,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yj" = (
+"yr" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yk" = (
+"ys" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yl" = (
+"yt" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
@@ -12962,17 +13343,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"ym" = (
+"yu" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yn" = (
+"yv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yo" = (
+"yw" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 1;
 	tag_south = 2;
@@ -12980,13 +13361,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yp" = (
+"yx" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yq" = (
+"yy" = (
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -13003,7 +13384,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yr" = (
+"yz" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/item/device/antibody_scanner,
@@ -13013,21 +13394,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"ys" = (
+"yA" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yt" = (
+"yB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yu" = (
+"yC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13041,7 +13422,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yv" = (
+"yD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -13067,7 +13448,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"yw" = (
+"yE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13085,14 +13466,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yx" = (
+"yF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yy" = (
+"yG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -13105,7 +13486,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yz" = (
+"yH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13117,7 +13498,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yA" = (
+"yI" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	frequency = 1379;
@@ -13136,7 +13517,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yB" = (
+"yJ" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1379;
@@ -13152,7 +13533,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yC" = (
+"yK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13166,7 +13547,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yD" = (
+"yL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -13180,7 +13561,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yE" = (
+"yM" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	frequency = 1379;
@@ -13213,7 +13594,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yF" = (
+"yN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13232,7 +13613,7 @@
 /obj/effect/floor_decal/sign/v,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yG" = (
+"yO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -13246,7 +13627,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yH" = (
+"yP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13258,7 +13639,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yI" = (
+"yQ" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -13272,7 +13653,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yJ" = (
+"yR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -13286,7 +13667,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"yK" = (
+"yS" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -13299,7 +13680,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/outpost/research/eva)
-"yL" = (
+"yT" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 1
@@ -13308,7 +13689,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/outpost/research/eva)
-"yM" = (
+"yU" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -13318,7 +13699,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/outpost/research/eva)
-"yN" = (
+"yV" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
 	id_tag = "research_sensor";
@@ -13334,12 +13715,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"yO" = (
+"yW" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"yP" = (
+"yX" = (
 /obj/structure/ore_box,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -13352,26 +13733,26 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"yQ" = (
+"yY" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yR" = (
+"yZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yS" = (
+"za" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	icon_state = "map";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yT" = (
+"zb" = (
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
@@ -13379,7 +13760,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yU" = (
+"zc" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
 	state = 2
@@ -13395,13 +13776,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yV" = (
+"zd" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yW" = (
+"ze" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/newscaster{
 	pixel_x = 32;
@@ -13409,7 +13790,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yX" = (
+"zf" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/gloves,
 /obj/item/weapon/storage/box/masks,
@@ -13417,7 +13798,7 @@
 /obj/effect/floor_decal/corner/lime/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yY" = (
+"zg" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -13431,7 +13812,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yZ" = (
+"zh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13442,7 +13823,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"za" = (
+"zi" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13452,7 +13833,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zb" = (
+"zj" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -13481,7 +13862,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zc" = (
+"zk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13491,7 +13872,7 @@
 /obj/effect/floor_decal/corner/lime/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zd" = (
+"zl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13502,7 +13883,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"ze" = (
+"zm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -13516,7 +13897,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zf" = (
+"zn" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/clothing/mask/gas,
 /obj/effect/floor_decal/corner/lime/full{
@@ -13533,7 +13914,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zg" = (
+"zo" = (
 /obj/machinery/shower{
 	dir = 1
 	},
@@ -13550,7 +13931,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zh" = (
+"zp" = (
 /obj/machinery/shower{
 	dir = 1
 	},
@@ -13562,7 +13943,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zi" = (
+"zq" = (
 /obj/machinery/shower{
 	dir = 1
 	},
@@ -13574,7 +13955,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zj" = (
+"zr" = (
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for shutters.";
 	id = "virologyquar";
@@ -13591,7 +13972,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zk" = (
+"zs" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 10
@@ -13601,13 +13982,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zl" = (
+"zt" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zm" = (
+"zu" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -13617,11 +13998,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zn" = (
+"zv" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled,
 /area/turbolift/medical_sub)
-"zo" = (
+"zw" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -13637,7 +14018,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"zp" = (
+"zx" = (
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
@@ -13651,7 +14032,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zq" = (
+"zy" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -13668,18 +14049,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"zr" = (
+"zz" = (
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 4;
 	icon_state = "freezer"
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zs" = (
+"zA" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zt" = (
+"zB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
@@ -13690,7 +14071,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zu" = (
+"zC" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	icon_state = "map";
 	dir = 1
@@ -13704,13 +14085,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zv" = (
+"zD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zw" = (
+"zE" = (
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -13726,7 +14107,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"zx" = (
+"zF" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - \[F.4] Research"
 	},
@@ -13740,13 +14121,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"zy" = (
+"zG" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "\[F.4] Research Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"zz" = (
+"zH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -13769,7 +14150,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"zA" = (
+"zI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13791,7 +14172,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zB" = (
+"zJ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -13810,7 +14191,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zC" = (
+"zK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13834,7 +14215,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zD" = (
+"zL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -13848,14 +14229,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"zE" = (
+"zM" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zF" = (
+"zN" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -13866,7 +14247,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zG" = (
+"zO" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 9
@@ -13874,15 +14255,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zH" = (
+"zP" = (
 /obj/turbolift_map_holder/aurora/medical,
 /turf/simulated/floor/tiled,
 /area/turbolift/medical_sub)
-"zI" = (
+"zQ" = (
 /obj/structure/closet/excavation,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zJ" = (
+"zR" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -13892,7 +14273,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zK" = (
+"zS" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/shoes/magboots,
@@ -13901,7 +14282,7 @@
 /obj/item/weapon/storage/belt/archaeology,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zL" = (
+"zT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -13914,7 +14295,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"zM" = (
+"zU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -13930,7 +14311,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zN" = (
+"zV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -13940,7 +14321,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zO" = (
+"zW" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 22
@@ -13961,7 +14342,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zP" = (
+"zX" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
@@ -13983,7 +14364,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zQ" = (
+"zY" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -14000,7 +14381,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"zR" = (
+"zZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -14018,7 +14399,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"zS" = (
+"Aa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -14037,7 +14418,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"zT" = (
+"Ab" = (
 /obj/machinery/button/remote/airlock{
 	id = "riso1";
 	name = "Door Bolt Control";
@@ -14052,7 +14433,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zU" = (
+"Ac" = (
 /obj/machinery/atmospherics/valve/digital/open,
 /obj/structure/cable/blue{
 	d1 = 4;
@@ -14061,7 +14442,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zV" = (
+"Ad" = (
 /obj/machinery/button/remote/airlock{
 	id = "riso2";
 	name = "Door Bolt Control";
@@ -14082,7 +14463,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zW" = (
+"Ae" = (
 /obj/structure/cable/blue{
 	d1 = 2;
 	d2 = 8;
@@ -14095,7 +14476,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zX" = (
+"Af" = (
 /obj/machinery/atmospherics/valve/digital/open,
 /obj/structure/cable/blue{
 	d1 = 4;
@@ -14106,7 +14487,7 @@
 /obj/effect/floor_decal/industrial/warning/cee,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zY" = (
+"Ag" = (
 /obj/machinery/button/remote/airlock{
 	id = "riso3";
 	name = "Door Bolt Control";
@@ -14122,7 +14503,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zZ" = (
+"Ah" = (
 /obj/structure/cable/blue{
 	d1 = 2;
 	d2 = 8;
@@ -14130,15 +14511,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Aa" = (
+"Ai" = (
 /obj/machinery/atmospherics/valve/digital/open,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Ab" = (
+"Aj" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Ac" = (
+"Ak" = (
 /obj/machinery/power/terminal{
 	icon_state = "term";
 	dir = 1
@@ -14150,7 +14531,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Ad" = (
+"Al" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -14163,7 +14544,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Ae" = (
+"Am" = (
 /obj/item/weapon/storage/lockbox/vials,
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /obj/item/weapon/reagent_containers/syringe/antiviral,
@@ -14196,7 +14577,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Af" = (
+"An" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -14210,7 +14591,7 @@
 /obj/machinery/disease2/diseaseanalyser,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ag" = (
+"Ao" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -14218,13 +14599,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ah" = (
+"Ap" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ai" = (
+"Aq" = (
 /obj/structure/table/standard,
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology North"
@@ -14243,7 +14624,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Aj" = (
+"Ar" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
@@ -14255,7 +14636,7 @@
 /obj/machinery/computer/med_data/laptop,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ak" = (
+"As" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -14278,7 +14659,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Al" = (
+"At" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -14288,7 +14669,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Am" = (
+"Au" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -14306,7 +14687,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"An" = (
+"Av" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -14317,7 +14698,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"Ao" = (
+"Aw" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
@@ -14326,7 +14707,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ap" = (
+"Ax" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -14336,7 +14717,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Aq" = (
+"Ay" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 9
@@ -14348,19 +14729,19 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ar" = (
+"Az" = (
 /turf/simulated/wall/r_wall,
 /area/medical/patient_wing)
-"As" = (
+"AA" = (
 /obj/structure/closet/excavation,
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"At" = (
+"AB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Au" = (
+"AC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -14374,11 +14755,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"Av" = (
+"AD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Aw" = (
+"AE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	icon_state = "map-scrubbers";
@@ -14386,7 +14767,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Ax" = (
+"AF" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
@@ -14402,10 +14783,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Ay" = (
+"AG" = (
+/turf/simulated/wall,
+/area/outpost/research/eva)
+"AH" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/isolation_a)
-"Az" = (
+"AI" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "riso1";
 	name = "Access Airlock";
@@ -14419,7 +14803,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_a)
-"AA" = (
+"AJ" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14432,7 +14816,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_a)
-"AB" = (
+"AK" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -14444,7 +14828,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_a)
-"AC" = (
+"AL" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "riso2";
 	name = "Access Airlock";
@@ -14458,7 +14842,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_b)
-"AD" = (
+"AM" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14471,7 +14855,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_b)
-"AE" = (
+"AN" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -14483,10 +14867,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_b)
-"AF" = (
+"AO" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/isolation_b)
-"AG" = (
+"AP" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "riso3";
 	name = "Access Airlock";
@@ -14500,7 +14884,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_c)
-"AH" = (
+"AQ" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14513,7 +14897,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_c)
-"AI" = (
+"AR" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -14525,7 +14909,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_c)
-"AJ" = (
+"AS" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Science Substation";
 	req_one_access = list(11,24)
@@ -14538,7 +14922,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"AK" = (
+"AT" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -14551,12 +14935,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"AL" = (
+"AU" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"AM" = (
+"AV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/access_button{
@@ -14576,7 +14960,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"AN" = (
+"AW" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/fancy/vials,
 /obj/machinery/button/remote/blast_door{
@@ -14593,17 +14977,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"AO" = (
+"AX" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"AP" = (
+"AY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"AQ" = (
+"AZ" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
@@ -14613,7 +14997,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"AR" = (
+"Ba" = (
 /obj/machinery/computer/diseasesplicer,
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -14624,7 +15008,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"AS" = (
+"Bb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -14644,7 +15028,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"AT" = (
+"Bc" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Quarantine Airlock";
 	dir = 4;
@@ -14655,13 +15039,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"AU" = (
+"Bd" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"AV" = (
+"Be" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
@@ -14673,7 +15057,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"AW" = (
+"Bf" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
@@ -14684,13 +15068,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"AX" = (
+"Bg" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"AY" = (
+"Bh" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
@@ -14700,7 +15084,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"AZ" = (
+"Bi" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -14715,7 +15099,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ba" = (
+"Bj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -14735,7 +15119,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Bb" = (
+"Bk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14760,7 +15144,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Bc" = (
+"Bl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14778,7 +15162,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Bd" = (
+"Bm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14792,7 +15176,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Be" = (
+"Bn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 9
@@ -14807,7 +15191,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Bf" = (
+"Bo" = (
 /obj/structure/closet/excavation,
 /obj/machinery/light{
 	dir = 8
@@ -14818,13 +15202,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bg" = (
+"Bp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bh" = (
+"Bq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -14834,7 +15218,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bi" = (
+"Br" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14853,7 +15237,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bj" = (
+"Bs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
 	icon_state = "intact"
@@ -14866,7 +15250,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bk" = (
+"Bt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 9
@@ -14880,7 +15264,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bl" = (
+"Bu" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -14889,7 +15273,7 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bm" = (
+"Bv" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light{
 	dir = 4;
@@ -14897,7 +15281,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bn" = (
+"Bw" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 9
@@ -14908,7 +15292,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Bo" = (
+"Bx" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	use_power = 0
@@ -14922,12 +15306,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_a)
-"Bp" = (
+"By" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_a)
-"Bq" = (
+"Bz" = (
 /obj/machinery/alarm/monitor/isolation{
 	alarm_id = "isolation_one";
 	dir = 8;
@@ -14940,7 +15324,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_a)
-"Br" = (
+"BA" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	use_power = 0
@@ -14954,12 +15338,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_b)
-"Bs" = (
+"BB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_b)
-"Bt" = (
+"BC" = (
 /obj/machinery/alarm/monitor/isolation{
 	alarm_id = "isolation_two";
 	dir = 8;
@@ -14972,7 +15356,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_b)
-"Bu" = (
+"BD" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	use_power = 0
@@ -14986,12 +15370,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_c)
-"Bv" = (
+"BE" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_c)
-"Bw" = (
+"BF" = (
 /obj/machinery/alarm/monitor/isolation{
 	alarm_id = "isolation_three";
 	dir = 8;
@@ -15004,7 +15388,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_c)
-"Bx" = (
+"BG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -15018,7 +15402,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"By" = (
+"BH" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -15032,7 +15416,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Bz" = (
+"BI" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -15046,7 +15430,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BA" = (
+"BJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15055,7 +15439,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BB" = (
+"BK" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -15069,7 +15453,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BC" = (
+"BL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15088,7 +15472,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BD" = (
+"BM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15111,7 +15495,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BE" = (
+"BN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15136,7 +15520,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BF" = (
+"BO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15164,7 +15548,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BG" = (
+"BP" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -15182,7 +15566,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BH" = (
+"BQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15204,7 +15588,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BI" = (
+"BR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 9
@@ -15222,7 +15606,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"BJ" = (
+"BS" = (
 /obj/structure/bed/padded,
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
@@ -15233,18 +15617,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BK" = (
+"BT" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BL" = (
+"BU" = (
 /obj/item/roller,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BM" = (
+"BV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15259,7 +15643,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"BN" = (
+"BW" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes,
 /obj/structure/disposalpipe/trunk{
@@ -15267,14 +15651,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BO" = (
+"BX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BP" = (
+"BY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -15283,7 +15667,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BQ" = (
+"BZ" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
@@ -15296,7 +15680,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BR" = (
+"Ca" = (
 /obj/machinery/disease2/isolator,
 /obj/machinery/light{
 	dir = 4;
@@ -15311,7 +15695,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BS" = (
+"Cb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15332,7 +15716,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"BT" = (
+"Cc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -15342,7 +15726,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BU" = (
+"Cd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -15350,13 +15734,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BV" = (
+"Ce" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BW" = (
+"Cf" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -15371,7 +15755,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"BX" = (
+"Cg" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -15383,7 +15767,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"BY" = (
+"Ch" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -15397,7 +15781,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"BZ" = (
+"Ci" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -15412,7 +15796,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ca" = (
+"Cj" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -15431,7 +15815,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Cb" = (
+"Ck" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 9
@@ -15448,7 +15832,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Cc" = (
+"Cl" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -15460,7 +15844,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Cd" = (
+"Cm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -15472,13 +15856,13 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Ce" = (
+"Cn" = (
 /turf/simulated/wall/r_wall,
 /area/medical/patient_a)
-"Cf" = (
+"Co" = (
 /turf/simulated/wall/r_wall,
 /area/medical/patient_b)
-"Cg" = (
+"Cp" = (
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
@@ -15488,17 +15872,17 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Ch" = (
+"Cq" = (
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Ci" = (
+"Cr" = (
 /obj/machinery/floodlight,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Cj" = (
+"Cs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -15514,7 +15898,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"Ck" = (
+"Ct" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -15529,7 +15913,7 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Cl" = (
+"Cu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -15539,7 +15923,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Cm" = (
+"Cv" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -15550,7 +15934,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Cn" = (
+"Cw" = (
 /obj/item/weapon/storage/box/excavation,
 /obj/item/weapon/pickaxe,
 /obj/machinery/status_display{
@@ -15564,7 +15948,7 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Co" = (
+"Cx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -15574,7 +15958,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Cp" = (
+"Cy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -15586,7 +15970,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Cq" = (
+"Cz" = (
 /obj/item/device/radio/intercom{
 	frequency = 1459;
 	name = "Station Intercom (General)";
@@ -15594,17 +15978,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_a)
-"Cr" = (
+"CA" = (
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_a)
-"Cs" = (
+"CB" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Isolation Cell A";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_a)
-"Ct" = (
+"CC" = (
 /obj/item/device/radio/intercom{
 	frequency = 1459;
 	name = "Station Intercom (General)";
@@ -15612,20 +15996,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_b)
-"Cu" = (
+"CD" = (
 /obj/effect/landmark{
 	name = "bluespacerift"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_b)
-"Cv" = (
+"CE" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Isolation Cell B";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_b)
-"Cw" = (
+"CF" = (
 /obj/item/device/radio/intercom{
 	frequency = 1459;
 	name = "Station Intercom (General)";
@@ -15633,17 +16017,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"Cx" = (
+"CG" = (
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"Cy" = (
+"CH" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Isolation Cell C";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"Cz" = (
+"CI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15653,7 +16037,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"CA" = (
+"CJ" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "sl2s";
 	pixel_y = -26
@@ -15665,7 +16049,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"CB" = (
+"CK" = (
 /obj/machinery/camera/network/engineering_outpost{
 	c_tag = "Research Sublevel - Cavern Entrance";
 	dir = 4;
@@ -15673,7 +16057,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/maintenance/sublevel)
-"CC" = (
+"CL" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Cell A";
 	dir = 4;
@@ -15688,7 +16072,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CD" = (
+"CM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -15697,7 +16081,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CE" = (
+"CN" = (
 /obj/machinery/door/window/westleft{
 	name = "Virology Isolation Cell Alpha";
 	req_access = list(39)
@@ -15715,7 +16099,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CF" = (
+"CO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15724,14 +16108,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CG" = (
+"CP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CH" = (
+"CQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15740,7 +16124,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CI" = (
+"CR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15753,7 +16137,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CJ" = (
+"CS" = (
 /obj/machinery/computer/centrifuge,
 /obj/item/weapon/storage/secure/safe{
 	pixel_x = 32
@@ -15770,7 +16154,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CK" = (
+"CT" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	frequency = 1379;
@@ -15795,7 +16179,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CL" = (
+"CU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15809,7 +16193,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"CM" = (
+"CV" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -15821,7 +16205,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"CN" = (
+"CW" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 4
@@ -15830,7 +16214,7 @@
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"CO" = (
+"CX" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -15844,14 +16228,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"CP" = (
+"CY" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"CQ" = (
+"CZ" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -15859,7 +16243,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"CR" = (
+"Da" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -15867,14 +16251,14 @@
 /obj/effect/floor_decal/corner/lime,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"CS" = (
+"Db" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"CT" = (
+"Dc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -15888,7 +16272,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"CU" = (
+"Dd" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/corner/pink/full{
 	icon_state = "corner_white_full";
@@ -15897,7 +16281,7 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"CV" = (
+"De" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -15914,7 +16298,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"CW" = (
+"Df" = (
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -15943,10 +16327,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"CX" = (
+"Dg" = (
 /turf/simulated/wall,
 /area/medical/patient_a)
-"CY" = (
+"Dh" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/corner/pink/full{
 	icon_state = "corner_white_full";
@@ -15955,7 +16339,7 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"CZ" = (
+"Di" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -15972,7 +16356,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Da" = (
+"Dj" = (
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -16001,19 +16385,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Db" = (
+"Dk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Dc" = (
+"Dl" = (
 /obj/machinery/suspension_gen,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Dd" = (
+"Dm" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"De" = (
+"Dn" = (
 /obj/machinery/door/window{
 	dir = 4;
 	name = "Air Tank Access";
@@ -16025,14 +16409,14 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Df" = (
+"Do" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Dg" = (
+"Dp" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
 	dir = 2;
@@ -16041,7 +16425,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Dh" = (
+"Dq" = (
 /obj/item/weapon/storage/box/excavation,
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/wrench,
@@ -16050,12 +16434,12 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Di" = (
+"Dr" = (
 /obj/effect/floor_decal/corner/paleblue/full,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Dj" = (
+"Ds" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -16069,61 +16453,61 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Dk" = (
+"Dt" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Dl" = (
+"Du" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_a)
-"Dm" = (
+"Dv" = (
 /obj/machinery/artifact_scanpad,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/isolation_a)
-"Dn" = (
+"Dw" = (
 /obj/machinery/artifact_analyser,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/isolation_a)
-"Do" = (
+"Dx" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_b)
-"Dp" = (
+"Dy" = (
 /obj/machinery/artifact_scanpad,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/isolation_b)
-"Dq" = (
+"Dz" = (
 /obj/machinery/artifact_analyser,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/isolation_b)
-"Dr" = (
+"DA" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"Ds" = (
+"DB" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"Dt" = (
+"DC" = (
 /obj/structure/bed,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"Du" = (
+"DD" = (
 /obj/structure/crematorium{
 	id = "slimemurder"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"Dv" = (
+"DE" = (
 /obj/machinery/button/crematorium{
 	id = "slimemurder";
 	pixel_x = -4;
@@ -16139,31 +16523,31 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"Dw" = (
+"DF" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/xenobiology)
-"Dx" = (
+"DG" = (
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Dy" = (
+"DH" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Dz" = (
+"DI" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DA" = (
+"DJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -16172,7 +16556,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DB" = (
+"DK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -16181,7 +16565,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DC" = (
+"DL" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/virusdish/random,
 /obj/item/weapon/virusdish/random,
@@ -16192,7 +16576,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DD" = (
+"DM" = (
 /obj/machinery/smartfridge/secure/virology{
 	density = 0;
 	pixel_y = -32
@@ -16206,7 +16590,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DE" = (
+"DN" = (
 /obj/machinery/disease2/incubator,
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -16217,7 +16601,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DF" = (
+"DO" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/item/clothing/under/color/white,
 /obj/item/clothing/under/color/white,
@@ -16239,7 +16623,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DG" = (
+"DP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -16249,7 +16633,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DH" = (
+"DQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -16259,10 +16643,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DI" = (
+"DR" = (
 /turf/simulated/wall,
 /area/medical/morgue)
-"DJ" = (
+"DS" = (
 /obj/machinery/door/firedoor,
 /obj/structure/plasticflaps/airtight,
 /obj/machinery/door/airlock/medical{
@@ -16274,7 +16658,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"DK" = (
+"DT" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
@@ -16285,7 +16669,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"DL" = (
+"DU" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -16297,7 +16681,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"DM" = (
+"DV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -16307,7 +16691,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"DN" = (
+"DW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -16319,7 +16703,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"DO" = (
+"DX" = (
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
@@ -16332,11 +16716,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"DP" = (
+"DY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"DQ" = (
+"DZ" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
 /obj/machinery/vending/wallmed1{
@@ -16350,7 +16734,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"DR" = (
+"Ea" = (
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
@@ -16363,11 +16747,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"DS" = (
+"Eb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"DT" = (
+"Ec" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
 /obj/machinery/vending/wallmed1{
@@ -16381,7 +16765,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"DU" = (
+"Ed" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"Ee" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -16395,7 +16782,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"DV" = (
+"Ef" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -16406,7 +16793,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"DW" = (
+"Eg" = (
+/turf/simulated/wall,
+/area/outpost/research/hallway)
+"Eh" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Xenoarchaeology Department";
 	req_access = list(65)
@@ -16421,23 +16811,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"DX" = (
+"Ei" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"DY" = (
+"Ej" = (
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"DZ" = (
+"Ek" = (
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"Ea" = (
-/turf/simulated/wall,
-/area/medical/virology)
-"Eb" = (
+"El" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -16446,12 +16833,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ec" = (
+"Em" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ed" = (
+"En" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -16474,7 +16861,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Ee" = (
+"Eo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -16494,7 +16881,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Ef" = (
+"Ep" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -16511,7 +16898,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Eg" = (
+"Eq" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -16524,7 +16911,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Eh" = (
+"Er" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 4
@@ -16542,24 +16929,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ei" = (
+"Es" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/ramp,
 /area/medical/virology)
-"Ej" = (
+"Et" = (
 /obj/structure/morgue,
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
 	},
 /area/medical/morgue)
-"Ek" = (
+"Eu" = (
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
 	},
 /area/medical/morgue)
-"El" = (
+"Ev" = (
 /obj/structure/morgue{
 	icon_state = "morgue1";
 	dir = 8
@@ -16569,7 +16956,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Em" = (
+"Ew" = (
 /obj/machinery/light_switch{
 	pixel_y = 27
 	},
@@ -16578,7 +16965,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"En" = (
+"Ex" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -16594,7 +16981,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Eo" = (
+"Ey" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
@@ -16608,7 +16995,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ep" = (
+"Ez" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -16624,7 +17011,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Eq" = (
+"EA" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -16640,7 +17027,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Er" = (
+"EB" = (
 /obj/structure/table/standard,
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -16649,7 +17036,7 @@
 /obj/effect/floor_decal/corner/pink/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"Es" = (
+"EC" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -16665,7 +17052,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"Et" = (
+"ED" = (
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc{
 	dir = 4;
@@ -16682,7 +17069,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"Eu" = (
+"EE" = (
 /obj/structure/table/standard,
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -16691,7 +17078,7 @@
 /obj/effect/floor_decal/corner/pink/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Ev" = (
+"EF" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -16707,7 +17094,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Ew" = (
+"EG" = (
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc{
 	dir = 4;
@@ -16724,7 +17111,64 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Ex" = (
+"EH" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/bodyscanner{
+	tag = "icon-body_scanner_0 (WEST)";
+	icon_state = "body_scanner_0";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"EI" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/body_scanconsole{
+	tag = "icon-body_scannerconsole (WEST)";
+	icon_state = "body_scannerconsole";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"EJ" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/bed/chair/office/light{
+	tag = "icon-officechair_white (EAST)";
+	icon_state = "officechair_white";
+	dir = 4
+	},
+/obj/machinery/firealarm/north,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"EK" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"EL" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 8
@@ -16733,7 +17177,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ey" = (
+"EM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -16744,7 +17188,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ez" = (
+"EN" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -16754,7 +17198,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"EA" = (
+"EO" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -16764,7 +17208,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"EB" = (
+"EP" = (
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -16781,7 +17225,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"EC" = (
+"EQ" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -16794,7 +17238,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"ED" = (
+"ER" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 1
@@ -16803,15 +17247,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"EE" = (
+"ES" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"EF" = (
+"ET" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"EG" = (
+"EU" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/toolbox/emergency{
 	pixel_x = 0;
@@ -16819,7 +17263,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"EH" = (
+"EV" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -16834,7 +17278,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"EI" = (
+"EW" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -16851,7 +17295,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"EJ" = (
+"EX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
@@ -16866,7 +17310,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"EK" = (
+"EY" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -16877,7 +17321,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"EL" = (
+"EZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16900,7 +17344,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"EM" = (
+"Fa" = (
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
@@ -16911,13 +17355,13 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"EN" = (
+"Fb" = (
 /obj/machinery/door/window/eastleft,
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"EO" = (
+"Fc" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Quarantine"
 	},
@@ -16926,7 +17370,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"EP" = (
+"Fd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -16935,20 +17379,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"EQ" = (
+"Fe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"ER" = (
+"Ff" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"ES" = (
+"Fg" = (
 /obj/structure/bed/padded,
 /obj/item/clothing/under/color/white,
 /obj/item/clothing/shoes/white,
@@ -16961,7 +17405,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"ET" = (
+"Fh" = (
 /obj/structure/morgue,
 /obj/machinery/light{
 	dir = 8
@@ -16971,7 +17415,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"EU" = (
+"Fi" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -16986,7 +17430,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"EV" = (
+"Fj" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
@@ -16996,7 +17440,7 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"EW" = (
+"Fk" = (
 /obj/machinery/newscaster{
 	pixel_x = 30;
 	pixel_y = 0
@@ -17011,7 +17455,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"EX" = (
+"Fl" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -17023,7 +17467,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"EY" = (
+"Fm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -17032,7 +17476,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"EZ" = (
+"Fn" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -17044,7 +17488,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"Fa" = (
+"Fo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
 	id = "isoA_window_tint"
@@ -17064,7 +17508,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/patient_a)
-"Fb" = (
+"Fp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Sub-Acute A"
@@ -17078,7 +17522,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"Fc" = (
+"Fq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
@@ -17098,7 +17542,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/patient_a)
-"Fd" = (
+"Fr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
 	id = "isoB_window_tint"
@@ -17118,7 +17562,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/patient_b)
-"Fe" = (
+"Fs" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Sub-Acute B"
@@ -17132,7 +17576,52 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Ff" = (
+"Ft" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Fu" = (
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Fv" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Fw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/outpost/research/hallway)
+"Fx" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
@@ -17142,7 +17631,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Fg" = (
+"Fy" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17156,7 +17645,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Fh" = (
+"Fz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17170,7 +17659,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Fi" = (
+"FA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17189,7 +17678,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Fj" = (
+"FB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
@@ -17204,7 +17693,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Fk" = (
+"FC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -17218,7 +17707,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Fl" = (
+"FD" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 6
@@ -17228,7 +17717,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Fm" = (
+"FE" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -17240,7 +17729,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Fn" = (
+"FF" = (
 /obj/machinery/door/airlock/research{
 	name = "Secure Disposals";
 	req_access = list(55)
@@ -17248,7 +17737,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"Fo" = (
+"FG" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Cell B";
 	dir = 4;
@@ -17263,7 +17752,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fp" = (
+"FH" = (
 /obj/machinery/door/window/westleft{
 	name = "Virology Isolation Cell Beta";
 	req_access = list(39)
@@ -17281,7 +17770,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fq" = (
+"FI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -17290,7 +17779,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fr" = (
+"FJ" = (
 /obj/item/weapon/folder/white,
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin,
@@ -17306,18 +17795,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fs" = (
+"FK" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ft" = (
+"FL" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fu" = (
+"FM" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/lime/full{
 	icon_state = "corner_white_full";
@@ -17325,7 +17814,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fv" = (
+"FN" = (
 /obj/structure/table/standard,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17338,14 +17827,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fw" = (
+"FO" = (
 /obj/item/weapon/stool/padded,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fx" = (
+"FP" = (
 /obj/structure/bed/padded,
 /obj/item/clothing/under/color/white,
 /obj/item/clothing/shoes/white,
@@ -17355,7 +17844,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fy" = (
+"FQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/dark{
@@ -17363,7 +17852,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Fz" = (
+"FR" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/bodybags,
 /obj/item/weapon/storage/box/bodybags,
@@ -17372,7 +17861,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"FA" = (
+"FS" = (
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -17388,42 +17877,42 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"FB" = (
+"FT" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FC" = (
+"FU" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FD" = (
+"FV" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FE" = (
+"FW" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FF" = (
+"FX" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FG" = (
+"FY" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FH" = (
+"FZ" = (
 /obj/machinery/iv_drip,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FI" = (
+"Ga" = (
 /obj/structure/closet/crate/freezer{
 	name = "O- Blood Packs"
 	},
@@ -17435,14 +17924,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FJ" = (
+"Gb" = (
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FK" = (
+"Gc" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -17457,7 +17946,7 @@
 /obj/effect/floor_decal/sign/a,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FL" = (
+"Gd" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Patient Wing Hallway East"
 	},
@@ -17467,13 +17956,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FM" = (
+"Ge" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FN" = (
+"Gf" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -17488,7 +17977,7 @@
 /obj/effect/floor_decal/sign/b,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FO" = (
+"Gg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -17502,7 +17991,72 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"FP" = (
+"Gh" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 6
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Gi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Gj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Gk" = (
+/obj/machinery/door/airlock/glass_research{
+	name = "Test Range"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/outpost/research/hallway)
+"Gl" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -17523,7 +18077,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"FQ" = (
+"Gm" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -17531,7 +18085,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"FR" = (
+"Gn" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
@@ -17539,14 +18093,14 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"FS" = (
+"Go" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"FT" = (
+"Gp" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -17565,7 +18119,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"FU" = (
+"Gq" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17583,7 +18137,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"FV" = (
+"Gr" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17602,7 +18156,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"FW" = (
+"Gs" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17620,7 +18174,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"FX" = (
+"Gt" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17635,7 +18189,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"FY" = (
+"Gu" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17654,7 +18208,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"FZ" = (
+"Gv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -17680,7 +18234,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Ga" = (
+"Gw" = (
 /obj/machinery/computer/operating{
 	name = "Xenobiology Operating Computer"
 	},
@@ -17693,7 +18247,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Gb" = (
+"Gx" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
@@ -17709,7 +18263,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Gc" = (
+"Gy" = (
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -17726,7 +18280,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Gd" = (
+"Gz" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 8
@@ -17734,7 +18288,7 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ge" = (
+"GA" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -17742,14 +18296,14 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Gf" = (
+"GB" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Gg" = (
+"GC" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/blast_door{
@@ -17768,7 +18322,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Gh" = (
+"GD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -17791,17 +18345,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"Gi" = (
+"GE" = (
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Gj" = (
+"GF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Gk" = (
+"GG" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/item/weapon/storage/box/monkeycubes,
@@ -17813,11 +18367,11 @@
 /obj/effect/floor_decal/corner/lime/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Gl" = (
+"GH" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Gm" = (
+"GI" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -17825,7 +18379,7 @@
 /obj/effect/floor_decal/corner/lime/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Gn" = (
+"GJ" = (
 /obj/structure/table/standard,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17836,7 +18390,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Go" = (
+"GK" = (
 /obj/structure/bed/padded,
 /obj/item/clothing/under/color/white,
 /obj/item/clothing/shoes/white,
@@ -17846,7 +18400,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Gp" = (
+"GL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 6
@@ -17859,7 +18413,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Gq" = (
+"GM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17871,7 +18425,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Gr" = (
+"GN" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -17888,7 +18442,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Gs" = (
+"GO" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
 	req_access = list(6)
@@ -17908,7 +18462,7 @@
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue)
-"Gt" = (
+"GP" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17929,7 +18483,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Gu" = (
+"GQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -17953,7 +18507,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Gv" = (
+"GR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -17974,7 +18528,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Gw" = (
+"GS" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	autoclose = 1;
 	dir = 2;
@@ -17999,7 +18553,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Gx" = (
+"GT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18018,7 +18572,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Gy" = (
+"GU" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j1";
 	dir = 4
@@ -18044,7 +18598,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Gz" = (
+"GV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18064,7 +18618,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GA" = (
+"GW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18085,7 +18639,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GB" = (
+"GX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18106,7 +18660,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GC" = (
+"GY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18125,7 +18679,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GD" = (
+"GZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18143,7 +18697,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GE" = (
+"Ha" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18161,7 +18715,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GF" = (
+"Hb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -18179,7 +18733,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GG" = (
+"Hc" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -18193,7 +18747,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GH" = (
+"Hd" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -18206,14 +18760,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GI" = (
+"He" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GJ" = (
+"Hf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -18225,13 +18779,64 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"GK" = (
+"Hg" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Hh" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Hi" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Hj" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/outpost/research/hallway)
+"Hk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"GL" = (
+"Hl" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Camera Corridor 2";
 	dir = 8
@@ -18251,7 +18856,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"GM" = (
+"Hm" = (
 /obj/machinery/optable{
 	name = "Xenobiology Operating Table"
 	},
@@ -18266,13 +18871,13 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"GN" = (
+"Hn" = (
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"GO" = (
+"Ho" = (
 /obj/structure/table/standard,
 /obj/item/weapon/circular_saw,
 /obj/item/weapon/scalpel{
@@ -18292,7 +18897,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"GP" = (
+"Hp" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
@@ -18305,17 +18910,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"GQ" = (
+"Hq" = (
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"GR" = (
+"Hr" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"GS" = (
+"Hs" = (
 /obj/machinery/door/window/westright{
 	name = "Containment Pen";
 	req_access = list(47)
@@ -18328,7 +18933,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"GT" = (
+"Ht" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -18344,14 +18949,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"GU" = (
+"Hu" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 6";
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"GV" = (
+"Hv" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -18361,12 +18966,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"GW" = (
+"Hw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"GX" = (
+"Hx" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/cups,
 /obj/machinery/newscaster{
@@ -18374,20 +18979,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"GY" = (
+"Hy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"GZ" = (
+"Hz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ha" = (
+"HA" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes,
 /obj/structure/disposalpipe/trunk{
@@ -18399,7 +19004,7 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Hb" = (
+"HB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -18412,7 +19017,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Hc" = (
+"HC" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Morgue";
 	dir = 8;
@@ -18427,10 +19032,10 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Hd" = (
+"HD" = (
 /turf/simulated/wall,
 /area/medical/medbay4)
-"He" = (
+"HE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical{
 	name = "Staff Wing";
@@ -18446,10 +19051,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"Hf" = (
+"HF" = (
 /turf/simulated/wall,
 /area/medical/ward)
-"Hg" = (
+"HG" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Patient Ward";
 	req_access = list(5)
@@ -18464,12 +19069,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Hh" = (
+"HH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Hi" = (
+"HI" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -18481,7 +19086,7 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"Hj" = (
+"HJ" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -18492,22 +19097,22 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"Hk" = (
+"HK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Hl" = (
+"HL" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Hm" = (
+"HM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Hn" = (
+"HN" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -18519,7 +19124,7 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"Ho" = (
+"HO" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -18530,12 +19135,48 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"Hp" = (
+"HP" = (
+/obj/machinery/door/window/southright,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"HQ" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/item/device/firing_pin/test_range,
+/obj/item/device/firing_pin/test_range,
+/obj/item/device/firing_pin/test_range,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"HR" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"HS" = (
+/obj/structure/table/reinforced,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/structure/closet/crate{
+	name = "Target Crate"
+	},
+/obj/item/weapon/storage/box/monkeycubes,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"HT" = (
 /obj/effect/floor_decal/corner/mauve/full,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Hq" = (
+"HU" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -18544,7 +19185,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Hr" = (
+"HV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -18559,12 +19200,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Hs" = (
+"HW" = (
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/research_maintenance)
-"Ht" = (
+"HX" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Camera Corridor 1";
 	dir = 4
@@ -18575,11 +19216,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Hu" = (
+"HY" = (
 /obj/item/toy/plushie/spider,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"Hv" = (
+"HZ" = (
 /obj/machinery/smartfridge/secure/extract,
 /obj/effect/floor_decal/corner/white/full,
 /turf/simulated/floor/tiled{
@@ -18587,7 +19228,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Hw" = (
+"Ia" = (
 /obj/effect/floor_decal/corner/white{
 	icon_state = "corner_white";
 	dir = 10
@@ -18597,7 +19238,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Hx" = (
+"Ib" = (
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
 	pixel_x = 26;
@@ -18613,14 +19254,14 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Hy" = (
+"Ic" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Hz" = (
+"Id" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -18641,7 +19282,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"HA" = (
+"Ie" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -18667,20 +19308,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"HB" = (
+"If" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"HC" = (
+"Ig" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"HD" = (
+"Ih" = (
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
@@ -18689,13 +19330,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"HE" = (
+"Ii" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/lime,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"HF" = (
+"Ij" = (
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -18703,7 +19344,7 @@
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"HG" = (
+"Ik" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -18715,7 +19356,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"HH" = (
+"Il" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -18727,11 +19368,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"HI" = (
+"Im" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"HJ" = (
+"In" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Starboard";
 	dir = 8
@@ -18739,14 +19380,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"HK" = (
+"Io" = (
 /obj/structure/flora/pottedplant/random,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"HL" = (
+"Ip" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18761,7 +19402,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"HM" = (
+"Iq" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -18769,7 +19410,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"HN" = (
+"Ir" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -18779,7 +19420,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"HO" = (
+"Is" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18793,7 +19434,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"HP" = (
+"It" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -18805,7 +19446,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"HQ" = (
+"Iu" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -18822,12 +19463,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"HR" = (
+"Iv" = (
 /obj/structure/bed/chair/comfy/teal,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"HS" = (
+"Iw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -18839,7 +19480,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"HT" = (
+"Ix" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -18851,12 +19492,12 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"HU" = (
+"Iy" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"HV" = (
+"Iz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 5
@@ -18864,14 +19505,14 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"HW" = (
+"IA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"HX" = (
+"IB" = (
 /obj/structure/bed/chair/comfy/teal{
 	dir = 8;
 	icon_state = "comfychair_preview"
@@ -18879,14 +19520,26 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"HY" = (
+"IC" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"ID" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"IE" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Toxins Lab";
 	req_access = list(7)
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"HZ" = (
+"IF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -18900,7 +19553,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/hallway)
-"Ia" = (
+"IG" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Toxins Lab";
 	req_access = list(7)
@@ -18914,7 +19567,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ib" = (
+"IH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -18926,7 +19579,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ic" = (
+"II" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -18936,7 +19589,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Id" = (
+"IJ" = (
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
@@ -18954,7 +19607,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ie" = (
+"IK" = (
 /obj/item/device/radio/intercom{
 	frequency = 1459;
 	name = "Station Intercom (General)";
@@ -18967,7 +19620,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"If" = (
+"IL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
@@ -18977,14 +19630,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ig" = (
+"IM" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ih" = (
+"IN" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Fore"
 	},
@@ -18994,18 +19647,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ii" = (
+"IO" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ij" = (
+"IP" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ik" = (
+"IQ" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Cell C";
 	dir = 4;
@@ -19020,7 +19673,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Il" = (
+"IR" = (
 /obj/machinery/door/window/westleft{
 	name = "Virology Isolation Cell Ceta";
 	req_access = list(39)
@@ -19038,7 +19691,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Im" = (
+"IS" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -19054,7 +19707,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"In" = (
+"IT" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -19062,7 +19715,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Io" = (
+"IU" = (
 /obj/structure/sink{
 	pixel_y = 16
 	},
@@ -19071,14 +19724,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Ip" = (
+"IV" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Iq" = (
+"IW" = (
 /obj/effect/landmark{
 	name = "blobstart"
 	},
@@ -19088,14 +19741,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ir" = (
+"IX" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Is" = (
+"IY" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
@@ -19104,7 +19757,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"It" = (
+"IZ" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -19118,7 +19771,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Iu" = (
+"Ja" = (
 /obj/structure/bed/chair/wheelchair{
 	icon_state = "wheelchair";
 	dir = 4
@@ -19126,7 +19779,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Iv" = (
+"Jb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19137,7 +19790,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Iw" = (
+"Jc" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/medical,
 /obj/machinery/vending/wallmed1{
@@ -19147,10 +19800,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Ix" = (
+"Jd" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Iy" = (
+"Je" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/lime{
@@ -19159,14 +19812,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Iz" = (
+"Jf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"IA" = (
+"Jg" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/medical,
 /obj/machinery/vending/wallmed1{
@@ -19176,12 +19829,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"IB" = (
+"Jh" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"IC" = (
+"Ji" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -19189,7 +19842,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"ID" = (
+"Jj" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 8
@@ -19202,7 +19855,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"IE" = (
+"Jk" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -19211,7 +19864,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"IF" = (
+"Jl" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -19223,19 +19876,19 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"IG" = (
+"Jm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"IH" = (
+"Jn" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"II" = (
+"Jo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -19246,7 +19899,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"IJ" = (
+"Jp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"Jq" = (
+/obj/machinery/light{
+	dir = 4;
+	status = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"Jr" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 8
@@ -19254,7 +19920,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"IK" = (
+"Js" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -19265,7 +19931,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"IL" = (
+"Jt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -19280,7 +19946,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"IM" = (
+"Ju" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -19288,7 +19954,7 @@
 	icon_state = "plating"
 	},
 /area/turbolift/research_maintenance)
-"IN" = (
+"Jv" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -19296,7 +19962,7 @@
 	icon_state = "plating"
 	},
 /area/turbolift/research_maintenance)
-"IO" = (
+"Jw" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -19304,7 +19970,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IP" = (
+"Jx" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
@@ -19320,14 +19986,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IQ" = (
+"Jy" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IR" = (
+"Jz" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
@@ -19341,7 +20007,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IS" = (
+"JA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -19349,7 +20015,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IT" = (
+"JB" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/blast_door{
@@ -19372,7 +20038,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"IU" = (
+"JC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19395,7 +20061,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"IV" = (
+"JD" = (
 /obj/machinery/door/window/eastleft{
 	name = "Simian Storage";
 	req_access = list(39)
@@ -19405,19 +20071,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"IW" = (
+"JE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"IX" = (
+"JF" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"IY" = (
+"JG" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
 	dir = 4
@@ -19427,14 +20093,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"IZ" = (
+"JH" = (
 /obj/machinery/cryopod{
 	icon_state = "body_scanner_0";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ja" = (
+"JI" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -19442,7 +20108,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Jb" = (
+"JJ" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
 /obj/effect/floor_decal/industrial/warning{
@@ -19454,7 +20120,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Jc" = (
+"JK" = (
 /obj/structure/bed/chair/wheelchair{
 	icon_state = "wheelchair";
 	dir = 4
@@ -19470,7 +20136,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Jd" = (
+"JL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19488,7 +20154,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Je" = (
+"JM" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
 	dir = 4
@@ -19508,13 +20174,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Jf" = (
+"JN" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Jg" = (
+"JO" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
 	dir = 8
@@ -19531,7 +20197,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Jh" = (
+"JP" = (
 /obj/structure/bed/chair/comfy/teal{
 	icon_state = "comfychair_preview";
 	dir = 1
@@ -19539,12 +20205,12 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ji" = (
+"JQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Jj" = (
+"JR" = (
 /obj/machinery/vending/coffee,
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
@@ -19555,7 +20221,7 @@
 	dir = 5
 	},
 /area/medical/patient_wing)
-"Jk" = (
+"JS" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled{
@@ -19563,7 +20229,7 @@
 	dir = 5
 	},
 /area/medical/patient_wing)
-"Jl" = (
+"JT" = (
 /obj/machinery/vending/snack,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -19573,13 +20239,13 @@
 	dir = 5
 	},
 /area/medical/patient_wing)
-"Jm" = (
+"JU" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/cups,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Jn" = (
+"JV" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
@@ -19590,13 +20256,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Jo" = (
+"JW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Jp" = (
+"JX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -19612,7 +20278,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Jq" = (
+"JY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -19626,7 +20292,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Jr" = (
+"JZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -19644,7 +20310,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Js" = (
+"Ka" = (
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1379;
@@ -19677,7 +20343,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Jt" = (
+"Kb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -19691,7 +20357,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ju" = (
+"Kc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -19705,7 +20371,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Jv" = (
+"Kd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -19719,7 +20385,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Jw" = (
+"Ke" = (
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1379;
@@ -19743,7 +20409,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Jx" = (
+"Kf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -19759,7 +20425,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Jy" = (
+"Kg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -19768,7 +20434,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Jz" = (
+"Kh" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
@@ -19780,7 +20446,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"JA" = (
+"Ki" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/beakers{
 	pixel_x = 2;
@@ -19801,7 +20467,7 @@
 /obj/item/weapon/storage/bag/slimes,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"JB" = (
+"Kj" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/syringes,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19816,7 +20482,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"JC" = (
+"Kk" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
@@ -19828,7 +20494,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"JD" = (
+"Kl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -19837,13 +20503,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"JE" = (
+"Km" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"JF" = (
+"Kn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 9
@@ -19854,7 +20520,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"JG" = (
+"Ko" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -19870,18 +20536,18 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"JH" = (
+"Kp" = (
 /mob/living/carbon/slime,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"JI" = (
+"Kq" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 5";
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"JJ" = (
+"Kr" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -19890,10 +20556,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"JK" = (
+"Ks" = (
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"JL" = (
+"Kt" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19913,7 +20579,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"JM" = (
+"Ku" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -19930,7 +20596,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"JN" = (
+"Kv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -19950,7 +20616,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"JO" = (
+"Kw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19966,11 +20632,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"JP" = (
+"Kx" = (
 /obj/structure/curtain,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"JQ" = (
+"Ky" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -19981,7 +20647,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"JR" = (
+"Kz" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/lime{
@@ -19989,12 +20655,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"JS" = (
+"KA" = (
 /obj/structure/flora/pottedplant/random,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"JT" = (
+"KB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -20006,7 +20672,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"JU" = (
+"KC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20015,7 +20681,7 @@
 	dir = 5
 	},
 /area/medical/patient_wing)
-"JV" = (
+"KD" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/light,
 /obj/structure/sign/nosmoking_1{
@@ -20030,20 +20696,20 @@
 	dir = 5
 	},
 /area/medical/patient_wing)
-"JW" = (
+"KE" = (
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/medical/patient_wing)
-"JX" = (
+"KF" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"JY" = (
+"KG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -20058,7 +20724,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"JZ" = (
+"KH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -20074,20 +20740,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ka" = (
+"KI" = (
 /obj/turbolift_map_holder/aurora/research,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/research_maintenance)
-"Kb" = (
+"KJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/mauve/full,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Kc" = (
+"KK" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
@@ -20098,14 +20764,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Kd" = (
+"KL" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ke" = (
+"KM" = (
 /obj/structure/sink{
 	icon_state = "sink";
 	dir = 8;
@@ -20124,7 +20790,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kf" = (
+"KN" = (
 /obj/machinery/shower{
 	dir = 1
 	},
@@ -20134,7 +20800,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kg" = (
+"KO" = (
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -20161,7 +20827,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kh" = (
+"KP" = (
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	id_tag = "xeno_airlock_control";
 	name = "Xenobiology Access Console";
@@ -20186,13 +20852,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ki" = (
+"KQ" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kj" = (
+"KR" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped,
 /obj/item/weapon/reagent_containers/spray/cleaner,
@@ -20206,7 +20872,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kk" = (
+"KS" = (
 /obj/structure/table/standard,
 /obj/machinery/reagentgrinder,
 /obj/effect/floor_decal/corner/red{
@@ -20215,17 +20881,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kl" = (
+"KT" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Km" = (
+"KU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kn" = (
+"KV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -20251,40 +20917,40 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"Ko" = (
+"KW" = (
 /turf/simulated/wall,
 /area/crew_quarters/medbreak)
-"Kp" = (
+"KX" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"Kq" = (
+"KY" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"Kr" = (
+"KZ" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"Ks" = (
+"La" = (
 /turf/unsimulated/chasm_mask,
 /area/crew_quarters/medbreak)
-"Kt" = (
+"Lb" = (
 /obj/structure/table/standard,
 /obj/item/weapon/cane,
 /obj/item/weapon/storage/box/rxglasses,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Ku" = (
+"Lc" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
 	dir = 4
@@ -20301,14 +20967,14 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Kv" = (
+"Ld" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Kw" = (
+"Le" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -20316,7 +20982,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Kx" = (
+"Lf" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
 	dir = 8
@@ -20336,18 +21002,32 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Ky" = (
+"Lg" = (
 /turf/simulated/wall/r_wall,
 /area/medical/ward)
-"Kz" = (
+"Lh" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/medical/patient_wing)
-"KA" = (
+"Li" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"Lj" = (
+/obj/structure/target_stake,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"Lk" = (
 /obj/effect/floor_decal/corner/mauve/full,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"KB" = (
+"Ll" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -20361,7 +21041,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"KC" = (
+"Lm" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
 	},
@@ -20377,7 +21057,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KD" = (
+"Ln" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/item/weapon/storage/box/monkeycubes,
@@ -20386,7 +21066,7 @@
 /obj/effect/floor_decal/corner/mauve/full,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KE" = (
+"Lo" = (
 /obj/structure/table/standard,
 /obj/item/stack/material/phoron{
 	amount = 5
@@ -20397,7 +21077,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KF" = (
+"Lp" = (
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -20406,27 +21086,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KG" = (
+"Lq" = (
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"KH" = (
+"Lr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"KI" = (
+"Ls" = (
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"KJ" = (
+"Lt" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/item/device/radio/intercom{
@@ -20438,11 +21118,11 @@
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"KK" = (
+"Lu" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"KL" = (
+"Lv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20454,7 +21134,7 @@
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"KM" = (
+"Lw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -20463,17 +21143,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"KN" = (
+"Lx" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"KO" = (
+"Ly" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"KP" = (
+"Lz" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/storage)
-"KQ" = (
+"LA" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
 	req_access = list(8)
@@ -20481,7 +21161,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/rnd/storage)
-"KR" = (
+"LB" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
 	req_access = list(8)
@@ -20496,7 +21176,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/rnd/storage)
-"KS" = (
+"LC" = (
 /obj/structure/sink{
 	pixel_y = 26
 	},
@@ -20515,7 +21195,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KT" = (
+"LD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -20530,7 +21210,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KU" = (
+"LE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 9
@@ -20546,17 +21226,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KV" = (
+"LF" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KW" = (
+"LG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KX" = (
+"LH" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/blast_door{
@@ -20575,7 +21255,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"KY" = (
+"LI" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -20598,7 +21278,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"KZ" = (
+"LJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -20612,26 +21292,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"La" = (
+"LK" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Lb" = (
+"LL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Lc" = (
+"LM" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Ld" = (
+"LN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Le" = (
+"LO" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -20645,14 +21325,14 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Lf" = (
+"LP" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Lg" = (
+"LQ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -20667,13 +21347,13 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"Lh" = (
+"LR" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Li" = (
+"LS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
 	dir = 4;
@@ -20690,14 +21370,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Lj" = (
+"LT" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Lk" = (
+"LU" = (
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Pill Cabinet";
 	pixel_y = -32
@@ -20710,7 +21390,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Ll" = (
+"LV" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -20730,7 +21410,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Lm" = (
+"LW" = (
 /obj/machinery/vending/snack,
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
@@ -20741,21 +21421,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Ln" = (
+"LX" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"Lo" = (
+"LY" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Lp" = (
+"LZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10;
 	icon_state = "intact"
@@ -20766,7 +21446,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Lq" = (
+"Ma" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Toxins Mixing Fore"
 	},
@@ -20776,17 +21456,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Lr" = (
+"Mb" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ls" = (
+"Mc" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Lt" = (
+"Md" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
@@ -20797,25 +21477,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Lu" = (
+"Me" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	icon_state = "intact";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Lv" = (
+"Mf" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Lw" = (
+"Mg" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Lx" = (
+"Mh" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Toxins Storage"
 	},
@@ -20824,7 +21504,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Ly" = (
+"Mi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -20837,33 +21517,33 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Lz" = (
+"Mj" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"LA" = (
+"Mk" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/mauve/full,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"LB" = (
+"Ml" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"LC" = (
+"Mm" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"LD" = (
+"Mn" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -20879,14 +21559,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"LE" = (
+"Mo" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 4";
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"LF" = (
+"Mp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -20898,7 +21578,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"LG" = (
+"Mq" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -20907,7 +21587,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LH" = (
+"Mr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -20917,7 +21597,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LI" = (
+"Ms" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
@@ -20930,7 +21610,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LJ" = (
+"Mt" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/donut,
 /obj/structure/disposalpipe/junction/yjunction{
@@ -20950,7 +21630,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LK" = (
+"Mu" = (
 /obj/item/weapon/stool/padded,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20974,7 +21654,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LL" = (
+"Mv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20992,7 +21672,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LM" = (
+"Mw" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Staff Break Room";
 	req_access = list(5)
@@ -21015,7 +21695,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LN" = (
+"Mx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -21032,7 +21712,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"LO" = (
+"My" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -21054,7 +21734,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"LP" = (
+"Mz" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/unary/freezer{
 	icon_state = "freezer_0";
@@ -21062,39 +21742,39 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"LQ" = (
+"MA" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"LR" = (
+"MB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"LS" = (
+"MC" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"LT" = (
+"MD" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"LU" = (
+"ME" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"LV" = (
+"MF" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
 	frequency = 1441;
@@ -21105,11 +21785,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"LW" = (
+"MG" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"LX" = (
+"MH" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -21117,7 +21797,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"LY" = (
+"MI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -21126,13 +21806,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"LZ" = (
+"MJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Ma" = (
+"MK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -21147,7 +21827,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Mb" = (
+"ML" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
 	dir = 4;
@@ -21156,7 +21836,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Mc" = (
+"MM" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -21171,7 +21851,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Md" = (
+"MN" = (
 /obj/machinery/door/window/northright{
 	name = "Containment Pen";
 	req_access = list(47)
@@ -21184,7 +21864,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Me" = (
+"MO" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -21204,7 +21884,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Mf" = (
+"MP" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -21220,7 +21900,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Mg" = (
+"MQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -21240,7 +21920,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Mh" = (
+"MR" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Aft";
@@ -21248,7 +21928,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Mi" = (
+"MS" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -21268,7 +21948,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Mj" = (
+"MT" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -21285,7 +21965,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Mk" = (
+"MU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -21311,7 +21991,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"Ml" = (
+"MV" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -21322,7 +22002,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"Mm" = (
+"MW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -21331,7 +22011,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"Mn" = (
+"MX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -21343,7 +22023,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"Mo" = (
+"MY" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
 /obj/machinery/light{
@@ -21358,13 +22038,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Mp" = (
+"MZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Mq" = (
+"Na" = (
 /obj/structure/table/glass,
 /obj/item/device/radio{
 	anchored = 1;
@@ -21379,7 +22059,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Mr" = (
+"Nb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/structure/disposalpipe/segment,
@@ -21391,7 +22071,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Ms" = (
+"Nc" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -21399,7 +22079,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Mt" = (
+"Nd" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -21413,16 +22093,16 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"Mu" = (
+"Ne" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Mv" = (
+"Nf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Mw" = (
+"Ng" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -21437,20 +22117,20 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/medical/medbay4)
-"Mx" = (
+"Nh" = (
 /obj/structure/table/rack,
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"My" = (
+"Ni" = (
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Mz" = (
+"Nj" = (
 /obj/structure/table/rack,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
@@ -21471,7 +22151,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"MA" = (
+"Nk" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/belt/medical,
 /obj/item/weapon/storage/belt/medical,
@@ -21485,21 +22165,21 @@
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"MB" = (
+"Nl" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
 /obj/item/weapon/storage/toolbox/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"MC" = (
+"Nm" = (
 /obj/structure/closet/secure_closet/medical3,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"MD" = (
+"Nn" = (
 /turf/simulated/wall/r_wall,
 /area/medical/medbay4)
-"ME" = (
+"No" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
@@ -21509,14 +22189,14 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MF" = (
+"Np" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MG" = (
+"Nq" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 5
@@ -21524,13 +22204,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MH" = (
+"Nr" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MI" = (
+"Ns" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	icon_state = "map_vent_in";
 	dir = 8;
@@ -21546,7 +22226,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MJ" = (
+"Nt" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/alarm{
 	dir = 4;
@@ -21556,17 +22236,17 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"MK" = (
+"Nu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"ML" = (
+"Nv" = (
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"MM" = (
+"Nw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -21581,7 +22261,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"MN" = (
+"Nx" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21589,7 +22269,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"MO" = (
+"Ny" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -21597,7 +22277,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"MP" = (
+"Nz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -21621,7 +22301,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"MQ" = (
+"NA" = (
 /obj/machinery/door/window/southright{
 	name = "Containment Pen";
 	req_access = list(47)
@@ -21637,7 +22317,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"MR" = (
+"NB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -21660,7 +22340,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"MS" = (
+"NC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -21684,7 +22364,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"MT" = (
+"ND" = (
 /obj/machinery/door/window/southright{
 	name = "Containment Pen";
 	req_access = list(47)
@@ -21700,7 +22380,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"MU" = (
+"NE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -21723,7 +22403,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"MV" = (
+"NF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -21747,7 +22427,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"MW" = (
+"NG" = (
 /obj/machinery/door/window/southright{
 	name = "Containment Pen";
 	req_access = list(47)
@@ -21763,7 +22443,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"MX" = (
+"NH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -21786,7 +22466,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"MY" = (
+"NI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -21797,11 +22477,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"MZ" = (
+"NJ" = (
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"Na" = (
+"NK" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
@@ -21809,14 +22489,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"Nb" = (
+"NL" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Staff Smoking Lounge"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"Nc" = (
+"NM" = (
 /obj/machinery/recharge_station,
 /obj/machinery/alarm{
 	dir = 4;
@@ -21831,7 +22511,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Nd" = (
+"NN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21841,12 +22521,12 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Ne" = (
+"NO" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Nf" = (
+"NP" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -21857,7 +22537,7 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"Ng" = (
+"NQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -21866,7 +22546,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Nh" = (
+"NR" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Auxiliary Storage";
 	req_access = list(5)
@@ -21880,7 +22560,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"Ni" = (
+"NS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -21889,7 +22569,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"Nj" = (
+"NT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -21898,29 +22578,29 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"Nk" = (
+"NU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"Nl" = (
+"NV" = (
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"Nm" = (
+"NW" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 6
 	},
 /turf/simulated/mineral,
 /area/mine/unexplored)
-"Nn" = (
+"NX" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"No" = (
+"NY" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -21931,13 +22611,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Np" = (
+"NZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Nq" = (
+"Oa" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
 	name = "To Space"
@@ -21945,7 +22625,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Nr" = (
+"Ob" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10;
 	icon_state = "intact"
@@ -21961,14 +22641,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ns" = (
+"Oc" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	icon_state = "intact";
 	dir = 1
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"Nt" = (
+"Od" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -21982,7 +22662,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Nu" = (
+"Oe" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/light{
 	dir = 8
@@ -21990,29 +22670,29 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Nv" = (
+"Of" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Nw" = (
+"Og" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Nx" = (
+"Oh" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Ny" = (
+"Oi" = (
 /obj/structure/bed/chair/comfy/beige,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"Nz" = (
+"Oj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -22022,7 +22702,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"NA" = (
+"Ok" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22034,7 +22714,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"NB" = (
+"Ol" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Staff Smoking Lounge";
 	req_access = list(5)
@@ -22051,7 +22731,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"NC" = (
+"Om" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22069,7 +22749,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"ND" = (
+"On" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22086,7 +22766,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"NE" = (
+"Oo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22107,7 +22787,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"NF" = (
+"Op" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -22126,13 +22806,13 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"NG" = (
+"Oq" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/cups,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"NH" = (
+"Or" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/item/weapon/tape_roll,
@@ -22141,7 +22821,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"NI" = (
+"Os" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -22153,13 +22833,13 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"NJ" = (
+"Ot" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"NK" = (
+"Ou" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
 	name = "Grenade Crate";
@@ -22181,25 +22861,25 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"NL" = (
+"Ov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"NM" = (
+"Ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"NN" = (
+"Ox" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"NO" = (
+"Oy" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/light{
 	dir = 4;
@@ -22207,11 +22887,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"NP" = (
+"Oz" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/mineral,
 /area/mine/unexplored)
-"NQ" = (
+"OA" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/light{
 	dir = 8
@@ -22219,7 +22899,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"NR" = (
+"OB" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -22227,7 +22907,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"NS" = (
+"OC" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
@@ -22238,21 +22918,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"NT" = (
+"OD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"NU" = (
+"OE" = (
 /obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"NV" = (
+"OF" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"NW" = (
+"OG" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
 	name = "CO2 to Connector"
@@ -22262,7 +22942,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"NX" = (
+"OH" = (
 /obj/structure/closet/bombcloset,
 /obj/structure/cable/green{
 	d2 = 4;
@@ -22278,7 +22958,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"NY" = (
+"OI" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -22289,14 +22969,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"NZ" = (
+"OJ" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Oa" = (
+"OK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -22311,7 +22991,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Ob" = (
+"OL" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22319,7 +22999,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Oc" = (
+"OM" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -22327,14 +23007,14 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Od" = (
+"ON" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Oe" = (
+"OO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -22346,7 +23026,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"Of" = (
+"OP" = (
 /obj/structure/table/glass,
 /obj/item/weapon/material/ashtray/bronze,
 /obj/item/device/radio{
@@ -22362,13 +23042,13 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"Og" = (
+"OQ" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"Oh" = (
+"OR" = (
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -22389,10 +23069,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"Oi" = (
+"OS" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep/medical)
-"Oj" = (
+"OT" = (
 /obj/machinery/door/airlock/medical{
 	name = "Staff Dormitories";
 	req_access = list(5)
@@ -22407,7 +23087,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Ok" = (
+"OU" = (
 /obj/machinery/door/airlock/medical{
 	name = "Staff Hygiene Facilities";
 	req_access = list(5)
@@ -22417,14 +23097,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"Ol" = (
+"OV" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25;
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Om" = (
+"OW" = (
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
@@ -22439,7 +23119,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"On" = (
+"OX" = (
 /obj/structure/table/standard,
 /obj/item/device/radio{
 	frequency = 1487;
@@ -22472,13 +23152,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Oo" = (
+"OY" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/syringegun,
 /obj/item/weapon/gun/launcher/syringe,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Op" = (
+"OZ" = (
 /obj/structure/closet/l3closet/general,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/suit/bio_suit/general,
@@ -22486,14 +23166,14 @@
 /obj/item/clothing/head/bio_hood/general,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Oq" = (
+"Pa" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored)
-"Or" = (
+"Pb" = (
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Os" = (
+"Pc" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
 	},
@@ -22502,7 +23182,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ot" = (
+"Pd" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 5
@@ -22517,7 +23197,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ou" = (
+"Pe" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
 	icon_state = "map_off";
@@ -22537,25 +23217,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ov" = (
+"Pf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ow" = (
+"Pg" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ox" = (
+"Ph" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Oy" = (
+"Pi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -22574,7 +23254,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Oz" = (
+"Pj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -22588,7 +23268,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"OA" = (
+"Pk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -22602,7 +23282,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"OB" = (
+"Pl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -22619,12 +23299,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"OC" = (
+"Pm" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"OD" = (
+"Pn" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/machinery/light{
 	dir = 4;
@@ -22633,7 +23313,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"OE" = (
+"Po" = (
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
@@ -22642,28 +23322,28 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"OF" = (
+"Pp" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 1";
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"OG" = (
+"Pq" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 2";
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"OH" = (
+"Pr" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 3";
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"OI" = (
+"Ps" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -22677,7 +23357,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"OJ" = (
+"Pt" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
 /obj/machinery/light{
@@ -22689,7 +23369,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"OK" = (
+"Pu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -22697,7 +23377,7 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"OL" = (
+"Pv" = (
 /obj/structure/sink{
 	pixel_y = 16
 	},
@@ -22709,11 +23389,11 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"OM" = (
+"Pw" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"ON" = (
+"Px" = (
 /obj/machinery/requests_console{
 	department = "Medical Bay";
 	departmentType = 1;
@@ -22722,12 +23402,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"OO" = (
+"Py" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"OP" = (
+"Pz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -22742,11 +23422,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/medbay4)
-"OQ" = (
+"PA" = (
 /obj/structure/lattice/catwalk,
 /turf/simulated/open,
 /area/mine/unexplored)
-"OR" = (
+"PB" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
 	frequency = 1441;
@@ -22758,7 +23438,7 @@
 /obj/structure/lattice/catwalk,
 /turf/simulated/open,
 /area/mine/unexplored)
-"OS" = (
+"PC" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
@@ -22779,7 +23459,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"OT" = (
+"PD" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
@@ -22798,7 +23478,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"OU" = (
+"PE" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
@@ -22815,7 +23495,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"OV" = (
+"PF" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	icon_state = "phoronrwindow";
@@ -22835,7 +23515,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"OW" = (
+"PG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -22853,7 +23533,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"OX" = (
+"PH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -22867,7 +23547,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"OY" = (
+"PI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -22886,7 +23566,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"OZ" = (
+"PJ" = (
 /obj/machinery/button/remote/blast_door{
 	id = "mixvent";
 	name = "Mixing Room Vent Control";
@@ -22912,7 +23592,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Pa" = (
+"PK" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Toxins Lab";
 	req_access = list(7)
@@ -22931,7 +23611,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Pb" = (
+"PL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -22949,7 +23629,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Pc" = (
+"PM" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -22957,12 +23637,12 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Pd" = (
+"PN" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Pe" = (
+"PO" = (
 /obj/machinery/computer/area_atmos,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning{
@@ -22970,14 +23650,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Pf" = (
+"PP" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Pg" = (
+"PQ" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -22987,7 +23667,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Ph" = (
+"PR" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 22
@@ -22998,7 +23678,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Pi" = (
+"PS" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -23006,7 +23686,7 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Pj" = (
+"PT" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -23018,7 +23698,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Pk" = (
+"PU" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -23037,7 +23717,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Pl" = (
+"PV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -23048,13 +23728,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"Pm" = (
+"PW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"Pn" = (
+"PX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -23063,7 +23743,7 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"Po" = (
+"PY" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -23076,24 +23756,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Pp" = (
+"PZ" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Pq" = (
+"Qa" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Pr" = (
+"Qb" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Ps" = (
+"Qc" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
@@ -23104,7 +23784,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Pt" = (
+"Qd" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair/office/light,
 /obj/effect/landmark/start{
@@ -23112,13 +23792,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Pu" = (
+"Qe" = (
 /obj/structure/sign/greencross{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Pv" = (
+"Qf" = (
 /obj/machinery/door/blast/regular{
 	dir = 1;
 	id = "mixvent";
@@ -23126,18 +23806,18 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"Pw" = (
+"Qg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"Px" = (
+"Qh" = (
 /obj/machinery/air_sensor{
 	id_tag = "HT";
 	name = "Gas Sensor - High-Temp Chamber"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"Py" = (
+"Qi" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/sparker{
 	dir = 2;
@@ -23146,7 +23826,7 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"Pz" = (
+"Qj" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	icon_state = "phoronrwindow";
@@ -23166,20 +23846,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"PA" = (
+"Qk" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"PB" = (
+"Ql" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"PC" = (
+"Qm" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 6
@@ -23193,14 +23873,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"PD" = (
+"Qn" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"PE" = (
+"Qo" = (
 /obj/structure/bed,
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
@@ -23213,7 +23893,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"PF" = (
+"Qp" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -23223,7 +23903,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"PG" = (
+"Qq" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/green,
 /obj/machinery/light/small,
@@ -23232,7 +23912,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"PH" = (
+"Qr" = (
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
@@ -23240,13 +23920,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"PI" = (
+"Qs" = (
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"PJ" = (
+"Qt" = (
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"PK" = (
+"Qu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -23255,7 +23935,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"PL" = (
+"Qv" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
 	dir = 6
@@ -23268,7 +23948,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"PM" = (
+"Qw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23282,10 +23962,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"PN" = (
+"Qx" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"PO" = (
+"Qy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"Qz" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23293,7 +23989,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"PP" = (
+"QA" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
@@ -23302,13 +23998,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"PQ" = (
+"QB" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"PR" = (
+"QC" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
@@ -23317,7 +24013,7 @@
 	},
 /turf/simulated/open,
 /area/mine/unexplored)
-"PS" = (
+"QD" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	frequency = 1441;
@@ -23327,14 +24023,14 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"PT" = (
+"QE" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"PU" = (
+"QF" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	icon_state = "phoronrwindow";
@@ -23357,14 +24053,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"PV" = (
+"QG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"PW" = (
+"QH" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23376,7 +24072,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"PX" = (
+"QI" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -23395,7 +24091,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"PY" = (
+"QJ" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	icon_state = "door_open";
@@ -23403,7 +24099,7 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"PZ" = (
+"QK" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	icon_state = "door_open";
@@ -23411,19 +24107,35 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"Qa" = (
+"QL" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"QM" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"QN" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"QO" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"Qb" = (
+"QP" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"Qc" = (
+"QQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	icon_state = "intact";
 	dir = 9
@@ -23435,11 +24147,11 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"Qd" = (
+"QR" = (
 /obj/structure/dispenser,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Qe" = (
+"QS" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 5
@@ -23453,7 +24165,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Qf" = (
+"QT" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -23461,7 +24173,17 @@
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Qh" = (
+"QU" = (
+/obj/structure/toilet{
+	icon_state = "toilet00";
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/medbreak)
+"QV" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair{
 	dir = 1
@@ -23471,7 +24193,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Qi" = (
+"QW" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -23481,7 +24203,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Qj" = (
+"QX" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -23494,7 +24216,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Qk" = (
+"QY" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair{
 	dir = 1
@@ -23504,7 +24226,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Ql" = (
+"QZ" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
@@ -23525,7 +24247,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Qm" = (
+"Ra" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	icon_state = "phoronrwindow";
@@ -23542,7 +24264,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Qn" = (
+"Rb" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room Access";
 	req_access = list(7)
@@ -23557,7 +24279,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Qo" = (
+"Rc" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/prox_sensor,
 /obj/item/device/assembly/prox_sensor,
@@ -23569,7 +24291,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Qp" = (
+"Rd" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/signaler,
 /obj/item/device/assembly/signaler,
@@ -23580,7 +24302,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Qq" = (
+"Re" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/timer,
 /obj/item/device/assembly/timer,
@@ -23593,7 +24315,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Qr" = (
+"Rf" = (
 /obj/structure/table/standard,
 /obj/item/device/transfer_valve,
 /obj/item/device/transfer_valve,
@@ -23610,14 +24332,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Qs" = (
+"Rg" = (
 /obj/machinery/vending/phoronresearch,
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Qt" = (
+"Rh" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Toxins Testing Observation"
 	},
@@ -23627,7 +24349,7 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Qu" = (
+"Ri" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
@@ -23637,7 +24359,7 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Qv" = (
+"Rj" = (
 /obj/effect/floor_decal/corner/red/full{
 	icon_state = "corner_white_full";
 	dir = 1
@@ -23647,11 +24369,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Qw" = (
+"Rk" = (
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Qx" = (
+"Rl" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"Rm" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"Rn" = (
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -23659,7 +24395,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Qy" = (
+"Ro" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 9
@@ -23668,7 +24404,7 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Qz" = (
+"Rp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
@@ -23681,7 +24417,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QA" = (
+"Rq" = (
 /obj/item/target,
 /obj/item/target,
 /obj/item/target/alien,
@@ -23697,7 +24433,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QB" = (
+"Rr" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -23711,21 +24447,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QC" = (
+"Rs" = (
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QD" = (
+"Rt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QE" = (
+"Ru" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QF" = (
+"Rv" = (
 /obj/machinery/door/window/southright{
 	dir = 8;
 	name = "Toxins Launcher";
@@ -23740,14 +24476,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"QG" = (
+"Rw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"QH" = (
+"Rx" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair{
 	dir = 1
@@ -23757,7 +24493,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"QI" = (
+"Ry" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -23766,7 +24502,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"QJ" = (
+"Rz" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Toxins Testing Storage";
@@ -23777,7 +24513,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QK" = (
+"RA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -23791,7 +24527,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QL" = (
+"RB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -23801,7 +24537,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QM" = (
+"RC" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room";
 	req_access = list(7)
@@ -23815,7 +24551,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QN" = (
+"RD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -23828,7 +24564,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QO" = (
+"RE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -23837,24 +24573,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QP" = (
+"RF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QQ" = (
+"RG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QR" = (
+"RH" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QS" = (
+"RI" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -23865,11 +24601,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"QT" = (
+"RJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"QU" = (
+"RK" = (
 /obj/machinery/requests_console{
 	department = "Medical Bay";
 	departmentType = 1;
@@ -23878,14 +24614,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"QV" = (
+"RL" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_x = 32;
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"QW" = (
+"RM" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -23893,7 +24629,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"QX" = (
+"RN" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1379;
@@ -23910,7 +24646,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"QY" = (
+"RO" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -23934,7 +24670,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"QZ" = (
+"RP" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1379;
@@ -23963,7 +24699,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Ra" = (
+"RQ" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
 	icon_state = "door_locked";
@@ -23981,7 +24717,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Rb" = (
+"RR" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 10
@@ -24006,7 +24742,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rc" = (
+"RS" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -24023,19 +24759,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rd" = (
+"RT" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Re" = (
+"RU" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/floor_decal/corner/red/full,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rf" = (
+"RV" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -24046,7 +24782,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rg" = (
+"RW" = (
 /obj/structure/table/standard,
 /obj/item/weapon/wrench,
 /obj/item/weapon/screwdriver,
@@ -24056,7 +24792,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rh" = (
+"RX" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -24064,7 +24800,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Ri" = (
+"RY" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -24073,7 +24809,7 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rj" = (
+"RZ" = (
 /obj/structure/bed/chair,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the test chamber.";
@@ -24089,7 +24825,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rk" = (
+"Sa" = (
 /obj/structure/bed/chair,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the test chamber.";
@@ -24111,11 +24847,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rl" = (
+"Sb" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/mineral,
 /area/mine/unexplored)
-"Rm" = (
+"Sc" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair{
 	dir = 1
@@ -24125,7 +24861,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Rn" = (
+"Sd" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -24134,12 +24870,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Ro" = (
+"Se" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Rp" = (
+"Sf" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -24148,7 +24884,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Rq" = (
+"Sg" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair{
 	dir = 1
@@ -24158,13 +24894,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Rr" = (
+"Sh" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/rnd/mixing)
-"Rs" = (
+"Si" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -24172,7 +24908,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"Rt" = (
+"Sj" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -24194,7 +24930,7 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Ru" = (
+"Sk" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -24212,7 +24948,7 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Rv" = (
+"Sl" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -24234,13 +24970,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Rw" = (
+"Sm" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: BOMB RANGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"Rx" = (
+"Sn" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -24253,7 +24989,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/mixing)
-"Ry" = (
+"So" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24261,20 +24997,20 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/mixing)
-"Rz" = (
+"Sp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/mineral,
 /area/mine/unexplored)
-"RA" = (
+"Sq" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/rnd/mixing)
-"RB" = (
+"Sr" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 4
@@ -24287,7 +25023,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/mixing)
-"RC" = (
+"Ss" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -24296,7 +25032,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"RD" = (
+"St" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -24304,7 +25040,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"RE" = (
+"Su" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -24312,7 +25048,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"RF" = (
+"Sv" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -24323,7 +25059,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"RG" = (
+"Sw" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -24341,11 +25077,11 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/mixing)
-"RH" = (
+"Sx" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/rnd/mixing)
-"RI" = (
+"Sy" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -24359,14 +25095,14 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/mixing)
-"RJ" = (
+"Sz" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 8
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"RK" = (
+"SA" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
 	name = "BOMB RANGE";
@@ -24375,13 +25111,13 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"RL" = (
+"SB" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: BOMB RANGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored)
-"RM" = (
+"SC" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -24391,7 +25127,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"RN" = (
+"SD" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -24409,37 +25145,40 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"RO" = (
+"SE" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"RP" = (
+"SF" = (
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"RQ" = (
+"SG" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"RR" = (
+"SH" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"RS" = (
+"SI" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Machinery Maintenance";
 	req_access = list(11)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"RT" = (
+"SJ" = (
+/turf/simulated/wall,
+/area/maintenance/disposal)
+"SK" = (
 /obj/machinery/crusher_base,
 /turf/simulated/floor/reinforced,
 /area/maintenance/disposal)
-"RU" = (
+"SL" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
 	name = "KEEP CLEAR: MEDICAL EXOSUIT PARKING";
@@ -24447,7 +25186,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"RV" = (
+"SM" = (
 /obj/structure/ladder/up,
 /obj/item/device/radio/intercom{
 	dir = 0;
@@ -24456,7 +25195,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"RW" = (
+"SN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -24471,21 +25210,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"RX" = (
+"SO" = (
 /obj/random/junk,
 /turf/simulated/floor/reinforced{
 	roof_type = null
 	},
 /area/maintenance/disposal)
-"RY" = (
+"SP" = (
 /turf/simulated/floor/reinforced{
 	roof_type = null
 	},
 /area/maintenance/disposal)
-"RZ" = (
+"SQ" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/test_area)
-"Sa" = (
+"SR" = (
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -24496,7 +25235,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/test_area)
-"Sb" = (
+"SS" = (
 /obj/item/modular_computer/telescreen/preset/trashcompactor{
 	pixel_x = -32
 	},
@@ -24511,14 +25250,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"Sc" = (
+"ST" = (
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"Sd" = (
+"SU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -24530,12 +25269,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"Se" = (
+"SV" = (
 /turf/simulated/floor/tiled/airless{
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/test_area)
-"Sf" = (
+"SW" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	id_tag = "crusher";
 	name = "Compactor Access";
@@ -24543,24 +25282,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"Sg" = (
+"SX" = (
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
-"Sh" = (
+"SY" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"Si" = (
+"SZ" = (
 /obj/structure/window/reinforced{
 	dir = 5;
 	health = 1e+007
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
-"Sj" = (
+"Ta" = (
 /obj/machinery/light/spot{
 	icon_state = "tube1";
 	dir = 8
@@ -24572,11 +25311,11 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
-"Sk" = (
+"Tb" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
-"Sl" = (
+"Tc" = (
 /obj/machinery/light/spot{
 	icon_state = "tube1";
 	dir = 4
@@ -24588,7 +25327,7 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
-"Sm" = (
+"Td" = (
 /obj/machinery/light/spot,
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Toxins Testing Aft";
@@ -24597,888 +25336,6 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
-"So" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor{
-	dir = 4;
-	name = "Firelock"
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/engineering/hallway)
-"Sp" = (
-/turf/simulated/wall,
-/area/engineering/atmos)
-"St" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/simulated/floor{
-	icon_state = "plating"
-	},
-/area/engineering/gravity_gen)
-"Su" = (
-/obj/machinery/camera/network/engineering_outpost{
-	c_tag = "Engineering Sublevel - Gravity Chamber";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor{
-	icon_state = "plating"
-	},
-/area/engineering/gravity_gen)
-"Sv" = (
-/turf/simulated/wall,
-/area/maintenance/sublevel)
-"Sx" = (
-/turf/simulated/wall,
-/area/bridge/aibunker)
-"SC" = (
-/turf/simulated/wall,
-/area/outpost/research/anomaly_analysis)
-"SF" = (
-/turf/simulated/wall,
-/area/outpost/research/analysis)
-"SI" = (
-/turf/simulated/wall,
-/area/outpost/research/emergency_storage)
-"SQ" = (
-/turf/simulated/wall,
-/area/outpost/research/eva)
-"Tc" = (
-/turf/simulated/wall,
-/area/outpost/research/hallway)
-"Tj" = (
-/turf/simulated/wall,
-/area/maintenance/disposal)
-"Tk" = (
-/obj/structure/table/rack,
-/obj/item/hoist_kit,
-/turf/simulated/floor/asteroid/ash/rocky,
-/area/mine/unexplored)
-"Tl" = (
-/obj/machinery/door/firedoor{
-	dir = 4;
-	name = "Firelock"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	name = "Anomalous Materials Locker Room";
-	req_access = list(65)
-	},
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/anomaly_analysis)
-"Tm" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"Tn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"To" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"Tp" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"Tq" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"Tr" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"Ts" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	icon_state = "map";
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
-"Tt" = (
-/obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
-"Tu" = (
-/obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
-"Tv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	dir = 2;
-	name = "light switch ";
-	pixel_x = 0;
-	pixel_y = 36
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	is_critical = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/simulated/floor/plating,
-/area/outpost/engineering/power)
-"Tw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Break Room";
-	req_one_access = list(11,24)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/outpost/engineering/hallway)
-"Tx" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Restrooms";
-	req_one_access = list(11,24)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/freezer,
-/area/outpost/engineering/meeting)
-"Ty" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/valve/digital{
-	dir = 4;
-	icon_state = "map_valve0";
-	name = "Air Bypass valve"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
-"Tz" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Tesla Bay";
-	req_access = list(11)
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/engineering/power)
-"TA" = (
-/obj/machinery/atmospherics/pipe/zpipe/up/cyan{
-	icon_state = "up";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
-"TB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Storage";
-	req_one_access = list(11,24)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "plating"
-	},
-/area/outpost/engineering/hallway)
-"TC" = (
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Storage";
-	req_one_access = list(11,24)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "plating"
-	},
-/area/outpost/engineering/hallway)
-"TD" = (
-/obj/machinery/atmospherics/pipe/zpipe/up/yellow{
-	icon_state = "up";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
-"TE" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access = list(11,24)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/sublevel)
-"TF" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access = list(11,24)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/sublevel)
-"TG" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/rig_module/vision/nvg,
-/turf/simulated/floor/plating,
-/area/security/nuke_storage)
-"TH" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/rig_module/chem_dispenser/injector,
-/turf/simulated/floor/plating,
-/area/security/nuke_storage)
-"TI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	desc = "It opens and closes. It has a small sign engraved: Bunker capacity: 6. Only facility's Command Staff is permitted.";
-	icon_state = "door_locked";
-	id_tag = "bunker3";
-	locked = 1;
-	name = "Command Bunker";
-	req_access = list(19);
-	secured_wires = 1
-	},
-/turf/simulated/floor{
-	icon_state = "plating"
-	},
-/area/bridge/aibunker)
-"TJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/item/device/radio/intercom/locked{
-	frequency = 1347;
-	locked_frequency = 1347;
-	name = "Bunker Entrance Intercom";
-	pixel_x = 0;
-	pixel_y = 22
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"TK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/firealarm/north,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"TL" = (
-/obj/machinery/door/airlock/highsecurity{
-	id_tag = null;
-	name = "Auxiliary Commanding Post";
-	req_access = list(19)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"TM" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"TN" = (
-/obj/structure/table/reinforced/steel,
-/obj/machinery/cell_charger,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"TO" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/weapon/storage/firstaid/regular,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"TP" = (
-/obj/machinery/firealarm/north,
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"TQ" = (
-/obj/structure/toilet{
-	icon_state = "toilet00";
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/medbreak)
-"TR" = (
-/obj/structure/toilet{
-	icon_state = "toilet00";
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/medbreak)
-"TS" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"TT" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"TU" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"TV" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"TW" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"TX" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"TY" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/bodyscanner{
-	tag = "icon-body_scanner_0 (WEST)";
-	icon_state = "body_scanner_0";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"TZ" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/body_scanconsole{
-	tag = "icon-body_scannerconsole (WEST)";
-	icon_state = "body_scannerconsole";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Ua" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/structure/bed/chair/office/light{
-	tag = "icon-officechair_white (EAST)";
-	icon_state = "officechair_white";
-	dir = 4
-	},
-/obj/machinery/firealarm/north,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Ub" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin,
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Uc" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"Ud" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Ue" = (
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Uf" = (
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Ug" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/pen,
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Uh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/outpost/research/hallway)
-"Ui" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"Uj" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Uk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Ul" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Um" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Un" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Test Range"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/hallway)
-"Uo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/hallway)
-"Up" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/hallway)
-"Uq" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"Ur" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Us" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Ut" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Uu" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Uv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/outpost/research/hallway)
-"Uw" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"Ux" = (
-/obj/machinery/door/window/southright,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"Uy" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/item/device/firing_pin/test_range,
-/obj/item/device/firing_pin/test_range,
-/obj/item/device/firing_pin/test_range,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"Uz" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UA" = (
-/obj/structure/table/reinforced,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/structure/closet/crate{
-	name = "Target Crate"
-	},
-/obj/item/weapon/storage/box/monkeycubes,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UB" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"UC" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UD" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UE" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UF" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UG" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"UH" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"UI" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UJ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UK" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UL" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"UM" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UN" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UO" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UP" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"UQ" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UR" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"US" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UT" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"UU" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UV" = (
-/obj/structure/target_stake,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UW" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UX" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UY" = (
-/obj/machinery/light{
-	dir = 4;
-	status = 2
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"UZ" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
 
 (1,1,1) = {"
 aa
@@ -29954,9 +29811,9 @@ aa
 aa
 jL
 jL
-lf
-lj
-lf
+lh
+ll
+lh
 jL
 jL
 aa
@@ -30210,11 +30067,11 @@ aa
 aa
 aa
 aa
-ld
 lf
+lh
+lh
+lh
 lf
-lf
-ld
 aa
 aa
 aa
@@ -30468,9 +30325,9 @@ aa
 aa
 jL
 jL
-lf
-lf
-lf
+lh
+lh
+lh
 jL
 jL
 aa
@@ -30724,11 +30581,11 @@ aa
 aa
 aa
 aa
-le
+lg
 jL
 jL
 jL
-lZ
+mb
 aa
 aa
 aa
@@ -33027,7 +32884,7 @@ dg
 dg
 hk
 hP
-iq
+ir
 dg
 dg
 cs
@@ -33805,7 +33662,7 @@ at
 kl
 at
 at
-kT
+kU
 al
 aa
 aa
@@ -34576,7 +34433,7 @@ jM
 ko
 at
 at
-kU
+kV
 al
 aa
 aa
@@ -34833,7 +34690,7 @@ at
 kp
 bp
 kJ
-kV
+kW
 al
 aa
 aa
@@ -35604,7 +35461,7 @@ ct
 bR
 kH
 aP
-kW
+kX
 al
 aa
 aa
@@ -37139,7 +36996,7 @@ at
 fP
 at
 hS
-ir
+is
 bn
 jm
 at
@@ -37396,7 +37253,7 @@ fQ
 fP
 at
 hT
-is
+it
 iT
 jn
 aP
@@ -37419,9 +37276,9 @@ aa
 aa
 aa
 jB
-pY
-qw
-qH
+qa
+qz
+qK
 jB
 aa
 aa
@@ -37648,7 +37505,7 @@ cy
 dp
 dZ
 al
-Tv
+fp
 at
 fP
 at
@@ -37676,9 +37533,9 @@ aa
 aa
 jB
 jB
-pZ
-qx
-qI
+qb
+qA
+qL
 jB
 aa
 aa
@@ -37932,10 +37789,10 @@ aa
 aa
 aa
 jB
-pt
-qa
-qy
-qJ
+pv
+qc
+qB
+qM
 jB
 aa
 aa
@@ -38164,7 +38021,7 @@ al
 al
 fr
 fR
-Tz
+gA
 fr
 fR
 al
@@ -38189,7 +38046,7 @@ aa
 aa
 aa
 jB
-pu
+pw
 jB
 jB
 jB
@@ -38419,17 +38276,17 @@ cA
 dr
 eb
 eN
-fx
+fs
 fS
 gB
 ho
-fs
-it
+fy
+iu
 iV
 jq
 jN
 kt
-iz
+iA
 aa
 aa
 aa
@@ -38446,7 +38303,7 @@ aa
 aa
 aa
 jB
-pv
+px
 jB
 aa
 aa
@@ -38680,13 +38537,13 @@ ft
 fT
 gC
 fT
-fs
-iu
-ix
+fy
+iv
+iy
 jq
 jO
 ku
-iz
+iA
 aa
 aa
 aa
@@ -38703,7 +38560,7 @@ aa
 aa
 aa
 jB
-pu
+pw
 jB
 aa
 aa
@@ -38936,14 +38793,14 @@ bw
 fu
 fU
 gB
-hq
-fs
-iv
+hp
+fy
+iw
 iW
 jr
 jP
 kv
-iz
+iA
 aa
 aa
 aa
@@ -38960,7 +38817,7 @@ aa
 aa
 aa
 jB
-pu
+pw
 jB
 aa
 aa
@@ -39190,17 +39047,17 @@ cD
 du
 ed
 eP
-Tw
+fv
 fV
 gD
-hr
-TB
-iw
+hq
+hU
+ix
 iX
 js
 jQ
 jt
-iz
+iA
 aa
 aa
 aa
@@ -39217,7 +39074,7 @@ aa
 jB
 jB
 jB
-pw
+py
 jB
 aa
 aa
@@ -39451,13 +39308,13 @@ fw
 fT
 gE
 fT
-TC
-ix
-ix
+hV
+iy
+iy
 jt
 jt
 jt
-iz
+iA
 aa
 aa
 aa
@@ -39472,9 +39329,9 @@ aa
 aa
 aa
 jB
-oJ
-pb
-px
+oL
+pd
+pz
 jB
 aa
 aa
@@ -39708,13 +39565,13 @@ fu
 fT
 gE
 fT
-fs
-ix
+fy
+iy
 iY
 iY
 iY
 iY
-iz
+iA
 aa
 aa
 aa
@@ -39729,9 +39586,9 @@ aa
 aa
 aa
 jB
-oK
-pc
-py
+oM
+pe
+pA
 jB
 aa
 aa
@@ -39961,17 +39818,17 @@ cc
 dv
 eg
 ba
-fx
+fs
 fT
 gE
 fT
-fs
-iy
-iY
-iY
-iY
-iY
+fy
 iz
+iY
+iY
+iY
+iY
+iA
 aa
 aa
 aa
@@ -39988,7 +39845,7 @@ aa
 jB
 jB
 jB
-pz
+pB
 jB
 aa
 aa
@@ -40040,11 +39897,11 @@ aa
 aa
 aa
 jL
-lj
-lf
-PR
-lf
-lj
+ll
+lh
+QC
+lh
+ll
 jL
 ac
 ac
@@ -40218,17 +40075,17 @@ cF
 dw
 eh
 eS
-fx
+fs
 fT
 gE
 fT
-fs
-iz
-iz
-iz
-iz
-iz
-iz
+fy
+iA
+iA
+iA
+iA
+iA
+iA
 hW
 hW
 hW
@@ -40245,7 +40102,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -40297,11 +40154,11 @@ aa
 aa
 aa
 jL
-lf
-lf
-lf
-lf
-lf
+lh
+lh
+lh
+lh
+lh
 jL
 ac
 ac
@@ -40475,18 +40332,18 @@ bA
 bA
 eh
 eT
-fx
-fX
-gG
+fs
+fW
+gF
 fT
 hW
-iA
+iB
 iZ
 ju
 jR
 kw
 kK
-St
+kS
 kx
 hY
 aa
@@ -40502,7 +40359,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -40554,11 +40411,11 @@ aa
 aa
 aa
 jL
-OQ
-lf
-lf
-lf
-OQ
+PA
+lh
+lh
+lh
+PA
 jL
 ac
 ac
@@ -40732,13 +40589,13 @@ cG
 cG
 ei
 eU
-fx
-fY
+fs
+fX
 gE
-hs
+hr
 hW
-iB
-iB
+iC
+iC
 jv
 jS
 kx
@@ -40759,7 +40616,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -40808,14 +40665,14 @@ aa
 aa
 aa
 aa
-Nm
-NP
-Oq
-OR
-OQ
-OQ
-OQ
-OQ
+NW
+Oz
+Pa
+PB
+PA
+PA
+PA
+PA
 jL
 ac
 ac
@@ -40989,12 +40846,12 @@ cH
 dx
 ej
 eV
-fx
-fZ
-gH
-hp
+fs
+fY
+gG
+hs
 hW
-iB
+iC
 ja
 jw
 jS
@@ -41016,7 +40873,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -41061,22 +40918,22 @@ ac
 ac
 ac
 ac
-KO
-KO
-KO
-KO
-Nn
-KO
-KO
-OS
-Pv
-Pv
-Pv
-Ql
+Ly
+Ly
+Ly
+Ly
+NX
+Ly
+Ly
+PC
+Qf
+Qf
+Qf
+QZ
 jL
 ac
 ac
-Rr
+Sh
 ac
 ac
 ac
@@ -41247,11 +41104,11 @@ ba
 ba
 ba
 ba
-ga
-gI
+fZ
+gH
 ht
 hW
-iC
+iD
 jb
 hW
 jS
@@ -41273,7 +41130,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -41318,26 +41175,26 @@ ac
 ac
 ac
 ac
-KO
-Lo
-LP
-ME
+Ly
+LY
+Mz
 No
-NQ
-NU
-OT
-Pw
-Pw
-Qa
-OU
+NY
+OA
+OE
+PD
+Qg
+Qg
+QO
+PE
 ac
 ac
-QW
-Rs
-Rs
-Rs
-RD
-mb
+RM
+Si
+Si
+Si
+St
+md
 ac
 ac
 aa
@@ -41505,17 +41362,17 @@ ek
 ek
 ba
 fT
-gJ
+gI
 hu
 hX
-iD
+iE
 jc
 jx
 jT
 kx
 kx
-kS
-kX
+kT
+kY
 hW
 aa
 aa
@@ -41530,7 +41387,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -41575,25 +41432,25 @@ aa
 ac
 ac
 ac
-KO
-Lp
-LQ
-MF
+Ly
+LZ
+MA
 Np
-Lo
-Or
-OU
-Px
-PS
-Qb
-OU
+NZ
+LY
+Pb
+PE
+Qh
+QD
+QP
+PE
 ac
 ac
-QX
+RN
 ac
 ac
 ac
-RE
+Su
 ac
 ac
 ac
@@ -41760,19 +41617,19 @@ cJ
 dz
 el
 eW
-Tx
-gb
-gK
+fx
+ga
+gJ
 fT
 hW
-iE
+iF
 jd
 hW
 jU
 kx
 kx
 kx
-Su
+kZ
 hW
 aa
 aa
@@ -41787,7 +41644,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -41832,25 +41689,25 @@ aa
 ac
 ac
 aa
-KO
-Lq
-LR
-MG
+Ly
+Ma
+MB
 Nq
-NR
-Os
-OT
-Py
-PT
-Qc
-OU
+Oa
+OB
+Pc
+PD
+Qi
+QE
+QQ
+PE
 ac
-KO
-QY
-KO
+Ly
+RO
+Ly
 aa
 ac
-RE
+Su
 ac
 ac
 ac
@@ -42018,11 +41875,11 @@ ba
 em
 cJ
 ba
-fW
-So
-fW
+gb
+gK
+gb
 hY
-iF
+iG
 ja
 ju
 jU
@@ -42044,7 +41901,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -42054,16 +41911,16 @@ aa
 aa
 aa
 aa
-rt
-rF
-rF
+rx
+rJ
+rJ
 aa
-sD
-sD
+sI
+sI
 ac
 ac
-sD
-sD
+sI
+sI
 aa
 aa
 aa
@@ -42077,39 +41934,39 @@ aa
 aa
 aa
 aa
-ac
-ac
-ac
-ac
-qz
 ac
 ac
 ac
 ac
+qC
+ac
+ac
+ac
+ac
 ac
 ac
 aa
-KO
-Lr
-LS
-MH
+Ly
+Mb
+MC
 Nr
-NS
-Ot
-OV
-Pz
-PU
-Pz
-Qm
+Ob
+OC
+Pd
+PF
+Qj
+QF
+Qj
+Ra
 ac
-KO
-QZ
-KO
+Ly
+RP
+Ly
 aa
 ac
-RE
+Su
 ac
-RK
+SA
 ac
 aa
 aa
@@ -42279,8 +42136,8 @@ fT
 gE
 fT
 hW
-iG
-iB
+iH
+iC
 jv
 jU
 kx
@@ -42301,7 +42158,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -42315,13 +42172,13 @@ ac
 ac
 ac
 ac
-sE
+sJ
 ac
 ac
 ac
-sE
+sJ
 ac
-vp
+vw
 aa
 aa
 aa
@@ -42346,27 +42203,27 @@ ac
 ac
 ac
 aa
-KO
-KO
-LT
-LT
-KO
-NT
-Ou
-OW
-PA
-PV
-Qd
-KO
-KO
-KO
-Ra
-KO
-KO
-RA
-RE
-RH
-RL
+Ly
+Ly
+MD
+MD
+Ly
+OD
+Pe
+PG
+Qk
+QG
+QR
+Ly
+Ly
+Ly
+RQ
+Ly
+Ly
+Sq
+Su
+Sx
+SB
 ac
 aa
 aa
@@ -42536,8 +42393,8 @@ fT
 gE
 fT
 hW
-iH
-iH
+iI
+iI
 jw
 jV
 ky
@@ -42558,7 +42415,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -42578,7 +42435,7 @@ ac
 ac
 ac
 ac
-vq
+vx
 aa
 aa
 aa
@@ -42592,36 +42449,36 @@ aa
 aa
 aa
 aa
-TS
-TS
-TS
-TS
-TS
-TS
-TS
-TS
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 ac
-mb
+md
 aa
-KO
-Ls
-LU
-LU
-Ns
-NU
-Ov
-OX
-PB
-MH
-Or
-KO
-Qy
-QJ
-Rb
-KO
+Ly
+Mc
+ME
+ME
+Oc
+OE
+Pf
+PH
+Ql
+Nr
+Pb
+Ly
+Ro
+Rz
+RR
+Ly
 ac
 ac
-RE
+Su
 ac
 aa
 aa
@@ -42788,7 +42645,7 @@ ac
 ac
 ac
 ac
-fs
+fy
 fT
 gE
 fT
@@ -42797,13 +42654,13 @@ hW
 hW
 hW
 hW
-fs
-fs
-fs
-fs
-fs
-fs
-fs
+fy
+fy
+fy
+fy
+fy
+fy
+fy
 jB
 jB
 jB
@@ -42815,7 +42672,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -42829,14 +42686,14 @@ ac
 ac
 ac
 ac
-sF
+sK
 ac
 ac
 ac
 ac
 ac
-vr
-rt
+vy
+rx
 aa
 aa
 aa
@@ -42849,36 +42706,36 @@ aa
 aa
 aa
 aa
-TS
-TY
-Ud
-Uj
-Ur
-Ux
-UC
-TS
-TS
-TS
-TS
-KO
-Lt
-LV
-MI
-Nt
-NV
-Ow
-OY
-PC
-PW
-Qe
-Qn
-Qz
-QK
-Rc
-KO
+Ed
+EH
+Ft
+Gh
+Hg
+HP
+IC
+Ed
+Ed
+Ed
+Ed
+Ly
+Md
+MF
+Ns
+Od
+OF
+Pg
+PI
+Qm
+QH
+QS
+Rb
+Rp
+RA
+RS
+Ly
 ac
 ac
-RE
+Su
 ac
 aa
 aa
@@ -43045,22 +42902,22 @@ ac
 ac
 ac
 ac
-fs
+fy
 gc
 gL
 fT
-fx
-fx
-fx
-fx
-fx
 fs
-kO
-kO
-kO
-kO
-lc
 fs
+fs
+fs
+fs
+fy
+kO
+kO
+kO
+kO
+le
+fy
 kz
 kz
 jB
@@ -43072,7 +42929,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -43085,10 +42942,10 @@ ac
 ac
 ac
 ac
-se
-sD
-sD
-tM
+si
+sI
+sI
+tU
 ac
 ac
 ac
@@ -43106,36 +42963,36 @@ aa
 aa
 aa
 aa
-TS
-TZ
-Ue
-Uk
-Us
-Uy
-UC
-UX
-UC
-UC
-UZ
-KO
-Lu
-LW
-LW
-Ns
-NW
-Ox
-OZ
-Ow
-PX
-Qf
-KO
-QA
-QL
-Rd
-KO
+Ed
+EI
+Fu
+Gi
+Hh
+HQ
+IC
+Jp
+IC
+IC
+Li
+Ly
+Me
+MG
+MG
+Oc
+OG
+Ph
+PJ
+Pg
+QI
+QT
+Ly
+Rq
+RB
+RT
+Ly
 ac
 ac
-RE
+Su
 ac
 ac
 aa
@@ -43302,7 +43159,7 @@ ac
 ac
 ac
 ac
-fs
+fy
 gd
 gE
 fT
@@ -43311,13 +43168,13 @@ fT
 fT
 jy
 jW
-fs
+fy
 kO
 kO
-kY
+la
 kO
 kO
-fs
+fy
 kz
 kz
 jB
@@ -43329,7 +43186,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -43343,9 +43200,9 @@ ac
 ac
 ac
 ac
-sG
-Tk
-tN
+sL
+tp
+tV
 ac
 ac
 ac
@@ -43363,37 +43220,37 @@ aa
 aa
 aa
 aa
-TS
-Ua
-Ue
-Uk
-Us
-Uz
-UE
-UE
-UE
-UE
-UV
-KO
-KO
-KO
-KO
-KO
-KO
-KO
-Pa
-KO
-KO
-KO
-KO
-KO
-QM
-KO
-KO
-KO
-RA
-RE
-RH
+Ed
+EJ
+Fu
+Gi
+Hh
+HR
+ID
+ID
+ID
+ID
+Lj
+Ly
+Ly
+Ly
+Ly
+Ly
+Ly
+Ly
+PK
+Ly
+Ly
+Ly
+Ly
+Ly
+RC
+Ly
+Ly
+Ly
+Sq
+Su
+Sx
 jL
 aa
 aa
@@ -43412,11 +43269,11 @@ aa
 aa
 aa
 aa
-RZ
-RZ
-RZ
-RZ
-RZ
+SQ
+SQ
+SQ
+SQ
+SQ
 aa
 aa
 aa
@@ -43559,7 +43416,7 @@ ac
 ac
 ac
 ac
-fs
+fy
 ge
 gM
 hv
@@ -43568,13 +43425,13 @@ hv
 hv
 jz
 jX
-fs
+fy
 kO
 kO
 kO
 kO
 kO
-fs
+fy
 kz
 kz
 jB
@@ -43586,7 +43443,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -43620,36 +43477,36 @@ aa
 aa
 aa
 aa
-TS
-Ub
-Ug
-Um
-Uu
-UA
-UC
-UY
-UC
-UC
-UC
-KP
-Lv
-Lv
-MJ
-Nu
-NX
-ML
-OA
-KP
+Ed
+EK
+Fv
+Gj
+Hi
+HS
+IC
+Jq
+IC
+IC
+IC
+Lz
+Mf
+Mf
+Nt
+Oe
+OH
+Nv
+Pk
+Lz
 aa
-KO
-Qo
-QB
-QN
-Re
-KO
+Ly
+Rc
+Rr
+RD
+RU
+Ly
 aa
 ac
-RE
+Su
 ac
 aa
 aa
@@ -43668,13 +43525,13 @@ aa
 aa
 aa
 aa
-RZ
-RZ
-Sg
-Si
-Sg
-RZ
-RZ
+SQ
+SQ
+SX
+SZ
+SX
+SQ
+SQ
 aa
 aa
 aa
@@ -43816,7 +43673,7 @@ ac
 ac
 ac
 ac
-fs
+fy
 gf
 gN
 hw
@@ -43825,13 +43682,13 @@ fT
 je
 jA
 jY
-fs
+fy
 kO
 kO
 kO
 kO
 kO
-fs
+fy
 kz
 kz
 jB
@@ -43843,7 +43700,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -43864,49 +43721,49 @@ ac
 ac
 ac
 ac
-rF
+rJ
 aa
 aa
 aa
 ac
 ac
-yK
-xv
-xv
-xv
-xv
-xv
-xv
-xv
-uZ
-Uh
-Un
-Uv
-vs
-xe
-xy
-xy
-xy
-xy
-KP
-Lv
-LX
-Lv
-Lv
-NY
-Oy
-Pb
-KP
+yS
+xD
+xD
+xD
+xD
+xD
+xD
+xD
+vg
+Fw
+Gk
+Hj
+vz
+xl
+xG
+xG
+xG
+xG
+Lz
+Mf
+MH
+Mf
+Mf
+OI
+Pi
+PL
+Lz
 aa
-KO
-Qp
-QC
-QO
-Rf
-KO
-aa
-ac
+Ly
+Rd
+Rs
 RE
+RV
+Ly
+aa
+ac
+Su
 ac
 ac
 aa
@@ -43924,15 +43781,15 @@ aa
 aa
 aa
 aa
-RZ
-RZ
-Sg
-Sg
-Sj
-Sg
-Sg
-RZ
-RZ
+SQ
+SQ
+SX
+SX
+Ta
+SX
+SX
+SQ
+SQ
 aa
 aa
 aa
@@ -44073,24 +43930,24 @@ ac
 ac
 ac
 ac
-fs
-fs
+fy
+fy
 gO
 gO
-fs
-fs
-fs
-fs
+fy
+fy
+fy
+fy
 jZ
-fs
+fy
 kO
 kO
-kZ
+lb
 kO
 kO
-fs
+fy
 kz
-lk
+lm
 jB
 aa
 aa
@@ -44100,7 +43957,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -44121,76 +43978,76 @@ ac
 ac
 ac
 ac
-rF
+rJ
 aa
 ac
 ac
 ac
 ac
-yL
-xv
-zI
-As
-Bf
-Cg
-Db
+yT
+xD
+zQ
+AA
+Bo
+Cp
+Dk
+AG
+EL
+Fx
+vC
+Cx
+HT
+IE
+Jr
+JV
+KG
+Lk
+LA
+Mg
+MI
+Nu
+Mg
+OJ
+Pj
+PM
+Lz
+aa
+Ly
+Re
+Rs
+RF
+RW
+Ly
+ac
+ac
+Su
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 SQ
-Ex
-Ff
-vv
-Co
-Hp
-HY
-IJ
-Jn
-JY
-KA
-KQ
-Lw
-LY
-MK
-Lw
-NZ
-Oz
-Pc
-KP
-aa
-KO
-Qq
-QC
-QP
-Rg
-KO
-ac
-ac
-RE
-ac
-ac
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-RZ
-RZ
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-RZ
-RZ
+SQ
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SQ
+SQ
 aa
 aa
 aa
@@ -44331,21 +44188,21 @@ ac
 ac
 ac
 ac
-fs
+fy
 gP
 hx
-fs
+fy
 ac
 ac
 jB
 ka
-fs
+fy
 kO
 kO
 kO
 kO
 kO
-fs
+fy
 kz
 kz
 jB
@@ -44357,7 +44214,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -44384,71 +44241,71 @@ ac
 ac
 ac
 ac
-yM
-xv
-zJ
-At
-Bg
-Ch
-Dc
+yU
+xD
+zR
+AB
+Bp
+Cq
+Dl
+AG
+vi
+uK
+vC
+Hk
+HU
+IF
+Js
+JW
+Hk
+wa
+Lz
+Mh
+MJ
+Nv
+Nv
+Nv
+Pk
+PN
+Lz
+aa
+Ly
+Rf
+Rt
+RG
+RX
+Ly
+Sm
+Sq
+Su
+Sx
+SB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 SQ
-vb
-uD
-vv
-GK
-Hq
-HZ
-IK
-Jo
-GK
-vT
-KP
-Lx
-LZ
-ML
-ML
-ML
-OA
-Pd
-KP
-aa
-KO
-Qr
-QD
-QQ
-Rh
-KO
-Rw
-RA
-RE
-RH
-RL
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-RZ
-RZ
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-RZ
-RZ
+SQ
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SQ
+SQ
 aa
 aa
 aa
@@ -44588,21 +44445,21 @@ ac
 ac
 ac
 ac
-fs
+fy
 gQ
 hy
-fs
+fy
 ac
 ac
 jB
 ka
-fs
-fs
-fs
-fs
-fs
-fs
-fs
+fy
+fy
+fy
+fy
+fy
+fy
+fy
 kz
 kz
 jB
@@ -44614,7 +44471,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -44639,45 +44496,45 @@ ac
 ac
 ac
 ac
-xv
-xv
-xv
-xv
-zK
-zK
-Bh
-Ci
-Dd
-DU
-vb
-vu
-FP
-GL
-Hr
-Ia
-IL
-Jp
-JZ
-KB
-KR
+xD
+xD
+xD
+xD
+zS
+zS
+Bq
+Cr
+Dm
+Ee
+vi
+vB
+Gl
+Hl
+HV
+IG
+Jt
+JX
+KH
+Ll
+LB
+Mi
+MK
+Nw
+Mi
+OK
+Pl
+PO
+Lz
+aa
 Ly
-Ma
-MM
+Rg
+Rs
+Rs
+RY
 Ly
-Oa
-OB
-Pe
-KP
-aa
-KO
-Qs
-QC
-QC
-Ri
-KO
 ac
 ac
-RE
+Su
 ac
 aa
 ac
@@ -44692,21 +44549,21 @@ aa
 aa
 aa
 aa
-RZ
-RZ
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-RZ
-RZ
+SQ
+SQ
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SQ
+SQ
 aa
 aa
 aa
@@ -44845,10 +44702,10 @@ ac
 ac
 ac
 ac
-fs
+fy
 gR
 gR
-fs
+fy
 ac
 ac
 jB
@@ -44861,7 +44718,7 @@ kz
 kz
 kz
 kz
-ll
+ln
 jB
 aa
 aa
@@ -44871,7 +44728,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -44895,46 +44752,46 @@ ac
 ac
 ac
 ac
-xb
-xw
-yd
-yN
-zo
-zL
-Au
-Bi
-Cj
-zL
-DV
-vb
-vA
-vY
-xy
-xy
-xy
-xy
-xy
-xy
-xy
-KP
+xi
+xE
+yl
+yV
+zw
+zT
+AC
+Br
+Cs
+zT
+Ef
+vi
+vH
+wf
+xG
+xG
+xG
+xG
+xG
+xG
+xG
 Lz
+Mj
+Mj
+Nx
+Of
+OL
+Pm
+Pm
 Lz
-MN
-Nv
-Ob
-OC
-OC
-KP
 aa
-KO
-Qt
-QC
-QC
-Rj
-Rt
+Ly
+Rh
+Rs
+Rs
+RZ
+Sj
 ac
 ac
-RE
+Su
 ac
 ac
 ac
@@ -44948,23 +44805,23 @@ ac
 ac
 ac
 aa
-RZ
-RZ
-Se
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-RZ
-RZ
+SQ
+SQ
+SV
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SQ
+SQ
 aa
 aa
 aa
@@ -45113,12 +44970,12 @@ kc
 kA
 kP
 kA
-la
+lc
 kA
 kA
 kA
 kA
-lm
+lo
 jB
 aa
 aa
@@ -45128,7 +44985,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -45152,76 +45009,76 @@ ac
 ac
 ac
 ac
-xc
-xx
-ye
-yO
-zp
-zM
-Av
-Bj
-Ck
-De
-SQ
-Ey
-vx
-FQ
-xy
-Hs
-Hs
-Hs
-Hs
-Ka
-xy
-KP
+xj
+xF
+ym
+yW
+zx
+zU
+AD
+Bs
+Ct
+Dn
+AG
+EM
+vE
+Gm
+xG
+HW
+HW
+HW
+HW
+KI
+xG
 Lz
-Mb
-MO
-Nw
-Oc
-OD
-OC
-KP
+Mj
+ML
+Ny
+Og
+OM
+Pn
+Pm
+Lz
 aa
-KO
-Qu
-QC
-QR
-Rj
-Ru
-oL
-oL
-RF
-oL
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Ly
+Ri
+Rs
+RH
 RZ
-Se
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-RZ
+Sk
+oN
+oN
+Sv
+oN
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+SQ
+SV
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SQ
 aa
 aa
 aa
@@ -45375,7 +45232,7 @@ jB
 jB
 jB
 jB
-TE
+lp
 jB
 aa
 aa
@@ -45385,7 +45242,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -45409,76 +45266,76 @@ ac
 ac
 ac
 ac
-xd
-xw
-yf
-yP
-zq
-zN
-Aw
-Bk
-Cl
-Df
-SQ
-Ez
-vv
-vT
-xy
-Hs
-Hs
-IM
-Hs
-Hs
-xy
-KP
-KP
-KP
-KP
-KP
-KP
-KP
-KP
-KP
+xk
+xE
+yn
+yX
+zy
+zV
+AE
+Bt
+Cu
+Do
+AG
+EN
+vC
+wa
+xG
+HW
+HW
+Ju
+HW
+HW
+xG
+Lz
+Lz
+Lz
+Lz
+Lz
+Lz
+Lz
+Lz
+Lz
 aa
-KO
-Qv
-QE
-QS
-Rk
-Rv
-Rx
-RB
-RG
+Ly
+Rj
+Ru
 RI
-RM
-RN
-RN
-RN
-RN
-RN
-RN
-RN
-RN
-RN
-RN
-RM
 Sa
-Se
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sk
-Si
-Sg
-Sg
-Sg
-Sg
-Sm
-Si
-RZ
+Sl
+Sn
+Sr
+Sw
+Sy
+SC
+SD
+SD
+SD
+SD
+SD
+SD
+SD
+SD
+SD
+SD
+SC
+SR
+SV
+SX
+SX
+SX
+SX
+SX
+SX
+Tb
+SZ
+SX
+SX
+SX
+SX
+Td
+SZ
+SQ
 aa
 aa
 aa
@@ -45632,7 +45489,7 @@ aa
 aa
 aa
 jB
-lo
+lq
 jB
 aa
 aa
@@ -45642,7 +45499,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -45667,75 +45524,75 @@ ac
 ac
 ac
 ac
-xv
-xv
-xv
-xv
-zO
-Ax
-Bl
-Cm
-Dg
+xD
+xD
+xD
+xD
+zW
+AF
+Bu
+Cv
+Dp
+AG
+vi
+Fy
+wa
+xG
+HW
+HW
+HW
+HW
+HW
+xG
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Ly
+Ly
+Rv
+Ly
+Ly
+Ly
+So
+Ss
+lw
+Sz
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+SL
 SQ
-vb
-Fg
-vT
-xy
-Hs
-Hs
-Hs
-Hs
-Hs
-xy
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-KO
-KO
-QF
-KO
-KO
-KO
-Ry
-RC
-lu
-RJ
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-RU
-RZ
-Se
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-RZ
+SV
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SQ
 aa
 aa
 aa
@@ -45889,7 +45746,7 @@ aa
 aa
 aa
 jB
-lo
+lq
 jB
 aa
 aa
@@ -45899,7 +45756,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 aa
 aa
@@ -45911,13 +45768,13 @@ aa
 aa
 aa
 ac
-rO
-sf
-sH
-sH
-sH
-uq
-rO
+rS
+sj
+sM
+sM
+sM
+uy
+rS
 ac
 ac
 ac
@@ -45927,72 +45784,72 @@ ac
 ac
 ac
 ac
-xv
-zP
+xD
+zX
+AG
+Bv
+Cw
+Dq
+AG
+EO
+Fz
+wa
+xG
+HW
+HW
+Jv
+HW
+HW
+xG
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Ly
+Rw
+RJ
+Sb
+Sb
+Sp
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
 SQ
-Bm
-Cn
-Dh
 SQ
-EA
-Fh
-vT
-xy
-Hs
-Hs
-IN
-Hs
-Hs
-xy
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-KO
-QG
-QT
-Rl
-Rl
-Rz
-aa
-aa
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-aa
-aa
-RZ
-RZ
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-RZ
-RZ
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SQ
+SQ
 aa
 aa
 aa
@@ -46132,8 +45989,8 @@ eX
 fz
 gg
 gS
-TA
-TD
+hz
+ic
 iJ
 cg
 jE
@@ -46146,7 +46003,7 @@ aa
 aa
 aa
 jB
-lo
+lq
 jB
 aa
 aa
@@ -46156,7 +46013,7 @@ aa
 aa
 aa
 jB
-py
+pA
 jB
 jB
 aa
@@ -46168,87 +46025,87 @@ aa
 aa
 ac
 ac
-rO
-sg
-sI
-tj
-tO
-ur
-rO
-uZ
-vs
-vs
-vs
-vs
-xe
-xy
-xy
-xy
-xy
-zQ
+rS
+sk
+sN
+tq
+tW
+uz
+rS
+vg
+vz
+vz
+vz
+vz
+xl
+xG
+xG
+xG
+xG
+zY
+AG
+AG
+AG
+AG
+Eg
+EP
+FA
+wa
+xG
+HW
+HW
+HW
+HW
+HW
+xG
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
 SQ
 SQ
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
 SQ
 SQ
-Tc
-EB
-Fi
-vT
-xy
-Hs
-Hs
-Hs
-Hs
-Hs
-xy
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ac
-ac
-ac
-ac
-ac
-aa
-aa
-aa
-aa
-RZ
-RZ
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-RZ
-RZ
 aa
 aa
 aa
@@ -46403,7 +46260,7 @@ aa
 aa
 aa
 jB
-lo
+lq
 jB
 aa
 aa
@@ -46413,8 +46270,8 @@ aa
 aa
 aa
 jB
-pA
-qb
+pC
+qd
 jB
 aa
 aa
@@ -46425,39 +46282,39 @@ aa
 aa
 ac
 ac
-rO
-sh
-sJ
-sJ
-tP
-ur
-rO
-va
-vt
-vQ
-vt
-vQ
-vt
-vQ
-vt
-vQ
-vt
-zR
-vt
-Bn
-Co
-Di
-Tc
-EC
-Fh
-FR
-xy
-xy
-xy
-xy
-xy
-xy
-xy
+rS
+sl
+sO
+sO
+tX
+uz
+rS
+vh
+vA
+vX
+vA
+vX
+vA
+vX
+vA
+vX
+vA
+zZ
+vA
+Bw
+Cx
+Dr
+Eg
+EQ
+Fz
+Gn
+xG
+xG
+xG
+xG
+xG
+xG
+xG
 aa
 aa
 aa
@@ -46492,19 +46349,19 @@ aa
 aa
 aa
 aa
-RZ
-RZ
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-RZ
-RZ
+SQ
+SQ
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SQ
+SQ
 aa
 aa
 aa
@@ -46660,7 +46517,7 @@ aa
 aa
 aa
 jB
-lo
+lq
 jB
 jB
 jB
@@ -46670,8 +46527,8 @@ jB
 jB
 jB
 jB
-pB
-qb
+pD
+qd
 jB
 aa
 aa
@@ -46682,39 +46539,39 @@ aa
 aa
 ac
 ac
-rO
-si
-sK
-tk
-tQ
-ut
-rO
-vb
-vu
-vR
-vR
-vR
-vR
-vR
-yg
-vR
-vR
-zS
-vR
-vR
-Cp
-Dj
-DW
-vd
-Fj
-FS
-vt
-Ht
-vt
-vt
-vt
-Kb
-xy
+rS
+sm
+sP
+tr
+tY
+uA
+rS
+vi
+vB
+vY
+vY
+vY
+vY
+vY
+yo
+vY
+vY
+Aa
+vY
+vY
+Cy
+Ds
+Eh
+vk
+FB
+Go
+vA
+HX
+vA
+vA
+vA
+KJ
+xG
 aa
 aa
 aa
@@ -46750,17 +46607,17 @@ aa
 aa
 aa
 aa
-RZ
-RZ
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-Sg
-RZ
-RZ
+SQ
+SQ
+SX
+SX
+SX
+SX
+SX
+SX
+SX
+SQ
+SQ
 aa
 aa
 aa
@@ -46917,18 +46774,18 @@ aa
 aa
 aa
 jB
-lp
+lr
 kA
-ma
-ma
-ma
-ma
-ma
-ma
-ma
-pd
-pC
-Sv
+mc
+mc
+mc
+mc
+mc
+mc
+mc
+pf
+pE
+qe
 jB
 aa
 aa
@@ -46939,39 +46796,39 @@ aa
 aa
 aa
 ac
-rO
-SC
-SC
-SC
-Tl
-SC
-rO
-vc
-vv
-vS
-wm
-uE
-wm
-xz
-yh
-uE
-wm
-uE
-uU
-uE
-wm
-Dk
-Tc
+rS
+sn
+sn
+sn
+tZ
+sn
+rS
+vj
+vC
+vZ
+wt
+uL
+wt
+xH
+yp
+uL
+wt
+uL
 vb
-Fk
-FT
-vR
-vR
-Ib
-vR
-Jq
-Kc
-xy
+uL
+wt
+Dt
+Eg
+vi
+FC
+Gp
+vY
+vY
+IH
+vY
+JY
+KK
+xG
 aa
 aa
 aa
@@ -47008,15 +46865,15 @@ aa
 aa
 aa
 aa
-RZ
-RZ
-Sg
-Sg
-Sl
-Sg
-Sg
-RZ
-RZ
+SQ
+SQ
+SX
+SX
+Tc
+SX
+SX
+SQ
+SQ
 aa
 aa
 aa
@@ -47161,8 +47018,8 @@ fD
 gi
 gU
 hD
-Sp
-Sp
+ig
+ig
 cg
 cg
 cg
@@ -47174,7 +47031,7 @@ jB
 jB
 jB
 jB
-TF
+ls
 jB
 jB
 jB
@@ -47184,8 +47041,8 @@ jB
 jB
 jB
 jB
-pD
-Sv
+pF
+qe
 jB
 aa
 aa
@@ -47196,39 +47053,39 @@ aa
 aa
 aa
 aa
-rO
-sj
-sL
-tl
-tS
-uu
-uP
-vd
-vw
-vT
-wn
-wn
-wn
-wn
-wn
-wn
-wn
-wn
-Ay
-Ay
-Ay
-Ay
-xy
-ED
-Fl
-FU
-wm
-uU
-Ic
-wm
-Jr
-Kd
-xy
+rS
+so
+sQ
+ts
+ua
+uB
+uW
+vk
+vD
+wa
+wu
+wu
+wu
+wu
+wu
+wu
+wu
+wu
+AH
+AH
+AH
+AH
+xG
+ER
+FD
+Gq
+wt
+vb
+II
+wt
+JZ
+KL
+xG
 aa
 aa
 aa
@@ -47266,13 +47123,13 @@ aa
 aa
 aa
 aa
-RZ
-RZ
-Sg
-Si
-Sg
-RZ
-RZ
+SQ
+SQ
+SX
+SZ
+SX
+SQ
+SQ
 aa
 aa
 aa
@@ -47418,7 +47275,7 @@ fE
 gj
 gV
 hE
-ig
+ih
 iN
 iN
 jG
@@ -47431,7 +47288,7 @@ kG
 kG
 kG
 kG
-lr
+lt
 jB
 aa
 aa
@@ -47441,8 +47298,8 @@ aa
 aa
 aa
 jB
-pE
-qc
+pG
+qf
 jB
 aa
 aa
@@ -47453,39 +47310,39 @@ aa
 aa
 aa
 aa
-rO
-sk
-sM
-tm
-tT
-uv
-rO
-vc
-vv
-vU
-wo
-wI
-xf
-xA
-yi
-yQ
-zr
-zT
-Az
-Bo
-Cq
-Dl
+rS
+sp
+sR
+tt
+ub
+uC
+rS
+vj
+vC
+wb
+wv
+wP
+xm
+xI
+yq
+yY
+zz
+Ab
+AI
+Bx
+Cz
+Du
 jB
-Sv
-Sv
-FV
+qe
+qe
+Gr
 jB
 jB
-Dw
-Dw
-Js
-Dw
-Dw
+DF
+DF
+Ka
+DF
+DF
 aa
 aa
 aa
@@ -47524,11 +47381,11 @@ aa
 aa
 aa
 aa
-RZ
-RZ
-RZ
-RZ
-RZ
+SQ
+SQ
+SQ
+SQ
+SQ
 aa
 aa
 aa
@@ -47675,7 +47532,7 @@ fF
 gk
 gW
 hF
-ih
+ii
 iO
 jh
 jH
@@ -47698,8 +47555,8 @@ aa
 aa
 aa
 jB
-pF
-qd
+pH
+qg
 jB
 aa
 aa
@@ -47710,39 +47567,39 @@ aa
 aa
 aa
 aa
-rO
-sl
-sN
-tn
-tU
-uw
-rO
-vb
-vv
-vT
-wp
-wJ
-xg
-xB
-yj
-yR
-xC
-zU
-AA
-Bp
-Cr
-Dm
+rS
+sq
+sS
+tu
+uc
+uD
+rS
+vi
+vC
+wa
+ww
+wQ
+xn
+xJ
+yr
+yZ
+xK
+Ac
+AJ
+By
+CA
+Dv
 jB
-EE
+ES
 kz
-FW
+Gs
 jB
 jB
-Dw
-IO
-Jt
-Ke
-Dw
+DF
+Jw
+Kb
+KM
+DF
 aa
 aa
 aa
@@ -47932,7 +47789,7 @@ fG
 cY
 gX
 hE
-ii
+ij
 iP
 ji
 jI
@@ -47955,7 +47812,7 @@ aa
 aa
 aa
 jB
-pG
+pI
 jB
 jB
 aa
@@ -47967,47 +47824,47 @@ aa
 aa
 aa
 aa
-rO
-sm
-sO
-to
-tV
-ux
-rO
-ve
-vx
-vV
-wn
-wK
-xh
-xC
-yk
-yS
-zs
-yT
-AB
-Bq
-Cs
-Dn
+rS
+sr
+sT
+tv
+ud
+uE
+rS
+vl
+vE
+wc
+wu
+wR
+xo
+xK
+ys
+za
+zA
+zb
+AK
+Bz
+CB
+Dw
 jB
-EF
+ET
 kz
-FX
+Gt
 jB
-Hu
-Dw
-IP
-Ju
-Kf
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
+HY
+DF
+Jx
+Kc
+KN
+DF
+DF
+DF
+DF
+DF
+DF
+DF
+DF
+DF
 aa
 aa
 aa
@@ -48183,13 +48040,13 @@ bF
 cl
 cU
 dF
-Ts
+ew
 fd
 fH
 gl
 gY
 hE
-ii
+ij
 iQ
 iN
 jJ
@@ -48211,9 +48068,9 @@ aa
 aa
 aa
 aa
-pe
-pH
-qe
+pg
+pJ
+qh
 ac
 aa
 aa
@@ -48224,47 +48081,47 @@ aa
 aa
 aa
 aa
-rO
-sn
-sP
-tp
-tW
-uy
-rO
-vb
-vy
-vW
-wq
-wL
-xi
-xD
-yl
-wL
-zt
-zV
-Ay
-Ay
-Ay
-Ay
+rS
+ss
+sU
+tw
+ue
+uF
+rS
+vi
+vF
+wd
+wx
+wS
+xp
+xL
+yt
+wS
+zB
+Ad
+AH
+AH
+AH
+AH
 jB
-EG
-Fm
-FY
+EU
+FE
+Gu
 jB
-Dw
-Dw
-IQ
-Jv
-Kg
-Dw
-KS
-LA
-Mc
-MP
-Nx
-Od
-OE
-Dw
+DF
+DF
+Jy
+Kd
+KO
+DF
+LC
+Mk
+MM
+Nz
+Oh
+ON
+Po
+DF
 aa
 aa
 aa
@@ -48446,7 +48303,7 @@ fI
 gm
 gZ
 hG
-ij
+ik
 iR
 jj
 jK
@@ -48468,9 +48325,9 @@ aa
 aa
 aa
 ac
-pf
-pI
-qf
+ph
+pK
+qi
 ac
 aa
 aa
@@ -48481,47 +48338,47 @@ aa
 aa
 aa
 aa
-rO
-so
-sQ
-tq
-tX
-uz
-uQ
-vc
-vv
-vU
-wn
-wM
-wP
-xE
-xE
-yT
-yR
-zW
-AC
-Br
-Ct
-Do
+rS
+st
+sV
+tx
+uf
+uG
+uX
+vj
+vC
+wb
+wu
+wT
+wW
+xM
+xM
+zb
+yZ
+Ae
+AL
+BA
+CC
+Dx
 jB
-Sv
-Sv
-FZ
+qe
+qe
+Gv
 jB
-Dw
-Dw
-Dw
-Jw
-Dw
-Dw
-KT
-LB
-Md
-MQ
-Gi
-Gi
-OF
-Dw
+DF
+DF
+DF
+Ke
+DF
+DF
+LD
+Ml
+MN
+NA
+GE
+GE
+Pp
+DF
 aa
 aa
 aa
@@ -48703,8 +48560,8 @@ fJ
 gn
 ha
 hH
-Sp
-Sp
+ig
+ig
 cg
 cg
 cg
@@ -48726,7 +48583,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 ac
@@ -48735,50 +48592,50 @@ aa
 aa
 aa
 aa
-rj
-rj
-rj
-rO
-rO
-rO
-rO
-tR
-rO
-rO
-vb
-vz
-vX
-wr
-wN
-wN
-xF
-ym
-yU
-zu
-zX
-AD
-Bs
-Cu
-Dp
+rm
+rm
+rm
+rS
+rS
+rS
+rS
+ug
+rS
+rS
+vi
+vG
+we
+wy
+wU
+wU
+xN
+yu
+zc
+zC
+Af
+AM
+BB
+CD
+Dy
 jB
-Bx
-Cz
-EJ
+BG
+CI
+EX
 jB
-Dw
-Id
-IR
-Jx
-Kh
-KC
-KU
-LB
-Me
-MR
-Gi
-Gi
-Gi
-Dw
+DF
+IJ
+Jz
+Kf
+KP
+Lm
+LE
+Ml
+MO
+NB
+GE
+GE
+GE
+DF
 aa
 aa
 aa
@@ -48960,8 +48817,8 @@ fF
 go
 hb
 hI
-ik
-ik
+il
+il
 cg
 aa
 aa
@@ -48983,7 +48840,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 ac
@@ -48991,51 +48848,51 @@ aa
 aa
 aa
 aa
-rj
-rj
-ru
-rG
-rG
-rG
-SF
-tr
-tZ
-uA
-uR
-vc
-vv
-vU
-ws
-wO
-xj
-xG
-yn
-wP
-yR
-yT
-AE
-Bt
-Cv
-Dq
+rm
+rm
+ry
+rK
+rK
+rK
+sW
+ty
+uh
+uH
+uY
+vj
+vC
+wb
+wz
+wV
+xq
+xO
+yv
+wW
+yZ
+zb
+AN
+BC
+CE
+Dz
 jB
-By
+BH
 jB
 jB
 jB
-Dw
-Ie
-GQ
-Jy
-GQ
-GQ
-GQ
-LB
-Ij
-Dw
-Dw
-Dw
-Dw
-Dw
+DF
+IK
+Hq
+Kg
+Hq
+Hq
+Hq
+Ml
+IP
+DF
+DF
+DF
+DF
+DF
 aa
 aa
 aa
@@ -49214,11 +49071,11 @@ dI
 eA
 er
 fG
-Ty
+gp
 hc
 hJ
-il
-il
+im
+im
 cg
 aa
 aa
@@ -49240,59 +49097,59 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
-qz
+qC
 ac
 aa
 aa
 aa
 aa
-rj
-rk
-rv
-rH
-rP
-sp
-SF
-ts
-ua
-uB
-uS
-vb
-vA
-vY
-ws
-wP
-xk
-xH
-xA
-wP
-yR
-zY
-AF
-AF
-AF
-AF
+rm
+rn
+rz
+rL
+rT
+su
+sW
+tz
+ui
+uI
+uZ
+vi
+vH
+wf
+wz
+wW
+xr
+xP
+xI
+wW
+yZ
+Ag
+AO
+AO
+AO
+AO
 jB
-By
+BH
 jB
-Dw
-Dw
-Dw
-If
-GQ
-Jy
-GQ
-GQ
-GQ
-LB
-Mf
-MS
-Nx
-Od
-OE
-Dw
+DF
+DF
+DF
+IL
+Hq
+Kg
+Hq
+Hq
+Hq
+Ml
+MP
+NC
+Oh
+ON
+Po
+DF
 aa
 aa
 aa
@@ -49474,8 +49331,8 @@ fJ
 gq
 hd
 hK
-im
-im
+in
+in
 cg
 aa
 aa
@@ -49497,7 +49354,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 ac
@@ -49505,51 +49362,51 @@ aa
 aa
 aa
 aa
-rj
-rl
-rw
-rI
-rQ
-sq
-sR
-tt
-ub
-uC
-uT
-vf
-vB
-vU
-ws
-wP
-xl
-xI
-yo
-yV
-yR
-zZ
-AG
-Bu
-Cw
-Dr
+rm
+ro
+rA
+rM
+rU
+sv
+sX
+tA
+uj
+uJ
+va
+vm
+vI
+wb
+wz
+wW
+xs
+xQ
+yw
+zd
+yZ
+Ah
+AP
+BD
+CF
+DA
 jB
-EH
+EV
 jB
-Ga
-GM
-Hv
-Ig
-GQ
-Jz
-Ki
-Ki
-GQ
-LB
-Md
-MT
-Gi
-JH
-OG
-Dw
+Gw
+Hm
+HZ
+IM
+Hq
+Kh
+KQ
+KQ
+Hq
+Ml
+MN
+ND
+GE
+Kp
+Pq
+DF
 aa
 aa
 aa
@@ -49731,8 +49588,8 @@ fD
 gr
 cY
 hK
-in
-in
+io
+io
 cg
 aa
 aa
@@ -49754,7 +49611,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 ac
@@ -49762,51 +49619,51 @@ aa
 aa
 aa
 aa
-rj
-rj
-rj
-rj
-rj
-rj
-rj
-tu
-uc
-uD
-uD
-uD
-uc
-vT
-ws
-wQ
-wP
-xJ
-yp
-wP
-xC
-Aa
-AH
-Bv
-Cx
-Ds
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+tB
+uk
+uK
+uK
+uK
+uk
+wa
+wz
+wX
+wW
+xR
+yx
+wW
+xK
+Ai
+AQ
+BE
+CG
+DB
 jB
-By
+BH
 jB
-Gb
-GN
-Hw
-Ig
-GQ
-JA
-Kj
-KD
-KV
-LB
-Mg
-MU
-Gi
-Gi
-Gi
-Dw
+Gx
+Hn
+Ia
+IM
+Hq
+Ki
+KR
+Ln
+LF
+Ml
+MQ
+NE
+GE
+GE
+GE
+DF
 aa
 aa
 aa
@@ -50011,7 +49868,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -50025,45 +49882,45 @@ aa
 aa
 aa
 aa
-sS
-tv
-ud
-uE
-uU
-uE
-vC
-vZ
-wt
-wR
-xm
-wR
-yq
-yW
-zv
-Ab
-AI
-Bw
-Cy
-Dt
+sY
+tC
+ul
+uL
+vb
+uL
+vJ
+wg
+wA
+wY
+xt
+wY
+yy
+ze
+zD
+Aj
+AR
+BF
+CH
+DC
 jB
-EI
+EW
 jB
-Gc
-GO
-Hx
-Ig
-GQ
-JB
-Kk
-KE
-GQ
-LB
-Mh
-Dw
-Dw
-Dw
-Dw
-Dw
+Gy
+Ho
+Ib
+IM
+Hq
+Kj
+KS
+Lo
+Hq
+Ml
+MR
+DF
+DF
+DF
+DF
+DF
 aa
 aa
 aa
@@ -50245,7 +50102,7 @@ fE
 gt
 hf
 hM
-io
+ip
 iS
 cg
 aa
@@ -50268,7 +50125,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -50282,45 +50139,45 @@ aa
 aa
 aa
 aa
-sS
-SI
-ue
-SI
-uV
-uV
-vD
-uV
-wn
-wn
-wn
-wn
-wn
-wn
-wn
-wn
+sY
+tD
+um
+tD
+vc
+vc
+vK
+vc
+wu
+wu
+wu
+wu
+wu
+wu
+wu
+wu
 jB
 jB
 jB
 jB
 jB
-By
+BH
 jB
-Dw
-Dw
-Dw
-Ih
-GQ
-JC
-Kl
-Kl
-GQ
-LB
-Mf
-MV
-Nx
-Od
-OE
-Dw
+DF
+DF
+DF
+IN
+Hq
+Kk
+KT
+KT
+Hq
+Ml
+MP
+NF
+Oh
+ON
+Po
+DF
 aa
 aa
 aa
@@ -50525,7 +50382,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -50539,16 +50396,16 @@ aa
 aa
 aa
 aa
-sS
-tw
-uf
-uF
-uV
-vg
-vE
-wa
-wu
-uV
+sY
+tE
+un
+uM
+vc
+vn
+vL
+wh
+wB
+vc
 aa
 aa
 aa
@@ -50556,28 +50413,28 @@ aa
 aa
 aa
 jB
-Bx
-Cz
-Cz
-Cz
-EJ
+BG
+CI
+CI
+CI
+EX
 jB
-Gd
-GP
-Hy
-Ii
-GQ
-JD
-Km
-Km
-KW
-LB
-Md
-MW
-Gi
-Gi
-OH
-Dw
+Gz
+Hp
+Ic
+IO
+Hq
+Kl
+KU
+KU
+LG
+Ml
+MN
+NG
+GE
+GE
+Pr
+DF
 aa
 aa
 aa
@@ -50759,7 +50616,7 @@ fH
 gu
 hh
 hO
-ip
+iq
 cg
 aa
 aa
@@ -50782,7 +50639,7 @@ aa
 aa
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -50796,16 +50653,16 @@ aa
 aa
 aa
 aa
-sS
-tx
-ug
-ug
-uV
-vh
-vF
-wb
-wv
-uV
+sY
+tF
+uo
+uo
+vc
+vo
+vM
+wi
+wC
+vc
 aa
 aa
 aa
@@ -50813,28 +50670,28 @@ aa
 aa
 aa
 jB
-By
+BH
 jB
 jB
 jB
 jB
 jB
-Ge
-GQ
-GQ
-GQ
-GQ
-JE
-GQ
-GQ
-GQ
-LB
-Mi
-MX
-Gi
-Gi
-Gi
-Dw
+GA
+Hq
+Hq
+Hq
+Hq
+Km
+Hq
+Hq
+Hq
+Ml
+MS
+NH
+GE
+GE
+GE
+DF
 aa
 aa
 aa
@@ -51016,7 +50873,7 @@ fK
 gv
 hi
 hO
-ip
+iq
 cg
 aa
 aa
@@ -51039,7 +50896,7 @@ aa
 aa
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -51053,16 +50910,16 @@ aa
 aa
 aa
 aa
-sS
-ty
-uh
-uG
-uV
-vi
-vG
-vG
-ww
-uV
+sY
+tG
+up
+uN
+vc
+vp
+vN
+vN
+wD
+vc
 aa
 aa
 aa
@@ -51070,28 +50927,28 @@ jB
 jB
 jB
 jB
-By
+BH
 jB
-Du
-DX
-DY
-Fn
-Gf
-GR
-GR
-GR
-IS
-JF
-GR
-GR
-GR
-LC
-GQ
-Dw
-Dw
-Dw
-Dw
-Dw
+DD
+Ei
+Ej
+FF
+GB
+Hr
+Hr
+Hr
+JA
+Kn
+Hr
+Hr
+Hr
+Mm
+Hq
+DF
+DF
+DF
+DF
+DF
 aa
 aa
 aa
@@ -51267,13 +51124,13 @@ bI
 cq
 de
 dN
-Tt
+eG
 cY
 fL
 gw
 hj
 hO
-ip
+iq
 cg
 aa
 aa
@@ -51296,7 +51153,7 @@ aa
 aa
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -51310,41 +51167,41 @@ aa
 aa
 aa
 aa
-sS
-sS
-sS
-sS
-uV
-vj
-vH
-wc
-vj
-uV
+sY
+sY
+sY
+sY
+vc
+vq
+vO
+wj
+vq
+vc
 aa
 aa
 aa
 jB
-zw
-vP
-AJ
-Bz
+zE
+vW
+AS
+BI
 jB
-Dv
-DY
-DY
-Dw
-Gg
-GS
-Hz
-Ij
-IT
-GS
-Hz
-KF
-KX
-GS
-Mj
-Dw
+DE
+Ej
+Ej
+DF
+GC
+Hs
+Id
+IP
+JB
+Hs
+Id
+Lp
+LH
+Hs
+MT
+DF
 aa
 aa
 aa
@@ -51524,7 +51381,7 @@ bE
 ci
 cN
 dO
-Tu
+eH
 fb
 cg
 cg
@@ -51553,7 +51410,7 @@ aa
 aa
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -51571,37 +51428,37 @@ aa
 aa
 aa
 aa
-uV
-uV
-uV
-uV
-uV
-uV
+vc
+vc
+vc
+vc
+vc
+vc
 aa
 aa
 aa
 jB
-zx
-Ac
-Sv
-BA
+zF
+Ak
+qe
+BJ
 jB
-Du
-DZ
-DY
-Dw
-Gh
-GT
-HA
-Dw
-IU
-JG
-Kn
-Dw
-KY
-LD
-Mk
-Dw
+DD
+Ek
+Ej
+DF
+GD
+Ht
+Ie
+DF
+JC
+Ko
+KV
+DF
+LI
+Mn
+MU
+DF
 aa
 aa
 aa
@@ -51810,7 +51667,7 @@ aa
 aa
 aa
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -51838,27 +51695,27 @@ aa
 aa
 aa
 jB
-zy
-Ad
-AK
-BB
+zG
+Al
+AT
+BK
 jB
-Dw
-Dw
-Dw
-Dw
-Gi
-Gi
-HB
-Dw
-Gi
-Gi
-HB
-Dw
-Gi
-Gi
-HB
-Dw
+DF
+DF
+DF
+DF
+GE
+GE
+If
+DF
+GE
+GE
+If
+DF
+GE
+GE
+If
+DF
 aa
 aa
 aa
@@ -52067,7 +51924,7 @@ aa
 aa
 aa
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -52098,24 +51955,24 @@ jB
 jB
 jB
 jB
-lo
+lq
 jB
 aa
 aa
 aa
-Dw
-Gi
-Gi
-HC
-Dw
-Gi
-JH
-HC
-Dw
-Gi
-Gi
-HC
-Dw
+DF
+GE
+GE
+Ig
+DF
+GE
+Kp
+Ig
+DF
+GE
+GE
+Ig
+DF
 aa
 aa
 aa
@@ -52324,7 +52181,7 @@ aa
 aa
 aa
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -52354,25 +52211,25 @@ aa
 aa
 aa
 jB
-AL
-BC
+AU
+BL
 jB
 aa
 aa
 aa
-Dw
-Gi
-GU
-HD
-Dw
-Gi
-JI
-HD
-Dw
-Gi
-LE
-HD
-Dw
+DF
+GE
+Hu
+Ih
+DF
+GE
+Kq
+Ih
+DF
+GE
+Mo
+Ih
+DF
 aa
 aa
 aa
@@ -52581,7 +52438,7 @@ aa
 aa
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -52611,25 +52468,25 @@ aa
 aa
 aa
 jB
-AL
-BD
+AU
+BM
 jB
 aa
 aa
 aa
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
-Dw
+DF
+DF
+DF
+DF
+DF
+DF
+DF
+DF
+DF
+DF
+DF
+DF
+DF
 aa
 aa
 aa
@@ -52838,7 +52695,7 @@ aa
 aa
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -52869,7 +52726,7 @@ aa
 aa
 jB
 jB
-BE
+BN
 jB
 jB
 aa
@@ -53095,7 +52952,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 ac
@@ -53126,8 +52983,8 @@ aa
 aa
 aa
 jB
-BF
-qc
+BO
+qf
 jB
 aa
 aa
@@ -53352,7 +53209,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 ac
@@ -53383,8 +53240,8 @@ ac
 ac
 ac
 jB
-BG
-CA
+BP
+CJ
 jB
 aa
 aa
@@ -53608,9 +53465,9 @@ aa
 aa
 ac
 ac
-pe
-pJ
-qg
+pg
+pL
+qj
 ac
 ac
 ac
@@ -53622,9 +53479,9 @@ ac
 ac
 ac
 ac
-pe
-sT
-qg
+pg
+sZ
+qj
 ac
 ac
 ac
@@ -53640,7 +53497,7 @@ ac
 ac
 ac
 jB
-BH
+BQ
 jB
 jB
 aa
@@ -53865,40 +53722,40 @@ aa
 aa
 aa
 ac
-pg
-pK
-qh
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-sr
-sU
-qh
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-AM
-BI
-CB
+pi
+pM
+qk
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+sw
+ta
+qk
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+qD
+AV
+BR
+CK
 aa
 aa
 aa
@@ -54122,9 +53979,9 @@ aa
 aa
 aa
 ac
-pf
-pL
-qf
+ph
+pN
+qi
 ac
 ac
 ac
@@ -54136,9 +53993,9 @@ ac
 ac
 ac
 ac
-pf
-pI
-qf
+ph
+pK
+qi
 ac
 ac
 ac
@@ -54198,10 +54055,10 @@ aa
 aa
 aa
 aa
-RO
-RO
-RO
-RO
+SE
+SE
+SE
+SE
 aa
 aa
 aa
@@ -54394,7 +54251,7 @@ ac
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 ac
@@ -54453,13 +54310,13 @@ aa
 aa
 aa
 aa
-RO
-RO
-RO
-RV
-Sb
-RO
-RO
+SE
+SE
+SE
+SM
+SS
+SE
+SE
 aa
 aa
 aa
@@ -54649,9 +54506,9 @@ ac
 ac
 ac
 ac
-qz
+qC
 ac
-pH
+pJ
 ac
 ac
 ac
@@ -54710,13 +54567,13 @@ aa
 aa
 aa
 aa
-RO
-RP
-RS
-RP
-Sc
-RP
-RO
+SE
+SF
+SI
+SF
+ST
+SF
+SE
 aa
 aa
 aa
@@ -54908,7 +54765,7 @@ ac
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 ac
@@ -54967,13 +54824,13 @@ aa
 aa
 aa
 aa
-RO
-RQ
-Tj
-RW
-Sd
-Sf
-RO
+SE
+SG
+SJ
+SN
+SU
+SW
+SE
 aa
 aa
 aa
@@ -55165,7 +55022,7 @@ ac
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -55224,13 +55081,13 @@ aa
 aa
 aa
 aa
-RO
-RR
-RT
-RX
-RY
-RX
-Sh
+SE
+SH
+SK
+SO
+SP
+SO
+SY
 aa
 aa
 aa
@@ -55422,7 +55279,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -55481,13 +55338,13 @@ aa
 aa
 aa
 aa
-RO
-RP
-RT
-RY
-RX
-RY
-RO
+SE
+SF
+SK
+SP
+SO
+SP
+SE
 aa
 aa
 aa
@@ -55679,7 +55536,7 @@ aa
 aa
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -55738,13 +55595,13 @@ aa
 aa
 aa
 aa
-RO
-RP
-RT
-RX
-RY
-RY
-Sh
+SE
+SF
+SK
+SO
+SP
+SP
+SY
 aa
 aa
 aa
@@ -55936,7 +55793,7 @@ aa
 aa
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -55995,13 +55852,13 @@ aa
 aa
 aa
 aa
-RO
-RO
-RO
-RO
-RO
-RO
-RO
+SE
+SE
+SE
+SE
+SE
+SE
+SE
 aa
 aa
 aa
@@ -56193,7 +56050,7 @@ aa
 aa
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -56450,7 +56307,7 @@ aa
 aa
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -56707,7 +56564,7 @@ aa
 aa
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -56964,7 +56821,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -57221,7 +57078,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -57478,7 +57335,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -57735,7 +57592,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -57751,19 +57608,19 @@ aa
 aa
 aa
 aa
-uW
-Ak
-AS
-BS
-Ea
-Ak
-AS
-BS
-Ea
-Ak
-AS
-BS
-uW
+vd
+As
+Bb
+Cb
+xv
+As
+Bb
+Cb
+xv
+As
+Bb
+Cb
+vd
 ac
 aa
 aa
@@ -57992,7 +57849,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -58008,19 +57865,19 @@ aa
 aa
 aa
 aa
-uW
-BJ
-CC
-Dx
-Ea
-BJ
-Fo
-Dx
-Ea
-BJ
-Ik
-Dx
-uW
+vd
+BS
+CL
+DG
+xv
+BS
+FG
+DG
+xv
+BS
+IQ
+DG
+vd
 ac
 ac
 aa
@@ -58249,7 +58106,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -58265,19 +58122,19 @@ aa
 aa
 aa
 aa
-uW
-BK
-xX
-Dy
-Ea
-BK
-xX
-Dy
-Ea
-BK
-xX
-Dy
-uW
+vd
+BT
+yf
+DH
+xv
+BT
+yf
+DH
+xv
+BT
+yf
+DH
+vd
 ac
 ac
 aa
@@ -58506,7 +58363,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -58522,19 +58379,19 @@ aa
 aa
 aa
 aa
-uW
-BL
-CD
-Dz
-Ea
-BL
-CD
-Dz
-Ea
-BL
-CD
-Dz
-uW
+vd
+BU
+CM
+DI
+xv
+BU
+CM
+DI
+xv
+BU
+CM
+DI
+vd
 ac
 ac
 ac
@@ -58762,9 +58619,9 @@ aa
 ac
 ac
 ac
-pe
-pJ
-qg
+pg
+pL
+qj
 ac
 aa
 aa
@@ -58777,22 +58634,22 @@ aa
 aa
 aa
 aa
-uW
-uW
-uW
-BM
-CE
-BM
-Ea
-BM
-Fp
-BM
-Ea
-BM
-Il
-BM
-uW
-uW
+vd
+vd
+vd
+BV
+CN
+BV
+xv
+BV
+FH
+BV
+xv
+BV
+IR
+BV
+vd
+vd
 ac
 ac
 aa
@@ -59019,9 +58876,9 @@ aa
 ac
 ac
 aa
-pf
-pI
-qf
+ph
+pK
+qi
 ac
 aa
 aa
@@ -59030,26 +58887,26 @@ kj
 jL
 kj
 kj
-uW
-uW
-uW
-uW
-uW
-Ae
-AN
-BN
-CF
-xX
-Eb
-xX
-CF
-xX
-GV
-xX
-CF
-xX
-xX
-JL
+vd
+vd
+vd
+vd
+vd
+Am
+AW
+BW
+CO
+yf
+El
+yf
+CO
+yf
+Hv
+yf
+CO
+yf
+yf
+Kt
 ac
 ac
 ac
@@ -59277,36 +59134,36 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
 kj
 kj
 af
-wd
+wk
 af
 jL
-uW
-xK
-yr
-yX
-zz
-Af
-AO
-BO
-CF
-DA
-Ec
-Ec
-Fq
-Gj
-GW
-HE
-Im
-IV
-JJ
-JM
+vd
+xS
+yz
+zf
+zH
+An
+AX
+BX
+CO
+DJ
+Em
+Em
+FI
+GF
+Hw
+Ii
+IS
+JD
+Kr
+Ku
 ac
 ac
 ac
@@ -59534,7 +59391,7 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -59542,28 +59399,28 @@ kj
 jL
 af
 af
-wx
-wS
-xn
-xL
-ys
-yY
-zA
-Ag
-AP
-BP
-CG
-DB
-Ah
-EK
-Fr
-Gk
-xX
-HF
-In
-IW
-IW
-JM
+wE
+wZ
+xu
+xT
+yA
+zg
+zI
+Ao
+AY
+BY
+CP
+DK
+Ap
+EY
+FJ
+GG
+yf
+Ij
+IT
+JE
+JE
+Ku
 ac
 ac
 ac
@@ -59791,36 +59648,36 @@ aa
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
 kj
 kj
 ac
-we
+wl
 af
 jL
-uW
-xM
-yt
-yZ
-zB
-Ah
-Ah
-Ah
-CH
-DC
-Ed
-EL
-AS
-AS
-BS
-uW
-Io
-IX
-JK
-JN
+vd
+xU
+yB
+zh
+zJ
+Ap
+Ap
+Ap
+CQ
+DL
+En
+EZ
+Bb
+Bb
+Cb
+vd
+IU
+JF
+Ks
+Kv
 ac
 ac
 ac
@@ -60048,7 +59905,7 @@ ac
 ac
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
@@ -60058,26 +59915,26 @@ kj
 jL
 kj
 kj
-uW
-TP
-yu
-za
-zz
-Ai
-AQ
-BQ
-CI
-DD
-uW
-EM
-Fs
-Gl
-GX
-uW
-Ak
-BS
-uW
-uW
+vd
+xV
+yC
+zi
+zH
+Aq
+AZ
+BZ
+CR
+DM
+vd
+Fa
+FK
+GH
+Hx
+vd
+As
+Cb
+vd
+vd
 ac
 ac
 ac
@@ -60305,40 +60162,40 @@ ac
 ac
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
-uW
-uW
-uW
-uW
-uW
-uW
-uW
-xO
-yv
-zb
-Ea
-Aj
-AR
-BR
-CJ
-DE
-Ee
-EN
-xX
-xX
-xX
-HG
-Ip
-IY
-uW
+vd
+vd
+vd
+vd
+vd
+vd
+vd
+xW
+yD
+zj
+xv
+Ar
+Ba
+Ca
+CS
+DN
+Eo
+Fb
+yf
+yf
+yf
+Ik
+IV
+JG
+vd
 ac
 ac
 ac
 ac
-mb
+md
 ac
 ac
 ac
@@ -60562,35 +60419,35 @@ ac
 ac
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
-uW
-vk
-vI
-wf
-wy
-wT
-Ea
-xP
-yw
-zc
-Ea
-Ak
-AS
-BS
-Ea
-Ak
-Ef
-EO
-Ft
-Ft
+vd
+vr
+vP
+wm
+wF
+xa
+xv
 xX
-HH
-Iq
-IZ
-JL
+yE
+zk
+xv
+As
+Bb
+Cb
+xv
+As
+Ep
+Fc
+FL
+FL
+yf
+Il
+IW
+JH
+Kt
 ac
 ac
 ac
@@ -60819,35 +60676,35 @@ ac
 ac
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
-uW
-vl
-vI
-vI
-vI
-wU
-Ea
-xQ
-yx
-zd
-zz
-Al
-AT
-BT
-Ea
-DF
-Eg
-AO
-Fu
-Gm
-xX
-HI
-xX
-xX
-JM
+vd
+vs
+vP
+vP
+vP
+xb
+xv
+xY
+yF
+zl
+zH
+At
+Bc
+Cc
+xv
+DO
+Eq
+AX
+FM
+GI
+yf
+Im
+yf
+yf
+Ku
 ac
 ac
 ac
@@ -61076,35 +60933,35 @@ ac
 ac
 ac
 ac
-pH
+pJ
 ac
 aa
 aa
-uW
-vk
-vI
-wg
-wz
-wV
-xo
-xR
-yy
-ze
-zC
-Ag
-AP
-BU
-CK
-DG
-Eh
-EP
-Fv
-Gn
-GY
-HJ
-xX
-xX
-JM
+vd
+vr
+vP
+wn
+wG
+xc
+xw
+xZ
+yG
+zm
+zK
+Ao
+AY
+Cd
+CT
+DP
+Er
+Fd
+FN
+GJ
+Hy
+In
+yf
+yf
+Ku
 ac
 ac
 ac
@@ -61333,35 +61190,35 @@ ac
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
-uW
-uW
-uW
-wh
-wA
-vI
-Ea
-xS
-yz
-zf
-uW
-Am
-AU
-BV
-CL
-DH
-Ei
-EQ
-Fw
-Ft
-GZ
-HG
-Ir
-Ja
-JN
+vd
+vd
+vd
+wo
+wH
+vP
+xv
+ya
+yH
+zn
+vd
+Au
+Bd
+Ce
+CU
+DQ
+Es
+Fe
+FO
+FL
+Hz
+Ik
+IX
+JI
+Kv
 ac
 ac
 ac
@@ -61590,47 +61447,47 @@ ac
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
 aa
 aa
-uW
-wi
-wB
-wi
-uW
-uW
-yA
-uW
-uW
-Ak
-AS
-BS
-uW
-uW
-uW
-ER
-xX
-xX
-GZ
-HH
-Is
-Jb
-uW
+vd
+wp
+wI
+wp
+vd
+vd
+yI
+vd
+vd
+As
+Bb
+Cb
+vd
+vd
+vd
+Ff
+yf
+yf
+Hz
+Il
+IY
+JJ
+vd
 ac
 aa
 aa
 ac
-Ml
-MY
-MY
-Oe
-Oi
-Oi
-Oi
-Oi
+MV
+NI
+NI
+OO
+OS
+OS
+OS
+OS
 aa
 aa
 aa
@@ -61847,47 +61704,47 @@ ac
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
 aa
 aa
-uW
-uW
-uW
-uW
-uW
-xT
-yB
-zg
-uW
+vd
+vd
+vd
+vd
+vd
+yb
+yJ
+zo
+vd
 ac
 ac
 ac
 aa
 aa
-uW
-ES
-Fx
-Go
-Ha
-uW
-uW
-uW
-uW
+vd
+Fg
+FP
+GK
+HA
+vd
+vd
+vd
+vd
 aa
 aa
 aa
 ac
-Mm
-MZ
-Ny
-Of
+MW
+NJ
 Oi
-Pf
-PD
-Oi
+OP
+OS
+PP
+Qn
+OS
 aa
 aa
 aa
@@ -62087,15 +61944,15 @@ kj
 kj
 kj
 jL
-nv
-nv
-nv
-nv
-nv
-nv
-nv
-nv
-nv
+nx
+nx
+nx
+nx
+nx
+nx
+nx
+nx
+nx
 jL
 kj
 kj
@@ -62104,7 +61961,7 @@ kj
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -62114,37 +61971,37 @@ aa
 aa
 aa
 aa
-uW
-xU
-yC
-zh
-uW
+vd
+yc
+yK
+zp
+vd
 ac
 ac
 ac
 ac
-rt
-uW
-uW
-uW
-uW
-uW
-uW
-DI
-DI
-DI
+rx
+vd
+vd
+vd
+vd
+vd
+vd
+DR
+DR
+DR
 aa
 aa
 aa
 ac
-Mm
-Na
-Nz
-Og
-Oi
-Pg
-PE
-Oi
+MW
+NK
+Oj
+OQ
+OS
+PQ
+Qo
+OS
 aa
 aa
 aa
@@ -62344,15 +62201,15 @@ kj
 kj
 kj
 kj
-nv
-nv
-nv
-nv
-nv
-nv
-nv
-nv
-nv
+nx
+nx
+nx
+nx
+nx
+nx
+nx
+nx
+nx
 kj
 kj
 kj
@@ -62361,7 +62218,7 @@ kj
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -62371,37 +62228,37 @@ aa
 aa
 aa
 aa
-uW
-xV
-yD
-zi
-uW
+vd
+yd
+yL
+zq
+vd
 aa
 ac
 ac
 ac
-DI
-Ej
-ET
-Ej
-Ej
-Ej
-Ej
-ET
-Ej
-DI
+DR
+Et
+Fh
+Et
+Et
+Et
+Et
+Fh
+Et
+DR
 aa
 aa
 ac
 ac
-Mn
-Nb
-NA
-Oh
-Oi
-Ph
-PD
-Oi
+MX
+NL
+Ok
+OR
+OS
+PR
+Qn
+OS
 aa
 aa
 aa
@@ -62601,15 +62458,15 @@ kj
 kj
 kj
 kj
-nv
-nv
-nv
-pM
-qi
-qB
-nv
-nv
-nv
+nx
+nx
+nx
+pO
+ql
+qE
+nx
+nx
+nx
 kj
 kj
 kj
@@ -62618,7 +62475,7 @@ kj
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 aa
@@ -62627,38 +62484,38 @@ aa
 aa
 aa
 aa
-uW
-uW
-uW
-yE
-uW
-uW
+vd
+vd
+vd
+yM
+vd
+vd
 ac
 ac
 ac
 ac
-DI
-Ek
-Ek
-Ek
-Ek
-Ek
-Ek
-Ek
-Ek
-DI
-Ko
-Ko
-KZ
-LF
-Ko
-Ko
-NB
-Oi
-Oi
-Pi
-PE
-Oi
+DR
+Eu
+Eu
+Eu
+Eu
+Eu
+Eu
+Eu
+Eu
+DR
+KW
+KW
+LJ
+Mp
+KW
+KW
+Ol
+OS
+OS
+PS
+Qo
+OS
 aa
 aa
 aa
@@ -62858,15 +62715,15 @@ kj
 kj
 kj
 kj
-nv
-nv
-ph
-pN
-qj
-qC
-TG
-nv
-nv
+nx
+nx
+pj
+pP
+qm
+qF
+qN
+nx
+nx
 kj
 kj
 kj
@@ -62875,7 +62732,7 @@ kj
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 ac
@@ -62884,38 +62741,38 @@ aa
 aa
 aa
 ac
-wW
-xp
-xW
-yF
-zj
-uW
+xd
+xx
+ye
+yN
+zr
+vd
 ac
 ac
 ac
 ac
-DI
-Ek
-Ek
-Ek
-Ek
-Ek
-Ek
-Ek
-Ek
-DI
-Kp
-KG
-La
-LG
-Mo
-Nc
-NC
-Oj
-OI
-Pj
-PF
-Oi
+DR
+Eu
+Eu
+Eu
+Eu
+Eu
+Eu
+Eu
+Eu
+DR
+KX
+Lq
+LK
+Mq
+MY
+NM
+Om
+OT
+Ps
+PT
+Qp
+OS
 aa
 aa
 aa
@@ -63115,15 +62972,15 @@ kj
 kj
 kj
 kj
-nv
-nv
-pi
-pO
-qk
-qD
-qL
-nv
-nv
+nx
+nx
+pk
+pQ
+qn
+qG
+qO
+nx
+nx
 kj
 kj
 kj
@@ -63132,7 +62989,7 @@ kj
 ac
 ac
 ac
-pH
+pJ
 ac
 ac
 ac
@@ -63141,38 +62998,38 @@ aa
 aa
 ac
 ac
-wX
-xq
-xX
-yG
-zk
-zD
-An
-An
-An
-CM
-DI
-El
-El
-Fy
-Gp
-Hb
-El
-El
-El
-DI
-Kq
-KH
-Lb
-LH
-Mp
-Mp
-ND
-Oi
-OJ
-Pk
-PG
-Oi
+xe
+xy
+yf
+yO
+zs
+zL
+Av
+Av
+Av
+CV
+DR
+Ev
+Ev
+FQ
+GL
+HB
+Ev
+Ev
+Ev
+DR
+KY
+Lr
+LL
+Mr
+MZ
+MZ
+On
+OS
+Pt
+PU
+Qq
+OS
 aa
 aa
 aa
@@ -63372,15 +63229,15 @@ kj
 kj
 kj
 kj
-nv
-nv
-pj
-pO
-nw
-qD
-qM
-nv
-nv
+nx
+nx
+pl
+pQ
+ny
+qG
+qP
+nx
+nx
 kj
 kj
 kj
@@ -63388,50 +63245,50 @@ kj
 kj
 kj
 ac
-pe
-pJ
-qg
+pg
+pL
+qj
 ac
 ac
 ac
 ac
-pe
-qg
+pg
+qj
 ac
-wX
-xr
-xY
-yH
-zl
-zE
-Ao
-AV
-Ao
-CN
-DI
-Ej
-Ej
-Fz
-Gq
-Ej
-Ej
-Ej
-Ej
-DI
-Kr
-KI
-Lc
-LI
-Mq
-Lc
-NE
-Ko
-Ko
-Ko
-Ko
-Ko
-Ko
-Ko
+xe
+xz
+yg
+yP
+zt
+zM
+Aw
+Be
+Aw
+CW
+DR
+Et
+Et
+FR
+GM
+Et
+Et
+Et
+Et
+DR
+KZ
+Ls
+LM
+Ms
+Na
+LM
+Oo
+KW
+KW
+KW
+KW
+KW
+KW
+KW
 aa
 aa
 aa
@@ -63629,66 +63486,66 @@ kj
 kj
 kj
 kj
-nv
-nv
-pk
-pO
-ql
-qD
-TH
-nv
-nv
-pW
+nx
+nx
+pm
+pQ
+qo
+qG
+qQ
+nx
+nx
+pY
+qV
+qV
+qV
+qV
+qV
 qS
-qS
-qS
-qS
-qS
-qP
-ss
-sV
-tz
-ui
-ui
-ui
-ui
-vJ
-wj
+sx
+tb
+tH
+uq
+uq
+uq
+uq
+vQ
+wq
 ac
-wX
-xs
-xX
-yI
-zm
-zF
-Ap
-Ap
-BW
-CO
-DI
-Em
-Ek
-Ek
-Gq
-Ek
-Ek
-Ek
-Ek
-DI
-Ko
-KJ
-Ld
-LJ
-Mr
-Nd
-NF
-Ok
-OK
-Pl
-PH
-PY
-TQ
-Ko
+xe
+xA
+yf
+yQ
+zu
+zN
+Ax
+Ax
+Cf
+CX
+DR
+Ew
+Eu
+Eu
+GM
+Eu
+Eu
+Eu
+Eu
+DR
+KW
+Lt
+LN
+Mt
+Nb
+NN
+Op
+OU
+Pu
+PV
+Qr
+QJ
+QU
+KW
 aa
 aa
 aa
@@ -63886,66 +63743,66 @@ kj
 kj
 kj
 kj
-nv
-nv
-pl
-ok
-qm
-qE
-qO
-nv
-nv
-qv
+nx
+nx
+pn
+om
+qp
+qH
+qR
+nx
+nx
+qy
 kj
 kj
 kj
 kj
 kj
 ac
-st
-sW
-qf
+sy
+tc
+qi
 ac
 ac
 ac
 ac
-vK
-qf
+vR
+qi
 ac
-wY
-xt
-xX
-xX
-zl
-zG
-Aq
-AW
-BX
-CP
-DJ
-Ek
-Ek
-Ek
-Gq
-Ek
-Ek
-Ek
-Ek
-DI
-Ko
-Ko
-Le
-LK
-Lc
-Ne
-NG
-Ko
-OL
-Pm
-PI
-Ko
-Ko
-Ko
+xf
+xB
+yf
+yf
+zt
+zO
+Ay
+Bf
+Cg
+CY
+DS
+Eu
+Eu
+Eu
+GM
+Eu
+Eu
+Eu
+Eu
+DR
+KW
+KW
+LO
+Mu
+LM
+NO
+Oq
+KW
+Pv
+PW
+Qs
+KW
+KW
+KW
 aa
 aa
 aa
@@ -64143,16 +64000,16 @@ kj
 kj
 kj
 kj
-nv
-nv
-nv
-nv
-qn
-nv
-nv
-nv
-nv
-qv
+nx
+nx
+nx
+nx
+qq
+nx
+nx
+nx
+nx
+qy
 kj
 kj
 kj
@@ -64160,49 +64017,49 @@ kj
 kj
 kj
 jB
-sX
-tA
+td
+tI
 jB
 ac
 ac
 ac
-vL
+vS
 ac
 ac
-uW
-uW
-uW
-uW
-uW
-uW
-Ar
-AX
-BY
-CP
-DI
-En
-EU
-FA
-Gr
-Hc
-El
-It
-El
-DI
-Ks
-Ko
-Lf
-LL
-Ms
+vd
+vd
+vd
+vd
+vd
+vd
+Az
+Bg
+Ch
+CY
+DR
+Ex
+Fi
+FS
+GN
+HC
+Ev
+IZ
+Ev
+DR
 La
-NH
-Ko
-OM
-Pn
-PI
-PZ
-TQ
-Ko
+KW
+LP
+Mv
+Nc
+LK
+Or
+KW
+Pw
+PX
+Qs
+QK
+QU
+KW
 aa
 aa
 aa
@@ -64400,16 +64257,16 @@ kj
 kj
 kj
 jL
-nv
-nv
-nv
-nv
-qo
-nv
-nv
-nv
-nv
-qv
+nx
+nx
+nx
+nx
+qr
+nx
+nx
+nx
+nx
+qy
 kj
 kj
 kj
@@ -64417,49 +64274,49 @@ kj
 kj
 kj
 jB
-sY
-tB
+te
+tJ
 jB
 aa
 jB
 jB
-vM
+vT
 jB
 ac
-uW
-xu
-xu
-xu
-xu
-zH
-Ar
-AY
-BZ
-CQ
-DI
-DI
-DI
-DI
-Gs
-DI
-DI
-DI
-DI
-DI
-Ko
-Ko
-Lg
-LM
-Mt
-Nf
-NI
-Ko
-Ko
-Ko
-Ko
-Ko
-Ko
-Ko
+vd
+xC
+xC
+xC
+xC
+zP
+Az
+Bh
+Ci
+CZ
+DR
+DR
+DR
+DR
+GO
+DR
+DR
+DR
+DR
+DR
+KW
+KW
+LQ
+Mw
+Nd
+NP
+Os
+KW
+KW
+KW
+KW
+KW
+KW
+KW
 aa
 aa
 aa
@@ -64660,13 +64517,13 @@ kj
 jL
 kj
 ac
-lg
-qp
-qF
-qP
+li
+qs
+qI
 qS
-qS
-pX
+qV
+qV
+pZ
 kj
 kj
 kj
@@ -64674,47 +64531,47 @@ kj
 kj
 kj
 jB
-sZ
-tC
+tf
+tK
 jB
 aa
 jB
-vm
-vN
+vt
+vU
 jB
-wC
-uW
-xu
-xu
-xu
-xu
-xu
-Ar
-AZ
-BY
-CR
-DK
-Eo
-EV
-FB
-Gt
-Hd
-HK
-Iu
-Jc
-Iu
-Kt
-KK
-Lh
-LN
-Mu
-Mu
-NJ
-Ol
-ON
-Po
-PJ
-MD
+wJ
+vd
+xC
+xC
+xC
+xC
+xC
+Az
+Bi
+Ch
+Da
+DT
+Ey
+Fj
+FT
+GP
+HD
+Io
+Ja
+JK
+Ja
+Lb
+Lu
+LR
+Mx
+Ne
+Ne
+Ot
+OV
+Px
+PY
+Qt
+Nn
 aa
 aa
 aa
@@ -64917,9 +64774,9 @@ ac
 ac
 ac
 ac
-lg
-nw
-oi
+li
+ny
+ok
 ac
 ac
 ac
@@ -64931,47 +64788,47 @@ kj
 kj
 kj
 jB
-ta
-tD
+tg
+tL
 jB
 jB
 jB
-vn
-vO
+vu
+vV
 jB
-wD
+wK
 jB
-xu
-xZ
-xu
-zn
-xu
-Ar
-Ba
-Ca
-Ap
-DL
-Ep
-Ap
-Ap
-Gu
-He
-HL
-Iv
-Jd
-JO
-Iv
-KL
-Li
-LO
-Mv
-Ng
-Mv
-Om
-Mv
-Mv
-PK
-MD
+xC
+yh
+xC
+zv
+xC
+Az
+Bj
+Cj
+Ax
+DU
+Ez
+Ax
+Ax
+GQ
+HE
+Ip
+Jb
+JL
+Kw
+Jb
+Lv
+LS
+My
+Nf
+NQ
+Nf
+OW
+Nf
+Nf
+Qu
+Nn
 aa
 aa
 aa
@@ -65174,9 +65031,9 @@ ac
 ac
 ac
 ac
-lg
-nw
-oi
+li
+ny
+ok
 ac
 ac
 ac
@@ -65188,47 +65045,47 @@ kj
 kj
 kj
 jB
-tb
-tE
-uj
-uH
-uX
-vo
-vP
-wk
-wE
+th
+tM
+ur
+uO
+ve
+vv
+vW
+wr
+wL
 jB
-xu
-xu
-xu
-xu
-xu
-Ar
-Bb
-Cb
-CS
-DM
-Eq
-EW
-CS
-Gv
-Hf
-Hf
-Hf
-Hf
-Hf
-Hf
-Hf
-Hf
-Hf
-Mw
-Nh
-Mw
-Hd
-OO
-Pp
-PL
-MD
+xC
+xC
+xC
+xC
+xC
+Az
+Bk
+Ck
+Db
+DV
+EA
+Fk
+Db
+GR
+HF
+HF
+HF
+HF
+HF
+HF
+HF
+HF
+HF
+Ng
+NR
+Ng
+HD
+Py
+PZ
+Qv
+Nn
 aa
 aa
 aa
@@ -65421,19 +65278,19 @@ ac
 ac
 ac
 ac
-ls
+lu
 jL
-ls
+lu
 jL
-ls
-ls
-ls
+lu
+lu
+lu
 ac
 ac
 ac
-lg
-nw
-oi
+li
+ny
+ok
 ac
 ac
 ac
@@ -65445,53 +65302,53 @@ kj
 kj
 kj
 jB
-tc
-tc
-uk
+ti
+ti
+us
 kz
-Sv
-Sv
-Sv
-Sv
-wF
+qe
+qe
+qe
+qe
+wM
 jB
-xu
-xu
-xu
-xu
-xu
+xC
+xC
+xC
+xC
+xC
 jB
-Bc
+Bl
 jB
-CT
-DN
-Ar
-Ar
-FC
-Gw
-Hf
-HM
-Iw
-Je
-JP
-Ku
-Iw
-Lj
-Hf
-Mx
-Ni
-NK
-Hd
-Hd
-OP
-PM
-MD
-MD
-MD
-MD
-MD
-MD
-MD
+Dc
+DW
+Az
+Az
+FU
+GS
+HF
+Iq
+Jc
+JM
+Kx
+Lc
+Jc
+LT
+HF
+Nh
+NS
+Ou
+HD
+HD
+Pz
+Qw
+Nn
+Nn
+Nn
+Nn
+Nn
+Nn
+Nn
 aa
 aa
 aa
@@ -65677,20 +65534,20 @@ kj
 ac
 ac
 ac
-lg
-lt
-lt
-lt
-lt
-mR
-nv
-nw
-oi
+li
+lv
+lv
+lv
+lv
+mT
+nx
+ny
+ok
 ac
 ac
-lg
-nw
-oi
+li
+ny
+ok
 ac
 ac
 ac
@@ -65704,13 +65561,13 @@ kj
 jB
 jB
 jB
-ul
-uI
-uY
-uI
-uI
-uI
-wG
+ut
+uP
+vf
+uP
+uP
+uP
+wN
 jB
 jB
 jB
@@ -65718,37 +65575,37 @@ jB
 jB
 jB
 jB
-Bd
-Cc
+Bm
+Cl
 ac
 ac
 aa
-Ar
-FD
-Gx
-Hf
-HN
-Ix
-Jf
-JP
-Kv
-Ix
-Lk
-Hf
-My
-Nj
-NL
-On
-Hd
-Pq
-Tm
-PN
-Qh
-Qw
-QH
-QU
-Rm
-MD
+Az
+FV
+GT
+HF
+Ir
+Jd
+JN
+Kx
+Ld
+Jd
+LU
+HF
+Ni
+NT
+Ov
+OX
+HD
+Qa
+Qx
+QL
+QV
+Rk
+Rx
+RK
+Sc
+Nn
 aa
 aa
 aa
@@ -65935,19 +65792,19 @@ ac
 ac
 ac
 jL
-lt
-lE
-lt
-lt
-lt
-nw
-nw
-oj
-oL
-oL
+lv
+lG
+lv
+lv
+lv
+ny
+ny
+ol
+oN
+oN
 jL
-nw
-oi
+ny
+ok
 ac
 ac
 ac
@@ -65961,51 +65818,51 @@ kj
 kj
 aa
 jB
-um
+uu
 jB
 jB
 jB
 jB
 jB
-wH
-wZ
-wZ
-wZ
-yJ
-wZ
-wZ
-wZ
-Be
-Cd
+wO
+xg
+xg
+xg
+yR
+xg
+xg
+xg
+Bn
+Cm
 ac
 ac
 aa
-Ar
-FE
-Gy
-Hg
-HO
-Iy
-Iy
-JQ
-Kw
-Kw
-Ll
-Hf
-Mz
-Nk
-NM
-Oo
-OP
-Pr
-Tn
-To
-Qi
-Tq
-QI
-Pr
-Rn
-MD
+Az
+FW
+GU
+HG
+Is
+Je
+Je
+Ky
+Le
+Le
+LV
+HF
+Nj
+NU
+Ow
+OY
+Pz
+Qb
+Qy
+QM
+QW
+Rl
+Ry
+Qb
+Sd
+Nn
 aa
 aa
 aa
@@ -66191,19 +66048,19 @@ kj
 ac
 ac
 ac
-lg
-lt
-lt
-lt
-lt
-lt
-nw
-nw
-ok
-nw
-nw
-nw
-qq
+li
+lv
+lv
+lv
+lv
+lv
+ny
+ny
+om
+ny
+ny
+ny
+qt
 jL
 ac
 ac
@@ -66218,51 +66075,51 @@ aa
 aa
 aa
 jB
-uk
+us
 jB
 aa
 aa
 aa
 jB
 jB
-xa
+xh
 jB
-xa
+xh
 jB
-xa
+xh
 jB
-xa
+xh
 jB
 jB
 ac
 ac
 ac
-EX
-FF
-Gz
-Hh
-HP
-Iz
-Iz
-JR
-Iz
-KM
-Lm
-Hf
-MA
-Nl
-NN
-Op
-Hd
-Ps
-PO
-PN
-Pr
-PN
-Pr
-PN
-Ro
-MD
+Fl
+FX
+GV
+HH
+It
+Jf
+Jf
+Kz
+Jf
+Lw
+LW
+HF
+Nk
+NV
+Ox
+OZ
+HD
+Qc
+Qz
+QL
+Qb
+QL
+Qb
+QL
+Se
+Nn
 aa
 aa
 aa
@@ -66449,17 +66306,17 @@ kj
 ac
 ac
 jL
-lt
-lt
-lt
-lt
-lt
-nw
-nR
-ol
-lu
-lu
-lu
+lv
+lv
+lv
+lv
+lv
+ny
+nT
+on
+lw
+lw
+lw
 jL
 ac
 ac
@@ -66475,7 +66332,7 @@ aa
 aa
 aa
 jB
-uk
+us
 jB
 aa
 aa
@@ -66494,32 +66351,32 @@ ac
 ac
 ac
 ac
-EY
-FG
-GA
-Hf
-HQ
-Ix
-Jf
-JP
-Kv
-Ix
-Jf
-Hf
-MB
+Fm
+FY
+GW
+HF
+Iu
+Jd
+JN
+Kx
+Ld
+Jd
+JN
+HF
 Nl
-Nl
-Op
-OP
-Pt
-PP
-Tp
-Qj
-Tr
-QI
-Pr
-Rp
-MD
+NV
+NV
+OZ
+Pz
+Qd
+QA
+QN
+QX
+Rm
+Ry
+Qb
+Sf
+Nn
 aa
 aa
 aa
@@ -66705,15 +66562,15 @@ kj
 kj
 ac
 ac
-lg
-lt
-lt
-lt
-lt
-lt
-nv
-nw
-om
+li
+lv
+lv
+lv
+lv
+lv
+nx
+ny
+oo
 ac
 ac
 ac
@@ -66732,7 +66589,7 @@ aa
 aa
 aa
 jB
-uk
+us
 jB
 aa
 aa
@@ -66751,32 +66608,32 @@ ac
 ac
 ac
 ac
-EZ
-FH
-GB
-Hf
-HM
-IA
+Fn
+FZ
+GX
+HF
+Iq
 Jg
-JP
+JO
 Kx
-IA
-Lj
-Hf
-MC
-MC
-NO
-Hd
-Hd
-Pu
-PQ
-PN
-Qk
-Qx
-QH
-QV
-Rq
-MD
+Lf
+Jg
+LT
+HF
+Nm
+Nm
+Oy
+HD
+HD
+Qe
+QB
+QL
+QY
+Rn
+Rx
+RL
+Sg
+Nn
 aa
 aa
 aa
@@ -66963,13 +66820,13 @@ kj
 ac
 ac
 ac
-lu
+lw
 jL
-lu
+lw
 jL
-lu
-lu
-lu
+lw
+lw
+lw
 ac
 ac
 ac
@@ -66989,7 +66846,7 @@ aa
 aa
 aa
 jB
-uk
+us
 jB
 aa
 aa
@@ -67004,36 +66861,36 @@ ac
 ac
 ac
 ac
-Ce
-Ce
-Ce
-Ce
-Ce
-FI
-GC
-Hf
-Hf
-Hf
-Hf
-Hf
-Ky
-Ky
-Ky
-Ky
-MD
-MD
-MD
-MD
-MD
-MD
-MD
-MD
-MD
-MD
-MD
-MD
-MD
-MD
+Cn
+Cn
+Cn
+Cn
+Cn
+Ga
+GY
+HF
+HF
+HF
+HF
+HF
+Lg
+Lg
+Lg
+Lg
+Nn
+Nn
+Nn
+Nn
+Nn
+Nn
+Nn
+Nn
+Nn
+Nn
+Nn
+Nn
+Nn
+Nn
 aa
 aa
 aa
@@ -67246,7 +67103,7 @@ aa
 aa
 aa
 jB
-uk
+us
 jB
 aa
 aa
@@ -67261,19 +67118,19 @@ aa
 ac
 ac
 ac
-Ce
-CU
-DO
-Er
-Fa
-FJ
-GD
-Hi
-HR
-IB
+Cn
+Dd
+DX
+EB
+Fo
+Gb
+GZ
+HI
+Iv
 Jh
-JS
-Ar
+JP
+KA
+Az
 aa
 aa
 ac
@@ -67503,7 +67360,7 @@ aa
 aa
 aa
 jB
-uk
+us
 jB
 jB
 jB
@@ -67518,19 +67375,19 @@ aa
 ac
 ac
 ac
-Ce
-CV
-DP
-Es
-Fb
-FK
-GE
-Hj
-HS
-IC
+Cn
+De
+DY
+EC
+Fp
+Gc
+Ha
+HJ
+Iw
 Ji
-JT
-Ar
+JQ
+KB
+Az
 aa
 jL
 ac
@@ -67736,7 +67593,7 @@ kj
 kj
 ac
 ac
-mb
+md
 kj
 kj
 kj
@@ -67760,34 +67617,34 @@ aa
 aa
 aa
 jB
-un
-uJ
-uJ
-uJ
-uJ
-uJ
-uJ
-uJ
-uJ
-ya
+uv
+uQ
+uQ
+uQ
+uQ
+uQ
+uQ
+uQ
+uQ
+yi
 jB
 aa
 aa
 ac
 ac
-Ce
-CW
-DQ
-Et
-Fc
-FL
-GF
-Hk
-HT
-ID
+Cn
+Df
+DZ
+ED
+Fq
+Gd
+Hb
+HK
+Ix
 Jj
-JU
-Ar
+JR
+KC
+Az
 aa
 af
 ac
@@ -68026,27 +67883,27 @@ jB
 jB
 jB
 jB
-yb
+yj
 jB
 aa
 aa
 ac
 ac
-Ce
-CX
-CX
-CX
-CX
-FM
-BY
-Hl
-HU
-IE
+Cn
+Dg
+Dg
+Dg
+Dg
+Ge
+Ch
+HL
+Iy
 Jk
-JV
-Kz
-KN
-Ln
+JS
+KD
+Lh
+Lx
+LX
 ac
 ac
 af
@@ -68289,19 +68146,19 @@ aa
 aa
 aa
 ac
-Cf
-CY
-DR
-Eu
-Fd
-FJ
-GG
-Hm
-HV
-IF
+Co
+Dh
+Ea
+EE
+Fr
+Gb
+Hc
+HM
+Iz
 Jl
-JW
-Ar
+JT
+KE
+Az
 aa
 af
 ac
@@ -68546,19 +68403,19 @@ aa
 aa
 aa
 ac
-Cf
-CZ
-DS
-Ev
-Fe
-FN
-GH
-Hn
-HW
-IG
-Hl
-JX
-Ar
+Co
+Di
+Eb
+EF
+Fs
+Gf
+Hd
+HN
+IA
+Jm
+HL
+KF
+Az
 aa
 jL
 ac
@@ -68803,19 +68660,19 @@ aa
 aa
 aa
 aa
-Cf
-Da
-DT
-Ew
-Fd
-FJ
-GI
-Ho
-HX
-IH
-Jm
-HX
-Ar
+Co
+Dj
+Ec
+EG
+Fr
+Gb
+He
+HO
+IB
+Jn
+JU
+IB
+Az
 aa
 aa
 aa
@@ -69060,19 +68917,19 @@ aa
 aa
 aa
 aa
-Cf
-Cf
-Cf
-Cf
-Cf
-FO
-GJ
-Ar
-FO
-II
-II
-GJ
-Ar
+Co
+Co
+Co
+Co
+Co
+Gg
+Hf
+Az
+Gg
+Jo
+Jo
+Hf
+Az
 aa
 aa
 aa
@@ -71595,12 +71452,12 @@ jL
 jL
 jL
 jL
-nS
-nS
-nS
-nS
-nS
-nS
+nU
+nU
+nU
+nU
+nU
+nU
 kj
 kj
 kj
@@ -71852,12 +71709,12 @@ kj
 kj
 kj
 kj
-nS
-nS
-nS
-nS
-nS
-nS
+nU
+nU
+nU
+nU
+nU
+nU
 kj
 kj
 kj
@@ -72109,15 +71966,15 @@ kj
 ac
 ac
 kj
-nS
-on
-oM
-pm
-nS
-nS
+nU
+op
+oO
+po
+nU
+nU
 kj
 jL
-qT
+qW
 ac
 ac
 ac
@@ -72126,7 +71983,7 @@ ac
 ac
 ac
 ac
-su
+sz
 jL
 kj
 kj
@@ -72366,12 +72223,12 @@ ac
 ac
 ac
 kj
-nS
-oo
-oN
-pn
-nS
-nS
+nU
+oq
+oP
+pp
+nU
+nU
 jL
 ac
 ac
@@ -72618,27 +72475,27 @@ jL
 kj
 kj
 kj
-lF
-mc
-mt
-mS
-lK
-lK
-lK
-oO
-lK
-lK
-lK
-lK
+lH
+me
+mv
+mU
+lM
+lM
+lM
+oQ
+lM
+lM
+lM
+lM
 ac
 ac
-ls
-oL
-oL
+lu
+oN
+oN
 jL
-oL
+oN
 jL
-oL
+oN
 ac
 ac
 ac
@@ -72875,28 +72732,28 @@ jL
 kj
 kj
 ac
-lG
-md
-mu
-mT
-lK
-nT
-op
-oP
-op
-pP
-lK
-lK
+lI
+mf
+mw
+mV
+lM
+nV
+or
+oR
+or
+pR
+lM
+lM
 ac
-lg
-qX
-lK
-rf
-rf
-rf
-rf
-rJ
-oi
+li
+ra
+lM
+ri
+ri
+ri
+ri
+rN
+ok
 ac
 kj
 kj
@@ -72909,7 +72766,7 @@ jL
 aa
 aa
 jB
-yb
+yj
 jB
 aa
 aa
@@ -73132,27 +72989,27 @@ jL
 kj
 ac
 ac
-lH
-me
-mv
-mU
-lK
-nU
-oq
-oQ
-oq
-pQ
-lK
-lK
-oL
-qU
+lJ
+mg
+mx
+mW
+lM
+nW
+os
+oS
+os
+pS
+lM
+lM
+oN
 qX
-qX
-rf
-rf
-rf
-rx
-rf
+ra
+ra
+ri
+ri
+ri
+rB
+ri
 jL
 ac
 ac
@@ -73389,28 +73246,28 @@ jL
 kj
 ac
 ac
-lG
-mf
-mw
-mV
-nx
-nV
-or
-oR
-po
-pR
-qr
-qG
-qQ
-qV
+lI
+mh
+my
+mX
+nz
+nX
+ot
+oT
+pq
+pT
+qu
+qJ
+qT
 qY
-qX
-rf
-rf
-rf
-rf
-rf
-oi
+rb
+ra
+ri
+ri
+ri
+ri
+ri
+ok
 ac
 ac
 kj
@@ -73646,27 +73503,27 @@ jL
 kj
 ac
 ac
-lI
-mg
-mx
-mW
 lK
-nW
-oq
-oQ
-oq
-pS
-lK
-lK
-qR
-qW
+mi
+mz
+mY
+lM
+nY
+os
+oS
+os
+pU
+lM
+lM
+qU
 qZ
-qX
-rf
-rf
-rf
-rf
-rf
+rc
+ra
+ri
+ri
+ri
+ri
+ri
 jL
 ac
 ac
@@ -73903,30 +73760,30 @@ jL
 kj
 kj
 ac
-lJ
+lL
+mf
+mA
+mZ
+lM
+nV
+ou
+oR
+or
+pR
+lM
+lM
+ac
+li
+rd
+lM
+ri
+ri
+ri
+ri
+ri
+ok
+ac
 md
-my
-mX
-lK
-nT
-os
-oP
-op
-pP
-lK
-lK
-ac
-lg
-ra
-lK
-rf
-rf
-rf
-rf
-rf
-oi
-ac
-mb
 ac
 ac
 kj
@@ -74160,29 +74017,29 @@ jL
 kj
 kj
 kj
-lJ
-mh
-mz
-mS
-lK
-lK
-lK
-oS
-pp
-pp
-pp
-pp
+lL
+mj
+mB
+mU
+lM
+lM
+lM
+oU
+pr
+pr
+pr
+pr
 ac
-lg
-rb
-rd
+li
+re
 rg
+rj
 jL
-rg
+rj
 jL
-rg
-oL
-oL
+rj
+oN
+oN
 ac
 ac
 kj
@@ -74417,30 +74274,30 @@ jL
 kj
 kj
 kj
-lK
-mi
-mA
-mY
-ny
-nX
-ot
-oT
-pp
-pT
-qs
-pp
+lM
+mk
+mC
+na
+nA
+nZ
+ov
+oV
+pr
+pV
+qv
+pr
 ac
-lg
-rc
-re
-re
-re
-re
-re
-re
-re
-sv
-om
+li
+rf
+rh
+rh
+rh
+rh
+rh
+rh
+rh
+sA
+oo
 kj
 kj
 kj
@@ -74671,32 +74528,32 @@ kj
 kj
 jL
 jL
-lb
-lb
-lb
-lK
-mj
-mB
-mZ
-nz
-nY
-ou
-oU
-pq
-pU
-qt
-pp
+ld
+ld
+ld
+lM
+ml
+mD
+nb
+nB
+oa
+ow
+oW
+ps
+pW
+qw
+pr
 jL
-qT
-lu
-lu
-lu
-lu
-lu
-lu
-lu
 qW
-sw
+lw
+lw
+lw
+lw
+lw
+lw
+lw
+qZ
+sB
 jL
 kj
 kj
@@ -74928,21 +74785,21 @@ kj
 kj
 jL
 jL
-lb
-lb
-lb
-lK
-mk
-mC
-na
-nA
-nZ
-ov
-oV
-pp
-pV
-qu
-pp
+ld
+ld
+ld
+lM
+mm
+mE
+nc
+nC
+ob
+ox
+oX
+pr
+pX
+qx
+pr
 kj
 kj
 kj
@@ -74951,12 +74808,12 @@ ac
 ac
 ac
 ac
-rh
-rh
-sx
-rh
-rh
-rh
+rk
+rk
+sC
+rk
+rk
+rk
 kj
 kj
 kj
@@ -75185,21 +75042,21 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lK
-lK
-mD
-lK
-nB
-lK
-lK
-lK
-pp
-pp
-pp
-pp
+ld
+ld
+ld
+lM
+lM
+mF
+lM
+nD
+lM
+lM
+lM
+pr
+pr
+pr
+pr
 kj
 kj
 kj
@@ -75208,12 +75065,12 @@ kj
 kj
 ac
 ac
-rh
-rR
-sy
-td
-td
-rh
+rk
+rV
+sD
+tj
+tj
+rk
 kj
 kj
 kj
@@ -75441,21 +75298,21 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lv
-lL
-lw
-mE
-nb
-nC
-oa
-ow
-oW
-lb
-lb
-lb
+ld
+ld
+ld
+lx
+lN
+ly
+mG
+nd
+nE
+oc
+oy
+oY
+ld
+ld
+ld
 kj
 kj
 kj
@@ -75465,12 +75322,12 @@ kj
 kj
 kj
 kj
-rh
-rS
-sy
-rD
-tF
-rh
+rk
+rW
+sD
+rH
+tN
+rk
 jB
 jB
 jB
@@ -75697,22 +75554,22 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lb
-lw
-lM
-ml
-mF
-nc
-nC
-lx
-ox
-oX
-lb
-lb
-lb
+ld
+ld
+ld
+ld
+ly
+lO
+mn
+mH
+ne
+nE
+lz
+oz
+oZ
+ld
+ld
+ld
 kj
 kj
 kj
@@ -75722,21 +75579,21 @@ kj
 kj
 kj
 kj
-rh
-rT
-sz
-te
-tG
-uo
-uK
-uK
-uK
-uK
-wl
-uJ
-uJ
-uJ
-yc
+rk
+rX
+sE
+tk
+tO
+uw
+uR
+uR
+uR
+uR
+ws
+uQ
+uQ
+uQ
+yk
 jB
 aa
 aa
@@ -75954,23 +75811,23 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lh
-lx
-ly
-ly
-ly
-nd
-nC
-ly
-lx
-lx
-pr
-lb
-lb
-lb
+ld
+ld
+ld
+lj
+lz
+lA
+lA
+lA
+nf
+nE
+lA
+lz
+lz
+pt
+ld
+ld
+ld
 kj
 kj
 kj
@@ -75978,13 +75835,13 @@ kj
 kj
 kj
 kj
-rh
-rh
-rh
-rh
-rh
-tH
-rh
+rk
+rk
+rk
+rk
+rk
+tP
+rk
 jB
 jB
 jB
@@ -76211,37 +76068,37 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-li
-ly
-lN
-ly
-ly
-ne
-nD
-ly
-lN
-ly
-ps
-lb
-lb
-lb
+ld
+ld
+ld
+lk
+lA
+lP
+lA
+lA
+ng
+nF
+lA
+lP
+lA
+pu
+ld
+ld
+ld
 kj
 kj
 kj
 kj
-rh
-rh
-rh
-rh
-rh
-rU
-sA
-tf
-tI
-rh
+rk
+rk
+rk
+rk
+rk
+rY
+sF
+tl
+tQ
+rk
 jB
 jB
 jB
@@ -76469,39 +76326,39 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
+ld
+ld
+ld
+lB
+lA
+lA
+mI
+nh
+nG
+lA
 lz
-ly
-ly
-mG
-nf
-nE
-ly
-lx
-oY
-lb
-lb
-lb
+pa
+ld
+ld
+ld
 kj
 kj
 kj
 kj
 kj
-rh
-rh
-rh
-rh
-rh
-TI
-rh
-rh
-rh
-rh
-rh
-rh
-rh
+rk
+rk
+rk
+rk
+rk
+rZ
+rk
+rk
+rk
+rk
+rk
+rk
+rk
 kj
 jL
 aa
@@ -76726,39 +76583,39 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lb
-ly
-ly
-mH
-ng
-nF
-ly
-ly
-lb
-lb
-lb
-lb
+ld
+ld
+ld
+ld
+lA
+lA
+mJ
+ni
+nH
+lA
+lA
+ld
+ld
+ld
+ld
 kj
 kj
 kj
 kj
 kj
-rh
-rh
-rm
-ry
-Sx
-TJ
-sB
-tg
-tJ
+rk
+rk
+rp
 rC
-TN
-rh
-rh
+rs
+sa
+sG
+tm
+tR
+rG
+uS
+rk
+rk
 kj
 jL
 aa
@@ -76983,39 +76840,39 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lb
-lO
-mm
-mI
-nh
-nG
-ob
-oy
-lb
-lb
-lb
-lb
-pW
-qS
-qS
-qS
-qS
-ri
-ri
-rn
-rz
-Sx
-TK
-rC
-rC
-rC
+ld
+ld
+ld
+ld
+lQ
+mo
+mK
+nj
+nI
+od
+oA
+ld
+ld
+ld
+ld
+pY
+qV
+qV
+qV
+qV
+rl
+rl
+rq
 rD
-TO
-rh
-rh
+rs
+sb
+rG
+rG
+rG
+rH
+uT
+rk
+rk
 kj
 jL
 aa
@@ -77241,38 +77098,38 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-ly
-ly
-mJ
-ni
-nH
-ly
-ly
-lb
-lb
-lb
-lb
-qv
+ld
+ld
+ld
+lA
+lA
+mL
+nk
+nJ
+lA
+lA
+ld
+ld
+ld
+ld
+qy
 kj
 kj
 kj
 kj
-rh
-rh
-ro
-rA
-rK
-rY
-sC
-th
-tK
-up
-uN
-rh
-rh
+rk
+rk
+rr
+rE
+rO
+sc
+sH
+tn
+tS
+ux
+uU
+rk
+rk
 kj
 jL
 aa
@@ -77498,38 +77355,38 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lP
-mn
-mK
-nj
-nI
-oc
-oz
-lb
-lb
-lb
-lb
-qv
+ld
+ld
+ld
+lR
+mp
+mM
+nl
+nK
+oe
+oB
+ld
+ld
+ld
+ld
+qy
 kj
 kj
 kj
 kj
-rh
-rh
-Sx
-Sx
-Sx
-TL
-Sx
-ti
-tL
-Sx
-uO
-rh
-rh
+rk
+rk
+rs
+rs
+rs
+sd
+rs
+to
+tT
+rs
+uV
+rk
+rk
 kj
 jL
 aa
@@ -77755,38 +77612,38 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lQ
-mo
-mL
-nk
-nJ
-od
-oA
-lb
-lb
-lb
-lb
-qv
+ld
+ld
+ld
+lS
+mq
+mN
+nm
+nL
+of
+oC
+ld
+ld
+ld
+ld
+qy
 kj
 kj
 kj
 kj
-rh
-rh
-rp
-rB
-rL
-TM
-rh
-rh
-rh
-rh
-rh
-rh
-rh
+rk
+rk
+rt
+rF
+rP
+se
+rk
+rk
+rk
+rk
+rk
+rk
+rk
 kj
 jL
 aa
@@ -78012,38 +77869,38 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lR
-mp
-mM
-nl
-nK
-oe
-oB
-lb
-lb
-lb
-lb
-qv
+ld
+ld
+ld
+lT
+mr
+mO
+nn
+nM
+og
+oD
+ld
+ld
+ld
+ld
+qy
 kj
 kj
 kj
 kj
-rh
-rh
-rq
-rC
-rM
-sb
-rh
-rh
-rh
-rh
-rh
-rh
-rh
+rk
+rk
+ru
+rG
+rQ
+sf
+rk
+rk
+rk
+rk
+rk
+rk
+rk
 kj
 jL
 aa
@@ -78268,34 +78125,34 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lA
-lS
-mq
-lb
-nm
-mN
-of
-oC
-lA
-lb
-lb
-lb
-qv
+ld
+ld
+ld
+lC
+lU
+ms
+ld
+no
+mP
+oh
+oE
+lC
+ld
+ld
+ld
+qy
 kj
 kj
 kj
 kj
-rh
-rh
-rr
-rD
-rC
-sc
-rh
-rh
+rk
+rk
+rv
+rH
+rG
+sg
+rk
+rk
 kj
 kj
 kj
@@ -78525,34 +78382,34 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lB
-lT
-lb
-mN
-nn
-nL
-lb
-oD
-oZ
-lb
-lb
-lb
-qv
+ld
+ld
+ld
+lD
+lV
+ld
+mP
+np
+nN
+ld
+oF
+pb
+ld
+ld
+ld
+qy
 kj
 kj
 kj
 kj
-rh
-rh
-rs
-rE
-rN
-sd
-rh
-rh
+rk
+rk
+rw
+rI
+rR
+sh
+rk
+rk
 kj
 kj
 kj
@@ -78782,34 +78639,34 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lC
-lU
-mr
-mO
-no
-nM
-og
-oE
-lB
-lb
-lb
-lb
-qv
+ld
+ld
+ld
+lE
+lW
+mt
+mQ
+nq
+nO
+oi
+oG
+lD
+ld
+ld
+ld
+qy
 kj
 kj
 kj
 kj
-rh
-rh
-rh
-rh
-rh
-rh
-rh
-rh
+rk
+rk
+rk
+rk
+rk
+rk
+rk
+rk
 kj
 kj
 kj
@@ -79039,34 +78896,34 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lB
-lV
-lb
-lb
-np
-lb
-lb
-oF
-lB
-lb
-lb
-lb
-qv
+ld
+ld
+ld
+lD
+lX
+ld
+ld
+nr
+ld
+ld
+oH
+lD
+ld
+ld
+ld
+qy
 kj
 kj
 kj
 kj
-rh
-rh
-rh
-rh
-rh
-rh
-rh
-rh
+rk
+rk
+rk
+rk
+rk
+rk
+rk
+rk
 kj
 kj
 kj
@@ -79297,21 +79154,21 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lW
-lb
-mP
-nq
-nN
-lb
-oG
-lb
-lb
-lb
-pW
-pX
+ld
+ld
+ld
+lY
+ld
+mR
+ns
+nP
+ld
+oI
+ld
+ld
+ld
+pY
+pZ
 kj
 kj
 kj
@@ -79554,20 +79411,20 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lX
-lb
-lx
-nr
-nO
-lb
-oH
-lb
-lb
-lb
-qv
+ld
+ld
+ld
+lZ
+ld
+lz
+nt
+nQ
+ld
+oJ
+ld
+ld
+ld
+qy
 kj
 kj
 kj
@@ -79811,20 +79668,20 @@ kj
 kj
 kj
 kj
-lb
-lb
-lD
-lY
-ms
-mQ
-ns
-nP
-oh
-oI
-pa
-lb
-lb
-qv
+ld
+ld
+lF
+ma
+mu
+mS
+nu
+nR
+oj
+oK
+pc
+ld
+ld
+qy
 kj
 kj
 kj
@@ -80069,19 +79926,19 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lb
-lb
-nt
-lb
-lb
-lb
-lb
-lb
-pW
-pX
+ld
+ld
+ld
+ld
+ld
+nv
+ld
+ld
+ld
+ld
+ld
+pY
+pZ
 kj
 kj
 kj
@@ -80326,18 +80183,18 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lb
-lb
-nu
-nQ
-nQ
-nQ
-nQ
-nQ
-pX
+ld
+ld
+ld
+ld
+ld
+nw
+nS
+nS
+nS
+nS
+nS
+pZ
 kj
 kj
 kj
@@ -80584,16 +80441,16 @@ kj
 kj
 kj
 kj
-lb
-lb
-lb
-lb
-lb
-lb
-lb
-lb
-lb
-lb
+ld
+ld
+ld
+ld
+ld
+ld
+ld
+ld
+ld
+ld
 kj
 kj
 kj

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -2067,17 +2067,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"ew" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	icon_state = "map";
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
 "ex" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	icon_state = "intact";
@@ -2176,27 +2165,6 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "eF" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
-"eG" = (
-/obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
-"eH" = (
-/obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	icon_state = "map";
 	dir = 1
@@ -2494,31 +2462,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"fp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	dir = 2;
-	name = "light switch ";
-	pixel_x = 0;
-	pixel_y = 36
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	is_critical = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/simulated/floor/plating,
-/area/outpost/engineering/power)
 "fq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2548,7 +2491,7 @@
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
 "fs" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/outpost/engineering/hallway)
 "ft" = (
 /obj/structure/grille,
@@ -2574,23 +2517,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/engineering/hallway)
-"fv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Break Room";
-	req_one_access = list(11,24)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/outpost/engineering/hallway)
 "fw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -2604,17 +2530,7 @@
 /turf/simulated/floor/plating,
 /area/outpost/engineering/hallway)
 "fx" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Restrooms";
-	req_one_access = list(11,24)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/freezer,
-/area/outpost/engineering/meeting)
-"fy" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/outpost/engineering/hallway)
 "fz" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2794,17 +2710,24 @@
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "fW" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/door/firedoor{
+	dir = 4;
+	name = "Firelock"
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "fX" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/hallway)
+"fY" = (
 /obj/machinery/newscaster{
 	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"fY" = (
+"fZ" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -2818,22 +2741,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"fZ" = (
+"ga" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"ga" = (
+"gb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/outpost/engineering/hallway)
-"gb" = (
-/obj/machinery/door/firedoor{
-	dir = 4;
-	name = "Firelock"
-	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "gc" = (
@@ -2926,18 +2842,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"gp" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/valve/digital{
-	dir = 4;
-	icon_state = "map_valve0";
-	name = "Air Bypass valve"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
 "gq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	icon_state = "intact";
@@ -3023,19 +2927,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"gA" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Tesla Bay";
-	req_access = list(11)
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/engineering/power)
 "gB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3101,7 +2992,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"gF" = (
+"gG" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3113,7 +3004,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"gG" = (
+"gH" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3137,7 +3028,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"gH" = (
+"gI" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3151,7 +3042,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"gI" = (
+"gJ" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3170,7 +3061,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"gJ" = (
+"gK" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3178,24 +3069,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/outpost/engineering/hallway)
-"gK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor{
-	dir = 4;
-	name = "Firelock"
-	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "gL" = (
@@ -3515,6 +3388,10 @@
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "hp" = (
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/hallway)
+"hq" = (
 /obj/machinery/light,
 /obj/machinery/camera/network/engineering_outpost{
 	c_tag = "Engineering Sublevel - Corridor Camera 1";
@@ -3523,7 +3400,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"hq" = (
+"hr" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -3534,15 +3411,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
-"hr" = (
+"hs" = (
 /obj/machinery/station_map{
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled,
-/area/outpost/engineering/hallway)
-"hs" = (
-/obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "ht" = (
@@ -3600,13 +3473,6 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/hallway)
-"hz" = (
-/obj/machinery/atmospherics/pipe/zpipe/up/cyan{
-	icon_state = "up";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "hA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4;
@@ -3784,34 +3650,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"hU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Storage";
-	req_one_access = list(11,24)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "plating"
-	},
-/area/outpost/engineering/hallway)
-"hV" = (
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Storage";
-	req_one_access = list(11,24)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "plating"
-	},
-/area/outpost/engineering/hallway)
 "hW" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/gravity_gen)
@@ -3885,13 +3723,6 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"ic" = (
-/obj/machinery/atmospherics/pipe/zpipe/up/yellow{
-	icon_state = "up";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "id" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -3919,9 +3750,6 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "ig" = (
-/turf/simulated/wall,
-/area/engineering/atmos)
-"ih" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_atmos{
 	name = "Distribution and Waste";
@@ -3929,7 +3757,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"ii" = (
+"ih" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced,
@@ -3947,7 +3775,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"ij" = (
+"ii" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced,
@@ -3957,7 +3785,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"ik" = (
+"ij" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced,
@@ -3974,27 +3802,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"il" = (
+"ik" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"im" = (
+"il" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"in" = (
+"im" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"io" = (
+"in" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"ip" = (
+"io" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/visible/black,
@@ -4016,14 +3844,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"iq" = (
+"ip" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"ir" = (
+"iq" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -4039,12 +3867,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"is" = (
+"ir" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"it" = (
+"is" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -4054,7 +3882,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"iu" = (
+"it" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 1
@@ -4063,7 +3891,7 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"iv" = (
+"iu" = (
 /obj/machinery/camera/network/engineering_outpost{
 	c_tag = "Engineering Sublevel -Tesla Parts Storage";
 	dir = 5;
@@ -4073,7 +3901,7 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"iw" = (
+"iv" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -4088,7 +3916,7 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"ix" = (
+"iw" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -4100,12 +3928,12 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"iy" = (
+"ix" = (
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"iz" = (
+"iy" = (
 /obj/machinery/power/tesla_coil,
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -4115,10 +3943,10 @@
 	icon_state = "plating"
 	},
 /area/outpost/engineering/storage)
-"iA" = (
+"iz" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/engineering/storage)
-"iB" = (
+"iA" = (
 /obj/structure/table/standard,
 /obj/item/stack/material/plasteel{
 	amount = 10
@@ -4130,17 +3958,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iC" = (
+"iB" = (
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iD" = (
+"iC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iE" = (
+"iD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -4154,7 +3982,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iF" = (
+"iE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -4166,7 +3994,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iG" = (
+"iF" = (
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -4177,13 +4005,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iH" = (
+"iG" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
-"iI" = (
+"iH" = (
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
@@ -5266,22 +5094,12 @@
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
 "kS" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/simulated/floor{
-	icon_state = "plating"
-	},
-/area/engineering/gravity_gen)
-"kT" = (
 /obj/machinery/gravity_generator/main/station,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/engineering/gravity_gen)
-"kU" = (
+"kT" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering Sublevel - Engine Camera 1";
 	dir = 1;
@@ -5295,7 +5113,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"kV" = (
+"kU" = (
 /obj/machinery/light,
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -5304,7 +5122,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"kW" = (
+"kV" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -5316,7 +5134,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"kX" = (
+"kW" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering Sublevel - Engine Camera 2";
 	dir = 1;
@@ -5335,23 +5153,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"kY" = (
+"kX" = (
 /obj/machinery/light,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/engineering/gravity_gen)
-"kZ" = (
-/obj/machinery/camera/network/engineering_outpost{
-	c_tag = "Engineering Sublevel - Gravity Chamber";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor{
-	icon_state = "plating"
-	},
-/area/engineering/gravity_gen)
-"la" = (
+"kY" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -5359,7 +5167,7 @@
 	icon_state = "plating"
 	},
 /area/turbolift/engineering_maintenance)
-"lb" = (
+"kZ" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -5367,7 +5175,7 @@
 	icon_state = "plating"
 	},
 /area/turbolift/engineering_maintenance)
-"lc" = (
+"la" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -5381,33 +5189,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"ld" = (
+"lb" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"le" = (
+"lc" = (
 /obj/turbolift_map_holder/aurora/engineering,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/engineering_maintenance)
-"lf" = (
+"ld" = (
 /obj/structure/sign/drop,
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored)
-"lg" = (
+"le" = (
 /obj/structure/sign/securearea{
 	name = "\improper DANGER: REACTOR VENT SHAFT"
 	},
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored)
-"lh" = (
+"lf" = (
 /turf/simulated/open,
 /area/mine/unexplored)
-"li" = (
+"lg" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"lj" = (
+"lh" = (
 /obj/machinery/door/window{
 	base_state = "right";
 	dir = 2;
@@ -5424,7 +5232,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lk" = (
+"li" = (
 /obj/machinery/door/window{
 	base_state = "right";
 	dir = 2;
@@ -5441,23 +5249,23 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ll" = (
+"lj" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/open,
 /area/mine/unexplored)
-"lm" = (
+"lk" = (
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"ln" = (
+"ll" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"lo" = (
+"lm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -5471,41 +5279,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
+"lo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/sublevel)
 "lp" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access = list(11,24)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/sublevel)
-"lq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/sublevel)
-"lr" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -5519,19 +5308,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"ls" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access = list(11,24)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/sublevel)
-"lt" = (
+"lr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 9
@@ -5542,25 +5319,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"lu" = (
+"ls" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 4
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"lv" = (
+"lt" = (
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/vault_sub)
-"lw" = (
+"lu" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"lx" = (
+"lv" = (
 /obj/machinery/computer/aiupload,
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
@@ -5577,27 +5354,27 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ly" = (
+"lw" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lz" = (
+"lx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lA" = (
+"ly" = (
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lB" = (
+"lz" = (
 /obj/machinery/ai_status_display{
 	pixel_x = 32
 	},
@@ -5607,7 +5384,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lC" = (
+"lA" = (
 /obj/effect/decal/warning_stripes,
 /obj/machinery/porta_turret{
 	dir = 4
@@ -5617,20 +5394,20 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lD" = (
+"lB" = (
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lE" = (
+"lC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lF" = (
+"lD" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -5639,7 +5416,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lG" = (
+"lE" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -5647,7 +5424,7 @@
 	icon_state = "plating"
 	},
 /area/turbolift/vault_sub)
-"lH" = (
+"lF" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 4;
@@ -5655,7 +5432,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_cyborg_station)
-"lI" = (
+"lG" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -5663,7 +5440,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_cyborg_station)
-"lJ" = (
+"lH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -5683,7 +5460,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"lK" = (
+"lI" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -5702,13 +5479,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"lL" = (
+"lJ" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_cyborg_station)
-"lM" = (
+"lK" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload_foyer)
-"lN" = (
+"lL" = (
 /obj/structure/table/standard,
 /obj/item/weapon/aiModule/nanotrasen,
 /obj/item/weapon/aiModule/reset,
@@ -5721,7 +5498,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lO" = (
+"lM" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
@@ -5733,7 +5510,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lP" = (
+"lN" = (
 /obj/machinery/porta_turret{
 	dir = 4
 	},
@@ -5743,7 +5520,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lQ" = (
+"lO" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -5769,7 +5546,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"lR" = (
+"lP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
@@ -5778,7 +5555,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lS" = (
+"lQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 4
@@ -5788,7 +5565,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lT" = (
+"lR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 4
@@ -5798,7 +5575,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lU" = (
+"lS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 4
@@ -5811,7 +5588,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lV" = (
+"lT" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - Beta Core 2";
 	dir = 1
@@ -5829,7 +5606,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lW" = (
+"lU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 4
@@ -5840,7 +5617,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lX" = (
+"lV" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
@@ -5854,7 +5631,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lY" = (
+"lW" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI SMES";
 	req_access = list(16)
@@ -5879,7 +5656,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"lZ" = (
+"lX" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
@@ -5893,7 +5670,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ma" = (
+"lY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
 	icon_state = "intact"
@@ -5906,11 +5683,11 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mb" = (
+"lZ" = (
 /obj/structure/sign/vacuum,
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored)
-"mc" = (
+"ma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
@@ -5920,13 +5697,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"md" = (
+"mb" = (
 /obj/effect/landmark{
 	name = "cavernspawn"
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"me" = (
+"mc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5945,18 +5722,18 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"mf" = (
+"md" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_cyborg_station)
-"mg" = (
+"me" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mh" = (
+"mf" = (
 /obj/structure/closet/crate{
 	name = "Camera Assembly Crate"
 	},
@@ -5982,14 +5759,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mi" = (
+"mg" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mj" = (
+"mh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6007,14 +5784,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"mk" = (
+"mi" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ml" = (
+"mj" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -6031,7 +5808,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mm" = (
+"mk" = (
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
@@ -6040,7 +5817,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mn" = (
+"ml" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark{
@@ -6048,7 +5825,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mo" = (
+"mm" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -6072,7 +5849,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"mp" = (
+"mn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/porta_turret{
 	dir = 4
@@ -6083,7 +5860,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mq" = (
+"mo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -6092,7 +5869,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mr" = (
+"mp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6101,7 +5878,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ms" = (
+"mq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 9
@@ -6111,7 +5888,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mt" = (
+"mr" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	frequency = 1343;
@@ -6145,7 +5922,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mu" = (
+"ms" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI SMES";
 	req_access = list(16)
@@ -6156,7 +5933,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mv" = (
+"mt" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6177,7 +5954,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"mw" = (
+"mu" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6191,7 +5968,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mx" = (
+"mv" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6205,7 +5982,7 @@
 	dir = 8
 	},
 /area/turret_protected/ai_cyborg_station)
-"my" = (
+"mw" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -6225,7 +6002,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mz" = (
+"mx" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6239,7 +6016,7 @@
 	dir = 4
 	},
 /area/turret_protected/ai_cyborg_station)
-"mA" = (
+"my" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6254,7 +6031,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mB" = (
+"mz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6280,7 +6057,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"mC" = (
+"mA" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 4;
@@ -6300,7 +6077,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mD" = (
+"mB" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6321,7 +6098,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mE" = (
+"mC" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 8;
@@ -6335,7 +6112,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mF" = (
+"mD" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload";
 	req_access = list(16)
@@ -6350,7 +6127,7 @@
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"mG" = (
+"mE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6362,7 +6139,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mH" = (
+"mF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -6374,7 +6151,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mI" = (
+"mG" = (
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
@@ -6392,7 +6169,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"mJ" = (
+"mH" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6406,7 +6183,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"mK" = (
+"mI" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -6433,7 +6210,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"mL" = (
+"mJ" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 8;
@@ -6444,21 +6221,21 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mM" = (
+"mK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mN" = (
+"mL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mO" = (
+"mM" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -6473,7 +6250,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mP" = (
+"mN" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 4;
@@ -6481,7 +6258,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"mQ" = (
+"mO" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -6499,7 +6276,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"mR" = (
+"mP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/spiderling_remains,
@@ -6508,7 +6285,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mS" = (
+"mQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6517,13 +6294,13 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"mT" = (
+"mR" = (
 /obj/turbolift_map_holder/aurora/vault,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/vault_sub)
-"mU" = (
+"mS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -6536,12 +6313,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_cyborg_station)
-"mV" = (
+"mT" = (
 /obj/machinery/cryopod/robot,
 /obj/item/toy/figure/borg,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_cyborg_station)
-"mW" = (
+"mU" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -6550,7 +6327,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mX" = (
+"mV" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/blood/oil/streak{
 	amount = 0
@@ -6559,7 +6336,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mY" = (
+"mW" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -6568,14 +6345,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
-"mZ" = (
+"mX" = (
 /obj/machinery/cryopod/robot,
 /obj/machinery/computer/cryopod/robot{
 	pixel_y = -32
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_cyborg_station)
-"na" = (
+"mY" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -6587,13 +6364,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nb" = (
+"mZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nc" = (
+"na" = (
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
 	locked_frequency = 1343;
@@ -6612,7 +6389,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nd" = (
+"nb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/motion{
 	c_tag = "AI Core - Upload Room";
@@ -6626,7 +6403,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ne" = (
+"nc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -6636,7 +6413,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nf" = (
+"nd" = (
 /obj/machinery/hologram/holopad,
 /obj/item/weapon/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6650,7 +6427,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ng" = (
+"ne" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;
@@ -6678,7 +6455,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nh" = (
+"nf" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "door_locked";
@@ -6697,7 +6474,7 @@
 	temperature = 273.15
 	},
 /area/turret_protected/ai)
-"ni" = (
+"ng" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "ai_core_airlock";
@@ -6739,7 +6516,7 @@
 	temperature = 273.15
 	},
 /area/turret_protected/ai)
-"nj" = (
+"nh" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "door_locked";
@@ -6773,7 +6550,7 @@
 	temperature = 273.15
 	},
 /area/turret_protected/ai)
-"nk" = (
+"ni" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -6810,7 +6587,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nl" = (
+"nj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
 	icon_state = "map"
@@ -6829,7 +6606,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nm" = (
+"nk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -6841,7 +6618,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nn" = (
+"nl" = (
 /obj/machinery/flasher{
 	id = "AI";
 	pixel_x = 22;
@@ -6865,7 +6642,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"no" = (
+"nm" = (
 /obj/item/device/radio/intercom{
 	listening = 0;
 	name = "Custom Channel";
@@ -6917,7 +6694,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"np" = (
+"nn" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 8;
@@ -6930,7 +6707,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"nq" = (
+"no" = (
 /obj/effect/decal/warning_stripes,
 /obj/machinery/light/small{
 	dir = 8
@@ -6955,7 +6732,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nr" = (
+"np" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI SMES";
 	req_access = list(16)
@@ -6980,7 +6757,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ns" = (
+"nq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -6993,7 +6770,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nt" = (
+"nr" = (
 /obj/effect/decal/warning_stripes,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7010,7 +6787,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nu" = (
+"ns" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - SMES Room 1";
 	dir = 8
@@ -7043,7 +6820,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nv" = (
+"nt" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -7051,7 +6828,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"nw" = (
+"nu" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -7059,13 +6836,13 @@
 	},
 /turf/simulated/wall,
 /area/turret_protected/ai)
-"nx" = (
+"nv" = (
 /turf/simulated/wall/r_wall,
 /area/security/nuke_storage)
-"ny" = (
+"nw" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"nz" = (
+"nx" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Cyborg Station";
 	req_access = list(16)
@@ -7078,7 +6855,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nA" = (
+"ny" = (
 /obj/machinery/door/window/northleft{
 	req_access = list(16)
 	},
@@ -7095,14 +6872,14 @@
 	dir = 1
 	},
 /area/turret_protected/ai_upload_foyer)
-"nB" = (
+"nz" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nC" = (
+"nA" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -7110,7 +6887,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nD" = (
+"nB" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload";
 	req_access = list(16)
@@ -7124,7 +6901,7 @@
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nE" = (
+"nC" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -7135,7 +6912,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nF" = (
+"nD" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -7147,7 +6924,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nG" = (
+"nE" = (
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
@@ -7166,7 +6943,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"nH" = (
+"nF" = (
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
@@ -7182,7 +6959,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"nI" = (
+"nG" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -7211,7 +6988,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"nJ" = (
+"nH" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -7227,7 +7004,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nK" = (
+"nI" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 8;
@@ -7239,14 +7016,14 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nL" = (
+"nJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nM" = (
+"nK" = (
 /obj/machinery/power/apc/super/critical{
 	dir = 4;
 	name = "east bump";
@@ -7272,7 +7049,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nN" = (
+"nL" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -7285,7 +7062,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"nO" = (
+"nM" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 8;
@@ -7293,7 +7070,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"nP" = (
+"nN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7305,7 +7082,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nQ" = (
+"nO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7316,7 +7093,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nR" = (
+"nP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -7331,7 +7108,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"nS" = (
+"nQ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -7339,17 +7116,17 @@
 	},
 /turf/simulated/wall,
 /area/turret_protected/ai)
-"nT" = (
+"nR" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Command - Vault Sublevel Elevator Access";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"nU" = (
+"nS" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_server_room)
-"nV" = (
+"nT" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -7357,7 +7134,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nW" = (
+"nU" = (
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
 	locked_frequency = 1343;
@@ -7370,14 +7147,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nX" = (
+"nV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nY" = (
+"nW" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -7386,7 +7163,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"nZ" = (
+"nX" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -7400,7 +7177,7 @@
 	dir = 1
 	},
 /area/turret_protected/ai_upload_foyer)
-"oa" = (
+"nY" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -7410,7 +7187,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ob" = (
+"nZ" = (
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
@@ -7419,7 +7196,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oc" = (
+"oa" = (
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/structure/table/rack,
@@ -7430,7 +7207,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"od" = (
+"ob" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -7454,7 +7231,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"oe" = (
+"oc" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -7470,7 +7247,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"of" = (
+"od" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -7484,7 +7261,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"og" = (
+"oe" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -7503,7 +7280,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oh" = (
+"of" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 8;
@@ -7517,7 +7294,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oi" = (
+"og" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	frequency = 1343;
@@ -7548,7 +7325,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oj" = (
+"oh" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI SMES";
 	req_access = list(16)
@@ -7559,14 +7336,14 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"ok" = (
+"oi" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 1
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"ol" = (
+"oj" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 1
@@ -7576,14 +7353,14 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"om" = (
+"ok" = (
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"on" = (
+"ol" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -7592,18 +7369,18 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"oo" = (
+"om" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"op" = (
+"on" = (
 /obj/machinery/computer/message_monitor,
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_server_room)
-"oq" = (
+"oo" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -7624,7 +7401,7 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_server_room)
-"or" = (
+"op" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -7632,15 +7409,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"os" = (
+"oq" = (
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ot" = (
+"or" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ou" = (
+"os" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -7651,7 +7428,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ov" = (
+"ot" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -7666,12 +7443,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ow" = (
+"ou" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"ox" = (
+"ov" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -7682,7 +7459,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oy" = (
+"ow" = (
 /obj/structure/table/standard,
 /obj/item/weapon/aiModule/freeform,
 /obj/item/weapon/aiModule/protectStation,
@@ -7696,7 +7473,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oz" = (
+"ox" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark{
@@ -7704,7 +7481,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oA" = (
+"oy" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -7725,7 +7502,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"oB" = (
+"oz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
 	icon_state = "intact"
@@ -7735,7 +7512,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oC" = (
+"oA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -7744,7 +7521,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oD" = (
+"oB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -7757,7 +7534,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oE" = (
+"oC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -7769,7 +7546,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oF" = (
+"oD" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -7784,7 +7561,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oG" = (
+"oE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -7796,7 +7573,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oH" = (
+"oF" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - Beta Core 1"
 	},
@@ -7814,7 +7591,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oI" = (
+"oG" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI SMES";
 	req_access = list(16)
@@ -7838,7 +7615,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oJ" = (
+"oH" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -7853,7 +7630,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oK" = (
+"oI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
 	icon_state = "intact"
@@ -7866,7 +7643,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oL" = (
+"oJ" = (
 /obj/structure/cable{
 	icon_state = "12-0"
 	},
@@ -7881,7 +7658,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"oM" = (
+"oK" = (
 /obj/effect/decal/warning_stripes,
 /obj/structure/ladder/up{
 	pixel_y = 16
@@ -7890,13 +7667,13 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"oN" = (
+"oL" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"oO" = (
+"oM" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -7910,7 +7687,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_server_room)
-"oP" = (
+"oN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7926,7 +7703,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_server_room)
-"oQ" = (
+"oO" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Messaging Server";
 	req_access = list(16)
@@ -7945,7 +7722,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oR" = (
+"oP" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -7969,7 +7746,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oS" = (
+"oQ" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -7983,7 +7760,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oT" = (
+"oR" = (
 /obj/machinery/porta_turret,
 /obj/effect/decal/warning_stripes,
 /obj/structure/cable/cyan{
@@ -7995,7 +7772,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oU" = (
+"oS" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
 	req_access = list(16)
@@ -8014,7 +7791,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oV" = (
+"oT" = (
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
 	locked_frequency = 1343;
@@ -8038,7 +7815,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oW" = (
+"oU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -8053,13 +7830,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oX" = (
+"oV" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"oY" = (
+"oW" = (
 /obj/machinery/computer/borgupload,
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
@@ -8073,7 +7850,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"oZ" = (
+"oX" = (
 /obj/machinery/computer/robotics,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark{
@@ -8081,7 +7858,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"pa" = (
+"oY" = (
 /obj/machinery/alarm/cold{
 	dir = 1;
 	pixel_y = -22
@@ -8094,7 +7871,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"pb" = (
+"oZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -8103,7 +7880,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"pc" = (
+"pa" = (
 /obj/machinery/door/window/northright,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -8114,7 +7891,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"pd" = (
+"pb" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -8127,14 +7904,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pe" = (
+"pc" = (
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pf" = (
+"pd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
@@ -8151,7 +7928,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pg" = (
+"pe" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 9
@@ -8160,7 +7937,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"ph" = (
+"pf" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 5
@@ -8169,7 +7946,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pi" = (
+"pg" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 1
@@ -8178,13 +7955,13 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pj" = (
+"ph" = (
 /obj/item/weapon/hand_tele,
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"pk" = (
+"pi" = (
 /obj/item/weapon/aiModule/freeformcore{
 	pixel_x = -4;
 	pixel_y = -8
@@ -8198,29 +7975,29 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"pl" = (
+"pj" = (
 /obj/item/weapon/rig/hazmat,
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"pm" = (
+"pk" = (
 /obj/item/rig_module/device/rcd,
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"pn" = (
+"pl" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"po" = (
+"pm" = (
 /obj/machinery/message_server,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_server_room)
-"pp" = (
+"pn" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - Messaging Server";
 	dir = 1
@@ -8231,16 +8008,16 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_server_room)
-"pq" = (
+"po" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"pr" = (
+"pp" = (
 /turf/simulated/wall/r_wall,
 /area/tcommsat/mainlvl_tcomms__relay)
-"ps" = (
+"pq" = (
 /obj/structure/plasticflaps/airtight,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8256,7 +8033,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/mainlvl_tcomms__relay)
-"pt" = (
+"pr" = (
 /obj/machinery/door/window{
 	base_state = "left";
 	dir = 1;
@@ -8273,7 +8050,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"pu" = (
+"ps" = (
 /obj/machinery/door/window{
 	base_state = "left";
 	dir = 1;
@@ -8290,7 +8067,7 @@
 	temperature = 278
 	},
 /area/turret_protected/ai)
-"pv" = (
+"pt" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -8300,7 +8077,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"pw" = (
+"pu" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8311,7 +8088,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"px" = (
+"pv" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -8325,7 +8102,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"py" = (
+"pw" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Supermatter Cooling Access";
 	req_access = list(11)
@@ -8340,7 +8117,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"pz" = (
+"px" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -8360,7 +8137,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pA" = (
+"py" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8374,7 +8151,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pB" = (
+"pz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8392,7 +8169,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pC" = (
+"pA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8410,7 +8187,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pD" = (
+"pB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8427,7 +8204,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pE" = (
+"pC" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -8459,7 +8236,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pF" = (
+"pD" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8484,7 +8261,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pG" = (
+"pE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8511,7 +8288,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pH" = (
+"pF" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -8528,7 +8305,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pI" = (
+"pG" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
 	icon_state = "door_locked";
@@ -8549,7 +8326,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"pJ" = (
+"pH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8565,7 +8342,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pK" = (
+"pI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8585,7 +8362,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pL" = (
+"pJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8605,7 +8382,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pM" = (
+"pK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -8621,7 +8398,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pN" = (
+"pL" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 4
@@ -8630,7 +8407,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"pO" = (
+"pM" = (
 /obj/structure/closet/secure_closet/freezer/money,
 /obj/item/weapon/storage/belt/champion,
 /obj/item/stack/material/gold,
@@ -8644,7 +8421,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"pP" = (
+"pN" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 9
@@ -8658,18 +8435,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"pQ" = (
+"pO" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"pR" = (
+"pP" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/cable/cyan,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"pS" = (
+"pQ" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - Lobby";
 	dir = 1
@@ -8680,20 +8457,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"pT" = (
+"pR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"pU" = (
+"pS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"pV" = (
+"pT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -8707,7 +8484,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"pW" = (
+"pU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -8725,7 +8502,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"pX" = (
+"pV" = (
 /obj/machinery/alarm/cold{
 	dir = 8;
 	icon_state = "alarm0";
@@ -8740,7 +8517,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"pY" = (
+"pW" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -8748,7 +8525,7 @@
 	},
 /turf/simulated/wall,
 /area/mine/unexplored)
-"pZ" = (
+"pX" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -8756,19 +8533,19 @@
 	},
 /turf/simulated/wall,
 /area/mine/unexplored)
-"qa" = (
+"pY" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/black,
 /turf/simulated/floor/plating{
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"qb" = (
+"pZ" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/green,
 /turf/simulated/floor/plating{
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"qc" = (
+"qa" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -8779,24 +8556,21 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"qd" = (
+"qb" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"qe" = (
-/turf/simulated/wall,
-/area/maintenance/sublevel)
-"qf" = (
+"qc" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"qg" = (
+"qd" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1379;
@@ -8809,7 +8583,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"qh" = (
+"qe" = (
 /obj/machinery/camera/network/engineering_outpost{
 	c_tag = "Engineering Sublevel - Cavern Entrance";
 	dir = 4;
@@ -8830,7 +8604,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/sublevel)
-"qi" = (
+"qf" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 6
@@ -8839,7 +8613,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"qj" = (
+"qg" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 10
@@ -8848,7 +8622,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"qk" = (
+"qh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -8862,26 +8636,26 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"ql" = (
+"qi" = (
 /obj/effect/decal/warning_stripes,
 /obj/machinery/nuclearbomb/station,
 /turf/simulated/floor/reinforced,
 /area/security/nuke_storage)
-"qm" = (
+"qj" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qn" = (
+"qk" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qo" = (
+"ql" = (
 /obj/machinery/porta_turret/stationary,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qp" = (
+"qm" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -8889,7 +8663,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qq" = (
+"qn" = (
 /obj/machinery/door/airlock/vault/bolted{
 	req_access = list(20)
 	},
@@ -8900,7 +8674,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qr" = (
+"qo" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8921,7 +8695,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qs" = (
+"qp" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -8929,7 +8703,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qt" = (
+"qq" = (
 /obj/machinery/light/small/emergency,
 /obj/structure/sign/securearea{
 	pixel_y = -32
@@ -8941,7 +8715,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qu" = (
+"qr" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
 	req_access = list(16)
@@ -8951,7 +8725,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
-"qv" = (
+"qs" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Command - Telecomms Main Level Relay";
 	dir = 1
@@ -8970,7 +8744,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"qw" = (
+"qt" = (
 /obj/machinery/telecomms/relay/preset/station,
 /obj/structure/sign/nosmoking_1{
 	pixel_x = 0;
@@ -8981,7 +8755,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"qx" = (
+"qu" = (
 /obj/item/device/radio/intercom{
 	pixel_y = -26
 	},
@@ -8990,7 +8764,7 @@
 	temperature = 278
 	},
 /area/tcommsat/mainlvl_tcomms__relay)
-"qy" = (
+"qv" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8998,13 +8772,13 @@
 	},
 /turf/simulated/wall,
 /area/mine/unexplored)
-"qz" = (
+"qw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor/plating{
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"qA" = (
+"qx" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -9015,7 +8789,7 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"qB" = (
+"qy" = (
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
 	dir = 4
@@ -9029,13 +8803,13 @@
 	roof_type = null
 	},
 /area/maintenance/sublevel)
-"qC" = (
+"qz" = (
 /obj/effect/landmark{
 	name = "carpspawn"
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"qD" = (
+"qA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -9048,7 +8822,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"qE" = (
+"qB" = (
 /obj/structure/safe/station,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -9058,7 +8832,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"qF" = (
+"qC" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 10
@@ -9072,11 +8846,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qG" = (
+"qD" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qH" = (
+"qE" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -9085,7 +8859,7 @@
 /obj/structure/cable,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qI" = (
+"qF" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -9102,7 +8876,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"qJ" = (
+"qG" = (
 /obj/item/device/radio/intercom/locked{
 	frequency = 1343;
 	locked_frequency = 1343;
@@ -9124,14 +8898,14 @@
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"qK" = (
+"qH" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/zpipe/down/black{
 	dir = 1
 	},
 /turf/simulated/open,
 /area/maintenance/sublevel)
-"qL" = (
+"qI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "11-1"
@@ -9141,19 +8915,11 @@
 	},
 /turf/simulated/open,
 /area/maintenance/sublevel)
-"qM" = (
+"qJ" = (
 /obj/structure/ladder,
 /turf/simulated/open,
 /area/maintenance/sublevel)
-"qN" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/rig_module/vision/nvg,
-/turf/simulated/floor/plating,
-/area/security/nuke_storage)
-"qO" = (
+"qL" = (
 /obj/item/rig_module/mounted/egun{
 	pixel_x = 4;
 	pixel_y = 4
@@ -9168,7 +8934,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"qP" = (
+"qM" = (
 /obj/item/weapon/rig/hazard{
 	pixel_x = -8;
 	pixel_y = 0
@@ -9186,15 +8952,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/nuke_storage)
-"qQ" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/rig_module/chem_dispenser/injector,
-/turf/simulated/floor/plating,
-/area/security/nuke_storage)
-"qR" = (
+"qO" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -9205,7 +8963,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"qS" = (
+"qP" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9213,14 +8971,14 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"qT" = (
+"qQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"qU" = (
+"qR" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -9230,7 +8988,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"qV" = (
+"qS" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9238,20 +8996,20 @@
 	},
 /turf/simulated/wall,
 /area/mine/unexplored)
-"qW" = (
+"qT" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/turret_protected/ai_upload_foyer)
-"qX" = (
+"qU" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"qY" = (
+"qV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9262,19 +9020,19 @@
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"qZ" = (
+"qW" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"ra" = (
+"qX" = (
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"rb" = (
+"qY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -9287,7 +9045,7 @@
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"rc" = (
+"qZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9298,7 +9056,7 @@
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"rd" = (
+"ra" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9310,7 +9068,7 @@
 	icon_state = "plating"
 	},
 /area/turret_protected/ai_upload_foyer)
-"re" = (
+"rb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9321,7 +9079,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rf" = (
+"rc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -9332,7 +9090,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rg" = (
+"rd" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -9344,19 +9102,19 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"rh" = (
+"re" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"ri" = (
+"rf" = (
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/ai_sub)
-"rj" = (
+"rg" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -9365,10 +9123,10 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"rk" = (
+"rh" = (
 /turf/simulated/wall/r_wall,
 /area/bridge/aibunker)
-"rl" = (
+"ri" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9376,10 +9134,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/bridge/aibunker)
-"rm" = (
+"rj" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/analysis)
-"rn" = (
+"rk" = (
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/structure/table/standard,
 /obj/machinery/light_switch{
@@ -9387,21 +9145,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"ro" = (
+"rl" = (
 /obj/structure/reagent_dispensers/coolanttank,
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rp" = (
+"rm" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rq" = (
+"rn" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9416,25 +9174,22 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rr" = (
+"ro" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rs" = (
-/turf/simulated/wall,
-/area/bridge/aibunker)
-"rt" = (
+"rp" = (
 /obj/item/modular_computer/console/preset/security,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"ru" = (
+"rq" = (
 /obj/item/modular_computer/console/preset/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rv" = (
+"rr" = (
 /obj/structure/bed/chair,
 /obj/machinery/computer/security/telescreen{
 	name = "Access Monitor";
@@ -9445,7 +9200,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rw" = (
+"rs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/airlock{
 	id = "bunker1";
@@ -9458,10 +9213,10 @@
 /obj/item/bodybag,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rx" = (
+"rt" = (
 /turf/simulated/wall,
 /area/mine/unexplored)
-"ry" = (
+"ru" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -9474,12 +9229,12 @@
 	dir = 5
 	},
 /area/outpost/research/analysis)
-"rz" = (
+"rv" = (
 /obj/item/weapon/stool/padded,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rA" = (
+"rw" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
@@ -9490,13 +9245,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rB" = (
+"rx" = (
 /obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/ai_sub)
-"rC" = (
+"ry" = (
 /obj/structure/closet/crate{
 	name = "Emergency Fuel"
 	},
@@ -9508,7 +9263,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rD" = (
+"rz" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -9519,7 +9274,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rE" = (
+"rA" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -9541,7 +9296,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rF" = (
+"rB" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -9553,14 +9308,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rG" = (
+"rC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rH" = (
+"rD" = (
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rI" = (
+"rE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
@@ -9576,22 +9331,22 @@
 /obj/item/device/radio,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rJ" = (
+"rF" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"rK" = (
+"rG" = (
 /obj/machinery/radiocarbon_spectrometer,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/outpost/research/analysis)
-"rL" = (
+"rH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rM" = (
+"rI" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -9610,13 +9365,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rN" = (
+"rJ" = (
 /obj/turbolift_map_holder/aurora/aiaccess,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/ai_sub)
-"rO" = (
+"rK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access = list(56)
 	},
@@ -9631,7 +9386,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rP" = (
+"rL" = (
 /obj/machinery/newscaster{
 	pixel_x = -32;
 	pixel_y = 0
@@ -9640,18 +9395,18 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rQ" = (
+"rM" = (
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rR" = (
+"rN" = (
 /obj/item/modular_computer/console/preset/medical,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rS" = (
+"rO" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/anomaly_analysis)
-"rT" = (
+"rP" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -9659,7 +9414,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rU" = (
+"rQ" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
@@ -9676,7 +9431,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"rV" = (
+"rR" = (
 /obj/structure/table/rack{
 	dir = 1
 	},
@@ -9688,20 +9443,20 @@
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rW" = (
+"rS" = (
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rX" = (
+"rT" = (
 /obj/effect/decal/warning_stripes,
 /obj/structure/ladder/up{
 	pixel_y = 16
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"rY" = (
+"rU" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -9719,63 +9474,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"rZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	desc = "It opens and closes. It has a small sign engraved: Bunker capacity: 6. Only facility's Command Staff is permitted.";
-	icon_state = "door_locked";
-	id_tag = "bunker3";
-	locked = 1;
-	name = "Command Bunker";
-	req_access = list(19);
-	secured_wires = 1
-	},
-/turf/simulated/floor{
-	icon_state = "plating"
-	},
-/area/bridge/aibunker)
-"sa" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/item/device/radio/intercom/locked{
-	frequency = 1347;
-	locked_frequency = 1347;
-	name = "Bunker Entrance Intercom";
-	pixel_x = 0;
-	pixel_y = 22
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"sb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/firealarm/north,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"sc" = (
+"rY" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -9788,31 +9487,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sd" = (
-/obj/machinery/door/airlock/highsecurity{
-	id_tag = null;
-	name = "Auxiliary Commanding Post";
-	req_access = list(19)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"se" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"sf" = (
+"sb" = (
 /obj/machinery/firealarm/south,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -9820,7 +9495,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sg" = (
+"sc" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
@@ -9829,15 +9504,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sh" = (
+"sd" = (
 /obj/item/modular_computer/console/preset/command,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"si" = (
+"se" = (
 /obj/structure/closet,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"sj" = (
+"sf" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9860,17 +9535,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/anomaly_analysis)
-"sk" = (
+"sg" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sl" = (
+"sh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sm" = (
+"si" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/bio_suit/anomaly,
 /obj/item/clothing/head/bio_hood/anomaly,
@@ -9886,15 +9561,12 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"sn" = (
-/turf/simulated/wall,
-/area/outpost/research/anomaly_analysis)
-"so" = (
+"sj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/mauve,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sp" = (
+"sk" = (
 /obj/machinery/alarm{
 	dir = 2;
 	pixel_y = 25
@@ -9908,7 +9580,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sq" = (
+"sl" = (
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -9925,7 +9597,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sr" = (
+"sm" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 0;
 	pixel_y = 32
@@ -9936,7 +9608,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"ss" = (
+"sn" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 4
@@ -9946,7 +9618,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"st" = (
+"so" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "anolaser"
@@ -9956,7 +9628,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"su" = (
+"sp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -9965,7 +9637,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"sv" = (
+"sq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 1
@@ -9983,7 +9655,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"sw" = (
+"sr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -10000,7 +9672,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"sx" = (
+"ss" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 1
@@ -10015,7 +9687,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"sy" = (
+"st" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 5
@@ -10031,11 +9703,11 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"sz" = (
+"su" = (
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/turret_protected/ai_upload_foyer)
-"sA" = (
+"sv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -10047,7 +9719,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"sB" = (
+"sw" = (
 /obj/machinery/light/small/emergency,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10059,7 +9731,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"sC" = (
+"sx" = (
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "bunker1";
 	name = "Command Bunker Access";
@@ -10074,7 +9746,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sD" = (
+"sy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -10083,7 +9755,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sE" = (
+"sz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -10096,7 +9768,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sF" = (
+"sA" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10115,7 +9787,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"sG" = (
+"sB" = (
 /obj/machinery/button/remote/airlock{
 	id = "bunker3";
 	name = "Bunker Inner Airlock Bolt Control";
@@ -10125,35 +9797,35 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sH" = (
+"sC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/vending/wallmed2{
 	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"sI" = (
+"sD" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"sJ" = (
+"sE" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"sK" = (
+"sF" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"sL" = (
+"sG" = (
 /obj/structure/table/rack,
 /obj/item/weapon/ladder_mobile,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"sM" = (
+"sH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10173,17 +9845,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/anomaly_analysis)
-"sN" = (
+"sI" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sO" = (
+"sJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sP" = (
+"sK" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/bio_suit/anomaly,
 /obj/item/clothing/head/bio_hood/anomaly,
@@ -10202,7 +9874,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"sQ" = (
+"sL" = (
 /obj/item/device/radio/intercom{
 	frequency = 1459;
 	name = "Station Intercom (General)";
@@ -10215,13 +9887,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sR" = (
+"sM" = (
 /obj/structure/table/standard,
 /obj/item/weapon/flame/lighter/random,
 /obj/item/weapon/crowbar,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sS" = (
+"sN" = (
 /obj/machinery/artifact_analyser,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10230,17 +9902,17 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/anomaly_analysis)
-"sT" = (
+"sO" = (
 /obj/machinery/artifact_scanpad,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/anomaly_analysis)
-"sU" = (
+"sP" = (
 /obj/machinery/conveyor_switch{
 	id = "anolaser"
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"sV" = (
+"sQ" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "anolaser"
@@ -10251,10 +9923,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"sW" = (
-/turf/simulated/wall,
-/area/outpost/research/analysis)
-"sX" = (
+"sR" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
@@ -10272,10 +9941,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/analysis)
-"sY" = (
+"sS" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/emergency_storage)
-"sZ" = (
+"sT" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 8
@@ -10284,7 +9953,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"ta" = (
+"sU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -10306,7 +9975,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"tb" = (
+"sV" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -10332,7 +10001,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"tc" = (
+"sW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10348,7 +10017,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"td" = (
+"sX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10369,7 +10038,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"te" = (
+"sY" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -10389,7 +10058,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tf" = (
+"sZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10412,7 +10081,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tg" = (
+"ta" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10434,7 +10103,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"th" = (
+"tb" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -10452,14 +10121,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"ti" = (
+"tc" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tj" = (
+"td" = (
 /obj/structure/table/rack{
 	dir = 1
 	},
@@ -10469,7 +10138,7 @@
 /obj/item/clothing/head/helmet/space/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tk" = (
+"te" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera/network/command{
@@ -10487,7 +10156,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tl" = (
+"tf" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10511,7 +10180,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"tm" = (
+"tg" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -26;
 	pixel_y = 0
@@ -10522,14 +10191,14 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tn" = (
+"th" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"to" = (
+"ti" = (
 /obj/structure/closet,
 /obj/item/weapon/reagent_containers/food/snacks/liquidfood,
 /obj/item/weapon/reagent_containers/food/snacks/liquidfood,
@@ -10544,16 +10213,11 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tp" = (
-/obj/structure/table/rack,
-/obj/item/hoist_kit,
-/turf/simulated/floor/asteroid/ash/rocky,
-/area/mine/unexplored)
-"tq" = (
+"tj" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tr" = (
+"tk" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/bio_suit/anomaly,
 /obj/item/clothing/head/bio_hood/anomaly,
@@ -10570,7 +10234,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"ts" = (
+"tl" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -10585,11 +10249,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tt" = (
+"tm" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tu" = (
+"tn" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/dropper{
 	pixel_y = -4
@@ -10601,10 +10265,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tv" = (
+"to" = (
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tw" = (
+"tp" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
 	dir = 4;
@@ -10621,7 +10285,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tx" = (
+"tq" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "anolaser"
@@ -10637,7 +10301,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"ty" = (
+"tr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -10652,7 +10316,7 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"tz" = (
+"ts" = (
 /obj/machinery/door/window/westleft{
 	dir = 4;
 	name = "Monkey Pen";
@@ -10675,7 +10339,7 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"tA" = (
+"tt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -10693,7 +10357,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"tB" = (
+"tu" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Corridor Camera 6"
 	},
@@ -10704,7 +10368,7 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"tC" = (
+"tv" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
 	dir = 1
@@ -10712,20 +10376,17 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"tD" = (
-/turf/simulated/wall,
-/area/outpost/research/emergency_storage)
-"tE" = (
+"tw" = (
 /obj/machinery/power/emitter{
 	anchored = 0
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"tF" = (
+"tx" = (
 /obj/machinery/suspension_gen,
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"tG" = (
+"ty" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/gloves{
 	pixel_x = 4;
@@ -10741,7 +10402,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"tH" = (
+"tz" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/structure/cable{
 	d1 = 1;
@@ -10753,7 +10414,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"tI" = (
+"tA" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
 	icon_state = "door_locked";
@@ -10763,7 +10424,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tJ" = (
+"tB" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "sl3s";
 	pixel_y = -26
@@ -10775,13 +10436,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tK" = (
+"tC" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tL" = (
+"tD" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -10794,7 +10455,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tM" = (
+"tE" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10810,7 +10471,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"tN" = (
+"tF" = (
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -10818,7 +10479,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tO" = (
+"tG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -10828,7 +10489,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tP" = (
+"tH" = (
 /obj/machinery/door/airlock/hatch{
 	desc = "It opens and closes. It has a small sign engraved: Bunker capacity: 6. Only facility's Command Staff is permitted.";
 	icon_state = "door_closed";
@@ -10847,7 +10508,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"tQ" = (
+"tI" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -10863,7 +10524,7 @@
 	icon_state = "plating"
 	},
 /area/bridge/aibunker)
-"tR" = (
+"tJ" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
@@ -10872,14 +10533,14 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tS" = (
+"tK" = (
 /obj/effect/decal/cleanable/cobweb2{
 	icon_state = "spiderling";
 	name = "dead spider"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tT" = (
+"tL" = (
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
@@ -10889,22 +10550,22 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"tU" = (
+"tM" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"tV" = (
+"tN" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"tW" = (
+"tO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tX" = (
+"tP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10914,7 +10575,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tY" = (
+"tQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10924,10 +10585,14 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"tZ" = (
+"tR" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
+	},
+/obj/machinery/door/airlock/research{
+	name = "Anomalous Materials";
+	req_access = list(65)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10935,13 +10600,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/research{
-	name = "Anomalous Materials Locker Room";
-	req_access = list(65)
-	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"ua" = (
+"tS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -10959,7 +10620,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"ub" = (
+"tT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10974,7 +10635,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uc" = (
+"tU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -10994,7 +10655,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"ud" = (
+"tV" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -11006,7 +10667,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"ue" = (
+"tW" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -11018,31 +10679,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uf" = (
+"tX" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"ug" = (
-/obj/machinery/door/firedoor{
-	dir = 4;
-	name = "Firelock"
-	},
-/obj/machinery/door/airlock/research{
-	name = "Anomalous Materials";
-	req_access = list(65)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/anomaly_analysis)
-"uh" = (
+"tZ" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -11054,7 +10698,7 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"ui" = (
+"ua" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -11070,7 +10714,7 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uj" = (
+"ub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 1
@@ -11092,7 +10736,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uk" = (
+"uc" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -11100,7 +10744,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"ul" = (
+"ud" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -11112,7 +10756,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"um" = (
+"ue" = (
 /obj/machinery/door/airlock/research{
 	name = "Supply Closet";
 	req_access = list(65)
@@ -11125,7 +10769,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/emergency_storage)
-"un" = (
+"uf" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -11133,10 +10777,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"uo" = (
+"ug" = (
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"up" = (
+"uh" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/lights/bulbs{
 	pixel_x = 5;
@@ -11152,7 +10796,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"uq" = (
+"ui" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -11163,7 +10807,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"ur" = (
+"uj" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -11184,7 +10828,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"us" = (
+"uk" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11199,7 +10843,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"ut" = (
+"ul" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11214,7 +10858,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uu" = (
+"um" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11230,7 +10874,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uv" = (
+"un" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -11244,7 +10888,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uw" = (
+"uo" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -11261,14 +10905,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"ux" = (
+"up" = (
 /obj/machinery/computer/cryopod{
 	pixel_x = 32;
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"uy" = (
+"uq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -11289,7 +10933,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/anomaly_analysis)
-"uz" = (
+"ur" = (
 /obj/structure/closet/secure_closet/xenoarchaeologist{
 	req_access = list(47)
 	},
@@ -11298,14 +10942,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"uA" = (
+"ut" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_analysis)
-"uB" = (
+"uu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -11315,11 +10959,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uC" = (
+"uv" = (
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uD" = (
+"uw" = (
 /obj/structure/table/rack,
 /obj/item/clothing/head/welding,
 /obj/item/weapon/weldingtool,
@@ -11329,7 +10973,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uE" = (
+"ux" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
 /obj/item/weapon/screwdriver{
@@ -11338,19 +10982,19 @@
 /obj/item/weapon/melee/baton/loaded,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uF" = (
+"uy" = (
 /obj/machinery/light/small,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uG" = (
+"uz" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Anomalous Materials Lab";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uH" = (
+"uA" = (
 /obj/machinery/door/window/westleft{
 	dir = 2;
 	name = "Monkey Pen";
@@ -11371,7 +11015,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uI" = (
+"uB" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -11389,7 +11033,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uJ" = (
+"uC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 1
@@ -11406,17 +11050,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uK" = (
+"uD" = (
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uL" = (
+"uE" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uM" = (
+"uF" = (
 /obj/structure/closet/hydrant{
 	pixel_x = -32
 	},
@@ -11428,7 +11072,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"uN" = (
+"uG" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/item/weapon/storage/box/monkeycubes,
@@ -11436,18 +11080,18 @@
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor/plating,
 /area/outpost/research/emergency_storage)
-"uO" = (
+"uH" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uP" = (
+"uI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uQ" = (
+"uJ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -11458,7 +11102,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"uR" = (
+"uK" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -11471,30 +11115,16 @@
 	icon_state = "plating"
 	},
 /area/maintenance/sublevel)
-"uS" = (
-/obj/structure/table/reinforced/steel,
-/obj/machinery/cell_charger,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"uT" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/weapon/storage/firstaid/regular,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/aibunker)
-"uU" = (
+"uN" = (
 /obj/machinery/cryopod,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"uV" = (
+"uO" = (
 /obj/structure/cryofeed,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
-"uW" = (
+"uP" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
@@ -11512,7 +11142,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uX" = (
+"uQ" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
@@ -11523,7 +11153,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/anomaly_analysis)
-"uY" = (
+"uR" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -11538,7 +11168,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"uZ" = (
+"uS" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 5
@@ -11549,7 +11179,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"va" = (
+"uT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 1
@@ -11566,7 +11196,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vb" = (
+"uU" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -11577,13 +11207,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vc" = (
+"uV" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/anomaly_storage)
-"vd" = (
+"uW" = (
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
-"ve" = (
+"uX" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Medbay Substation";
 	req_one_access = list(11,24)
@@ -11591,7 +11221,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vf" = (
+"uY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance{
@@ -11599,7 +11229,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vg" = (
+"uZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11622,28 +11252,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/hallway)
-"vh" = (
+"va" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vi" = (
+"vb" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vj" = (
+"vc" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vk" = (
+"vd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -11657,7 +11287,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vl" = (
+"ve" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
@@ -11668,7 +11298,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vm" = (
+"vf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 1
@@ -11685,7 +11315,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vn" = (
+"vg" = (
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -11701,31 +11331,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_storage)
-"vo" = (
+"vh" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"vp" = (
+"vi" = (
 /obj/machinery/artifact_scanpad,
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/anomaly_storage)
-"vq" = (
+"vj" = (
 /obj/machinery/artifact_harvester,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/anomaly_storage)
-"vr" = (
+"vk" = (
 /obj/structure/crematorium{
 	id = "patientmurder"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"vs" = (
+"vl" = (
 /obj/machinery/button/crematorium{
 	id = "patientmurder";
 	pixel_x = -4;
@@ -11738,13 +11368,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"vt" = (
+"vm" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "\[F.4] Medical Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vu" = (
+"vn" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - \[F.4] Medical"
 	},
@@ -11758,7 +11388,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vv" = (
+"vo" = (
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
@@ -11774,24 +11404,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vw" = (
+"vp" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"vx" = (
+"vq" = (
 /obj/structure/table/rack,
 /obj/item/weapon/pickaxe,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"vy" = (
+"vr" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/steel{
 	amount = 10
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"vz" = (
+"vs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11811,14 +11441,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/hallway)
-"vA" = (
+"vt" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vB" = (
+"vu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -11832,7 +11462,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vC" = (
+"vv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -11846,7 +11476,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vD" = (
+"vw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
@@ -11861,7 +11491,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vE" = (
+"vx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -11873,7 +11503,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vF" = (
+"vy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -11892,7 +11522,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vG" = (
+"vz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -11906,7 +11536,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vH" = (
+"vA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -11920,7 +11550,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vI" = (
+"vB" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -11939,7 +11569,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vJ" = (
+"vC" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -11954,7 +11584,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vK" = (
+"vD" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
@@ -11973,7 +11603,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_storage)
-"vL" = (
+"vE" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -11987,17 +11617,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_storage)
-"vM" = (
+"vF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	icon_state = "map";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"vN" = (
+"vG" = (
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"vO" = (
+"vH" = (
 /obj/item/weapon/anodevice{
 	pixel_x = 3;
 	pixel_y = 3
@@ -12006,10 +11636,10 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"vP" = (
+"vI" = (
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"vQ" = (
+"vJ" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 1
@@ -12023,7 +11653,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"vR" = (
+"vK" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 5
@@ -12037,7 +11667,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"vS" = (
+"vL" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12047,7 +11677,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"vT" = (
+"vM" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12067,7 +11697,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vU" = (
+"vN" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -12080,7 +11710,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vV" = (
+"vO" = (
 /obj/machinery/power/terminal{
 	icon_state = "term";
 	dir = 1
@@ -12092,7 +11722,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vW" = (
+"vP" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -12100,14 +11730,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"vX" = (
+"vQ" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vY" = (
+"vR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -12117,25 +11747,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"vZ" = (
+"vS" = (
 /obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"wa" = (
+"vT" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"wb" = (
+"vU" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"wc" = (
+"vV" = (
 /obj/machinery/light,
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Corridor Camera 5";
@@ -12147,7 +11777,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"wd" = (
+"vW" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -12159,7 +11789,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"we" = (
+"vX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/mauve{
@@ -12168,7 +11798,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"wf" = (
+"vY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -12178,7 +11808,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"wg" = (
+"vZ" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
 	dir = 4
@@ -12189,7 +11819,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"wh" = (
+"wa" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
@@ -12202,11 +11832,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_storage)
-"wi" = (
+"wb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"wj" = (
+"wc" = (
 /obj/item/weapon/anobattery{
 	pixel_x = -6;
 	pixel_y = 2
@@ -12229,19 +11859,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"wk" = (
+"wd" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"wl" = (
+"we" = (
 /obj/effect/decal/cleanable/blood,
 /obj/random/junk,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"wm" = (
+"wf" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -12258,32 +11888,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wn" = (
+"wg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wo" = (
+"wh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wp" = (
+"wi" = (
 /obj/structure/morgue{
 	icon_state = "morgue1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wq" = (
+"wj" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/airless{
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"wr" = (
+"wk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
 	name = "Medbay Substation";
@@ -12296,7 +11926,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"ws" = (
+"wl" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(19)
 	},
@@ -12313,17 +11943,17 @@
 	icon_state = "plating"
 	},
 /area/maintenance/sublevel)
-"wt" = (
+"wm" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"wu" = (
+"wn" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/isolation_monitoring)
-"wv" = (
+"wo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12338,7 +11968,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_monitoring)
-"ww" = (
+"wp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12353,7 +11983,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_monitoring)
-"wx" = (
+"wq" = (
 /obj/machinery/door/airlock/research{
 	name = "Anomaly Isolation";
 	req_access = list(65)
@@ -12369,7 +11999,7 @@
 	},
 /turf/simulated/floor,
 /area/outpost/research/isolation_monitoring)
-"wy" = (
+"wr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12386,7 +12016,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_monitoring)
-"wz" = (
+"ws" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12398,7 +12028,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_monitoring)
-"wA" = (
+"wt" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12414,7 +12044,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_monitoring)
-"wB" = (
+"wu" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
@@ -12427,7 +12057,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly_storage)
-"wC" = (
+"wv" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -12438,16 +12068,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"wD" = (
+"ww" = (
 /obj/machinery/artifact_scanpad,
 /obj/machinery/light/small,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/anomaly_storage)
-"wE" = (
+"wx" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"wF" = (
+"wy" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/bodybags,
 /obj/machinery/alarm{
@@ -12457,7 +12087,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wG" = (
+"wz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -12465,13 +12095,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wH" = (
+"wA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wI" = (
+"wB" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes,
 /obj/structure/disposalpipe/trunk{
@@ -12482,7 +12112,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"wJ" = (
+"wC" = (
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
 	dir = 4
@@ -12491,7 +12121,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/sublevel)
-"wK" = (
+"wD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -12506,7 +12136,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"wL" = (
+"wE" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -12514,7 +12144,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"wM" = (
+"wF" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -12522,7 +12152,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"wN" = (
+"wG" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -12536,7 +12166,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"wO" = (
+"wH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -12550,15 +12180,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"wP" = (
+"wI" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wQ" = (
+"wJ" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wR" = (
+"wK" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -12568,7 +12198,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wS" = (
+"wL" = (
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
@@ -12581,7 +12211,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wT" = (
+"wM" = (
 /obj/structure/cable/blue{
 	d2 = 8;
 	icon_state = "0-8"
@@ -12594,29 +12224,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wU" = (
+"wN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wV" = (
+"wO" = (
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/tape_roll,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wW" = (
+"wP" = (
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wX" = (
+"wQ" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wY" = (
+"wR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"wZ" = (
+"wS" = (
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
@@ -12624,20 +12254,20 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"xa" = (
+"wT" = (
 /obj/structure/table/standard,
 /obj/item/weapon/scalpel,
 /obj/item/weapon/autopsy_scanner,
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"xb" = (
+"wU" = (
 /obj/machinery/optable,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"xc" = (
+"wV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12645,7 +12275,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"xd" = (
+"wW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -12657,7 +12287,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"xe" = (
+"wX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -12666,7 +12296,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"xf" = (
+"wY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -12678,7 +12308,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"xg" = (
+"wZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -12688,7 +12318,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"xh" = (
+"xa" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -12703,7 +12333,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"xi" = (
+"xb" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 9
@@ -12712,7 +12342,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/mine/unexplored)
-"xj" = (
+"xc" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1379;
@@ -12730,7 +12360,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/mine/unexplored)
-"xk" = (
+"xd" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 5
@@ -12739,7 +12369,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/mine/unexplored)
-"xl" = (
+"xe" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12760,22 +12390,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/hallway)
-"xm" = (
+"xf" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xn" = (
+"xg" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xo" = (
+"xh" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xp" = (
+"xi" = (
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
@@ -12783,20 +12413,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xq" = (
+"xj" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/firstaid/regular,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xr" = (
+"xk" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xs" = (
+"xl" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xt" = (
+"xm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/light_switch{
 	pixel_x = 27;
@@ -12804,14 +12434,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xu" = (
+"xn" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
-"xv" = (
-/turf/simulated/wall,
-/area/medical/virology)
-"xw" = (
+"xo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -12830,7 +12457,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xx" = (
+"xp" = (
 /obj/structure/sign/biohazard{
 	pixel_x = -32
 	},
@@ -12846,7 +12473,7 @@
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xy" = (
+"xq" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -12854,7 +12481,7 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xz" = (
+"xr" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -12866,7 +12493,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xA" = (
+"xs" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -12874,7 +12501,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xB" = (
+"xt" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -12882,13 +12509,13 @@
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xC" = (
+"xu" = (
 /turf/simulated/floor/tiled,
 /area/turbolift/medical_sub)
-"xD" = (
+"xv" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/eva)
-"xE" = (
+"xw" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -12913,7 +12540,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"xF" = (
+"xx" = (
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
@@ -12934,10 +12561,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"xG" = (
+"xy" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/hallway)
-"xH" = (
+"xz" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -12952,26 +12579,26 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"xI" = (
+"xA" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xJ" = (
+"xB" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xK" = (
+"xC" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	icon_state = "map";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xL" = (
+"xD" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
@@ -12982,18 +12609,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xM" = (
+"xE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xN" = (
+"xF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/visible/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xO" = (
+"xG" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -13001,12 +12628,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xP" = (
+"xH" = (
 /obj/structure/table/standard,
 /obj/item/clothing/gloves/latex,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xQ" = (
+"xI" = (
 /obj/structure/table/standard,
 /obj/machinery/computer/atmoscontrol/laptop{
 	monitored_alarm_ids = list("isolation_one","isolation_two","isolation_three");
@@ -13014,14 +12641,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xR" = (
+"xJ" = (
 /obj/structure/table/standard,
 /obj/item/weapon/folder,
 /obj/item/device/camera,
 /obj/item/weapon/pen,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"xS" = (
+"xK" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/beakers,
 /obj/item/weapon/storage/box/syringes{
@@ -13035,7 +12662,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xT" = (
+"xL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -13043,7 +12670,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xU" = (
+"xM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -13054,15 +12681,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xV" = (
-/obj/machinery/firealarm/north,
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"xW" = (
+"xO" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -13085,7 +12704,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xX" = (
+"xP" = (
 /obj/effect/floor_decal/corner/lime/full{
 	icon_state = "corner_white_full";
 	dir = 8
@@ -13095,7 +12714,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xY" = (
+"xQ" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -13108,7 +12727,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"xZ" = (
+"xR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -13120,7 +12739,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"ya" = (
+"xS" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/clothing/mask/gas,
 /obj/effect/floor_decal/corner/lime/full{
@@ -13137,7 +12756,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yb" = (
+"xT" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/clothing/mask/gas,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -13152,7 +12771,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yc" = (
+"xU" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/clothing/mask/gas,
 /obj/machinery/alarm{
@@ -13166,14 +12785,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yd" = (
+"xV" = (
 /obj/structure/closet/wardrobe/virology_white,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"ye" = (
+"xW" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 9
@@ -13181,20 +12800,20 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yf" = (
+"xX" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yg" = (
+"xY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yh" = (
+"xZ" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/turbolift/medical_sub)
-"yi" = (
+"ya" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -13214,7 +12833,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"yj" = (
+"yb" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13230,7 +12849,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"yk" = (
+"yc" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -13245,7 +12864,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"yl" = (
+"yd" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -13270,14 +12889,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"ym" = (
+"ye" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1;
 	icon_state = "map"
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"yn" = (
+"yf" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1379;
@@ -13286,7 +12905,7 @@
 /obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"yo" = (
+"yg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -13298,7 +12917,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"yp" = (
+"yh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -13308,7 +12927,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"yq" = (
+"yi" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
@@ -13322,17 +12941,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yr" = (
+"yj" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"ys" = (
+"yk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yt" = (
+"yl" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
@@ -13343,17 +12962,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yu" = (
+"ym" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yv" = (
+"yn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yw" = (
+"yo" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 1;
 	tag_south = 2;
@@ -13361,13 +12980,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yx" = (
+"yp" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yy" = (
+"yq" = (
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -13384,7 +13003,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yz" = (
+"yr" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/item/device/antibody_scanner,
@@ -13394,21 +13013,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yA" = (
+"ys" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yB" = (
+"yt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yC" = (
+"yu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13422,7 +13041,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yD" = (
+"yv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -13448,7 +13067,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"yE" = (
+"yw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13466,14 +13085,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yF" = (
+"yx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yG" = (
+"yy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -13486,7 +13105,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yH" = (
+"yz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13498,7 +13117,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yI" = (
+"yA" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	frequency = 1379;
@@ -13517,7 +13136,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yJ" = (
+"yB" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1379;
@@ -13533,7 +13152,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yK" = (
+"yC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13547,7 +13166,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yL" = (
+"yD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -13561,7 +13180,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yM" = (
+"yE" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	frequency = 1379;
@@ -13594,7 +13213,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yN" = (
+"yF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13613,7 +13232,7 @@
 /obj/effect/floor_decal/sign/v,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yO" = (
+"yG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -13627,7 +13246,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yP" = (
+"yH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13639,7 +13258,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yQ" = (
+"yI" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -13653,7 +13272,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"yR" = (
+"yJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -13667,7 +13286,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"yS" = (
+"yK" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -13680,7 +13299,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/outpost/research/eva)
-"yT" = (
+"yL" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
 	dir = 1
@@ -13689,7 +13308,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/outpost/research/eva)
-"yU" = (
+"yM" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -13699,7 +13318,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/outpost/research/eva)
-"yV" = (
+"yN" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
 	id_tag = "research_sensor";
@@ -13715,12 +13334,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"yW" = (
+"yO" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"yX" = (
+"yP" = (
 /obj/structure/ore_box,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -13733,26 +13352,26 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"yY" = (
+"yQ" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"yZ" = (
+"yR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"za" = (
+"yS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	icon_state = "map";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zb" = (
+"yT" = (
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
@@ -13760,7 +13379,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zc" = (
+"yU" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
 	state = 2
@@ -13776,13 +13395,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zd" = (
+"yV" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"ze" = (
+"yW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/newscaster{
 	pixel_x = 32;
@@ -13790,7 +13409,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zf" = (
+"yX" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/gloves,
 /obj/item/weapon/storage/box/masks,
@@ -13798,7 +13417,7 @@
 /obj/effect/floor_decal/corner/lime/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zg" = (
+"yY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -13812,7 +13431,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zh" = (
+"yZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13823,7 +13442,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zi" = (
+"za" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13833,7 +13452,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zj" = (
+"zb" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -13862,7 +13481,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zk" = (
+"zc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13872,7 +13491,7 @@
 /obj/effect/floor_decal/corner/lime/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zl" = (
+"zd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13883,7 +13502,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zm" = (
+"ze" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -13897,7 +13516,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zn" = (
+"zf" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/clothing/mask/gas,
 /obj/effect/floor_decal/corner/lime/full{
@@ -13914,7 +13533,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zo" = (
+"zg" = (
 /obj/machinery/shower{
 	dir = 1
 	},
@@ -13931,7 +13550,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zp" = (
+"zh" = (
 /obj/machinery/shower{
 	dir = 1
 	},
@@ -13943,7 +13562,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zq" = (
+"zi" = (
 /obj/machinery/shower{
 	dir = 1
 	},
@@ -13955,7 +13574,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zr" = (
+"zj" = (
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for shutters.";
 	id = "virologyquar";
@@ -13972,7 +13591,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zs" = (
+"zk" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 10
@@ -13982,13 +13601,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zt" = (
+"zl" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zu" = (
+"zm" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -13998,11 +13617,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zv" = (
+"zn" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled,
 /area/turbolift/medical_sub)
-"zw" = (
+"zo" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -14018,7 +13637,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"zx" = (
+"zp" = (
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
@@ -14032,7 +13651,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zy" = (
+"zq" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -14049,18 +13668,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"zz" = (
+"zr" = (
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 4;
 	icon_state = "freezer"
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zA" = (
+"zs" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zB" = (
+"zt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
@@ -14071,7 +13690,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zC" = (
+"zu" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	icon_state = "map";
 	dir = 1
@@ -14085,13 +13704,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zD" = (
+"zv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"zE" = (
+"zw" = (
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -14107,7 +13726,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"zF" = (
+"zx" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - \[F.4] Research"
 	},
@@ -14121,13 +13740,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"zG" = (
+"zy" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "\[F.4] Research Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"zH" = (
+"zz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -14150,7 +13769,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"zI" = (
+"zA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14172,7 +13791,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zJ" = (
+"zB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -14191,7 +13810,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zK" = (
+"zC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14215,7 +13834,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zL" = (
+"zD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -14229,14 +13848,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"zM" = (
+"zE" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zN" = (
+"zF" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -14247,7 +13866,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zO" = (
+"zG" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 9
@@ -14255,15 +13874,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"zP" = (
+"zH" = (
 /obj/turbolift_map_holder/aurora/medical,
 /turf/simulated/floor/tiled,
 /area/turbolift/medical_sub)
-"zQ" = (
+"zI" = (
 /obj/structure/closet/excavation,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zR" = (
+"zJ" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -14273,7 +13892,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zS" = (
+"zK" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/shoes/magboots,
@@ -14282,7 +13901,7 @@
 /obj/item/weapon/storage/belt/archaeology,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zT" = (
+"zL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -14295,7 +13914,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"zU" = (
+"zM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -14311,7 +13930,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zV" = (
+"zN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -14321,7 +13940,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zW" = (
+"zO" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 22
@@ -14342,7 +13961,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zX" = (
+"zP" = (
 /obj/machinery/door/firedoor{
 	dir = 4;
 	name = "Firelock"
@@ -14364,7 +13983,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"zY" = (
+"zQ" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -14381,7 +14000,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"zZ" = (
+"zR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -14399,7 +14018,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Aa" = (
+"zS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -14418,7 +14037,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ab" = (
+"zT" = (
 /obj/machinery/button/remote/airlock{
 	id = "riso1";
 	name = "Door Bolt Control";
@@ -14433,7 +14052,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Ac" = (
+"zU" = (
 /obj/machinery/atmospherics/valve/digital/open,
 /obj/structure/cable/blue{
 	d1 = 4;
@@ -14442,7 +14061,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Ad" = (
+"zV" = (
 /obj/machinery/button/remote/airlock{
 	id = "riso2";
 	name = "Door Bolt Control";
@@ -14463,7 +14082,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Ae" = (
+"zW" = (
 /obj/structure/cable/blue{
 	d1 = 2;
 	d2 = 8;
@@ -14476,7 +14095,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Af" = (
+"zX" = (
 /obj/machinery/atmospherics/valve/digital/open,
 /obj/structure/cable/blue{
 	d1 = 4;
@@ -14487,7 +14106,7 @@
 /obj/effect/floor_decal/industrial/warning/cee,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Ag" = (
+"zY" = (
 /obj/machinery/button/remote/airlock{
 	id = "riso3";
 	name = "Door Bolt Control";
@@ -14503,7 +14122,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Ah" = (
+"zZ" = (
 /obj/structure/cable/blue{
 	d1 = 2;
 	d2 = 8;
@@ -14511,15 +14130,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Ai" = (
+"Aa" = (
 /obj/machinery/atmospherics/valve/digital/open,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Aj" = (
+"Ab" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
-"Ak" = (
+"Ac" = (
 /obj/machinery/power/terminal{
 	icon_state = "term";
 	dir = 1
@@ -14531,7 +14150,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Al" = (
+"Ad" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -14544,7 +14163,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Am" = (
+"Ae" = (
 /obj/item/weapon/storage/lockbox/vials,
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /obj/item/weapon/reagent_containers/syringe/antiviral,
@@ -14577,7 +14196,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"An" = (
+"Af" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -14591,7 +14210,7 @@
 /obj/machinery/disease2/diseaseanalyser,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ao" = (
+"Ag" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -14599,13 +14218,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ap" = (
+"Ah" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Aq" = (
+"Ai" = (
 /obj/structure/table/standard,
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology North"
@@ -14624,7 +14243,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ar" = (
+"Aj" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
@@ -14636,7 +14255,7 @@
 /obj/machinery/computer/med_data/laptop,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"As" = (
+"Ak" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -14659,7 +14278,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"At" = (
+"Al" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -14669,7 +14288,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Au" = (
+"Am" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -14687,7 +14306,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Av" = (
+"An" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -14698,7 +14317,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"Aw" = (
+"Ao" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
@@ -14707,7 +14326,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ax" = (
+"Ap" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -14717,7 +14336,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ay" = (
+"Aq" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 9
@@ -14729,19 +14348,19 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Az" = (
+"Ar" = (
 /turf/simulated/wall/r_wall,
 /area/medical/patient_wing)
-"AA" = (
+"As" = (
 /obj/structure/closet/excavation,
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"AB" = (
+"At" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"AC" = (
+"Au" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -14755,11 +14374,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"AD" = (
+"Av" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"AE" = (
+"Aw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	icon_state = "map-scrubbers";
@@ -14767,7 +14386,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"AF" = (
+"Ax" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
@@ -14783,13 +14402,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"AG" = (
-/turf/simulated/wall,
-/area/outpost/research/eva)
-"AH" = (
+"Ay" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/isolation_a)
-"AI" = (
+"Az" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "riso1";
 	name = "Access Airlock";
@@ -14803,7 +14419,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_a)
-"AJ" = (
+"AA" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14816,7 +14432,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_a)
-"AK" = (
+"AB" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -14828,7 +14444,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_a)
-"AL" = (
+"AC" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "riso2";
 	name = "Access Airlock";
@@ -14842,7 +14458,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_b)
-"AM" = (
+"AD" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14855,7 +14471,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_b)
-"AN" = (
+"AE" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -14867,10 +14483,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_b)
-"AO" = (
+"AF" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/research/isolation_b)
-"AP" = (
+"AG" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "riso3";
 	name = "Access Airlock";
@@ -14884,7 +14500,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_c)
-"AQ" = (
+"AH" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14897,7 +14513,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_c)
-"AR" = (
+"AI" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -14909,7 +14525,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/outpost/research/isolation_c)
-"AS" = (
+"AJ" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Science Substation";
 	req_one_access = list(11,24)
@@ -14922,7 +14538,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"AT" = (
+"AK" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -14935,12 +14551,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"AU" = (
+"AL" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"AV" = (
+"AM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/access_button{
@@ -14960,7 +14576,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"AW" = (
+"AN" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/fancy/vials,
 /obj/machinery/button/remote/blast_door{
@@ -14977,17 +14593,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"AX" = (
+"AO" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"AY" = (
+"AP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"AZ" = (
+"AQ" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
@@ -14997,7 +14613,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ba" = (
+"AR" = (
 /obj/machinery/computer/diseasesplicer,
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -15008,7 +14624,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Bb" = (
+"AS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -15028,7 +14644,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Bc" = (
+"AT" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Quarantine Airlock";
 	dir = 4;
@@ -15039,13 +14655,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Bd" = (
+"AU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Be" = (
+"AV" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
@@ -15057,7 +14673,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Bf" = (
+"AW" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
@@ -15068,13 +14684,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Bg" = (
+"AX" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Bh" = (
+"AY" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
@@ -15084,7 +14700,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Bi" = (
+"AZ" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -15099,7 +14715,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Bj" = (
+"Ba" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -15119,7 +14735,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Bk" = (
+"Bb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15144,7 +14760,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Bl" = (
+"Bc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15162,7 +14778,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Bm" = (
+"Bd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15176,7 +14792,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Bn" = (
+"Be" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 9
@@ -15191,7 +14807,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Bo" = (
+"Bf" = (
 /obj/structure/closet/excavation,
 /obj/machinery/light{
 	dir = 8
@@ -15202,13 +14818,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bp" = (
+"Bg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bq" = (
+"Bh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15218,7 +14834,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Br" = (
+"Bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15237,7 +14853,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bs" = (
+"Bj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
 	icon_state = "intact"
@@ -15250,7 +14866,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bt" = (
+"Bk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 9
@@ -15264,7 +14880,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bu" = (
+"Bl" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -15273,7 +14889,7 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bv" = (
+"Bm" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light{
 	dir = 4;
@@ -15281,7 +14897,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Bw" = (
+"Bn" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 9
@@ -15292,7 +14908,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Bx" = (
+"Bo" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	use_power = 0
@@ -15306,12 +14922,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_a)
-"By" = (
+"Bp" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_a)
-"Bz" = (
+"Bq" = (
 /obj/machinery/alarm/monitor/isolation{
 	alarm_id = "isolation_one";
 	dir = 8;
@@ -15324,7 +14940,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_a)
-"BA" = (
+"Br" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	use_power = 0
@@ -15338,12 +14954,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_b)
-"BB" = (
+"Bs" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_b)
-"BC" = (
+"Bt" = (
 /obj/machinery/alarm/monitor/isolation{
 	alarm_id = "isolation_two";
 	dir = 8;
@@ -15356,7 +14972,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_b)
-"BD" = (
+"Bu" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	use_power = 0
@@ -15370,12 +14986,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_c)
-"BE" = (
+"Bv" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_c)
-"BF" = (
+"Bw" = (
 /obj/machinery/alarm/monitor/isolation{
 	alarm_id = "isolation_three";
 	dir = 8;
@@ -15388,7 +15004,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_c)
-"BG" = (
+"Bx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -15402,7 +15018,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BH" = (
+"By" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -15416,7 +15032,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BI" = (
+"Bz" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -15430,7 +15046,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BJ" = (
+"BA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15439,7 +15055,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BK" = (
+"BB" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -15453,7 +15069,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BL" = (
+"BC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15472,7 +15088,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BM" = (
+"BD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15495,7 +15111,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BN" = (
+"BE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15520,7 +15136,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BO" = (
+"BF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15548,7 +15164,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BP" = (
+"BG" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -15566,7 +15182,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BQ" = (
+"BH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15588,7 +15204,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"BR" = (
+"BI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 9
@@ -15606,7 +15222,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"BS" = (
+"BJ" = (
 /obj/structure/bed/padded,
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
@@ -15617,18 +15233,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BT" = (
+"BK" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BU" = (
+"BL" = (
 /obj/item/roller,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BV" = (
+"BM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15643,7 +15259,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"BW" = (
+"BN" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes,
 /obj/structure/disposalpipe/trunk{
@@ -15651,14 +15267,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BX" = (
+"BO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BY" = (
+"BP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -15667,7 +15283,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"BZ" = (
+"BQ" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
@@ -15680,7 +15296,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ca" = (
+"BR" = (
 /obj/machinery/disease2/isolator,
 /obj/machinery/light{
 	dir = 4;
@@ -15695,7 +15311,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Cb" = (
+"BS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15716,7 +15332,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Cc" = (
+"BT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -15726,7 +15342,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Cd" = (
+"BU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -15734,13 +15350,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ce" = (
+"BV" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Cf" = (
+"BW" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -15755,7 +15371,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Cg" = (
+"BX" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -15767,7 +15383,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ch" = (
+"BY" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -15781,7 +15397,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ci" = (
+"BZ" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -15796,7 +15412,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Cj" = (
+"Ca" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -15815,7 +15431,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ck" = (
+"Cb" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 9
@@ -15832,7 +15448,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Cl" = (
+"Cc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -15844,7 +15460,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Cm" = (
+"Cd" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -15856,13 +15472,13 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Cn" = (
+"Ce" = (
 /turf/simulated/wall/r_wall,
 /area/medical/patient_a)
-"Co" = (
+"Cf" = (
 /turf/simulated/wall/r_wall,
 /area/medical/patient_b)
-"Cp" = (
+"Cg" = (
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
@@ -15872,17 +15488,17 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Cq" = (
+"Ch" = (
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Cr" = (
+"Ci" = (
 /obj/machinery/floodlight,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Cs" = (
+"Cj" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -15898,7 +15514,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"Ct" = (
+"Ck" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -15913,7 +15529,7 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Cu" = (
+"Cl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -15923,7 +15539,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Cv" = (
+"Cm" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -15934,7 +15550,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Cw" = (
+"Cn" = (
 /obj/item/weapon/storage/box/excavation,
 /obj/item/weapon/pickaxe,
 /obj/machinery/status_display{
@@ -15948,7 +15564,7 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Cx" = (
+"Co" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -15958,7 +15574,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Cy" = (
+"Cp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -15970,7 +15586,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Cz" = (
+"Cq" = (
 /obj/item/device/radio/intercom{
 	frequency = 1459;
 	name = "Station Intercom (General)";
@@ -15978,17 +15594,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_a)
-"CA" = (
+"Cr" = (
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_a)
-"CB" = (
+"Cs" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Isolation Cell A";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_a)
-"CC" = (
+"Ct" = (
 /obj/item/device/radio/intercom{
 	frequency = 1459;
 	name = "Station Intercom (General)";
@@ -15996,20 +15612,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_b)
-"CD" = (
+"Cu" = (
 /obj/effect/landmark{
 	name = "bluespacerift"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_b)
-"CE" = (
+"Cv" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Isolation Cell B";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_b)
-"CF" = (
+"Cw" = (
 /obj/item/device/radio/intercom{
 	frequency = 1459;
 	name = "Station Intercom (General)";
@@ -16017,17 +15633,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"CG" = (
+"Cx" = (
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"CH" = (
+"Cy" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Isolation Cell C";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"CI" = (
+"Cz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16037,7 +15653,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"CJ" = (
+"CA" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "sl2s";
 	pixel_y = -26
@@ -16049,7 +15665,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"CK" = (
+"CB" = (
 /obj/machinery/camera/network/engineering_outpost{
 	c_tag = "Research Sublevel - Cavern Entrance";
 	dir = 4;
@@ -16057,7 +15673,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/maintenance/sublevel)
-"CL" = (
+"CC" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Cell A";
 	dir = 4;
@@ -16072,7 +15688,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CM" = (
+"CD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -16081,7 +15697,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CN" = (
+"CE" = (
 /obj/machinery/door/window/westleft{
 	name = "Virology Isolation Cell Alpha";
 	req_access = list(39)
@@ -16099,7 +15715,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CO" = (
+"CF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -16108,14 +15724,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CP" = (
+"CG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CQ" = (
+"CH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -16124,7 +15740,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CR" = (
+"CI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -16137,7 +15753,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CS" = (
+"CJ" = (
 /obj/machinery/computer/centrifuge,
 /obj/item/weapon/storage/secure/safe{
 	pixel_x = 32
@@ -16154,7 +15770,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CT" = (
+"CK" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	frequency = 1379;
@@ -16179,7 +15795,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"CU" = (
+"CL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -16193,7 +15809,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"CV" = (
+"CM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -16205,7 +15821,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"CW" = (
+"CN" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 4
@@ -16214,7 +15830,7 @@
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"CX" = (
+"CO" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -16228,14 +15844,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"CY" = (
+"CP" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"CZ" = (
+"CQ" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -16243,7 +15859,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Da" = (
+"CR" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -16251,14 +15867,14 @@
 /obj/effect/floor_decal/corner/lime,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Db" = (
+"CS" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Dc" = (
+"CT" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -16272,7 +15888,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"Dd" = (
+"CU" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/corner/pink/full{
 	icon_state = "corner_white_full";
@@ -16281,7 +15897,7 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"De" = (
+"CV" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -16298,7 +15914,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"Df" = (
+"CW" = (
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -16327,10 +15943,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"Dg" = (
+"CX" = (
 /turf/simulated/wall,
 /area/medical/patient_a)
-"Dh" = (
+"CY" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/corner/pink/full{
 	icon_state = "corner_white_full";
@@ -16339,7 +15955,7 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Di" = (
+"CZ" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -16356,7 +15972,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Dj" = (
+"Da" = (
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -16385,19 +16001,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Dk" = (
+"Db" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Dl" = (
+"Dc" = (
 /obj/machinery/suspension_gen,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Dm" = (
+"Dd" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Dn" = (
+"De" = (
 /obj/machinery/door/window{
 	dir = 4;
 	name = "Air Tank Access";
@@ -16409,14 +16025,14 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Do" = (
+"Df" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Dp" = (
+"Dg" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
 	dir = 2;
@@ -16425,7 +16041,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Dq" = (
+"Dh" = (
 /obj/item/weapon/storage/box/excavation,
 /obj/item/weapon/pickaxe,
 /obj/item/weapon/wrench,
@@ -16434,12 +16050,12 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
-"Dr" = (
+"Di" = (
 /obj/effect/floor_decal/corner/paleblue/full,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ds" = (
+"Dj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -16453,61 +16069,61 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Dt" = (
+"Dk" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Du" = (
+"Dl" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_a)
-"Dv" = (
+"Dm" = (
 /obj/machinery/artifact_scanpad,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/isolation_a)
-"Dw" = (
+"Dn" = (
 /obj/machinery/artifact_analyser,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/isolation_a)
-"Dx" = (
+"Do" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_b)
-"Dy" = (
+"Dp" = (
 /obj/machinery/artifact_scanpad,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/isolation_b)
-"Dz" = (
+"Dq" = (
 /obj/machinery/artifact_analyser,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/isolation_b)
-"DA" = (
+"Dr" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"DB" = (
+"Ds" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"DC" = (
+"Dt" = (
 /obj/structure/bed,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_c)
-"DD" = (
+"Du" = (
 /obj/structure/crematorium{
 	id = "slimemurder"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"DE" = (
+"Dv" = (
 /obj/machinery/button/crematorium{
 	id = "slimemurder";
 	pixel_x = -4;
@@ -16523,31 +16139,31 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"DF" = (
+"Dw" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/xenobiology)
-"DG" = (
+"Dx" = (
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DH" = (
+"Dy" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DI" = (
+"Dz" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DJ" = (
+"DA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -16556,7 +16172,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DK" = (
+"DB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -16565,7 +16181,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DL" = (
+"DC" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/virusdish/random,
 /obj/item/weapon/virusdish/random,
@@ -16576,7 +16192,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DM" = (
+"DD" = (
 /obj/machinery/smartfridge/secure/virology{
 	density = 0;
 	pixel_y = -32
@@ -16590,7 +16206,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DN" = (
+"DE" = (
 /obj/machinery/disease2/incubator,
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -16601,7 +16217,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DO" = (
+"DF" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/item/clothing/under/color/white,
 /obj/item/clothing/under/color/white,
@@ -16623,7 +16239,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DP" = (
+"DG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -16633,7 +16249,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DQ" = (
+"DH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -16643,10 +16259,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"DR" = (
+"DI" = (
 /turf/simulated/wall,
 /area/medical/morgue)
-"DS" = (
+"DJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/plasticflaps/airtight,
 /obj/machinery/door/airlock/medical{
@@ -16658,7 +16274,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"DT" = (
+"DK" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
@@ -16669,7 +16285,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"DU" = (
+"DL" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -16681,7 +16297,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"DV" = (
+"DM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -16691,7 +16307,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"DW" = (
+"DN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -16703,7 +16319,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"DX" = (
+"DO" = (
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
@@ -16716,11 +16332,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"DY" = (
+"DP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"DZ" = (
+"DQ" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
 /obj/machinery/vending/wallmed1{
@@ -16734,7 +16350,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"Ea" = (
+"DR" = (
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
@@ -16747,11 +16363,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Eb" = (
+"DS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Ec" = (
+"DT" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
 /obj/machinery/vending/wallmed1{
@@ -16765,10 +16381,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Ed" = (
-/turf/simulated/wall/r_wall,
-/area/rnd/test_range)
-"Ee" = (
+"DU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -16782,7 +16395,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"Ef" = (
+"DV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -16793,10 +16406,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
-"Eg" = (
-/turf/simulated/wall,
-/area/outpost/research/hallway)
-"Eh" = (
+"DW" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Xenoarchaeology Department";
 	req_access = list(65)
@@ -16811,20 +16421,23 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ei" = (
+"DX" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"Ej" = (
+"DY" = (
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"Ek" = (
+"DZ" = (
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"El" = (
+"Ea" = (
+/turf/simulated/wall,
+/area/medical/virology)
+"Eb" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -16833,12 +16446,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Em" = (
+"Ec" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"En" = (
+"Ed" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -16861,7 +16474,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Eo" = (
+"Ee" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -16881,7 +16494,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Ep" = (
+"Ef" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -16898,7 +16511,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Eq" = (
+"Eg" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -16911,7 +16524,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Er" = (
+"Eh" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 4
@@ -16929,24 +16542,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Es" = (
+"Ei" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/ramp,
 /area/medical/virology)
-"Et" = (
+"Ej" = (
 /obj/structure/morgue,
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
 	},
 /area/medical/morgue)
-"Eu" = (
+"Ek" = (
 /turf/simulated/floor/tiled/dark{
 	name = "cooled dark floor";
 	temperature = 278
 	},
 /area/medical/morgue)
-"Ev" = (
+"El" = (
 /obj/structure/morgue{
 	icon_state = "morgue1";
 	dir = 8
@@ -16956,7 +16569,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Ew" = (
+"Em" = (
 /obj/machinery/light_switch{
 	pixel_y = 27
 	},
@@ -16965,7 +16578,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Ex" = (
+"En" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -16981,7 +16594,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Ey" = (
+"Eo" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
@@ -16995,7 +16608,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ez" = (
+"Ep" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -17011,7 +16624,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"EA" = (
+"Eq" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -17027,7 +16640,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"EB" = (
+"Er" = (
 /obj/structure/table/standard,
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -17036,7 +16649,7 @@
 /obj/effect/floor_decal/corner/pink/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"EC" = (
+"Es" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -17052,7 +16665,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"ED" = (
+"Et" = (
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc{
 	dir = 4;
@@ -17069,7 +16682,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"EE" = (
+"Eu" = (
 /obj/structure/table/standard,
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -17078,7 +16691,7 @@
 /obj/effect/floor_decal/corner/pink/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"EF" = (
+"Ev" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -17094,7 +16707,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"EG" = (
+"Ew" = (
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc{
 	dir = 4;
@@ -17111,64 +16724,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"EH" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/bodyscanner{
-	tag = "icon-body_scanner_0 (WEST)";
-	icon_state = "body_scanner_0";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"EI" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/body_scanconsole{
-	tag = "icon-body_scannerconsole (WEST)";
-	icon_state = "body_scannerconsole";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"EJ" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/structure/bed/chair/office/light{
-	tag = "icon-officechair_white (EAST)";
-	icon_state = "officechair_white";
-	dir = 4
-	},
-/obj/machinery/firealarm/north,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"EK" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin,
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"EL" = (
+"Ex" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 8
@@ -17177,7 +16733,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"EM" = (
+"Ey" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -17188,7 +16744,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"EN" = (
+"Ez" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -17198,7 +16754,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"EO" = (
+"EA" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -17208,7 +16764,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"EP" = (
+"EB" = (
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -17225,7 +16781,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"EQ" = (
+"EC" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -17238,7 +16794,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"ER" = (
+"ED" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 1
@@ -17247,15 +16803,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"ES" = (
+"EE" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"ET" = (
+"EF" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"EU" = (
+"EG" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/toolbox/emergency{
 	pixel_x = 0;
@@ -17263,7 +16819,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"EV" = (
+"EH" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17278,7 +16834,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"EW" = (
+"EI" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17295,7 +16851,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"EX" = (
+"EJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
@@ -17310,7 +16866,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"EY" = (
+"EK" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -17321,7 +16877,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"EZ" = (
+"EL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -17344,7 +16900,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Fa" = (
+"EM" = (
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
@@ -17355,13 +16911,13 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fb" = (
+"EN" = (
 /obj/machinery/door/window/eastleft,
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fc" = (
+"EO" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Quarantine"
 	},
@@ -17370,7 +16926,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fd" = (
+"EP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -17379,20 +16935,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fe" = (
+"EQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ff" = (
+"ER" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fg" = (
+"ES" = (
 /obj/structure/bed/padded,
 /obj/item/clothing/under/color/white,
 /obj/item/clothing/shoes/white,
@@ -17405,7 +16961,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Fh" = (
+"ET" = (
 /obj/structure/morgue,
 /obj/machinery/light{
 	dir = 8
@@ -17415,7 +16971,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Fi" = (
+"EU" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -17430,7 +16986,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Fj" = (
+"EV" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
@@ -17440,7 +16996,7 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Fk" = (
+"EW" = (
 /obj/machinery/newscaster{
 	pixel_x = 30;
 	pixel_y = 0
@@ -17455,7 +17011,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Fl" = (
+"EX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -17467,7 +17023,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"Fm" = (
+"EY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -17476,7 +17032,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"Fn" = (
+"EZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -17488,7 +17044,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"Fo" = (
+"Fa" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
 	id = "isoA_window_tint"
@@ -17508,7 +17064,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/patient_a)
-"Fp" = (
+"Fb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Sub-Acute A"
@@ -17522,7 +17078,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
-"Fq" = (
+"Fc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
@@ -17542,7 +17098,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/patient_a)
-"Fr" = (
+"Fd" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
 	id = "isoB_window_tint"
@@ -17562,7 +17118,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/patient_b)
-"Fs" = (
+"Fe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Sub-Acute B"
@@ -17576,52 +17132,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
-"Ft" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Fu" = (
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Fv" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/pen,
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Fw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/outpost/research/hallway)
-"Fx" = (
+"Ff" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
@@ -17631,7 +17142,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Fy" = (
+"Fg" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17645,7 +17156,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Fz" = (
+"Fh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17659,7 +17170,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"FA" = (
+"Fi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17678,7 +17189,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"FB" = (
+"Fj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
@@ -17693,7 +17204,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"FC" = (
+"Fk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -17707,7 +17218,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"FD" = (
+"Fl" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 6
@@ -17717,7 +17228,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"FE" = (
+"Fm" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -17729,7 +17240,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"FF" = (
+"Fn" = (
 /obj/machinery/door/airlock/research{
 	name = "Secure Disposals";
 	req_access = list(55)
@@ -17737,7 +17248,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"FG" = (
+"Fo" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Cell B";
 	dir = 4;
@@ -17752,7 +17263,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"FH" = (
+"Fp" = (
 /obj/machinery/door/window/westleft{
 	name = "Virology Isolation Cell Beta";
 	req_access = list(39)
@@ -17770,7 +17281,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"FI" = (
+"Fq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -17779,7 +17290,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"FJ" = (
+"Fr" = (
 /obj/item/weapon/folder/white,
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin,
@@ -17795,18 +17306,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"FK" = (
+"Fs" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"FL" = (
+"Ft" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"FM" = (
+"Fu" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/lime/full{
 	icon_state = "corner_white_full";
@@ -17814,7 +17325,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"FN" = (
+"Fv" = (
 /obj/structure/table/standard,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17827,14 +17338,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"FO" = (
+"Fw" = (
 /obj/item/weapon/stool/padded,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"FP" = (
+"Fx" = (
 /obj/structure/bed/padded,
 /obj/item/clothing/under/color/white,
 /obj/item/clothing/shoes/white,
@@ -17844,7 +17355,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"FQ" = (
+"Fy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/dark{
@@ -17852,7 +17363,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"FR" = (
+"Fz" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/bodybags,
 /obj/item/weapon/storage/box/bodybags,
@@ -17861,7 +17372,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"FS" = (
+"FA" = (
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -17877,42 +17388,42 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"FT" = (
+"FB" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FU" = (
+"FC" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FV" = (
+"FD" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FW" = (
+"FE" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FX" = (
+"FF" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FY" = (
+"FG" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"FZ" = (
+"FH" = (
 /obj/machinery/iv_drip,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ga" = (
+"FI" = (
 /obj/structure/closet/crate/freezer{
 	name = "O- Blood Packs"
 	},
@@ -17924,14 +17435,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Gb" = (
+"FJ" = (
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Gc" = (
+"FK" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -17946,7 +17457,7 @@
 /obj/effect/floor_decal/sign/a,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Gd" = (
+"FL" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Patient Wing Hallway East"
 	},
@@ -17956,13 +17467,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ge" = (
+"FM" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Gf" = (
+"FN" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -17977,7 +17488,7 @@
 /obj/effect/floor_decal/sign/b,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Gg" = (
+"FO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -17991,72 +17502,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"Gh" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Gi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Gj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Gk" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Test Range"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/hallway)
-"Gl" = (
+"FP" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -18077,7 +17523,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Gm" = (
+"FQ" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -18085,7 +17531,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Gn" = (
+"FR" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
@@ -18093,14 +17539,14 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Go" = (
+"FS" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Gp" = (
+"FT" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -18119,7 +17565,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Gq" = (
+"FU" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -18137,7 +17583,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Gr" = (
+"FV" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -18156,7 +17602,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Gs" = (
+"FW" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -18174,7 +17620,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Gt" = (
+"FX" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -18189,7 +17635,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Gu" = (
+"FY" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -18208,7 +17654,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Gv" = (
+"FZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -18234,7 +17680,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
-"Gw" = (
+"Ga" = (
 /obj/machinery/computer/operating{
 	name = "Xenobiology Operating Computer"
 	},
@@ -18247,7 +17693,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Gx" = (
+"Gb" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
@@ -18263,7 +17709,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Gy" = (
+"Gc" = (
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -18280,7 +17726,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Gz" = (
+"Gd" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 8
@@ -18288,7 +17734,7 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"GA" = (
+"Ge" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -18296,14 +17742,14 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"GB" = (
+"Gf" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"GC" = (
+"Gg" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/blast_door{
@@ -18322,7 +17768,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"GD" = (
+"Gh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -18345,17 +17791,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"GE" = (
+"Gi" = (
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"GF" = (
+"Gj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"GG" = (
+"Gk" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/item/weapon/storage/box/monkeycubes,
@@ -18367,11 +17813,11 @@
 /obj/effect/floor_decal/corner/lime/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"GH" = (
+"Gl" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"GI" = (
+"Gm" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -18379,7 +17825,7 @@
 /obj/effect/floor_decal/corner/lime/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"GJ" = (
+"Gn" = (
 /obj/structure/table/standard,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18390,7 +17836,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"GK" = (
+"Go" = (
 /obj/structure/bed/padded,
 /obj/item/clothing/under/color/white,
 /obj/item/clothing/shoes/white,
@@ -18400,7 +17846,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"GL" = (
+"Gp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 6
@@ -18413,7 +17859,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"GM" = (
+"Gq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -18425,7 +17871,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"GN" = (
+"Gr" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -18442,7 +17888,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"GO" = (
+"Gs" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
 	req_access = list(6)
@@ -18462,7 +17908,7 @@
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue)
-"GP" = (
+"Gt" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -18483,7 +17929,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GQ" = (
+"Gu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -18507,7 +17953,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GR" = (
+"Gv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18528,7 +17974,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GS" = (
+"Gw" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	autoclose = 1;
 	dir = 2;
@@ -18553,7 +17999,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GT" = (
+"Gx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18572,7 +18018,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GU" = (
+"Gy" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j1";
 	dir = 4
@@ -18598,7 +18044,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GV" = (
+"Gz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18618,7 +18064,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GW" = (
+"GA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18639,7 +18085,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GX" = (
+"GB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18660,7 +18106,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GY" = (
+"GC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18679,7 +18125,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"GZ" = (
+"GD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18697,7 +18143,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ha" = (
+"GE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18715,7 +18161,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Hb" = (
+"GF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -18733,7 +18179,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Hc" = (
+"GG" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -18747,7 +18193,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Hd" = (
+"GH" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -18760,14 +18206,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"He" = (
+"GI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Hf" = (
+"GJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -18779,64 +18225,13 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"Hg" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Hh" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Hi" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/test_range)
-"Hj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/outpost/research/hallway)
-"Hk" = (
+"GK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Hl" = (
+"GL" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Camera Corridor 2";
 	dir = 8
@@ -18856,7 +18251,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Hm" = (
+"GM" = (
 /obj/machinery/optable{
 	name = "Xenobiology Operating Table"
 	},
@@ -18871,13 +18266,13 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Hn" = (
+"GN" = (
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Ho" = (
+"GO" = (
 /obj/structure/table/standard,
 /obj/item/weapon/circular_saw,
 /obj/item/weapon/scalpel{
@@ -18897,7 +18292,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Hp" = (
+"GP" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
@@ -18910,17 +18305,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Hq" = (
+"GQ" = (
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Hr" = (
+"GR" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Hs" = (
+"GS" = (
 /obj/machinery/door/window/westright{
 	name = "Containment Pen";
 	req_access = list(47)
@@ -18933,7 +18328,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Ht" = (
+"GT" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -18949,14 +18344,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Hu" = (
+"GU" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 6";
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Hv" = (
+"GV" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -18966,12 +18361,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Hw" = (
+"GW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Hx" = (
+"GX" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/cups,
 /obj/machinery/newscaster{
@@ -18979,20 +18374,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Hy" = (
+"GY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Hz" = (
+"GZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"HA" = (
+"Ha" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes,
 /obj/structure/disposalpipe/trunk{
@@ -19004,7 +18399,7 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"HB" = (
+"Hb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -19017,7 +18412,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"HC" = (
+"Hc" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Morgue";
 	dir = 8;
@@ -19032,10 +18427,10 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"HD" = (
+"Hd" = (
 /turf/simulated/wall,
 /area/medical/medbay4)
-"HE" = (
+"He" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical{
 	name = "Staff Wing";
@@ -19051,10 +18446,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"HF" = (
+"Hf" = (
 /turf/simulated/wall,
 /area/medical/ward)
-"HG" = (
+"Hg" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Patient Ward";
 	req_access = list(5)
@@ -19069,12 +18464,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"HH" = (
+"Hh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"HI" = (
+"Hi" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19086,7 +18481,7 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"HJ" = (
+"Hj" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19097,22 +18492,22 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"HK" = (
+"Hk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"HL" = (
+"Hl" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"HM" = (
+"Hm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"HN" = (
+"Hn" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19124,7 +18519,7 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"HO" = (
+"Ho" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19135,48 +18530,12 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"HP" = (
-/obj/machinery/door/window/southright,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"HQ" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/item/device/firing_pin/test_range,
-/obj/item/device/firing_pin/test_range,
-/obj/item/device/firing_pin/test_range,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"HR" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"HS" = (
-/obj/structure/table/reinforced,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/structure/closet/crate{
-	name = "Target Crate"
-	},
-/obj/item/weapon/storage/box/monkeycubes,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"HT" = (
+"Hp" = (
 /obj/effect/floor_decal/corner/mauve/full,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"HU" = (
+"Hq" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -19185,7 +18544,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"HV" = (
+"Hr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -19200,12 +18559,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"HW" = (
+"Hs" = (
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/research_maintenance)
-"HX" = (
+"Ht" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Camera Corridor 1";
 	dir = 4
@@ -19216,11 +18575,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"HY" = (
+"Hu" = (
 /obj/item/toy/plushie/spider,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"HZ" = (
+"Hv" = (
 /obj/machinery/smartfridge/secure/extract,
 /obj/effect/floor_decal/corner/white/full,
 /turf/simulated/floor/tiled{
@@ -19228,7 +18587,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Ia" = (
+"Hw" = (
 /obj/effect/floor_decal/corner/white{
 	icon_state = "corner_white";
 	dir = 10
@@ -19238,7 +18597,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Ib" = (
+"Hx" = (
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
 	pixel_x = 26;
@@ -19254,14 +18613,14 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Ic" = (
+"Hy" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Id" = (
+"Hz" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -19282,7 +18641,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"Ie" = (
+"HA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19308,20 +18667,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"If" = (
+"HB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Ig" = (
+"HC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Ih" = (
+"HD" = (
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
@@ -19330,13 +18689,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Ii" = (
+"HE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/lime,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ij" = (
+"HF" = (
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -19344,7 +18703,7 @@
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ik" = (
+"HG" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19356,7 +18715,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Il" = (
+"HH" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -19368,11 +18727,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Im" = (
+"HI" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"In" = (
+"HJ" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Starboard";
 	dir = 8
@@ -19380,14 +18739,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Io" = (
+"HK" = (
 /obj/structure/flora/pottedplant/random,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Ip" = (
+"HL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19402,7 +18761,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Iq" = (
+"HM" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -19410,7 +18769,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Ir" = (
+"HN" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -19420,7 +18779,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Is" = (
+"HO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19434,7 +18793,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"It" = (
+"HP" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -19446,7 +18805,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Iu" = (
+"HQ" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -19463,12 +18822,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Iv" = (
+"HR" = (
 /obj/structure/bed/chair/comfy/teal,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Iw" = (
+"HS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -19480,7 +18839,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ix" = (
+"HT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -19492,12 +18851,12 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Iy" = (
+"HU" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Iz" = (
+"HV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 5
@@ -19505,14 +18864,14 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"IA" = (
+"HW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"IB" = (
+"HX" = (
 /obj/structure/bed/chair/comfy/teal{
 	dir = 8;
 	icon_state = "comfychair_preview"
@@ -19520,26 +18879,14 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"IC" = (
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"ID" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"IE" = (
+"HY" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Toxins Lab";
 	req_access = list(7)
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"IF" = (
+"HZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -19553,7 +18900,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/hallway)
-"IG" = (
+"Ia" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Toxins Lab";
 	req_access = list(7)
@@ -19567,7 +18914,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"IH" = (
+"Ib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -19579,7 +18926,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"II" = (
+"Ic" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -19589,7 +18936,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"IJ" = (
+"Id" = (
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
@@ -19607,7 +18954,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IK" = (
+"Ie" = (
 /obj/item/device/radio/intercom{
 	frequency = 1459;
 	name = "Station Intercom (General)";
@@ -19620,7 +18967,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IL" = (
+"If" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
@@ -19630,14 +18977,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IM" = (
+"Ig" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IN" = (
+"Ih" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Fore"
 	},
@@ -19647,18 +18994,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IO" = (
+"Ii" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IP" = (
+"Ij" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"IQ" = (
+"Ik" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Virology Cell C";
 	dir = 4;
@@ -19673,7 +19020,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"IR" = (
+"Il" = (
 /obj/machinery/door/window/westleft{
 	name = "Virology Isolation Cell Ceta";
 	req_access = list(39)
@@ -19691,7 +19038,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"IS" = (
+"Im" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -19707,7 +19054,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"IT" = (
+"In" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -19715,7 +19062,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"IU" = (
+"Io" = (
 /obj/structure/sink{
 	pixel_y = 16
 	},
@@ -19724,14 +19071,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"IV" = (
+"Ip" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"IW" = (
+"Iq" = (
 /obj/effect/landmark{
 	name = "blobstart"
 	},
@@ -19741,14 +19088,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"IX" = (
+"Ir" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"IY" = (
+"Is" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
@@ -19757,7 +19104,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"IZ" = (
+"It" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -19771,7 +19118,7 @@
 	temperature = 278
 	},
 /area/medical/morgue)
-"Ja" = (
+"Iu" = (
 /obj/structure/bed/chair/wheelchair{
 	icon_state = "wheelchair";
 	dir = 4
@@ -19779,7 +19126,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Jb" = (
+"Iv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19790,7 +19137,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Jc" = (
+"Iw" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/medical,
 /obj/machinery/vending/wallmed1{
@@ -19800,10 +19147,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Jd" = (
+"Ix" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Je" = (
+"Iy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/lime{
@@ -19812,14 +19159,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Jf" = (
+"Iz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Jg" = (
+"IA" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/medical,
 /obj/machinery/vending/wallmed1{
@@ -19829,12 +19176,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Jh" = (
+"IB" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Ji" = (
+"IC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -19842,7 +19189,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Jj" = (
+"ID" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 8
@@ -19855,7 +19202,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"Jk" = (
+"IE" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -19864,7 +19211,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"Jl" = (
+"IF" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -19876,19 +19223,19 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/medical/patient_wing)
-"Jm" = (
+"IG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Jn" = (
+"IH" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"Jo" = (
+"II" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -19899,20 +19246,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing)
-"Jp" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"Jq" = (
-/obj/machinery/light{
-	dir = 4;
-	status = 2
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"Jr" = (
+"IJ" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 8
@@ -19920,7 +19254,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Js" = (
+"IK" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -19931,7 +19265,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Jt" = (
+"IL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -19946,7 +19280,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ju" = (
+"IM" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -19954,7 +19288,7 @@
 	icon_state = "plating"
 	},
 /area/turbolift/research_maintenance)
-"Jv" = (
+"IN" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -19962,7 +19296,7 @@
 	icon_state = "plating"
 	},
 /area/turbolift/research_maintenance)
-"Jw" = (
+"IO" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -19970,7 +19304,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Jx" = (
+"IP" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
@@ -19986,14 +19320,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Jy" = (
+"IQ" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Jz" = (
+"IR" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
@@ -20007,7 +19341,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"JA" = (
+"IS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -20015,7 +19349,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"JB" = (
+"IT" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/blast_door{
@@ -20038,7 +19372,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"JC" = (
+"IU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -20061,7 +19395,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"JD" = (
+"IV" = (
 /obj/machinery/door/window/eastleft{
 	name = "Simian Storage";
 	req_access = list(39)
@@ -20071,19 +19405,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"JE" = (
+"IW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"JF" = (
+"IX" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"JG" = (
+"IY" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
 	dir = 4
@@ -20093,14 +19427,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"JH" = (
+"IZ" = (
 /obj/machinery/cryopod{
 	icon_state = "body_scanner_0";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"JI" = (
+"Ja" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -20108,7 +19442,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"JJ" = (
+"Jb" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
 /obj/effect/floor_decal/industrial/warning{
@@ -20120,7 +19454,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"JK" = (
+"Jc" = (
 /obj/structure/bed/chair/wheelchair{
 	icon_state = "wheelchair";
 	dir = 4
@@ -20136,7 +19470,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"JL" = (
+"Jd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20154,7 +19488,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"JM" = (
+"Je" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
 	dir = 4
@@ -20174,13 +19508,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"JN" = (
+"Jf" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"JO" = (
+"Jg" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
 	dir = 8
@@ -20197,7 +19531,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"JP" = (
+"Jh" = (
 /obj/structure/bed/chair/comfy/teal{
 	icon_state = "comfychair_preview";
 	dir = 1
@@ -20205,12 +19539,12 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"JQ" = (
+"Ji" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"JR" = (
+"Jj" = (
 /obj/machinery/vending/coffee,
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
@@ -20221,7 +19555,7 @@
 	dir = 5
 	},
 /area/medical/patient_wing)
-"JS" = (
+"Jk" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled{
@@ -20229,7 +19563,7 @@
 	dir = 5
 	},
 /area/medical/patient_wing)
-"JT" = (
+"Jl" = (
 /obj/machinery/vending/snack,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -20239,13 +19573,13 @@
 	dir = 5
 	},
 /area/medical/patient_wing)
-"JU" = (
+"Jm" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/cups,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"JV" = (
+"Jn" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
@@ -20256,13 +19590,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"JW" = (
+"Jo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"JX" = (
+"Jp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -20278,7 +19612,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"JY" = (
+"Jq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -20292,7 +19626,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"JZ" = (
+"Jr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -20310,7 +19644,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ka" = (
+"Js" = (
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1379;
@@ -20343,7 +19677,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kb" = (
+"Jt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -20357,7 +19691,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kc" = (
+"Ju" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -20371,7 +19705,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kd" = (
+"Jv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -20385,7 +19719,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ke" = (
+"Jw" = (
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1379;
@@ -20409,7 +19743,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kf" = (
+"Jx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -20425,7 +19759,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kg" = (
+"Jy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -20434,7 +19768,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kh" = (
+"Jz" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
@@ -20446,7 +19780,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ki" = (
+"JA" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/beakers{
 	pixel_x = 2;
@@ -20467,7 +19801,7 @@
 /obj/item/weapon/storage/bag/slimes,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kj" = (
+"JB" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/syringes,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -20482,7 +19816,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kk" = (
+"JC" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
@@ -20494,7 +19828,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kl" = (
+"JD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -20503,13 +19837,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Km" = (
+"JE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Kn" = (
+"JF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 9
@@ -20520,7 +19854,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ko" = (
+"JG" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -20536,18 +19870,18 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Kp" = (
+"JH" = (
 /mob/living/carbon/slime,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Kq" = (
+"JI" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 5";
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Kr" = (
+"JJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -20556,10 +19890,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"Ks" = (
+"JK" = (
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Kt" = (
+"JL" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -20579,7 +19913,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Ku" = (
+"JM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -20596,7 +19930,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Kv" = (
+"JN" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -20616,7 +19950,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"Kw" = (
+"JO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20632,11 +19966,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Kx" = (
+"JP" = (
 /obj/structure/curtain,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Ky" = (
+"JQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -20647,7 +19981,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Kz" = (
+"JR" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/lime{
@@ -20655,12 +19989,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"KA" = (
+"JS" = (
 /obj/structure/flora/pottedplant/random,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"KB" = (
+"JT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -20672,7 +20006,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"KC" = (
+"JU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20681,7 +20015,7 @@
 	dir = 5
 	},
 /area/medical/patient_wing)
-"KD" = (
+"JV" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/light,
 /obj/structure/sign/nosmoking_1{
@@ -20696,20 +20030,20 @@
 	dir = 5
 	},
 /area/medical/patient_wing)
-"KE" = (
+"JW" = (
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/medical/patient_wing)
-"KF" = (
+"JX" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
-"KG" = (
+"JY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -20724,7 +20058,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"KH" = (
+"JZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -20740,20 +20074,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"KI" = (
+"Ka" = (
 /obj/turbolift_map_holder/aurora/research,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
 /area/turbolift/research_maintenance)
-"KJ" = (
+"Kb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/mauve/full,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"KK" = (
+"Kc" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
@@ -20764,14 +20098,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"KL" = (
+"Kd" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"KM" = (
+"Ke" = (
 /obj/structure/sink{
 	icon_state = "sink";
 	dir = 8;
@@ -20790,7 +20124,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KN" = (
+"Kf" = (
 /obj/machinery/shower{
 	dir = 1
 	},
@@ -20800,7 +20134,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KO" = (
+"Kg" = (
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -20827,7 +20161,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KP" = (
+"Kh" = (
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	id_tag = "xeno_airlock_control";
 	name = "Xenobiology Access Console";
@@ -20852,13 +20186,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KQ" = (
+"Ki" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KR" = (
+"Kj" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped,
 /obj/item/weapon/reagent_containers/spray/cleaner,
@@ -20872,7 +20206,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KS" = (
+"Kk" = (
 /obj/structure/table/standard,
 /obj/machinery/reagentgrinder,
 /obj/effect/floor_decal/corner/red{
@@ -20881,17 +20215,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KT" = (
+"Kl" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KU" = (
+"Km" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"KV" = (
+"Kn" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -20917,40 +20251,40 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"KW" = (
+"Ko" = (
 /turf/simulated/wall,
 /area/crew_quarters/medbreak)
-"KX" = (
+"Kp" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"KY" = (
+"Kq" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"KZ" = (
+"Kr" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"La" = (
+"Ks" = (
 /turf/unsimulated/chasm_mask,
 /area/crew_quarters/medbreak)
-"Lb" = (
+"Kt" = (
 /obj/structure/table/standard,
 /obj/item/weapon/cane,
 /obj/item/weapon/storage/box/rxglasses,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Lc" = (
+"Ku" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
 	dir = 4
@@ -20967,14 +20301,14 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Ld" = (
+"Kv" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Le" = (
+"Kw" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -20982,7 +20316,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Lf" = (
+"Kx" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
 	dir = 8
@@ -21002,32 +20336,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Lg" = (
+"Ky" = (
 /turf/simulated/wall/r_wall,
 /area/medical/ward)
-"Lh" = (
+"Kz" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/medical/patient_wing)
-"Li" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"Lj" = (
-/obj/structure/target_stake,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/test_range)
-"Lk" = (
+"KA" = (
 /obj/effect/floor_decal/corner/mauve/full,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Ll" = (
+"KB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -21041,7 +20361,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway)
-"Lm" = (
+"KC" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
 	},
@@ -21057,7 +20377,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ln" = (
+"KD" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/item/weapon/storage/box/monkeycubes,
@@ -21066,7 +20386,7 @@
 /obj/effect/floor_decal/corner/mauve/full,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Lo" = (
+"KE" = (
 /obj/structure/table/standard,
 /obj/item/stack/material/phoron{
 	amount = 5
@@ -21077,7 +20397,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Lp" = (
+"KF" = (
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -21086,27 +20406,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Lq" = (
+"KG" = (
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"Lr" = (
+"KH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"Ls" = (
+"KI" = (
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"Lt" = (
+"KJ" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/item/device/radio/intercom{
@@ -21118,11 +20438,11 @@
 	dir = 5
 	},
 /area/crew_quarters/medbreak)
-"Lu" = (
+"KK" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Lv" = (
+"KL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21134,7 +20454,7 @@
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Lw" = (
+"KM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -21143,17 +20463,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Lx" = (
+"KN" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"Ly" = (
+"KO" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"Lz" = (
+"KP" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/storage)
-"LA" = (
+"KQ" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
 	req_access = list(8)
@@ -21161,7 +20481,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/rnd/storage)
-"LB" = (
+"KR" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
 	req_access = list(8)
@@ -21176,7 +20496,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/rnd/storage)
-"LC" = (
+"KS" = (
 /obj/structure/sink{
 	pixel_y = 26
 	},
@@ -21195,7 +20515,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"LD" = (
+"KT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -21210,7 +20530,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"LE" = (
+"KU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 9
@@ -21226,17 +20546,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"LF" = (
+"KV" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"LG" = (
+"KW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"LH" = (
+"KX" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/blast_door{
@@ -21255,7 +20575,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"LI" = (
+"KY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -21278,7 +20598,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"LJ" = (
+"KZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -21292,26 +20612,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"LK" = (
+"La" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LL" = (
+"Lb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LM" = (
+"Lc" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LN" = (
+"Ld" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LO" = (
+"Le" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -21325,14 +20645,14 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LP" = (
+"Lf" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"LQ" = (
+"Lg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -21347,13 +20667,13 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"LR" = (
+"Lh" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"LS" = (
+"Li" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
 	dir = 4;
@@ -21370,14 +20690,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"LT" = (
+"Lj" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"LU" = (
+"Lk" = (
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Pill Cabinet";
 	pixel_y = -32
@@ -21390,7 +20710,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"LV" = (
+"Ll" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -21410,7 +20730,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"LW" = (
+"Lm" = (
 /obj/machinery/vending/snack,
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
@@ -21421,21 +20741,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"LX" = (
+"Ln" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"LY" = (
+"Lo" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"LZ" = (
+"Lp" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10;
 	icon_state = "intact"
@@ -21446,7 +20766,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ma" = (
+"Lq" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Toxins Mixing Fore"
 	},
@@ -21456,17 +20776,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Mb" = (
+"Lr" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Mc" = (
+"Ls" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Md" = (
+"Lt" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
@@ -21477,25 +20797,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Me" = (
+"Lu" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	icon_state = "intact";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Mf" = (
+"Lv" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Mg" = (
+"Lw" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Mh" = (
+"Lx" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Toxins Storage"
 	},
@@ -21504,7 +20824,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Mi" = (
+"Ly" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -21517,33 +20837,33 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Mj" = (
+"Lz" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Mk" = (
+"LA" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/mauve/full,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Ml" = (
+"LB" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Mm" = (
+"LC" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"Mn" = (
+"LD" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -21559,14 +20879,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Mo" = (
+"LE" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 4";
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Mp" = (
+"LF" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -21578,7 +20898,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"Mq" = (
+"LG" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -21587,7 +20907,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Mr" = (
+"LH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -21597,7 +20917,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Ms" = (
+"LI" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
@@ -21610,7 +20930,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Mt" = (
+"LJ" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/donut,
 /obj/structure/disposalpipe/junction/yjunction{
@@ -21630,7 +20950,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Mu" = (
+"LK" = (
 /obj/item/weapon/stool/padded,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21654,7 +20974,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Mv" = (
+"LL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -21672,7 +20992,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Mw" = (
+"LM" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Staff Break Room";
 	req_access = list(5)
@@ -21695,7 +21015,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Mx" = (
+"LN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -21712,7 +21032,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"My" = (
+"LO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -21734,7 +21054,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Mz" = (
+"LP" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/unary/freezer{
 	icon_state = "freezer_0";
@@ -21742,39 +21062,39 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MA" = (
+"LQ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MB" = (
+"LR" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MC" = (
+"LS" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MD" = (
+"LT" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"ME" = (
+"LU" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MF" = (
+"LV" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
 	frequency = 1441;
@@ -21785,11 +21105,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MG" = (
+"LW" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"MH" = (
+"LX" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -21797,7 +21117,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"MI" = (
+"LY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -21806,13 +21126,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"MJ" = (
+"LZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"MK" = (
+"Ma" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -21827,7 +21147,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"ML" = (
+"Mb" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
 	dir = 4;
@@ -21836,7 +21156,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"MM" = (
+"Mc" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -21851,7 +21171,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"MN" = (
+"Md" = (
 /obj/machinery/door/window/northright{
 	name = "Containment Pen";
 	req_access = list(47)
@@ -21864,7 +21184,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"MO" = (
+"Me" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -21884,7 +21204,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"MP" = (
+"Mf" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -21900,7 +21220,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"MQ" = (
+"Mg" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -21920,7 +21240,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"MR" = (
+"Mh" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Aft";
@@ -21928,7 +21248,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"MS" = (
+"Mi" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -21948,7 +21268,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"MT" = (
+"Mj" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -21965,7 +21285,7 @@
 	dir = 5
 	},
 /area/rnd/xenobiology)
-"MU" = (
+"Mk" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -21991,7 +21311,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"MV" = (
+"Ml" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -22002,7 +21322,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"MW" = (
+"Mm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -22011,7 +21331,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"MX" = (
+"Mn" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -22023,7 +21343,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"MY" = (
+"Mo" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
 /obj/machinery/light{
@@ -22038,13 +21358,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"MZ" = (
+"Mp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Na" = (
+"Mq" = (
 /obj/structure/table/glass,
 /obj/item/device/radio{
 	anchored = 1;
@@ -22059,7 +21379,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Nb" = (
+"Mr" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/structure/disposalpipe/segment,
@@ -22071,7 +21391,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Nc" = (
+"Ms" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -22079,7 +21399,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Nd" = (
+"Mt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -22093,16 +21413,16 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"Ne" = (
+"Mu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Nf" = (
+"Mv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Ng" = (
+"Mw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -22117,20 +21437,20 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/medical/medbay4)
-"Nh" = (
+"Mx" = (
 /obj/structure/table/rack,
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
 /obj/item/device/flashlight,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Ni" = (
+"My" = (
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Nj" = (
+"Mz" = (
 /obj/structure/table/rack,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
@@ -22151,7 +21471,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Nk" = (
+"MA" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/belt/medical,
 /obj/item/weapon/storage/belt/medical,
@@ -22165,21 +21485,21 @@
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Nl" = (
+"MB" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
 /obj/item/weapon/storage/toolbox/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"Nm" = (
+"MC" = (
 /obj/structure/closet/secure_closet/medical3,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Nn" = (
+"MD" = (
 /turf/simulated/wall/r_wall,
 /area/medical/medbay4)
-"No" = (
+"ME" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
@@ -22189,14 +21509,14 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Np" = (
+"MF" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Nq" = (
+"MG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 5
@@ -22204,13 +21524,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Nr" = (
+"MH" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ns" = (
+"MI" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	icon_state = "map_vent_in";
 	dir = 8;
@@ -22226,7 +21546,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Nt" = (
+"MJ" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/alarm{
 	dir = 4;
@@ -22236,17 +21556,17 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Nu" = (
+"MK" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Nv" = (
+"ML" = (
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Nw" = (
+"MM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -22261,7 +21581,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Nx" = (
+"MN" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22269,7 +21589,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Ny" = (
+"MO" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -22277,7 +21597,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Nz" = (
+"MP" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -22301,7 +21621,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"NA" = (
+"MQ" = (
 /obj/machinery/door/window/southright{
 	name = "Containment Pen";
 	req_access = list(47)
@@ -22317,7 +21637,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"NB" = (
+"MR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -22340,7 +21660,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"NC" = (
+"MS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -22364,7 +21684,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"ND" = (
+"MT" = (
 /obj/machinery/door/window/southright{
 	name = "Containment Pen";
 	req_access = list(47)
@@ -22380,7 +21700,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"NE" = (
+"MU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -22403,7 +21723,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"NF" = (
+"MV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -22427,7 +21747,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"NG" = (
+"MW" = (
 /obj/machinery/door/window/southright{
 	name = "Containment Pen";
 	req_access = list(47)
@@ -22443,7 +21763,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"NH" = (
+"MX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -22466,7 +21786,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
-"NI" = (
+"MY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -22477,11 +21797,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"NJ" = (
+"MZ" = (
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"NK" = (
+"Na" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
@@ -22489,14 +21809,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"NL" = (
+"Nb" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Staff Smoking Lounge"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"NM" = (
+"Nc" = (
 /obj/machinery/recharge_station,
 /obj/machinery/alarm{
 	dir = 4;
@@ -22511,7 +21831,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"NN" = (
+"Nd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22521,12 +21841,12 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"NO" = (
+"Ne" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"NP" = (
+"Nf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -22537,7 +21857,7 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"NQ" = (
+"Ng" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -22546,7 +21866,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"NR" = (
+"Nh" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Auxiliary Storage";
 	req_access = list(5)
@@ -22560,7 +21880,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"NS" = (
+"Ni" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -22569,7 +21889,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"NT" = (
+"Nj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -22578,29 +21898,29 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"NU" = (
+"Nk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"NV" = (
+"Nl" = (
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"NW" = (
+"Nm" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 6
 	},
 /turf/simulated/mineral,
 /area/mine/unexplored)
-"NX" = (
+"Nn" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"NY" = (
+"No" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -22611,13 +21931,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"NZ" = (
+"Np" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Oa" = (
+"Nq" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
 	name = "To Space"
@@ -22625,7 +21945,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ob" = (
+"Nr" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10;
 	icon_state = "intact"
@@ -22641,14 +21961,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Oc" = (
+"Ns" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	icon_state = "intact";
 	dir = 1
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"Od" = (
+"Nt" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -22662,7 +21982,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Oe" = (
+"Nu" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/light{
 	dir = 8
@@ -22670,29 +21990,29 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Of" = (
+"Nv" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Og" = (
+"Nw" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Oh" = (
+"Nx" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Oi" = (
+"Ny" = (
 /obj/structure/bed/chair/comfy/beige,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"Oj" = (
+"Nz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -22702,7 +22022,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"Ok" = (
+"NA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22714,7 +22034,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"Ol" = (
+"NB" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Staff Smoking Lounge";
 	req_access = list(5)
@@ -22731,7 +22051,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"Om" = (
+"NC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22749,7 +22069,7 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"On" = (
+"ND" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22766,7 +22086,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Oo" = (
+"NE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22787,7 +22107,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Op" = (
+"NF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -22806,13 +22126,13 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Oq" = (
+"NG" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/cups,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Or" = (
+"NH" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/item/weapon/tape_roll,
@@ -22821,7 +22141,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"Os" = (
+"NI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -22833,13 +22153,13 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"Ot" = (
+"NJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Ou" = (
+"NK" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
 	name = "Grenade Crate";
@@ -22861,25 +22181,25 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Ov" = (
+"NL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Ow" = (
+"NM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"Ox" = (
+"NN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay4)
-"Oy" = (
+"NO" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/light{
 	dir = 4;
@@ -22887,11 +22207,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Oz" = (
+"NP" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/mineral,
 /area/mine/unexplored)
-"OA" = (
+"NQ" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/light{
 	dir = 8
@@ -22899,7 +22219,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"OB" = (
+"NR" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -22907,7 +22227,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"OC" = (
+"NS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
@@ -22918,21 +22238,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"OD" = (
+"NT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"OE" = (
+"NU" = (
 /obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"OF" = (
+"NV" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"OG" = (
+"NW" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
 	name = "CO2 to Connector"
@@ -22942,7 +22262,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"OH" = (
+"NX" = (
 /obj/structure/closet/bombcloset,
 /obj/structure/cable/green{
 	d2 = 4;
@@ -22958,7 +22278,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"OI" = (
+"NY" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -22969,14 +22289,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"OJ" = (
+"NZ" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"OK" = (
+"Oa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -22991,7 +22311,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"OL" = (
+"Ob" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22999,7 +22319,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"OM" = (
+"Oc" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -23007,14 +22327,14 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"ON" = (
+"Od" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"OO" = (
+"Oe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -23026,7 +22346,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"OP" = (
+"Of" = (
 /obj/structure/table/glass,
 /obj/item/weapon/material/ashtray/bronze,
 /obj/item/device/radio{
@@ -23042,13 +22362,13 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"OQ" = (
+"Og" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"OR" = (
+"Oh" = (
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -23069,10 +22389,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"OS" = (
+"Oi" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep/medical)
-"OT" = (
+"Oj" = (
 /obj/machinery/door/airlock/medical{
 	name = "Staff Dormitories";
 	req_access = list(5)
@@ -23087,7 +22407,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"OU" = (
+"Ok" = (
 /obj/machinery/door/airlock/medical{
 	name = "Staff Hygiene Facilities";
 	req_access = list(5)
@@ -23097,14 +22417,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"OV" = (
+"Ol" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25;
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"OW" = (
+"Om" = (
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
@@ -23119,7 +22439,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"OX" = (
+"On" = (
 /obj/structure/table/standard,
 /obj/item/device/radio{
 	frequency = 1487;
@@ -23152,13 +22472,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"OY" = (
+"Oo" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/syringegun,
 /obj/item/weapon/gun/launcher/syringe,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"OZ" = (
+"Op" = (
 /obj/structure/closet/l3closet/general,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/suit/bio_suit/general,
@@ -23166,14 +22486,14 @@
 /obj/item/clothing/head/bio_hood/general,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Pa" = (
+"Oq" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored)
-"Pb" = (
+"Or" = (
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Pc" = (
+"Os" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
 	},
@@ -23182,7 +22502,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Pd" = (
+"Ot" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 5
@@ -23197,7 +22517,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Pe" = (
+"Ou" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
 	icon_state = "map_off";
@@ -23217,25 +22537,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Pf" = (
+"Ov" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Pg" = (
+"Ow" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ph" = (
+"Ox" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Pi" = (
+"Oy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -23254,7 +22574,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Pj" = (
+"Oz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -23268,7 +22588,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Pk" = (
+"OA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -23282,7 +22602,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Pl" = (
+"OB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -23299,12 +22619,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Pm" = (
+"OC" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Pn" = (
+"OD" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/machinery/light{
 	dir = 4;
@@ -23313,7 +22633,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"Po" = (
+"OE" = (
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
@@ -23322,28 +22642,28 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Pp" = (
+"OF" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 1";
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Pq" = (
+"OG" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 2";
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Pr" = (
+"OH" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Xenobiology Cell 3";
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Ps" = (
+"OI" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -23357,7 +22677,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Pt" = (
+"OJ" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
 /obj/machinery/light{
@@ -23369,7 +22689,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Pu" = (
+"OK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -23377,7 +22697,7 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"Pv" = (
+"OL" = (
 /obj/structure/sink{
 	pixel_y = 16
 	},
@@ -23389,11 +22709,11 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"Pw" = (
+"OM" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"Px" = (
+"ON" = (
 /obj/machinery/requests_console{
 	department = "Medical Bay";
 	departmentType = 1;
@@ -23402,12 +22722,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Py" = (
+"OO" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Pz" = (
+"OP" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -23422,11 +22742,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/medbay4)
-"PA" = (
+"OQ" = (
 /obj/structure/lattice/catwalk,
 /turf/simulated/open,
 /area/mine/unexplored)
-"PB" = (
+"OR" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
 	frequency = 1441;
@@ -23438,7 +22758,7 @@
 /obj/structure/lattice/catwalk,
 /turf/simulated/open,
 /area/mine/unexplored)
-"PC" = (
+"OS" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
@@ -23459,7 +22779,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"PD" = (
+"OT" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
@@ -23478,7 +22798,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"PE" = (
+"OU" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
@@ -23495,7 +22815,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"PF" = (
+"OV" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	icon_state = "phoronrwindow";
@@ -23515,7 +22835,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"PG" = (
+"OW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -23533,7 +22853,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"PH" = (
+"OX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -23547,7 +22867,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"PI" = (
+"OY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -23566,7 +22886,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"PJ" = (
+"OZ" = (
 /obj/machinery/button/remote/blast_door{
 	id = "mixvent";
 	name = "Mixing Room Vent Control";
@@ -23592,7 +22912,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"PK" = (
+"Pa" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Toxins Lab";
 	req_access = list(7)
@@ -23611,7 +22931,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"PL" = (
+"Pb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -23629,7 +22949,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"PM" = (
+"Pc" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -23637,12 +22957,12 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"PN" = (
+"Pd" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"PO" = (
+"Pe" = (
 /obj/machinery/computer/area_atmos,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning{
@@ -23650,14 +22970,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
-"PP" = (
+"Pf" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"PQ" = (
+"Pg" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -23667,7 +22987,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"PR" = (
+"Ph" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 22
@@ -23678,7 +22998,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"PS" = (
+"Pi" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
@@ -23686,7 +23006,7 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"PT" = (
+"Pj" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -23698,7 +23018,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"PU" = (
+"Pk" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -23717,7 +23037,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"PV" = (
+"Pl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -23728,13 +23048,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"PW" = (
+"Pm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"PX" = (
+"Pn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -23743,7 +23063,7 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"PY" = (
+"Po" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -23756,24 +23076,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"PZ" = (
+"Pp" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Qa" = (
+"Pq" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Qb" = (
+"Pr" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Qc" = (
+"Ps" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
@@ -23784,7 +23104,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Qd" = (
+"Pt" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair/office/light,
 /obj/effect/landmark/start{
@@ -23792,13 +23112,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Qe" = (
+"Pu" = (
 /obj/structure/sign/greencross{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Qf" = (
+"Pv" = (
 /obj/machinery/door/blast/regular{
 	dir = 1;
 	id = "mixvent";
@@ -23806,18 +23126,18 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"Qg" = (
+"Pw" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"Qh" = (
+"Px" = (
 /obj/machinery/air_sensor{
 	id_tag = "HT";
 	name = "Gas Sensor - High-Temp Chamber"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"Qi" = (
+"Py" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/sparker{
 	dir = 2;
@@ -23826,7 +23146,7 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"Qj" = (
+"Pz" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	icon_state = "phoronrwindow";
@@ -23846,20 +23166,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Qk" = (
+"PA" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Ql" = (
+"PB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Qm" = (
+"PC" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 6
@@ -23873,14 +23193,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Qn" = (
+"PD" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Qo" = (
+"PE" = (
 /obj/structure/bed,
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
@@ -23893,7 +23213,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Qp" = (
+"PF" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -23903,7 +23223,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Qq" = (
+"PG" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/green,
 /obj/machinery/light/small,
@@ -23912,7 +23232,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
-"Qr" = (
+"PH" = (
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
@@ -23920,13 +23240,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"Qs" = (
+"PI" = (
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"Qt" = (
+"PJ" = (
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Qu" = (
+"PK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -23935,7 +23255,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Qv" = (
+"PL" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
 	dir = 6
@@ -23948,7 +23268,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Qw" = (
+"PM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23962,26 +23282,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
-"Qx" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+"PN" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Qy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"Qz" = (
+"PO" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23989,7 +23293,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"QA" = (
+"PP" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
@@ -23998,13 +23302,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"QB" = (
+"PQ" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"QC" = (
+"PR" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
@@ -24013,7 +23317,7 @@
 	},
 /turf/simulated/open,
 /area/mine/unexplored)
-"QD" = (
+"PS" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	frequency = 1441;
@@ -24023,14 +23327,14 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"QE" = (
+"PT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"QF" = (
+"PU" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	icon_state = "phoronrwindow";
@@ -24053,14 +23357,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"QG" = (
+"PV" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"QH" = (
+"PW" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24072,7 +23376,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"QI" = (
+"PX" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -24091,7 +23395,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"QJ" = (
+"PY" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	icon_state = "door_open";
@@ -24099,7 +23403,7 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"QK" = (
+"PZ" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	icon_state = "door_open";
@@ -24107,35 +23411,19 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/medbreak)
-"QL" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"QM" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"QN" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"QO" = (
+"Qa" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"QP" = (
+"Qb" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"QQ" = (
+"Qc" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	icon_state = "intact";
 	dir = 9
@@ -24147,11 +23435,11 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
-"QR" = (
+"Qd" = (
 /obj/structure/dispenser,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"QS" = (
+"Qe" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 5
@@ -24165,7 +23453,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"QT" = (
+"Qf" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -24173,17 +23461,7 @@
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"QU" = (
-/obj/structure/toilet{
-	icon_state = "toilet00";
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/medbreak)
-"QV" = (
+"Qh" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair{
 	dir = 1
@@ -24193,7 +23471,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"QW" = (
+"Qi" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -24203,7 +23481,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"QX" = (
+"Qj" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -24216,7 +23494,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"QY" = (
+"Qk" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair{
 	dir = 1
@@ -24226,7 +23504,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"QZ" = (
+"Ql" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
@@ -24247,7 +23525,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Ra" = (
+"Qm" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	icon_state = "phoronrwindow";
@@ -24264,7 +23542,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Rb" = (
+"Qn" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room Access";
 	req_access = list(7)
@@ -24279,7 +23557,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
-"Rc" = (
+"Qo" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/prox_sensor,
 /obj/item/device/assembly/prox_sensor,
@@ -24291,7 +23569,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rd" = (
+"Qp" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/signaler,
 /obj/item/device/assembly/signaler,
@@ -24302,7 +23580,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Re" = (
+"Qq" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/timer,
 /obj/item/device/assembly/timer,
@@ -24315,7 +23593,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rf" = (
+"Qr" = (
 /obj/structure/table/standard,
 /obj/item/device/transfer_valve,
 /obj/item/device/transfer_valve,
@@ -24332,14 +23610,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rg" = (
+"Qs" = (
 /obj/machinery/vending/phoronresearch,
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rh" = (
+"Qt" = (
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Toxins Testing Observation"
 	},
@@ -24349,7 +23627,7 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Ri" = (
+"Qu" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
@@ -24359,7 +23637,7 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rj" = (
+"Qv" = (
 /obj/effect/floor_decal/corner/red/full{
 	icon_state = "corner_white_full";
 	dir = 1
@@ -24369,25 +23647,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rk" = (
+"Qw" = (
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Rl" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"Rm" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay4)
-"Rn" = (
+"Qx" = (
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -24395,7 +23659,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Ro" = (
+"Qy" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 9
@@ -24404,7 +23668,7 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rp" = (
+"Qz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
@@ -24417,7 +23681,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rq" = (
+"QA" = (
 /obj/item/target,
 /obj/item/target,
 /obj/item/target/alien,
@@ -24433,7 +23697,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rr" = (
+"QB" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -24447,21 +23711,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rs" = (
+"QC" = (
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rt" = (
+"QD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Ru" = (
+"QE" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Rv" = (
+"QF" = (
 /obj/machinery/door/window/southright{
 	dir = 8;
 	name = "Toxins Launcher";
@@ -24476,14 +23740,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Rw" = (
+"QG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"Rx" = (
+"QH" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair{
 	dir = 1
@@ -24493,7 +23757,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Ry" = (
+"QI" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -24502,7 +23766,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Rz" = (
+"QJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Toxins Testing Storage";
@@ -24513,7 +23777,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RA" = (
+"QK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -24527,7 +23791,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RB" = (
+"QL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -24537,7 +23801,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RC" = (
+"QM" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room";
 	req_access = list(7)
@@ -24551,7 +23815,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RD" = (
+"QN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -24564,7 +23828,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RE" = (
+"QO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -24573,24 +23837,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RF" = (
+"QP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RG" = (
+"QQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RH" = (
+"QR" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RI" = (
+"QS" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -24601,11 +23865,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RJ" = (
+"QT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"RK" = (
+"QU" = (
 /obj/machinery/requests_console{
 	department = "Medical Bay";
 	departmentType = 1;
@@ -24614,14 +23878,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"RL" = (
+"QV" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_x = 32;
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"RM" = (
+"QW" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -24629,7 +23893,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"RN" = (
+"QX" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1379;
@@ -24646,7 +23910,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"RO" = (
+"QY" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -24670,7 +23934,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"RP" = (
+"QZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1379;
@@ -24699,7 +23963,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"RQ" = (
+"Ra" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
 	icon_state = "door_locked";
@@ -24717,7 +23981,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"RR" = (
+"Rb" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 10
@@ -24742,7 +24006,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RS" = (
+"Rc" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -24759,19 +24023,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RT" = (
+"Rd" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RU" = (
+"Re" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/floor_decal/corner/red/full,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RV" = (
+"Rf" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -24782,7 +24046,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RW" = (
+"Rg" = (
 /obj/structure/table/standard,
 /obj/item/weapon/wrench,
 /obj/item/weapon/screwdriver,
@@ -24792,7 +24056,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RX" = (
+"Rh" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -24800,7 +24064,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RY" = (
+"Ri" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -24809,7 +24073,7 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"RZ" = (
+"Rj" = (
 /obj/structure/bed/chair,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the test chamber.";
@@ -24825,7 +24089,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Sa" = (
+"Rk" = (
 /obj/structure/bed/chair,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the test chamber.";
@@ -24847,11 +24111,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"Sb" = (
+"Rl" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/mineral,
 /area/mine/unexplored)
-"Sc" = (
+"Rm" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair{
 	dir = 1
@@ -24861,7 +24125,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Sd" = (
+"Rn" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -24870,12 +24134,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Se" = (
+"Ro" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Sf" = (
+"Rp" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -24884,7 +24148,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Sg" = (
+"Rq" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair{
 	dir = 1
@@ -24894,13 +24158,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"Sh" = (
+"Rr" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/rnd/mixing)
-"Si" = (
+"Rs" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -24908,7 +24172,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"Sj" = (
+"Rt" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -24930,7 +24194,7 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Sk" = (
+"Ru" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -24948,7 +24212,7 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Sl" = (
+"Rv" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -24970,13 +24234,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
-"Sm" = (
+"Rw" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: BOMB RANGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
-"Sn" = (
+"Rx" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -24989,7 +24253,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/mixing)
-"So" = (
+"Ry" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24997,20 +24261,20 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/mixing)
-"Sp" = (
+"Rz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/mineral,
 /area/mine/unexplored)
-"Sq" = (
+"RA" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/rnd/mixing)
-"Sr" = (
+"RB" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 4
@@ -25023,7 +24287,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/mixing)
-"Ss" = (
+"RC" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -25032,7 +24296,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"St" = (
+"RD" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -25040,7 +24304,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"Su" = (
+"RE" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -25048,7 +24312,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"Sv" = (
+"RF" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -25059,7 +24323,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"Sw" = (
+"RG" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -25077,11 +24341,11 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/mixing)
-"Sx" = (
+"RH" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/rnd/mixing)
-"Sy" = (
+"RI" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -25095,14 +24359,14 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/mixing)
-"Sz" = (
+"RJ" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 8
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"SA" = (
+"RK" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
 	name = "BOMB RANGE";
@@ -25111,13 +24375,13 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"SB" = (
+"RL" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: BOMB RANGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored)
-"SC" = (
+"RM" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -25127,7 +24391,7 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"SD" = (
+"RN" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -25145,40 +24409,37 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"SE" = (
+"RO" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"SF" = (
+"RP" = (
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"SG" = (
+"RQ" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"SH" = (
+"RR" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"SI" = (
+"RS" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Machinery Maintenance";
 	req_access = list(11)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"SJ" = (
-/turf/simulated/wall,
-/area/maintenance/disposal)
-"SK" = (
+"RT" = (
 /obj/machinery/crusher_base,
 /turf/simulated/floor/reinforced,
 /area/maintenance/disposal)
-"SL" = (
+"RU" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
 	name = "KEEP CLEAR: MEDICAL EXOSUIT PARKING";
@@ -25186,7 +24447,7 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"SM" = (
+"RV" = (
 /obj/structure/ladder/up,
 /obj/item/device/radio/intercom{
 	dir = 0;
@@ -25195,7 +24456,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"SN" = (
+"RW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -25210,21 +24471,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"SO" = (
+"RX" = (
 /obj/random/junk,
 /turf/simulated/floor/reinforced{
 	roof_type = null
 	},
 /area/maintenance/disposal)
-"SP" = (
+"RY" = (
 /turf/simulated/floor/reinforced{
 	roof_type = null
 	},
 /area/maintenance/disposal)
-"SQ" = (
+"RZ" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/test_area)
-"SR" = (
+"Sa" = (
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -25235,7 +24496,7 @@
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/test_area)
-"SS" = (
+"Sb" = (
 /obj/item/modular_computer/telescreen/preset/trashcompactor{
 	pixel_x = -32
 	},
@@ -25250,14 +24511,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"ST" = (
+"Sc" = (
 /obj/machinery/light/small/emergency{
 	icon_state = "bulb1";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"SU" = (
+"Sd" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -25269,12 +24530,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"SV" = (
+"Se" = (
 /turf/simulated/floor/tiled/airless{
 	icon_state = "asteroidfloor"
 	},
 /area/rnd/test_area)
-"SW" = (
+"Sf" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	id_tag = "crusher";
 	name = "Compactor Access";
@@ -25282,24 +24543,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"SX" = (
+"Sg" = (
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
-"SY" = (
+"Sh" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"SZ" = (
+"Si" = (
 /obj/structure/window/reinforced{
 	dir = 5;
 	health = 1e+007
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
-"Ta" = (
+"Sj" = (
 /obj/machinery/light/spot{
 	icon_state = "tube1";
 	dir = 8
@@ -25311,11 +24572,11 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
-"Tb" = (
+"Sk" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
-"Tc" = (
+"Sl" = (
 /obj/machinery/light/spot{
 	icon_state = "tube1";
 	dir = 4
@@ -25327,7 +24588,7 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
-"Td" = (
+"Sm" = (
 /obj/machinery/light/spot,
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Sublevel - Toxins Testing Aft";
@@ -25336,6 +24597,888 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
+"So" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4;
+	name = "Firelock"
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/hallway)
+"Sp" = (
+/turf/simulated/wall,
+/area/engineering/atmos)
+"St" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/engineering/gravity_gen)
+"Su" = (
+/obj/machinery/camera/network/engineering_outpost{
+	c_tag = "Engineering Sublevel - Gravity Chamber";
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/engineering/gravity_gen)
+"Sv" = (
+/turf/simulated/wall,
+/area/maintenance/sublevel)
+"Sx" = (
+/turf/simulated/wall,
+/area/bridge/aibunker)
+"SC" = (
+/turf/simulated/wall,
+/area/outpost/research/anomaly_analysis)
+"SF" = (
+/turf/simulated/wall,
+/area/outpost/research/analysis)
+"SI" = (
+/turf/simulated/wall,
+/area/outpost/research/emergency_storage)
+"SQ" = (
+/turf/simulated/wall,
+/area/outpost/research/eva)
+"Tc" = (
+/turf/simulated/wall,
+/area/outpost/research/hallway)
+"Tj" = (
+/turf/simulated/wall,
+/area/maintenance/disposal)
+"Tk" = (
+/obj/structure/table/rack,
+/obj/item/hoist_kit,
+/turf/simulated/floor/asteroid/ash/rocky,
+/area/mine/unexplored)
+"Tl" = (
+/obj/machinery/door/firedoor{
+	dir = 4;
+	name = "Firelock"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Anomalous Materials Locker Room";
+	req_access = list(65)
+	},
+/turf/simulated/floor/tiled/white,
+/area/outpost/research/anomaly_analysis)
+"Tm" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"Tn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"To" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"Tp" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"Tq" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"Tr" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"Ts" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	icon_state = "map";
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
+"Tt" = (
+/obj/effect/floor_decal/corner/black{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
+"Tu" = (
+/obj/effect/floor_decal/corner/black{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	icon_state = "map";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
+"Tv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	dir = 2;
+	name = "light switch ";
+	pixel_x = 0;
+	pixel_y = 36
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	is_critical = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/simulated/floor/plating,
+/area/outpost/engineering/power)
+"Tw" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Break Room";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/hallway)
+"Tx" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Restrooms";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/freezer,
+/area/outpost/engineering/meeting)
+"Ty" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/valve/digital{
+	dir = 4;
+	icon_state = "map_valve0";
+	name = "Air Bypass valve"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
+"Tz" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Tesla Bay";
+	req_access = list(11)
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/engineering/power)
+"TA" = (
+/obj/machinery/atmospherics/pipe/zpipe/up/cyan{
+	icon_state = "up";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
+"TB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Storage";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/outpost/engineering/hallway)
+"TC" = (
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Storage";
+	req_one_access = list(11,24)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/outpost/engineering/hallway)
+"TD" = (
+/obj/machinery/atmospherics/pipe/zpipe/up/yellow{
+	icon_state = "up";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
+"TE" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access = list(11,24)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/sublevel)
+"TF" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/sublevel)
+"TG" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/rig_module/vision/nvg,
+/turf/simulated/floor/plating,
+/area/security/nuke_storage)
+"TH" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/rig_module/chem_dispenser/injector,
+/turf/simulated/floor/plating,
+/area/security/nuke_storage)
+"TI" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	desc = "It opens and closes. It has a small sign engraved: Bunker capacity: 6. Only facility's Command Staff is permitted.";
+	icon_state = "door_locked";
+	id_tag = "bunker3";
+	locked = 1;
+	name = "Command Bunker";
+	req_access = list(19);
+	secured_wires = 1
+	},
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/bridge/aibunker)
+"TJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/item/device/radio/intercom/locked{
+	frequency = 1347;
+	locked_frequency = 1347;
+	name = "Bunker Entrance Intercom";
+	pixel_x = 0;
+	pixel_y = 22
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"TK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"TL" = (
+/obj/machinery/door/airlock/highsecurity{
+	id_tag = null;
+	name = "Auxiliary Commanding Post";
+	req_access = list(19)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"TM" = (
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"TN" = (
+/obj/structure/table/reinforced/steel,
+/obj/machinery/cell_charger,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"TO" = (
+/obj/structure/table/reinforced/steel,
+/obj/item/weapon/storage/firstaid/regular,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/aibunker)
+"TP" = (
+/obj/machinery/firealarm/north,
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
+"TQ" = (
+/obj/structure/toilet{
+	icon_state = "toilet00";
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/medbreak)
+"TR" = (
+/obj/structure/toilet{
+	icon_state = "toilet00";
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/medbreak)
+"TS" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"TT" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"TU" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"TV" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"TW" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"TX" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"TY" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/bodyscanner{
+	tag = "icon-body_scanner_0 (WEST)";
+	icon_state = "body_scanner_0";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"TZ" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/body_scanconsole{
+	tag = "icon-body_scannerconsole (WEST)";
+	icon_state = "body_scannerconsole";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Ua" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/bed/chair/office/light{
+	tag = "icon-officechair_white (EAST)";
+	icon_state = "officechair_white";
+	dir = 4
+	},
+/obj/machinery/firealarm/north,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Ub" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Uc" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"Ud" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Ue" = (
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Uf" = (
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Ug" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Uh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/outpost/research/hallway)
+"Ui" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"Uj" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 6
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Uk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Ul" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Um" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Un" = (
+/obj/machinery/door/airlock/glass_research{
+	name = "Test Range"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/outpost/research/hallway)
+"Uo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/outpost/research/hallway)
+"Up" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/outpost/research/hallway)
+"Uq" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"Ur" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Us" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Ut" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Uu" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/test_range)
+"Uv" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/outpost/research/hallway)
+"Uw" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"Ux" = (
+/obj/machinery/door/window/southright,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"Uy" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/item/device/firing_pin/test_range,
+/obj/item/device/firing_pin/test_range,
+/obj/item/device/firing_pin/test_range,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"Uz" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UA" = (
+/obj/structure/table/reinforced,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/structure/closet/crate{
+	name = "Target Crate"
+	},
+/obj/item/weapon/storage/box/monkeycubes,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UB" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"UC" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UD" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UE" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UF" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UG" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"UH" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"UI" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UK" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UL" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"UM" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UO" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UP" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"UQ" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UR" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"US" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UT" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/test_range)
+"UU" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UV" = (
+/obj/structure/target_stake,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UW" = (
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UX" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UY" = (
+/obj/machinery/light{
+	dir = 4;
+	status = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
+"UZ" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/test_range)
 
 (1,1,1) = {"
 aa
@@ -29811,9 +29954,9 @@ aa
 aa
 jL
 jL
-lh
-ll
-lh
+lf
+lj
+lf
 jL
 jL
 aa
@@ -30067,11 +30210,11 @@ aa
 aa
 aa
 aa
+ld
 lf
-lh
-lh
-lh
 lf
+lf
+ld
 aa
 aa
 aa
@@ -30325,9 +30468,9 @@ aa
 aa
 jL
 jL
-lh
-lh
-lh
+lf
+lf
+lf
 jL
 jL
 aa
@@ -30581,11 +30724,11 @@ aa
 aa
 aa
 aa
-lg
+le
 jL
 jL
 jL
-mb
+lZ
 aa
 aa
 aa
@@ -32884,7 +33027,7 @@ dg
 dg
 hk
 hP
-ir
+iq
 dg
 dg
 cs
@@ -33662,7 +33805,7 @@ at
 kl
 at
 at
-kU
+kT
 al
 aa
 aa
@@ -34433,7 +34576,7 @@ jM
 ko
 at
 at
-kV
+kU
 al
 aa
 aa
@@ -34690,7 +34833,7 @@ at
 kp
 bp
 kJ
-kW
+kV
 al
 aa
 aa
@@ -35461,7 +35604,7 @@ ct
 bR
 kH
 aP
-kX
+kW
 al
 aa
 aa
@@ -36996,7 +37139,7 @@ at
 fP
 at
 hS
-is
+ir
 bn
 jm
 at
@@ -37253,7 +37396,7 @@ fQ
 fP
 at
 hT
-it
+is
 iT
 jn
 aP
@@ -37276,9 +37419,9 @@ aa
 aa
 aa
 jB
-qa
-qz
-qK
+pY
+qw
+qH
 jB
 aa
 aa
@@ -37505,7 +37648,7 @@ cy
 dp
 dZ
 al
-fp
+Tv
 at
 fP
 at
@@ -37533,9 +37676,9 @@ aa
 aa
 jB
 jB
-qb
-qA
-qL
+pZ
+qx
+qI
 jB
 aa
 aa
@@ -37789,10 +37932,10 @@ aa
 aa
 aa
 jB
-pv
-qc
-qB
-qM
+pt
+qa
+qy
+qJ
 jB
 aa
 aa
@@ -38021,7 +38164,7 @@ al
 al
 fr
 fR
-gA
+Tz
 fr
 fR
 al
@@ -38046,7 +38189,7 @@ aa
 aa
 aa
 jB
-pw
+pu
 jB
 jB
 jB
@@ -38276,17 +38419,17 @@ cA
 dr
 eb
 eN
-fs
+fx
 fS
 gB
 ho
-fy
-iu
+fs
+it
 iV
 jq
 jN
 kt
-iA
+iz
 aa
 aa
 aa
@@ -38303,7 +38446,7 @@ aa
 aa
 aa
 jB
-px
+pv
 jB
 aa
 aa
@@ -38537,13 +38680,13 @@ ft
 fT
 gC
 fT
-fy
-iv
-iy
+fs
+iu
+ix
 jq
 jO
 ku
-iA
+iz
 aa
 aa
 aa
@@ -38560,7 +38703,7 @@ aa
 aa
 aa
 jB
-pw
+pu
 jB
 aa
 aa
@@ -38793,14 +38936,14 @@ bw
 fu
 fU
 gB
-hp
-fy
-iw
+hq
+fs
+iv
 iW
 jr
 jP
 kv
-iA
+iz
 aa
 aa
 aa
@@ -38817,7 +38960,7 @@ aa
 aa
 aa
 jB
-pw
+pu
 jB
 aa
 aa
@@ -39047,17 +39190,17 @@ cD
 du
 ed
 eP
-fv
+Tw
 fV
 gD
-hq
-hU
-ix
+hr
+TB
+iw
 iX
 js
 jQ
 jt
-iA
+iz
 aa
 aa
 aa
@@ -39074,7 +39217,7 @@ aa
 jB
 jB
 jB
-py
+pw
 jB
 aa
 aa
@@ -39308,13 +39451,13 @@ fw
 fT
 gE
 fT
-hV
-iy
-iy
+TC
+ix
+ix
 jt
 jt
 jt
-iA
+iz
 aa
 aa
 aa
@@ -39329,9 +39472,9 @@ aa
 aa
 aa
 jB
-oL
-pd
-pz
+oJ
+pb
+px
 jB
 aa
 aa
@@ -39565,13 +39708,13 @@ fu
 fT
 gE
 fT
-fy
-iy
+fs
+ix
 iY
 iY
 iY
 iY
-iA
+iz
 aa
 aa
 aa
@@ -39586,9 +39729,9 @@ aa
 aa
 aa
 jB
-oM
-pe
-pA
+oK
+pc
+py
 jB
 aa
 aa
@@ -39818,17 +39961,17 @@ cc
 dv
 eg
 ba
-fs
+fx
 fT
 gE
 fT
-fy
+fs
+iy
+iY
+iY
+iY
+iY
 iz
-iY
-iY
-iY
-iY
-iA
 aa
 aa
 aa
@@ -39845,7 +39988,7 @@ aa
 jB
 jB
 jB
-pB
+pz
 jB
 aa
 aa
@@ -39897,11 +40040,11 @@ aa
 aa
 aa
 jL
-ll
-lh
-QC
-lh
-ll
+lj
+lf
+PR
+lf
+lj
 jL
 ac
 ac
@@ -40075,17 +40218,17 @@ cF
 dw
 eh
 eS
-fs
+fx
 fT
 gE
 fT
-fy
-iA
-iA
-iA
-iA
-iA
-iA
+fs
+iz
+iz
+iz
+iz
+iz
+iz
 hW
 hW
 hW
@@ -40102,7 +40245,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -40154,11 +40297,11 @@ aa
 aa
 aa
 jL
-lh
-lh
-lh
-lh
-lh
+lf
+lf
+lf
+lf
+lf
 jL
 ac
 ac
@@ -40332,18 +40475,18 @@ bA
 bA
 eh
 eT
-fs
-fW
-gF
+fx
+fX
+gG
 fT
 hW
-iB
+iA
 iZ
 ju
 jR
 kw
 kK
-kS
+St
 kx
 hY
 aa
@@ -40359,7 +40502,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -40411,11 +40554,11 @@ aa
 aa
 aa
 jL
-PA
-lh
-lh
-lh
-PA
+OQ
+lf
+lf
+lf
+OQ
 jL
 ac
 ac
@@ -40589,13 +40732,13 @@ cG
 cG
 ei
 eU
-fs
-fX
+fx
+fY
 gE
-hr
+hs
 hW
-iC
-iC
+iB
+iB
 jv
 jS
 kx
@@ -40616,7 +40759,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -40665,14 +40808,14 @@ aa
 aa
 aa
 aa
-NW
-Oz
-Pa
-PB
-PA
-PA
-PA
-PA
+Nm
+NP
+Oq
+OR
+OQ
+OQ
+OQ
+OQ
 jL
 ac
 ac
@@ -40846,12 +40989,12 @@ cH
 dx
 ej
 eV
-fs
-fY
-gG
-hs
+fx
+fZ
+gH
+hp
 hW
-iC
+iB
 ja
 jw
 jS
@@ -40873,7 +41016,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -40918,22 +41061,22 @@ ac
 ac
 ac
 ac
-Ly
-Ly
-Ly
-Ly
-NX
-Ly
-Ly
-PC
-Qf
-Qf
-Qf
-QZ
+KO
+KO
+KO
+KO
+Nn
+KO
+KO
+OS
+Pv
+Pv
+Pv
+Ql
 jL
 ac
 ac
-Sh
+Rr
 ac
 ac
 ac
@@ -41104,11 +41247,11 @@ ba
 ba
 ba
 ba
-fZ
-gH
+ga
+gI
 ht
 hW
-iD
+iC
 jb
 hW
 jS
@@ -41130,7 +41273,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -41175,26 +41318,26 @@ ac
 ac
 ac
 ac
-Ly
-LY
-Mz
+KO
+Lo
+LP
+ME
 No
-NY
-OA
-OE
-PD
-Qg
-Qg
-QO
-PE
+NQ
+NU
+OT
+Pw
+Pw
+Qa
+OU
 ac
 ac
-RM
-Si
-Si
-Si
-St
-md
+QW
+Rs
+Rs
+Rs
+RD
+mb
 ac
 ac
 aa
@@ -41362,17 +41505,17 @@ ek
 ek
 ba
 fT
-gI
+gJ
 hu
 hX
-iE
+iD
 jc
 jx
 jT
 kx
 kx
-kT
-kY
+kS
+kX
 hW
 aa
 aa
@@ -41387,7 +41530,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -41432,25 +41575,25 @@ aa
 ac
 ac
 ac
-Ly
-LZ
-MA
+KO
+Lp
+LQ
+MF
 Np
-NZ
-LY
-Pb
-PE
-Qh
-QD
-QP
-PE
+Lo
+Or
+OU
+Px
+PS
+Qb
+OU
 ac
 ac
-RN
+QX
 ac
 ac
 ac
-Su
+RE
 ac
 ac
 ac
@@ -41617,19 +41760,19 @@ cJ
 dz
 el
 eW
-fx
-ga
-gJ
+Tx
+gb
+gK
 fT
 hW
-iF
+iE
 jd
 hW
 jU
 kx
 kx
 kx
-kZ
+Su
 hW
 aa
 aa
@@ -41644,7 +41787,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -41689,25 +41832,25 @@ aa
 ac
 ac
 aa
-Ly
-Ma
-MB
+KO
+Lq
+LR
+MG
 Nq
-Oa
-OB
-Pc
-PD
-Qi
-QE
-QQ
-PE
+NR
+Os
+OT
+Py
+PT
+Qc
+OU
 ac
-Ly
-RO
-Ly
+KO
+QY
+KO
 aa
 ac
-Su
+RE
 ac
 ac
 ac
@@ -41875,11 +42018,11 @@ ba
 em
 cJ
 ba
-gb
-gK
-gb
+fW
+So
+fW
 hY
-iG
+iF
 ja
 ju
 jU
@@ -41901,7 +42044,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -41911,16 +42054,16 @@ aa
 aa
 aa
 aa
-rx
-rJ
-rJ
+rt
+rF
+rF
 aa
-sI
-sI
+sD
+sD
 ac
 ac
-sI
-sI
+sD
+sD
 aa
 aa
 aa
@@ -41934,39 +42077,39 @@ aa
 aa
 aa
 aa
-ac
-ac
-ac
-ac
-qC
 ac
 ac
 ac
 ac
+qz
+ac
+ac
+ac
+ac
 ac
 ac
 aa
-Ly
-Mb
-MC
+KO
+Lr
+LS
+MH
 Nr
-Ob
-OC
-Pd
-PF
-Qj
-QF
-Qj
-Ra
+NS
+Ot
+OV
+Pz
+PU
+Pz
+Qm
 ac
-Ly
-RP
-Ly
+KO
+QZ
+KO
 aa
 ac
-Su
+RE
 ac
-SA
+RK
 ac
 aa
 aa
@@ -42136,8 +42279,8 @@ fT
 gE
 fT
 hW
-iH
-iC
+iG
+iB
 jv
 jU
 kx
@@ -42158,7 +42301,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -42172,13 +42315,13 @@ ac
 ac
 ac
 ac
-sJ
+sE
 ac
 ac
 ac
-sJ
+sE
 ac
-vw
+vp
 aa
 aa
 aa
@@ -42203,27 +42346,27 @@ ac
 ac
 ac
 aa
-Ly
-Ly
-MD
-MD
-Ly
-OD
-Pe
-PG
-Qk
-QG
-QR
-Ly
-Ly
-Ly
-RQ
-Ly
-Ly
-Sq
-Su
-Sx
-SB
+KO
+KO
+LT
+LT
+KO
+NT
+Ou
+OW
+PA
+PV
+Qd
+KO
+KO
+KO
+Ra
+KO
+KO
+RA
+RE
+RH
+RL
 ac
 aa
 aa
@@ -42393,8 +42536,8 @@ fT
 gE
 fT
 hW
-iI
-iI
+iH
+iH
 jw
 jV
 ky
@@ -42415,7 +42558,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -42435,7 +42578,7 @@ ac
 ac
 ac
 ac
-vx
+vq
 aa
 aa
 aa
@@ -42449,36 +42592,36 @@ aa
 aa
 aa
 aa
-Ed
-Ed
-Ed
-Ed
-Ed
-Ed
-Ed
-Ed
+TS
+TS
+TS
+TS
+TS
+TS
+TS
+TS
 ac
-md
+mb
 aa
-Ly
-Mc
-ME
-ME
-Oc
-OE
-Pf
-PH
-Ql
-Nr
-Pb
-Ly
-Ro
-Rz
-RR
-Ly
+KO
+Ls
+LU
+LU
+Ns
+NU
+Ov
+OX
+PB
+MH
+Or
+KO
+Qy
+QJ
+Rb
+KO
 ac
 ac
-Su
+RE
 ac
 aa
 aa
@@ -42645,7 +42788,7 @@ ac
 ac
 ac
 ac
-fy
+fs
 fT
 gE
 fT
@@ -42654,13 +42797,13 @@ hW
 hW
 hW
 hW
-fy
-fy
-fy
-fy
-fy
-fy
-fy
+fs
+fs
+fs
+fs
+fs
+fs
+fs
 jB
 jB
 jB
@@ -42672,7 +42815,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -42686,14 +42829,14 @@ ac
 ac
 ac
 ac
-sK
+sF
 ac
 ac
 ac
 ac
 ac
-vy
-rx
+vr
+rt
 aa
 aa
 aa
@@ -42706,36 +42849,36 @@ aa
 aa
 aa
 aa
-Ed
-EH
-Ft
-Gh
-Hg
-HP
-IC
-Ed
-Ed
-Ed
-Ed
-Ly
-Md
-MF
-Ns
-Od
-OF
-Pg
-PI
-Qm
-QH
-QS
-Rb
-Rp
-RA
-RS
-Ly
+TS
+TY
+Ud
+Uj
+Ur
+Ux
+UC
+TS
+TS
+TS
+TS
+KO
+Lt
+LV
+MI
+Nt
+NV
+Ow
+OY
+PC
+PW
+Qe
+Qn
+Qz
+QK
+Rc
+KO
 ac
 ac
-Su
+RE
 ac
 aa
 aa
@@ -42902,22 +43045,22 @@ ac
 ac
 ac
 ac
-fy
+fs
 gc
 gL
 fT
+fx
+fx
+fx
+fx
+fx
 fs
-fs
-fs
-fs
-fs
-fy
 kO
 kO
 kO
 kO
-le
-fy
+lc
+fs
 kz
 kz
 jB
@@ -42929,7 +43072,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -42942,10 +43085,10 @@ ac
 ac
 ac
 ac
-si
-sI
-sI
-tU
+se
+sD
+sD
+tM
 ac
 ac
 ac
@@ -42963,36 +43106,36 @@ aa
 aa
 aa
 aa
-Ed
-EI
-Fu
-Gi
-Hh
-HQ
-IC
-Jp
-IC
-IC
-Li
-Ly
-Me
-MG
-MG
-Oc
-OG
-Ph
-PJ
-Pg
-QI
-QT
-Ly
-Rq
-RB
-RT
-Ly
+TS
+TZ
+Ue
+Uk
+Us
+Uy
+UC
+UX
+UC
+UC
+UZ
+KO
+Lu
+LW
+LW
+Ns
+NW
+Ox
+OZ
+Ow
+PX
+Qf
+KO
+QA
+QL
+Rd
+KO
 ac
 ac
-Su
+RE
 ac
 ac
 aa
@@ -43159,7 +43302,7 @@ ac
 ac
 ac
 ac
-fy
+fs
 gd
 gE
 fT
@@ -43168,13 +43311,13 @@ fT
 fT
 jy
 jW
-fy
+fs
 kO
 kO
-la
+kY
 kO
 kO
-fy
+fs
 kz
 kz
 jB
@@ -43186,7 +43329,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -43200,9 +43343,9 @@ ac
 ac
 ac
 ac
-sL
-tp
-tV
+sG
+Tk
+tN
 ac
 ac
 ac
@@ -43220,37 +43363,37 @@ aa
 aa
 aa
 aa
-Ed
-EJ
-Fu
-Gi
-Hh
-HR
-ID
-ID
-ID
-ID
-Lj
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-Ly
-PK
-Ly
-Ly
-Ly
-Ly
-Ly
-RC
-Ly
-Ly
-Ly
-Sq
-Su
-Sx
+TS
+Ua
+Ue
+Uk
+Us
+Uz
+UE
+UE
+UE
+UE
+UV
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+Pa
+KO
+KO
+KO
+KO
+KO
+QM
+KO
+KO
+KO
+RA
+RE
+RH
 jL
 aa
 aa
@@ -43269,11 +43412,11 @@ aa
 aa
 aa
 aa
-SQ
-SQ
-SQ
-SQ
-SQ
+RZ
+RZ
+RZ
+RZ
+RZ
 aa
 aa
 aa
@@ -43416,7 +43559,7 @@ ac
 ac
 ac
 ac
-fy
+fs
 ge
 gM
 hv
@@ -43425,13 +43568,13 @@ hv
 hv
 jz
 jX
-fy
+fs
 kO
 kO
 kO
 kO
 kO
-fy
+fs
 kz
 kz
 jB
@@ -43443,7 +43586,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -43477,36 +43620,36 @@ aa
 aa
 aa
 aa
-Ed
-EK
-Fv
-Gj
-Hi
-HS
-IC
-Jq
-IC
-IC
-IC
-Lz
-Mf
-Mf
-Nt
-Oe
-OH
-Nv
-Pk
-Lz
+TS
+Ub
+Ug
+Um
+Uu
+UA
+UC
+UY
+UC
+UC
+UC
+KP
+Lv
+Lv
+MJ
+Nu
+NX
+ML
+OA
+KP
 aa
-Ly
-Rc
-Rr
-RD
-RU
-Ly
+KO
+Qo
+QB
+QN
+Re
+KO
 aa
 ac
-Su
+RE
 ac
 aa
 aa
@@ -43525,13 +43668,13 @@ aa
 aa
 aa
 aa
-SQ
-SQ
-SX
-SZ
-SX
-SQ
-SQ
+RZ
+RZ
+Sg
+Si
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -43673,7 +43816,7 @@ ac
 ac
 ac
 ac
-fy
+fs
 gf
 gN
 hw
@@ -43682,13 +43825,13 @@ fT
 je
 jA
 jY
-fy
+fs
 kO
 kO
 kO
 kO
 kO
-fy
+fs
 kz
 kz
 jB
@@ -43700,7 +43843,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -43721,49 +43864,49 @@ ac
 ac
 ac
 ac
-rJ
+rF
 aa
 aa
 aa
 ac
 ac
-yS
-xD
-xD
-xD
-xD
-xD
-xD
-xD
-vg
-Fw
-Gk
-Hj
-vz
-xl
-xG
-xG
-xG
-xG
-Lz
-Mf
-MH
-Mf
-Mf
-OI
-Pi
-PL
-Lz
+yK
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+uZ
+Uh
+Un
+Uv
+vs
+xe
+xy
+xy
+xy
+xy
+KP
+Lv
+LX
+Lv
+Lv
+NY
+Oy
+Pb
+KP
 aa
-Ly
-Rd
-Rs
+KO
+Qp
+QC
+QO
+Rf
+KO
+aa
+ac
 RE
-RV
-Ly
-aa
-ac
-Su
 ac
 ac
 aa
@@ -43781,15 +43924,15 @@ aa
 aa
 aa
 aa
-SQ
-SQ
-SX
-SX
-Ta
-SX
-SX
-SQ
-SQ
+RZ
+RZ
+Sg
+Sg
+Sj
+Sg
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -43930,24 +44073,24 @@ ac
 ac
 ac
 ac
-fy
-fy
+fs
+fs
 gO
 gO
-fy
-fy
-fy
-fy
+fs
+fs
+fs
+fs
 jZ
-fy
+fs
 kO
 kO
-lb
+kZ
 kO
 kO
-fy
+fs
 kz
-lm
+lk
 jB
 aa
 aa
@@ -43957,7 +44100,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -43978,76 +44121,76 @@ ac
 ac
 ac
 ac
-rJ
+rF
 aa
 ac
 ac
 ac
 ac
-yT
-xD
-zQ
-AA
-Bo
-Cp
-Dk
-AG
-EL
-Fx
-vC
-Cx
-HT
-IE
-Jr
-JV
-KG
-Lk
-LA
-Mg
-MI
-Nu
-Mg
-OJ
-Pj
-PM
-Lz
-aa
-Ly
-Re
-Rs
-RF
-RW
-Ly
-ac
-ac
-Su
-ac
-ac
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+yL
+xv
+zI
+As
+Bf
+Cg
+Db
 SQ
-SQ
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SQ
-SQ
+Ex
+Ff
+vv
+Co
+Hp
+HY
+IJ
+Jn
+JY
+KA
+KQ
+Lw
+LY
+MK
+Lw
+NZ
+Oz
+Pc
+KP
+aa
+KO
+Qq
+QC
+QP
+Rg
+KO
+ac
+ac
+RE
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+RZ
+RZ
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -44188,21 +44331,21 @@ ac
 ac
 ac
 ac
-fy
+fs
 gP
 hx
-fy
+fs
 ac
 ac
 jB
 ka
-fy
+fs
 kO
 kO
 kO
 kO
 kO
-fy
+fs
 kz
 kz
 jB
@@ -44214,7 +44357,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -44241,71 +44384,71 @@ ac
 ac
 ac
 ac
-yU
-xD
-zR
-AB
-Bp
-Cq
-Dl
-AG
-vi
-uK
-vC
-Hk
-HU
-IF
-Js
-JW
-Hk
-wa
-Lz
-Mh
-MJ
-Nv
-Nv
-Nv
-Pk
-PN
-Lz
-aa
-Ly
-Rf
-Rt
-RG
-RX
-Ly
-Sm
-Sq
-Su
-Sx
-SB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+yM
+xv
+zJ
+At
+Bg
+Ch
+Dc
 SQ
-SQ
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SQ
-SQ
+vb
+uD
+vv
+GK
+Hq
+HZ
+IK
+Jo
+GK
+vT
+KP
+Lx
+LZ
+ML
+ML
+ML
+OA
+Pd
+KP
+aa
+KO
+Qr
+QD
+QQ
+Rh
+KO
+Rw
+RA
+RE
+RH
+RL
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+RZ
+RZ
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -44445,21 +44588,21 @@ ac
 ac
 ac
 ac
-fy
+fs
 gQ
 hy
-fy
+fs
 ac
 ac
 jB
 ka
-fy
-fy
-fy
-fy
-fy
-fy
-fy
+fs
+fs
+fs
+fs
+fs
+fs
+fs
 kz
 kz
 jB
@@ -44471,7 +44614,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -44496,45 +44639,45 @@ ac
 ac
 ac
 ac
-xD
-xD
-xD
-xD
-zS
-zS
-Bq
-Cr
-Dm
-Ee
-vi
-vB
-Gl
-Hl
-HV
-IG
-Jt
-JX
-KH
-Ll
-LB
-Mi
-MK
-Nw
-Mi
-OK
-Pl
-PO
-Lz
-aa
+xv
+xv
+xv
+xv
+zK
+zK
+Bh
+Ci
+Dd
+DU
+vb
+vu
+FP
+GL
+Hr
+Ia
+IL
+Jp
+JZ
+KB
+KR
 Ly
-Rg
-Rs
-Rs
-RY
+Ma
+MM
 Ly
+Oa
+OB
+Pe
+KP
+aa
+KO
+Qs
+QC
+QC
+Ri
+KO
 ac
 ac
-Su
+RE
 ac
 aa
 ac
@@ -44549,21 +44692,21 @@ aa
 aa
 aa
 aa
-SQ
-SQ
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SQ
-SQ
+RZ
+RZ
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -44702,10 +44845,10 @@ ac
 ac
 ac
 ac
-fy
+fs
 gR
 gR
-fy
+fs
 ac
 ac
 jB
@@ -44718,7 +44861,7 @@ kz
 kz
 kz
 kz
-ln
+ll
 jB
 aa
 aa
@@ -44728,7 +44871,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -44752,76 +44895,76 @@ ac
 ac
 ac
 ac
-xi
-xE
-yl
-yV
-zw
-zT
-AC
-Br
-Cs
-zT
-Ef
-vi
-vH
-wf
-xG
-xG
-xG
-xG
-xG
-xG
-xG
+xb
+xw
+yd
+yN
+zo
+zL
+Au
+Bi
+Cj
+zL
+DV
+vb
+vA
+vY
+xy
+xy
+xy
+xy
+xy
+xy
+xy
+KP
 Lz
-Mj
-Mj
-Nx
-Of
-OL
-Pm
-Pm
 Lz
+MN
+Nv
+Ob
+OC
+OC
+KP
 aa
-Ly
-Rh
-Rs
-Rs
+KO
+Qt
+QC
+QC
+Rj
+Rt
+ac
+ac
+RE
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
 RZ
-Sj
-ac
-ac
-Su
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-aa
-SQ
-SQ
-SV
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SQ
-SQ
+RZ
+Se
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -44970,12 +45113,12 @@ kc
 kA
 kP
 kA
-lc
+la
 kA
 kA
 kA
 kA
-lo
+lm
 jB
 aa
 aa
@@ -44985,7 +45128,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -45009,76 +45152,76 @@ ac
 ac
 ac
 ac
-xj
-xF
-ym
-yW
-zx
-zU
-AD
-Bs
-Ct
-Dn
-AG
-EM
-vE
-Gm
-xG
-HW
-HW
-HW
-HW
-KI
-xG
+xc
+xx
+ye
+yO
+zp
+zM
+Av
+Bj
+Ck
+De
+SQ
+Ey
+vx
+FQ
+xy
+Hs
+Hs
+Hs
+Hs
+Ka
+xy
+KP
 Lz
-Mj
-ML
-Ny
-Og
-OM
-Pn
-Pm
-Lz
+Mb
+MO
+Nw
+Oc
+OD
+OC
+KP
 aa
-Ly
-Ri
-Rs
-RH
+KO
+Qu
+QC
+QR
+Rj
+Ru
+oL
+oL
+RF
+oL
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 RZ
-Sk
-oN
-oN
-Sv
-oN
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-SQ
-SV
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SQ
+Se
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+RZ
 aa
 aa
 aa
@@ -45232,7 +45375,7 @@ jB
 jB
 jB
 jB
-lp
+TE
 jB
 aa
 aa
@@ -45242,7 +45385,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -45266,76 +45409,76 @@ ac
 ac
 ac
 ac
-xk
-xE
-yn
-yX
-zy
-zV
-AE
-Bt
-Cu
-Do
-AG
-EN
-vC
-wa
-xG
-HW
-HW
-Ju
-HW
-HW
-xG
-Lz
-Lz
-Lz
-Lz
-Lz
-Lz
-Lz
-Lz
-Lz
-aa
-Ly
-Rj
-Ru
-RI
-Sa
-Sl
-Sn
-Sr
-Sw
-Sy
-SC
-SD
-SD
-SD
-SD
-SD
-SD
-SD
-SD
-SD
-SD
-SC
-SR
-SV
-SX
-SX
-SX
-SX
-SX
-SX
-Tb
-SZ
-SX
-SX
-SX
-SX
-Td
-SZ
+xd
+xw
+yf
+yP
+zq
+zN
+Aw
+Bk
+Cl
+Df
 SQ
+Ez
+vv
+vT
+xy
+Hs
+Hs
+IM
+Hs
+Hs
+xy
+KP
+KP
+KP
+KP
+KP
+KP
+KP
+KP
+KP
+aa
+KO
+Qv
+QE
+QS
+Rk
+Rv
+Rx
+RB
+RG
+RI
+RM
+RN
+RN
+RN
+RN
+RN
+RN
+RN
+RN
+RN
+RN
+RM
+Sa
+Se
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sk
+Si
+Sg
+Sg
+Sg
+Sg
+Sm
+Si
+RZ
 aa
 aa
 aa
@@ -45489,7 +45632,7 @@ aa
 aa
 aa
 jB
-lq
+lo
 jB
 aa
 aa
@@ -45499,7 +45642,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -45524,75 +45667,75 @@ ac
 ac
 ac
 ac
-xD
-xD
-xD
-xD
-zW
-AF
-Bu
-Cv
-Dp
-AG
-vi
-Fy
-wa
-xG
-HW
-HW
-HW
-HW
-HW
-xG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-Ly
-Ly
-Rv
-Ly
-Ly
-Ly
-So
-Ss
-lw
-Sz
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-SL
+xv
+xv
+xv
+xv
+zO
+Ax
+Bl
+Cm
+Dg
 SQ
-SV
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SQ
+vb
+Fg
+vT
+xy
+Hs
+Hs
+Hs
+Hs
+Hs
+xy
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+KO
+KO
+QF
+KO
+KO
+KO
+Ry
+RC
+lu
+RJ
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+RU
+RZ
+Se
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+RZ
 aa
 aa
 aa
@@ -45746,7 +45889,7 @@ aa
 aa
 aa
 jB
-lq
+lo
 jB
 aa
 aa
@@ -45756,7 +45899,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 aa
 aa
@@ -45768,13 +45911,13 @@ aa
 aa
 aa
 ac
-rS
-sj
-sM
-sM
-sM
-uy
-rS
+rO
+sf
+sH
+sH
+sH
+uq
+rO
 ac
 ac
 ac
@@ -45784,72 +45927,72 @@ ac
 ac
 ac
 ac
-xD
-zX
-AG
-Bv
-Cw
-Dq
-AG
-EO
-Fz
-wa
-xG
-HW
-HW
-Jv
-HW
-HW
-xG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-Ly
-Rw
-RJ
-Sb
-Sb
-Sp
-aa
-aa
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-aa
-aa
+xv
+zP
 SQ
+Bm
+Cn
+Dh
 SQ
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SQ
-SQ
+EA
+Fh
+vT
+xy
+Hs
+Hs
+IN
+Hs
+Hs
+xy
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+KO
+QG
+QT
+Rl
+Rl
+Rz
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+RZ
+RZ
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -45989,8 +46132,8 @@ eX
 fz
 gg
 gS
-hz
-ic
+TA
+TD
 iJ
 cg
 jE
@@ -46003,7 +46146,7 @@ aa
 aa
 aa
 jB
-lq
+lo
 jB
 aa
 aa
@@ -46013,7 +46156,7 @@ aa
 aa
 aa
 jB
-pA
+py
 jB
 jB
 aa
@@ -46025,87 +46168,87 @@ aa
 aa
 ac
 ac
-rS
-sk
-sN
-tq
-tW
-uz
-rS
-vg
-vz
-vz
-vz
-vz
-xl
-xG
-xG
-xG
-xG
-zY
-AG
-AG
-AG
-AG
-Eg
-EP
-FA
-wa
-xG
-HW
-HW
-HW
-HW
-HW
-xG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ac
-ac
-ac
-ac
-ac
-aa
-aa
-aa
-aa
+rO
+sg
+sI
+tj
+tO
+ur
+rO
+uZ
+vs
+vs
+vs
+vs
+xe
+xy
+xy
+xy
+xy
+zQ
 SQ
 SQ
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
 SQ
 SQ
+Tc
+EB
+Fi
+vT
+xy
+Hs
+Hs
+Hs
+Hs
+Hs
+xy
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+RZ
+RZ
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -46260,7 +46403,7 @@ aa
 aa
 aa
 jB
-lq
+lo
 jB
 aa
 aa
@@ -46270,8 +46413,8 @@ aa
 aa
 aa
 jB
-pC
-qd
+pA
+qb
 jB
 aa
 aa
@@ -46282,39 +46425,39 @@ aa
 aa
 ac
 ac
-rS
-sl
-sO
-sO
-tX
-uz
-rS
-vh
-vA
-vX
-vA
-vX
-vA
-vX
-vA
-vX
-vA
-zZ
-vA
-Bw
-Cx
-Dr
-Eg
-EQ
-Fz
-Gn
-xG
-xG
-xG
-xG
-xG
-xG
-xG
+rO
+sh
+sJ
+sJ
+tP
+ur
+rO
+va
+vt
+vQ
+vt
+vQ
+vt
+vQ
+vt
+vQ
+vt
+zR
+vt
+Bn
+Co
+Di
+Tc
+EC
+Fh
+FR
+xy
+xy
+xy
+xy
+xy
+xy
+xy
 aa
 aa
 aa
@@ -46349,19 +46492,19 @@ aa
 aa
 aa
 aa
-SQ
-SQ
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SQ
-SQ
+RZ
+RZ
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -46517,7 +46660,7 @@ aa
 aa
 aa
 jB
-lq
+lo
 jB
 jB
 jB
@@ -46527,8 +46670,8 @@ jB
 jB
 jB
 jB
-pD
-qd
+pB
+qb
 jB
 aa
 aa
@@ -46539,39 +46682,39 @@ aa
 aa
 ac
 ac
-rS
-sm
-sP
-tr
-tY
-uA
-rS
-vi
-vB
-vY
-vY
-vY
-vY
-vY
-yo
-vY
-vY
-Aa
-vY
-vY
-Cy
-Ds
-Eh
-vk
-FB
-Go
-vA
-HX
-vA
-vA
-vA
-KJ
-xG
+rO
+si
+sK
+tk
+tQ
+ut
+rO
+vb
+vu
+vR
+vR
+vR
+vR
+vR
+yg
+vR
+vR
+zS
+vR
+vR
+Cp
+Dj
+DW
+vd
+Fj
+FS
+vt
+Ht
+vt
+vt
+vt
+Kb
+xy
 aa
 aa
 aa
@@ -46607,17 +46750,17 @@ aa
 aa
 aa
 aa
-SQ
-SQ
-SX
-SX
-SX
-SX
-SX
-SX
-SX
-SQ
-SQ
+RZ
+RZ
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -46774,18 +46917,18 @@ aa
 aa
 aa
 jB
-lr
+lp
 kA
-mc
-mc
-mc
-mc
-mc
-mc
-mc
-pf
-pE
-qe
+ma
+ma
+ma
+ma
+ma
+ma
+ma
+pd
+pC
+Sv
 jB
 aa
 aa
@@ -46796,84 +46939,84 @@ aa
 aa
 aa
 ac
-rS
-sn
-sn
-sn
-tZ
-sn
-rS
-vj
-vC
-vZ
-wt
-uL
-wt
-xH
-yp
-uL
-wt
-uL
-vb
-uL
-wt
-Dt
-Eg
-vi
-FC
-Gp
-vY
-vY
-IH
-vY
-JY
-KK
-xG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-SQ
-SQ
-SX
-SX
+rO
+SC
+SC
+SC
+Tl
+SC
+rO
+vc
+vv
+vS
+wm
+uE
+wm
+xz
+yh
+uE
+wm
+uE
+uU
+uE
+wm
+Dk
 Tc
-SX
-SX
-SQ
-SQ
+vb
+Fk
+FT
+vR
+vR
+Ib
+vR
+Jq
+Kc
+xy
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+RZ
+RZ
+Sg
+Sg
+Sl
+Sg
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -47018,8 +47161,8 @@ fD
 gi
 gU
 hD
-ig
-ig
+Sp
+Sp
 cg
 cg
 cg
@@ -47031,7 +47174,7 @@ jB
 jB
 jB
 jB
-ls
+TF
 jB
 jB
 jB
@@ -47041,8 +47184,8 @@ jB
 jB
 jB
 jB
-pF
-qe
+pD
+Sv
 jB
 aa
 aa
@@ -47053,39 +47196,39 @@ aa
 aa
 aa
 aa
-rS
-so
-sQ
-ts
-ua
-uB
-uW
-vk
-vD
-wa
-wu
-wu
-wu
-wu
-wu
-wu
-wu
-wu
-AH
-AH
-AH
-AH
-xG
-ER
-FD
-Gq
-wt
-vb
-II
-wt
-JZ
-KL
-xG
+rO
+sj
+sL
+tl
+tS
+uu
+uP
+vd
+vw
+vT
+wn
+wn
+wn
+wn
+wn
+wn
+wn
+wn
+Ay
+Ay
+Ay
+Ay
+xy
+ED
+Fl
+FU
+wm
+uU
+Ic
+wm
+Jr
+Kd
+xy
 aa
 aa
 aa
@@ -47123,13 +47266,13 @@ aa
 aa
 aa
 aa
-SQ
-SQ
-SX
-SZ
-SX
-SQ
-SQ
+RZ
+RZ
+Sg
+Si
+Sg
+RZ
+RZ
 aa
 aa
 aa
@@ -47275,7 +47418,7 @@ fE
 gj
 gV
 hE
-ih
+ig
 iN
 iN
 jG
@@ -47288,7 +47431,7 @@ kG
 kG
 kG
 kG
-lt
+lr
 jB
 aa
 aa
@@ -47298,8 +47441,8 @@ aa
 aa
 aa
 jB
-pG
-qf
+pE
+qc
 jB
 aa
 aa
@@ -47310,39 +47453,39 @@ aa
 aa
 aa
 aa
-rS
-sp
-sR
-tt
-ub
-uC
-rS
-vj
-vC
-wb
-wv
-wP
-xm
-xI
-yq
-yY
-zz
-Ab
-AI
-Bx
-Cz
-Du
+rO
+sk
+sM
+tm
+tT
+uv
+rO
+vc
+vv
+vU
+wo
+wI
+xf
+xA
+yi
+yQ
+zr
+zT
+Az
+Bo
+Cq
+Dl
 jB
-qe
-qe
-Gr
+Sv
+Sv
+FV
 jB
 jB
-DF
-DF
-Ka
-DF
-DF
+Dw
+Dw
+Js
+Dw
+Dw
 aa
 aa
 aa
@@ -47381,11 +47524,11 @@ aa
 aa
 aa
 aa
-SQ
-SQ
-SQ
-SQ
-SQ
+RZ
+RZ
+RZ
+RZ
+RZ
 aa
 aa
 aa
@@ -47532,7 +47675,7 @@ fF
 gk
 gW
 hF
-ii
+ih
 iO
 jh
 jH
@@ -47555,8 +47698,8 @@ aa
 aa
 aa
 jB
-pH
-qg
+pF
+qd
 jB
 aa
 aa
@@ -47567,39 +47710,39 @@ aa
 aa
 aa
 aa
-rS
-sq
-sS
-tu
-uc
-uD
-rS
-vi
-vC
-wa
-ww
-wQ
-xn
-xJ
-yr
-yZ
-xK
-Ac
-AJ
-By
-CA
-Dv
+rO
+sl
+sN
+tn
+tU
+uw
+rO
+vb
+vv
+vT
+wp
+wJ
+xg
+xB
+yj
+yR
+xC
+zU
+AA
+Bp
+Cr
+Dm
 jB
-ES
+EE
 kz
-Gs
+FW
 jB
 jB
-DF
-Jw
-Kb
-KM
-DF
+Dw
+IO
+Jt
+Ke
+Dw
 aa
 aa
 aa
@@ -47789,7 +47932,7 @@ fG
 cY
 gX
 hE
-ij
+ii
 iP
 ji
 jI
@@ -47812,7 +47955,7 @@ aa
 aa
 aa
 jB
-pI
+pG
 jB
 jB
 aa
@@ -47824,47 +47967,47 @@ aa
 aa
 aa
 aa
-rS
-sr
-sT
-tv
-ud
-uE
-rS
-vl
-vE
-wc
-wu
-wR
-xo
-xK
-ys
-za
-zA
-zb
-AK
-Bz
-CB
-Dw
+rO
+sm
+sO
+to
+tV
+ux
+rO
+ve
+vx
+vV
+wn
+wK
+xh
+xC
+yk
+yS
+zs
+yT
+AB
+Bq
+Cs
+Dn
 jB
-ET
+EF
 kz
-Gt
+FX
 jB
-HY
-DF
-Jx
-Kc
-KN
-DF
-DF
-DF
-DF
-DF
-DF
-DF
-DF
-DF
+Hu
+Dw
+IP
+Ju
+Kf
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
 aa
 aa
 aa
@@ -48040,13 +48183,13 @@ bF
 cl
 cU
 dF
-ew
+Ts
 fd
 fH
 gl
 gY
 hE
-ij
+ii
 iQ
 iN
 jJ
@@ -48068,9 +48211,9 @@ aa
 aa
 aa
 aa
-pg
-pJ
-qh
+pe
+pH
+qe
 ac
 aa
 aa
@@ -48081,47 +48224,47 @@ aa
 aa
 aa
 aa
-rS
-ss
-sU
-tw
-ue
-uF
-rS
-vi
-vF
-wd
-wx
-wS
-xp
-xL
-yt
-wS
-zB
-Ad
-AH
-AH
-AH
-AH
+rO
+sn
+sP
+tp
+tW
+uy
+rO
+vb
+vy
+vW
+wq
+wL
+xi
+xD
+yl
+wL
+zt
+zV
+Ay
+Ay
+Ay
+Ay
 jB
-EU
-FE
-Gu
+EG
+Fm
+FY
 jB
-DF
-DF
-Jy
-Kd
-KO
-DF
-LC
-Mk
-MM
-Nz
-Oh
-ON
-Po
-DF
+Dw
+Dw
+IQ
+Jv
+Kg
+Dw
+KS
+LA
+Mc
+MP
+Nx
+Od
+OE
+Dw
 aa
 aa
 aa
@@ -48303,7 +48446,7 @@ fI
 gm
 gZ
 hG
-ik
+ij
 iR
 jj
 jK
@@ -48325,9 +48468,9 @@ aa
 aa
 aa
 ac
-ph
-pK
-qi
+pf
+pI
+qf
 ac
 aa
 aa
@@ -48338,47 +48481,47 @@ aa
 aa
 aa
 aa
-rS
-st
-sV
-tx
-uf
-uG
-uX
-vj
-vC
-wb
-wu
-wT
-wW
-xM
-xM
-zb
-yZ
-Ae
-AL
-BA
-CC
-Dx
+rO
+so
+sQ
+tq
+tX
+uz
+uQ
+vc
+vv
+vU
+wn
+wM
+wP
+xE
+xE
+yT
+yR
+zW
+AC
+Br
+Ct
+Do
 jB
-qe
-qe
-Gv
+Sv
+Sv
+FZ
 jB
-DF
-DF
-DF
-Ke
-DF
-DF
-LD
-Ml
-MN
-NA
-GE
-GE
-Pp
-DF
+Dw
+Dw
+Dw
+Jw
+Dw
+Dw
+KT
+LB
+Md
+MQ
+Gi
+Gi
+OF
+Dw
 aa
 aa
 aa
@@ -48560,8 +48703,8 @@ fJ
 gn
 ha
 hH
-ig
-ig
+Sp
+Sp
 cg
 cg
 cg
@@ -48583,7 +48726,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 ac
@@ -48592,50 +48735,50 @@ aa
 aa
 aa
 aa
-rm
-rm
-rm
-rS
-rS
-rS
-rS
-ug
-rS
-rS
-vi
-vG
-we
-wy
-wU
-wU
-xN
-yu
-zc
-zC
-Af
-AM
-BB
-CD
-Dy
+rj
+rj
+rj
+rO
+rO
+rO
+rO
+tR
+rO
+rO
+vb
+vz
+vX
+wr
+wN
+wN
+xF
+ym
+yU
+zu
+zX
+AD
+Bs
+Cu
+Dp
 jB
-BG
-CI
-EX
+Bx
+Cz
+EJ
 jB
-DF
-IJ
-Jz
-Kf
-KP
-Lm
-LE
-Ml
-MO
-NB
-GE
-GE
-GE
-DF
+Dw
+Id
+IR
+Jx
+Kh
+KC
+KU
+LB
+Me
+MR
+Gi
+Gi
+Gi
+Dw
 aa
 aa
 aa
@@ -48817,8 +48960,8 @@ fF
 go
 hb
 hI
-il
-il
+ik
+ik
 cg
 aa
 aa
@@ -48840,7 +48983,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 ac
@@ -48848,51 +48991,51 @@ aa
 aa
 aa
 aa
-rm
-rm
-ry
-rK
-rK
-rK
-sW
-ty
-uh
-uH
-uY
-vj
-vC
-wb
-wz
-wV
-xq
-xO
-yv
-wW
-yZ
-zb
-AN
-BC
-CE
-Dz
+rj
+rj
+ru
+rG
+rG
+rG
+SF
+tr
+tZ
+uA
+uR
+vc
+vv
+vU
+ws
+wO
+xj
+xG
+yn
+wP
+yR
+yT
+AE
+Bt
+Cv
+Dq
 jB
-BH
+By
 jB
 jB
 jB
-DF
-IK
-Hq
-Kg
-Hq
-Hq
-Hq
-Ml
-IP
-DF
-DF
-DF
-DF
-DF
+Dw
+Ie
+GQ
+Jy
+GQ
+GQ
+GQ
+LB
+Ij
+Dw
+Dw
+Dw
+Dw
+Dw
 aa
 aa
 aa
@@ -49071,11 +49214,11 @@ dI
 eA
 er
 fG
-gp
+Ty
 hc
 hJ
-im
-im
+il
+il
 cg
 aa
 aa
@@ -49097,59 +49240,59 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
-qC
+qz
 ac
 aa
 aa
 aa
 aa
-rm
-rn
-rz
-rL
-rT
-su
-sW
-tz
-ui
-uI
-uZ
-vi
-vH
-wf
-wz
-wW
-xr
-xP
-xI
-wW
-yZ
-Ag
-AO
-AO
-AO
-AO
+rj
+rk
+rv
+rH
+rP
+sp
+SF
+ts
+ua
+uB
+uS
+vb
+vA
+vY
+ws
+wP
+xk
+xH
+xA
+wP
+yR
+zY
+AF
+AF
+AF
+AF
 jB
-BH
+By
 jB
-DF
-DF
-DF
-IL
-Hq
-Kg
-Hq
-Hq
-Hq
-Ml
-MP
-NC
-Oh
-ON
-Po
-DF
+Dw
+Dw
+Dw
+If
+GQ
+Jy
+GQ
+GQ
+GQ
+LB
+Mf
+MS
+Nx
+Od
+OE
+Dw
 aa
 aa
 aa
@@ -49331,8 +49474,8 @@ fJ
 gq
 hd
 hK
-in
-in
+im
+im
 cg
 aa
 aa
@@ -49354,7 +49497,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 ac
@@ -49362,51 +49505,51 @@ aa
 aa
 aa
 aa
-rm
-ro
-rA
-rM
-rU
-sv
-sX
-tA
-uj
-uJ
-va
-vm
-vI
-wb
-wz
-wW
-xs
-xQ
-yw
-zd
-yZ
-Ah
-AP
-BD
-CF
-DA
+rj
+rl
+rw
+rI
+rQ
+sq
+sR
+tt
+ub
+uC
+uT
+vf
+vB
+vU
+ws
+wP
+xl
+xI
+yo
+yV
+yR
+zZ
+AG
+Bu
+Cw
+Dr
 jB
-EV
+EH
 jB
-Gw
-Hm
-HZ
-IM
-Hq
-Kh
-KQ
-KQ
-Hq
-Ml
-MN
-ND
-GE
-Kp
-Pq
-DF
+Ga
+GM
+Hv
+Ig
+GQ
+Jz
+Ki
+Ki
+GQ
+LB
+Md
+MT
+Gi
+JH
+OG
+Dw
 aa
 aa
 aa
@@ -49588,8 +49731,8 @@ fD
 gr
 cY
 hK
-io
-io
+in
+in
 cg
 aa
 aa
@@ -49611,7 +49754,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 ac
@@ -49619,51 +49762,51 @@ aa
 aa
 aa
 aa
-rm
-rm
-rm
-rm
-rm
-rm
-rm
-tB
-uk
-uK
-uK
-uK
-uk
-wa
-wz
-wX
-wW
-xR
-yx
-wW
-xK
-Ai
-AQ
-BE
-CG
-DB
+rj
+rj
+rj
+rj
+rj
+rj
+rj
+tu
+uc
+uD
+uD
+uD
+uc
+vT
+ws
+wQ
+wP
+xJ
+yp
+wP
+xC
+Aa
+AH
+Bv
+Cx
+Ds
 jB
-BH
+By
 jB
-Gx
-Hn
-Ia
-IM
-Hq
-Ki
-KR
-Ln
-LF
-Ml
-MQ
-NE
-GE
-GE
-GE
-DF
+Gb
+GN
+Hw
+Ig
+GQ
+JA
+Kj
+KD
+KV
+LB
+Mg
+MU
+Gi
+Gi
+Gi
+Dw
 aa
 aa
 aa
@@ -49868,7 +50011,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -49882,45 +50025,45 @@ aa
 aa
 aa
 aa
-sY
-tC
-ul
-uL
-vb
-uL
-vJ
-wg
-wA
-wY
-xt
-wY
-yy
-ze
-zD
-Aj
-AR
-BF
-CH
-DC
+sS
+tv
+ud
+uE
+uU
+uE
+vC
+vZ
+wt
+wR
+xm
+wR
+yq
+yW
+zv
+Ab
+AI
+Bw
+Cy
+Dt
 jB
-EW
+EI
 jB
-Gy
-Ho
-Ib
-IM
-Hq
-Kj
-KS
-Lo
-Hq
-Ml
-MR
-DF
-DF
-DF
-DF
-DF
+Gc
+GO
+Hx
+Ig
+GQ
+JB
+Kk
+KE
+GQ
+LB
+Mh
+Dw
+Dw
+Dw
+Dw
+Dw
 aa
 aa
 aa
@@ -50102,7 +50245,7 @@ fE
 gt
 hf
 hM
-ip
+io
 iS
 cg
 aa
@@ -50125,7 +50268,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -50139,45 +50282,45 @@ aa
 aa
 aa
 aa
-sY
-tD
-um
-tD
-vc
-vc
-vK
-vc
-wu
-wu
-wu
-wu
-wu
-wu
-wu
-wu
+sS
+SI
+ue
+SI
+uV
+uV
+vD
+uV
+wn
+wn
+wn
+wn
+wn
+wn
+wn
+wn
 jB
 jB
 jB
 jB
 jB
-BH
+By
 jB
-DF
-DF
-DF
-IN
-Hq
-Kk
-KT
-KT
-Hq
-Ml
-MP
-NF
-Oh
-ON
-Po
-DF
+Dw
+Dw
+Dw
+Ih
+GQ
+JC
+Kl
+Kl
+GQ
+LB
+Mf
+MV
+Nx
+Od
+OE
+Dw
 aa
 aa
 aa
@@ -50382,7 +50525,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -50396,16 +50539,16 @@ aa
 aa
 aa
 aa
-sY
-tE
-un
-uM
-vc
-vn
-vL
-wh
-wB
-vc
+sS
+tw
+uf
+uF
+uV
+vg
+vE
+wa
+wu
+uV
 aa
 aa
 aa
@@ -50413,28 +50556,28 @@ aa
 aa
 aa
 jB
-BG
-CI
-CI
-CI
-EX
+Bx
+Cz
+Cz
+Cz
+EJ
 jB
-Gz
-Hp
-Ic
-IO
-Hq
-Kl
-KU
-KU
-LG
-Ml
-MN
-NG
-GE
-GE
-Pr
-DF
+Gd
+GP
+Hy
+Ii
+GQ
+JD
+Km
+Km
+KW
+LB
+Md
+MW
+Gi
+Gi
+OH
+Dw
 aa
 aa
 aa
@@ -50616,7 +50759,7 @@ fH
 gu
 hh
 hO
-iq
+ip
 cg
 aa
 aa
@@ -50639,7 +50782,7 @@ aa
 aa
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -50653,16 +50796,16 @@ aa
 aa
 aa
 aa
-sY
-tF
-uo
-uo
-vc
-vo
-vM
-wi
-wC
-vc
+sS
+tx
+ug
+ug
+uV
+vh
+vF
+wb
+wv
+uV
 aa
 aa
 aa
@@ -50670,28 +50813,28 @@ aa
 aa
 aa
 jB
-BH
+By
 jB
 jB
 jB
 jB
 jB
-GA
-Hq
-Hq
-Hq
-Hq
-Km
-Hq
-Hq
-Hq
-Ml
-MS
-NH
-GE
-GE
-GE
-DF
+Ge
+GQ
+GQ
+GQ
+GQ
+JE
+GQ
+GQ
+GQ
+LB
+Mi
+MX
+Gi
+Gi
+Gi
+Dw
 aa
 aa
 aa
@@ -50873,7 +51016,7 @@ fK
 gv
 hi
 hO
-iq
+ip
 cg
 aa
 aa
@@ -50896,7 +51039,7 @@ aa
 aa
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -50910,16 +51053,16 @@ aa
 aa
 aa
 aa
-sY
-tG
-up
-uN
-vc
-vp
-vN
-vN
-wD
-vc
+sS
+ty
+uh
+uG
+uV
+vi
+vG
+vG
+ww
+uV
 aa
 aa
 aa
@@ -50927,28 +51070,28 @@ jB
 jB
 jB
 jB
-BH
+By
 jB
-DD
-Ei
-Ej
-FF
-GB
-Hr
-Hr
-Hr
-JA
-Kn
-Hr
-Hr
-Hr
-Mm
-Hq
-DF
-DF
-DF
-DF
-DF
+Du
+DX
+DY
+Fn
+Gf
+GR
+GR
+GR
+IS
+JF
+GR
+GR
+GR
+LC
+GQ
+Dw
+Dw
+Dw
+Dw
+Dw
 aa
 aa
 aa
@@ -51124,13 +51267,13 @@ bI
 cq
 de
 dN
-eG
+Tt
 cY
 fL
 gw
 hj
 hO
-iq
+ip
 cg
 aa
 aa
@@ -51153,7 +51296,7 @@ aa
 aa
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -51167,41 +51310,41 @@ aa
 aa
 aa
 aa
-sY
-sY
-sY
-sY
-vc
-vq
-vO
-wj
-vq
-vc
+sS
+sS
+sS
+sS
+uV
+vj
+vH
+wc
+vj
+uV
 aa
 aa
 aa
 jB
-zE
-vW
-AS
-BI
+zw
+vP
+AJ
+Bz
 jB
-DE
-Ej
-Ej
-DF
-GC
-Hs
-Id
-IP
-JB
-Hs
-Id
-Lp
-LH
-Hs
-MT
-DF
+Dv
+DY
+DY
+Dw
+Gg
+GS
+Hz
+Ij
+IT
+GS
+Hz
+KF
+KX
+GS
+Mj
+Dw
 aa
 aa
 aa
@@ -51381,7 +51524,7 @@ bE
 ci
 cN
 dO
-eH
+Tu
 fb
 cg
 cg
@@ -51410,7 +51553,7 @@ aa
 aa
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -51428,37 +51571,37 @@ aa
 aa
 aa
 aa
-vc
-vc
-vc
-vc
-vc
-vc
+uV
+uV
+uV
+uV
+uV
+uV
 aa
 aa
 aa
 jB
-zF
-Ak
-qe
-BJ
+zx
+Ac
+Sv
+BA
 jB
-DD
-Ek
-Ej
-DF
-GD
-Ht
-Ie
-DF
-JC
-Ko
-KV
-DF
-LI
-Mn
-MU
-DF
+Du
+DZ
+DY
+Dw
+Gh
+GT
+HA
+Dw
+IU
+JG
+Kn
+Dw
+KY
+LD
+Mk
+Dw
 aa
 aa
 aa
@@ -51667,7 +51810,7 @@ aa
 aa
 aa
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -51695,27 +51838,27 @@ aa
 aa
 aa
 jB
-zG
-Al
-AT
-BK
+zy
+Ad
+AK
+BB
 jB
-DF
-DF
-DF
-DF
-GE
-GE
-If
-DF
-GE
-GE
-If
-DF
-GE
-GE
-If
-DF
+Dw
+Dw
+Dw
+Dw
+Gi
+Gi
+HB
+Dw
+Gi
+Gi
+HB
+Dw
+Gi
+Gi
+HB
+Dw
 aa
 aa
 aa
@@ -51924,7 +52067,7 @@ aa
 aa
 aa
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -51955,24 +52098,24 @@ jB
 jB
 jB
 jB
-lq
+lo
 jB
 aa
 aa
 aa
-DF
-GE
-GE
-Ig
-DF
-GE
-Kp
-Ig
-DF
-GE
-GE
-Ig
-DF
+Dw
+Gi
+Gi
+HC
+Dw
+Gi
+JH
+HC
+Dw
+Gi
+Gi
+HC
+Dw
 aa
 aa
 aa
@@ -52181,7 +52324,7 @@ aa
 aa
 aa
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -52211,25 +52354,25 @@ aa
 aa
 aa
 jB
-AU
-BL
+AL
+BC
 jB
 aa
 aa
 aa
-DF
-GE
-Hu
-Ih
-DF
-GE
-Kq
-Ih
-DF
-GE
-Mo
-Ih
-DF
+Dw
+Gi
+GU
+HD
+Dw
+Gi
+JI
+HD
+Dw
+Gi
+LE
+HD
+Dw
 aa
 aa
 aa
@@ -52438,7 +52581,7 @@ aa
 aa
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -52468,25 +52611,25 @@ aa
 aa
 aa
 jB
-AU
-BM
+AL
+BD
 jB
 aa
 aa
 aa
-DF
-DF
-DF
-DF
-DF
-DF
-DF
-DF
-DF
-DF
-DF
-DF
-DF
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
+Dw
 aa
 aa
 aa
@@ -52695,7 +52838,7 @@ aa
 aa
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -52726,7 +52869,7 @@ aa
 aa
 jB
 jB
-BN
+BE
 jB
 jB
 aa
@@ -52952,7 +53095,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 ac
@@ -52983,8 +53126,8 @@ aa
 aa
 aa
 jB
-BO
-qf
+BF
+qc
 jB
 aa
 aa
@@ -53209,7 +53352,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 ac
@@ -53240,8 +53383,8 @@ ac
 ac
 ac
 jB
-BP
-CJ
+BG
+CA
 jB
 aa
 aa
@@ -53465,9 +53608,9 @@ aa
 aa
 ac
 ac
-pg
-pL
-qj
+pe
+pJ
+qg
 ac
 ac
 ac
@@ -53479,9 +53622,9 @@ ac
 ac
 ac
 ac
-pg
-sZ
-qj
+pe
+sT
+qg
 ac
 ac
 ac
@@ -53497,7 +53640,7 @@ ac
 ac
 ac
 jB
-BQ
+BH
 jB
 jB
 aa
@@ -53722,40 +53865,40 @@ aa
 aa
 aa
 ac
-pi
-pM
-qk
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-sw
-ta
-qk
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-qD
-AV
-BR
-CK
+pg
+pK
+qh
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+sr
+sU
+qh
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+AM
+BI
+CB
 aa
 aa
 aa
@@ -53979,9 +54122,9 @@ aa
 aa
 aa
 ac
-ph
-pN
-qi
+pf
+pL
+qf
 ac
 ac
 ac
@@ -53993,9 +54136,9 @@ ac
 ac
 ac
 ac
-ph
-pK
-qi
+pf
+pI
+qf
 ac
 ac
 ac
@@ -54055,10 +54198,10 @@ aa
 aa
 aa
 aa
-SE
-SE
-SE
-SE
+RO
+RO
+RO
+RO
 aa
 aa
 aa
@@ -54251,7 +54394,7 @@ ac
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 ac
@@ -54310,13 +54453,13 @@ aa
 aa
 aa
 aa
-SE
-SE
-SE
-SM
-SS
-SE
-SE
+RO
+RO
+RO
+RV
+Sb
+RO
+RO
 aa
 aa
 aa
@@ -54506,9 +54649,9 @@ ac
 ac
 ac
 ac
-qC
+qz
 ac
-pJ
+pH
 ac
 ac
 ac
@@ -54567,13 +54710,13 @@ aa
 aa
 aa
 aa
-SE
-SF
-SI
-SF
-ST
-SF
-SE
+RO
+RP
+RS
+RP
+Sc
+RP
+RO
 aa
 aa
 aa
@@ -54765,7 +54908,7 @@ ac
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 ac
@@ -54824,13 +54967,13 @@ aa
 aa
 aa
 aa
-SE
-SG
-SJ
-SN
-SU
-SW
-SE
+RO
+RQ
+Tj
+RW
+Sd
+Sf
+RO
 aa
 aa
 aa
@@ -55022,7 +55165,7 @@ ac
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -55081,13 +55224,13 @@ aa
 aa
 aa
 aa
-SE
-SH
-SK
-SO
-SP
-SO
-SY
+RO
+RR
+RT
+RX
+RY
+RX
+Sh
 aa
 aa
 aa
@@ -55279,7 +55422,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -55338,13 +55481,13 @@ aa
 aa
 aa
 aa
-SE
-SF
-SK
-SP
-SO
-SP
-SE
+RO
+RP
+RT
+RY
+RX
+RY
+RO
 aa
 aa
 aa
@@ -55536,7 +55679,7 @@ aa
 aa
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -55595,13 +55738,13 @@ aa
 aa
 aa
 aa
-SE
-SF
-SK
-SO
-SP
-SP
-SY
+RO
+RP
+RT
+RX
+RY
+RY
+Sh
 aa
 aa
 aa
@@ -55793,7 +55936,7 @@ aa
 aa
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -55852,13 +55995,13 @@ aa
 aa
 aa
 aa
-SE
-SE
-SE
-SE
-SE
-SE
-SE
+RO
+RO
+RO
+RO
+RO
+RO
+RO
 aa
 aa
 aa
@@ -56050,7 +56193,7 @@ aa
 aa
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -56307,7 +56450,7 @@ aa
 aa
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -56564,7 +56707,7 @@ aa
 aa
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -56821,7 +56964,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -57078,7 +57221,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -57335,7 +57478,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -57592,7 +57735,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -57608,19 +57751,19 @@ aa
 aa
 aa
 aa
-vd
-As
-Bb
-Cb
-xv
-As
-Bb
-Cb
-xv
-As
-Bb
-Cb
-vd
+uW
+Ak
+AS
+BS
+Ea
+Ak
+AS
+BS
+Ea
+Ak
+AS
+BS
+uW
 ac
 aa
 aa
@@ -57849,7 +57992,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -57865,19 +58008,19 @@ aa
 aa
 aa
 aa
-vd
-BS
-CL
-DG
-xv
-BS
-FG
-DG
-xv
-BS
-IQ
-DG
-vd
+uW
+BJ
+CC
+Dx
+Ea
+BJ
+Fo
+Dx
+Ea
+BJ
+Ik
+Dx
+uW
 ac
 ac
 aa
@@ -58106,7 +58249,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -58122,19 +58265,19 @@ aa
 aa
 aa
 aa
-vd
-BT
-yf
-DH
-xv
-BT
-yf
-DH
-xv
-BT
-yf
-DH
-vd
+uW
+BK
+xX
+Dy
+Ea
+BK
+xX
+Dy
+Ea
+BK
+xX
+Dy
+uW
 ac
 ac
 aa
@@ -58363,7 +58506,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -58379,19 +58522,19 @@ aa
 aa
 aa
 aa
-vd
-BU
-CM
-DI
-xv
-BU
-CM
-DI
-xv
-BU
-CM
-DI
-vd
+uW
+BL
+CD
+Dz
+Ea
+BL
+CD
+Dz
+Ea
+BL
+CD
+Dz
+uW
 ac
 ac
 ac
@@ -58619,9 +58762,9 @@ aa
 ac
 ac
 ac
-pg
-pL
-qj
+pe
+pJ
+qg
 ac
 aa
 aa
@@ -58634,22 +58777,22 @@ aa
 aa
 aa
 aa
-vd
-vd
-vd
-BV
-CN
-BV
-xv
-BV
-FH
-BV
-xv
-BV
-IR
-BV
-vd
-vd
+uW
+uW
+uW
+BM
+CE
+BM
+Ea
+BM
+Fp
+BM
+Ea
+BM
+Il
+BM
+uW
+uW
 ac
 ac
 aa
@@ -58876,9 +59019,9 @@ aa
 ac
 ac
 aa
-ph
-pK
-qi
+pf
+pI
+qf
 ac
 aa
 aa
@@ -58887,26 +59030,26 @@ kj
 jL
 kj
 kj
-vd
-vd
-vd
-vd
-vd
-Am
-AW
-BW
-CO
-yf
-El
-yf
-CO
-yf
-Hv
-yf
-CO
-yf
-yf
-Kt
+uW
+uW
+uW
+uW
+uW
+Ae
+AN
+BN
+CF
+xX
+Eb
+xX
+CF
+xX
+GV
+xX
+CF
+xX
+xX
+JL
 ac
 ac
 ac
@@ -59134,36 +59277,36 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
 kj
 kj
 af
-wk
+wd
 af
 jL
-vd
-xS
-yz
-zf
-zH
-An
-AX
-BX
-CO
-DJ
-Em
-Em
-FI
-GF
-Hw
-Ii
-IS
-JD
-Kr
-Ku
+uW
+xK
+yr
+yX
+zz
+Af
+AO
+BO
+CF
+DA
+Ec
+Ec
+Fq
+Gj
+GW
+HE
+Im
+IV
+JJ
+JM
 ac
 ac
 ac
@@ -59391,7 +59534,7 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -59399,28 +59542,28 @@ kj
 jL
 af
 af
-wE
-wZ
-xu
-xT
-yA
-zg
-zI
-Ao
-AY
-BY
-CP
-DK
-Ap
-EY
-FJ
-GG
-yf
-Ij
-IT
-JE
-JE
-Ku
+wx
+wS
+xn
+xL
+ys
+yY
+zA
+Ag
+AP
+BP
+CG
+DB
+Ah
+EK
+Fr
+Gk
+xX
+HF
+In
+IW
+IW
+JM
 ac
 ac
 ac
@@ -59648,36 +59791,36 @@ aa
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
 kj
 kj
 ac
-wl
+we
 af
 jL
-vd
-xU
-yB
-zh
-zJ
-Ap
-Ap
-Ap
-CQ
-DL
-En
-EZ
-Bb
-Bb
-Cb
-vd
-IU
-JF
-Ks
-Kv
+uW
+xM
+yt
+yZ
+zB
+Ah
+Ah
+Ah
+CH
+DC
+Ed
+EL
+AS
+AS
+BS
+uW
+Io
+IX
+JK
+JN
 ac
 ac
 ac
@@ -59905,7 +60048,7 @@ ac
 ac
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
@@ -59915,26 +60058,26 @@ kj
 jL
 kj
 kj
-vd
-xV
-yC
-zi
-zH
-Aq
-AZ
-BZ
-CR
-DM
-vd
-Fa
-FK
-GH
-Hx
-vd
-As
-Cb
-vd
-vd
+uW
+TP
+yu
+za
+zz
+Ai
+AQ
+BQ
+CI
+DD
+uW
+EM
+Fs
+Gl
+GX
+uW
+Ak
+BS
+uW
+uW
 ac
 ac
 ac
@@ -60162,40 +60305,40 @@ ac
 ac
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-xW
-yD
-zj
-xv
-Ar
-Ba
-Ca
-CS
-DN
-Eo
-Fb
-yf
-yf
-yf
-Ik
-IV
-JG
-vd
+uW
+uW
+uW
+uW
+uW
+uW
+uW
+xO
+yv
+zb
+Ea
+Aj
+AR
+BR
+CJ
+DE
+Ee
+EN
+xX
+xX
+xX
+HG
+Ip
+IY
+uW
 ac
 ac
 ac
 ac
-md
+mb
 ac
 ac
 ac
@@ -60419,35 +60562,35 @@ ac
 ac
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
-vd
-vr
-vP
-wm
-wF
-xa
-xv
+uW
+vk
+vI
+wf
+wy
+wT
+Ea
+xP
+yw
+zc
+Ea
+Ak
+AS
+BS
+Ea
+Ak
+Ef
+EO
+Ft
+Ft
 xX
-yE
-zk
-xv
-As
-Bb
-Cb
-xv
-As
-Ep
-Fc
-FL
-FL
-yf
-Il
-IW
-JH
-Kt
+HH
+Iq
+IZ
+JL
 ac
 ac
 ac
@@ -60676,35 +60819,35 @@ ac
 ac
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
-vd
-vs
-vP
-vP
-vP
-xb
-xv
-xY
-yF
-zl
-zH
-At
-Bc
-Cc
-xv
-DO
-Eq
-AX
-FM
-GI
-yf
-Im
-yf
-yf
-Ku
+uW
+vl
+vI
+vI
+vI
+wU
+Ea
+xQ
+yx
+zd
+zz
+Al
+AT
+BT
+Ea
+DF
+Eg
+AO
+Fu
+Gm
+xX
+HI
+xX
+xX
+JM
 ac
 ac
 ac
@@ -60933,35 +61076,35 @@ ac
 ac
 ac
 ac
-pJ
+pH
 ac
 aa
 aa
-vd
-vr
-vP
-wn
-wG
-xc
-xw
-xZ
-yG
-zm
-zK
-Ao
-AY
-Cd
-CT
-DP
-Er
-Fd
-FN
-GJ
-Hy
-In
-yf
-yf
-Ku
+uW
+vk
+vI
+wg
+wz
+wV
+xo
+xR
+yy
+ze
+zC
+Ag
+AP
+BU
+CK
+DG
+Eh
+EP
+Fv
+Gn
+GY
+HJ
+xX
+xX
+JM
 ac
 ac
 ac
@@ -61190,35 +61333,35 @@ ac
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
-vd
-vd
-vd
-wo
-wH
-vP
-xv
-ya
-yH
-zn
-vd
-Au
-Bd
-Ce
-CU
-DQ
-Es
-Fe
-FO
-FL
-Hz
-Ik
-IX
-JI
-Kv
+uW
+uW
+uW
+wh
+wA
+vI
+Ea
+xS
+yz
+zf
+uW
+Am
+AU
+BV
+CL
+DH
+Ei
+EQ
+Fw
+Ft
+GZ
+HG
+Ir
+Ja
+JN
 ac
 ac
 ac
@@ -61447,47 +61590,47 @@ ac
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
 aa
 aa
-vd
-wp
-wI
-wp
-vd
-vd
-yI
-vd
-vd
-As
-Bb
-Cb
-vd
-vd
-vd
-Ff
-yf
-yf
-Hz
-Il
-IY
-JJ
-vd
+uW
+wi
+wB
+wi
+uW
+uW
+yA
+uW
+uW
+Ak
+AS
+BS
+uW
+uW
+uW
+ER
+xX
+xX
+GZ
+HH
+Is
+Jb
+uW
 ac
 aa
 aa
 ac
-MV
-NI
-NI
-OO
-OS
-OS
-OS
-OS
+Ml
+MY
+MY
+Oe
+Oi
+Oi
+Oi
+Oi
 aa
 aa
 aa
@@ -61704,47 +61847,47 @@ ac
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
 aa
 aa
-vd
-vd
-vd
-vd
-vd
-yb
-yJ
-zo
-vd
+uW
+uW
+uW
+uW
+uW
+xT
+yB
+zg
+uW
 ac
 ac
 ac
 aa
 aa
-vd
-Fg
-FP
-GK
-HA
-vd
-vd
-vd
-vd
+uW
+ES
+Fx
+Go
+Ha
+uW
+uW
+uW
+uW
 aa
 aa
 aa
 ac
-MW
-NJ
+Mm
+MZ
+Ny
+Of
 Oi
-OP
-OS
-PP
-Qn
-OS
+Pf
+PD
+Oi
 aa
 aa
 aa
@@ -61944,15 +62087,15 @@ kj
 kj
 kj
 jL
-nx
-nx
-nx
-nx
-nx
-nx
-nx
-nx
-nx
+nv
+nv
+nv
+nv
+nv
+nv
+nv
+nv
+nv
 jL
 kj
 kj
@@ -61961,7 +62104,7 @@ kj
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -61971,37 +62114,37 @@ aa
 aa
 aa
 aa
-vd
-yc
-yK
-zp
-vd
+uW
+xU
+yC
+zh
+uW
 ac
 ac
 ac
 ac
-rx
-vd
-vd
-vd
-vd
-vd
-vd
-DR
-DR
-DR
+rt
+uW
+uW
+uW
+uW
+uW
+uW
+DI
+DI
+DI
 aa
 aa
 aa
 ac
-MW
-NK
-Oj
-OQ
-OS
-PQ
-Qo
-OS
+Mm
+Na
+Nz
+Og
+Oi
+Pg
+PE
+Oi
 aa
 aa
 aa
@@ -62201,15 +62344,15 @@ kj
 kj
 kj
 kj
-nx
-nx
-nx
-nx
-nx
-nx
-nx
-nx
-nx
+nv
+nv
+nv
+nv
+nv
+nv
+nv
+nv
+nv
 kj
 kj
 kj
@@ -62218,7 +62361,7 @@ kj
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -62228,37 +62371,37 @@ aa
 aa
 aa
 aa
-vd
-yd
-yL
-zq
-vd
+uW
+xV
+yD
+zi
+uW
 aa
 ac
 ac
 ac
-DR
-Et
-Fh
-Et
-Et
-Et
-Et
-Fh
-Et
-DR
+DI
+Ej
+ET
+Ej
+Ej
+Ej
+Ej
+ET
+Ej
+DI
 aa
 aa
 ac
 ac
-MX
-NL
-Ok
-OR
-OS
-PR
-Qn
-OS
+Mn
+Nb
+NA
+Oh
+Oi
+Ph
+PD
+Oi
 aa
 aa
 aa
@@ -62458,15 +62601,15 @@ kj
 kj
 kj
 kj
-nx
-nx
-nx
-pO
-ql
-qE
-nx
-nx
-nx
+nv
+nv
+nv
+pM
+qi
+qB
+nv
+nv
+nv
 kj
 kj
 kj
@@ -62475,7 +62618,7 @@ kj
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 aa
@@ -62484,38 +62627,38 @@ aa
 aa
 aa
 aa
-vd
-vd
-vd
-yM
-vd
-vd
+uW
+uW
+uW
+yE
+uW
+uW
 ac
 ac
 ac
 ac
-DR
-Eu
-Eu
-Eu
-Eu
-Eu
-Eu
-Eu
-Eu
-DR
-KW
-KW
-LJ
-Mp
-KW
-KW
-Ol
-OS
-OS
-PS
-Qo
-OS
+DI
+Ek
+Ek
+Ek
+Ek
+Ek
+Ek
+Ek
+Ek
+DI
+Ko
+Ko
+KZ
+LF
+Ko
+Ko
+NB
+Oi
+Oi
+Pi
+PE
+Oi
 aa
 aa
 aa
@@ -62715,15 +62858,15 @@ kj
 kj
 kj
 kj
-nx
-nx
-pj
-pP
-qm
-qF
-qN
-nx
-nx
+nv
+nv
+ph
+pN
+qj
+qC
+TG
+nv
+nv
 kj
 kj
 kj
@@ -62732,7 +62875,7 @@ kj
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 ac
@@ -62741,38 +62884,38 @@ aa
 aa
 aa
 ac
-xd
-xx
-ye
-yN
-zr
-vd
+wW
+xp
+xW
+yF
+zj
+uW
 ac
 ac
 ac
 ac
-DR
-Eu
-Eu
-Eu
-Eu
-Eu
-Eu
-Eu
-Eu
-DR
-KX
-Lq
-LK
-Mq
-MY
-NM
-Om
-OT
-Ps
-PT
-Qp
-OS
+DI
+Ek
+Ek
+Ek
+Ek
+Ek
+Ek
+Ek
+Ek
+DI
+Kp
+KG
+La
+LG
+Mo
+Nc
+NC
+Oj
+OI
+Pj
+PF
+Oi
 aa
 aa
 aa
@@ -62972,15 +63115,15 @@ kj
 kj
 kj
 kj
-nx
-nx
-pk
-pQ
-qn
-qG
-qO
-nx
-nx
+nv
+nv
+pi
+pO
+qk
+qD
+qL
+nv
+nv
 kj
 kj
 kj
@@ -62989,7 +63132,7 @@ kj
 ac
 ac
 ac
-pJ
+pH
 ac
 ac
 ac
@@ -62998,38 +63141,38 @@ aa
 aa
 ac
 ac
-xe
-xy
-yf
-yO
-zs
-zL
-Av
-Av
-Av
-CV
-DR
-Ev
-Ev
-FQ
-GL
-HB
-Ev
-Ev
-Ev
-DR
-KY
-Lr
-LL
-Mr
-MZ
-MZ
-On
-OS
-Pt
-PU
-Qq
-OS
+wX
+xq
+xX
+yG
+zk
+zD
+An
+An
+An
+CM
+DI
+El
+El
+Fy
+Gp
+Hb
+El
+El
+El
+DI
+Kq
+KH
+Lb
+LH
+Mp
+Mp
+ND
+Oi
+OJ
+Pk
+PG
+Oi
 aa
 aa
 aa
@@ -63229,15 +63372,15 @@ kj
 kj
 kj
 kj
-nx
-nx
-pl
-pQ
-ny
-qG
-qP
-nx
-nx
+nv
+nv
+pj
+pO
+nw
+qD
+qM
+nv
+nv
 kj
 kj
 kj
@@ -63245,50 +63388,50 @@ kj
 kj
 kj
 ac
-pg
-pL
-qj
+pe
+pJ
+qg
 ac
 ac
 ac
 ac
-pg
-qj
+pe
+qg
 ac
-xe
-xz
-yg
-yP
-zt
-zM
-Aw
-Be
-Aw
-CW
-DR
-Et
-Et
-FR
-GM
-Et
-Et
-Et
-Et
-DR
-KZ
-Ls
-LM
-Ms
-Na
-LM
-Oo
-KW
-KW
-KW
-KW
-KW
-KW
-KW
+wX
+xr
+xY
+yH
+zl
+zE
+Ao
+AV
+Ao
+CN
+DI
+Ej
+Ej
+Fz
+Gq
+Ej
+Ej
+Ej
+Ej
+DI
+Kr
+KI
+Lc
+LI
+Mq
+Lc
+NE
+Ko
+Ko
+Ko
+Ko
+Ko
+Ko
+Ko
 aa
 aa
 aa
@@ -63486,66 +63629,66 @@ kj
 kj
 kj
 kj
-nx
-nx
-pm
-pQ
-qo
-qG
-qQ
-nx
-nx
-pY
-qV
-qV
-qV
-qV
-qV
+nv
+nv
+pk
+pO
+ql
+qD
+TH
+nv
+nv
+pW
 qS
-sx
-tb
-tH
-uq
-uq
-uq
-uq
-vQ
-wq
+qS
+qS
+qS
+qS
+qP
+ss
+sV
+tz
+ui
+ui
+ui
+ui
+vJ
+wj
 ac
-xe
-xA
-yf
-yQ
-zu
-zN
-Ax
-Ax
-Cf
-CX
-DR
-Ew
-Eu
-Eu
-GM
-Eu
-Eu
-Eu
-Eu
-DR
-KW
-Lt
-LN
-Mt
-Nb
-NN
-Op
-OU
-Pu
-PV
-Qr
-QJ
-QU
-KW
+wX
+xs
+xX
+yI
+zm
+zF
+Ap
+Ap
+BW
+CO
+DI
+Em
+Ek
+Ek
+Gq
+Ek
+Ek
+Ek
+Ek
+DI
+Ko
+KJ
+Ld
+LJ
+Mr
+Nd
+NF
+Ok
+OK
+Pl
+PH
+PY
+TQ
+Ko
 aa
 aa
 aa
@@ -63743,66 +63886,66 @@ kj
 kj
 kj
 kj
-nx
-nx
-pn
-om
-qp
-qH
-qR
-nx
-nx
-qy
+nv
+nv
+pl
+ok
+qm
+qE
+qO
+nv
+nv
+qv
 kj
 kj
 kj
 kj
 kj
 ac
-sy
-tc
-qi
+st
+sW
+qf
 ac
 ac
 ac
 ac
-vR
-qi
+vK
+qf
 ac
-xf
-xB
-yf
-yf
-zt
-zO
-Ay
-Bf
-Cg
-CY
-DS
-Eu
-Eu
-Eu
-GM
-Eu
-Eu
-Eu
-Eu
-DR
-KW
-KW
-LO
-Mu
-LM
-NO
-Oq
-KW
-Pv
-PW
-Qs
-KW
-KW
-KW
+wY
+xt
+xX
+xX
+zl
+zG
+Aq
+AW
+BX
+CP
+DJ
+Ek
+Ek
+Ek
+Gq
+Ek
+Ek
+Ek
+Ek
+DI
+Ko
+Ko
+Le
+LK
+Lc
+Ne
+NG
+Ko
+OL
+Pm
+PI
+Ko
+Ko
+Ko
 aa
 aa
 aa
@@ -64000,16 +64143,16 @@ kj
 kj
 kj
 kj
-nx
-nx
-nx
-nx
-qq
-nx
-nx
-nx
-nx
-qy
+nv
+nv
+nv
+nv
+qn
+nv
+nv
+nv
+nv
+qv
 kj
 kj
 kj
@@ -64017,49 +64160,49 @@ kj
 kj
 kj
 jB
-td
-tI
+sX
+tA
 jB
 ac
 ac
 ac
-vS
+vL
 ac
 ac
-vd
-vd
-vd
-vd
-vd
-vd
-Az
-Bg
-Ch
-CY
-DR
-Ex
-Fi
-FS
-GN
-HC
-Ev
-IZ
-Ev
-DR
+uW
+uW
+uW
+uW
+uW
+uW
+Ar
+AX
+BY
+CP
+DI
+En
+EU
+FA
+Gr
+Hc
+El
+It
+El
+DI
+Ks
+Ko
+Lf
+LL
+Ms
 La
-KW
-LP
-Mv
-Nc
-LK
-Or
-KW
-Pw
-PX
-Qs
-QK
-QU
-KW
+NH
+Ko
+OM
+Pn
+PI
+PZ
+TQ
+Ko
 aa
 aa
 aa
@@ -64257,16 +64400,16 @@ kj
 kj
 kj
 jL
-nx
-nx
-nx
-nx
-qr
-nx
-nx
-nx
-nx
-qy
+nv
+nv
+nv
+nv
+qo
+nv
+nv
+nv
+nv
+qv
 kj
 kj
 kj
@@ -64274,49 +64417,49 @@ kj
 kj
 kj
 jB
-te
-tJ
+sY
+tB
 jB
 aa
 jB
 jB
-vT
+vM
 jB
 ac
-vd
-xC
-xC
-xC
-xC
-zP
-Az
-Bh
-Ci
-CZ
-DR
-DR
-DR
-DR
-GO
-DR
-DR
-DR
-DR
-DR
-KW
-KW
-LQ
-Mw
-Nd
-NP
-Os
-KW
-KW
-KW
-KW
-KW
-KW
-KW
+uW
+xu
+xu
+xu
+xu
+zH
+Ar
+AY
+BZ
+CQ
+DI
+DI
+DI
+DI
+Gs
+DI
+DI
+DI
+DI
+DI
+Ko
+Ko
+Lg
+LM
+Mt
+Nf
+NI
+Ko
+Ko
+Ko
+Ko
+Ko
+Ko
+Ko
 aa
 aa
 aa
@@ -64517,13 +64660,13 @@ kj
 jL
 kj
 ac
-li
-qs
-qI
+lg
+qp
+qF
+qP
 qS
-qV
-qV
-pZ
+qS
+pX
 kj
 kj
 kj
@@ -64531,47 +64674,47 @@ kj
 kj
 kj
 jB
-tf
-tK
+sZ
+tC
 jB
 aa
 jB
-vt
-vU
+vm
+vN
 jB
-wJ
-vd
-xC
-xC
-xC
-xC
-xC
-Az
-Bi
-Ch
-Da
-DT
-Ey
-Fj
-FT
-GP
-HD
-Io
-Ja
-JK
-Ja
-Lb
-Lu
-LR
-Mx
-Ne
-Ne
-Ot
-OV
-Px
-PY
-Qt
-Nn
+wC
+uW
+xu
+xu
+xu
+xu
+xu
+Ar
+AZ
+BY
+CR
+DK
+Eo
+EV
+FB
+Gt
+Hd
+HK
+Iu
+Jc
+Iu
+Kt
+KK
+Lh
+LN
+Mu
+Mu
+NJ
+Ol
+ON
+Po
+PJ
+MD
 aa
 aa
 aa
@@ -64774,9 +64917,9 @@ ac
 ac
 ac
 ac
-li
-ny
-ok
+lg
+nw
+oi
 ac
 ac
 ac
@@ -64788,47 +64931,47 @@ kj
 kj
 kj
 jB
-tg
-tL
+ta
+tD
 jB
 jB
 jB
-vu
-vV
+vn
+vO
 jB
-wK
+wD
 jB
-xC
-yh
-xC
-zv
-xC
-Az
-Bj
-Cj
-Ax
-DU
-Ez
-Ax
-Ax
-GQ
-HE
-Ip
-Jb
-JL
-Kw
-Jb
-Lv
-LS
-My
-Nf
-NQ
-Nf
-OW
-Nf
-Nf
-Qu
-Nn
+xu
+xZ
+xu
+zn
+xu
+Ar
+Ba
+Ca
+Ap
+DL
+Ep
+Ap
+Ap
+Gu
+He
+HL
+Iv
+Jd
+JO
+Iv
+KL
+Li
+LO
+Mv
+Ng
+Mv
+Om
+Mv
+Mv
+PK
+MD
 aa
 aa
 aa
@@ -65031,9 +65174,9 @@ ac
 ac
 ac
 ac
-li
-ny
-ok
+lg
+nw
+oi
 ac
 ac
 ac
@@ -65045,47 +65188,47 @@ kj
 kj
 kj
 jB
-th
-tM
-ur
-uO
-ve
-vv
-vW
-wr
-wL
+tb
+tE
+uj
+uH
+uX
+vo
+vP
+wk
+wE
 jB
-xC
-xC
-xC
-xC
-xC
-Az
-Bk
-Ck
-Db
-DV
-EA
-Fk
-Db
-GR
-HF
-HF
-HF
-HF
-HF
-HF
-HF
-HF
-HF
-Ng
-NR
-Ng
-HD
-Py
-PZ
-Qv
-Nn
+xu
+xu
+xu
+xu
+xu
+Ar
+Bb
+Cb
+CS
+DM
+Eq
+EW
+CS
+Gv
+Hf
+Hf
+Hf
+Hf
+Hf
+Hf
+Hf
+Hf
+Hf
+Mw
+Nh
+Mw
+Hd
+OO
+Pp
+PL
+MD
 aa
 aa
 aa
@@ -65278,19 +65421,19 @@ ac
 ac
 ac
 ac
-lu
+ls
 jL
-lu
+ls
 jL
-lu
-lu
-lu
+ls
+ls
+ls
 ac
 ac
 ac
-li
-ny
-ok
+lg
+nw
+oi
 ac
 ac
 ac
@@ -65302,53 +65445,53 @@ kj
 kj
 kj
 jB
-ti
-ti
-us
+tc
+tc
+uk
 kz
-qe
-qe
-qe
-qe
-wM
+Sv
+Sv
+Sv
+Sv
+wF
 jB
-xC
-xC
-xC
-xC
-xC
+xu
+xu
+xu
+xu
+xu
 jB
-Bl
+Bc
 jB
-Dc
-DW
-Az
-Az
-FU
-GS
-HF
-Iq
-Jc
-JM
-Kx
-Lc
-Jc
-LT
-HF
-Nh
-NS
-Ou
-HD
-HD
-Pz
-Qw
-Nn
-Nn
-Nn
-Nn
-Nn
-Nn
-Nn
+CT
+DN
+Ar
+Ar
+FC
+Gw
+Hf
+HM
+Iw
+Je
+JP
+Ku
+Iw
+Lj
+Hf
+Mx
+Ni
+NK
+Hd
+Hd
+OP
+PM
+MD
+MD
+MD
+MD
+MD
+MD
+MD
 aa
 aa
 aa
@@ -65534,20 +65677,20 @@ kj
 ac
 ac
 ac
-li
-lv
-lv
-lv
-lv
-mT
-nx
-ny
-ok
+lg
+lt
+lt
+lt
+lt
+mR
+nv
+nw
+oi
 ac
 ac
-li
-ny
-ok
+lg
+nw
+oi
 ac
 ac
 ac
@@ -65561,13 +65704,13 @@ kj
 jB
 jB
 jB
-ut
-uP
-vf
-uP
-uP
-uP
-wN
+ul
+uI
+uY
+uI
+uI
+uI
+wG
 jB
 jB
 jB
@@ -65575,37 +65718,37 @@ jB
 jB
 jB
 jB
-Bm
-Cl
+Bd
+Cc
 ac
 ac
 aa
-Az
-FV
-GT
-HF
-Ir
-Jd
-JN
-Kx
-Ld
-Jd
-LU
-HF
-Ni
-NT
-Ov
-OX
-HD
-Qa
-Qx
-QL
-QV
-Rk
-Rx
-RK
-Sc
-Nn
+Ar
+FD
+Gx
+Hf
+HN
+Ix
+Jf
+JP
+Kv
+Ix
+Lk
+Hf
+My
+Nj
+NL
+On
+Hd
+Pq
+Tm
+PN
+Qh
+Qw
+QH
+QU
+Rm
+MD
 aa
 aa
 aa
@@ -65792,19 +65935,19 @@ ac
 ac
 ac
 jL
-lv
-lG
-lv
-lv
-lv
-ny
-ny
-ol
-oN
-oN
+lt
+lE
+lt
+lt
+lt
+nw
+nw
+oj
+oL
+oL
 jL
-ny
-ok
+nw
+oi
 ac
 ac
 ac
@@ -65818,51 +65961,51 @@ kj
 kj
 aa
 jB
-uu
+um
 jB
 jB
 jB
 jB
 jB
-wO
-xg
-xg
-xg
-yR
-xg
-xg
-xg
-Bn
-Cm
+wH
+wZ
+wZ
+wZ
+yJ
+wZ
+wZ
+wZ
+Be
+Cd
 ac
 ac
 aa
-Az
-FW
-GU
-HG
-Is
-Je
-Je
-Ky
-Le
-Le
-LV
-HF
-Nj
-NU
-Ow
-OY
-Pz
-Qb
-Qy
-QM
-QW
-Rl
-Ry
-Qb
-Sd
-Nn
+Ar
+FE
+Gy
+Hg
+HO
+Iy
+Iy
+JQ
+Kw
+Kw
+Ll
+Hf
+Mz
+Nk
+NM
+Oo
+OP
+Pr
+Tn
+To
+Qi
+Tq
+QI
+Pr
+Rn
+MD
 aa
 aa
 aa
@@ -66048,19 +66191,19 @@ kj
 ac
 ac
 ac
-li
-lv
-lv
-lv
-lv
-lv
-ny
-ny
-om
-ny
-ny
-ny
-qt
+lg
+lt
+lt
+lt
+lt
+lt
+nw
+nw
+ok
+nw
+nw
+nw
+qq
 jL
 ac
 ac
@@ -66075,51 +66218,51 @@ aa
 aa
 aa
 jB
-us
+uk
 jB
 aa
 aa
 aa
 jB
 jB
-xh
+xa
 jB
-xh
+xa
 jB
-xh
+xa
 jB
-xh
+xa
 jB
 jB
 ac
 ac
 ac
-Fl
-FX
-GV
-HH
-It
-Jf
-Jf
-Kz
-Jf
-Lw
-LW
-HF
-Nk
-NV
-Ox
-OZ
-HD
-Qc
-Qz
-QL
-Qb
-QL
-Qb
-QL
-Se
-Nn
+EX
+FF
+Gz
+Hh
+HP
+Iz
+Iz
+JR
+Iz
+KM
+Lm
+Hf
+MA
+Nl
+NN
+Op
+Hd
+Ps
+PO
+PN
+Pr
+PN
+Pr
+PN
+Ro
+MD
 aa
 aa
 aa
@@ -66306,17 +66449,17 @@ kj
 ac
 ac
 jL
-lv
-lv
-lv
-lv
-lv
-ny
-nT
-on
-lw
-lw
-lw
+lt
+lt
+lt
+lt
+lt
+nw
+nR
+ol
+lu
+lu
+lu
 jL
 ac
 ac
@@ -66332,7 +66475,7 @@ aa
 aa
 aa
 jB
-us
+uk
 jB
 aa
 aa
@@ -66351,32 +66494,32 @@ ac
 ac
 ac
 ac
-Fm
-FY
-GW
-HF
-Iu
-Jd
-JN
-Kx
-Ld
-Jd
-JN
-HF
+EY
+FG
+GA
+Hf
+HQ
+Ix
+Jf
+JP
+Kv
+Ix
+Jf
+Hf
+MB
 Nl
-NV
-NV
-OZ
-Pz
-Qd
-QA
-QN
-QX
-Rm
-Ry
-Qb
-Sf
-Nn
+Nl
+Op
+OP
+Pt
+PP
+Tp
+Qj
+Tr
+QI
+Pr
+Rp
+MD
 aa
 aa
 aa
@@ -66562,15 +66705,15 @@ kj
 kj
 ac
 ac
-li
-lv
-lv
-lv
-lv
-lv
-nx
-ny
-oo
+lg
+lt
+lt
+lt
+lt
+lt
+nv
+nw
+om
 ac
 ac
 ac
@@ -66589,7 +66732,7 @@ aa
 aa
 aa
 jB
-us
+uk
 jB
 aa
 aa
@@ -66608,32 +66751,32 @@ ac
 ac
 ac
 ac
-Fn
-FZ
-GX
-HF
-Iq
+EZ
+FH
+GB
+Hf
+HM
+IA
 Jg
-JO
+JP
 Kx
-Lf
-Jg
-LT
-HF
-Nm
-Nm
-Oy
-HD
-HD
-Qe
-QB
-QL
-QY
-Rn
-Rx
-RL
-Sg
-Nn
+IA
+Lj
+Hf
+MC
+MC
+NO
+Hd
+Hd
+Pu
+PQ
+PN
+Qk
+Qx
+QH
+QV
+Rq
+MD
 aa
 aa
 aa
@@ -66820,13 +66963,13 @@ kj
 ac
 ac
 ac
-lw
+lu
 jL
-lw
+lu
 jL
-lw
-lw
-lw
+lu
+lu
+lu
 ac
 ac
 ac
@@ -66846,7 +66989,7 @@ aa
 aa
 aa
 jB
-us
+uk
 jB
 aa
 aa
@@ -66861,36 +67004,36 @@ ac
 ac
 ac
 ac
-Cn
-Cn
-Cn
-Cn
-Cn
-Ga
-GY
-HF
-HF
-HF
-HF
-HF
-Lg
-Lg
-Lg
-Lg
-Nn
-Nn
-Nn
-Nn
-Nn
-Nn
-Nn
-Nn
-Nn
-Nn
-Nn
-Nn
-Nn
-Nn
+Ce
+Ce
+Ce
+Ce
+Ce
+FI
+GC
+Hf
+Hf
+Hf
+Hf
+Hf
+Ky
+Ky
+Ky
+Ky
+MD
+MD
+MD
+MD
+MD
+MD
+MD
+MD
+MD
+MD
+MD
+MD
+MD
+MD
 aa
 aa
 aa
@@ -67103,7 +67246,7 @@ aa
 aa
 aa
 jB
-us
+uk
 jB
 aa
 aa
@@ -67118,19 +67261,19 @@ aa
 ac
 ac
 ac
-Cn
-Dd
-DX
-EB
-Fo
-Gb
-GZ
-HI
-Iv
+Ce
+CU
+DO
+Er
+Fa
+FJ
+GD
+Hi
+HR
+IB
 Jh
-JP
-KA
-Az
+JS
+Ar
 aa
 aa
 ac
@@ -67360,7 +67503,7 @@ aa
 aa
 aa
 jB
-us
+uk
 jB
 jB
 jB
@@ -67375,19 +67518,19 @@ aa
 ac
 ac
 ac
-Cn
-De
-DY
-EC
-Fp
-Gc
-Ha
-HJ
-Iw
+Ce
+CV
+DP
+Es
+Fb
+FK
+GE
+Hj
+HS
+IC
 Ji
-JQ
-KB
-Az
+JT
+Ar
 aa
 jL
 ac
@@ -67593,7 +67736,7 @@ kj
 kj
 ac
 ac
-md
+mb
 kj
 kj
 kj
@@ -67617,34 +67760,34 @@ aa
 aa
 aa
 jB
-uv
-uQ
-uQ
-uQ
-uQ
-uQ
-uQ
-uQ
-uQ
-yi
+un
+uJ
+uJ
+uJ
+uJ
+uJ
+uJ
+uJ
+uJ
+ya
 jB
 aa
 aa
 ac
 ac
-Cn
-Df
-DZ
-ED
-Fq
-Gd
-Hb
-HK
-Ix
+Ce
+CW
+DQ
+Et
+Fc
+FL
+GF
+Hk
+HT
+ID
 Jj
-JR
-KC
-Az
+JU
+Ar
 aa
 af
 ac
@@ -67883,27 +68026,27 @@ jB
 jB
 jB
 jB
-yj
+yb
 jB
 aa
 aa
 ac
 ac
-Cn
-Dg
-Dg
-Dg
-Dg
-Ge
-Ch
-HL
-Iy
+Ce
+CX
+CX
+CX
+CX
+FM
+BY
+Hl
+HU
+IE
 Jk
-JS
-KD
-Lh
-Lx
-LX
+JV
+Kz
+KN
+Ln
 ac
 ac
 af
@@ -68146,19 +68289,19 @@ aa
 aa
 aa
 ac
-Co
-Dh
-Ea
-EE
-Fr
-Gb
-Hc
-HM
-Iz
+Cf
+CY
+DR
+Eu
+Fd
+FJ
+GG
+Hm
+HV
+IF
 Jl
-JT
-KE
-Az
+JW
+Ar
 aa
 af
 ac
@@ -68403,19 +68546,19 @@ aa
 aa
 aa
 ac
-Co
-Di
-Eb
-EF
-Fs
-Gf
-Hd
-HN
-IA
-Jm
-HL
-KF
-Az
+Cf
+CZ
+DS
+Ev
+Fe
+FN
+GH
+Hn
+HW
+IG
+Hl
+JX
+Ar
 aa
 jL
 ac
@@ -68660,19 +68803,19 @@ aa
 aa
 aa
 aa
-Co
-Dj
-Ec
-EG
-Fr
-Gb
-He
-HO
-IB
-Jn
-JU
-IB
-Az
+Cf
+Da
+DT
+Ew
+Fd
+FJ
+GI
+Ho
+HX
+IH
+Jm
+HX
+Ar
 aa
 aa
 aa
@@ -68917,19 +69060,19 @@ aa
 aa
 aa
 aa
-Co
-Co
-Co
-Co
-Co
-Gg
-Hf
-Az
-Gg
-Jo
-Jo
-Hf
-Az
+Cf
+Cf
+Cf
+Cf
+Cf
+FO
+GJ
+Ar
+FO
+II
+II
+GJ
+Ar
 aa
 aa
 aa
@@ -71452,12 +71595,12 @@ jL
 jL
 jL
 jL
-nU
-nU
-nU
-nU
-nU
-nU
+nS
+nS
+nS
+nS
+nS
+nS
 kj
 kj
 kj
@@ -71709,12 +71852,12 @@ kj
 kj
 kj
 kj
-nU
-nU
-nU
-nU
-nU
-nU
+nS
+nS
+nS
+nS
+nS
+nS
 kj
 kj
 kj
@@ -71966,15 +72109,15 @@ kj
 ac
 ac
 kj
-nU
-op
-oO
-po
-nU
-nU
+nS
+on
+oM
+pm
+nS
+nS
 kj
 jL
-qW
+qT
 ac
 ac
 ac
@@ -71983,7 +72126,7 @@ ac
 ac
 ac
 ac
-sz
+su
 jL
 kj
 kj
@@ -72223,12 +72366,12 @@ ac
 ac
 ac
 kj
-nU
-oq
-oP
-pp
-nU
-nU
+nS
+oo
+oN
+pn
+nS
+nS
 jL
 ac
 ac
@@ -72475,27 +72618,27 @@ jL
 kj
 kj
 kj
-lH
-me
-mv
-mU
-lM
-lM
-lM
-oQ
-lM
-lM
-lM
-lM
+lF
+mc
+mt
+mS
+lK
+lK
+lK
+oO
+lK
+lK
+lK
+lK
 ac
 ac
-lu
-oN
-oN
+ls
+oL
+oL
 jL
-oN
+oL
 jL
-oN
+oL
 ac
 ac
 ac
@@ -72732,28 +72875,28 @@ jL
 kj
 kj
 ac
-lI
-mf
-mw
-mV
-lM
-nV
-or
-oR
-or
-pR
-lM
-lM
+lG
+md
+mu
+mT
+lK
+nT
+op
+oP
+op
+pP
+lK
+lK
 ac
-li
-ra
-lM
-ri
-ri
-ri
-ri
-rN
-ok
+lg
+qX
+lK
+rf
+rf
+rf
+rf
+rJ
+oi
 ac
 kj
 kj
@@ -72766,7 +72909,7 @@ jL
 aa
 aa
 jB
-yj
+yb
 jB
 aa
 aa
@@ -72989,27 +73132,27 @@ jL
 kj
 ac
 ac
-lJ
-mg
-mx
-mW
-lM
-nW
-os
-oS
-os
-pS
-lM
-lM
-oN
+lH
+me
+mv
+mU
+lK
+nU
+oq
+oQ
+oq
+pQ
+lK
+lK
+oL
+qU
 qX
-ra
-ra
-ri
-ri
-ri
-rB
-ri
+qX
+rf
+rf
+rf
+rx
+rf
 jL
 ac
 ac
@@ -73246,28 +73389,28 @@ jL
 kj
 ac
 ac
-lI
-mh
-my
-mX
-nz
-nX
-ot
-oT
-pq
-pT
-qu
-qJ
-qT
+lG
+mf
+mw
+mV
+nx
+nV
+or
+oR
+po
+pR
+qr
+qG
+qQ
+qV
 qY
-rb
-ra
-ri
-ri
-ri
-ri
-ri
-ok
+qX
+rf
+rf
+rf
+rf
+rf
+oi
 ac
 ac
 kj
@@ -73503,27 +73646,27 @@ jL
 kj
 ac
 ac
+lI
+mg
+mx
+mW
 lK
-mi
-mz
-mY
-lM
-nY
-os
-oS
-os
-pU
-lM
-lM
-qU
+nW
+oq
+oQ
+oq
+pS
+lK
+lK
+qR
+qW
 qZ
-rc
-ra
-ri
-ri
-ri
-ri
-ri
+qX
+rf
+rf
+rf
+rf
+rf
 jL
 ac
 ac
@@ -73760,30 +73903,30 @@ jL
 kj
 kj
 ac
-lL
-mf
-mA
-mZ
-lM
-nV
-ou
-oR
-or
-pR
-lM
-lM
-ac
-li
-rd
-lM
-ri
-ri
-ri
-ri
-ri
-ok
-ac
+lJ
 md
+my
+mX
+lK
+nT
+os
+oP
+op
+pP
+lK
+lK
+ac
+lg
+ra
+lK
+rf
+rf
+rf
+rf
+rf
+oi
+ac
+mb
 ac
 ac
 kj
@@ -74017,29 +74160,29 @@ jL
 kj
 kj
 kj
-lL
-mj
-mB
-mU
-lM
-lM
-lM
-oU
-pr
-pr
-pr
-pr
+lJ
+mh
+mz
+mS
+lK
+lK
+lK
+oS
+pp
+pp
+pp
+pp
 ac
-li
-re
+lg
+rb
+rd
 rg
-rj
 jL
-rj
+rg
 jL
-rj
-oN
-oN
+rg
+oL
+oL
 ac
 ac
 kj
@@ -74274,30 +74417,30 @@ jL
 kj
 kj
 kj
-lM
-mk
-mC
-na
-nA
-nZ
-ov
-oV
-pr
-pV
-qv
-pr
+lK
+mi
+mA
+mY
+ny
+nX
+ot
+oT
+pp
+pT
+qs
+pp
 ac
-li
-rf
-rh
-rh
-rh
-rh
-rh
-rh
-rh
-sA
-oo
+lg
+rc
+re
+re
+re
+re
+re
+re
+re
+sv
+om
 kj
 kj
 kj
@@ -74528,32 +74671,32 @@ kj
 kj
 jL
 jL
-ld
-ld
-ld
-lM
-ml
-mD
-nb
-nB
-oa
-ow
-oW
-ps
-pW
-qw
-pr
+lb
+lb
+lb
+lK
+mj
+mB
+mZ
+nz
+nY
+ou
+oU
+pq
+pU
+qt
+pp
 jL
+qT
+lu
+lu
+lu
+lu
+lu
+lu
+lu
 qW
-lw
-lw
-lw
-lw
-lw
-lw
-lw
-qZ
-sB
+sw
 jL
 kj
 kj
@@ -74785,21 +74928,21 @@ kj
 kj
 jL
 jL
-ld
-ld
-ld
-lM
-mm
-mE
-nc
-nC
-ob
-ox
-oX
-pr
-pX
-qx
-pr
+lb
+lb
+lb
+lK
+mk
+mC
+na
+nA
+nZ
+ov
+oV
+pp
+pV
+qu
+pp
 kj
 kj
 kj
@@ -74808,12 +74951,12 @@ ac
 ac
 ac
 ac
-rk
-rk
-sC
-rk
-rk
-rk
+rh
+rh
+sx
+rh
+rh
+rh
 kj
 kj
 kj
@@ -75042,21 +75185,21 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lM
-lM
-mF
-lM
-nD
-lM
-lM
-lM
-pr
-pr
-pr
-pr
+lb
+lb
+lb
+lK
+lK
+mD
+lK
+nB
+lK
+lK
+lK
+pp
+pp
+pp
+pp
 kj
 kj
 kj
@@ -75065,12 +75208,12 @@ kj
 kj
 ac
 ac
-rk
-rV
-sD
-tj
-tj
-rk
+rh
+rR
+sy
+td
+td
+rh
 kj
 kj
 kj
@@ -75298,21 +75441,21 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lx
-lN
-ly
-mG
-nd
-nE
-oc
-oy
-oY
-ld
-ld
-ld
+lb
+lb
+lb
+lv
+lL
+lw
+mE
+nb
+nC
+oa
+ow
+oW
+lb
+lb
+lb
 kj
 kj
 kj
@@ -75322,12 +75465,12 @@ kj
 kj
 kj
 kj
-rk
-rW
-sD
-rH
-tN
-rk
+rh
+rS
+sy
+rD
+tF
+rh
 jB
 jB
 jB
@@ -75554,22 +75697,22 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-ld
-ly
-lO
-mn
-mH
-ne
-nE
-lz
-oz
-oZ
-ld
-ld
-ld
+lb
+lb
+lb
+lb
+lw
+lM
+ml
+mF
+nc
+nC
+lx
+ox
+oX
+lb
+lb
+lb
 kj
 kj
 kj
@@ -75579,21 +75722,21 @@ kj
 kj
 kj
 kj
-rk
-rX
-sE
-tk
-tO
-uw
-uR
-uR
-uR
-uR
-ws
-uQ
-uQ
-uQ
-yk
+rh
+rT
+sz
+te
+tG
+uo
+uK
+uK
+uK
+uK
+wl
+uJ
+uJ
+uJ
+yc
 jB
 aa
 aa
@@ -75811,23 +75954,23 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lj
-lz
-lA
-lA
-lA
-nf
-nE
-lA
-lz
-lz
-pt
-ld
-ld
-ld
+lb
+lb
+lb
+lh
+lx
+ly
+ly
+ly
+nd
+nC
+ly
+lx
+lx
+pr
+lb
+lb
+lb
 kj
 kj
 kj
@@ -75835,13 +75978,13 @@ kj
 kj
 kj
 kj
-rk
-rk
-rk
-rk
-rk
-tP
-rk
+rh
+rh
+rh
+rh
+rh
+tH
+rh
 jB
 jB
 jB
@@ -76068,37 +76211,37 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lk
-lA
-lP
-lA
-lA
-ng
-nF
-lA
-lP
-lA
-pu
-ld
-ld
-ld
+lb
+lb
+lb
+li
+ly
+lN
+ly
+ly
+ne
+nD
+ly
+lN
+ly
+ps
+lb
+lb
+lb
 kj
 kj
 kj
 kj
-rk
-rk
-rk
-rk
-rk
-rY
-sF
-tl
-tQ
-rk
+rh
+rh
+rh
+rh
+rh
+rU
+sA
+tf
+tI
+rh
 jB
 jB
 jB
@@ -76326,39 +76469,39 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lB
-lA
-lA
-mI
-nh
-nG
-lA
+lb
+lb
+lb
 lz
-pa
-ld
-ld
-ld
+ly
+ly
+mG
+nf
+nE
+ly
+lx
+oY
+lb
+lb
+lb
 kj
 kj
 kj
 kj
 kj
-rk
-rk
-rk
-rk
-rk
-rZ
-rk
-rk
-rk
-rk
-rk
-rk
-rk
+rh
+rh
+rh
+rh
+rh
+TI
+rh
+rh
+rh
+rh
+rh
+rh
+rh
 kj
 jL
 aa
@@ -76583,39 +76726,39 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-ld
-lA
-lA
-mJ
-ni
-nH
-lA
-lA
-ld
-ld
-ld
-ld
+lb
+lb
+lb
+lb
+ly
+ly
+mH
+ng
+nF
+ly
+ly
+lb
+lb
+lb
+lb
 kj
 kj
 kj
 kj
 kj
-rk
-rk
-rp
+rh
+rh
+rm
+ry
+Sx
+TJ
+sB
+tg
+tJ
 rC
-rs
-sa
-sG
-tm
-tR
-rG
-uS
-rk
-rk
+TN
+rh
+rh
 kj
 jL
 aa
@@ -76840,39 +76983,39 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-ld
-lQ
-mo
-mK
-nj
-nI
-od
-oA
-ld
-ld
-ld
-ld
-pY
-qV
-qV
-qV
-qV
-rl
-rl
-rq
+lb
+lb
+lb
+lb
+lO
+mm
+mI
+nh
+nG
+ob
+oy
+lb
+lb
+lb
+lb
+pW
+qS
+qS
+qS
+qS
+ri
+ri
+rn
+rz
+Sx
+TK
+rC
+rC
+rC
 rD
-rs
-sb
-rG
-rG
-rG
-rH
-uT
-rk
-rk
+TO
+rh
+rh
 kj
 jL
 aa
@@ -77098,38 +77241,38 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lA
-lA
-mL
-nk
-nJ
-lA
-lA
-ld
-ld
-ld
-ld
-qy
+lb
+lb
+lb
+ly
+ly
+mJ
+ni
+nH
+ly
+ly
+lb
+lb
+lb
+lb
+qv
 kj
 kj
 kj
 kj
-rk
-rk
-rr
-rE
-rO
-sc
-sH
-tn
-tS
-ux
-uU
-rk
-rk
+rh
+rh
+ro
+rA
+rK
+rY
+sC
+th
+tK
+up
+uN
+rh
+rh
 kj
 jL
 aa
@@ -77355,38 +77498,38 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lR
-mp
-mM
-nl
-nK
-oe
-oB
-ld
-ld
-ld
-ld
-qy
+lb
+lb
+lb
+lP
+mn
+mK
+nj
+nI
+oc
+oz
+lb
+lb
+lb
+lb
+qv
 kj
 kj
 kj
 kj
-rk
-rk
-rs
-rs
-rs
-sd
-rs
-to
-tT
-rs
-uV
-rk
-rk
+rh
+rh
+Sx
+Sx
+Sx
+TL
+Sx
+ti
+tL
+Sx
+uO
+rh
+rh
 kj
 jL
 aa
@@ -77612,38 +77755,38 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lS
-mq
-mN
-nm
-nL
-of
-oC
-ld
-ld
-ld
-ld
-qy
+lb
+lb
+lb
+lQ
+mo
+mL
+nk
+nJ
+od
+oA
+lb
+lb
+lb
+lb
+qv
 kj
 kj
 kj
 kj
-rk
-rk
-rt
-rF
-rP
-se
-rk
-rk
-rk
-rk
-rk
-rk
-rk
+rh
+rh
+rp
+rB
+rL
+TM
+rh
+rh
+rh
+rh
+rh
+rh
+rh
 kj
 jL
 aa
@@ -77869,38 +78012,38 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lT
-mr
-mO
-nn
-nM
-og
-oD
-ld
-ld
-ld
-ld
-qy
+lb
+lb
+lb
+lR
+mp
+mM
+nl
+nK
+oe
+oB
+lb
+lb
+lb
+lb
+qv
 kj
 kj
 kj
 kj
-rk
-rk
-ru
-rG
-rQ
-sf
-rk
-rk
-rk
-rk
-rk
-rk
-rk
+rh
+rh
+rq
+rC
+rM
+sb
+rh
+rh
+rh
+rh
+rh
+rh
+rh
 kj
 jL
 aa
@@ -78125,34 +78268,34 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lC
-lU
-ms
-ld
-no
-mP
-oh
-oE
-lC
-ld
-ld
-ld
-qy
+lb
+lb
+lb
+lA
+lS
+mq
+lb
+nm
+mN
+of
+oC
+lA
+lb
+lb
+lb
+qv
 kj
 kj
 kj
 kj
-rk
-rk
-rv
-rH
-rG
-sg
-rk
-rk
+rh
+rh
+rr
+rD
+rC
+sc
+rh
+rh
 kj
 kj
 kj
@@ -78382,34 +78525,34 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lD
-lV
-ld
-mP
-np
-nN
-ld
-oF
-pb
-ld
-ld
-ld
-qy
+lb
+lb
+lb
+lB
+lT
+lb
+mN
+nn
+nL
+lb
+oD
+oZ
+lb
+lb
+lb
+qv
 kj
 kj
 kj
 kj
-rk
-rk
-rw
-rI
-rR
-sh
-rk
-rk
+rh
+rh
+rs
+rE
+rN
+sd
+rh
+rh
 kj
 kj
 kj
@@ -78639,34 +78782,34 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lE
-lW
-mt
-mQ
-nq
-nO
-oi
-oG
-lD
-ld
-ld
-ld
-qy
+lb
+lb
+lb
+lC
+lU
+mr
+mO
+no
+nM
+og
+oE
+lB
+lb
+lb
+lb
+qv
 kj
 kj
 kj
 kj
-rk
-rk
-rk
-rk
-rk
-rk
-rk
-rk
+rh
+rh
+rh
+rh
+rh
+rh
+rh
+rh
 kj
 kj
 kj
@@ -78896,34 +79039,34 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lD
-lX
-ld
-ld
-nr
-ld
-ld
-oH
-lD
-ld
-ld
-ld
-qy
+lb
+lb
+lb
+lB
+lV
+lb
+lb
+np
+lb
+lb
+oF
+lB
+lb
+lb
+lb
+qv
 kj
 kj
 kj
 kj
-rk
-rk
-rk
-rk
-rk
-rk
-rk
-rk
+rh
+rh
+rh
+rh
+rh
+rh
+rh
+rh
 kj
 kj
 kj
@@ -79154,21 +79297,21 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lY
-ld
-mR
-ns
-nP
-ld
-oI
-ld
-ld
-ld
-pY
-pZ
+lb
+lb
+lb
+lW
+lb
+mP
+nq
+nN
+lb
+oG
+lb
+lb
+lb
+pW
+pX
 kj
 kj
 kj
@@ -79411,20 +79554,20 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-lZ
-ld
-lz
-nt
-nQ
-ld
-oJ
-ld
-ld
-ld
-qy
+lb
+lb
+lb
+lX
+lb
+lx
+nr
+nO
+lb
+oH
+lb
+lb
+lb
+qv
 kj
 kj
 kj
@@ -79668,20 +79811,20 @@ kj
 kj
 kj
 kj
-ld
-ld
-lF
-ma
-mu
-mS
-nu
-nR
-oj
-oK
-pc
-ld
-ld
-qy
+lb
+lb
+lD
+lY
+ms
+mQ
+ns
+nP
+oh
+oI
+pa
+lb
+lb
+qv
 kj
 kj
 kj
@@ -79926,19 +80069,19 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-ld
-ld
-nv
-ld
-ld
-ld
-ld
-ld
-pY
-pZ
+lb
+lb
+lb
+lb
+lb
+nt
+lb
+lb
+lb
+lb
+lb
+pW
+pX
 kj
 kj
 kj
@@ -80183,18 +80326,18 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-ld
-ld
-nw
-nS
-nS
-nS
-nS
-nS
-pZ
+lb
+lb
+lb
+lb
+lb
+nu
+nQ
+nQ
+nQ
+nQ
+nQ
+pX
 kj
 kj
 kj
@@ -80441,16 +80584,16 @@ kj
 kj
 kj
 kj
-ld
-ld
-ld
-ld
-ld
-ld
-ld
-ld
-ld
-ld
+lb
+lb
+lb
+lb
+lb
+lb
+lb
+lb
+lb
+lb
 kj
 kj
 kj


### PR DESCRIPTION
The bane of many new malf/traitorAI players who are unfamiliar with binary talk commands, this channel frequently blasted nefarious plans over common for unsuspecting evil AIs.

It has been silenced, but can be turned on manually like any other intercom.