### PR TITLE
Fixed the Stack Machine from eating Materials

### DIFF
--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -123,9 +123,10 @@
 		var/turf/T = get_turf(input)
 		for(var/obj/item/O in T)
 			if(!O) return
-			if(istype(O, /obj/item/stack) && stack_storage[O.type] != null)
-				stack_storage[O.type]++
-				qdel(O)
+			var/obj/item/stack/S = O
+			if(istype(S) && stack_storage[S.type] != null)
+				stack_storage[S.type] += S.amount
+				qdel(S)
 			else
 				O.forceMove(output.loc)
 

--- a/html/changelogs/burgerbb-holy_fuck.yml
+++ b/html/changelogs/burgerbb-holy_fuck.yml
@@ -1,0 +1,6 @@
+author: BurgerBB
+
+delete-after: True
+
+changes: 
+  - rscadd: "Fixes the stacking machine from eating materials due to an oversight."


### PR DESCRIPTION
# Overview
The stacker was coded to accept 1 sheet at a time, meaning that if you insert a stack of 50 sheets into the stacker, it will count that as only 1 sheet because people don't know how to code.