### PR TITLE
The Final Burrito Tweak to End All Burrito Tweaks

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -969,61 +969,41 @@ I said no!
 		/obj/item/weapon/reagent_containers/food/snacks/tortilla,
 		/obj/item/weapon/reagent_containers/food/snacks/tofu
 	)
-	reagents = list("spacespice" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/burrito_vegan
 
 /datum/recipe/burrito_spicy
 	fruit = list("chili" = 2)
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/tortilla,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball
+		/obj/item/weapon/reagent_containers/food/snacks/burrito
 	)
-	reagents = list("spacespice" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/burrito_spicy
 
 /datum/recipe/burrito_cheese
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/tortilla,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
+		/obj/item/weapon/reagent_containers/food/snacks/burrito,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 	)
-	reagents = list("spacespice" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/burrito_cheese
 
 /datum/recipe/burrito_cheese_spicy
 	fruit = list("chili" = 2)
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/tortilla,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
+		/obj/item/weapon/reagent_containers/food/snacks/burrito,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 	)
-	reagents = list("spacespice" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/burrito_cheese_spicy
 
 /datum/recipe/burrito_hell
 	fruit = list("chili" = 10)
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/tortilla,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball
+		/obj/item/weapon/reagent_containers/food/snacks/burrito_spicy
 	)
-	reagents = list("spacespice" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/burrito_hell
 	reagent_mix = RECIPE_REAGENT_REPLACE //Already hot sauce
 
 /datum/recipe/burrito_mystery
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/tortilla,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
+		/obj/item/weapon/reagent_containers/food/snacks/burrito,
 		/obj/item/weapon/reagent_containers/food/snacks/mysterysoup
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/burrito_mystery
@@ -1084,8 +1064,8 @@ I said no!
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/meatball,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
-
 	)
+	fruit = list("cabbage" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/stuffed_meatball
 
 /datum/recipe/egg_pancake
@@ -1133,11 +1113,11 @@ I said no!
 	)
 	reagents = list("spacespice" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/cheese_cracker
+	result_quantity = 4
 
 /datum/recipe/bacon_and_eggs
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/bacon,
-		/obj/item/weapon/reagent_containers/food/snacks/friedegg,
 		/obj/item/weapon/reagent_containers/food/snacks/friedegg
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/bacon_and_eggs

--- a/html/changelogs/burgerbb-burritos.yml
+++ b/html/changelogs/burgerbb-burritos.yml
@@ -1,0 +1,6 @@
+author: BurgerBB
+
+delete-after: True
+
+changes: 
+  - tweak: "Tweaked the recipes for Burritos to prevent bugs."


### PR DESCRIPTION
# Overview
After playing chef, I've discovered that there have been some new problems regarding burritos. I don't know why these are happening now as they weren't when I implemented it, so I'm changing recipes. For example:

Let's say that there are two recipies, one that calls for A, B, and C, and one that calls for A and B, 
if I put in ingredients A, B, and C, it will make the recipe A and B.

I don't know why, but this PR makes it so that could never happen. Burritos are now made differently, and for the 100,000th time that nerd has to update the wiki again.
