### PR TITLE
Adds a SQL migration to fix a oversight

### DIFF
--- a/SQL/migrate/V022__cargo_schemafix.sql
+++ b/SQL/migrate/V022__cargo_schemafix.sql
@@ -1,0 +1,7 @@
+--
+-- Allow null in path_old and set the default to null for suppliers_old and path_old
+--
+ALTER TABLE `ss13_cargo_items`
+	CHANGE COLUMN `suppliers_old` `suppliers_old` TEXT NULL DEFAULT NULL COMMENT 'JSON list of suppliers' AFTER `deleted_at`,
+	CHANGE COLUMN `path_old` `path_old` VARCHAR(150) NULL DEFAULT NULL AFTER `suppliers_old`;
+


### PR DESCRIPTION
Adds a SQL migration to allow the path_old and suppliers_old in the cargo_items table to be nulled.
Sets their default to null aswell