### PR TITLE
Code and Map Bugfixes

### DIFF
--- a/code/game/machinery/crusher_piston.dm
+++ b/code/game/machinery/crusher_piston.dm
@@ -75,14 +75,14 @@
 	var/oldloc = loc
 	var/obj/machinery/crusher_base/left = locate(/obj/machinery/crusher_base, get_step(src, WEST))
 	var/obj/machinery/crusher_base/right = locate(/obj/machinery/crusher_base, get_step(src, EAST))
-	
+
 	loc=null
 	if(left)
 		left.update_icon()
 	if(right)
 		right.update_icon()
 	loc=oldloc
-	
+
 	QDEL_NULL(pstn)
 	return ..()
 
@@ -100,7 +100,7 @@
 		return
 	if(default_part_replacement(user, O))
 		return
-	
+
 	//Stuff you can do if the maint hatch is open
 	if(panel_open)
 		if(iswrench(O))
@@ -138,7 +138,7 @@
 
 	if(QDELETED(left))
 		left = null
-		
+
 	if(QDELETED(right))
 		right = null
 
@@ -164,7 +164,7 @@
 			holographic_overlay(src, icon, "[asmtype]-overlay-green")
 	if(panel_open)
 		add_overlay("[asmtype]-hatch")
-	update_above()	
+	update_above()
 
 /obj/machinery/crusher_base/power_change()
 	..()
@@ -214,7 +214,7 @@
 					status = "stage1"
 					action_start_time = world.time
 					initial = 1
-		
+
 		//Extend the second piston
 		else if(status == "stage1")
 			if(valve_check())
@@ -248,7 +248,7 @@
 					status = "stage3"
 					action_start_time = world.time
 					initial = 1
-		
+
 		//Wait a moment, then reverse the direction
 		else if(status == "stage3")
 			if(initial)
@@ -308,7 +308,7 @@
 			action_start_time = world.time
 			initial = 1
 			update_icon()
-	
+
 	//Move all the items in the move list
 	for(var/atom/movable/AM in items_to_move)
 		if(!AM.simulated)
@@ -322,7 +322,7 @@
 		if(!AM.piston_move())
 			items_to_crush += AM
 		CHECK_TICK
-	
+
 	//Destroy all the items in the crush list
 	for(var/atom/movable/AM in items_to_crush)
 		items_to_crush -= AM
@@ -366,7 +366,7 @@
 	name = "trash compactor piston"
 	desc = "A colossal piston used for crushing garbage."
 	icon = 'icons/obj/machines/crusherpiston.dmi' //Placeholder TODO: Get a proper icon
-	icon_state = "piston_0" 
+	icon_state = "piston_0"
 	density = 0
 	anchored = 1
 	pixel_y = -64
@@ -513,6 +513,8 @@
 // The crush act proc
 //
 /atom/movable/proc/crush_act()
+	if(!simulated)
+		return
 	ex_act(1)
 	if(!QDELETED(src))
 		qdel(src)//Just as a failsafe

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -317,6 +317,7 @@
 	base_icon = "chainsaw_off"
 	flags = CONDUCT
 	force = 10
+	force_unwielded = 10
 	force_wielded = 20
 	throwforce = 5
 	w_class = ITEMSIZE_LARGE
@@ -361,8 +362,9 @@
 	var/turf/T = get_turf(src)
 	T.audible_message(span("notice", "\The [src] rumbles to life."))
 	playsound(src, "sound/weapons/chainsawstart.ogg", 25, 0, 30)
-	force = 20
-	force_wielded = 40
+	force = 15
+	force_unwielded = 30
+	force_wielded = 60
 	throwforce = 20
 	icon_state = "chainsaw_on"
 	base_icon = "chainsaw_on"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -182,7 +182,6 @@
 	update_icon()
 	return 1
 
-// this should probably use dump_contents()
 /obj/structure/closet/ex_act(severity)
 	switch(severity)
 		if(1)
@@ -194,15 +193,16 @@
 
 	if (health <= 0)
 		for (var/atom/movable/A as mob|obj in src)
-			A.forceMove(loc)
 			A.ex_act(severity + 1)
