### PR TITLE
Let's stack the FSM that is the DMM reader.

### DIFF
--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -405,7 +405,8 @@ var/global/dmm_suite/preloader/_preloader = new
 
 	// Associative keys are fed in without quotation marks.
 	// So if none of the other cases apply, return simply the string that was given.
-	else if(is_key)
+	// This case is also triggered for item values. So I guess we're also looking for text.
+	else if(is_key || istext(text))
 		. = text
 
 //build a list from variables in text form (e.g {var1="derp"; var2; var3=7} => list(var1="derp", var2, var3=7))


### PR DESCRIPTION
Okay.

So someone decided to strip the quotes from assoc lists. Which means they're no longer returned by default. So I stacked that condition onto the reader. Not sure if this is a good solution, but it works. The only thing to do other than this would be to redo the FSM to be a bit less stacked onto.