### PR TITLE
Reverts alcohol changes partially

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -52,9 +52,9 @@ var/list/cheartstopper = list("potassium_chloride")                       // Thi
 #define INTOX_DEATH      0.45
 
 //How many units of intoxication to remove per second
-#define INTOX_FILTER_HEALTHY 0.015
-#define INTOX_FILTER_BRUISED 0.010
-#define INTOX_FILTER_DAMAGED 0.05
+#define INTOX_FILTER_HEALTHY 0.035
+#define INTOX_FILTER_BRUISED 0.02
+#define INTOX_FILTER_DAMAGED 0.010
 
 #define	BASE_DIZZY 50 //Base dizziness from getting drunk.
 #define DIZZY_ADD_SCALE 15 //Amount added for every 0.01 percent over the JUDGEIMP limit

--- a/code/modules/mob/living/carbon/human/intoxication.dm
+++ b/code/modules/mob/living/carbon/human/intoxication.dm
@@ -136,7 +136,7 @@ var/mob/living/carbon/human/alcohol_clumsy = 0
 
 /datum/modifier/drunk/custom_validity()
 	var/mob/living/carbon/human/H = target
-	if(istype(H))
+	if(!istype(H))
 		return 0
 	if(H.get_blood_alcohol() >= INTOX_MUSCLEIMP*H.species.ethanol_resistance)
 		return 1

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -130,7 +130,7 @@
 
 /datum/reagent/alcohol/affect_ingest(mob/living/carbon/M, alien, removed)
 
-	M.intoxication += (strength * removed) * 0.075
+	M.intoxication += (strength / 100) * removed
 
 	if (druggy != 0)
 		M.druggy = max(M.druggy, druggy)


### PR DESCRIPTION
* Restores old rates of gaining and losing intoxication.
The strength of alcohol was implemented with the original formula in mind, you cannot simply add another curve and expect it to fit. The rate of getting drunk was way too fast (increased 7 fold!). I also doubled the rate of losing alcohol, since gains and losses typically work in balance with one another.
* Fixes a bug which spammed, "You're drunk"

@BurgerLUA The reason why we don't have monolith PRs is because it was a tremendous bitch to hop between the separate lines while I was doing the maths backwards in your PR.
