### PR TITLE
Vote Troll Logging

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -5,13 +5,13 @@
 // will get logs that are one big line if the system is Linux and they are using notepad.  This solves it by adding CR to every line ending
 // in the logs.  ascii character 13 = CR
 
-#define SEVERITY_ALERT    1
-#define SEVERITY_CRITICAL 2
-#define SEVERITY_ERROR    3
-#define SEVERITY_WARNING  4
-#define SEVERITY_NOTICE   5
-#define SEVERITY_INFO     6
-#define SEVERITY_DEBUG    7
+#define SEVERITY_ALERT    1 //Alert: action must be taken immediately
+#define SEVERITY_CRITICAL 2 //Critical: critical conditions
+#define SEVERITY_ERROR    3 //Error: error conditions
+#define SEVERITY_WARNING  4 //Warning: warning conditions
+#define SEVERITY_NOTICE   5 //Notice: normal but significant condition
+#define SEVERITY_INFO     6 //Informational: informational messages
+#define SEVERITY_DEBUG    7 //Debug: debug-level messages
 
 /var/global/log_end = world.system_type == UNIX ? ascii2text(13) : ""
 

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -387,6 +387,12 @@ var/datum/controller/subsystem/ticker/SSticker
 	SSjobs.DivideOccupations() // Apparently important for new antagonist system to register specific job antags properly.
 
 	if(!src.mode.can_start())
+		var/list/voted_not_ready = list()
+		for(var/mob/abstract/new_player/player in player_list)
+			if((player.client)&&(!player.ready))
+				voted_not_ready += player.ckey
+		message_admins("The following players voted for [mode.name], but did not ready up: [jointext(voted_not_ready, ", ")]")
+		log_game("Ticker: Players voted for [mode.name], but did not ready up: [jointext(voted_not_ready, ", ")]")
 		world << "<B>Unable to start [mode.name].</B> Not enough players, [mode.required_players] players needed. Reverting to pre-game lobby."
 		current_state = GAME_STATE_PREGAME
 		mode.fail_setup()

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -259,6 +259,7 @@ var/datum/controller/subsystem/vote/SSvote
 			if("restart")
 				choices.Add("Restart Round","Continue Playing")
 			if("gamemode")
+				round_voters.Cut() //Delete the old list, since we are having a new gamemode vote
 				if(SSticker.current_state >= 2)
 					return 0
 				choices.Add(config.votable_modes)


### PR DESCRIPTION
Provides the admins with a list of players that voted for a gamemode but didnt ready up for it, if the start of the round fails.

not using log_and_message_admins since the prefix can not be overwritten

https://forums.aurorastation.org/viewtopic.php?f=18&t=10844&start=20#p96979