### PR TITLE
Fix 'space wind'

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -141,13 +141,28 @@ mob/living/carbon/human/airflow_hit(atom/A)
 		Stun(round(airflow_speed * vsc.airflow_stun/2))
 	. = ..()
 
-zone/proc/movables()
+zone/proc/movables(list/origins)
 	. = list()
-	for(var/turf/T in contents)
-		CHECK_TICK
+	if (!origins || !origins.len)
+		return
 
-		for(var/aa in T)
-			var/atom/movable/A = aa
-			if(!A.simulated || A.anchored || istype(A, /obj/effect) || istype(A, /mob/abstract/eye))
-				continue
-			. += A
+	var/list/A	// this should be the longer list
+	var/list/B
+	if (contents.len > origins)
+		A = contents
+		B = origins
+	else
+		A = origins
+		B = contents
+
+	for (var/t in A)
+		var/turf/T = t
+		for (var/tt in B)
+			var/turf/TT = tt
+			if (T.contents.len > !!T.lighting_overlay && get_dist(T, TT) <= EDGE_KNOCKDOWN_MAX_DISTANCE)
+				for (var/am in T)
+					var/atom/movable/AM = am
+					if (AM.simulated && !AM.anchored && !istype(AM, /obj/effect) && !istype(AM, /mob/abstract))
+						.[AM] = TRUE
+
+			CHECK_TICK

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -146,17 +146,15 @@ zone/proc/movables(list/origins)
 	if (!origins || !origins.len)
 		return
 
-	var/turf/T
-	var/turf/TT
+	var/static/list/movables_tcache = typecacheof(list(/obj/effect, /mob/abstract))
+
 	var/atom/movable/AM
-	for (var/t in contents)
-		T = t
-		for (var/am in T)
+	for (var/testing_turf in contents)
+		for (var/am in testing_turf)
 			AM = am
-			if (AM.simulated && !AM.anchored && !istype(AM, /obj/effect) && !istype(AM, /mob/abstract))
-				for (var/tt in origins)
-					TT = tt
-					if (get_dist(T, TT) <= EDGE_KNOCKDOWN_MAX_DISTANCE)
+			if (AM.simulated && !AM.anchored && !movables_tcache[AM.type])
+				for (var/source_turf in origins)
+					if (get_dist(testing_turf, source_turf) <= EDGE_KNOCKDOWN_MAX_DISTANCE)
 						.[AM] = TRUE
 						break
 

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -146,23 +146,18 @@ zone/proc/movables(list/origins)
 	if (!origins || !origins.len)
 		return
 
-	var/list/A	// this should be the longer list
-	var/list/B
-	if (contents.len > origins)
-		A = contents
-		B = origins
-	else
-		A = origins
-		B = contents
-
-	for (var/t in A)
-		var/turf/T = t
-		for (var/tt in B)
-			var/turf/TT = tt
-			if (T.contents.len > !!T.lighting_overlay && get_dist(T, TT) <= EDGE_KNOCKDOWN_MAX_DISTANCE)
-				for (var/am in T)
-					var/atom/movable/AM = am
-					if (AM.simulated && !AM.anchored && !istype(AM, /obj/effect) && !istype(AM, /mob/abstract))
+	var/turf/T
+	var/turf/TT
+	var/atom/movable/AM
+	for (var/t in contents)
+		T = t
+		for (var/am in T)
+			AM = am
+			if (AM.simulated && !AM.anchored && !istype(AM, /obj/effect) && !istype(AM, /mob/abstract))
+				for (var/tt in origins)
+					TT = tt
+					if (get_dist(T, TT) <= EDGE_KNOCKDOWN_MAX_DISTANCE)
 						.[AM] = TRUE
+						break
 
-			CHECK_TICK
+					CHECK_TICK

--- a/code/ZAS/ConnectionGroup.dm
+++ b/code/ZAS/ConnectionGroup.dm
@@ -169,11 +169,11 @@ Class Procs:
 		var/list/attracted
 		var/list/repelled
 		if(differential > 0)
-			attracted = A.movables()
-			repelled = B.movables()
+			attracted = A.movables(connecting_turfs)
+			repelled = B.movables(connecting_turfs)
 		else
-			attracted = B.movables()
-			repelled = A.movables()
+			attracted = B.movables(connecting_turfs)
+			repelled = A.movables(connecting_turfs)
 
 		// These are async, with waitfor = FALSE
 		flow(attracted, abs(differential), 0)
@@ -239,7 +239,7 @@ Class Procs:
 
 	var/differential = A.air.return_pressure() - air.return_pressure()
 	if(abs(differential) >= vsc.airflow_lightest_pressure)
-		var/list/attracted = A.movables()
+		var/list/attracted = A.movables(connecting_turfs)
 		// This call is async, with waitfor = FALSE
 		flow(attracted, abs(differential), differential < 0)
 

--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -7,6 +7,7 @@
 #define BLOCKED 3
 
 #define ZONE_MIN_SIZE 14 //zones with less than this many turfs will always merge, even if the connection is not direct
+#define EDGE_KNOCKDOWN_MAX_DISTANCE 16	// Maximum distance between an airflow origin and a movable before knockdown no longer applies.
 
 #define CANPASS_ALWAYS 1
 #define CANPASS_DENSITY 2

--- a/html/changelogs/lohikar-spacewind.yml
+++ b/html/changelogs/lohikar-spacewind.yml
@@ -1,0 +1,5 @@
+author: Lohikar
+
+delete-after: True
+changes: 
+  - bugfix: "ZAS Knockdown now has a distance cap. (Fixes 'space wind')"


### PR DESCRIPTION
changes:
- ZAS knockdown is now only applied to movables that are within 16 tiles of one of the edge's turfs. There's probably faster ways to do this, but this should be fine for now.

Fixes #2917.