+		dump_contents()
+		new /obj/item/stack/material/steel(get_turf(src))
 		qdel(src)
 
 /obj/structure/closet/proc/damage(var/damage)
 	health -= damage
 	if(health <= 0)
-		for(var/atom/movable/A in src)
-			A.forceMove(loc)
+		dump_contents()
+		new /obj/item/stack/material/steel(get_turf(src))
 		qdel(src)
 
 /obj/structure/closet/bullet_act(var/obj/item/projectile/Proj)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -452,3 +452,12 @@
 
 /obj/structure/closet/onDropInto(var/atom/movable/AM)
 	return
+
+/obj/structure/closet/crush_act()
+	for (var/atom/movable/A as mob|obj in src)
+		if(istype(A, /mob/living))
+			var/mob/living/M = A
+			M.gib()
+		else
+			qdel(A)
+	qdel(src)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -454,10 +454,12 @@
 	return
 
 /obj/structure/closet/crush_act()
-	for (var/atom/movable/A as mob|obj in src)
+	for (var/atom/movable/A in src)
 		if(istype(A, /mob/living))
 			var/mob/living/M = A
 			M.gib()
-		else
-			qdel(A)
+		else if(A.simulated)
+			A.ex_act(1)
+	dump_contents()
+	new /obj/item/stack/material/steel(get_turf(src))
 	qdel(src)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -134,6 +134,7 @@
 	density = 0
 	anchored = 1
 	use_power = 0
+	var/spray_amount = 20
 	var/on = 0
 	var/obj/effect/mist/mymist = null
 	var/ismist = 0				//needs a var so we can make it linger~
@@ -220,6 +221,10 @@
 //Yes, showers are super powerful as far as washing goes.
 /obj/machinery/shower/proc/wash(atom/movable/O as obj|mob)
 	if(!on) return
+
+	var/obj/effect/effect/water/W = new(get_turf(src))
+	W.create_reagents(spray_amount)
+	reagents.trans_to_obj(W, spray_amount)
 
 	if(isliving(O))
 		var/mob/living/L = O

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -222,14 +222,11 @@
 /obj/machinery/shower/proc/wash(atom/movable/O as obj|mob)
 	if(!on) return
 
-	var/obj/effect/effect/water/W = new(get_turf(src))
+	var/obj/effect/effect/water/W = new(O)
 	W.create_reagents(spray_amount)
-	reagents.trans_to_obj(W, spray_amount)
-
-	if(isliving(O))
-		var/mob/living/L = O
-		L.ExtinguishMob()
-		L.fire_stacks = -20 //Douse ourselves with water to avoid fire more easily
+	W.reagents.add_reagent("water", spray_amount)
+	W.reagents.trans_to_obj(O)
+	W.set_up(O)
 
 	if(iscarbon(O))
 		var/mob/living/carbon/M = O
@@ -300,10 +297,6 @@
 				if(H.belt.clean_blood())
 					H.update_inv_belt(0)
 			H.clean_blood(washshoes)
-
-		else if(istype(O, /mob/living/carbon/slime)) // Makes slimes to take damage from shower
-			var/mob/living/carbon/slime/S = O
-			S.adjustToxLoss(rand(15, 40)) // Slimes die when they reach 200 toxins, so killing them with shower will take few seconds
 		else
 			if(M.wear_mask)						//if the mob is not human, it cleans the mask without asking for bitflags
 				if(M.wear_mask.clean_blood())

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -225,7 +225,7 @@
 	var/obj/effect/effect/water/W = new(O)
 	W.create_reagents(spray_amount)
 	W.reagents.add_reagent("water", spray_amount)
-	W.reagents.splash(O, spray_amount)
+	W.set_up(O, spray_amount)
 
 	if(iscarbon(O))
 		var/mob/living/carbon/M = O

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -298,7 +298,7 @@
 
 		else if(istype(O, /mob/living/carbon/slime)) // Makes slimes to take damage from shower
 			var/mob/living/carbon/slime/S = O
-			S.adjustToxLoss(30)
+			S.adjustToxLoss(rand(15, 40)) // Slimes die when they reach 200 toxins, so killing them with shower will take few seconds
 		else
 			if(M.wear_mask)						//if the mob is not human, it cleans the mask without asking for bitflags
 				if(M.wear_mask.clean_blood())
