### PR TITLE
Hunter killer's unarmed attacks can now shred

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -97,6 +97,7 @@
 	damage = 12
 	attack_sound = 'sound/weapons/beartrap_shut.ogg'
 	attack_name = "power fist"
+	shredding = 1
 
 /datum/unarmed_attack/terminator/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/armour,var/attack_damage,var/zone)
 	..()


### PR DESCRIPTION
At the request of cake, hunter killer's unarmed attacks have been given the shredding, that allow them to open airlocks, smashes windows and etc.