### PR TITLE
Minor Explosion Fixes

### DIFF
--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -78,11 +78,14 @@
 	GET_ZONE_NEIGHBOURS(src, check_dirs)
 	. = check_dirs
 	for(var/dir in csrfz_check)
-
 		//for each pair of "adjacent" cardinals (e.g. NORTH and WEST, but not NORTH and SOUTH)
 		if((dir & check_dirs) == dir)
 			//check that they are connected by the corner turf
 			var/turf/simulated/T = get_step(src, dir)
+			if (!istype(T))
+				. &= ~dir
+				continue
+
 			var/connected_dirs
 			GET_ZONE_NEIGHBOURS(T, connected_dirs)
 			if(connected_dirs && (dir & reverse_dir[connected_dirs]) == dir)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -160,6 +160,7 @@
 				L.source_atom.update_light()
 
 /atom/proc/ex_act()
+	set waitfor = FALSE
 	return
 
 /atom/proc/emag_act(var/remaining_charges, var/mob/user, var/emag_source)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -735,6 +735,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 			   DISMEMBERMENT
 ****************************************************/
 
+/obj/item/organ/external/proc/post_droplimb(mob/living/carbon/human/victim)
+	victim.updatehealth()
+	victim.UpdateDamageIcon()
+	victim.regenerate_icons()
+	dir = 2
+
 //Handles dismemberment
 /obj/item/organ/external/proc/droplimb(var/clean, var/disintegrate = DROPLIMB_EDGE, var/ignore_children = null)
 
@@ -781,11 +787,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			victim.organs |= stump
 			stump.update_damages()
 
-	spawn(1)
-		victim.updatehealth()
-		victim.UpdateDamageIcon()
-		victim.regenerate_icons()
-		dir = 2
+	addtimer(CALLBACK(src, .proc/post_droplimb, victim), 0)
 
 	switch(disintegrate)
 		if(DROPLIMB_EDGE)
@@ -797,7 +799,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			if(!clean)
 				 //Throw limb around.
 				if(src && istype(loc,/turf))
-					throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
+					INVOKE_ASYNC(src, /atom/movable/.proc/throw_at, get_edge_target_turf(src,pick(alldirs)), rand(1,3), 30)
 				dir = 2
 		if(DROPLIMB_BURN)
 			new /obj/effect/decal/cleanable/ash(get_turf(victim))
@@ -812,19 +814,20 @@ Note that amputating the affected organ does in fact remove the infection from t
 			if(victim.species.blood_color)
 				gore.basecolor = victim.species.blood_color
 			gore.update_icon()
-			gore.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
+			INVOKE_ASYNC(gore, /atom/movable/.proc/throw_at, get_edge_target_turf(src, pick(alldirs)), rand(1,3), 30)
 
 			for(var/obj/item/organ/I in internal_organs)
 				I.removed()
 				if(istype(loc,/turf))
-					I.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
+					INVOKE_ASYNC(I, /atom/movable/.proc/throw_at, get_edge_target_turf(src, pick(alldirs)), rand(1,3), 30)
 
+			var/turf/Tloc = get_turf(src)
 			for(var/obj/item/I in src)
 				if(I.w_class <= 2)
 					qdel(I)
 					continue
-				I.loc = get_turf(src)
-				I.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
+				I.forceMove(Tloc)
+				INVOKE_ASYNC(I, /atom/movable/.proc/throw_at, get_edge_target_turf(src, pick(alldirs)), rand(1,3), 30)
 
 			qdel(src)
 


### PR DESCRIPTION
changes:
- Sleeps in ex_act() should no longer stall explosions (this could sometimes be significant).
- ZAS should no longer runtime when CSRFZ checks a non-simulated turf.
- throw_at() sleeps should no longer delay `droplimb()` calls.

Fixes #3572.