@@ -330,6 +330,7 @@
 	wash_floor()
 	if(!mobpresent)	return
 	for(var/mob/living/L in loc)
+		wash(L) // Why was it not here before?
 		process_heat(L)
 
 /obj/machinery/shower/proc/wash_floor()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -295,6 +295,10 @@
 				if(H.belt.clean_blood())
 					H.update_inv_belt(0)
 			H.clean_blood(washshoes)
+
+		else if(istype(O, /mob/living/carbon/slime)) // Makes slimes to take damage from shower
+			var/mob/living/carbon/slime/S = O
+			S.adjustToxLoss(30)
 		else
 			if(M.wear_mask)						//if the mob is not human, it cleans the mask without asking for bitflags
 				if(M.wear_mask.clean_blood())

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -225,8 +225,7 @@
 	var/obj/effect/effect/water/W = new(O)
 	W.create_reagents(spray_amount)
 	W.reagents.add_reagent("water", spray_amount)
-	W.reagents.trans_to_obj(O)
-	W.set_up(O)
+	W.reagents.splash(O, spray_amount)
 
 	if(iscarbon(O))
 		var/mob/living/carbon/M = O

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -87,7 +87,6 @@
 	return return_air() // Otherwise their head is above the water, so get the air from the atmosphere instead.
 
 /turf/simulated/floor/beach/water/Entered(atom/movable/AM, atom/oldloc)
-	numobjects += 1
 	clean()
 	START_PROCESSING(SSprocessing, src)
 	if(istype(AM, /mob/living))

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -86,24 +86,26 @@
 	return return_air() // Otherwise their head is above the water, so get the air from the atmosphere instead.
 
 /turf/simulated/floor/beach/water/Entered(atom/movable/AM, atom/oldloc)
+	wash_floor(get_turf(src))
+	START_PROCESSING(SSprocessing, src)
 	if(istype(AM, /mob/living))
 		var/mob/living/L = AM
 		if(!istype(oldloc, /turf/simulated/floor/beach/water))
 			to_chat(L, "<span class='warning'>You get drenched in water from entering \the [src]!</span>")
-		var/obj/effect/effect/water/W = new(L)
-		W.create_reagents(700)
-		W.reagents.add_reagent("water", 700)
-		W.reagents.trans_to_obj(L)
-		W.set_up(L)
-	AM.water_act(5)
+		wash(L)
 	..()
 
 /turf/simulated/floor/beach/water/Exited(atom/movable/AM, atom/newloc)
+	wash_floor(get_turf(src))
+	STOP_PROCESSING(SSprocessing, src)
 	if(istype(AM, /mob/living))
 		var/mob/living/L = AM
 		if(!istype(newloc, /turf/simulated/floor/beach/water))
 			to_chat(L, "<span class='warning'>You climb out of \the [src].</span>")
 	..()
+
+/turf/simulated/floor/beach/water/process()
+	wash_floor(get_turf(src))
 
 /mob/living/proc/can_breathe_water()
 	return FALSE
@@ -113,11 +115,109 @@
 		return species.can_breathe_water()
 	return ..()
 
-// Use this to have things react to having water applied to them.
-/atom/movable/proc/water_act(amount)
-	return
+/turf/simulated/floor/beach/water/proc/wash_floor(var/turf/T)
+	T.clean(src)
 
