### PR TITLE
Changes how ipc resurrection works

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -213,9 +213,9 @@
 
 				var/mob/living/carbon/human/unbranded_frame/new_shell = new(get_turf(loc), TRUE, "Unbranded Frame")
 				new_shell.set_species(src.chest.linked_frame)
+				src.forceMove(null) //so people won't mess around with the chassis until it is deleted
 				M.brainmob.mind.transfer_to(new_shell)
 				qdel(M)
-				src.forceMove(null) //so people won't mess around with the chassis until it is deleted
 				var/newname = sanitizeSafe(input(new_shell,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)
 				if(!newname)
 					var/datum/language/L = all_languages[new_shell.species.default_language]

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -215,18 +215,15 @@
 				var/mob/living/carbon/human/unbranded_frame/new_shell = new(get_turf(loc), TRUE, "Unbranded Frame")
 				new_shell.set_species(src.chest.linked_frame)
 				M.brainmob.mind.transfer_to(new_shell)
+				qdel(M)
 				var/newname = sanitizeSafe(input(new_shell,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)
 				if(!newname || newname == "")
 					var/datum/language/L = all_languages[new_shell.species.default_language]
 					newname = L.get_random_name()
 				new_shell.real_name = newname
 				new_shell.name = new_shell.real_name
-				var/datum/nano_module/appearance_changer/AC = new(src, new_shell)
-				AC.name = "Synthetic Customization Workshop"
-				AC.flags = APPEARANCE_ALL_HAIR | APPEARANCE_SKIN | APPEARANCE_EYE_COLOR
-				AC.ui_interact(new_shell)
-				qdel(M)
-				qdel(src)
+				new_shell.change_appearance(APPEARANCE_ALL_HAIR | APPEARANCE_SKIN | APPEARANCE_EYE_COLOR, new_shell.loc, new_shell)
+					qdel(src)
 				return
 
 			else

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -8,6 +8,7 @@
 	var/list/part = null // Order of args is important for installing robolimbs.
 	var/sabotaged = 0 //Emagging limbs can have repercussions when installed as prosthetics.
 	var/model_info
+	var/linked_frame = "Unbranded Frame"
 	dir = SOUTH
 
 /obj/item/robot_parts/set_dir()
@@ -21,6 +22,7 @@
 		if(R)
 			name = "[R.company] [initial(name)]"
 			desc = "[R.desc]"
+			linked_frame = R.linked_frame
 			if(icon_state in icon_states(R.icon))
 				icon = R.icon
 	else
@@ -59,6 +61,7 @@
 	desc = "A heavily reinforced case containing cyborg logic boards, with space for a standard power cell."
 	icon_state = "chest"
 	part = list("groin","chest")
+	model_info = 1
 	var/wires = 0.0
 	var/obj/item/weapon/cell/cell = null
 
@@ -67,6 +70,7 @@
 	desc = "A standard reinforced braincase, with spine-plugged neural socket and sensor gimbals."
 	icon_state = "head"
 	part = list("head")
+	model_info = 1
 	var/obj/item/device/flash/flash1 = null
 	var/obj/item/device/flash/flash2 = null
 	var/law_manager = TRUE
@@ -208,14 +212,15 @@
 					user << "<span class='warning'>This [W] does not seem to fit.</span>"
 					return
 
-				var/mob/living/carbon/human/unbranded_frame/shell = new(get_turf(user))
-				M.brainmob.mind.transfer_to(shell)
-				var/newname = sanitizeSafe(input(shell,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)
+				var/mob/living/carbon/human/unbranded_frame/new_shell = new(get_turf(loc), TRUE, "Unbranded Frame")
+				new_shell.set_species(src.chest.linked_frame)
+				M.brainmob.mind.transfer_to(new_shell)
+				var/newname = sanitizeSafe(input(new_shell,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)
 				if(!newname || newname == "")
-					var/datum/language/L = all_languages[shell.species.default_language]
+					var/datum/language/L = all_languages[new_shell.species.default_language]
 					newname = L.get_random_name()
-				shell.real_name = newname
-				shell.name = shell.real_name
+				new_shell.real_name = newname
+				new_shell.name = new_shell.real_name
 				qdel(M)
 				qdel(src)
 				return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -69,6 +69,7 @@
 	part = list("head")
 	var/obj/item/device/flash/flash1 = null
 	var/obj/item/device/flash/flash2 = null
+	var/law_manager = TRUE
 
 /obj/item/robot_parts/robot_suit
 	name = "endoskeleton"
@@ -201,38 +202,57 @@
 				user << "<span class='warning'>This [W] does not seem to fit.</span>"
 				return
 
-			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), TRUE)
-			if(!O)	return
+			if(!src.head.law_manager)
 
-			user.drop_item()
+				if(!is_alien_whitelisted(M.brainmob, "Machine") && config.usealienwhitelist)
+					user << "<span class='warning'>This [W] does not seem to fit.</span>"
+					return
 
-			O.mmi = W
-			O.invisibility = 0
-			O.custom_name = created_name
-			O.updatename("Default")
+				var/mob/living/carbon/human/unbranded_frame/shell = new(get_turf(user))
+				M.brainmob.mind.transfer_to(shell)
+				var/newname = sanitizeSafe(input(shell,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)
+				if(!newname || newname == "")
+					var/datum/language/L = all_languages[shell.species.default_language]
+					newname = L.get_random_name()
+				shell.real_name = newname
+				shell.name = shell.real_name
+				qdel(M)
+				qdel(src)
+				return
 
-			M.brainmob.mind.transfer_to(O)
+			else
+				var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), TRUE)
+				if(!O)	return
 
-			if(O.mind && O.mind.special_role)
-				O.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting. --NeoFite")
+				user.drop_item()
 
-			O.job = "Cyborg"
+				O.mmi = W
+				O.invisibility = 0
+				O.custom_name = created_name
+				O.updatename("Default")
 
-			O.cell = chest.cell
-			O.cell.loc = O
-			W.loc = O//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
+				M.brainmob.mind.transfer_to(O)
 
-			// Since we "magically" installed a cell, we also have to update the correct component.
-			if(O.cell)
-				var/datum/robot_component/cell_component = O.components["power cell"]
-				cell_component.wrapped = O.cell
-				cell_component.installed = 1
+				if(O.mind && O.mind.special_role)
+					O.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting. --NeoFite")
 
-			feedback_inc("cyborg_birth",1)
-			callHook("borgify", list(O))
-			O.Namepick()
+				O.job = "Cyborg"
 
-			qdel(src)
+				O.cell = chest.cell
+				O.cell.loc = O
+				W.loc = O//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
+
+				// Since we "magically" installed a cell, we also have to update the correct component.
+				if(O.cell)
+					var/datum/robot_component/cell_component = O.components["power cell"]
+					cell_component.wrapped = O.cell
+					cell_component.installed = 1
+
+				feedback_inc("cyborg_birth",1)
+				callHook("borgify", list(O))
+				O.Namepick()
+
+				qdel(src)
 		else
 			user << "<span class='warning'>The MMI must go in after everything else!</span>"
 
@@ -271,6 +291,14 @@
 
 /obj/item/robot_parts/head/attackby(obj/item/W as obj, mob/user as mob)
 	..()
+	if(ismultitool(W))
+		if(law_manager)
+			user << "<span class='notice'>You disable the lawing circuits on \the [src].</span>"
+			law_manager = FALSE
+		else
+			user << "<span class='notice'>You enable the lawing circuits on \the [src].</span>"
+			law_manager = TRUE
+
 	if(istype(W, /obj/item/device/flash))
 		if(istype(user,/mob/living/silicon/robot))
 			var/current_module = user.get_active_hand()

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -9,6 +9,7 @@
 	var/sabotaged = 0 //Emagging limbs can have repercussions when installed as prosthetics.
 	var/model_info
 	var/linked_frame = "Unbranded Frame"
+	var/model
 	dir = SOUTH
 
 /obj/item/robot_parts/set_dir()
@@ -61,7 +62,6 @@
 	desc = "A heavily reinforced case containing cyborg logic boards, with space for a standard power cell."
 	icon_state = "chest"
 	part = list("groin","chest")
-	model_info = 1
 	var/wires = 0.0
 	var/obj/item/weapon/cell/cell = null
 
@@ -211,8 +211,7 @@
 					user << "<span class='warning'>\The [W] does not seem to fit.</span>"
 					return
 
-				var/mob/living/carbon/human/unbranded_frame/new_shell = new(get_turf(loc), TRUE, "Unbranded Frame")
-				new_shell.set_species(src.chest.linked_frame)
+				var/mob/living/carbon/human/new_shell = new(get_turf(loc), src.chest.linked_frame)
 				src.forceMove(null) //so people won't mess around with the chassis until it is deleted
 				M.brainmob.mind.transfer_to(new_shell)
 				qdel(M)
@@ -347,3 +346,40 @@
 		user << "<span class='warning'>You short out the safeties.</span>"
 		sabotaged = 1
 		return 1
+
+//branded chest, to be used in ipc ressurection
+
+/obj/item/robot_parts/chest/bishop
+	name = "Bishop cybernetics torso"
+	model_info = 1
+	model = PROSTHETIC_BC
+
+/obj/item/robot_parts/chest/hephaestus
+	name = "Hephaestus industries torso"
+	model_info = 1
+	model = PROSTHETIC_HI
+
+/obj/item/robot_parts/chest/zenghu
+	name = "Zeng-Hu pharmaceuticals torso"
+	model_info = 1
+	model = PROSTHETIC_ZH
+
+/obj/item/robot_parts/chest/synthskin
+	name = "Human synthskin torso"
+	model_info = 1
+	model = PROSTHETIC_SYNTHSKIN
+
+/obj/item/robot_parts/chest/xion
+	name = "Xion manufacturing group torso"
+	model_info = 1
+	model = PROSTHETIC_XMG
+
+/obj/item/robot_parts/chest/ipc
+	name = "Hephaestus integrated torso"
+	model_info = 1
+	model = PROSTHETIC_IPC
+
+/obj/item/robot_parts/chest/industrial
+	name = "Hephaestus industrial torso"
+	model_info = 1
+	model = PROSTHETIC_IND

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -208,7 +208,7 @@
 			if(!src.head.law_manager)
 
 				if(!is_alien_whitelisted(M.brainmob, "Machine") && config.usealienwhitelist)
-					user << "<span class='warning'>This [W] does not seem to fit.</span>"
+					user << "<span class='warning'>\The [W] does not seem to fit.</span>"
 					return
 
 				var/mob/living/carbon/human/new_shell = new(get_turf(loc), TRUE, src.chest.linked_frame)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -211,7 +211,7 @@
 					user << "<span class='warning'>\The [W] does not seem to fit.</span>"
 					return
 
-				var/mob/living/carbon/human/new_shell = new(get_turf(loc), TRUE, "Unbranded Frame")
+				var/mob/living/carbon/human/unbranded_frame/new_shell = new(get_turf(loc), TRUE, "Unbranded Frame")
 				new_shell.set_species(src.chest.linked_frame)
 				M.brainmob.mind.transfer_to(new_shell)
 				qdel(M)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -9,7 +9,6 @@
 	var/sabotaged = 0 //Emagging limbs can have repercussions when installed as prosthetics.
 	var/model_info
 	var/linked_frame = "Unbranded Frame"
-	var/model
 	dir = SOUTH
 
 /obj/item/robot_parts/set_dir()
@@ -352,34 +351,28 @@
 /obj/item/robot_parts/chest/bishop
 	name = "Bishop cybernetics torso"
 	model_info = 1
-	model = PROSTHETIC_BC
+	linked_frame = "Bishop Accessory Frame"
 
 /obj/item/robot_parts/chest/hephaestus
 	name = "Hephaestus industries torso"
-	model_info = 1
-	model = PROSTHETIC_HI
+	linked_frame = "Hephaestus G2 Industrial Frame"
 
 /obj/item/robot_parts/chest/zenghu
 	name = "Zeng-Hu pharmaceuticals torso"
-	model_info = 1
-	model = PROSTHETIC_ZH
+	linked_frame = "Zeng-Hu Mobility Frame"
 
 /obj/item/robot_parts/chest/synthskin
 	name = "Human synthskin torso"
-	model_info = 1
-	model = PROSTHETIC_SYNTHSKIN
+	linked_frame = "Hephaestus G1 Industrial Frame"
 
 /obj/item/robot_parts/chest/xion
 	name = "Xion manufacturing group torso"
-	model_info = 1
-	model = PROSTHETIC_XMG
+	linked_frame = "Xion Industrial Frame"
 
 /obj/item/robot_parts/chest/ipc
 	name = "Hephaestus integrated torso"
-	model_info = 1
-	model = PROSTHETIC_IPC
+	linked_frame = "Baseline Frame"
 
 /obj/item/robot_parts/chest/industrial
 	name = "Hephaestus industrial torso"
-	model_info = 1
-	model = PROSTHETIC_IND
+	linked_frame = "Bishop Accessory Frame"

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -218,7 +218,7 @@
 				src.mouse_opacity = FALSE //so people won't mess around with the chassis until it is deleted
 				src.alpha = 0 //same reason as above
 				var/newname = sanitizeSafe(input(new_shell,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)
-				if(!newname || newname == "")
+				if(!newname)
 					var/datum/language/L = all_languages[new_shell.species.default_language]
 					newname = L.get_random_name()
 				new_shell.real_name = newname

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -211,7 +211,8 @@
 					user << "<span class='warning'>\The [W] does not seem to fit.</span>"
 					return
 
-				var/mob/living/carbon/human/new_shell = new(get_turf(loc), TRUE, src.chest.linked_frame)
+				var/mob/living/carbon/human/new_shell = new(get_turf(loc), TRUE, "Unbranded Frame")
+				new_shell.set_species(src.chest.linked_frame)
 				M.brainmob.mind.transfer_to(new_shell)
 				qdel(M)
 				src.forceMove(null) //so people won't mess around with the chassis until it is deleted

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -221,6 +221,10 @@
 					newname = L.get_random_name()
 				new_shell.real_name = newname
 				new_shell.name = new_shell.real_name
+				var/datum/nano_module/appearance_changer/AC = new(src, new_shell)
+				AC.name = "Synthetic Customization Workshop"
+				AC.flags = APPEARANCE_ALL_HAIR | APPEARANCE_SKIN | APPEARANCE_EYE_COLOR
+				AC.ui_interact(new_shell)
 				qdel(M)
 				qdel(src)
 				return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -202,7 +202,7 @@
 				return
 
 			if(jobban_isbanned(M.brainmob, "Cyborg"))
-				user << "<span class='warning'>This [W] does not seem to fit.</span>"
+				user << "<span class='warning'>\The [W] does not seem to fit.</span>"
 				return
 
 			if(!src.head.law_manager)
@@ -211,12 +211,10 @@
 					user << "<span class='warning'>This [W] does not seem to fit.</span>"
 					return
 
-				var/mob/living/carbon/human/unbranded_frame/new_shell = new(get_turf(loc), TRUE, "Unbranded Frame")
-				new_shell.set_species(src.chest.linked_frame)
+				var/mob/living/carbon/human/new_shell = new(get_turf(loc), TRUE, src.chest.linked_frame)
 				M.brainmob.mind.transfer_to(new_shell)
 				qdel(M)
-				src.mouse_opacity = FALSE //so people won't mess around with the chassis until it is deleted
-				src.alpha = 0 //same reason as above
+				src.forceMove(null) //so people won't mess around with the chassis until it is deleted
 				var/newname = sanitizeSafe(input(new_shell,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)
 				if(!newname)
 					var/datum/language/L = all_languages[new_shell.species.default_language]

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -70,7 +70,6 @@
 	desc = "A standard reinforced braincase, with spine-plugged neural socket and sensor gimbals."
 	icon_state = "head"
 	part = list("head")
-	model_info = 1
 	var/obj/item/device/flash/flash1 = null
 	var/obj/item/device/flash/flash2 = null
 	var/law_manager = TRUE
@@ -216,6 +215,8 @@
 				new_shell.set_species(src.chest.linked_frame)
 				M.brainmob.mind.transfer_to(new_shell)
 				qdel(M)
+				src.mouse_opacity = FALSE //so people won't mess around with the chassis until it is deleted
+				src.alpha = 0 //same reason as above
 				var/newname = sanitizeSafe(input(new_shell,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)
 				if(!newname || newname == "")
 					var/datum/language/L = all_languages[new_shell.species.default_language]

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -223,7 +223,7 @@
 				new_shell.real_name = newname
 				new_shell.name = new_shell.real_name
 				new_shell.change_appearance(APPEARANCE_ALL_HAIR | APPEARANCE_SKIN | APPEARANCE_EYE_COLOR, new_shell.loc, new_shell)
-					qdel(src)
+				qdel(src)
 				return
 
 			else

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -104,6 +104,9 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 /mob/living/carbon/human/industrial_bishop/Initialize(mapload)
 	. = ..(mapload, "Bishop Accessory Frame")
 
+/mob/living/carbon/human/unbranded_frame/Initialize(mapload)
+	. = ..(mapload, "Unbranded Frame")
+
 /mob/living/carbon/human/terminator/Initialize(mapload)
 	. = ..(mapload, "Hunter-Killer")
 	add_language(LANGUAGE_SOL_COMMON, 1)

--- a/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
@@ -373,13 +373,14 @@
 	short_name = "unbran"
 	name_plural = "Unbranded Frames"
 
-	blurb = "."
+	blurb = "A simple and archaic robotic frame, used mostly as a temporary body before posibrains are transferred to any specialized chassis."
 
 	icobase = 'icons/mob/human_races/robotic.dmi'
 	deform = 'icons/mob/human_races/robotic.dmi'
 	eyes = "eyes_s"
 
 	brute_mod = 1.2
+	bald = 1
 
 	appearance_flags = HAS_EYE_COLOR
 	spawn_flags = IS_RESTRICTED
@@ -392,16 +393,19 @@
 	)
 
 	has_limbs = list(
-		"chest" =  list("path" = /obj/item/organ/external/chest/ipc),
-		"groin" =  list("path" = /obj/item/organ/external/groin/ipc),
-		"head" =   list("path" = /obj/item/organ/external/head/ipc),
-		"l_arm" =  list("path" = /obj/item/organ/external/arm/ipc),
-		"r_arm" =  list("path" = /obj/item/organ/external/arm/right/ipc),
-		"l_leg" =  list("path" = /obj/item/organ/external/leg/ipc),
-		"r_leg" =  list("path" = /obj/item/organ/external/leg/right/ipc),
-		"l_hand" = list("path" = /obj/item/organ/external/hand/ipc),
-		"r_hand" = list("path" = /obj/item/organ/external/hand/right/ipc),
-		"l_foot" = list("path" = /obj/item/organ/external/foot/ipc),
-		"r_foot" = list("path" = /obj/item/organ/external/foot/right/ipc)
+		"chest" =  list("path" = /obj/item/organ/external/chest/unbranded),
+		"groin" =  list("path" = /obj/item/organ/external/groin/unbranded),
+		"head" =   list("path" = /obj/item/organ/external/head/unbranded),
+		"l_arm" =  list("path" = /obj/item/organ/external/arm/unbranded),
+		"r_arm" =  list("path" = /obj/item/organ/external/arm/right/unbranded),
+		"l_leg" =  list("path" = /obj/item/organ/external/leg/unbranded),
+		"r_leg" =  list("path" = /obj/item/organ/external/leg/right/unbranded),
+		"l_hand" = list("path" = /obj/item/organ/external/hand/unbranded),
+		"r_hand" = list("path" = /obj/item/organ/external/hand/right/unbranded),
+		"l_foot" = list("path" = /obj/item/organ/external/foot/unbranded),
+		"r_foot" = list("path" = /obj/item/organ/external/foot/right/unbranded)
 	)
 
+/datum/species/machine/unbranded/get_light_color(mob/living/carbon/human/H)
+	if (istype(H))
+		return rgb(H.r_eyes, H.g_eyes, H.b_eyes)

--- a/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
@@ -267,7 +267,7 @@
 
 	icobase = 'icons/mob/human_races/r_ind_xion.dmi'
 	deform = 'icons/mob/human_races/r_ind_xion.dmi'
-	
+
 	eyes = "xion_eyes"
 	flags = IS_IPC
 	passive_temp_gain = 5
@@ -367,3 +367,41 @@
 /datum/species/machine/bishop/get_light_color(mob/living/carbon/human/H)
 	if (istype(H))
 		return rgb(H.r_eyes, H.g_eyes, H.b_eyes)
+
+/datum/species/machine/unbranded
+	name = "Unbranded Frame"
+	short_name = "unbran"
+	name_plural = "Unbranded Frames"
+
+	blurb = "."
+
+	icobase = 'icons/mob/human_races/robotic.dmi'
+	deform = 'icons/mob/human_races/robotic.dmi'
+	eyes = "eyes_s"
+
+	brute_mod = 1.2
+
+	appearance_flags = HAS_EYE_COLOR
+	spawn_flags = IS_RESTRICTED
+
+
+	has_organ = list(
+		"brain"   = /obj/item/organ/mmi_holder/posibrain,
+		"cell"    = /obj/item/organ/cell,
+		"optics"  = /obj/item/organ/eyes/optical_sensor
+	)
+
+	has_limbs = list(
+		"chest" =  list("path" = /obj/item/organ/external/chest/ipc),
+		"groin" =  list("path" = /obj/item/organ/external/groin/ipc),
+		"head" =   list("path" = /obj/item/organ/external/head/ipc),
+		"l_arm" =  list("path" = /obj/item/organ/external/arm/ipc),
+		"r_arm" =  list("path" = /obj/item/organ/external/arm/right/ipc),
+		"l_leg" =  list("path" = /obj/item/organ/external/leg/ipc),
+		"r_leg" =  list("path" = /obj/item/organ/external/leg/right/ipc),
+		"l_hand" = list("path" = /obj/item/organ/external/hand/ipc),
+		"r_hand" = list("path" = /obj/item/organ/external/hand/right/ipc),
+		"l_foot" = list("path" = /obj/item/organ/external/foot/ipc),
+		"r_foot" = list("path" = /obj/item/organ/external/foot/right/ipc)
+	)
+

--- a/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine_subspecies.dm
@@ -379,18 +379,10 @@
 	deform = 'icons/mob/human_races/robotic.dmi'
 	eyes = "eyes_s"
 
-	brute_mod = 1.2
 	bald = 1
 
 	appearance_flags = HAS_EYE_COLOR
 	spawn_flags = IS_RESTRICTED
-
-
-	has_organ = list(
-		"brain"   = /obj/item/organ/mmi_holder/posibrain,
-		"cell"    = /obj/item/organ/cell,
-		"optics"  = /obj/item/organ/eyes/optical_sensor
-	)
 
 	has_limbs = list(
 		"chest" =  list("path" = /obj/item/organ/external/chest/unbranded),

--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -59,14 +59,14 @@ var/global/datum/robolimb/basic_robolimb
 	icon = 'icons/mob/human_races/r_machine.dmi'
 	unavailable_at_chargen = 1
 	paintable = 1
-	linked_frame = "Hephaestus G1 Industrial Frame"
+	linked_frame = "Baseline Frame"
 
 /datum/robolimb/industrial
 	company = PROSTHETIC_IND
 	desc = "This limb is more robust than the standard Hephaestus Integrated Limb, and is better suited for industrial machinery."
 	icon = 'icons/mob/human_races/r_industrial.dmi'
 	unavailable_at_chargen = 1
-	linked_frame = "Shell Frame"
+	linked_frame = "Hephaestus G1 Industrial Frame"
 
 /datum/robolimb/terminator
 	company = PROSTHETIC_HK

--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -59,7 +59,7 @@ var/global/datum/robolimb/basic_robolimb
 	icon = 'icons/mob/human_races/r_machine.dmi'
 	unavailable_at_chargen = 1
 	paintable = 1
-	linked_frame = "Baseline Frame"
+	linked_frame = "Hephaestus G1 Industrial Frame"
 
 /datum/robolimb/industrial
 	company = PROSTHETIC_IND

--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -19,7 +19,7 @@ var/global/datum/robolimb/basic_robolimb
 		"Human",
 		"Skrell",
 		"Tajara",
-		"Zhan-Khazan Tajara", 
+		"Zhan-Khazan Tajara",
 		"M'sai Tajara",
 		"Unathi",
 		"Vaurca Worker",
@@ -27,26 +27,31 @@ var/global/datum/robolimb/basic_robolimb
 		"Baseline Frame"
 	)
 	var/paintable = 0 //tired of istype exceptions. bullshirt to find, and by god do i know it after this project.
+	var/linked_frame = "Unbranded Frame" //which machine species this limb will create
 
 /datum/robolimb/bishop
 	company = PROSTHETIC_BC
 	desc = "This limb is coated in a brilliant silver illuminated from the inside with blue status lights."
 	icon = 'icons/mob/human_races/r_ind_bishop.dmi'
+	linked_frame = "Bishop Accessory Frame"
 
 /datum/robolimb/hesphaistos
 	company = PROSTHETIC_HI
 	desc = "This limb is covered in thick plating coated with a militaristic olive drab."
 	icon = 'icons/mob/human_races/r_ind_hephaestus.dmi'
+	linked_frame = "Hephaestus G2 Industrial Frame"
 
 /datum/robolimb/zenghu
 	company = PROSTHETIC_ZH
 	desc = "This limb has sleek white plating over a graphene-based nanofiber weave."
 	icon = 'icons/mob/human_races/r_ind_zenghu.dmi'
+	linked_frame = "Zeng-Hu Mobility Frame"
 
 /datum/robolimb/xion
 	company = PROSTHETIC_XMG
 	desc = "This limb has a minimalist black and grey casing with exposed orange wiring channels."
 	icon = 'icons/mob/human_races/r_ind_xion.dmi'
+	linked_frame = "Xion Industrial Frame"
 
 /datum/robolimb/ipc
 	company = PROSTHETIC_IPC
@@ -54,12 +59,14 @@ var/global/datum/robolimb/basic_robolimb
 	icon = 'icons/mob/human_races/r_machine.dmi'
 	unavailable_at_chargen = 1
 	paintable = 1
+	linked_frame = "Baseline Frame"
 
 /datum/robolimb/industrial
 	company = PROSTHETIC_IND
 	desc = "This limb is more robust than the standard Hephaestus Integrated Limb, and is better suited for industrial machinery."
 	icon = 'icons/mob/human_races/r_industrial.dmi'
 	unavailable_at_chargen = 1
+	linked_frame = "Shell Frame"
 
 /datum/robolimb/terminator
 	company = PROSTHETIC_HK
@@ -72,3 +79,4 @@ var/global/datum/robolimb/basic_robolimb
 	desc = "This limb is designed to mimic the Human form. It does so with moderate success."
 	icon = 'icons/mob/human_races/r_human.dmi'
 	species_can_use = list("Human")
+	linked_frame = "Shell Frame"

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -82,13 +82,6 @@
 		owner.Paralyse(emp_counter/6)
 		owner << "<span class='danger'>%#/ERR: Power leak detected!$%^/</span>"
 
-/obj/item/organ/cell/replaced()
-	. = ..()
-	// This is very ghetto way of rebooting an IPC. TODO better way.
-	if(owner && owner.stat == DEAD)
-		owner.stat = 0
-		owner.visible_message("<span class='danger'>\The [owner] twitches visibly!</span>")
-
 /obj/item/organ/eyes/optical_sensor
 	name = "optical sensor"
 	singular_name = "optical sensor"
@@ -141,17 +134,6 @@
 	if(istype(holder_mob))
 		holder_mob.drop_from_inventory(src)
 	qdel(src)
-
-/obj/item/organ/mmi_holder/Initialize(mapload)
-	. = ..()
-	// This is very ghetto way of rebooting an IPC. TODO better way.
-	if (!mapload)
-		addtimer(CALLBACK(src, .proc/attempt_revive), 1)
-
-/obj/item/organ/mmi_holder/proc/attempt_revive()
-	if (owner && owner.stat == DEAD)
-		owner.stat = 0
-		owner.visible_message("<span class='danger'>\The [owner] twitches visibly!</span>")
 
 /obj/item/organ/mmi_holder/posibrain/Initialize()
 	robotize()
@@ -408,3 +390,61 @@
 	encased = "support frame"
 	force_skintone = TRUE
 	robotize_type = PROSTHETIC_SYNTHSKIN
+
+//unbranded
+
+/obj/item/organ/external/head/unbranded
+	dislocated = -1
+	can_intake_reagents = 0
+	encased = "support frame"
+	robotize_type = "Unbranded"
+
+/obj/item/organ/external/chest/unbranded
+	dislocated = -1
+	encased = "support frame"
+	robotize_type = "Unbranded"
+
+/obj/item/organ/external/groin/unbranded
+	dislocated = -1
+	encased = "support frame"
+	robotize_type = "Unbranded"
+
+/obj/item/organ/external/arm/unbranded
+	dislocated = -1
+	encased = "support frame"
+	robotize_type = "Unbranded"
+
+/obj/item/organ/external/arm/right/unbranded
+	dislocated = -1
+	encased = "support frame"
+	robotize_type = "Unbranded"
+
+/obj/item/organ/external/leg/unbranded
+	dislocated = -1
+	encased = "support frame"
+	robotize_type = "Unbranded"
+
+/obj/item/organ/external/leg/right/unbranded
+	dislocated = -1
+	encased = "support frame"
+	robotize_type = "Unbranded"
+
+/obj/item/organ/external/foot/unbranded
+	dislocated = -1
+	encased = "support frame"
+	robotize_type = "Unbranded"
+
+/obj/item/organ/external/foot/right/unbranded
+	dislocated = -1
+	encased = "support frame"
+	robotize_type = "Unbranded"
+
+/obj/item/organ/external/hand/unbranded
+	dislocated = -1
+	encased = "support frame"
+	robotize_type = "Unbranded"
+
+/obj/item/organ/external/hand/right/unbranded
+	dislocated = -1
+	encased = "support frame"
+	robotize_type = "Unbranded"

--- a/html/changelogs/alberyk-synthchangesneveragain.yml
+++ b/html/changelogs/alberyk-synthchangesneveragain.yml
@@ -3,4 +3,4 @@ delete-after: True
 
 changes:
   - rscdel: "Replacing a dead ipc's powercell or posibrain should not revive them anymore."
-  - rscadd: "Robotics can now create ipcs using a cyborg chassis that had its law system disabled, the new ipc's chassis will be based on the torso's brand."
+  - rscadd: "Robotics can now create ipcs using a cyborg chassis that had its law system disabled, the new ipc's chassis will be based on the torso's brand. While robotics is unable to print torsos with their own brand, they should be available at cargo."

--- a/html/changelogs/alberyk-synthchangesneveragain.yml
+++ b/html/changelogs/alberyk-synthchangesneveragain.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+delete-after: True
+
+changes:
+  - rscdel: "Replacing a dead ipc's powercell or posibrain should not revive them anymore."
+  - rscadd: "Robotics can now create ipcs using a cyborg chassis that had its law system disabled, the new ipc's chassis will be based on the torso's brand."


### PR DESCRIPTION
This prs removes the old method of ipc resurrection, which was just removing and placing the mmi/heart back into the body, which was really lazy and caused a lot of bugs.

Now, robotics can create a ipcs frames using the different brands in the robotics frabricator, based on the torso's brand. The law manager can disable by using a multitool on the head which is the diffence between creating a cyborg or an ipc. Also; it allows you to customize your snowflakness after your new body is created.

Changes: you can't print all torso types from robotics anymore, but there are torsos that come with their own brand, that you should be able to buy from cargo, that will allow someone to create another type of ipc.

Feedback Topic: https://forums.aurorastation.org/viewtopic.php?f=18&t=10705