### PR TITLE
Fixes resisting out of grabs while hypnotized (or stunned)

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -676,16 +676,16 @@ default behaviour is:
 /mob/living/proc/escape_buckle()
 	if(buckled)
 		buckled.user_unbuckle_mob(src)
-+
+
 /mob/living/var/last_resist
-+
+
  /mob/living/proc/resist_grab()
-+	if (last_resist + 4 > world.time)
-+		return
-+	last_resist = world.time
-+	if (stat || paralysis || stunned)
-+		src << "<span class='notice'>You can't move...</span>"
-+		return
+	if (last_resist + 4 > world.time)
+		return
+	last_resist = world.time
+	if (stat || paralysis || stunned)
+		src << "<span class='notice'>You can't move...</span>"
+		return
 	var/resisting = 0
 	for(var/obj/O in requests)
 		requests.Remove(O)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -676,8 +676,16 @@ default behaviour is:
 /mob/living/proc/escape_buckle()
 	if(buckled)
 		buckled.user_unbuckle_mob(src)
-
-/mob/living/proc/resist_grab()
++
+/mob/living/var/last_resist
++
+ /mob/living/proc/resist_grab()
++	if (last_resist + 4 > world.time)
++		return
++	last_resist = world.time
++	if (stat || paralysis || stunned)
++		src << "<span class='notice'>You can't move...</span>"
++		return
 	var/resisting = 0
 	for(var/obj/O in requests)
 		requests.Remove(O)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -679,7 +679,7 @@ default behaviour is:
 
 /mob/living/var/last_resist
 
- /mob/living/proc/resist_grab()
+/mob/living/proc/resist_grab()
 	if (last_resist + 4 > world.time)
 		return
 	last_resist = world.time

--- a/html/changelogs/Changelog - NoResistance.yml
+++ b/html/changelogs/Changelog - NoResistance.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "No longer can your victims resist their way out of a good sucking after being hypnotized by your vampire."


### PR DESCRIPTION
Previously, people could resist spam their way out of grabs while hypnotized, causing vampires to have to eat shit and die for trying to use their basic solo target abilities.

This was due to there being no special exceptions in place for resisting out of a grab when you are stunned.

Fixes #4689