-/mob/living/water_act(amount)
-	adjust_fire_stacks(-amount * 5)
-	for(var/atom/movable/AM in contents)
-		AM.water_act(amount)
+// Taken from shower
+/turf/simulated/floor/beach/water/proc/wash(atom/movable/O as obj|mob)
+
+	var/obj/effect/effect/water/W = new(O)
+	W.create_reagents(700)
+	W.reagents.add_reagent("water", 700)
+	W.reagents.trans_to_obj(O)
+	W.set_up(O)
+
+	if(iscarbon(O))
+		var/mob/living/carbon/M = O
+		if(M.r_hand)
+			M.r_hand.clean_blood()
+		if(M.l_hand)
+			M.l_hand.clean_blood()
+		if(M.back)
+			if(M.back.clean_blood())
+				M.update_inv_back(0)
+
+		//flush away reagents on the skin
+		if(M.touching)
+			var/remove_amount = M.touching.maximum_volume * M.reagent_permeability() //take off your suit first
+			M.touching.remove_any(remove_amount)
+
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			var/washgloves = 1
+			var/washshoes = 1
+			var/washmask = 1
+			var/washears = 1
+			var/washglasses = 1
+
+			if(H.wear_suit)
+				washgloves = !(H.wear_suit.flags_inv & HIDEGLOVES)
+				washshoes = !(H.wear_suit.flags_inv & HIDESHOES)
+
+			if(H.head)
+				washmask = !(H.head.flags_inv & HIDEMASK)
+				washglasses = !(H.head.flags_inv & HIDEEYES)
+				washears = !(H.head.flags_inv & HIDEEARS)
+
+			if(H.wear_mask)
+				if (washears)
+					washears = !(H.wear_mask.flags_inv & HIDEEARS)
+				if (washglasses)
+					washglasses = !(H.wear_mask.flags_inv & HIDEEYES)
+
+			if(H.head)
+				if(H.head.clean_blood())
+					H.update_inv_head(0)
+			if(H.wear_suit)
+				if(H.wear_suit.clean_blood())
+					H.update_inv_wear_suit(0)
+			else if(H.w_uniform)
+				if(H.w_uniform.clean_blood())
+					H.update_inv_w_uniform(0)
+			if(H.gloves && washgloves)
+				if(H.gloves.clean_blood())
+					H.update_inv_gloves(0)
+			if(H.shoes && washshoes)
+				if(H.shoes.clean_blood())
+					H.update_inv_shoes(0)
+			if(H.wear_mask && washmask)
+				if(H.wear_mask.clean_blood())
+					H.update_inv_wear_mask(0)
+			if(H.glasses && washglasses)
+				if(H.glasses.clean_blood())
+					H.update_inv_glasses(0)
+			if(H.l_ear && washears)
+				if(H.l_ear.clean_blood())
+					H.update_inv_ears(0)
+			if(H.r_ear && washears)
+				if(H.r_ear.clean_blood())
+					H.update_inv_ears(0)
+			if(H.belt)
+				if(H.belt.clean_blood())
+					H.update_inv_belt(0)
+			H.clean_blood(washshoes)
+		else
+			if(M.wear_mask)						//if the mob is not human, it cleans the mask without asking for bitflags
+				if(M.wear_mask.clean_blood())
+					M.update_inv_wear_mask(0)
+			M.clean_blood()
+	else
+		O.clean_blood()
+
+	if(istype(O, /obj/item/weapon/light))
+		var/obj/item/weapon/light/L = O
+		L.brightness_color = initial(L.brightness_color)
+		L.update()
+	else if(istype(O, /obj/machinery/light))
+		var/obj/machinery/light/L = O
+		L.brightness_color = initial(L.brightness_color)
+		L.update()
+
+	O.color = initial(O.color)
+
+	if(isturf(loc))
+		var/turf/tile = loc
+		loc.clean_blood()
+		for(var/obj/effect/E in tile)
+			if(istype(E,/obj/effect/rune) || istype(E,/obj/effect/decal/cleanable) || istype(E,/obj/effect/overlay))
+				qdel(E)

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -88,6 +88,8 @@
 	return return_air() // Otherwise their head is above the water, so get the air from the atmosphere instead.
 
 /turf/simulated/floor/beach/water/Entered(atom/movable/AM, atom/oldloc)
+	if(!SSATOMS_IS_PROBABLY_DONE)
+		return
 	reagents.add_reagent("water", 2)
 	clean(src)
 	START_PROCESSING(SSprocessing, src)
@@ -102,6 +104,8 @@
 	..()
 
 /turf/simulated/floor/beach/water/Exited(atom/movable/AM, atom/newloc)
+	if(!SSATOMS_IS_PROBABLY_DONE)
+		return
 	reagents.add_reagent("water", 2)
 	clean(src)
 	if(istype(AM, /obj) && numobjects)

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -23,6 +23,7 @@
 	movement_cost = 2
 	var/watertype = "water5"
 	var/obj/effect/water_effect/water_overlay
