### PR TITLE
Preemptive Scrubber Tweaks

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -30,8 +30,7 @@
 		"fuel",
 		"blood",
 		"sterilizine",
-		"ipecac",
-		"soporific"
+		"ipecac"
 	)
 
 

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -5,9 +5,34 @@
 	endWhen			= 35
 	var/interval 	= 2
 	var/list/vents  = list()
-	var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment",\
-	"condensedcapsaicin","mindbreaker","lube","plantbgone","banana","space_drugs",\
-	"holywater","ethanol","hot_coco","sacid", "hyperzine", "ethanol")
+	var/list/gunk = list(
+		"water",
+		"carbon",
+		"flour",
+		"radium",
+		"toxin",
+		"cleaner",
+		"nutriment",
+		"condensedcapsaicin",
+		"mindbreaker",
+		"lube",
+		"plantbgone",
+		"banana",
+		"space_drugs",
+		"holywater",
+		"ethanol",
+		"hot_coco",
+		"sacid",
+		"hyperzine",
+		"ethanol",
+		"paint",
+		"luminol",
+		"fuel",
+		"blood",
+		"sterilizine",
+		"ipecac",
+		"soporific"
+	)
 
 
 
@@ -28,10 +53,10 @@
 
 		if(vent && vent.loc)
 
-			var/datum/reagents/R = new/datum/reagents(50)
+			var/datum/reagents/R = new/datum/reagents(35)
 			R.my_atom = vent
 			var/chem = pick(gunk)
-			R.add_reagent(chem, 50)
+			R.add_reagent(chem, 35)
 
 			var/datum/effect/effect/system/smoke_spread/chem/smoke = new
 			smoke.show_log = 0 // This displays a log on creation

--- a/html/changelogs/burgerbb-scrubs.yml
+++ b/html/changelogs/burgerbb-scrubs.yml
@@ -1,0 +1,7 @@
+author: BurgerBB
+
+delete-after: True
+
+changes: 
+  - balance: "Reduced the amount of reagents in a scrubber blast from 50 to 35."
+  - tweak: "Added paint, luminol, fuel, blood, sterilizine, ipecac, and soporific to scrubber event RNG."


### PR DESCRIPTION
# Overview
Now that when scrubbers hit you, you will breathe in the reagents along with digesting and touching them. Since breathing in is 50% more effective than digesting, this nerfs scrubber reagent potency by reducing the amount of chemicals each smokecloud has.

Also added the following reagents to reagent scrubber RNG:
paint, luminol, fuel, blood, sterilizine, ipecac, and soporific