### PR TITLE
The Great Xenomorph Buffing: Part One

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1,4 +1,4 @@
-// These should all be procs, you can add them to humans/subspecies by
+w// These should all be procs, you can add them to humans/subspecies by
 // species.dm's inherent_verbs ~ Z
 
 /mob/living/carbon/human/proc/tackle()
@@ -171,6 +171,66 @@
 		M.apply_damage(50,BRUTE)
 		if(M.stat == 2)
 			M.gib()
+
+
+/mob/living/carbon/human/proc/headbite()
+	set category = "Abilities"
+	set name = "Headbite"
+	set desc = "While grabbing someone by their neck, viciously tear through and shred their skull with your inner jaw."
+
+	if(last_special > world.time)
+		src << "<span class='warning'>Your inner jaw is still sore!</span>"
+		return
+
+	if(stat || paralysis || stunned || weakened || lying)
+		src << "<span class='warning'>You cannot do that in your current state.</span>"
+		return
+
+
+	var/obj/item/weapon/grab/G = src.get_active_hand()
+	if(!istype(G))
+		src << "<span class='warning'>You must be grabbing a creature in your active hand to headbite it.</span>"
+		return
+
+	if(G.state != GRAB_KILL)
+		src << "<span class='warning'>You must have a tighter grip to headbite them.</span>"
+		return
+
+	if(istype(G.affecting,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = G.affecting
+
+		if(!H.species.has_limbs["head"])
+			src << "<span class='warning'>\The [H] does not have a head!</span>"
+			return
+
+		var/obj/item/organ/external/affecting = H.get_organ("head")
+		if(!istype(affecting) || affecting.is_stump())
+			src << "<span class='warning'>\The [H] does not have a head!</span>"
+			return
+
+		visible_message("<span class='danger'>\The [src] prepares its inner jaw and tightens its grip on \the [H], aiming at its prey's head!</span>")
+		sleep(10)
+		if(!src.Adjacent(G.affecting))
+			return
+		visible_message("<span class='danger'>\The [src] extends its inner jaw, completely piercing through \the [H]'s skull!</span>")
+		playsound(H.loc, 'sound/effects/blobattack.ogg', 50, 1)
+		H.apply_damage(200,BRUTE, "head")
+
+	else
+		var/mob/living/M = G.affecting
+		if(istype(M))
+			visible_message("<span class='danger'>\The [src] rips and shreds viciously at \the [M]'s body with its sharp teeth and claws!</span>")
+			playsound(M.loc, 'sound/effects/blobattack.ogg', 50, 1)
+			M.gib()
+
+	last_special = world.time + 200
+
+//	else
+	//	var/mob/living/M = G.affecting
+	//	if(istype(M))
+	//		visible_message("<span class='danger'>\The [src] rips viciously at \the [M]'s body with its inner jaw!</span>")
+	//		playsound(M.loc, 'sound/effects/blobattack.ogg', 50, 1)
+	//		M.gib()
 
 /mob/living/carbon/human/proc/commune()
 	set category = "Abilities"
@@ -549,7 +609,7 @@
 		src << "<span class='warning'>Your powers are not capable of taking you that far.</span>"
 		return
 
-	if (T.get_lumcount() > 0.1)
+	if (!T.dynamic_lighting || T.get_lumcount() > 0.1)
 		src << "<span class='warning'>The destination is too bright.</span>"
 		return
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -225,13 +225,6 @@ w// These should all be procs, you can add them to humans/subspecies by
 
 	last_special = world.time + 200
 
-//	else
-	//	var/mob/living/M = G.affecting
-	//	if(istype(M))
-	//		visible_message("<span class='danger'>\The [src] rips viciously at \the [M]'s body with its inner jaw!</span>")
-	//		playsound(M.loc, 'sound/effects/blobattack.ogg', 50, 1)
-	//		M.gib()
-
 /mob/living/carbon/human/proc/commune()
 	set category = "Abilities"
 	set name = "Commune with creature"

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1,4 +1,4 @@
-w// These should all be procs, you can add them to humans/subspecies by
+// These should all be procs, you can add them to humans/subspecies by
 // species.dm's inherent_verbs ~ Z
 
 /mob/living/carbon/human/proc/tackle()

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_embryo.dm
@@ -60,12 +60,13 @@
 				if(prob(20))
 					owner.take_organ_damage(1)
 			if(prob(2))
+				owner  << "<span class='danger'>Your chest hurts.</span>"
 				if(prob(20))
 					owner.adjustToxLoss(1)
 					owner.updatehealth()
 			if(prob(2))
 				if(prob(20))
-					owner  << "<span class='danger'>Your chest hurts. It gets difficult to breathe...</span>"
+					owner  << "<span class='danger'>Your chest hurts badly. It gets difficult to breathe...</span>"
 					owner.emote("gasp")
 		if(5)
 			owner  << "<span class='danger'>You feel something tearing its way out of your chest!</span>"

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_embryo.dm
@@ -1,6 +1,6 @@
 /obj/item/organ/xenos/alien_embryo
 	name = "alien embryo"
-	desc = "All slimy and yuck."
+	desc = "All slimy and yucky."
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "larva0_dead"
 	parent_organ = "chest"
@@ -60,12 +60,15 @@
 				if(prob(20))
 					owner.take_organ_damage(1)
 			if(prob(2))
-				owner  << "<span class='danger'>Your stomach hurts.</span>"
 				if(prob(20))
 					owner.adjustToxLoss(1)
 					owner.updatehealth()
+			if(prob(2))
+				if(prob(20))
+					owner  << "<span class='danger'>Your chest hurts. It gets difficult to breathe...</span>"
+					owner.emote("gasp")
 		if(5)
-			owner  << "<span class='danger'>You feel something tearing its way out of your stomach!</span>"
+			owner  << "<span class='danger'>You feel something tearing its way out of your chest!</span>"
 			owner.adjustToxLoss(10)
 			owner.updatehealth()
 			if(prob(50))

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -12,7 +12,7 @@
 	has_fine_manipulation = 0
 	siemens_coefficient = 0
 	gluttonous = TRUE
-	mouth_size = 15	// Should be larger than any human-type.
+	mouth_size = 25	// Should be larger than any human-type.
 	allowed_eat_types = TYPE_ORGANIC | TYPE_SYNTHETIC | TYPE_HUMANOID
 	mob_size = 14
 	fall_mod = 0
@@ -38,10 +38,11 @@
 	sprint_cost_factor = 0.80
 	stamina_recovery = 5
 
+
 	virus_immune = 1
 
 	brute_mod = 0.25 // Hardened carapace.
-	burn_mod = 1.75    // Weak to fire.
+	burn_mod = 1   // Weaker to fire than brute damage. However, 1.75x is too big of a modifier.
 
 	warning_low_pressure = 50
 	hazard_low_pressure = -1
@@ -93,7 +94,7 @@
 	return "Xenomorph"
 
 /datum/species/xenos/get_random_name()
-	return "alien [caste_name] ([alien_number])"
+	return "[caste_name] ([alien_number])"
 
 /datum/species/xenos/can_understand(var/mob/other)
 
@@ -107,13 +108,13 @@
 					"<span class='notice'>You caress [target] with your scythe-like arm.</span>")
 
 /datum/species/xenos/handle_post_spawn(var/mob/living/carbon/human/H)
-
+	H.gender = NEUTER
 	if(H.mind)
 		H.mind.assigned_role = "Alien"
 		H.mind.special_role = "Alien"
 
 	alien_number++ //Keep track of how many aliens we've had so far.
-	H.real_name = "alien [caste_name] ([alien_number])"
+	H.real_name = "[caste_name] ([alien_number])"
 	H.name = H.real_name
 
 	..()
@@ -169,7 +170,7 @@
 
 /datum/species/xenos/drone
 	name = "Xenomorph Drone"
-	caste_name = "drone"
+	caste_name = "Drone"
 	weeds_plasma_rate = 15
 	slowdown = 1
 	tail = "xenos_drone_tail"
@@ -211,7 +212,7 @@
 
 	name = "Xenomorph Hunter"
 	weeds_plasma_rate = 5
-	caste_name = "hunter"
+	caste_name = "Hunter"
 	slowdown = -2
 	total_health = 150
 	tail = "xenos_hunter_tail"
@@ -235,7 +236,7 @@
 	inherent_verbs = list(
 		/mob/living/proc/ventcrawl,
 		/mob/living/carbon/human/proc/tackle,
-		/mob/living/carbon/human/proc/gut,
+		/mob/living/carbon/human/proc/headbite,
 		/mob/living/carbon/human/proc/leap,
 		/mob/living/carbon/human/proc/psychic_whisper,
 		/mob/living/proc/devour,
@@ -246,7 +247,7 @@
 /datum/species/xenos/sentinel
 	name = "Xenomorph Sentinel"
 	weeds_plasma_rate = 10
-	caste_name = "sentinel"
+	caste_name = "Sentinel"
 	slowdown = 0
 	total_health = 125
 	tail = "xenos_sentinel_tail"
@@ -280,7 +281,7 @@
 	total_health = 250
 	weeds_heal_rate = 5
 	weeds_plasma_rate = 20
-	caste_name = "queen"
+	caste_name = "Queen"
 	slowdown = 4
 	tail = "xenos_queen_tail"
 	rarity_value = 10
@@ -300,7 +301,6 @@
 		)
 
 	inherent_verbs = list(
-		/mob/living/proc/ventcrawl,
 		/mob/living/carbon/human/proc/psychic_whisper,
 		/mob/living/proc/devour,
 		/mob/living/carbon/human/proc/regurgitate,
@@ -309,7 +309,7 @@
 		/mob/living/carbon/human/proc/transfer_plasma,
 		/mob/living/carbon/human/proc/corrosive_acid,
 		/mob/living/carbon/human/proc/neurotoxin,
-		/mob/living/carbon/human/proc/gut,
+		/mob/living/carbon/human/proc/headbite,
 		/mob/living/carbon/human/proc/resin,
 		/mob/living/carbon/human/proc/darkness_eyes
 		)
@@ -318,11 +318,15 @@
 	..()
 	// Make sure only one official queen exists at any point.
 	if(!alien_queen_exists(1,H))
-		H.real_name = "alien queen ([alien_number])"
+		H.real_name = "Queen ([alien_number])"
 		H.name = H.real_name
 	else
-		H.real_name = "alien princess ([alien_number])"
+		H.real_name = "Princess ([alien_number])"
 		H.name = H.real_name
+
+/datum/species/xenos/queen/handle_post_spawn(var/mob/living/carbon/human/H)
+	H.gender = FEMALE
+	return ..()
 
 /datum/hud_data/alien
 

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -301,6 +301,7 @@
 		)
 
 	inherent_verbs = list(
+		/mob/living/proc/ventcrawl,
 		/mob/living/carbon/human/proc/psychic_whisper,
 		/mob/living/proc/devour,
 		/mob/living/carbon/human/proc/regurgitate,

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -12,7 +12,7 @@
 	has_fine_manipulation = 0
 	siemens_coefficient = 0
 	gluttonous = TRUE
-	mouth_size = 25	// Should be larger than any human-type.
+	mouth_size = 15	// Should be larger than any human-type.
 	allowed_eat_types = TYPE_ORGANIC | TYPE_SYNTHETIC | TYPE_HUMANOID
 	mob_size = 14
 	fall_mod = 0

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -762,7 +762,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 				"<span class='moderate'><b>Your [src.name] flashes away into ashes!</b></span>",\
 				"<span class='danger'>You hear a crackling sound[gore].</span>")
 		if(DROPLIMB_BLUNT)