+	var/numobjects = 0
 
 /turf/simulated/floor/beach/water/pool
 	name = "pool"
@@ -86,9 +87,11 @@
 	return return_air() // Otherwise their head is above the water, so get the air from the atmosphere instead.
 
 /turf/simulated/floor/beach/water/Entered(atom/movable/AM, atom/oldloc)
-	wash_floor(get_turf(src))
+	numobjects += 1
+	clean()
 	START_PROCESSING(SSprocessing, src)
 	if(istype(AM, /mob/living))
+		numobjects += 1
 		var/mob/living/L = AM
 		if(!istype(oldloc, /turf/simulated/floor/beach/water))
 			to_chat(L, "<span class='warning'>You get drenched in water from entering \the [src]!</span>")
@@ -96,16 +99,18 @@
 	..()
 
 /turf/simulated/floor/beach/water/Exited(atom/movable/AM, atom/newloc)
-	wash_floor(get_turf(src))
-	STOP_PROCESSING(SSprocessing, src)
+	clean()
+	if(!numobjects)
+		STOP_PROCESSING(SSprocessing, src)
 	if(istype(AM, /mob/living))
+		numobjects -= 1
 		var/mob/living/L = AM
 		if(!istype(newloc, /turf/simulated/floor/beach/water))
 			to_chat(L, "<span class='warning'>You climb out of \the [src].</span>")
 	..()
 
 /turf/simulated/floor/beach/water/process()
-	wash_floor(get_turf(src))
+	clean()
 
 /mob/living/proc/can_breathe_water()
 	return FALSE
@@ -115,17 +120,13 @@
 		return species.can_breathe_water()
 	return ..()
 
-/turf/simulated/floor/beach/water/proc/wash_floor(var/turf/T)
-	T.clean(src)
-
 // Taken from shower
 /turf/simulated/floor/beach/water/proc/wash(atom/movable/O as obj|mob)
 
 	var/obj/effect/effect/water/W = new(O)
-	W.create_reagents(700)
-	W.reagents.add_reagent("water", 700)
-	W.reagents.trans_to_obj(O)
-	W.set_up(O)
+	W.create_reagents(60)
+	W.reagents.add_reagent("water", 60)
+	W.reagents.splash(O, 60)
 
 	if(iscarbon(O))
 		var/mob/living/carbon/M = O

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -90,6 +90,11 @@
 		var/mob/living/L = AM
 		if(!istype(oldloc, /turf/simulated/floor/beach/water))
 			to_chat(L, "<span class='warning'>You get drenched in water from entering \the [src]!</span>")
+		var/obj/effect/effect/water/W = new(L)
+		W.create_reagents(700)
+		W.reagents.add_reagent("water", 700)
+		W.reagents.trans_to_obj(L)
+		W.set_up(L)
 	AM.water_act(5)
 	..()
 

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -94,11 +94,7 @@
 	if (!moving_upwards || next_floor == floors[floors.len])	// If moving down or moving to the top floor, squish.
 		for(var/turf/T in destination)
 			for(var/atom/movable/AM in T)
-				if(istype(AM, /mob/living))
-					var/mob/living/M = AM
-					M.gib()
-				else if(AM.simulated && !istype(AM, /mob/abstract/eye))
-					qdel(AM)
+				AM.crush_act()
 
 	origin.move_contents_to(destination)
 

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -94,17 +94,7 @@
 	if (!moving_upwards || next_floor == floors[floors.len])	// If moving down or moving to the top floor, squish.
 		for(var/turf/T in destination)
 			for(var/atom/movable/AM in T)
-				if(istype(AM, /obj/structure/closet))
-					var/obj/structure/closet/C = AM
-					for (var/atom/movable/A as mob|obj in C)
-						if(istype(A, /mob/living))
-							var/mob/living/M = A
-							M.gib()
-						else
-							A.ex_act(2)
-					AM.crush_act()
-				else
-					AM.crush_act()
+				AM.crush_act()
 
 	origin.move_contents_to(destination)
 

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -94,7 +94,17 @@
 	if (!moving_upwards || next_floor == floors[floors.len])	// If moving down or moving to the top floor, squish.
 		for(var/turf/T in destination)
 			for(var/atom/movable/AM in T)
