### PR TITLE
Fixes final ticket logging bugs

### DIFF
--- a/SQL/migrate/V023__Tickets_nullable_taker.sql
+++ b/SQL/migrate/V023__Tickets_nullable_taker.sql
@@ -1,0 +1,6 @@
+--
+-- Fixes a bug by allowing the "Taken by" admin to be null.
+--
+
+ALTER TABLE `ss13_tickets`
+  MODIFY `taken_by` VARCHAR(32) NULL DEFAULT NULL;

--- a/code/modules/admin/ticket.dm
+++ b/code/modules/admin/ticket.dm
@@ -135,14 +135,30 @@ var/global/list/ticket_panels = list()
 	if (!establish_db_connection(dbcon))
 		return
 
-	var/DBQuery/Q = dbcon.NewQuery("INSERT INTO ss13_tickets (game_id, message_count, admin_count, admin_list, opened_by, taken_by, closed_by, response_delay, opened_at, closed_at) VALUES (:g_id:, :m_count:, :a_count:, :a_list:, :opened_by:, :taken_by, :closed_by:, :delay:, :opened_at:, :closed_at:)")
-	Q.Execute(list("g_id" = game_id, "m_count" = length(msgs), "a_count" = length(assigned_admins), "a_list" = json_encode(assigned_admins), "opened_by" = owner, "taken_by" = assigned_admins[1], "closed_by" = closed_by, "delay" = response_time, "opened_at" = SQLtime(opened_rt), "closed_at" = SQLtime(closed_rt)))
+	var/DBQuery/Q = dbcon.NewQuery({"INSERT INTO ss13_tickets
+		(game_id, message_count, admin_count, admin_list, opened_by, taken_by,
+		 closed_by, response_delay, opened_at, closed_at)
+	VALUES
+		(:g_id:, :m_count:, :a_count:, :a_list:, :opened_by:, :taken_by:,
+		 :closed_by:, :delay:, :opened_at:, :closed_at:)"})
+	Q.Execute(list(
+		"g_id" = game_id,
+		"m_count" = length(msgs),
+		"a_count" = length(assigned_admins),
+		"a_list" = json_encode(assigned_admins),
+		"opened_by" = owner,
+		"taken_by" = length(assigned_admins) ? assigned_admins[1] : null,
+		"closed_by" = closed_by,
+		"delay" = response_time || -1,
+		"opened_at" = SQLtime(opened_rt),
+		"closed_at" = SQLtime(closed_rt)
+	))
 
 /datum/ticket/proc/append_message(m_from, m_to, msg)
 	msgs += new /datum/ticket_msg(m_from, m_to, msg)
 
 	if (!response_time && m_from != owner)
-		response_time = round((world.time - opened_time) SECONDS)
+		response_time = round((world.time - opened_time) / 10)
 
 	update_ticket_panels()
 


### PR DESCRIPTION
Fixes the following bugs:
* Runtime from closing ticket with no response (these can now also be filtered by looking for all tickets with a response time of `-1`. Implying no response).
* Unpopulated SQL arg due to missing closing `:`'s.
* Response time was disabled in multiples of 1/10ths, as opposed to actual seconds.