### PR TITLE
Map & Ore sanity

### DIFF
--- a/code/controllers/subsystems/initialization/atlas.dm
+++ b/code/controllers/subsystems/initialization/atlas.dm
@@ -23,6 +23,11 @@ var/datum/controller/subsystem/atlas/SSatlas
 	NEW_SS_GLOBAL(SSatlas)
 
 /datum/controller/subsystem/atlas/Initialize(timeofday)
+	// Quick sanity check.
+	if (world.maxx != WORLD_MIN_SIZE || world.maxy != WORLD_MIN_SIZE || world.maxz != 1)
+		world << "<span class='warning'>WARNING: Suspected pre-compiled map: things may break horribly!</span>"
+		log_ss("atlas", "-- WARNING: Suspected pre-compiled map! --")
+
 	maploader = new
 
 	var/datum/map/M

--- a/code/controllers/subsystems/initialization/misc_early.dm
+++ b/code/controllers/subsystems/initialization/misc_early.dm
@@ -44,4 +44,9 @@
 
 	global_initialize_webhooks()
 
+	// Setup ore.
+	for(var/oretype in subtypesof(/ore))
+		var/ore/OD = new oretype()
+		ore_data[OD.name] = OD
+
 	..()

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -177,6 +177,10 @@
 		for(var/alloytype in typesof(/datum/alloy)-/datum/alloy)
 			alloy_data += new alloytype()
 
+	for (var/O in ore_data)
+		ores_processing[O] = 0
+		ores_stored[O] = 0
+
 //Locate our output and input machinery.
 	for (var/dir in cardinal)
 		src.input = locate(/obj/machinery/mineral/input, get_step(src, dir))

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -177,13 +177,6 @@
 		for(var/alloytype in typesof(/datum/alloy)-/datum/alloy)
 			alloy_data += new alloytype()
 
-	if(!ore_data || !ore_data.len)
-		for(var/oretype in typesof(/ore)-/ore)
-			var/ore/OD = new oretype()
-			ore_data[OD.name] = OD
-			ores_processing[OD.name] = 0
-			ores_stored[OD.name] = 0
-
 //Locate our output and input machinery.
 	for (var/dir in cardinal)
 		src.input = locate(/obj/machinery/mineral/input, get_step(src, dir))

--- a/code/world.dm
+++ b/code/world.dm
@@ -1,5 +1,6 @@
 #define WORLD_ICON_SIZE 32
 #define PIXEL_MULTIPLIER WORLD_ICON_SIZE/32
+#define WORLD_MIN_SIZE 32
 
 /*
 	The initialization of the game happens roughly like this:
@@ -56,8 +57,8 @@ var/global/datum/global_init/init = new ()
 	area = /area/space
 	view = "15x15"
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
-	maxx = 32	// So that we don't get map-window-popin at boot. DMMS will expand this.
-	maxy = 32
+	maxx = WORLD_MIN_SIZE	// So that we don't get map-window-popin at boot. DMMS will expand this.
+	maxy = WORLD_MIN_SIZE
 
 
 #define RECOMMENDED_VERSION 510


### PR DESCRIPTION
changes:
- SSatlas will now warn if it detects a compiled-in map.
- The asteroid gen no longer stops working if no smelter is mapped in.
- Multiple smelters can now be mapped in without all but one being nonfunctional.