-				AM.crush_act()
+				if(istype(AM, /obj/structure/closet))
+					var/obj/structure/closet/C = AM
+					for (var/atom/movable/A as mob|obj in C)
+						if(istype(A, /mob/living))
+							var/mob/living/M = A
+							M.gib()
+						else
+							A.ex_act(2)
+					AM.crush_act()
+				else
+					AM.crush_act()
 
 	origin.move_contents_to(destination)
 

--- a/html/changelogs/Sindorman-bugfixes.yml
+++ b/html/changelogs/Sindorman-bugfixes.yml
@@ -4,7 +4,7 @@ delete-after: True
 
 changes:
   - maptweak: "Access to Research Division Maint door is fixed"
-  - maptweak: "Added missing firelocks to interstitial level of security"
+  - maptweak: "Added missing firelocks to construction level of security"
   - bugfix: "Fixed broken small light icon to appear properly"
   - tweak: "Shower now reacts with mobs as water supposed to, damaging slimes."
   - tweak: "Pool, Ocean or generic water turfs now cleans anything that enters it, cleans it's own turf and damages slimes."
@@ -13,3 +13,4 @@ changes:
   - tweak: "Closets now spawn one sheet of metal upon being destroyed"
   - tweak: "Turbolifts now properly destroy atoms, and gib any mobs that are in closets"
   - bugfix: "Crusher no longer kills AI eye"
+  - maptweak: "Medical construction level now has full camera coverage"

--- a/html/changelogs/Sindorman-bugfixes.yml
+++ b/html/changelogs/Sindorman-bugfixes.yml
@@ -1,0 +1,10 @@
+author: PoZe
+.
+delete-after: True
+
+changes:
+  - maptweak: "Access to Research Division Maint door is fixed"
+  - maptweak: "Added missing firelocks to interstitial level of security"
+  - bugfix: "Fixed broken small light icon to appear properly"
+  - tweak: "Shower now reacts with mobs as water supposed to, damaging slimes."
+  - tweak: "Pool, Ocean or generic water turfs now cleans anything that enters it, cleans it's own turf and damages slimes."

--- a/html/changelogs/Sindorman-bugfixes.yml
+++ b/html/changelogs/Sindorman-bugfixes.yml
@@ -8,3 +8,8 @@ changes:
   - bugfix: "Fixed broken small light icon to appear properly"
   - tweak: "Shower now reacts with mobs as water supposed to, damaging slimes."
   - tweak: "Pool, Ocean or generic water turfs now cleans anything that enters it, cleans it's own turf and damages slimes."
+  - tweak: "Fixed chainsaw unwielded force"
+  - balance: "Chainsaw powered force buffed, 30 unwielded and 60 wielded"
+  - tweak: "Closets now spawn one sheet of metal upon being destroyed"
+  - tweak: "Turbolifts now properly destroy atoms, and gib any mobs that are in closets"
+  - bugfix: "Crusher no longer kills AI eye"

--- a/html/changelogs/Sindorman-bugfixes.yml
+++ b/html/changelogs/Sindorman-bugfixes.yml
@@ -1,5 +1,5 @@
 author: PoZe
-.
+
 delete-after: True
 
 changes:

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -56021,6 +56021,10 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "bSh" = (
@@ -57144,7 +57148,8 @@
 "bUv" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hydroponics)
@@ -64623,6 +64628,18 @@
 	icon_state = "asteroidplating"
 	},
 /area/outpost/mining_main/eva)
