### PR TITLE
Fixes name issue for sentencing machine

### DIFF
--- a/code/game/machinery/computer/sentencing.dm
+++ b/code/game/machinery/computer/sentencing.dm
@@ -106,8 +106,9 @@
 	. += "<tr>"
 	. += "<th>Convict:</th>"
 	. += "<td><a href='?src=\ref[src];button=change_criminal;'>"
-	if( incident.card )
-		. += "[incident.card]"
+	var/obj/item/weapon/card/id/card = incident.card.resolve()
+	if( card )
+		. += "[card]"
 	else
 		. += "None"
 	. += "</a></td>"
@@ -191,8 +192,9 @@
 
 	. += "<tr><th colspan='2'>Convict</th></tr>"
 	. += "<tr><td colspan='2'><center>"
-	if( incident.card )
-		. += "[incident.card]"
+	var/obj/item/weapon/card/id/card = incident.card.resolve()
+	if( card )
+		. += "[card]"
 	else
 		. += "None"
 	. += "</center></td></tr>"
@@ -435,7 +437,8 @@
 	return .
 
 /obj/machinery/computer/sentencing/proc/render_innocent( var/mob/user )
-	ping( "\The [src] pings, \"[incident.card] has been found innocent of the accused crimes!\"" )
+	var/obj/item/weapon/card/id/card = incident.card.resolve()
+	ping( "\The [src] pings, \"[card] has been found innocent of the accused crimes!\"" )
 
 	qdel( incident )
 	incident = null
@@ -456,11 +459,11 @@
 		return
 
 	incident.renderGuilty( user )
-
+	var/obj/item/weapon/card/id/card = incident.card.resolve()
 	if( incident.brig_sentence < PERMABRIG_SENTENCE)
-		ping( "\The [src] pings, \"[incident.card] has been found guilty of their crimes!\"" )
+		ping( "\The [src] pings, \"[card] has been found guilty of their crimes!\"" )
 	else
-		pingx3( "\The [src] pings, \"[incident.card] has been found guilty of their crimes and earned a HuT Sentence\"" )
+		pingx3( "\The [src] pings, \"[card] has been found guilty of their crimes and earned a HuT Sentence\"" )
 
 	incident = null
 	menu_screen = "main_menu"
@@ -528,7 +531,7 @@
 			if( istype( C ))
 				if( incident && C.mob )
 					incident.criminal = C.mob
-					incident.card = C
+					incident.card = WEAKREF(C)
 					ping( "\The [src] pings, \"Convict [C] verified.\"" )
 			else if( incident.criminal )
 				ping( "\The [src] pings, \"Convict cleared.\"" )

--- a/code/game/machinery/computer/sentencing.dm
+++ b/code/game/machinery/computer/sentencing.dm
@@ -96,7 +96,6 @@
 
 /obj/machinery/computer/sentencing/proc/incident_report()
 	. = ""
-
 	if( !istype( incident ))
 		. += "There was an error loading the incident, please <a href='?src=\ref[src];button=change_menu;choice=main_menu'>Try Again</a>"
 		return .
@@ -106,8 +105,8 @@
 	. += "<tr>"
 	. += "<th>Convict:</th>"
 	. += "<td><a href='?src=\ref[src];button=change_criminal;'>"
-	var/obj/item/weapon/card/id/card = incident.card.resolve()
-	if( card )
+	if( istype(incident.card) )
+		var/obj/item/weapon/card/id/card = incident.card.resolve()
 		. += "[card]"
 	else
 		. += "None"
@@ -192,8 +191,8 @@
 
 	. += "<tr><th colspan='2'>Convict</th></tr>"
 	. += "<tr><td colspan='2'><center>"
-	var/obj/item/weapon/card/id/card = incident.card.resolve()
-	if( card )
+	if( istype(incident.card) )
+		var/obj/item/weapon/card/id/card = incident.card.resolve()
 		. += "[card]"
 	else
 		. += "None"

--- a/code/game/machinery/computer/sentencing.dm
+++ b/code/game/machinery/computer/sentencing.dm
@@ -106,8 +106,8 @@
 	. += "<tr>"
 	. += "<th>Convict:</th>"
 	. += "<td><a href='?src=\ref[src];button=change_criminal;'>"
-	if( incident.criminal )
-		. += "[incident.criminal]"
+	if( incident.card )
+		. += "[incident.card]"
 	else
 		. += "None"
 	. += "</a></td>"
@@ -191,8 +191,8 @@
 
 	. += "<tr><th colspan='2'>Convict</th></tr>"
 	. += "<tr><td colspan='2'><center>"
-	if( incident.criminal )
-		. += "[incident.criminal]"
+	if( incident.card )
+		. += "[incident.card]"
 	else
 		. += "None"
 	. += "</center></td></tr>"
@@ -435,7 +435,7 @@
 	return .
 
 /obj/machinery/computer/sentencing/proc/render_innocent( var/mob/user )
-	ping( "\The [src] pings, \"[incident.criminal] has been found innocent of the accused crimes!\"" )
+	ping( "\The [src] pings, \"[incident.card] has been found innocent of the accused crimes!\"" )
 
 	qdel( incident )
 	incident = null
@@ -458,9 +458,9 @@
 	incident.renderGuilty( user )
 
 	if( incident.brig_sentence < PERMABRIG_SENTENCE)
-		ping( "\The [src] pings, \"[incident.criminal] has been found guilty of their crimes!\"" )
+		ping( "\The [src] pings, \"[incident.card] has been found guilty of their crimes!\"" )
 	else
