### PR TITLE
Speculative fix for some head sprite bugs

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -9,7 +9,7 @@
 	item_flags = THICKMATERIAL
 	body_parts_covered = HEAD
 	armor = list(melee = 50, bullet = 15, laser = 50,energy = 10, bomb = 25, bio = 0, rad = 0)
-	flags_inv = HIDEEARS|HIDEEYES
+	flags_inv = HIDEEARS|BLOCKHEADHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = HEAD

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -733,7 +733,7 @@ There are several things that need to be remembered:
 	if(update_icons)   update_icons()
 
 
-/mob/living/carbon/human/update_inv_head(var/update_icons=1)
+/mob/living/carbon/human/update_inv_head(update_icons = TRUE, recurse = TRUE)
 	if (QDELING(src))
 		return
 
@@ -780,6 +780,10 @@ There are several things that need to be remembered:
 				ovr += SSicon_cache.light_overlay_cache["[cache_key]"]
 
 		overlays_raw[HEAD_LAYER] = ovr || standing
+
+	if (recurse)
+		update_hair(FALSE)
+		update_inv_wear_mask(FALSE, FALSE)
 
 	if(update_icons)
 		update_icons()
@@ -905,7 +909,7 @@ There are several things that need to be remembered:
 		update_icons()
 
 
-/mob/living/carbon/human/update_inv_wear_mask(var/update_icons=1)
+/mob/living/carbon/human/update_inv_wear_mask(update_icons = TRUE, recurse = TRUE)
 	if (QDELING(src))
 		return
 
@@ -938,6 +942,10 @@ There are several things that need to be remembered:
 			ovr = list(standing, bloodsies)
 
 		overlays_raw[FACEMASK_LAYER] = ovr || standing
+
+	if (recurse)
+		update_inv_head(FALSE, FALSE)
+		update_hair(FALSE)
 
 	if(update_icons)
 		update_icons()


### PR DESCRIPTION
changes:
- Helmets no longer cover eyes and now cover hair by default.
- Mask, hair, and helmet sprites will now all be updated if one of them changes. This should fix issues with hair being visible when it shouldn't be, and masks mysteriously disappearing.

Fixes #3326.