### PR TITLE
Adds a Neurologist Alt-title

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -159,7 +159,7 @@
 	selection_color = "#ffeef0"
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_psychiatrist)
 	minimal_access = list(access_medical, access_medical_equip, access_psychiatrist)
-	alt_titles = list("Psychologist")
+	alt_titles = list("Psychologist","Neurologist")
 
 	equip(var/mob/living/carbon/human/H, var/alt_title)
 		if(!H)

--- a/html/changelogs/Neurologist.yml
+++ b/html/changelogs/Neurologist.yml
@@ -1,0 +1,8 @@
+# Your name.  
+author: XanderDox
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - rscadd: "Added a Neurologist alt-title to Psychiatrist"


### PR DESCRIPTION
Adds a Neurologist Alt-title to Psychiatrist.

The Neurologist would primarily focus on the diagnosis and treatment of traumas, handling cloning and post-cloning treatment, and disabilities related to the brain, as opposed to hour-long counselling or talk therapy.
 