### PR TITLE
Removing tourettes

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -75,22 +75,6 @@
 	owner.disabilities &= ~UNINTELLIGIBLE
 	..()
 
-/datum/brain_trauma/mild/tourettes
-	name = "Tourettes Syndrome"
-	desc = "Patient is compelled to vulgarity."
-	scan_desc = "vulgarity problem"
-	gain_text = "Your mind fills with foul language!"
-	lose_text = "Your mind returns to decency."
-	cure_type = CURE_CRYSTAL
-
-/datum/brain_trauma/mild/tourettes/on_gain()
-	owner.disabilities |= TOURETTES
-	..()
-
-/datum/brain_trauma/mild/tourettes/on_lose()
-	owner.disabilities &= ~TOURETTES
-	..()
-
 /datum/brain_trauma/mild/gertie
 	name = "Gerstmann Syndrome"
 	desc = "Patient displays severe left right disorientation."

--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -84,14 +84,6 @@
 	New()
 		block=CLUMSYBLOCK
 
-/datum/dna/gene/disability/tourettes
-	name="Tourettes"
-	activation_message="You twitch."
-	disability=TOURETTES
-
-	New()
-		block=TWITCHBLOCK
-
 /datum/dna/gene/disability/nervousness
 	name="Nervousness"
 	activation_message="You feel nervous."

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -1316,7 +1316,7 @@
 				In your tenure as a psychiatrist aboard your assigned station you will likely encounter those affected by brain damage. Science in this regard has progressed, and in your disposal are several tools to cure these addled men and women. Keep in mind these bulletins:
 				<ul>
 					<li>1: Always talk to your patient first. Doctor-patient counseling is often necessary to get a good diagnosis of the patient's psychoma, and not to mention it can go a long way to comforting them. Never start treatment without counseling!</li>
-					<li>2: Some of the most common traumas you find will be those that affect the patient's physical actions, such as seizures or tourettes. These are typically remedied with 'chakra' therapy.</li>
+					<li>2: Some of the most common traumas you find will be those that affect the patient's physical actions, such as seizures. These are typically remedied with 'chakra' therapy.</li>
 					<li>3: The next most common traumas are those that affect the patient's behavior, such as phobias. These can be solved with hypnosis therapy.</li>
 					<li>4: Beyond those two, some traumas may cause the patient to hallucinate. These are best solved with isolation therapy.</li>
 					<li>5: Finally, some traumas escape easy categorization. In a few cases they can be solved with invasive brain surgery, but some traumas may only be suppressable with drug therapy.<br></li>

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -823,7 +823,7 @@
 /datum/reagent/mental/risperidone
 	name = "Risperidone"
 	id = "risperidone"
-	description = "Risperidone is a potent antipsychotic medication used to treat schizophrenia, stuttering, speech impediment, monophobia, hallucinations, tourettes, and muscle spasms. Side effects are common and include pacifism. Withdrawl symptoms are dangerous and almost always occur."
+	description = "Risperidone is a potent antipsychotic medication used to treat schizophrenia, stuttering, speech impediment, monophobia, hallucinations, and muscle spasms. Side effects are common and include pacifism. Withdrawl symptoms are dangerous and almost always occur."
 	reagent_state = LIQUID
 	color = "#888888"
 	metabolism = 0.02
@@ -840,7 +840,6 @@
 		/datum/brain_trauma/severe/monophobia = 10,
 		/datum/brain_trauma/mild/hallucinations = 10,
 		/datum/brain_trauma/mild/muscle_spasms = 20,
-		/datum/brain_trauma/mild/tourettes = 20
 	)
 	dosage_traumas = list(
 		/datum/brain_trauma/severe/pacifism = 25
@@ -849,7 +848,6 @@
 		/datum/brain_trauma/mild/hallucinations = 100,
 		/datum/brain_trauma/severe/split_personality = 10,
 		/datum/brain_trauma/special/imaginary_friend = 20,
-		/datum/brain_trauma/mild/tourettes = 50,
 		/datum/brain_trauma/severe/monophobia = 50
 	)
 	suppressing_reagents = list(
@@ -862,7 +860,7 @@
 /datum/reagent/mental/olanzapine
 	name = "Olanzapine"
 	id = "olanzapine"
-	description = "Olanzapine is a high-strength, expensive antipsychotic medication used to treat schizophrenia, stuttering, speech impediment, monophobia, hallucinations, tourettes, and muscle spasms. Side effects are common and include pacifism. The medication metabolizes quickly, and withdrawl is dangerous."
+	description = "Olanzapine is a high-strength, expensive antipsychotic medication used to treat schizophrenia, stuttering, speech impediment, monophobia, hallucinations, and muscle spasms. Side effects are common and include pacifism. The medication metabolizes quickly, and withdrawl is dangerous."
 	reagent_state = LIQUID
 	color = "#888888"
 	metabolism = 0.02
@@ -878,7 +876,6 @@
 		/datum/brain_trauma/mild/speech_impediment = 5,
 		/datum/brain_trauma/severe/monophobia = 5,
 		/datum/brain_trauma/mild/muscle_spasms = 10,
-		/datum/brain_trauma/mild/tourettes = 20
 	)
 	dosage_traumas = list(
 		/datum/brain_trauma/severe/pacifism = 25
@@ -898,7 +895,7 @@
 /datum/reagent/mental/hextrasenil
 	name = "Hextrasenil"
 	id = "hextrasenil"
-	description = "Hextrasenil is a super-strength, fast-metabolizing, expensive antipsychotic medication intended for the use in criminal rehabilitation that treats tourettes, schizophrenia, hallucinations, and loyalty issues. Side effects include undying loyalty to NanoTrasen and respect for authority. Withdrawl effects include undying hatred towards NanoTrasen."
+	description = "Hextrasenil is a super-strength, fast-metabolizing, expensive antipsychotic medication intended for the use in criminal rehabilitation that treats, schizophrenia, hallucinations, and loyalty issues. Side effects include undying loyalty to NanoTrasen and respect for authority. Withdrawl effects include undying hatred towards NanoTrasen."
 	reagent_state = LIQUID
 	color = "#888888"
 	metabolism = 0.04 //Not meant to last a long time.
@@ -910,7 +907,6 @@
 	suppress_traumas  = list(
 		/datum/brain_trauma/severe/split_personality = 5, //Gotta remove those enemies to nanotrasen.
 		/datum/brain_trauma/special/imaginary_friend = 5,
-		/datum/brain_trauma/mild/tourettes = 5
 	)
 	dosage_traumas = list(
 		/datum/brain_trauma/severe/pacifism = 25
@@ -945,9 +941,7 @@
 	goodmessage = list("You feel like you have nothing to hide.","You feel compelled to spill your secrets.","You feel like you can trust those around you.")
 	badmessage = list()
 	worstmessage = list()
-	suppress_traumas  = list(
-		/datum/brain_trauma/mild/tourettes = 1
-	)
+	suppress_traumas  = list()
 	dosage_traumas = list(
 		/datum/brain_trauma/severe/pacifism = 25
 	)

--- a/html/changelogs/Changelog - Tourettes.yml
+++ b/html/changelogs/Changelog - Tourettes.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rsdel: "After PISS consideration, CUNT has removed tourettes SHIT the game."


### PR DESCRIPTION
Removes the tourettes trauma from the game.

It's disruptive and obnoxious, and encourages spamming in the playerbase whenever it comes up.  It's also got very little to do with the actual disability it's referencing as it's written.

I would have tried rewriting it, but I can't actually seem to find any files that let me modify the behavior of the disability.  I assume they are serverside.  So I just removed the game's references to it so it won't show up.