+"clx" = (
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 
 (1,1,1) = {"
 aaa
@@ -90500,7 +90517,7 @@ bUu
 bSO
 bSO
 bSO
-bSO
+clx
 bWn
 bWm
 bWY
@@ -91529,7 +91546,7 @@ bUT
 bVs
 bVN
 bWb
-bWp
+bTt
 bWm
 bXb
 bXp

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -51453,7 +51453,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Division Maintenance";
 	req_access = list(47);
-	req_one_access = newlist()
+	req_one_access = null
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -2764,8 +2764,24 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "ff" = (
-/turf/simulated/floor/holofloor/tiled,
-/area/security/training)
+/obj/effect/floor_decal/corner/green/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/obj/structure/flora/pottedplant,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/medical/psych)
 "fg" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
@@ -5344,13 +5360,22 @@
 /turf/simulated/floor/tiled,
 /area/security/training)
 "jA" = (
-/obj/effect/floor_decal/corner/red{
+/obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/weightlifter,
-/turf/simulated/floor/tiled,
-/area/mine/unexplored)
+/obj/machinery/firealarm/west,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Isolation Room";
+	dir = 4;
+	icon_state = "camera";
+	network = list("Medical","Isolation Room")
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/psych)
 "jB" = (
 /obj/effect/floor_decal/corner/blue/full{
 	icon_state = "corner_white_full";
@@ -5471,32 +5496,18 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "jP" = (
-/obj/effect/floor_decal/corner/green/full{
-	icon_state = "corner_white_full";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/flora/pottedplant,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/dark,
 /area/medical/psych)
 "jQ" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/firealarm/west,
+/obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "jR" = (
@@ -6516,6 +6527,12 @@
 /obj/effect/floor_decal/corner/green/full,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Isolation Room";
+	dir = 4;
+	icon_state = "camera";
+	network = list("Medical","Isolation Room")
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
@@ -42451,7 +42468,7 @@ ab
 ab
 jG
 jL
-jQ
+jA
 kb
 kl
 kw
@@ -44766,7 +44783,7 @@ jH
 jM
 jV
 jG
-ko
+jP
 kB
 jG
 kS
@@ -45797,7 +45814,7 @@ jG
 kr
 jG
 jG
-jM
+jQ
 lf
 lq
 kc
@@ -46305,7 +46322,7 @@ aa
 ab
 ab
 jG
-jP
+ff
 jX
 ki
 kt

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -3329,6 +3329,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "gh" = (
@@ -3535,6 +3536,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/security/forensics_office)
 "gy" = (
@@ -4072,6 +4074,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/investigations)
 "hk" = (
@@ -4132,7 +4135,6 @@
 /area/security/forensics_office)
 "hn" = (
 /obj/structure/grille,
-/obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -4141,6 +4143,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/forensics_office)
 "ho" = (
@@ -4234,6 +4237,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/security/training)
 "hw" = (
@@ -4555,6 +4559,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/training)
 "ib" = (

--- a/maps/aurora/aurora-8_derelict.dmm
+++ b/maps/aurora/aurora-8_derelict.dmm
@@ -6343,9 +6343,9 @@
 /area/derelict/hallway/southeast)
 "sR" = (
 /obj/machinery/light/small{
-	icon_state = "bulb-broken";
+	base_state = "bulb_broken";
 	dir = 8;
-	base_state = "bulb-broken"
+	icon_state = "bulb_broken"
 	},
 /turf/simulated/floor/airless,
 /area/derelict/hallway/southeast)
@@ -7739,9 +7739,9 @@
 /area/derelict/hallway/southeast)
 "wp" = (
 /obj/machinery/light/small{
-	base_state = "bulb-broken";
+	base_state = "bulb_broken";
 	dir = 4;
-	icon_state = "bulb-broken"
+	icon_state = "bulb_broken"
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/airless,


### PR DESCRIPTION
- Access to Research Division Maintenance airlock is fixed #4477 

- Changed shower to wash any mob present on active shower tile, also added damage to slimes. #4483 

- Added missing emergency firelocks in interstatial level of security. #4444 

- Fixed wrong spelling of broken light  bulb icon state, issue #4541 

- Added for pool to use reagents water on mobs or objects, now pool cleans itself and user, plus damages slimes. #4544 #4545 

- `crush_act` now checks if atom is simulated. #4001 

- turbolifts now use `crush_act` on atoms.

- Closets have their own crush_act. They now gib mobs inside of them. issue #4538

- Closets uses its internal function to dump content upon destruction.

- Closet now spawn one sheet of steel when destroyed.

- Fixed chainsaw unwielded force to be appropriate. Buffed chainsaw on wielded/unwielded force. Wielded is now `60` and unwielded is `30` if it is powered. #4586 

- Added missing cameras to medical construction level. #4581 

- Hydroponics tray status no longer blocked by light fixture, moved it in a better spot. Added one more light to hydroponics to not have shadows. #4449 