### PR TITLE
Fixed mouth/eyes getting targeted point blank #4447

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -158,7 +158,7 @@
 
 /obj/item/projectile/proc/launch_projectile(atom/target, target_zone, mob/user, params, angle_override, forced_spread = 0)
 	original = target
-	def_zone = target_zone
+	def_zone = check_zone(target_zone)
 	firer = user
 	var/direct_target
 	if(get_turf(target) == get_turf(src))


### PR DESCRIPTION
Credit to TehFlaminTaco for helping me figure out the issue.
def_zone in launch_projectile wasn't doing a check_zone on the targeting area. Therefore, at point blank range you could shoot people in the mouth/eyes, instead of head.