### PR TITLE
Cargo Loot Improvements

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -258,18 +258,16 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 //Cargo random stock vars
 //These are used in randomstock.dm
 //And also for generating random loot crates in crates.dm
-#define TOTAL_STOCK 	80//The total number of items we'll spawn in cargo stock
+#define TOTAL_STOCK 	100//The total number of items we'll spawn in cargo stock
 
-
-#define STOCK_UNCOMMON_PROB	23
+#define STOCK_UNCOMMON_PROB	25
 //The probability, as a percentage for each item, that we'll choose from the uncommon spawns list
 
-#define STOCK_RARE_PROB	2.8
+#define STOCK_RARE_PROB	5
 //The probability, as a percentage for each item, that we'll choose from the rare spawns list
 
 //If an item is not rare or uncommon, it will be chosen from the common spawns list.
 //So the probability of a common item is 100 - (uncommon + rare)
-
 
 #define STOCK_LARGE_PROB	75
 //Large items are spawned on predetermined locations.

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -260,10 +260,10 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 //And also for generating random loot crates in crates.dm
 #define TOTAL_STOCK 	100//The total number of items we'll spawn in cargo stock
 
-#define STOCK_UNCOMMON_PROB	25
+#define STOCK_UNCOMMON_PROB	23
 //The probability, as a percentage for each item, that we'll choose from the uncommon spawns list
 
-#define STOCK_RARE_PROB	5
+#define STOCK_RARE_PROB	2.8
 //The probability, as a percentage for each item, that we'll choose from the rare spawns list
 
 //If an item is not rare or uncommon, it will be chosen from the common spawns list.

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -2,45 +2,8 @@
 	name = "random arcade"
 	desc = "random arcade machine"
 	icon_state = "arcade"
-
 	icon_screen = "invaders"
-	var/list/prizes = list(	/obj/item/weapon/storage/box/snappops			= 11,
-							/obj/item/clothing/under/syndicate/tacticool	= 5,
-							/obj/item/toy/sword								= 22,
-							/obj/item/weapon/gun/projectile/revolver/capgun	= 11,
-							/obj/item/toy/crossbow							= 11,
-							/obj/item/weapon/storage/fancy/crayons			= 11,
-							/obj/item/toy/spinningtoy						= 11,
-							/obj/item/toy/prize/ripley						= 1,
-							/obj/item/toy/prize/fireripley					= 1,
-							/obj/item/toy/prize/deathripley					= 1,
-							/obj/item/toy/prize/gygax						= 1,
-							/obj/item/toy/prize/durand						= 1,
-							/obj/item/toy/prize/honk						= 1,
-							/obj/item/toy/prize/marauder					= 1,
-							/obj/item/toy/prize/seraph						= 1,
-							/obj/item/toy/prize/mauler						= 1,
-							/obj/item/toy/prize/odysseus					= 1,
-							/obj/item/toy/prize/phazon						= 1,
-							/obj/item/toy/waterflower						= 5,
-							/obj/random/action_figure						= 11,
-							/obj/random/plushie								= 44,
-							/obj/item/toy/cultsword							= 5,
-							/obj/item/toy/syndicateballoon					= 5,
-							/obj/item/toy/nanotrasenballoon					= 5,
-							/obj/item/toy/katana							= 11,
-							/obj/item/toy/bosunwhistle						= 5,
-							/obj/item/weapon/storage/belt/champion			= 11,
-							/obj/item/weapon/pen/invisible					= 5,
-							/obj/item/weapon/grenade/fake					= 1,
-							/obj/item/weapon/bikehorn						= 11,
-							/obj/item/clothing/mask/fakemoustache			= 11,
-							/obj/item/clothing/mask/gas/clown_hat			= 11,
-							/obj/item/clothing/mask/gas/mime				= 11,
-							/obj/item/weapon/gun/energy/wand/toy			= 5,
-							/obj/item/device/binoculars						= 11,
-							/obj/item/device/megaphone						= 11
-						)
+	var/prize = /obj/random/arcade
 
 /obj/machinery/computer/arcade/Initialize()
 	. = ..()
