### PR TITLE
Reagent Cleanup/Tweaks

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -14,8 +14,6 @@ var/global/list/dead_mob_list = list()				//List of all dead mobs, including cli
 var/global/list/topic_commands = list()				//List of all API commands available
 var/global/list/topic_commands_names = list()				//List of all API commands available
 
-var/global/list/chemical_reactions_list				//list of all /datum/chemical_reaction datums. Used during chemical reactions
-var/global/list/chemical_reagents_list				//list of all /datum/reagent datums indexed by reagent id. Used by chemistry stuff
 var/global/list/landmarks_list = list()				//list of all landmarks created
 var/global/list/surgery_steps = list()				//list of all surgery steps  |BS12
 var/global/list/side_effects = list()				//list of all medical sideeffects types by thier names |BS12
@@ -238,10 +236,10 @@ var/global/list/cloaking_devices = list()
 /* // Uncomment to debug chemical reaction list.
 /client/verb/debug_chemical_list()
 
-	for (var/reaction in chemical_reactions_list)
-		. += "chemical_reactions_list\[\"[reaction]\"\] = \"[chemical_reactions_list[reaction]]\"\n"
-		if(islist(chemical_reactions_list[reaction]))
-			var/list/L = chemical_reactions_list[reaction]
+	for (var/reaction in SSchemistry.chemical_reactions)
+		. += "SSchemistry.chemical_reactions\[\"[reaction]\"\] = \"[SSchemistry.chemical_reactions[reaction]]\"\n"
+		if(islist(SSchemistry.chemical_reactions[reaction]))
+			var/list/L = SSchemistry.chemical_reactions[reaction]
 			for(var/t in L)
 				. += "    has: [t]\n"
 	world << .

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -5,7 +5,7 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 	priority = SS_PRIORITY_CHEMISTRY
 	init_order = SS_INIT_MISC_FIRST
 
-	var/list/active_holders
+	var/list/active_holders = list()
 	var/list/chemical_reactions
 	var/list/chemical_reagents
 
@@ -16,14 +16,16 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 
 /datum/controller/subsystem/chemistry/New()
 	NEW_SS_GLOBAL(SSchemistry)
-	active_holders = list()
-	chemical_reactions = chemical_reactions_list
-	chemical_reagents = chemical_reagents_list
-		
+
 /datum/controller/subsystem/chemistry/Initialize()
+	initialize_chemical_reagents()
+	initialize_chemical_reactions()
+	var/pre_secret_len = chemical_reactions.len
+	log_ss("chemistry", "Found [chemical_reagents.len] reagents, [pre_secret_len] reactions.")
 	load_secret_chemicals()
-	. = ..()
-	
+	log_ss("chemistry", "Loaded [chemical_reactions.len - pre_secret_len] secret recipes.")
+	..()
+
 /datum/controller/subsystem/chemistry/fire(resumed = FALSE)
 	if (!resumed)
 		processing_holders = active_holders.Copy()
@@ -75,20 +77,48 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 		cc.result = chemconfig[chemical]["result"]
 		cc.result_amount = chemconfig[chemical]["resultamount"]
 		cc.required_reagents = chemconfig[chemical]["required_reagents"]
-		if(!cc.result in chemical_reagents_list)
+		if(!cc.result in chemical_reagents)
 			log_debug("SSchemistry: Warning: Invalid result [cc.result] in [cc.name] reactions list.")
 			qdel(cc)
 
 		for(var/A in cc.required_reagents)
-			if(!(A in chemical_reagents_list))
+			if(!(A in chemical_reagents))
 				log_debug("SSchemistry: Warning: Invalid chemical [A] in [cc.name] required reagents list.")
 				qdel(cc)
 				break
 
 		if(LAZYLEN(cc.required_reagents))
 			var/reagent_id = cc.required_reagents[1]
-			LAZYINITLIST(chemical_reactions_list[reagent_id])
-			chemical_reactions_list[reagent_id] += cc
+			LAZYINITLIST(chemical_reactions[reagent_id])
+			chemical_reactions[reagent_id] += cc
 
-	chemical_reactions = chemical_reactions_list
+//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
+/datum/controller/subsystem/chemistry/proc/initialize_chemical_reagents()
+	var/paths = subtypesof(/datum/reagent)
+	chemical_reagents = list()
+	for(var/path in paths)
+		var/datum/reagent/D = new path()
+		if(!D.name)
+			continue
+		chemical_reagents[D.id] = D
 
+	sortTim(chemical_reagents, /proc/cmp_text_asc)
+
+
+//Chemical Reactions - Initialises all /datum/chemical_reaction into a list
+// It is filtered into multiple lists within a list.
+// For example:
+// chemical_reaction_list["phoron"] is a list of all reactions relating to phoron
+// Note that entries in the list are NOT duplicated. So if a reaction pertains to
+// more than one chemical it will still only appear in only one of the sublists.
+/datum/controller/subsystem/chemistry/proc/initialize_chemical_reactions()
+	var/paths = subtypesof(/datum/chemical_reaction)
+	chemical_reactions = list()
+
+	for(var/path in paths)
+		var/datum/chemical_reaction/D = new path()
+		if(D.required_reagents && D.required_reagents.len)
+			var/reagent_id = D.required_reagents[1]
+			if(!chemical_reactions[reagent_id])
+				chemical_reactions[reagent_id] = list()
+			chemical_reactions[reagent_id] += D

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -23,7 +23,7 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 	var/pre_secret_len = chemical_reactions.len
 	log_ss("chemistry", "Found [chemical_reagents.len] reagents, [pre_secret_len] reactions.")
 	load_secret_chemicals()
-	log_ss("chemistry", "Loaded [chemical_reactions.len - pre_secret_len] secret recipes.")
+	log_ss("chemistry", "Loaded [chemical_reactions.len - pre_secret_len] secret reactions.")
 	..()
 
 /datum/controller/subsystem/chemistry/fire(resumed = FALSE)

--- a/code/controllers/subsystems/garbage-debug.dm
+++ b/code/controllers/subsystems/garbage-debug.dm
@@ -286,8 +286,6 @@
 	SearchVar(dead_mob_list)
 	SearchVar(topic_commands)
 	SearchVar(topic_commands_names)
-	SearchVar(chemical_reactions_list)
-	SearchVar(chemical_reagents_list)
 	SearchVar(landmarks_list)
 	SearchVar(surgery_steps)
 	SearchVar(side_effects)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -262,7 +262,7 @@ var/list/advance_cures = 	list(
 		cure_id = advance_cures[res]
 
 		// Get the cure name from the cure_id
-		var/datum/reagent/D = chemical_reagents_list[cure_id]
+		var/datum/reagent/D = SSchemistry.chemical_reagents[cure_id]
 		cure = D.name
 
 

--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -1076,19 +1076,19 @@ var/list/global/random_stock_large = list(
 		//Can be slotted into any dispenser
 		if("chempack")
 			var/total = rand(2,6)
-			var/list/chems = chemical_reagents_list.Copy()
+			var/list/chems = SSchemistry.chemical_reagents.Copy()
 			var/list/exclusion = list("drink", "reagent", "adminordrazine", "beer2", "azoth", "elixir_life", "liquid_fire", "philosopher_stone", "undead_ichor")
 			chems -= exclusion
 			for (var/i=0,i<total,i++)
 				var/obj/item/weapon/reagent_containers/chem_disp_cartridge/C = new /obj/item/weapon/reagent_containers/chem_disp_cartridge(L)
 				var/rname = pick(chems)
-				var/datum/reagent/R = chemical_reagents_list[rname]
+				var/datum/reagent/R = SSchemistry.chemical_reagents[rname]
 
 				//If we get a drink, reroll it once.
 				//Should result in a higher chance of getting medicines and chemicals
-				if (istype(R, /datum/reagent/drink) || istype(R, /datum/reagent/ethanol))
+				if (istype(R, /datum/reagent/drink) || istype(R, /datum/reagent/alcohol/ethanol))
 					rname = pick(chems)
-					R = chemical_reagents_list[rname]
+					R = SSchemistry.chemical_reagents[rname]
 				C.reagents.add_reagent(rname, C.volume)
 				C.setLabel(R.name)
 

--- a/code/modules/item_worth/reagents.dm
+++ b/code/modules/item_worth/reagents.dm
@@ -30,16 +30,16 @@
 /datum/reagent/copper
 	value = 0.02
 
-/datum/reagent/ethanol
+/datum/reagent/alcohol/ethanol
 	value = 0.01
 
-/datum/reagent/butanol
+/datum/reagent/alcohol/butanol
 	value = 0.02
 
-/datum/reagent/butanol/xuizijuice
+/datum/reagent/alcohol/butanol/xuizijuice
 	value = 0.2
 
-/datum/reagent/butanol/xuizijuice
+/datum/reagent/alcohol/butanol/xuizijuice
 	value = 0.2
 
 /datum/reagent/hydrazine
@@ -147,349 +147,349 @@
 /datum/reagent/drink/nothing
 	value = 0
 
-/datum/reagent/ethanol/absinthe
+/datum/reagent/alcohol/ethanol/absinthe
 	value = 0.13
 
-/datum/reagent/ethanol/ale
+/datum/reagent/alcohol/ethanol/ale
 	value = 0.13
 
-/datum/reagent/ethanol/beer
+/datum/reagent/alcohol/ethanol/beer
 	value = 0.12
 
-/datum/reagent/ethanol/bitters
+/datum/reagent/alcohol/ethanol/bitters
 	value = 0.15
 
-/datum/reagent/ethanol/bluecuracao
+/datum/reagent/alcohol/ethanol/bluecuracao
 	value = 0.16
 
-/datum/reagent/ethanol/champagne
+/datum/reagent/alcohol/ethanol/champagne
 	value = 0.2
 
-/datum/reagent/ethanol/cognac
+/datum/reagent/alcohol/ethanol/cognac
 	value = 0.2
 
-/datum/reagent/ethanol/deadrum
+/datum/reagent/alcohol/ethanol/deadrum
 	value = 0.15
 
-/datum/reagent/ethanol/gin
+/datum/reagent/alcohol/ethanol/gin
 	value = 0.1
 
-/datum/reagent/ethanol/coffee/kahlua
+/datum/reagent/alcohol/ethanol/coffee/kahlua
 	value = 0.14
 
-/datum/reagent/ethanol/melonliquor
+/datum/reagent/alcohol/ethanol/melonliquor
 	value = 0.13
 
-/datum/reagent/ethanol/rum
+/datum/reagent/alcohol/ethanol/rum
 	value = 0.1
 
-/datum/reagent/ethanol/sake
+/datum/reagent/alcohol/ethanol/sake
 	value = 0.11
 
-/datum/reagent/ethanol/tequilla
+/datum/reagent/alcohol/ethanol/tequilla
 	value = 0.1
 
-/datum/reagent/ethanol/thirteenloko
+/datum/reagent/alcohol/ethanol/thirteenloko
 	value = 0.15
 
-/datum/reagent/ethanol/vermouth
+/datum/reagent/alcohol/ethanol/vermouth
 	value = 0.1
 
-/datum/reagent/ethanol/vodka
+/datum/reagent/alcohol/ethanol/vodka
 	value = 0.1
 
-/datum/reagent/ethanol/whiskey
+/datum/reagent/alcohol/ethanol/whiskey
 	value = 0.1
 
-/datum/reagent/ethanol/wine
+/datum/reagent/alcohol/ethanol/wine
 	value = 0.1
 
-/datum/reagent/ethanol/acid_spit
+/datum/reagent/alcohol/ethanol/acid_spit
 	value = 0.15
 
-/datum/reagent/ethanol/alliescocktail
+/datum/reagent/alcohol/ethanol/alliescocktail
 	value = 0.16
 
-/datum/reagent/ethanol/aloe
+/datum/reagent/alcohol/ethanol/aloe
 	value = 0.17
 
-/datum/reagent/ethanol/amasec
+/datum/reagent/alcohol/ethanol/amasec
 	value = 0.16
 
-/datum/reagent/ethanol/andalusia
+/datum/reagent/alcohol/ethanol/andalusia
 	value = 0.15
 
-/datum/reagent/ethanol/antifreeze
+/datum/reagent/alcohol/ethanol/antifreeze
 	value = 0.16
 
-/datum/reagent/ethanol/atomicbomb
+/datum/reagent/alcohol/ethanol/atomicbomb
 	value = 0.21
 
-/datum/reagent/ethanol/coffee/b52
+/datum/reagent/alcohol/ethanol/coffee/b52
 	value = 0.17
 
-/datum/reagent/ethanol/bahama_mama
+/datum/reagent/alcohol/ethanol/bahama_mama
 	value = 0.15
 
-/datum/reagent/ethanol/bananahonk
+/datum/reagent/alcohol/ethanol/bananahonk
 	value = 0.15
 
-/datum/reagent/ethanol/barefoot
+/datum/reagent/alcohol/ethanol/barefoot
 	value = 0.14
 
-/datum/reagent/ethanol/beepsky_smash
+/datum/reagent/alcohol/ethanol/beepsky_smash
 	value = 0.2
 
-/datum/reagent/ethanol/bilk
+/datum/reagent/alcohol/ethanol/bilk
 	value = 0.12
 
-/datum/reagent/ethanol/black_russian
+/datum/reagent/alcohol/ethanol/black_russian
 	value = 0.14
 
-/datum/reagent/ethanol/bloody_mary
+/datum/reagent/alcohol/ethanol/bloody_mary
 	value = 0.14
 
-/datum/reagent/ethanol/booger
+/datum/reagent/alcohol/ethanol/booger
 	value = 0.13
 
-/datum/reagent/ethanol/coffee/brave_bull
+/datum/reagent/alcohol/ethanol/coffee/brave_bull
 	value = 0.16
 
-/datum/reagent/ethanol/cmojito
+/datum/reagent/alcohol/ethanol/cmojito
 	value = 0.14
 
-/datum/reagent/ethanol/changelingsting
+/datum/reagent/alcohol/ethanol/changelingsting
 	value = 0.19
 
-/datum/reagent/ethanol/classic
+/datum/reagent/alcohol/ethanol/classic
 	value = 0.14
 
-/datum/reagent/ethanol/martini
+/datum/reagent/alcohol/ethanol/martini
 	value = 0.16
 
-/datum/reagent/ethanol/corkpopper
+/datum/reagent/alcohol/ethanol/corkpopper
 	value = 0.13
 
-/datum/reagent/ethanol/cuba_libre
+/datum/reagent/alcohol/ethanol/cuba_libre
 	value = 0.15
 
-/datum/reagent/ethanol/demonsblood
+/datum/reagent/alcohol/ethanol/demonsblood
 	value = 0.15
 
-/datum/reagent/ethanol/devilskiss
+/datum/reagent/alcohol/ethanol/devilskiss
 	value = 0.14
 
-/datum/reagent/ethanol/driestmartini
+/datum/reagent/alcohol/ethanol/driestmartini
 	value = 0.16
 
-/datum/reagent/ethanol/ginfizz
+/datum/reagent/alcohol/ethanol/ginfizz
 	value = 0.13
 
-/datum/reagent/ethanol/french75
+/datum/reagent/alcohol/ethanol/french75
 	value = 0.17
 
-/datum/reagent/ethanol/grog
+/datum/reagent/alcohol/ethanol/grog
 	value = 0.11
 
-/datum/reagent/ethanol/erikasurprise
+/datum/reagent/alcohol/ethanol/erikasurprise
 	value = 0.16
 
-/datum/reagent/ethanol/gargle_blaster
+/datum/reagent/alcohol/ethanol/gargle_blaster
 	value = 0.21
 
-/datum/reagent/ethanol/gintonic
+/datum/reagent/alcohol/ethanol/gintonic
 	value = 0.15
 
-/datum/reagent/ethanol/goldschlager
+/datum/reagent/alcohol/ethanol/goldschlager
 	value = 0.2
 
-/datum/reagent/ethanol/hippies_delight
+/datum/reagent/alcohol/ethanol/hippies_delight
 	value = 0.12
 
-/datum/reagent/ethanol/hooch
+/datum/reagent/alcohol/ethanol/hooch
 	value = 0.11
 
-/datum/reagent/ethanol/iced_beer
+/datum/reagent/alcohol/ethanol/iced_beer
 	value = 0.13
 
-/datum/reagent/ethanol/irishcarbomb
+/datum/reagent/alcohol/ethanol/irishcarbomb
 	value = 0.14
 
-/datum/reagent/ethanol/coffee/irishcoffee
+/datum/reagent/alcohol/ethanol/coffee/irishcoffee
 	value = 0.12
 
-/datum/reagent/ethanol/irish_cream
+/datum/reagent/alcohol/ethanol/irish_cream
 	value = 0.13
 
-/datum/reagent/ethanol/longislandicedtea
+/datum/reagent/alcohol/ethanol/longislandicedtea
 	value = 0.13
 
-/datum/reagent/ethanol/manhattan
+/datum/reagent/alcohol/ethanol/manhattan
 	value = 0.14
 
-/datum/reagent/ethanol/manhattan_proj
+/datum/reagent/alcohol/ethanol/manhattan_proj
 	value = 0.2
 
-/datum/reagent/ethanol/manly_dorf
+/datum/reagent/alcohol/ethanol/manly_dorf
 	value = 0.13
 
-/datum/reagent/ethanol/margarita
+/datum/reagent/alcohol/ethanol/margarita
 	value = 0.15
 
-/datum/reagent/ethanol/mead
+/datum/reagent/alcohol/ethanol/mead
 	value = 0.13
 
-/datum/reagent/ethanol/moonshine
+/datum/reagent/alcohol/ethanol/moonshine
 	value = 0.11
 
-/datum/reagent/ethanol/muscmule
+/datum/reagent/alcohol/ethanol/muscmule
 	value = 0.14
 
-/datum/reagent/ethanol/neurotoxin
+/datum/reagent/alcohol/ethanol/neurotoxin
 	value = 0.2
 
-/datum/reagent/ethanol/omimosa
+/datum/reagent/alcohol/ethanol/omimosa
 	value = 0.18
 
-/datum/reagent/ethanol/patron
+/datum/reagent/alcohol/ethanol/patron
 	value = 0.16
 
-/datum/reagent/ethanol/pinkgin
+/datum/reagent/alcohol/ethanol/pinkgin
 	value = 0.11
 
-/datum/reagent/ethanol/pinkgintonic
+/datum/reagent/alcohol/ethanol/pinkgintonic
 	value = 0.13
 
-/datum/reagent/ethanol/piratepunch
+/datum/reagent/alcohol/ethanol/piratepunch
 	value = 0.14
 
-/datum/reagent/ethanol/planterpunch
+/datum/reagent/alcohol/ethanol/planterpunch
 	value = 0.13
 
-/datum/reagent/ethanol/pwine
+/datum/reagent/alcohol/ethanol/pwine
 	value = 0.19
 
-/datum/reagent/ethanol/red_mead
+/datum/reagent/alcohol/ethanol/red_mead
 	value = 0.14
 
-/datum/reagent/ethanol/sbiten
+/datum/reagent/alcohol/ethanol/sbiten
 	value = 0.13
 
-/datum/reagent/ethanol/screwdrivercocktail
+/datum/reagent/alcohol/ethanol/screwdrivercocktail
 	value = 0.13
 
-/datum/reagent/ethanol/silencer
+/datum/reagent/alcohol/ethanol/silencer
 	value = 0.135
 
-/datum/reagent/ethanol/singulo
+/datum/reagent/alcohol/ethanol/singulo
 	value = 0.2
 
-/datum/reagent/ethanol/snowwhite
+/datum/reagent/alcohol/ethanol/snowwhite
 	value = 0.125
 
-/datum/reagent/ethanol/ssroyale
+/datum/reagent/alcohol/ethanol/ssroyale
 	value = 0.14
 
-/datum/reagent/ethanol/suidream
+/datum/reagent/alcohol/ethanol/suidream
 	value = 0.12
 
-/datum/reagent/ethanol/syndicatebomb
+/datum/reagent/alcohol/ethanol/syndicatebomb
 	value = 0.21
 
-/datum/reagent/ethanol/tequilla_sunrise
+/datum/reagent/alcohol/ethanol/tequilla_sunrise
 	value = 0.13
 
-/datum/reagent/ethanol/threemileisland
+/datum/reagent/alcohol/ethanol/threemileisland
 	value = 0.2
 
-/datum/reagent/ethanol/toxins_special
+/datum/reagent/alcohol/ethanol/toxins_special
 	value = 0.2
 
-/datum/reagent/ethanol/vodkamartini
+/datum/reagent/alcohol/ethanol/vodkamartini
 	value = 0.135
 
-/datum/reagent/ethanol/vodkatonic
+/datum/reagent/alcohol/ethanol/vodkatonic
 	value = 0.145
 
-/datum/reagent/ethanol/white_russian
+/datum/reagent/alcohol/ethanol/white_russian
 	value = 0.125
 
-/datum/reagent/ethanol/whiskey_cola
+/datum/reagent/alcohol/ethanol/whiskey_cola
 	value = 0.15
 
-/datum/reagent/ethanol/whiskeysoda
+/datum/reagent/alcohol/ethanol/whiskeysoda
 	value = 0.15
 
-/datum/reagent/ethanol/specialwhiskey
+/datum/reagent/alcohol/ethanol/specialwhiskey
 	value = 0.3
 
-/datum/reagent/ethanol/daiquiri
+/datum/reagent/alcohol/ethanol/daiquiri
 	value = 0.15
 
-/datum/reagent/ethanol/icepick
+/datum/reagent/alcohol/ethanol/icepick
 	value = 0.15
 
-/datum/reagent/ethanol/poussecafe
+/datum/reagent/alcohol/ethanol/poussecafe
 	value = 0.17
 
-/datum/reagent/ethanol/mintjulep
+/datum/reagent/alcohol/ethanol/mintjulep
 	value = 0.15
 
-/datum/reagent/ethanol/johncollins
+/datum/reagent/alcohol/ethanol/johncollins
 	value = 0.17
 
-/datum/reagent/ethanol/gimlet
+/datum/reagent/alcohol/ethanol/gimlet
 	value = 0.13
 
-/datum/reagent/ethanol/starsandstripes
+/datum/reagent/alcohol/ethanol/starsandstripes
 	value = 0.15
 
-/datum/reagent/ethanol/metropolitan
+/datum/reagent/alcohol/ethanol/metropolitan
 	value = 0.13
 
-/datum/reagent/ethanol/caruso
+/datum/reagent/alcohol/ethanol/caruso
 	value = 0.18
 
-/datum/reagent/ethanol/aprilshower
+/datum/reagent/alcohol/ethanol/aprilshower
 	value = 0.15
 
-/datum/reagent/ethanol/carthusiansazerac
+/datum/reagent/alcohol/ethanol/carthusiansazerac
 	value = 0.17
 
-/datum/reagent/ethanol/deweycocktail
+/datum/reagent/alcohol/ethanol/deweycocktail
 	value = 0.15
 
-/datum/reagent/ethanol/chartreusegreen
+/datum/reagent/alcohol/ethanol/chartreusegreen
 	value = 0.18
 
-/datum/reagent/ethanol/chartreuseyellow
+/datum/reagent/alcohol/ethanol/chartreuseyellow
 	value = 0.18
 
-/datum/reagent/ethanol/cremewhite
+/datum/reagent/alcohol/ethanol/cremewhite
 	value = 0.14
 
-/datum/reagent/ethanol/cremeyvette
+/datum/reagent/alcohol/ethanol/cremeyvette
 	value = 0.17
 
-/datum/reagent/ethanol/brandy
+/datum/reagent/alcohol/ethanol/brandy
 	value = 0.2
 
-/datum/reagent/ethanol/guinnes
+/datum/reagent/alcohol/ethanol/guinnes
 	value = 0.1
 
-/datum/reagent/ethanol/drambuie
+/datum/reagent/alcohol/ethanol/drambuie
 	value = 0.18
 
-/datum/reagent/ethanol/oldfashioned
+/datum/reagent/alcohol/ethanol/oldfashioned
 	value = 0.15
 
-/datum/reagent/ethanol/blindrussian
+/datum/reagent/alcohol/ethanol/blindrussian
 	value = 0.16
 
-/datum/reagent/ethanol/rustynail
+/datum/reagent/alcohol/ethanol/rustynail
 	value = 0.13
 
-/datum/reagent/ethanol/tallrussian
+/datum/reagent/alcohol/ethanol/tallrussian
 	value = 0.15
 
 /datum/reagent/inaprovaline

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -12,15 +12,15 @@
 	my_atom = A
 
 	//I dislike having these here but map-objects are initialised before world/New() is called. >_>
-	if(!chemical_reagents_list)
+	if(!SSchemistry.chemical_reagents)
 		//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
 		var/paths = typesof(/datum/reagent) - /datum/reagent
-		chemical_reagents_list = list()
+		SSchemistry.chemical_reagents = list()
 		for(var/path in paths)
 			var/datum/reagent/D = new path()
 			if(!D.name)
 				continue
-			chemical_reagents_list[D.id] = D
+			SSchemistry.chemical_reagents[D.id] = D
 
 /datum/reagents/Destroy()
 	. = ..()
@@ -114,7 +114,7 @@
 
 		//need to rebuild this to account for chain reactions
 		for(var/datum/reagent/R in reagent_list)
-			eligible_reactions |= chemical_reactions_list[R.id]
+			eligible_reactions |= SSchemistry.chemical_reactions[R.id]
 
 		for(var/datum/chemical_reaction/C in eligible_reactions)
 			if(C.can_happen(src) && C.process(src))
@@ -153,7 +153,7 @@
 			if(my_atom)
 				my_atom.on_reagent_change()
 			return 1
-	var/datum/reagent/D = chemical_reagents_list[id]
+	var/datum/reagent/D = SSchemistry.chemical_reagents[id]
 	if(D)
 		var/datum/reagent/R = new D.type()
 		reagent_list += R

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -11,17 +11,6 @@
 	maximum_volume = max
 	my_atom = A
 
-	//I dislike having these here but map-objects are initialised before world/New() is called. >_>
-	if(!SSchemistry.chemical_reagents)
-		//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
-		var/paths = typesof(/datum/reagent) - /datum/reagent
-		SSchemistry.chemical_reagents = list()
-		for(var/path in paths)
-			var/datum/reagent/D = new path()
-			if(!D.name)
-				continue
-			SSchemistry.chemical_reagents[D.id] = D
-
 /datum/reagents/Destroy()
 	. = ..()
 	if(SSchemistry)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1,15 +1,3 @@
-
-//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
-/proc/initialize_chemical_reagents()
-	var/paths = typesof(/datum/reagent) - /datum/reagent
-	chemical_reagents_list = list()
-	for(var/path in paths)
-		var/datum/reagent/D = new path()
-		if(!D.name)
-			continue
-		chemical_reagents_list[D.id] = D
-
-
 /datum/reagent
 	var/name = "Reagent"
 	var/id = "reagent"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -86,13 +86,13 @@
 	color = "#6E3B08"
 	taste_description = "copper"
 
-/datum/reagent/ethanol
-	name = "Ethanol" //Parent class for all alcoholic reagents.
-	id = "ethanol"
-	description = "A well-known alcohol with a variety of applications."
+/datum/reagent/alcohol //Parent class for all alcoholic reagents, though this one shouldn't be used anywhere.
+	name = null	// This null name should prevent alcohol from being added to global lists.
+	id = "alcohol"
+	description = "An abstract type you shouldn't be able to see."
 	reagent_state = LIQUID
 	color = "#404030"
-	ingest_met = 0.5
+
 	var/nutriment_factor = 0.5
 	var/strength = 100 // This is the Alcohol By Volume of the drink, value is in the range 0-100 unless you wanted to create some bizarre bluespace alcohol with <100
 
@@ -103,29 +103,61 @@
 	var/datum/modifier/caffeine_mod
 	var/caffeine  = 0
 
-	unaffected_species = IS_MACHINE	// Can act on dionae.
+	var/flammability_divisor = 10
 
+	unaffected_species = IS_MACHINE
+
+	taste_description = "mistakes"
+
+	glass_icon_state = "glass_clear"
+	glass_name = "glass of coder fuckups"
+	glass_desc = "A glass of distilled maintainer tears."
+
+/datum/reagent/alcohol/Destroy()
+	if (caffeine_mod)
+		QDEL_NULL(caffeine_mod)
+
+	return ..()
+
+/datum/reagent/alcohol/touch_mob(mob/living/L, amount)
+	if (istype(L) && strength > 40)
+		L.adjust_fire_stacks((amount / (flammability_divisor || 1)) * (strength / 100))
+
+/datum/reagent/alcohol/affect_blood(mob/living/carbon/M, alien, removed)
+	M.adjustToxLoss(removed * 2)
+
+/datum/reagent/alcohol/affect_ingest(mob/living/carbon/M, alien, removed)
+	M.intoxication += (strength / 100) * removed
+
+	if (druggy != 0)
+		M.druggy = max(M.druggy, druggy)
+
+	if (adj_temp > 0 && M.bodytemperature < targ_temp) // 310 is the normal bodytemp. 310.055
+		M.bodytemperature = min(targ_temp, M.bodytemperature + (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
+	if (adj_temp < 0 && M.bodytemperature > targ_temp)
+		M.bodytemperature = min(targ_temp, M.bodytemperature - (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
+
+	if (halluci)
+		M.hallucination = max(M.hallucination, halluci)
+
+	if (caffeine && !caffeine_mod)
+		caffeine_mod = M.add_modifier(/datum/modifier/stimulant, MODIFIER_REAGENT, src, _strength = caffeine, override = MODIFIER_OVERRIDE_STRENGTHEN)
+
+/datum/reagent/alcohol/ethanol
+	name = "Ethanol"
+	id = "ethanol"
+	description = "A well-known alcohol with a variety of applications."
+	ingest_met = 0.5
+	flammability_divisor = 10
+	
 	taste_description = "pure alcohol"
 
 	glass_icon_state = "glass_clear"
 	glass_name = "glass of ethanol"
 	glass_desc = "A well-known alcohol with a variety of applications."
 
-/datum/reagent/ethanol/Destroy()
-	if (caffeine_mod)
-		QDEL_NULL(caffeine_mod)
-	return ..()
-
-/datum/reagent/ethanol/touch_mob(var/mob/living/L, var/amount)
-	if(istype(L) && strength > 40)
-		L.adjust_fire_stacks((amount / 10) * (strength / 100))
-
-/datum/reagent/ethanol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.adjustToxLoss(removed * 2)
-	return
-
-/datum/reagent/ethanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	if(isvaurca(M))//Vaurca are damaged instead of getting nutrients, but they can still get drunk
+/datum/reagent/alcohol/ethanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_VAURCA)//Vaurca are damaged instead of getting nutrients, but they can still get drunk
 		M.adjustToxLoss(1.5 * removed * (strength / 100))
 	else
 		M.nutrition += nutriment_factor * removed
@@ -133,30 +165,12 @@
 	if(alien == IS_DIONA)
 		return //Diona can gain nutrients, but don't get drunk or suffer other effects
 
-	if(isunathi(M))//unathi are poisoned by alcohol as well
+	if (alien == IS_UNATHI)//unathi are poisoned by alcohol as well
 		M.adjustToxLoss(1.5 * removed * (strength / 100))
 
-	var/quantity = (strength / 100) * removed
-	M.intoxication += quantity
+	..()
 
-
-	if(druggy != 0)
-		M.druggy = max(M.druggy, druggy)
-
-	if(adj_temp > 0 && M.bodytemperature < targ_temp) // 310 is the normal bodytemp. 310.055
-		M.bodytemperature = min(targ_temp, M.bodytemperature + (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
-	if(adj_temp < 0 && M.bodytemperature > targ_temp)
-		M.bodytemperature = min(targ_temp, M.bodytemperature - (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
-
-	if(halluci)
-		M.hallucination = max(M.hallucination, halluci)
-
-	if (caffeine && !caffeine_mod)
-		caffeine_mod = M.add_modifier(/datum/modifier/stimulant, MODIFIER_REAGENT, src, _strength = caffeine, override = MODIFIER_OVERRIDE_STRENGTHEN)
-
-
-
-/datum/reagent/ethanol/touch_obj(var/obj/O)
+/datum/reagent/alcohol/ethanol/touch_obj(var/obj/O)
 	if(istype(O, /obj/item/weapon/paper))
 		var/obj/item/weapon/paper/paperaffected = O
 		paperaffected.clearpaper()
@@ -174,18 +188,16 @@
 	return
 
 
-//Butanol is a common alcohol that is fairly ineffective for humans and most other species, but highly intoxicating to unathi
-//Butanol duplicates a lot of code from ethanol. This is by design, it does not inherit.
-//Possible future todo: Add "alcohol" as a parent class to both ethanol and butanol
-/datum/reagent/butanol
-	name = "Butanol" //Parent class for all alcoholic reagents.
+// Butanol is a common alcohol that is fairly ineffective for humans and most other species, but highly intoxicating to unathi.
+// Most behavior is inherited from alcohol.
+/datum/reagent/alcohol/butanol
+	name = "Butanol"
 	id = "butanol"
 	description = "A fairly harmless alcohol that has intoxicating effects on certain species."
 	reagent_state = LIQUID
 	color = "#404030"
 	ingest_met = 0.17 //Extremely slow metabolic rate means the liver will generally purge it faster than it can intoxicate you
-	var/nutriment_factor = 0.5
-	var/strength = 100 // This is the ABV of the drink
+	flammability_divisor = 7	//Butanol is a bit less flammable than ethanol
 
 	taste_description = "alcohol"
 
@@ -193,15 +205,7 @@
 	glass_name = "glass of butanol"
 	glass_desc = "A fairly harmless alcohol that has intoxicating effects on certain species."
 
-/datum/reagent/butanol/touch_mob(var/mob/living/L, var/amount)
-	if(istype(L) && strength > 40)
-		L.adjust_fire_stacks((amount / 7) * (strength / 100)) //Butanol is a bit less flammable than ethanol
-
-/datum/reagent/butanol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.adjustToxLoss(removed)
-	return
-
-/datum/reagent/butanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/alcohol/butanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if (alien == IS_VAURCA)
 		M.adjustToxLoss(removed * (strength / 100))
 	else
@@ -210,8 +214,7 @@
 	if (alien == IS_UNATHI)
 		ingest_met = initial(ingest_met)*3
 
-	var/quantity = (strength / 100) * removed
-	M.intoxication += quantity
+	..()
 
 /datum/reagent/hydrazine
 	name = "Hydrazine"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -1344,7 +1344,7 @@
 
 // Basic
 
-/datum/reagent/ethanol/absinthe
+/datum/reagent/alcohol/ethanol/absinthe
 	name = "Absinthe"
 	id = "absinthe"
 	description = "Watch out that the Green Fairy doesn't come for you!"
@@ -1357,7 +1357,7 @@
 	glass_desc = "Wormwood, anise, oh my."
 	glass_center_of_mass = list("x"=16, "y"=5)
 
-/datum/reagent/ethanol/ale
+/datum/reagent/alcohol/ethanol/ale
 	name = "Ale"
 	id = "ale"
 	description = "A dark alchoholic beverage made by malted barley and yeast."
@@ -1370,7 +1370,7 @@
 	glass_desc = "A freezing pint of delicious ale"
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/beer
+/datum/reagent/alcohol/ethanol/beer
 	name = "Beer"
 	id = "beer"
 	description = "An alcoholic beverage made from malted grains, hops, yeast, and water."
@@ -1384,11 +1384,11 @@
 	glass_desc = "A freezing pint of beer"
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/beer/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/alcohol/ethanol/beer/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.jitteriness = max(M.jitteriness - 3, 0)
 
-/datum/reagent/ethanol/bitters
+/datum/reagent/alcohol/ethanol/bitters
 	name = "Aromatic Bitters"
 	id = "bitters"
 	description = "A very, very concentrated and bitter herbal alcohol."
@@ -1401,7 +1401,7 @@
 	glass_desc = "A pungent glass of bitters."
 	glass_center_of_mass = list ("x"=17, "y"=8)
 
-/datum/reagent/ethanol/bluecuracao
+/datum/reagent/alcohol/ethanol/bluecuracao
 	name = "Blue Curacao"
 	id = "bluecuracao"
 	description = "Exotically blue, fruity drink, distilled from oranges."
@@ -1414,7 +1414,7 @@
 	glass_desc = "Exotically blue, fruity drink, distilled from oranges."
 	glass_center_of_mass = list("x"=16, "y"=5)
 
-/datum/reagent/ethanol/champagne
+/datum/reagent/alcohol/ethanol/champagne
 	name = "Champagne"
 	id = "champagne"
 	description = "A classy sparkling wine, usually found in meeting rooms and basements."
@@ -1427,7 +1427,7 @@
 	glass_desc = "Off-white and bubbly. So passe."
 	glass_center_of_mass = list("x"=16, "y"=5)
 
-/datum/reagent/ethanol/cognac
+/datum/reagent/alcohol/ethanol/cognac
 	name = "Cognac"
 	id = "cognac"
 	description = "A sweet and strongly alchoholic drink, made after numerous distillations and years of maturing. Classy as fornication."
@@ -1440,7 +1440,7 @@
 	glass_desc = "Damn, you feel like some kind of French aristocrat just by holding this."
 	glass_center_of_mass = list("x"=16, "y"=6)
 
-/datum/reagent/ethanol/deadrum
+/datum/reagent/alcohol/ethanol/deadrum
 	name = "Deadrum"
 	id = "deadrum"
 	description = "Popular with the sailors. Not very popular with everyone else."
@@ -1453,11 +1453,11 @@
 	glass_desc = "Now you want to Pray for a pirate suit, don't you?"
 	glass_center_of_mass = list("x"=16, "y"=12)
 
-/datum/reagent/ethanol/deadrum/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/alcohol/ethanol/deadrum/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.dizziness +=5
 
-/datum/reagent/ethanol/gin
+/datum/reagent/alcohol/ethanol/gin
 	name = "Gin"
 	id = "gin"
 	description = "It's gin. In space. I say, good sir."
@@ -1470,7 +1470,7 @@
 	glass_desc = "A crystal clear glass of Griffeater gin."
 	glass_center_of_mass = list("x"=16, "y"=12)
 
-/datum/reagent/ethanol/victorygin
+/datum/reagent/alcohol/ethanol/victorygin
 	name = "Victory Gin"
 	id = "victorygin"
 	description = "An oily Adhomai-based gin."
@@ -1484,10 +1484,10 @@
 	glass_center_of_mass = list("x"=16, "y"=12)
 
 //Base type for alchoholic drinks containing coffee
-/datum/reagent/ethanol/coffee
+/datum/reagent/alcohol/ethanol/coffee
 	overdose = 45
 
-/datum/reagent/ethanol/coffee/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/alcohol/ethanol/coffee/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.dizziness = max(0, M.dizziness - 5)
 	M.drowsyness = max(0, M.drowsyness - 3)
@@ -1495,10 +1495,10 @@
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
-/datum/reagent/ethanol/coffee/overdose(var/mob/living/carbon/M, var/alien)
+/datum/reagent/alcohol/ethanol/coffee/overdose(var/mob/living/carbon/M, var/alien)
 	M.make_jittery(5)
 
-/datum/reagent/ethanol/coffee/kahlua
+/datum/reagent/alcohol/ethanol/coffee/kahlua
 	name = "Kahlua"
 	id = "kahlua"
 	description = "A widely known, Mexican coffee-flavoured liqueur. In production since 1936!"
@@ -1512,7 +1512,7 @@
 	glass_desc = "DAMN, THIS THING LOOKS ROBUST"
 	glass_center_of_mass = list("x"=15, "y"=7)
 
-/datum/reagent/ethanol/melonliquor
+/datum/reagent/alcohol/ethanol/melonliquor
 	name = "Melon Liquor"
 	id = "melonliquor"
 	description = "A relatively sweet and fruity 46 proof liquor."
@@ -1525,7 +1525,7 @@
 	glass_desc = "A relatively sweet and fruity 46 proof liquor."
 	glass_center_of_mass = list("x"=16, "y"=5)
 
-/datum/reagent/ethanol/rum
+/datum/reagent/alcohol/ethanol/rum
 	name = "Rum"
 	id = "rum"
 	description = "Yohoho and all that."
@@ -1538,7 +1538,7 @@
 	glass_desc = "Now you want to Pray for a pirate suit, don't you?"
 	glass_center_of_mass = list("x"=16, "y"=12)
 
-/datum/reagent/ethanol/sake
+/datum/reagent/alcohol/ethanol/sake
 	name = "Sake"
 	id = "sake"
 	description = "Anime's favorite drink."
@@ -1551,7 +1551,7 @@
 	glass_desc = "A glass of sake."
 	glass_center_of_mass = list("x"=16, "y"=12)
 
-/datum/reagent/ethanol/tequilla
+/datum/reagent/alcohol/ethanol/tequilla
 	name = "Tequila"
 	id = "tequilla"
 	description = "A strong and mildly flavoured, mexican produced spirit. Feeling thirsty hombre?"
@@ -1564,7 +1564,7 @@
 	glass_desc = "Now all that's missing is the weird colored shades!"
 	glass_center_of_mass = list("x"=16, "y"=12)
 
-/datum/reagent/ethanol/thirteenloko
+/datum/reagent/alcohol/ethanol/thirteenloko
 	name = "Thirteen Loko"
 	id = "thirteenloko"
 	description = "A potent mixture of caffeine and alcohol."
@@ -1578,14 +1578,14 @@
 	glass_name = "glass of Thirteen Loko"
 	glass_desc = "This is a glass of Thirteen Loko, it appears to be of the highest quality. The drink, not the glass."
 
-/datum/reagent/ethanol/thirteenloko/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/alcohol/ethanol/thirteenloko/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.drowsyness = max(0, M.drowsyness - 7)
 	if (M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	M.make_jittery(5)
 
-/datum/reagent/ethanol/vermouth
+/datum/reagent/alcohol/ethanol/vermouth
 	name = "Vermouth"
 	id = "vermouth"
 	description = "You suddenly feel a craving for a martini..."
@@ -1599,7 +1599,7 @@
 	glass_desc = "You wonder why you're even drinking this straight."
 	glass_center_of_mass = list("x"=16, "y"=12)
 
-/datum/reagent/ethanol/vodka
+/datum/reagent/alcohol/ethanol/vodka
 	name = "Vodka"
 	id = "vodka"
 	description = "Number one drink AND fueling choice for Russians worldwide."
@@ -1612,11 +1612,11 @@
 	glass_desc = "The glass contain wodka. Xynta."
 	glass_center_of_mass = list("x"=16, "y"=12)
 
-/datum/reagent/ethanol/vodka/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/alcohol/ethanol/vodka/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.apply_effect(max(M.total_radiation - 1 * removed, 0), IRRADIATE, blocked = 0)
 
-/datum/reagent/ethanol/whiskey
+/datum/reagent/alcohol/ethanol/whiskey
 	name = "Whiskey"
 	id = "whiskey"
 	description = "A superb and well-aged single-malt whiskey. Damn."
@@ -1629,7 +1629,7 @@
 	glass_desc = "The silky, smokey whiskey goodness inside the glass makes the drink look very classy."
 	glass_center_of_mass = list("x"=16, "y"=12)
 
-/datum/reagent/ethanol/wine
+/datum/reagent/alcohol/ethanol/wine
 	name = "Wine"
 	id = "wine"
 	description = "A premium alchoholic beverage made from distilled grape juice."
@@ -1644,7 +1644,7 @@
 
 // Cocktails
 
-/datum/reagent/ethanol/acid_spit
+/datum/reagent/alcohol/ethanol/acid_spit
 	name = "Acid Spit"
 	id = "acidspit"
 	description = "A drink for the daring, can be deadly if incorrectly prepared!"
@@ -1658,7 +1658,7 @@
 	glass_desc = "A drink from the company archives. Made from live aliens."
 	glass_center_of_mass = list("x"=16, "y"=7)
 
-/datum/reagent/ethanol/alliescocktail
+/datum/reagent/alcohol/ethanol/alliescocktail
 	name = "Allies Cocktail"
 	id = "alliescocktail"
 	description = "A drink made from your allies, not as sweet as when made from your enemies."
@@ -1671,7 +1671,7 @@
 	glass_desc = "A drink made from your allies."
 	glass_center_of_mass = list("x"=17, "y"=8)
 
-/datum/reagent/ethanol/aloe
+/datum/reagent/alcohol/ethanol/aloe
 	name = "Aloe"
 	id = "aloe"
 	description = "So very, very, very good."
@@ -1684,7 +1684,7 @@
 	glass_desc = "Very, very, very good."
 	glass_center_of_mass = list("x"=17, "y"=8)
 
-/datum/reagent/ethanol/amasec
+/datum/reagent/alcohol/ethanol/amasec
 	name = "Amasec"
 	id = "amasec"
 	description = "Official drink of the Gun Club!"
@@ -1698,7 +1698,7 @@
 	glass_desc = "Always handy before COMBAT!!!"
 	glass_center_of_mass = list("x"=16, "y"=9)
 
-/datum/reagent/ethanol/andalusia
+/datum/reagent/alcohol/ethanol/andalusia
 	name = "Andalusia"
 	id = "andalusia"
 	description = "A nice, strangely named drink."
@@ -1711,7 +1711,7 @@
 	glass_desc = "A nice, strange named drink."
 	glass_center_of_mass = list("x"=16, "y"=9)
 
-/datum/reagent/ethanol/antifreeze
+/datum/reagent/alcohol/ethanol/antifreeze
 	name = "Anti-freeze"
 	id = "antifreeze"
 	description = "Ultimate refreshment."
@@ -1726,7 +1726,7 @@
 	glass_desc = "The ultimate refreshment."
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/atomicbomb
+/datum/reagent/alcohol/ethanol/atomicbomb
 	name = "Atomic Bomb"
 	id = "atomicbomb"
 	description = "Nuclear proliferation never tasted so good."
@@ -1741,7 +1741,7 @@
 	glass_desc = "We cannot take legal responsibility for your actions after imbibing."
 	glass_center_of_mass = list("x"=15, "y"=7)
 
-/datum/reagent/ethanol/coffee/b52
+/datum/reagent/alcohol/ethanol/coffee/b52
 	name = "B-52"
 	id = "b52"
 	description = "Coffee, Irish Cream, and cognac. You will get bombed."
@@ -1753,7 +1753,7 @@
 	glass_name = "glass of B-52"
 	glass_desc = "Kahlua, Irish cream, and congac. You will get bombed."
 
-/datum/reagent/ethanol/bahama_mama
+/datum/reagent/alcohol/ethanol/bahama_mama
 	name = "Bahama mama"
 	id = "bahama_mama"
 	description = "Tropical cocktail."
@@ -1766,7 +1766,7 @@
 	glass_desc = "Tropical cocktail"
 	glass_center_of_mass = list("x"=16, "y"=5)
 
-/datum/reagent/ethanol/bananahonk
+/datum/reagent/alcohol/ethanol/bananahonk
 	name = "Banana Mama"
 	id = "bananahonk"
 	description = "A drink from Clown Heaven."
@@ -1780,7 +1780,7 @@
 	glass_desc = "A drink from Banana Heaven."
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/barefoot
+/datum/reagent/alcohol/ethanol/barefoot
 	name = "Barefoot"
 	id = "barefoot"
 	description = "Barefoot and pregnant"
@@ -1793,7 +1793,7 @@
 	glass_desc = "Barefoot and pregnant"
 	glass_center_of_mass = list("x"=17, "y"=8)
 
-/datum/reagent/ethanol/beepsky_smash
+/datum/reagent/alcohol/ethanol/beepsky_smash
 	name = "Beepsky Smash"
 	id = "beepskysmash"
 	description = "Deny drinking this and prepare for THE LAW."
@@ -1807,11 +1807,11 @@
 	glass_desc = "Heavy, hot and strong. Just like the Iron fist of the LAW."
 	glass_center_of_mass = list("x"=18, "y"=10)
 
-/datum/reagent/ethanol/beepsky_smash/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/alcohol/ethanol/beepsky_smash/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.Stun(2)
 
-/datum/reagent/ethanol/bilk
+/datum/reagent/alcohol/ethanol/bilk
 	name = "Bilk"
 	id = "bilk"
 	description = "This appears to be beer mixed with milk. Disgusting."
@@ -1824,7 +1824,7 @@
 	glass_name = "glass of bilk"
 	glass_desc = "A brew of milk and beer. For those alcoholics who fear osteoporosis."
 
-/datum/reagent/ethanol/black_russian
+/datum/reagent/alcohol/ethanol/black_russian
 	name = "Black Russian"
 	id = "blackrussian"
 	description = "For the lactose-intolerant. Still as classy as a White Russian."
@@ -1837,7 +1837,7 @@
 	glass_desc = "For the lactose-intolerant. Still as classy as a White Russian."
 	glass_center_of_mass = list("x"=16, "y"=9)
 
-/datum/reagent/ethanol/bloody_mary
+/datum/reagent/alcohol/ethanol/bloody_mary
 	name = "Bloody Mary"
 	id = "bloodymary"
 	description = "A strange yet pleasurable mixture made of vodka, tomato and lime juice. Or at least you THINK the red stuff is tomato juice."
@@ -1849,7 +1849,7 @@
 	glass_name = "glass of Bloody Mary"
 	glass_desc = "Tomato juice, mixed with Vodka and a lil' bit of lime. Tastes like liquid murder."
 
-/datum/reagent/ethanol/booger
+/datum/reagent/alcohol/ethanol/booger
 	name = "Booger"
 	id = "booger"
 	description = "Ewww..."
@@ -1861,7 +1861,7 @@
 	glass_name = "glass of Booger"
 	glass_desc = "Ewww..."
 
-/datum/reagent/ethanol/coffee/brave_bull
+/datum/reagent/alcohol/ethanol/coffee/brave_bull
 	name = "Brave Bull"
 	id = "bravebull"
 	description = "It's just as effective as Dutch-Courage!"
@@ -1875,7 +1875,7 @@
 	glass_desc = "Tequilla and coffee liquor, brought together in a mouthwatering mixture. Drink up."
 	glass_center_of_mass = list("x"=15, "y"=8)
 
-/datum/reagent/ethanol/cmojito
+/datum/reagent/alcohol/ethanol/cmojito
 	name = "Champagne Mojito"
 	id = "cmojito"
 	description = "A fizzy, minty and sweet drink."
@@ -1887,7 +1887,7 @@
 	glass_name = "glass of champagne mojito"
 	glass_desc = "Looks fun!"
 
-/datum/reagent/ethanol/changelingsting
+/datum/reagent/alcohol/ethanol/changelingsting
 	name = "Changeling Sting"
 	id = "changelingsting"
 	description = "You take a tiny sip and feel a burning sensation..."
@@ -1899,7 +1899,7 @@
 	glass_name = "glass of Changeling Sting"
 	glass_desc = "A stingy drink."
 
-/datum/reagent/ethanol/classic
+/datum/reagent/alcohol/ethanol/classic
 	name = "The Classic"
 	id = "classic"
 	description = "The classic bitter lemon cocktail."
@@ -1912,7 +1912,7 @@
 	glass_desc = "Just classic. Wow."
 	glass_center_of_mass = list("x"=17, "y"=8)
 
-/datum/reagent/ethanol/martini
+/datum/reagent/alcohol/ethanol/martini
 	name = "Classic Martini"
 	id = "martini"
 	description = "Vermouth with Gin. Not quite how 007 enjoyed it, but still delicious."
@@ -1925,7 +1925,7 @@
 	glass_desc = "Damn, the bartender even stirred it, not shook it."
 	glass_center_of_mass = list("x"=17, "y"=8)
 
-/datum/reagent/ethanol/corkpopper
+/datum/reagent/alcohol/ethanol/corkpopper
 	name = "Cork Popper"
 	id = "corkpopper"
 	description = "A fancy cocktail with a hint of lemon."
@@ -1938,7 +1938,7 @@
 	glass_desc = "The confusing scent only proves all the more alluring."
 	glass_center_of_mass = list("x"=16, "y"=9)
 
-/datum/reagent/ethanol/cuba_libre
+/datum/reagent/alcohol/ethanol/cuba_libre
 	name = "Cuba Libre"
 	id = "cubalibre"
 	description = "Rum, mixed with cola. Viva la revolucion."
@@ -1951,7 +1951,7 @@
 	glass_desc = "A classic mix of rum and cola."
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/demonsblood
+/datum/reagent/alcohol/ethanol/demonsblood
 	name = "Demons Blood"
 	id = "demonsblood"
 	description = "AHHHH!!!!"
@@ -1964,7 +1964,7 @@
 	glass_desc = "Just looking at this thing makes the hair at the back of your neck stand up."
 	glass_center_of_mass = list("x"=16, "y"=2)
 
-/datum/reagent/ethanol/devilskiss
+/datum/reagent/alcohol/ethanol/devilskiss
 	name = "Devils Kiss"
 	id = "devilskiss"
 	description = "Creepy time!"
@@ -1977,7 +1977,7 @@
 	glass_desc = "Creepy time!"
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/driestmartini
+/datum/reagent/alcohol/ethanol/driestmartini
 	name = "Driest Martini"
 	id = "driestmartini"
 	description = "Only for the experienced. You think you see sand floating in the glass."
@@ -1991,7 +1991,7 @@
 	glass_desc = "Only for the experienced. You think you see sand floating in the glass."
 	glass_center_of_mass = list("x"=17, "y"=8)
 
-/datum/reagent/ethanol/french75
+/datum/reagent/alcohol/ethanol/french75
 	name = "French 75"
 	id = "french75"
 	description = "A sharp and classy cocktail."
@@ -2004,7 +2004,7 @@
 	glass_desc = "It looks like a lemon shaved into your cocktail."
 	glass_center_of_mass = list("x"=16, "y"=5)
 
-/datum/reagent/ethanol/ginfizz
+/datum/reagent/alcohol/ethanol/ginfizz
 	name = "Gin Fizz"
 	id = "ginfizz"
 	description = "Refreshingly lemony, deliciously dry."
@@ -2017,7 +2017,7 @@
 	glass_desc = "Refreshingly lemony, deliciously dry."
 	glass_center_of_mass = list("x"=16, "y"=7)
 
-/datum/reagent/ethanol/grog
+/datum/reagent/alcohol/ethanol/grog
 	name = "Grog"
 	id = "grog"
 	description = "Watered-down rum, pirate approved!"
@@ -2030,7 +2030,7 @@
 	glass_name = "glass of grog"
 	glass_desc = "A fine and cepa drink for Space."
 
-/datum/reagent/ethanol/erikasurprise
+/datum/reagent/alcohol/ethanol/erikasurprise
 	name = "Erika Surprise"
 	id = "erikasurprise"
 	description = "The surprise is, it's green!"
@@ -2043,7 +2043,7 @@
 	glass_desc = "The surprise is, it's green!"
 	glass_center_of_mass = list("x"=16, "y"=9)
 
-/datum/reagent/ethanol/gargle_blaster
+/datum/reagent/alcohol/ethanol/gargle_blaster
 	name = "Pan-Galactic Gargle Blaster"
 	id = "gargleblaster"
 	description = "Whoah, this stuff looks volatile!"
@@ -2057,7 +2057,7 @@
 	glass_desc = "Does... does this mean that Arthur and Ford are on the station? Oh joy."
 	glass_center_of_mass = list("x"=17, "y"=6)
 
-/datum/reagent/ethanol/gintonic
+/datum/reagent/alcohol/ethanol/gintonic
 	name = "Gin and Tonic"
 	id = "gintonic"
 	description = "An all time classic, mild cocktail."
@@ -2070,7 +2070,7 @@
 	glass_desc = "A mild but still great cocktail. Drink up, like a true Englishman."
 	glass_center_of_mass = list("x"=16, "y"=7)
 
-/datum/reagent/ethanol/goldschlager
+/datum/reagent/alcohol/ethanol/goldschlager
 	name = "Goldschlager"
 	id = "goldschlager"
 	description = "100 proof cinnamon schnapps, made for alcoholic teen girls on spring break."
@@ -2083,7 +2083,7 @@
 	glass_desc = "100 proof that teen girls will drink anything with gold in it."
 	glass_center_of_mass = list("x"=16, "y"=12)
 
-/datum/reagent/ethanol/hippies_delight
+/datum/reagent/alcohol/ethanol/hippies_delight
 	name = "Hippies' Delight"
 	id = "hippiesdelight"
 	description = "You just don't get it maaaan."
@@ -2098,7 +2098,7 @@
 	glass_desc = "A drink enjoyed by people during the 1960's."
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/hooch
+/datum/reagent/alcohol/ethanol/hooch
 	name = "Hooch"
 	id = "hooch"
 	description = "Either someone's failure at cocktail making or attempt in alchohol production. In any case, do you really want to drink that?"
@@ -2110,7 +2110,7 @@
 	glass_name = "glass of Hooch"
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
-/datum/reagent/ethanol/iced_beer
+/datum/reagent/alcohol/ethanol/iced_beer
 	name = "Iced Beer"
 	id = "iced_beer"
 	description = "A beer which is so cold the air around it freezes."
@@ -2125,7 +2125,7 @@
 	glass_desc = "A beer so frosty, the air around it freezes."
 	glass_center_of_mass = list("x"=16, "y"=7)
 
-/datum/reagent/ethanol/irishcarbomb
+/datum/reagent/alcohol/ethanol/irishcarbomb
 	name = "Irish Car Bomb"
 	id = "irishcarbomb"
 	description = "Mmm, tastes like chocolate cake..."
@@ -2138,7 +2138,7 @@
 	glass_desc = "An irish car bomb."
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/coffee/irishcoffee
+/datum/reagent/alcohol/ethanol/coffee/irishcoffee
 	name = "Irish Coffee"
 	id = "irishcoffee"
 	description = "Coffee, and alcohol. More fun than a Mimosa to drink in the morning."
@@ -2152,7 +2152,7 @@
 	glass_desc = "Coffee and alcohol. More fun than a Mimosa to drink in the morning."
 	glass_center_of_mass = list("x"=15, "y"=10)
 
-/datum/reagent/ethanol/irish_cream
+/datum/reagent/alcohol/ethanol/irish_cream
 	name = "Irish Cream"
 	id = "irishcream"
 	description = "Whiskey-imbued cream, what else would you expect from the Irish."
@@ -2165,7 +2165,7 @@
 	glass_desc = "It's cream, mixed with whiskey. What else would you expect from the Irish?"
 	glass_center_of_mass = list("x"=16, "y"=9)
 
-/datum/reagent/ethanol/longislandicedtea
+/datum/reagent/alcohol/ethanol/longislandicedtea
 	name = "Long Island Iced Tea"
 	id = "longislandicedtea"
 	description = "The liquor cabinet, brought together in a delicious mix. Intended for middle-aged alcoholic women only."
@@ -2178,7 +2178,7 @@
 	glass_desc = "The liquor cabinet, brought together in a delicious mix. Intended for middle-aged alcoholic women only."
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/manhattan
+/datum/reagent/alcohol/ethanol/manhattan
 	name = "Manhattan"
 	id = "manhattan"
 	description = "The Detective's undercover drink of choice. He never could stomach gin..."
@@ -2191,7 +2191,7 @@
 	glass_desc = "The Detective's undercover drink of choice. He never could stomach gin..."
 	glass_center_of_mass = list("x"=17, "y"=8)
 
-/datum/reagent/ethanol/manhattan_proj
+/datum/reagent/alcohol/ethanol/manhattan_proj
 	name = "Manhattan Project"
 	id = "manhattan_proj"
 	description = "A scientist's drink of choice, for pondering ways to blow up the station."
@@ -2205,7 +2205,7 @@
 	glass_desc = "A scientist's drink of choice, for thinking how to blow up the station."
 	glass_center_of_mass = list("x"=17, "y"=8)
 
-/datum/reagent/ethanol/manly_dorf
+/datum/reagent/alcohol/ethanol/manly_dorf
 	name = "The Manly Dorf"
 	id = "manlydorf"
 	description = "Beer and Ale, brought together in a delicious mix. Intended for true men only."
@@ -2217,7 +2217,7 @@
 	glass_name = "glass of The Manly Dorf"
 	glass_desc = "A manly concotion made from Ale and Beer. Intended for true men only."
 
-/datum/reagent/ethanol/margarita
+/datum/reagent/alcohol/ethanol/margarita
 	name = "Margarita"
 	id = "margarita"
 	description = "On the rocks with salt on the rim. Arriba~!"
@@ -2230,7 +2230,7 @@
 	glass_desc = "On the rocks with salt on the rim. Arriba~!"
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/mead
+/datum/reagent/alcohol/ethanol/mead
 	name = "Mead"
 	id = "mead"
 	description = "A Viking's drink, though a cheap one."
@@ -2245,7 +2245,7 @@
 	glass_desc = "A Viking's beverage, though a cheap one."
 	glass_center_of_mass = list("x"=17, "y"=10)
 
-/datum/reagent/ethanol/moonshine
+/datum/reagent/alcohol/ethanol/moonshine
 	name = "Moonshine"
 	id = "moonshine"
 	description = "You've really hit rock bottom now... your liver packed its bags and left last night."
@@ -2257,7 +2257,7 @@
 	glass_name = "glass of moonshine"
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
-/datum/reagent/ethanol/muscmule
+/datum/reagent/alcohol/ethanol/muscmule
 	name = "Muscovite Mule"
 	id = "muscmule"
 	description = "A surprisingly gentle cocktail, with a hidden punch."
@@ -2270,7 +2270,7 @@
 	glass_desc = "Such a pretty green, this couldn't possible go wrong!"
 	glass_center_of_mass = list("x"=17, "y"=10)
 
-/datum/reagent/ethanol/neurotoxin
+/datum/reagent/alcohol/ethanol/neurotoxin
 	name = "Neurotoxin"
 	id = "neurotoxin"
 	description = "A strong neurotoxin that puts the subject into a death-like state."
@@ -2284,11 +2284,11 @@
 	glass_desc = "A drink that is guaranteed to knock you silly."
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/neurotoxin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/alcohol/ethanol/neurotoxin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.Weaken(3)
 
-/datum/reagent/ethanol/omimosa
+/datum/reagent/alcohol/ethanol/omimosa
 	name = "Orange Mimosa"
 	id = "omimosa"
 	description = "Wonderful start to any day."
@@ -2300,7 +2300,7 @@
 	glass_name = "glass of orange mimosa"
 	glass_desc = "Smells like a fresh start."
 
-/datum/reagent/ethanol/patron
+/datum/reagent/alcohol/ethanol/patron
 	name = "Patron"
 	id = "patron"
 	description = "Tequila with silver in it, a favorite of alcoholic women in the club scene."
@@ -2313,7 +2313,7 @@
 	glass_desc = "Drinking patron in the bar, with all the subpar ladies."
 	glass_center_of_mass = list("x"=7, "y"=8)
 
-/datum/reagent/ethanol/pinkgin
+/datum/reagent/alcohol/ethanol/pinkgin
 	name = "Pink Gin"
 	id = "pinkgin"
 	description = "Bitters and Gin."
@@ -2326,7 +2326,7 @@
 	glass_desc = "What an eccentric cocktail."
 	glass_center_of_mass = list("x"=16, "y"=9)
 
-/datum/reagent/ethanol/pinkgintonic
+/datum/reagent/alcohol/ethanol/pinkgintonic
 	name = "Pink Gin and Tonic."
 	id = "pinkgintonic"
 	description = "Bitterer gin and tonic."
@@ -2338,7 +2338,7 @@
 	glass_name = "glass of pink gin and tonic"
 	glass_desc = "You made gin and tonic more bitter... you madman!"
 
-/datum/reagent/ethanol/piratepunch
+/datum/reagent/alcohol/ethanol/piratepunch
 	name = "Pirate's Punch"
 	id = "piratepunch"
 	description = "Nautical punch!"
@@ -2351,7 +2351,7 @@
 	glass_desc = "Yarr harr fiddly dee, drink whatcha want 'cause a pirate is ye!"
 	glass_center_of_mass = list("x"=17, "y"=10)
 
-/datum/reagent/ethanol/planterpunch
+/datum/reagent/alcohol/ethanol/planterpunch
 	name = "Planter's Punch"
 	id = "planterpunch"
 	description = "A popular beach cocktail."
@@ -2364,7 +2364,7 @@
 	glass_desc = "This takes you back, back to those endless white beaches of yore."
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/pwine
+/datum/reagent/alcohol/ethanol/pwine
 	name = "Poison Wine"
 	id = "pwine"
 	description = "Is this even wine? Toxic! Hallucinogenic! Probably consumed in boatloads by your superiors!"
@@ -2379,7 +2379,7 @@
 	glass_desc = "A black ichor with an oily purple sheer on top. Are you sure you should drink this?"
 	glass_center_of_mass = list("x"=16, "y"=5)
 
-/datum/reagent/ethanol/pwine/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/alcohol/ethanol/pwine/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	if(dose > 30)
 		M.adjustToxLoss(2 * removed)
@@ -2392,7 +2392,7 @@
 			else
 				L.take_damage(100, 0)
 
-/datum/reagent/ethanol/red_mead
+/datum/reagent/alcohol/ethanol/red_mead
 	name = "Red Mead"
 	id = "red_mead"
 	description = "The true Viking's drink! Even though it has a strange red color."
@@ -2405,7 +2405,7 @@
 	glass_desc = "A true Viking's beverage, though its color is strange."
 	glass_center_of_mass = list("x"=17, "y"=10)
 
-/datum/reagent/ethanol/sbiten
+/datum/reagent/alcohol/ethanol/sbiten
 	name = "Sbiten"
 	id = "sbiten"
 	description = "A spicy mix of mead and spices! Might be a little hot for the little guys!"
@@ -2420,7 +2420,7 @@
 	glass_desc = "A spicy mix of Mead and Spices. Very hot."
 	glass_center_of_mass = list("x"=17, "y"=8)
 
-/datum/reagent/ethanol/screwdrivercocktail
+/datum/reagent/alcohol/ethanol/screwdrivercocktail
 	name = "Screwdriver"
 	id = "screwdrivercocktail"
 	description = "Vodka, mixed with plain ol' orange juice. The result is surprisingly delicious."
@@ -2433,7 +2433,7 @@
 	glass_desc = "A simple, yet superb mixture of Vodka and orange juice. Just the thing for the tired engineer."
 	glass_center_of_mass = list("x"=15, "y"=10)
 
-/datum/reagent/ethanol/silencer
+/datum/reagent/alcohol/ethanol/silencer
 	name = "Silencer"
 	id = "silencer"
 	description = "A drink from Mime Heaven."
@@ -2447,7 +2447,7 @@
 	glass_desc = "A drink from mime Heaven."
 	glass_center_of_mass = list("x"=16, "y"=9)
 
-/datum/reagent/ethanol/singulo
+/datum/reagent/alcohol/ethanol/singulo
 	name = "Singulo"
 	id = "singulo"
 	description = "A blue-space beverage!"
@@ -2460,7 +2460,7 @@
 	glass_desc = "A blue-space beverage."
 	glass_center_of_mass = list("x"=17, "y"=4)
 
-/datum/reagent/ethanol/snowwhite
+/datum/reagent/alcohol/ethanol/snowwhite
 	name = "Snow White"
 	id = "snowwhite"
 	description = "A cold refreshment"
@@ -2473,7 +2473,7 @@
 	glass_desc = "A cold refreshment."
 	glass_center_of_mass = list("x"=16, "y"=8)
 
-/datum/reagent/ethanol/ssroyale
+/datum/reagent/alcohol/ethanol/ssroyale
 	name = "Southside Royale"
 	id = "ssroyale"
 	description = "Classy cocktail containing citrus."
@@ -2486,7 +2486,7 @@
 	glass_desc = "This cocktail is better than you. Maybe it's the crossed arms that give it away. Or the rich parents."
 	glass_center_of_mass = list("x"=17, "y"=8)
 
-/datum/reagent/ethanol/suidream
+/datum/reagent/alcohol/ethanol/suidream
 	name = "Sui Dream"
 	id = "suidream"
 	description = "Comprised of: White soda, blue curacao, melon liquor."
@@ -2499,7 +2499,7 @@
 	glass_desc = "A froofy, fruity, and sweet mixed drink. Understanding the name only brings shame."
 	glass_center_of_mass = list("x"=16, "y"=5)
 
-/datum/reagent/ethanol/syndicatebomb
+/datum/reagent/alcohol/ethanol/syndicatebomb
 	name = "Syndicate Bomb"
 	id = "syndicatebomb"
 	description = "Tastes like terrorism!"
@@ -2512,7 +2512,7 @@
 	glass_desc = "Tastes like terrorism!"
 	glass_center_of_mass = list("x"=16, "y"=4)
 
-/datum/reagent/ethanol/tequilla_sunrise
+/datum/reagent/alcohol/ethanol/tequilla_sunrise
 	name = "Tequila Sunrise"
 	id = "tequillasunrise"
 	description = "Tequila and orange juice. Much like a Screwdriver, only Mexican~"
@@ -2524,7 +2524,7 @@
 	glass_name = "glass of Tequilla Sunrise"
 	glass_desc = "Oh great, now you feel nostalgic about sunrises back on Terra..."
 
-/datum/reagent/ethanol/threemileisland
+/datum/reagent/alcohol/ethanol/threemileisland
 	name = "Three Mile Island Iced Tea"
 	id = "threemileisland"
 	description = "Made for a woman, strong enough for a man."
@@ -2538,7 +2538,7 @@
 	glass_desc = "A glass of this is sure to prevent a meltdown."
 	glass_center_of_mass = list("x"=16, "y"=2)
 
-/datum/reagent/ethanol/toxins_special
+/datum/reagent/alcohol/ethanol/toxins_special
 	name = "Toxins Special"
 	id = "phoronspecial"
 	description = "This thing is ON FIRE! CALL THE DAMN SHUTTLE!"
@@ -2553,7 +2553,7 @@
 	glass_name = "glass of Toxins Special"
 	glass_desc = "Whoah, this thing is on FIRE"
 
-/datum/reagent/ethanol/vodkamartini
+/datum/reagent/alcohol/ethanol/vodkamartini
 	name = "Vodka Martini"
 	id = "vodkamartini"
 	description = "Vodka with Gin. Not quite how 007 enjoyed it, but still delicious."
@@ -2566,7 +2566,7 @@
 	glass_desc ="A bastardisation of the classic martini. Still great."
 	glass_center_of_mass = list("x"=17, "y"=8)
 
-/datum/reagent/ethanol/vodkatonic
+/datum/reagent/alcohol/ethanol/vodkatonic
 	name = "Vodka and Tonic"
 	id = "vodkatonic"
 	description = "For when a gin and tonic isn't russian enough."
@@ -2579,7 +2579,7 @@
 	glass_desc = "For when a gin and tonic isn't Russian enough."
 	glass_center_of_mass = list("x"=16, "y"=7)
 
-/datum/reagent/ethanol/white_russian
+/datum/reagent/alcohol/ethanol/white_russian
 	name = "White Russian"
 	id = "whiterussian"
 	description = "That's just, like, your opinion, man..."
@@ -2592,7 +2592,7 @@
 	glass_desc = "A very nice looking drink. But that's just, like, your opinion, man."
 	glass_center_of_mass = list("x"=16, "y"=9)
 
-/datum/reagent/ethanol/whiskey_cola
+/datum/reagent/alcohol/ethanol/whiskey_cola
 	name = "Whiskey Cola"
 	id = "whiskeycola"
 	description = "Whiskey, mixed with cola. Surprisingly refreshing."
@@ -2605,7 +2605,7 @@
 	glass_desc = "An innocent-looking mixture of cola and Whiskey. Delicious."
 	glass_center_of_mass = list("x"=16, "y"=9)
 
-/datum/reagent/ethanol/whiskeysoda
+/datum/reagent/alcohol/ethanol/whiskeysoda
 	name = "Whiskey Soda"
 	id = "whiskeysoda"
 	description = "For the more refined griffon."
@@ -2618,7 +2618,7 @@
 	glass_desc = "Ultimate refreshment."
 	glass_center_of_mass = list("x"=16, "y"=9)
 
-/datum/reagent/ethanol/specialwhiskey // I have no idea what this is and where it comes from
+/datum/reagent/alcohol/ethanol/specialwhiskey // I have no idea what this is and where it comes from
 	name = "Special Blend Whiskey"
 	id = "specialwhiskey"
 	description = "Just when you thought regular station whiskey was good... This silky, amber goodness has to come along and ruin everything."
@@ -2646,7 +2646,7 @@
 	glass_name = "glass of Diet Dr. Gibb"
 	glass_desc = "Regular Dr.Gibb is probably healthier than this cocktail of artificial flavors."
 
-/datum/reagent/ethanol/drdaniels
+/datum/reagent/alcohol/ethanol/drdaniels
 	name = "Dr. Daniels"
 	id = "dr_daniels"
 	description = "A limited edition tallboy of Dr. Gibb's Infusions."
@@ -2726,7 +2726,7 @@
 
 //aurora unique drinks
 
-/datum/reagent/ethanol/daiquiri
+/datum/reagent/alcohol/ethanol/daiquiri
 	name = "Daiquiri"
 	id = "daiquiri"
 	description = "Exotically blue, fruity drink, distilled from oranges."
@@ -2738,7 +2738,7 @@
 	glass_name = "glass of Daiquiri"
 	glass_desc = "A splendid looking cocktail."
 
-/datum/reagent/ethanol/icepick
+/datum/reagent/alcohol/ethanol/icepick
 	name = "Ice Pick"
 	id = "icepick"
 	description = "Big. And red. Hmm...."
@@ -2750,7 +2750,7 @@
 	glass_name = "glass of Ice Pick"
 	glass_desc = "Big. And red. Hmm..."
 
-/datum/reagent/ethanol/poussecafe
+/datum/reagent/alcohol/ethanol/poussecafe
 	name = "Pousse-Cafe"
 	id = "poussecafe"
 	description = "Smells of French and liquore."
@@ -2762,7 +2762,7 @@
 	glass_name = "glass of Pousse-Cafe"
 	glass_desc = "Smells of French and liquore."
 
-/datum/reagent/ethanol/mintjulep
+/datum/reagent/alcohol/ethanol/mintjulep
 	name = "Mint Julep"
 	id = "mintjulep"
 	description = "As old as time itself, but how does it taste?"
@@ -2774,7 +2774,7 @@
 	glass_name = "glass of Mint Julep"
 	glass_desc = "As old as time itself, but how does it taste?"
 
-/datum/reagent/ethanol/johncollins
+/datum/reagent/alcohol/ethanol/johncollins
 	name = "John Collins"
 	id = "johncollins"
 	description = "Crystal clear, yellow, and smells of whiskey. How could this go wrong?"
@@ -2786,7 +2786,7 @@
 	glass_name = "glass of John Collins"
 	glass_desc = "Named after a man, perhaps?"
 
-/datum/reagent/ethanol/gimlet
+/datum/reagent/alcohol/ethanol/gimlet
 	name = "Gimlet"
 	id = "gimlet"
 	description = "Small, elegant, and kicks."
@@ -2798,7 +2798,7 @@
 	glass_name = "glass of Gimlet"
 	glass_desc = "Small, elegant, and packs a punch."
 
-/datum/reagent/ethanol/starsandstripes
+/datum/reagent/alcohol/ethanol/starsandstripes
 	name = "Stars and Stripes"
 	id = "starsandstripes"
 	description = "Someone, somewhere, is saluting."
@@ -2810,7 +2810,7 @@
 	glass_name = "glass of Stars and Stripes"
 	glass_desc = "Someone, somewhere, is saluting."
 
-/datum/reagent/ethanol/metropolitan
+/datum/reagent/alcohol/ethanol/metropolitan
 	name = "Metropolitan"
 	id = "metropolitan"
 	description = "What more could you ask for?"
@@ -2822,7 +2822,7 @@
 	glass_name = "glass of Metropolitan"
 	glass_desc = "What more could you ask for?"
 
-/datum/reagent/ethanol/caruso
+/datum/reagent/alcohol/ethanol/caruso
 	name = "Caruso"
 	id = "caruso"
 	description = "Green, almost alien."
@@ -2834,7 +2834,7 @@
 	glass_name = "glass of Caruso"
 	glass_desc = "Green, almost alien."
 
-/datum/reagent/ethanol/aprilshower
+/datum/reagent/alcohol/ethanol/aprilshower
 	name = "April Shower"
 	id = "aprilshower"
 	description = "Smells of brandy."
@@ -2846,7 +2846,7 @@
 	glass_name = "glass of April Shower"
 	glass_desc = "Smells of brandy."
 
-/datum/reagent/ethanol/carthusiansazerac
+/datum/reagent/alcohol/ethanol/carthusiansazerac
 	name = "Carthusian Sazerac"
 	id = "carthusiansazerac"
 	description = "Whiskey and... Syrup?"
@@ -2858,7 +2858,7 @@
 	glass_name = "glass of Carthusian Sazerac"
 	glass_desc = "Whiskey and... Syrup?"
 
-/datum/reagent/ethanol/deweycocktail
+/datum/reagent/alcohol/ethanol/deweycocktail
 	name = "Dewey Cocktail"
 	id = "deweycocktail"
 	description = "Colours, look at all the colours!"
@@ -2870,7 +2870,7 @@
 	glass_name = "glass of Dewey Cocktail"
 	glass_desc = "Colours, look at all the colours!"
 
-/datum/reagent/ethanol/chartreusegreen
+/datum/reagent/alcohol/ethanol/chartreusegreen
 	name = "Green Chartreuse"
 	id = "chartreusegreen"
 	description = "A green, strong liqueur."
@@ -2882,7 +2882,7 @@
 	glass_name = "glass of Green Chartreuse"
 	glass_desc = "A green, strong liqueur."
 
-/datum/reagent/ethanol/chartreuseyellow
+/datum/reagent/alcohol/ethanol/chartreuseyellow
 	name = "Yellow Chartreuse"
 	id = "chartreuseyellow"
 	description = "A yellow, strong liqueur."
@@ -2894,7 +2894,7 @@
 	glass_name = "glass of Yellow Chartreuse"
 	glass_desc = "A yellow, strong liqueur."
 
-/datum/reagent/ethanol/cremewhite
+/datum/reagent/alcohol/ethanol/cremewhite
 	name = "White Creme de Menthe"
 	id = "cremewhite"
 	description = "Mint-flavoured alcohol, in a bottle."
@@ -2906,7 +2906,7 @@
 	glass_name = "glass of White Creme de Menthe"
 	glass_desc = "Mint-flavoured alcohol."
 
-/datum/reagent/ethanol/cremeyvette
+/datum/reagent/alcohol/ethanol/cremeyvette
 	name = "Creme de Yvette"
 	id = "cremeyvette"
 	description = "Berry-flavoured alcohol, in a bottle."
@@ -2918,7 +2918,7 @@
 	glass_name = "glass of Creme de Yvette"
 	glass_desc = "Berry-flavoured alcohol."
 
-/datum/reagent/ethanol/brandy
+/datum/reagent/alcohol/ethanol/brandy
 	name = "Brandy"
 	id = "brandy"
 	description = "Cheap knock off for cognac."
@@ -2930,7 +2930,7 @@
 	glass_name = "glass of Brandy"
 	glass_desc = "Cheap knock off for cognac."
 
-/datum/reagent/ethanol/guinnes
+/datum/reagent/alcohol/ethanol/guinnes
 	name = "Guinness"
 	id = "guinnes"
 	description = "Special Guinnes drink."
@@ -2942,7 +2942,7 @@
 	glass_name = "glass of Guinness"
 	glass_desc = "A glass of Guinness."
 
-/datum/reagent/ethanol/drambuie
+/datum/reagent/alcohol/ethanol/drambuie
 	name = "Drambuie"
 	id = "drambuie"
 	description = "A drink that smells like whiskey but tastes different."
@@ -2954,7 +2954,7 @@
 	glass_name = "glass of Drambuie"
 	glass_desc = "A drink that smells like whiskey but tastes different."
 
-/datum/reagent/ethanol/oldfashioned
+/datum/reagent/alcohol/ethanol/oldfashioned
 	name = "Old Fashioned"
 	id = "oldfashioned"
 	description = "That looks like it's from the sixties."
@@ -2966,7 +2966,7 @@
 	glass_name = "glass of Old Fashioned"
 	glass_desc = "That looks like it's from the sixties."
 
-/datum/reagent/ethanol/blindrussian
+/datum/reagent/alcohol/ethanol/blindrussian
 	name = "Blind Russian"
 	id = "blindrussian"
 	description = "You can't see?"
@@ -2978,7 +2978,7 @@
 	glass_name = "glass of Blind Russian"
 	glass_desc = "You can't see?"
 
-/datum/reagent/ethanol/rustynail
+/datum/reagent/alcohol/ethanol/rustynail
 	name = "Rusty Nail"
 	id = "rustynail"
 	description = "Smells like lemon."
@@ -2990,7 +2990,7 @@
 	glass_name = "glass of Rusty Nail"
 	glass_desc = "Smells like lemon."
 
-/datum/reagent/ethanol/tallrussian
+/datum/reagent/alcohol/ethanol/tallrussian
 	name = "Tall Black Russian"
 	id = "tallrussian"
 	description = "Just like black russian but taller."
@@ -3006,7 +3006,7 @@
 //=====================================
 // Organized here because why not.
 
-/datum/reagent/ethanol/badtouch
+/datum/reagent/alcohol/ethanol/badtouch
 	name = "Bad Touch"
 	id = "badtouch"
 	description = "We're nothing but mammals, after all."
@@ -3018,7 +3018,7 @@
 	glass_name = "glass of Bad Touch"
 	glass_desc = "We're nothing but mammals, after all."
 
-/datum/reagent/ethanol/bluelagoon
+/datum/reagent/alcohol/ethanol/bluelagoon
 	name = "Blue Lagoon"
 	id = "bluelagoon"
 	description = "Because lagoons shouldn't come in other colors."
@@ -3030,7 +3030,7 @@
 	glass_name = "glass of Blue Lagoon"
 	glass_desc = "Because lagoons shouldn't come in other colors."
 
-/datum/reagent/ethanol/boukha
+/datum/reagent/alcohol/ethanol/boukha
 	name = "Boukha"
 	id = "boukha"
 	description = "A distillation of figs, popular in the Serene Republic of Elyra."
@@ -3042,7 +3042,7 @@
 	glass_name = "glass of boukha"
 	glass_desc = "A distillation of figs, popular in the Serene Republic of Elyra."
 
-/datum/reagent/ethanol/fireball
+/datum/reagent/alcohol/ethanol/fireball
 	name = "Fireball"
 	id = "fireball"
 	description = "Whiskey that's been infused with cinnamon and hot pepper. Meant for mixing."
@@ -3059,10 +3059,10 @@
 	var/discomfort_message = "<span class='danger'>Your insides feel uncomfortably hot!</span>"
 	var/slime_temp_adj = 3
 
-/datum/reagent/ethanol/fireball/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/alcohol/ethanol/fireball/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustToxLoss(0.1 * removed)
 
-/datum/reagent/ethanol/fireball/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/alcohol/ethanol/fireball/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.species && (H.species.flags & (NO_PAIN)))
@@ -3079,7 +3079,7 @@
 		M.bodytemperature += rand(0, 15) + slime_temp_adj
 	holder.remove_reagent("frostoil", 2)
 
-/datum/reagent/ethanol/cherrytreefireball
+/datum/reagent/alcohol/ethanol/cherrytreefireball
 	name = "Cherry Tree Fireball"
 	id = "cherrytreefireball"
 	description = "An iced fruit cocktail shaken with cinnamon whiskey. Hot, cold and sweet all at once."
@@ -3091,7 +3091,7 @@
 	glass_name = "glass of Cherry Tree Fireball"
 	glass_desc = "An iced fruit cocktail shaken with cinnamon whiskey. Hot, cold and sweet all at once."
 
-/datum/reagent/ethanol/cobaltvelvet
+/datum/reagent/alcohol/ethanol/cobaltvelvet
 	name = "Cobalt Velvet"
 	id = "cobaltvelvet"
 	description = "An electric blue champagne cocktail that's popular on the club scene."
@@ -3103,7 +3103,7 @@
 	glass_name = "glass of Cobalt Velvet"
 	glass_desc = "An electric blue champagne cocktail that's popular on the club scene."
 
-/datum/reagent/ethanol/fringeweaver
+/datum/reagent/alcohol/ethanol/fringeweaver
 	name = "Fringe Weaver"
 	id = "fringeweaver"
 	description = "Effectively pure alcohol with a dose of sugar. It's as simple as it is strong."
@@ -3115,7 +3115,7 @@
 	glass_name = "glass of Fringe Weaver"
 	glass_desc = "Effectively pure alcohol with a dose of sugar. It's as simple as it is strong."
 
-/datum/reagent/ethanol/junglejuice
+/datum/reagent/alcohol/ethanol/junglejuice
 	name = "Jungle Juice"
 	id = "junglejuice"
 	description = "You're in the jungle now, baby."
@@ -3127,7 +3127,7 @@
 	glass_name = "glass of Jungle Juice"
 	glass_desc = "You're in the jungle now, baby."
 
-/datum/reagent/ethanol/marsarita
+/datum/reagent/alcohol/ethanol/marsarita
 	name = "Marsarita"
 	id = "marsarita"
 	description = "The margarita with a Martian twist. They call it something less embarrassing there."
@@ -3150,7 +3150,7 @@
 	glass_name = "glass of Melon Cooler"
 	glass_desc = "Summertime on the beach, in liquid form."
 
-/datum/reagent/ethanol/midnightkiss
+/datum/reagent/alcohol/ethanol/midnightkiss
 	name = "Midnight Kiss"
 	id = "midnightkiss"
 	description = "A champagne cocktail, quietly bubbling in a slender glass."
@@ -3173,7 +3173,7 @@
 	glass_name = "glass of Millionaire Sour"
 	glass_desc = "It's a good mix, a great mix. Best mix in the galaxy. It's terrific, you're gonna love it."
 
-/datum/reagent/ethanol/olympusmons
+/datum/reagent/alcohol/ethanol/olympusmons
 	name = "Olympus Mons"
 	id = "olympusmons"
 	description = "Another, stronger version of the Black Russian. It's popular in some Martian arcologies."
@@ -3185,7 +3185,7 @@
 	glass_name = "glass of Olympus Mons"
 	glass_desc = "Another, stronger version of the Black Russian. It's popular in some Martian arcologies."
 
-/datum/reagent/ethanol/europanail
+/datum/reagent/alcohol/ethanol/europanail
 	name = "Europa Nail"
 	id = "europanail"
 	description = "Named for Jupiter's moon. It looks about as crusty."
@@ -3219,7 +3219,7 @@
 	glass_name = "glass of Shirley Temple"
 	glass_desc = "Straight from the good ship Lollipop."
 
-/datum/reagent/ethanol/sugarrush
+/datum/reagent/alcohol/ethanol/sugarrush
 	name = "Sugar Rush"
 	id = "sugarrush"
 	description = "Sweet, light and fruity. As girly as it gets."
@@ -3231,7 +3231,7 @@
 	glass_name = "glass of Sugar Rush"
 	glass_desc = "Sweet, light and fruity. As girly as it gets."
 
-/datum/reagent/ethanol/sangria
+/datum/reagent/alcohol/ethanol/sangria
 	name = "Sangria"
 	id = "sangria"
 	description = "Red wine, splashed with brandy and infused with fruit."
@@ -3243,7 +3243,7 @@
 	glass_name = "glass of Sangria"
 	glass_desc = "Red wine, splashed with brandy and infused with fruit."
 
-/datum/reagent/ethanol/bassline
+/datum/reagent/alcohol/ethanol/bassline
 	name = "Bassline"
 	id = "bassline"
 	description = "A vodka cocktail from Vega De Rosa, Mendell City's entertainment district. Purple and deep."
@@ -3255,7 +3255,7 @@
 	glass_name = "glass of Bassline"
 	glass_desc = "A vodka cocktail from Vega De Rosa, Mendell City's entertainment district. Purple and deep."
 
-/datum/reagent/ethanol/bluebird
+/datum/reagent/alcohol/ethanol/bluebird
 	name = "Bluebird"
 	id = "bluebird"
 	description = "A gin drink popularized by a spy thriller in 2452."
@@ -3267,7 +3267,7 @@
 	glass_name = "glass of Bluebird"
 	glass_desc = "A gin drink popularized by a spy thriller in 2452."
 
-/datum/reagent/ethanol/whitewine
+/datum/reagent/alcohol/ethanol/whitewine
 	name = "White Wine"
 	id = "whitewine"
 	description = "A premium alchoholic beverage made from distilled grape juice."
@@ -3284,7 +3284,7 @@
 //=====================================
 //These are mainly for unathi, and have very little (but still some) effect on other species
 
-/datum/reagent/butanol/xuizijuice
+/datum/reagent/alcohol/butanol/xuizijuice
 	name = "Xuizi Juice"
 	id = "xuizijuice"
 	description = "Blended flower buds from a Moghean Xuizi cactus. Has a mild butanol content and is a staple recreational beverage in Unathi culture."
@@ -3296,7 +3296,7 @@
 	glass_name = "glass of Xuizi Juice"
 	glass_desc = "The clear green liquid smells like vanilla, tastes like water. Unathi swear it has a rich taste and texture."
 
-/datum/reagent/butanol/sarezhiwine
+/datum/reagent/alcohol/butanol/sarezhiwine
 	name = "Sarezhi Wine"
 	id = "sarezhiwine"
 	description = "An alcoholic beverage made from lightly fermented Sareszhi berries, considered an upper class delicacy on Moghes. Significant butanol content indicates intoxicating effects on Unathi."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -390,7 +390,7 @@
 
 	if(M.ingested)
 		for(var/datum/reagent/R in M.ingested.reagent_list)
-			if(istype(R, /datum/reagent/ethanol))
+			if(istype(R, /datum/reagent/alcohol/ethanol))
 				var/amount = min(P, R.volume)
 				M.ingested.remove_reagent(R.id, amount)
 				P -= amount
@@ -401,7 +401,7 @@
 	//as a treatment option if someone was dumb enough to do this
 	if(M.bloodstr)
 		for(var/datum/reagent/R in M.bloodstr.reagent_list)
-			if(istype(R, /datum/reagent/ethanol))
+			if(istype(R, /datum/reagent/alcohol/ethanol))
 				var/amount = min(P, R.volume)
 				M.bloodstr.remove_reagent(R.id, amount)
 				P -= amount

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1,22 +1,3 @@
-
-//Chemical Reactions - Initialises all /datum/chemical_reaction into a list
-// It is filtered into multiple lists within a list.
-// For example:
-// chemical_reaction_list["phoron"] is a list of all reactions relating to phoron
-// Note that entries in the list are NOT duplicated. So if a reaction pertains to
-// more than one chemical it will still only appear in only one of the sublists.
-/proc/initialize_chemical_reactions()
-	var/paths = typesof(/datum/chemical_reaction) - /datum/chemical_reaction
-	chemical_reactions_list = list()
-
-	for(var/path in paths)
-		var/datum/chemical_reaction/D = new path()
-		if(D.required_reagents && D.required_reagents.len)
-			var/reagent_id = D.required_reagents[1]
-			if(!chemical_reactions_list[reagent_id])
-				chemical_reactions_list[reagent_id] = list()
-			chemical_reactions_list[reagent_id] += D
-
 //helper that ensures the reaction rate holds after iterating
 //Ex. REACTION_RATE(0.3) means that 30% of the reagents will react each chemistry tick (~2 seconds by default).
 #define REACTION_RATE(rate) (1.0 - (1.0-rate)**(1.0/PROCESS_REACTION_ITER))

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -18,7 +18,7 @@
 	. = ..()
 	if(spawn_reagent)
 		reagents.add_reagent(spawn_reagent, volume)
-		var/datum/reagent/R = chemical_reagents_list[spawn_reagent]
+		var/datum/reagent/R = SSchemistry.chemical_reagents[spawn_reagent]
 		setLabel(R.name)
 
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/examine(mob/user)

--- a/code/modules/reagents/dispenser/cartridge_spawn.dm
+++ b/code/modules/reagents/dispenser/cartridge_spawn.dm
@@ -1,4 +1,4 @@
-/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"), reagent in chemical_reagents_list)
+/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"), reagent in SSchemistry.chemical_reagents)
 	set name = "Spawn Chemical Dispenser Cartridge"
 	set category = "Admin"
 
@@ -8,6 +8,6 @@
 		if("medium") C = new /obj/item/weapon/reagent_containers/chem_disp_cartridge/medium(usr.loc)
 		if("large") C = new /obj/item/weapon/reagent_containers/chem_disp_cartridge(usr.loc)
 	C.reagents.add_reagent(reagent, C.volume)
-	var/datum/reagent/R = chemical_reagents_list[reagent]
+	var/datum/reagent/R = SSchemistry.chemical_reagents[reagent]
 	C.setLabel(R.name)
 	log_admin("[key_name(usr)] spawned a [size] reagent container containing [reagent] at ([usr.x],[usr.y],[usr.z])",admin_key=key_name(usr))

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -28,7 +28,7 @@
 
 	for(var/T in reagent_ids)
 		reagent_volumes[T] = volume
-		var/datum/reagent/R = chemical_reagents_list[T]
+		var/datum/reagent/R = SSchemistry.chemical_reagents[T]
 		reagent_names += R.name
 
 	START_PROCESSING(SSprocessing, src)
@@ -101,14 +101,14 @@
 		if(t)
 			playsound(loc, 'sound/effects/pop.ogg', 50, 0)
 			mode = t
-			var/datum/reagent/R = chemical_reagents_list[reagent_ids[mode]]
+			var/datum/reagent/R = SSchemistry.chemical_reagents[reagent_ids[mode]]
 			usr << "<span class='notice'>Synthesizer is now producing '[R.name]'.</span>"
 
 /obj/item/weapon/reagent_containers/borghypo/examine(mob/user)
 	if(!..(user, 2))
 		return
 
-	var/datum/reagent/R = chemical_reagents_list[reagent_ids[mode]]
+	var/datum/reagent/R = SSchemistry.chemical_reagents[reagent_ids[mode]]
 
 	user << "<span class='notice'>It is currently producing [R.name] and has [reagent_volumes[reagent_ids[mode]]] out of [volume] units left.</span>"
 

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -79,18 +79,18 @@ var/list/lunchables_drink_reagents_ = list(
 
 // This default list is a bit different, it contains items we don't want
 var/list/lunchables_ethanol_reagents_ = list(
-	/datum/reagent/ethanol/acid_spit,
-	/datum/reagent/ethanol/atomicbomb,
-	/datum/reagent/ethanol/beepsky_smash,
-	/datum/reagent/ethanol/coffee,
-	/datum/reagent/ethanol/hippies_delight,
-	/datum/reagent/ethanol/hooch,
-	/datum/reagent/ethanol/thirteenloko,
-	/datum/reagent/ethanol/manhattan_proj,
-	/datum/reagent/ethanol/neurotoxin,
-	/datum/reagent/ethanol/pwine,
-	/datum/reagent/ethanol/threemileisland,
-	/datum/reagent/ethanol/toxins_special
+	/datum/reagent/alcohol/ethanol/acid_spit,
+	/datum/reagent/alcohol/ethanol/atomicbomb,
+	/datum/reagent/alcohol/ethanol/beepsky_smash,
+	/datum/reagent/alcohol/ethanol/coffee,
+	/datum/reagent/alcohol/ethanol/hippies_delight,
+	/datum/reagent/alcohol/ethanol/hooch,
+	/datum/reagent/alcohol/ethanol/thirteenloko,
+	/datum/reagent/alcohol/ethanol/manhattan_proj,
+	/datum/reagent/alcohol/ethanol/neurotoxin,
+	/datum/reagent/alcohol/ethanol/pwine,
+	/datum/reagent/alcohol/ethanol/threemileisland,
+	/datum/reagent/alcohol/ethanol/toxins_special
 )
 
 /proc/lunchables_lunches()
@@ -115,7 +115,7 @@ var/list/lunchables_ethanol_reagents_ = list(
 
 /proc/lunchables_ethanol_reagents()
 	if(!(lunchables_ethanol_reagents_[lunchables_ethanol_reagents_[1]]))
-		lunchables_ethanol_reagents_ = init_lunchable_reagent_list(lunchables_ethanol_reagents_, /datum/reagent/ethanol)
+		lunchables_ethanol_reagents_ = init_lunchable_reagent_list(lunchables_ethanol_reagents_, /datum/reagent/alcohol/ethanol)
 	return lunchables_ethanol_reagents_
 
 /proc/init_lunchable_list(var/list/lunches)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -66,18 +66,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			return_name = "Diamond"
 	return return_name
 
-/obj/machinery/computer/rdconsole/proc/CallReagentName(var/ID)
-	var/return_name = ID
-	var/datum/reagent/temp_reagent
-	for(var/R in (typesof(/datum/reagent) - /datum/reagent))
-		temp_reagent = null
-		temp_reagent = new R()
-		if(temp_reagent.id == ID)
-			return_name = temp_reagent.name
-			qdel(temp_reagent)
-			temp_reagent = null
-			break
-	return return_name
+/obj/machinery/computer/rdconsole/proc/CallReagentName(ID)
+	var/datum/reagent/R = SSchemistry.chemical_reagents[ID]
+	return R ? R.name : "(none)"
 
 /obj/machinery/computer/rdconsole/proc/SyncRDevices() //Makes sure it is properly sync'ed up with the devices attached to it (if any).
 	for(var/obj/machinery/r_n_d/D in range(3, src))

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -282,7 +282,7 @@
 			data = pick("bicaridine", "kelotane", "anti_toxin", "inaprovaline", "space_drugs", "sugar",
 						"tramadol", "dexalin", "cryptobiolin", "impedrezene", "hyperzine", "ethylredoxrazine",
 						"mindbreaker", "glucose")
-		var/datum/reagent/R = chemical_reagents_list[data]
+		var/datum/reagent/R = SSchemistry.chemical_reagents[data]
 		name = "[initial(name)] ([initial(R.name)])"
 
 	activate(var/mob/living/carbon/mob,var/multiplier)

--- a/code/world.dm
+++ b/code/world.dm
@@ -21,9 +21,6 @@ var/global/datum/global_init/init = new ()
 	makeDatumRefLists()
 	load_configuration()
 
-	initialize_chemical_reagents()
-	initialize_chemical_reactions()
-
 	qdel(src) //we're done
 	init = null
 


### PR DESCRIPTION
changes:
- The reagent and recipe lists have been moved fully into SSchemistry instead of a weird ref-shared global.
- The reagent list is now sorted alphabetically, which should make dialogs that involve selecting reagents much nicer to use (such as `Spawn-Chemical-Cartridge`).
- Butanol and Ethanol now share a parent: `/datum/reagent/alcohol`. Alcohol is an abstract type that won't be listed in any global reagent lists, and exists purely to pool code common to both butanol and ethanol.
- Butanol-based drinks can now cause hallucinations, body temperature changes, and stimulation similar to ethanol-based drinks.
- Reagent init is now in SSchemistry, both code-wise and init-stage wise.