### PR TITLE
Fix ticket butterfly

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -60,7 +60,7 @@
 		var/client/C = locate(href_list["priv_msg"])
 		var/datum/ticket/ticket = locate(href_list["ticket"])
 
-		if (!istype(ticket))
+		if (!isnull(ticket) && !istype(ticket))
 			return
 
 		if(ismob(C)) 		//Old stuff can feed-in mobs instead of clients


### PR DESCRIPTION
Random errors usually imply a singular, simple root cause.

Null ticket can be a thing. Because of laziness.