### PR TITLE
Fixes #4463

### DIFF
--- a/code/modules/cciaa/cciaa.dm
+++ b/code/modules/cciaa/cciaa.dm
@@ -129,7 +129,7 @@
 
 	if(!check_rights(0))		return
 
-	if(!mob.mind || mob.mind.special_role != "CCIA Agent")
+	if (!mob.mind || !(mob.mind.special_role in list("CCIA Agent", "ERT Commander")))
 		verbs -= /client/proc/returntobody
 		return
 


### PR DESCRIPTION
Makes returntobody() also check for ERT Commander role, an oversight on my part.