### PR TITLE
More Bugfixes

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -231,6 +231,7 @@
 			enabled = value
 		else if(href_list["command"] == "lethal")
 			lethal = value
+			lethal_icon = value
 		else if(href_list["command"] == "check_synth")
 			check_synth = value
 		else if(href_list["command"] == "check_weapons")

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -317,37 +317,6 @@
 	slot_flags = SLOT_EARS | SLOT_TWOEARS
 
 ///////////////////////////////////////////////////////////////////////
-//Glasses
-/*
-SEE_SELF  // can see self, no matter what
-SEE_MOBS  // can see all mobs, no matter what
-SEE_OBJS  // can see all objs, no matter what
-SEE_TURFS // can see all turfs (and areas), no matter what
-SEE_PIXELS// if an object is located on an unlit area, but some of its pixels are
-          // in a lit area (via pixel_x,y or smooth movement), can see those pixels
-BLIND     // can't see anything
-*/
-/obj/item/clothing/glasses
-	name = "glasses"
-	icon = 'icons/obj/clothing/glasses.dmi'
-	w_class = 2.0
-	body_parts_covered = EYES
-	slot_flags = SLOT_EYES
-	var/vision_flags = 0
-	var/darkness_view = 0//Base human is 2
-	var/see_invisible = -1
-	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/eyes.dmi',
-		"Resomi" = 'icons/mob/species/resomi/eyes.dmi'
-		)
-	species_restricted = list("exclude","Vaurca Breeder")
-
-/obj/item/clothing/glasses/update_clothing_icon()
-	if (ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_glasses()
-
-///////////////////////////////////////////////////////////////////////
 //Gloves
 /obj/item/clothing/gloves
 	name = "gloves"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -1,12 +1,24 @@
-
+///////////////////////////////////////////////////////////////////////
+//Glasses
+/*
+SEE_SELF  // can see self, no matter what
+SEE_MOBS  // can see all mobs, no matter what
+SEE_OBJS  // can see all objs, no matter what
+SEE_TURFS // can see all turfs (and areas), no matter what
+SEE_PIXELS// if an object is located on an unlit area, but some of its pixels are
+          // in a lit area (via pixel_x,y or smooth movement), can see those pixels
+BLIND     // can't see anything
+*/
 /obj/item/clothing/glasses
 	name = "glasses"
 	icon = 'icons/obj/clothing/glasses.dmi'
-	//w_class = 2.0
-	//slot_flags = SLOT_EYES
-	//var/vision_flags = 0
-	//var/darkness_view = 0//Base human is 2
+	w_class = 2.0
+	slot_flags = SLOT_EYES
+	body_parts_covered = EYES
+	var/vision_flags = 0
+	var/darkness_view = 0//Base human is 2
 	var/prescription = 0
+	var/see_invisible = -1
 	var/toggleable = 0
 	var/off_state = "degoggles"
 	var/active = 1
@@ -14,6 +26,17 @@
 	var/obj/screen/overlay = null
 	var/obj/item/clothing/glasses/hud/hud = null	// Hud glasses, if any
 	var/activated_color = null
+	sprite_sheets = list(
+		"Vox" = 'icons/mob/species/vox/eyes.dmi',
+		"Resomi" = 'icons/mob/species/resomi/eyes.dmi'
+		)
+	species_restricted = list("exclude","Vaurca Breeder")
+
+/obj/item/clothing/glasses/update_clothing_icon()
+	if (ismob(src.loc))
+		var/mob/M = src.loc
+		M.update_inv_glasses()
+
 
 /obj/item/clothing/glasses/attack_self(mob/user)
 	if(toggleable)

--- a/html/changelogs/Sindorman-bugfixes.yml
+++ b/html/changelogs/Sindorman-bugfixes.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes:
   - rscadd: "EMT room now has two GPS and two medical emergency medical radios"
   - maptweak: "Increased size of Toxin's airlock, allowing canister to refill from main air supply"
+  - bugfix: "Fixed tags(names) for medical construction level security cameras"

--- a/html/changelogs/Sindorman-bugfixes.yml
+++ b/html/changelogs/Sindorman-bugfixes.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - rscadd: "EMT room now has two GPS and two medical emergency medical radios"
-  - maptweak: "Increased size of Toxin's airlock, adding canister refill from main air supply"
+  - maptweak: "Increased size of Toxin's airlock, allowing canister to refill from main air supply"

--- a/html/changelogs/Sindorman-bugfixes.yml
+++ b/html/changelogs/Sindorman-bugfixes.yml
@@ -1,0 +1,7 @@
+author: PoZe
+
+delete-after: True
+
+changes:
+  - rscadd: "EMT room now has two GPS and two medical emergency medical radios"
+  - maptweak: "Increased size of Toxin's airlock, adding canister refill from main air supply"

--- a/html/changelogs/Sindorman-bugfixes.yml
+++ b/html/changelogs/Sindorman-bugfixes.yml
@@ -6,3 +6,5 @@ changes:
   - rscadd: "EMT room now has two GPS and two medical emergency medical radios"
   - maptweak: "Increased size of Toxin's airlock, allowing canister to refill from main air supply"
   - bugfix: "Fixed tags(names) for medical construction level security cameras"
+  - spellcheck: "Chemistry, and security construction levels request consoles names are fixed according to their room."
+ 

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -26221,9 +26221,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
 "Uk" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -26232,16 +26229,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
 "Ul" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
 "Um" = (
@@ -26329,6 +26327,15 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "Uw" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "toxinsairlock_airlock";
+	name = "exterior access button";
+	pixel_x = 25;
+	pixel_y = -25;
+	req_one_access = list(13,65)
+	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -26425,51 +26432,49 @@
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
 "UB" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 9
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 8
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "toxinsairlock_airlock";
-	name = "interior access button";
-	pixel_x = 0;
-	pixel_y = -25;
-	req_one_access = list(13,65)
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8;
+	name = "Distro to Canisters";
+	target_pressure = 150
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/rnd/mixing)
 "UC" = (
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/rnd/mixing)
 "UD" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
@@ -26562,7 +26567,7 @@
 "UL" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/mineral,
-/area/mine/unexplored)
+/area/rnd/mixing)
 "UM" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair{
@@ -26715,7 +26720,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/mineral,
-/area/mine/unexplored)
+/area/rnd/mixing)
 "Va" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -27208,6 +27213,42 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