@@ -55,11 +18,10 @@
 
 /obj/machinery/computer/arcade/proc/prizevend()
 	if(!contents.len)
-		var/prizeselect = pickweight(prizes)
-		new prizeselect(src.loc)
+		new prize(src.loc)
 	else
-		var/atom/movable/prize = pick(contents)
-		prize.loc = src.loc
+		var/atom/movable/chosen_prize = pick(contents)
+		chosen_prize.loc = src.loc
 
 /obj/machinery/computer/arcade/attack_ai(mob/user as mob)
 	return src.attack_hand(user)
@@ -69,7 +31,6 @@
 	if(stat & (NOPOWER|BROKEN))
 		..(severity)
 		return
-	var/empprize = null
 	var/num_of_prizes = 0
 	switch(severity)
 		if(1)
@@ -77,8 +38,7 @@
 		if(2)
 			num_of_prizes = rand(0,2)
 	for(num_of_prizes; num_of_prizes > 0; num_of_prizes--)
-		empprize = pickweight(prizes)
-		new empprize(src.loc)
+		new prize(src.loc)
 
 	..(severity)
 

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -939,3 +939,46 @@
 		/obj/item/weapon/material/sword/gladius
 	)
 
+/obj/random/arcade
+	name = "random arcade loot"
+	desc = "Arcade loot!"
+	icon = 'icons/obj/items.dmi'
+	icon_state = "gift3"
+	spawnlist = list(
+		/obj/item/weapon/storage/box/snappops			= 11,
+		/obj/item/clothing/under/syndicate/tacticool	= 5,
+		/obj/item/toy/sword								= 22,
+		/obj/item/weapon/gun/projectile/revolver/capgun	= 11,
+		/obj/item/toy/crossbow							= 11,
+		/obj/item/weapon/storage/fancy/crayons			= 11,
+		/obj/item/toy/spinningtoy						= 11,
+		/obj/item/toy/prize/ripley						= 1,
+		/obj/item/toy/prize/fireripley					= 1,
+		/obj/item/toy/prize/deathripley					= 1,
+		/obj/item/toy/prize/gygax						= 1,
+		/obj/item/toy/prize/durand						= 1,
+		/obj/item/toy/prize/honk						= 1,
+		/obj/item/toy/prize/marauder					= 1,
+		/obj/item/toy/prize/seraph						= 1,
+		/obj/item/toy/prize/mauler						= 1,
+		/obj/item/toy/prize/odysseus					= 1,
+		/obj/item/toy/prize/phazon						= 1,
+		/obj/item/toy/waterflower						= 5,
+		/obj/random/action_figure						= 11,
+		/obj/random/plushie								= 44,
+		/obj/item/toy/cultsword							= 5,
+		/obj/item/toy/syndicateballoon					= 5,
+		/obj/item/toy/nanotrasenballoon					= 5,
+		/obj/item/toy/katana							= 11,
+		/obj/item/toy/bosunwhistle						= 5,
+		/obj/item/weapon/storage/belt/champion			= 11,
+		/obj/item/weapon/pen/invisible					= 5,
+		/obj/item/weapon/grenade/fake					= 1,
+		/obj/item/weapon/bikehorn						= 11,
+		/obj/item/clothing/mask/fakemoustache			= 11,
+		/obj/item/clothing/mask/gas/clown_hat			= 11,
+		/obj/item/clothing/mask/gas/mime				= 11,
+		/obj/item/weapon/gun/energy/wand/toy			= 5,
+		/obj/item/device/binoculars						= 11,
+		/obj/item/device/megaphone						= 11
+	)

