### PR TITLE
Fixes ticket security issue

### DIFF
--- a/code/modules/admin/ticket.dm
+++ b/code/modules/admin/ticket.dm
@@ -106,7 +106,7 @@ proc/get_open_ticket_by_ckey(var/owner)
 
 	var/list/dat = list()
 
-	var/valid_holder = check_rights(R_MOD|R_ADMIN, FALSE)
+	var/valid_holder = check_rights(R_MOD|R_ADMIN, FALSE, ticket_panel_window.user)
 
 	var/list/ticket_dat = list()
 	for(var/id = tickets.len, id >= 1, id--)


### PR DESCRIPTION
Turns out, ticket panels are updated for everyone if anyone presses specific buttons. At which point, the usr may as well be an admin, and this will then give access to all the tickets for everyone. So i fix it.
