### PR TITLE
Shuriken Nerf

### DIFF
--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -93,3 +93,8 @@
 	name = "Chainsaw"
 	item_cost = 10
 	path = /obj/item/weapon/material/twohanded/chainsaw/fueled
+
+/datum/uplink_item/item/visible_weapons/throwing_star
+	name = "Steel Throwing Star"
+	item_cost = 2
+	path = /obj/item/weapon/material/star

--- a/code/datums/uplink/ninja_modules.dm
+++ b/code/datums/uplink/ninja_modules.dm
@@ -36,8 +36,8 @@
 
 /datum/uplink_item/item/ninja_modules/matter_fab
 	name = "Matter Fabricator"
-	desc = "A hardsuit matter fabricator that can produce sharp ninja stars used for throwing."
-	item_cost = 5
+	desc = "A hardsuit matter fabricator that can produce sharp steel ninja stars used for throwing."
+	item_cost = 4
 	path = /obj/item/rig_module/fabricator
 
 /datum/uplink_item/item/ninja_modules/sink

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -17,6 +17,12 @@
 
 /obj/item/weapon/material/star/throw_impact(atom/hit_atom)
 	..()
-	if(material.radioactivity > 0 && istype(hit_atom,/mob/living))
+	if (istype(hit_atom,/mob/living))
+
 		var/mob/living/M = hit_atom
-		M.adjustToxLoss(rand(25,50))
+
+		if(material.radioactivity > 0)
+			M.adjustToxLoss(material.radioactivity*2)
+
+		if(prob(30))
+			M.Weaken(4)

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -25,4 +25,4 @@
 			M.adjustToxLoss(material.radioactivity*2)
 
 		if(prob(30))
-			M.Weaken(4)
+			M.Weaken(7)

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -8,6 +8,7 @@
 	throw_range = 15
 	sharp = 1
 	edge =  1
+	w_class = ITEMSIZE_SMALL
 
 /obj/item/weapon/material/star/New()
 	..()
@@ -16,15 +17,6 @@
 
 /obj/item/weapon/material/star/throw_impact(atom/hit_atom)
 	..()
-	if(material.radioactivity>0 && istype(hit_atom,/mob/living))
+	if(material.radioactivity > 0 && istype(hit_atom,/mob/living))
 		var/mob/living/M = hit_atom
 		M.adjustToxLoss(rand(25,50))
-
-/obj/item/weapon/material/star/ninja
-	default_material = "uranium"
-
-/obj/item/weapon/material/star/ninja/throw_impact(atom/hit_atom)
-	..()
-	if(prob(30) && istype(hit_atom,/mob/living))
-		var/mob/living/M = hit_atom
-		M.Weaken(7)

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -315,15 +315,15 @@
 	desc = "A self-contained microfactory system for hardsuit integration."
 	selectable = 1
 	usable = 1
-	use_power_cost = 15
+	use_power_cost = 10
 	icon_state = "enet"
 
 	engage_string = "Fabricate Star"
 
 	interface_name = "death blossom launcher"
-	interface_desc = "An integrated microfactory that produces poisoned throwing stars from thin air and electricity."
+	interface_desc = "An integrated microfactory that produces steel throwing stars from thin air and electricity."
 
-	var/fabrication_type = /obj/item/weapon/material/star/ninja
+	var/fabrication_type = /obj/item/weapon/material/star
 	var/fire_force = 30
 	var/fire_distance = 10
 

--- a/html/changelogs/burgerbb-ninjanerf.yml
+++ b/html/changelogs/burgerbb-ninjanerf.yml
@@ -1,0 +1,6 @@
+author: BurgerBB
+
+delete-after: True
+
+changes: 
+  - balance: "Ninja matter fabricators now produce steel throwing stars instead of uranium throwing stars. Adjusted the power cost and price of the ninja matter fabricator. Adjusted the weight class of throwing stars to make them smaller. Added steel throwing stars to the traitor uplink."


### PR DESCRIPTION
# Overview
Honestly I find that uranium ninja throwing stars are ridiculously overpowered and honestly just dumb in terms of mechanics. On top of the already ridiculous effects of getting hit by a throwing star, a uranium throwing star deals an additional random 25-50 toxin damage per hit regardless of armor, and regardless of whether or not it sticks in the wound. For reference, the xray rifle deals 25 damage per hit. I'm like 90% sure a uranium throwing star is more deadly than it's energy sword, which is just silly.

This update makes it so that the ninja throwing stars produced in the fabricator are of steel quality. To lessen the impact of this nerf, I also made some tweaks to uplink cost as well as the production cost of steel throwing star. Steel throwing stars also have less weight, and as an added bonus they can be purchased from the traitor uplink for 1 telecrystal each.



