### PR TITLE
Footprints in the Ash

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -88,23 +88,28 @@
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			// Tracking blood
-			var/list/bloodDNA = null
+			var/list/bloodDNA = list()
+			var/will_track = 0
 			var/bloodcolor=""
 			if(H.shoes)
 				var/obj/item/clothing/shoes/S = H.shoes
 				if(istype(S))
 					S.handle_movement(src,(H.m_intent == "run" ? 1 : 0))
-					if(S.track_blood && S.blood_DNA)
-						bloodDNA = S.blood_DNA
+					if(S.track_blood)
+						if(S.blood_DNA)
+							bloodDNA = S.blood_DNA
 						bloodcolor=S.blood_color
 						S.track_blood--
+						will_track = 1
 			else
-				if(H.track_blood && H.feet_blood_DNA)
-					bloodDNA = H.feet_blood_DNA
+				if(H.track_blood)
+					if(H.feet_blood_DNA)
+						bloodDNA = H.feet_blood_DNA
 					bloodcolor = H.feet_blood_color
 					H.track_blood--
+					will_track = 1
 
-			if (bloodDNA)
+			if(will_track)
 				src.AddTracks(/obj/effect/decal/cleanable/blood/tracks/footprints,bloodDNA,H.dir,0,bloodcolor) // Coming
 				var/turf/simulated/from = get_step(H,reverse_direction(H.dir))
 				if(istype(from) && from)

--- a/code/modules/mining/mine_turf_types.dm
+++ b/code/modules/mining/mine_turf_types.dm
@@ -100,6 +100,38 @@
 	if (prob(20))
 		add_overlay("asteroid[rand(0, 9)]", TRUE)
 
+
+
+/turf/simulated/floor/asteroid/ash/Entered(atom/A, atom/OL)
+	..()
+
+	if(ishuman(A))
+		var/mob/living/carbon/human/H = A
+		var/obj/item/organ/external/l_foot = H.get_organ("l_foot")
+		var/obj/item/organ/external/r_foot = H.get_organ("r_foot")
+		var/hasfeet = 1
+		if((!l_foot || l_foot.is_stump()) && (!r_foot || r_foot.is_stump()))
+			hasfeet = 0
+		if(H.shoes && !H.buckled)//Adding ash to shoes
+			var/obj/item/clothing/shoes/S = H.shoes
+			if(istype(S))
+				S.blood_color = "#6C6564"
+				S.track_blood = max(12,S.track_blood)
+
+				if(!S.blood_overlay)
+					S.generate_blood_overlay()
+				if(S.blood_overlay && S.blood_overlay.color != "#6C6564")
+					S.cut_overlay(S.blood_overlay, TRUE)
+
+				S.blood_overlay.color = "#6C6564"
+				S.add_overlay(S.blood_overlay, TRUE)
+
+		else if (hasfeet)//Or feet
+			H.feet_blood_color = "#6C6564"
+			H.track_blood = max(12,H.track_blood)
+
+		H.update_inv_shoes(1)
+
 /turf/simulated/floor/asteroid/ash/rocky
 	name = "rocky ash"
 	icon_state = "rockyash"

--- a/html/changelogs/footprintsinthesand.yml
+++ b/html/changelogs/footprintsinthesand.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: LordFowl
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Footprints will now be created on ashy turfs, and ash will spread onto the shoes causing ash-tracks."


### PR DESCRIPTION
Ash will now track onto a user's boots, creating footprints in both the ash and any subsequent tiling the user steps on. Currently these footprints use the track template that blood uses, and indeed are a subtype of blood-tracks. The result is perhaps not the best sprite. Even so, I thought it at least a worthy experiment.

![image](https://user-images.githubusercontent.com/11169120/37924701-9f79371c-3100-11e8-87bb-768a9055fecf.png)
