### PR TITLE
Virology Report Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
@@ -13,7 +13,8 @@
 	radiation_mod = 0.5
 	brute_mod =     0.85
 	slowdown =      1
-	
+
+	virus_immune = TRUE
 	spawn_flags = IS_RESTRICTED
 
 /datum/species/human/spacer
@@ -29,7 +30,8 @@
 	flash_mod = 1.2
 	brute_mod = 1.1
 	burn_mod =  1.1
-	
+
+	virus_immune = TRUE
 	spawn_flags = IS_RESTRICTED
 
 /datum/species/human/vatgrown
@@ -49,7 +51,7 @@
 		"brain" =    /obj/item/organ/brain,
 		"eyes" =     /obj/item/organ/eyes
 		)
-		
+	virus_immune = TRUE
 	spawn_flags = IS_RESTRICTED
 
 /*

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -32,7 +32,7 @@
 	holder_type = /obj/item/weapon/holder/human
 	short_sighted = 1
 	gluttonous = TRUE
-
+	virus_immune = TRUE
 	spawn_flags = IS_RESTRICTED
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 	bump_flag = MONKEY

--- a/code/modules/mob/living/carbon/human/species/station/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca_subspecies.dm
@@ -53,6 +53,7 @@
 	toxins_mod = 1 //they're not used to all our weird human bacteria.
 	breakcuffs = list(MALE,FEMALE,NEUTER)
 	mob_size = 30
+	virus_immune = TRUE
 
 	speech_sounds = list('sound/voice/hiss1.ogg','sound/voice/hiss2.ogg','sound/voice/hiss3.ogg','sound/voice/hiss4.ogg')
 	speech_chance = 100

--- a/html/changelogs/XanderDox PR .yml
+++ b/html/changelogs/XanderDox PR .yml
@@ -1,0 +1,7 @@
+author: XanderDox
+
+delete-after: True
+
+changes: 
+  - bugfix: "Stopped unused human subspecies from appearing in virology reports."
+

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -58604,6 +58604,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/south,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "bWo" = (
@@ -91107,7 +91108,7 @@ bUS
 bVr
 bVM
 bWa
-bWo
+bTs
 bWl
 bXa
 bXo


### PR DESCRIPTION
Stops 'Gravity-Adapted Humans', 'Vat-Grown Humans', 'Space-Adapted Humans', and 'Resomi' from being listed under the species affected by viruses in the print out reports given by the disease analyzer in virology.

Unfortunately, Vaurca Breeder's datum refused to acknowledge the var used and continues to be listed occasionally. 

_This is my first Pull Request and I have absolutely no idea what I'm doing and Github Desktop is intuitive, so please provide feedback._