-		pingx3( "\The [src] pings, \"[incident.criminal] has been found guilty of their crimes and earned a HuT Sentence\"" )
+		pingx3( "\The [src] pings, \"[incident.card] has been found guilty of their crimes and earned a HuT Sentence\"" )
 
 	incident = null
 	menu_screen = "main_menu"
@@ -483,7 +483,7 @@
 //
 // 	incident.renderGuilty( user )
 //
-// 	ping( "\The [src] pings, \"[incident.criminal] has been fined for their crimes!\"" )
+// 	ping( "\The [src] pings, \"[incident.card] has been fined for their crimes!\"" )
 //
 // 	incident = null
 // 	menu_screen = "main_menu"
@@ -528,10 +528,12 @@
 			if( istype( C ))
 				if( incident && C.mob )
 					incident.criminal = C.mob
-					ping( "\The [src] pings, \"Convict [C.mob] verified.\"" )
+					incident.card = C
+					ping( "\The [src] pings, \"Convict [C] verified.\"" )
 			else if( incident.criminal )
 				ping( "\The [src] pings, \"Convict cleared.\"" )
 				incident.criminal = null
+				incident.card = null
 		if( "change_brig" )
 			if( !incident )
 				return

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -207,7 +207,7 @@
 	// Used for the 'time left' display
 	var/second = round(timeleft() % 60)
 	var/minute = round((timeleft() - second) / 60)
-
+	var/obj/item/weapon/card/id/card = incident.card.resolve()
 	. = "<h2>Timer System:</h2>"
 	. += "<b>Controls [src.id]</b><hr>"
 
@@ -215,7 +215,7 @@
 		. += "Insert a Securty Incident Report to load a criminal sentence<br>"
 	else
 		// Time Left display (uses releasetime)
-		. += "<b>Criminal</b>: [incident.card]\t"
+		. += "<b>Criminal</b>: [card]\t"
 		. += "<a href='?src=\ref[src];button=menu_mode;menu_choice=menu_charges'>Charges</a><br>"
 		. += "<b>Sentence</b>: [add_zero( "[minute]", 2 )]:[add_zero( "[second]", 2 )]\t"
 		// Start/Stop timer

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -207,7 +207,6 @@
 	// Used for the 'time left' display
 	var/second = round(timeleft() % 60)
 	var/minute = round((timeleft() - second) / 60)
-	var/obj/item/weapon/card/id/card = incident.card.resolve()
 	. = "<h2>Timer System:</h2>"
 	. += "<b>Controls [src.id]</b><hr>"
 
@@ -215,6 +214,7 @@
 		. += "Insert a Securty Incident Report to load a criminal sentence<br>"
 	else
 		// Time Left display (uses releasetime)
+		var/obj/item/weapon/card/id/card = incident.card.resolve()
 		. += "<b>Criminal</b>: [card]\t"
 		. += "<a href='?src=\ref[src];button=menu_mode;menu_choice=menu_charges'>Charges</a><br>"
 		. += "<b>Sentence</b>: [add_zero( "[minute]", 2 )]:[add_zero( "[second]", 2 )]\t"

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -215,7 +215,7 @@
 		. += "Insert a Securty Incident Report to load a criminal sentence<br>"
 	else
 		// Time Left display (uses releasetime)
-		. += "<b>Criminal</b>: [incident.criminal]\t"
+		. += "<b>Criminal</b>: [incident.card]\t"
 		. += "<a href='?src=\ref[src];button=menu_mode;menu_choice=menu_charges'>Charges</a><br>"
 		. += "<b>Sentence</b>: [add_zero( "[minute]", 2 )]:[add_zero( "[second]", 2 )]\t"
 		// Start/Stop timer

--- a/code/modules/law/incident.dm
+++ b/code/modules/law/incident.dm
@@ -8,6 +8,7 @@
 
 	var/list/arbiters = list( "Witness" = list() ) // The person or list of people who were involved in the conviction of the criminal
 	var/mob/living/carbon/human/criminal // The person who committed the crimes
+	var/obj/item/weapon/card/id/card // The ID of person commiting the crimes
 
 	var/datetime = "" //When the crime has been commited
 

--- a/code/modules/law/incident.dm
+++ b/code/modules/law/incident.dm
@@ -8,7 +8,7 @@
 
 	var/list/arbiters = list( "Witness" = list() ) // The person or list of people who were involved in the conviction of the criminal
 	var/mob/living/carbon/human/criminal // The person who committed the crimes
-	var/datum/weakref/card // The ID of person commiting the crimes
+	var/datum/weakref/card // The ID of the criminal
 
 	var/datetime = "" //When the crime has been commited
 

--- a/code/modules/law/incident.dm
+++ b/code/modules/law/incident.dm
@@ -8,7 +8,7 @@
 
 	var/list/arbiters = list( "Witness" = list() ) // The person or list of people who were involved in the conviction of the criminal
 	var/mob/living/carbon/human/criminal // The person who committed the crimes
-	var/obj/item/weapon/card/id/card // The ID of person commiting the crimes
+	var/datum/weakref/card // The ID of person commiting the crimes
 
 	var/datetime = "" //When the crime has been commited
 

--- a/html/changelogs/thegreatnacho - changeling_charges.yml
+++ b/html/changelogs/thegreatnacho - changeling_charges.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: TheGreatNacho
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Set the sentencing machine and brig timer to read the convicts name from their ID, instead of their mob."


### PR DESCRIPTION
Set the sentencing machine and brig timer to read the convicts name from their ID, instead of their mob.