--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -74,8 +74,6 @@ var/list/global/random_stock_common = list(
 	"light" = 1.8,
 	"aid" = 4,
 	"flame" = 2,
-	"crayons" = 1.5,
-	"figure" = 1,
 	"bombsupply" = 4.5,
 	"tech" = 5,
 	"smokes" = 2,
@@ -85,7 +83,6 @@ var/list/global/random_stock_common = list(
 	"circuitboard" = 2,
 	"smalloxy" = 3.2,
 	"belts" = 2,
-	"backpack" = 4.5,
 	"weldgear" = 2,
 	"inflatable" = 3,
 	"wheelchair" = 1,
@@ -122,8 +119,7 @@ var/list/global/random_stock_common = list(
 	"hailer" = 1.1,
 	"target" = 2,
 	"snacks" = 4,
-	"oxytank" = 2.5,//
-	"signs" = 4,
+	"oxytank" = 2.5,
 	"posters" = 3,
 	"parts" = 6,
 	"cane" = 2,
@@ -134,6 +130,7 @@ var/list/global/random_stock_common = list(
 	"paicard" = 2,
 	"phoronsheets" = 2,
 	"hide" = 1,
+	"arcade" = 2,
 	"nothing" = 0)
 
 var/list/global/random_stock_uncommon = list(
@@ -152,19 +149,16 @@ var/list/global/random_stock_uncommon = list(
 	"monkey" = 2,
 	"specialcrayon" = 1.5,
 	"contraband" = 2,
-	"figure" = 4,
-	"plushie" = 4,
 	"mediumcell" = 3,
 	"chempack" = 5,
 	"robolimbs" = 3,
 	"circuitboards" = 3,
 	"jetpack" = 3,
 	"xenocostume" = 1,
-	"bible" = 1,
 	"advwelder" = 2,
 	"sord" = 1,
 	"policebaton" = 1.5,
-	"stunbaton" = 0.75,//batons spawn with no powercell
+	"stunbaton" = 0.75, //batons spawn with no powercell
 	"firingpin" = 3,
 	"watches" = 3,
 	"MMI" = 1.5,
@@ -183,7 +177,6 @@ var/list/global/random_stock_uncommon = list(
 	"fireaxe" = 1,
 	"service" = 2,
 	"robot" = 2,
-	"latexb" = 0.5,
 	"taperoll" = 1,
 	"headset" = 2,
 	"bat" = 1.2,
@@ -196,7 +189,6 @@ var/list/global/random_stock_uncommon = list(
 	"exoquip" = 2,
 	"laserscalpel" = 1.3,
 	"electropack" = 1,
-	"beesmoker" = 1.5,
 	"monkeyhide" = 0.5,
 	"cathide" = 0.5,
 	"corgihide" = 0.5,
@@ -465,6 +457,11 @@ var/list/global/random_stock_large = list(
 /proc/spawn_stock(var/stock, var/atom/L, var/datum/cargospawner/CS = null)
 	//L is the location we spawn in. Using a single letter as shorthand because its written so often
 	switch(stock)
+		if("arcade")
+			new /obj/random/arcade(L)
+			new /obj/random/arcade(L)
+			new /obj/random/arcade(L)
+
 		if ("toolbox")
 			if (prob(5))
 				new /obj/item/weapon/storage/toolbox/syndicate(L)
@@ -562,8 +559,6 @@ var/list/global/random_stock_large = list(
 			new /obj/item/weapon/flame/lighter/random(L)
 			new /obj/item/weapon/storage/fancy/candle_box(L)
 			new /obj/item/weapon/storage/fancy/candle_box(L)
-		if ("crayons")
-			new /obj/item/weapon/storage/fancy/crayons(L)
 
 		if("bombsupply")
 			new /obj/random/bomb_supply(L)
@@ -640,9 +635,6 @@ var/list/global/random_stock_large = list(
 		if("belts")
 			new /obj/random/belt(L)
 			new /obj/random/belt(L)
-		if("backpack")
-			new /obj/random/backpack(L)
-			new /obj/random/backpack(L)
 		if("weldgear")
 			if (prob(50))
 				new /obj/item/clothing/glasses/welding(L)
@@ -1061,12 +1053,6 @@ var/list/global/random_stock_large = list(
 			while (number > 0)
 				new /obj/random/contraband(L)
 				number--
-		if("figure")
-			new /obj/random/action_figure(L)
-			new /obj/random/action_figure(L)
-			new /obj/random/action_figure(L)
-		if("plushie")
-			new /obj/random/plushie(L)
 		if("firingpin")
 			new /obj/item/weapon/storage/box/firingpins(L)
 		if("mediumcell")
@@ -1132,11 +1118,6 @@ var/list/global/random_stock_large = list(
 		if ("xenocostume")
 			new /obj/item/clothing/suit/xenos(L)
 			new /obj/item/clothing/head/xenos(L)
-		if ("bible")
-			if (prob(25))
-				new /obj/item/weapon/storage/bible/booze(L)
-			else
-				new /obj/item/weapon/storage/bible(L)
 		if ("advwelder")
 			new /obj/item/weapon/weldingtool/hugetank(L)
 
@@ -1159,22 +1140,6 @@ var/list/global/random_stock_large = list(
 		if ("voidsuit")
 			new /obj/random/voidsuit(L,1)
 
-		if ("signs")
-			var/list/allsigns = subtypesof(/obj/structure/sign)
-			allsigns -= typesof(/obj/structure/sign/double)
-			allsigns -= typesof(/obj/structure/sign/poster)
-			allsigns -= /obj/structure/sign/directions
-			allsigns -= typesof(/obj/structure/sign/christmas)
-			allsigns -= typesof(/obj/structure/sign/flag)
-
-			var/number = rand(1,5)
-
-			while (number > 0)
-				var/newsign = pick(allsigns)
-				if (newsign != /obj/structure/sign)//Dont want to spawn the generic parent class
-					var/obj/structure/sign/S = new newsign(L)
-					S.unfasten()
-					number--
 		if ("posters")
 			new /obj/item/weapon/contraband/poster(L)
 			if (prob(50))
@@ -1246,8 +1211,6 @@ var/list/global/random_stock_large = list(
 			newbot.on = 0//Deactivated
 			if (prob(10))
 				newbot.emag_act(9999,null)
-		if ("latexb")
-			new /obj/item/latexballon(L)
 
 	//Random headsets for low-security department
 	//No command or sec
@@ -1374,9 +1337,6 @@ var/list/global/random_stock_large = list(
 				cr.rigged = 1//Boobytrapped crate, will electrocute when you attempt to open it
 				//Can be disarmed with wirecutters or ignored with insulated gloves
 
-		if ("beesmoker")
-			new /obj/item/weapon/bee_smoker(L)
-
 		if("monkeyhide")
 			new /obj/item/stack/material/animalhide/monkey(L, 50)
 
@@ -1391,7 +1351,6 @@ var/list/global/random_stock_large = list(
 
 		if ("wintercoat")
 			new /obj/random/hoodie(L)
-
 
 		if("cookingoil")
 			var/turf/T = get_turf(L)

--- a/html/changelogs/burgerbb-cargotweaks2.yml
+++ b/html/changelogs/burgerbb-cargotweaks2.yml
@@ -3,5 +3,5 @@ author: BurgerBB
 delete-after: True
 
 changes: 
-  - balance: "Removed some useless items in cargo's warehouse. Reduced the chance of getting arcade loot in the warehouse."
-  - balance: "Increased the amount of loot in the warehouse from 80 to 100. Increased the uncommon loot chance from 23% to 25%. Increased the rare loot chance from 2.8% to 5%."
+  - balance: "Removed some useless item spawns in cargo's warehouse. Reduced the chance of getting arcade loot in the warehouse."
+  - balance: "Increased the amount of loot in the warehouse from 80 to 100."

--- a/html/changelogs/burgerbb-cargotweaks2.yml
+++ b/html/changelogs/burgerbb-cargotweaks2.yml
@@ -1,0 +1,7 @@
+author: BurgerBB
+
+delete-after: True
+
+changes: 
+  - balance: "Removed some useless items in cargo's warehouse. Reduced the chance of getting arcade loot in the warehouse."
+  - balance: "Increased the amount of loot in the warehouse from 80 to 100. Increased the uncommon loot chance from 23% to 25%. Increased the rare loot chance from 2.8% to 5%."


### PR DESCRIPTION
# Overview
Since the warehouse is now bigger, it would make sense to increase the amount of loot that spawns in the warehouse. This PR effectively does that, as well as removes some of the more useless items that can spawn in cargo.