### PR TITLE
Fixed Janicarts not opening doors

### DIFF
--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -108,7 +108,7 @@
 	var/obj/machinery/door/D = Obstacle
 	var/mob/living/carbon/human/H = load
 	if(istype(D) && istype(H))
-		D.Collide(H)		//a little hacky, but hey, it works, and respects access rights
+		H.Collide(D)		//a little hacky, but hey, it works, and respects access rights
 
 	. = ..()
 


### PR DESCRIPTION
Fixed the Janicart's inability to open doors by swapping the Door and the Driver on collision.