+"Wi" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/simulated/floor/tiled,
+/area/rnd/mixing)
+"Wj" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/mixing)
+"Wk" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "toxinsairlock_airlock";
+	name = "interior access button";
+	pixel_x = 0;
+	pixel_y = -25;
+	req_one_access = list(13,65)
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled,
+/area/rnd/mixing)
 
 (1,1,1) = {"
 aa
@@ -43317,9 +43358,9 @@ Tm
 Ty
 Sm
 ac
-ac
-Ux
-ac
+NP
+Uy
+NP
 ac
 ac
 Ve
@@ -43575,7 +43616,7 @@ Tz
 Sm
 ac
 NP
-Uy
+Uz
 NP
 aa
 ac
@@ -43830,9 +43871,9 @@ SS
 To
 SS
 TK
-ac
 NP
-Uz
+NP
+UA
 NP
 aa
 ac
@@ -44087,9 +44128,9 @@ ST
 Tp
 TA
 NP
-NP
-NP
-UA
+TY
+Uj
+Wk
 NP
 NP
 Va
@@ -44344,8 +44385,8 @@ SU
 PV
 TB
 NP
-TY
-Uj
+Wi
+Wj
 UB
 NP
 ac
@@ -45855,7 +45896,7 @@ aa
 ac
 ac
 ac
-Wc
+Wb
 ym
 We
 BR
@@ -46111,7 +46152,7 @@ ac
 ac
 VS
 VY
-VZ
+VY
 Wd
 ym
 AF
@@ -47137,7 +47178,7 @@ ac
 ac
 ac
 ac
-VW
+VU
 yn
 yL
 zx

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -59481,14 +59481,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "bZt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "bZu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -59612,17 +59612,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "bZJ" = (
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "bZK" = (
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Cryo - Main Level";
 	dir = 2
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "bZL" = (
 /obj/machinery/cryopod,
 /obj/machinery/light{
@@ -59631,7 +59631,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "bZM" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -59838,11 +59838,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "caj" = (
 /obj/machinery/cryopod,
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "cak" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small,
@@ -60041,7 +60041,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "caB" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -60155,7 +60155,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "caU" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -63952,7 +63952,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "cip" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -63980,7 +63980,7 @@
 "cis" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "cit" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -64007,20 +64007,20 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "cix" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "ciy" = (
 /obj/machinery/cryopod,
 /obj/item/device/radio/intercom{
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "ciz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
@@ -64574,7 +64574,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "clp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -64588,11 +64588,11 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
+/area/crew_quarters/sleep/cryo)
 "clq" = (
 /obj/structure/cryofeed,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/sleep/cryo)
 "clu" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -64636,6 +64636,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
+"cly" = (
+/turf/simulated/wall,
+/area/crew_quarters/sleep/cryo)
+"clz" = (
+/turf/simulated/wall,
+/area/crew_quarters/sleep/cryo)
+"clA" = (
+/turf/simulated/wall,
+/area/crew_quarters/sleep/cryo)
+"clB" = (
+/turf/simulated/wall,
+/area/crew_quarters/sleep/cryo)
+"clC" = (
+/turf/simulated/wall,
+/area/crew_quarters/sleep/cryo)
+"clD" = (
+/turf/simulated/wall,
+/area/crew_quarters/sleep/cryo)
 
 (1,1,1) = {"
 aaa
@@ -92068,7 +92086,7 @@ bWm
 bZH
 bZH
 bZH
-bPH
+cly
 cbh
 cbz
 cbU
@@ -92325,7 +92343,7 @@ bWm
 cai
 cai
 ciw
-bPH
+clz
 cbi
 cbA
 cbV
@@ -92582,7 +92600,7 @@ bZs
 cix
 bZJ
 clo
-bPH
+clA
 bPO
 bPL
 cbW
@@ -93096,7 +93114,7 @@ bZs
 bZK
 bZJ
 clp
-bPH
+clB
 cbj
 cbB
 cbY
@@ -93353,7 +93371,7 @@ bUz
 bZL
 caj
 ciy
-bPH
+clC
 cbk
 cbC
 cbZ
@@ -93610,7 +93628,7 @@ bUz
 clq
 clq
 clq
-bMj
+clD
 bPO
 cbB
 cca

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -45867,6 +45867,12 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/item/device/radio{
+	frequency = 1487;
+	name = "Medbay Emergency Radio Link";
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "bzG" = (
@@ -46474,6 +46480,9 @@
 	},
 /obj/item/device/radio{
 	pixel_x = -5
+	},
+/obj/item/device/gps{
+	gpstag = "MED0"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -11888,12 +11888,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	icon_state = "leftsecure";
-	name = "Secure Holding Cell";
-	req_access = list(2)
-	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "avA" = (

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -46476,7 +46476,7 @@
 /obj/structure/table/standard,
 /obj/item/weapon/storage/toolbox/emergency,
 /obj/item/device/gps{
-	gpstag = "MED0"
+	gpstag = "MED1"
 	},
 /obj/item/device/radio{
 	pixel_x = -5
@@ -92343,7 +92343,7 @@ bWm
 cai
 cai
 ciw
-clz
+cly
 cbi
 cbA
 cbV
@@ -92600,7 +92600,7 @@ bZs
 cix
 bZJ
 clo
-clA
+cly
 bPO
 bPL
 cbW
@@ -93114,7 +93114,7 @@ bZs
 bZK
 bZJ
 clp
-clB
+cly
 cbj
 cbB
 cbY
@@ -93371,7 +93371,7 @@ bUz
 bZL
 caj
 ciy
-clC
+cly
 cbk
 cbC
 cbZ
@@ -93628,7 +93628,7 @@ bUz
 clq
 clq
 clq
-clD
+cly
 bPO
 cbB
 cca

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -35457,7 +35457,7 @@
 	dir = 5
 	},
 /obj/machinery/requests_console{
-	department = "Psychiatrist's Desk";
+	department = "Chemist's Desk";
 	departmentType = 1;
 	pixel_x = 32;
 	pixel_y = 0

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -2779,7 +2779,10 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/machinery/camera/network/medbay,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Psychiatry Hallway";
+	network = list("Medical")
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "fg" = (
@@ -5369,10 +5372,10 @@
 	},
 /obj/machinery/firealarm/west,
 /obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Isolation Room";
+	c_tag = "Medical - Psychaitry Patient Room";
 	dir = 4;
 	icon_state = "camera";
-	network = list("Medical","Isolation Room")
+	network = list("Medical")
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
@@ -5499,7 +5502,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/camera/network/medbay,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Psychaitry Closet";
+	network = list("Medical")
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/psych)
 "jQ" = (
@@ -5507,7 +5513,10 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/machinery/camera/network/medbay,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Psychiatry Waiting";
+	network = list("Medical")
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "jR" = (
@@ -5988,10 +5997,10 @@
 /area/medical/psych)
 "kH" = (
 /obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Isolation Room";
+	c_tag = "Medical - Psychaitry Isolation Room";
 	dir = 4;
 	icon_state = "camera";
-	network = list("Medical","Isolation Room")
+	network = list("Medical")
 	},
 /turf/simulated/floor/reinforced,
 /area/medical/psych)
@@ -6529,10 +6538,10 @@
 	dir = 1
 	},
 /obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Isolation Room";
+	c_tag = "Medical - Psychaitry Isolation Room Entrance";
 	dir = 4;
 	icon_state = "camera";
-	network = list("Medical","Isolation Room")
+	network = list("Medical")
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -2794,7 +2794,7 @@
 	dir = 4
 	},
 /obj/machinery/requests_console{
-	department = "Forensic Technician";
+	department = "Security Weights Room";
 	departmentType = 5;
 	pixel_x = 0;
 	pixel_y = -32
@@ -4395,7 +4395,7 @@
 	dir = 1
 	},
 /obj/machinery/requests_console{
-	department = "Forensic Technician";
+	department = "Theoretical Training Room";
 	departmentType = 5;
 	pixel_x = 0;
 	pixel_y = -32


### PR DESCRIPTION
- Changed name of Chemistry request console. Fixed #4670 Fixed #4678 

- Deleted duplicate windoor in the brig. Fixed #4419 

- Added one more GPS and emergency medical radio link to EMT room. Fixed #4380 

- Replaced area of Mainlevel Cryostorage from primary hallway to cryostorage. Fixed #4290 

- Increased size of Toxin's airlock, adding ability to refill canister from main oxygen supply by using air distro that is used in Mining and Xenoarcheology airlocks. Fixed #4145 
![2018-04-30 2](https://user-images.githubusercontent.com/25555314/39442424-f8227c72-4c65-11e8-8522-74355ee4e7da.png)

- Changed c_tags for cameras in Medical construction level. Fixed #4677 

- Merged two definitions of glasses into one.
- Renamed few Request consoles in security construction level according to their room names. Fixed #4687 

- Fixed turrets without control panel not updating their lethal sprite in lethal mode.