### PR TITLE
Changes chemical warehouse spawning

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2044,6 +2044,7 @@
 #include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Food-Drinks.dm"
 #include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Medicine.dm"
 #include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Other.dm"
+#include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Secret.dm"
 #include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Toxins.dm"
 #include "code\modules\reagents\dispenser\_defines.dm"
 #include "code\modules\reagents\dispenser\cartridge.dm"

--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -1081,8 +1081,12 @@ var/list/global/random_stock_large = list(
 		if("chempack")
 			var/total = rand(2,6)
 			var/list/chems = SSchemistry.chemical_reagents.Copy()
-			var/list/exclusion = list("drink", "reagent", "adminordrazine", "beer2", "azoth", "elixir_life", "liquid_fire", "philosopher_stone", "undead_ichor")
+			var/list/exclusion = list("drink", "reagent") // only for these two. Use nospawn on the reagent for others.
 			chems -= exclusion
+			for(var/datum/reagent/Z in chems)
+				if(Z.nospawn)
+					chems -= Z
+
 			for (var/i=0,i<total,i++)
 				var/obj/item/weapon/reagent_containers/chem_disp_cartridge/C = new /obj/item/weapon/reagent_containers/chem_disp_cartridge(L)
 				var/rname = pick(chems)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -26,6 +26,7 @@
 	var/unaffected_species = IS_DIONA | IS_MACHINE	// Species that aren't affected by this reagent. Does not prevent affect_touch.
 	var/metabolism_min = 0.01 //How much for the medicine to be present in the system to actually have an effect.
 	var/list/conflicting_reagents //Reagents that conflict with this medicine, and cause adverse effects when in the blood.
+	var/nospawn = 0 // if the chemical should not be spawned in the cargo warehouse or anywhere else by default.
 
 /datum/reagent/proc/remove_self(var/amount) // Shortcut
 	if (!holder)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1006,35 +1006,6 @@
 /datum/reagent/ipecac/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustToxLoss(2 * removed) //If you inject it you're doing it wrong
 
-/datum/reagent/azoth
-	name = "Azoth"
-	id = "azoth"
-	description = "Azoth is a miraculous medicine, capable of healing internal injuries."
-	reagent_state = LIQUID
-	color = "#BF0000"
-	taste_description = "bitter metal"
-	overdose = 5
-
-/datum/reagent/azoth/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	..()
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		for (var/A in H.organs)
-			var/obj/item/organ/external/E = A
-			for (var/X in E.wounds)
-				var/datum/wound/W = X
-				if (W && W.internal)
-					E.wounds -= W
-					return 1
-
-			if(E.status & ORGAN_BROKEN)
-				E.status &= ~ORGAN_BROKEN
-				E.stage = 0
-				return 1
-
-/datum/reagent/azoth/overdose(var/mob/living/carbon/M, var/alien)
-	M.adjustBruteLoss(5)
-
 /datum/reagent/adipemcina //Based on quinapril
 	name = "Adipemcina"
 	id = "adipemcina"
@@ -1059,18 +1030,3 @@
 		if(prob(25))
 			M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
 			M.vomit()
-
-/datum/reagent/elixir
-	name = "Elixir of Life"
-	id = "elixir_life"
-	description = "A mythical substance, the cure for the ultimate illness."
-	color = "#ffd700"
-	affects_dead = 1
-	taste_description = "eternal blissfulness"
-
-/datum/reagent/elixir/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(ishuman(M))
-		if(M && M.stat == DEAD)
-			M.adjustOxyLoss(-rand(15,20))
-			M.visible_message("<span class='danger'>\The [M] shudders violently!</span>")
-			M.stat = 0

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -132,6 +132,7 @@
 	glass_icon_state = "golden_cup"
 	glass_name = "golden cup"
 	glass_desc = "It's magic. We don't have to explain it."
+	nospawn = 1
 
 /datum/reagent/adminordrazine/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	affect_blood(M, alien, removed)
@@ -460,99 +461,3 @@
 
 /datum/reagent/luminol/touch_mob(var/mob/living/L)
 	L.reveal_blood()
-
-/datum/reagent/estus
-	name = "liquid light"
-	id = "estus"
-	description = "This impossible substance slowly converts from a liquid into actual light."
-	reagent_state = LIQUID
-	color = "#ffff40"
-	scannable = 1
-	metabolism = REM * 0.25
-	taste_description = "bottled fire"
-	var/datum/modifier/modifier
-
-/datum/reagent/estus/affect_blood(var/mob/living/carbon/M, var/removed)
-	if (!modifier)
-		modifier = M.add_modifier(/datum/modifier/luminous, MODIFIER_REAGENT, src, _strength = 4, override = MODIFIER_OVERRIDE_STRENGTHEN)
-	if(isskeleton(M))
-		M.heal_organ_damage(10 * removed, 15 * removed)
-
-/datum/reagent/estus/affect_ingest(var/mob/living/carbon/M, var/removed)
-	if (!modifier)
-		modifier = M.add_modifier(/datum/modifier/luminous, MODIFIER_REAGENT, src, _strength = 4, override = MODIFIER_OVERRIDE_STRENGTHEN)
-	if(isskeleton(M))
-		M.heal_organ_damage(10 * removed, 15 * removed)
-
-/datum/reagent/estus/affect_touch(var/mob/living/carbon/M, var/removed)
-	if (!modifier)
-		modifier = M.add_modifier(/datum/modifier/luminous, MODIFIER_REAGENT, src, _strength = 4, override = MODIFIER_OVERRIDE_STRENGTHEN)
-	if(isskeleton(M))
-		M.heal_organ_damage(10 * removed, 15 * removed)
-
-/datum/reagent/liquid_fire
-	name = "Liquid Fire"
-	id = "liquid_fire"
-	description = "A dangerous flammable chemical, capable of causing fires when in contact with organic matter."
-	reagent_state = LIQUID
-	color = "#E25822"
-	touch_met = 5
-	taste_description = "metal"
-
-/datum/reagent/liquid_fire/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(istype(M))
-		M.adjust_fire_stacks(10)
-		M.IgniteMob()
-
-/datum/reagent/liquid_fire/touch_mob(var/mob/living/L, var/amount)
-	if(istype(L))
-		L.adjust_fire_stacks(10)
-		L.IgniteMob()
-
-/datum/reagent/black_matter
-	name = "Unstable Black Matter"
-	id = "black_matter"
-	description = "A pitch black blend of cosmic origins, handle with care."
-	color = "#000000"
-	taste_description = "emptyness"
-
-/datum/reagent/black_matter/touch_turf(var/turf/T)
-	var/obj/effect/portal/P = new /obj/effect/portal(T)
-	P.creator = null
-	P.icon = 'icons/obj/objects.dmi'
-	P.failchance = 0
-	P.icon_state = "anom"
-	P.name = "wormhole"
-	var/list/pick_turfs = list()
-	for(var/turf/simulated/floor/exit in turfs)
-		if(exit.z in current_map.station_levels)
-			pick_turfs += exit
-	P.target = pick(pick_turfs)
-	QDEL_IN(P, rand(150,300))
-	remove_self(volume)
-	return
-
-/datum/reagent/bluespace_dust
-	name = "Bluespace Dust"
-	id = "bluespace_dust"
-	description = "A dust composed of microscopic bluespace crystals."
-	color = "#1f8999"
-	taste_description = "fizzling blue"
-
-/datum/reagent/bluespace_dust/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(prob(25))
-		M.make_jittery(5)
-		M << "<span class='warning'>You feel unstable...</span>"
-
-	if(prob(10))
-		do_teleport(M, get_turf(M), 5, asoundin = 'sound/effects/phasein.ogg')
-
-/datum/reagent/bluespace_dust/touch_mob(var/mob/living/L, var/amount)
-	do_teleport(L, get_turf(L), amount, asoundin = 'sound/effects/phasein.ogg')
-
-/datum/reagent/philosopher_stone
-	name = "Philosopher's Stone"
-	id = "philosopher_stone"
-	description = "A mythical compound, rumored to be the catalyst of fantastic reactions."
-	color = "#f4c430"
-	taste_description = "heavenly knowledge"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Secret.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Secret.dm
@@ -1,0 +1,143 @@
+/datum/reagent/secret
+    nospawn = 1
+
+/datum/reagent/secret/estus
+	name = "liquid light"
+	id = "estus"
+	description = "This impossible substance slowly converts from a liquid into actual light."
+	reagent_state = LIQUID
+	color = "#ffff40"
+	scannable = 1
+	metabolism = REM * 0.25
+	taste_description = "bottled fire"
+	var/datum/modifier/modifier
+
+/datum/reagent/secret/estus/affect_blood(var/mob/living/carbon/M, var/removed)
+	if (!modifier)
+		modifier = M.add_modifier(/datum/modifier/luminous, MODIFIER_REAGENT, src, _strength = 4, override = MODIFIER_OVERRIDE_STRENGTHEN)
+	if(isskeleton(M))
+		M.heal_organ_damage(10 * removed, 15 * removed)
+
+/datum/reagent/secret/estus/affect_ingest(var/mob/living/carbon/M, var/removed)
+	if (!modifier)
+		modifier = M.add_modifier(/datum/modifier/luminous, MODIFIER_REAGENT, src, _strength = 4, override = MODIFIER_OVERRIDE_STRENGTHEN)
+	if(isskeleton(M))
+		M.heal_organ_damage(10 * removed, 15 * removed)
+
+/datum/reagent/secret/estus/affect_touch(var/mob/living/carbon/M, var/removed)
+	if (!modifier)
+		modifier = M.add_modifier(/datum/modifier/luminous, MODIFIER_REAGENT, src, _strength = 4, override = MODIFIER_OVERRIDE_STRENGTHEN)
+	if(isskeleton(M))
+		M.heal_organ_damage(10 * removed, 15 * removed)
+
+/datum/reagent/secret/liquid_fire
+	name = "Liquid Fire"
+	id = "liquid_fire"
+	description = "A dangerous flammable chemical, capable of causing fires when in contact with organic matter."
+	reagent_state = LIQUID
+	color = "#E25822"
+	touch_met = 5
+	taste_description = "metal"
+
+/datum/reagent/secret/liquid_fire/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(istype(M))
+		M.adjust_fire_stacks(10)
+		M.IgniteMob()
+
+/datum/reagent/secret/liquid_fire/touch_mob(var/mob/living/L, var/amount)
+	if(istype(L))
+		L.adjust_fire_stacks(10)
+		L.IgniteMob()
+
+/datum/reagent/secret/black_matter
+	name = "Unstable Black Matter"
+	id = "black_matter"
+	description = "A pitch black blend of cosmic origins, handle with care."
+	color = "#000000"
+	taste_description = "emptyness"
+
+/datum/reagent/secret/touch_turf(var/turf/T)
+	var/obj/effect/portal/P = new /obj/effect/portal(T)
+	P.creator = null
+	P.icon = 'icons/obj/objects.dmi'
+	P.failchance = 0
+	P.icon_state = "anom"
+	P.name = "wormhole"
+	var/list/pick_turfs = list()
+	for(var/turf/simulated/floor/exit in turfs)
+		if(exit.z in current_map.station_levels)
+			pick_turfs += exit
+	P.target = pick(pick_turfs)
+	QDEL_IN(P, rand(150,300))
+	remove_self(volume)
+	return
+
+/datum/reagent/secret/bluespace_dust
+	name = "Bluespace Dust"
+	id = "bluespace_dust"
+	description = "A dust composed of microscopic bluespace crystals."
+	color = "#1f8999"
+	taste_description = "fizzling blue"
+
+/datum/reagent/secret/bluespace_dust/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(prob(25))
+		M.make_jittery(5)
+		M << "<span class='warning'>You feel unstable...</span>"
+
+	if(prob(10))
+		do_teleport(M, get_turf(M), 5, asoundin = 'sound/effects/phasein.ogg')
+
+/datum/reagent/secret/bluespace_dust/touch_mob(var/mob/living/L, var/amount)
+	do_teleport(L, get_turf(L), amount, asoundin = 'sound/effects/phasein.ogg')
+
+/datum/reagent/secret/philosopher_stone
+	name = "Philosopher's Stone"
+	id = "philosopher_stone"
+	description = "A mythical compound, rumored to be the catalyst of fantastic reactions."
+	color = "#f4c430"
+	taste_description = "heavenly knowledge"
+
+/datum/reagent/secret/elixir
+	name = "Elixir of Life"
+	id = "elixir_life"
+	description = "A mythical substance, the cure for the ultimate illness."
+	color = "#ffd700"
+	affects_dead = 1
+	taste_description = "eternal blissfulness"
+
+/datum/reagent/secret/elixir/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(ishuman(M))
+		if(M && M.stat == DEAD)
+			M.adjustOxyLoss(-rand(15,20))
+			M.visible_message("<span class='danger'>\The [M] shudders violently!</span>")
+			M.stat = 0
+
+/datum/reagent/secret/azoth
+	name = "Azoth"
+	id = "azoth"
+	description = "Azoth is a miraculous medicine, capable of healing internal injuries."
+	reagent_state = LIQUID
+	color = "#BF0000"
+	taste_description = "bitter metal"
+	overdose = 5
+
+/datum/reagent/secret/azoth/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		for (var/A in H.organs)
+			var/obj/item/organ/external/E = A
+			for (var/X in E.wounds)
+				var/datum/wound/W = X
+				if (W && W.internal)
+					E.wounds -= W
+					return 1
+
+			if(E.status & ORGAN_BROKEN)
+				E.status &= ~ORGAN_BROKEN
+				E.stage = 0
+				return 1
+
+/datum/reagent/secret/azoth/overdose(var/mob/living/carbon/M, var/alien)
+	M.adjustBruteLoss(5)
+

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -395,6 +395,7 @@
 	glass_name = "glass of beer"
 	glass_desc = "A freezing pint of beer"
 	glass_center_of_mass = list("x"=16, "y"=8)
+	nospawn = 1
 
 /* Drugs */
 


### PR DESCRIPTION
Moved all secret chemicals under a /secret/ subtype of chemicals with a default value of nospawn set to 0. This should help blacklist shenanigans as it's harder to forget to add a variable to a new chemical than it is to add it to a list randomly located in the cargo spawn file. This also prevents secret chemicals from spawning in the cargo warehouse.
