### PR TITLE
Short Names for Commanded Dogs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -4,11 +4,17 @@
 	melee_damage_lower = 0
 	melee_damage_upper = 0
 	density = 0
+	var/short_name = null
 	var/list/command_buffer = list()
 	var/list/known_commands = list("stay", "stop", "attack", "follow")
 	var/mob/master = null //undisputed master. Their commands hold ultimate sway and ultimate power.
 	var/list/allowed_targets = list() //WHO CAN I KILL D:
 	var/retribution = 1 //whether or not they will attack us if we attack them like some kinda dick.
+
+/mob/living/simple_animal/hostile/commanded/Initialize()
+	..()
+	if(!short_name)
+		short_name = name
 
 /mob/living/simple_animal/hostile/commanded/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
 	if(thinking_enabled && !stat && ((speaker in friends) || speaker == master))
@@ -27,7 +33,8 @@
 		var/mob/speaker = command_buffer[1]
 		var/text = command_buffer[2]
 		var/filtered_name = lowertext(html_decode(name))
-		if(dd_hasprefix(text,filtered_name) || dd_hasprefix(text,"everyone") || dd_hasprefix(text, "everybody")) //in case somebody wants to command 8 bears at once.
+		var/filtered_short = lowertext(html_decode(short_name))
+		if(dd_hasprefix(text,filtered_name) || dd_hasprefix(text,filtered_short) || dd_hasprefix(text,"everyone") || dd_hasprefix(text, "everybody")) //in case somebody wants to command 8 bears at once.
 			var/substring = copytext(text,length(filtered_name)+1) //get rid of the name.
 			listen(speaker,substring)
 		command_buffer.Remove(command_buffer[1],command_buffer[2])

--- a/code/modules/mob/living/simple_animal/hostile/commanded/guard_dog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/guard_dog.dm
@@ -1,5 +1,6 @@
 /mob/living/simple_animal/hostile/commanded/dog
 	name = "guard dog"
+	short_name = "dog"
 	desc = "A dog trained to listen and obey its owner commands, this one is a german shepherd."
 
 	icon = 'icons/mob/dog.dmi'
@@ -83,10 +84,13 @@
 	if(!name_changed)
 
 		var/input = sanitizeSafe(input("What do you want to name the dog?", ,""), MAX_NAME_LEN)
+		var/short_input = sanitizeSafe(input("What nickname do you want to give the dog ?", , ""), MAX_NAME_LEN)
 
 		if(src && input && !M.stat && in_range(M,src))
 			name = input
 			real_name = input
+			if(short_input != "")
+				short_name = short_input
 			name_changed = 1
 			return 1
 
@@ -103,6 +107,7 @@
 
 /mob/living/simple_animal/hostile/commanded/dog/columbo
 	name = "Lt. Columbo"
+	short_name = "Columbo"
 	desc = "A dog trained to listen and obey its owner commands. This one looks about three days from retirement."
 
 	melee_damage_lower = 5

--- a/html/changelogs/arrow768-commanded-short-names.yml
+++ b/html/changelogs/arrow768-commanded-short-names.yml
@@ -2,4 +2,4 @@ author: Arrow768
 delete-after: True
 
 changes:
-  - rscadd: "It is not possible to call commanded animals by a nickname."
+  - rscadd: "It is now possible to call commanded animals by a nickname."

--- a/html/changelogs/arrow768-commanded-short-names.yml
+++ b/html/changelogs/arrow768-commanded-short-names.yml
@@ -1,0 +1,5 @@
+author: Arrow768
+delete-after: True
+
+changes:
+  - rscadd: "It is not possible to call commanded animals by a nickname."


### PR DESCRIPTION
Adds the ability to call a commanded animal by a short name.
Adds the ability to set the short name of a commanded animal (if you can rename it)
https://forums.aurorastation.org/viewtopic.php?f=18&t=10865&p=96711

ToDo:
- [ ] Testing