### PR TITLE
Add a approval step to cargo_items

### DIFF
--- a/SQL/migrate/V025__cargo_approval.sql
+++ b/SQL/migrate/V025__cargo_approval.sql
@@ -1,0 +1,9 @@
+--
+-- Combines the ss13_admin and ss13_player table
+--
+ALTER TABLE `ss13_cargo_items`
+	ADD COLUMN `created_by` VARCHAR(50) NULL DEFAULT NULL AFTER `order_by`,
+	ADD COLUMN `approved_by` VARCHAR(50) NULL DEFAULT NULL AFTER `created_by`,
+	ADD COLUMN `approved_at` DATETIME NULL DEFAULT NULL AFTER `created_at`;
+
+UPDATE ss13_cargo_items SET approved_at = NOW()

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -182,7 +182,7 @@ var/datum/controller/subsystem/cargo/SScargo
 			catch(var/exception/es)
 				log_debug("SScargo: Error when loading supplier: [es]")
 		//Load the items
-		var/DBQuery/item_query = dbcon.NewQuery("SELECT id, name, supplier, description, categories, price, items, access, container_type, groupable, item_mul FROM ss13_cargo_items WHERE deleted_at is NULL AND supplier IS NOT NULL ORDER BY order_by ASC, name ASC, supplier ASC")
+		var/DBQuery/item_query = dbcon.NewQuery("SELECT id, name, supplier, description, categories, price, items, access, container_type, groupable, item_mul FROM ss13_cargo_items WHERE deleted_at IS NULL AND approved_at IS NOT NULL AND supplier IS NOT NULL ORDER BY order_by ASC, name ASC, supplier ASC")
 		item_query.Execute()
 		while(item_query.NextRow())
 			CHECK_TICK


### PR DESCRIPTION
Expands the cargo table to require the approval of items before they are displayed on the server, enabling the creation of a module in the web interface

ToDo:
- [ ] Testing