-			var/gore = "[(status & ORGAN_ROBOT) ? "": " in shower of gore"]"
+			var/gore = "[(status & ORGAN_ROBOT) ? "": " in a shower of gore"]"
 			var/gore_sound = "[(status & ORGAN_ROBOT) ? "rending sound of tortured metal" : "sickening splatter of gore"]"
 			owner.visible_message(
 				"<span class='danger'>\The [owner]'s [src.name] explodes[gore]!</span>",\

--- a/html/changelogs/MattAtlas-4669.yml
+++ b/html/changelogs/MattAtlas-4669.yml
@@ -1,0 +1,30 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+ author: MattAtlas
+delete-after: True
+changes: 
+  - rscadd: "Added a 'Headbite' verb for Xenomorphs."
+  - rscdel: "Removed 'Gut' verb from Xenomorph Hunters and Queens."
+  - rscdel: "Queen can no longer ventcrawl."
+  - balance: "Xenomorphs have a higher resistance to burn damage. It is still, however, much more efficient than brute damage."

--- a/html/changelogs/MattAtlas-4669.yml
+++ b/html/changelogs/MattAtlas-4669.yml
@@ -1,27 +1,4 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes: 
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   maptweak
-#   spellcheck (typo fixes)
-#   experiment
-#   balance
-#################################
- author: MattAtlas
+author: MattAtlas
 delete-after: True
 changes: 
   - rscadd: "Added a 'Headbite' verb for Xenomorphs."


### PR DESCRIPTION
Buffs xenomorphs and makes them cooler.

- Changes the names to be "Caste (number)" instead of "alien caste (1)". For example, "Hunter (1)".
- Removes gut from Hunter and Queen. Adds a Xenomorph specific verb, Headbite, that works much like devour head, but cooler.
- Changes mentions of stomach to chest in alien_embryo. It's a CHESTburster.
- Buffs their resistance to burn damage. 1.75x in a station where the main weapons are energy weapons is a bit ridicolous, allowing laser rifles to 2-3 shot sentinels.
- Fixes a typo. "X explodes in shower of gore" to "X explodes in a shower of gore". 