### PR TITLE
Destroy for oxy candles

### DIFF
--- a/code/game/objects/items/devices/oxycandle.dm
+++ b/code/game/objects/items/devices/oxycandle.dm
@@ -71,3 +71,8 @@
 		item_state = icon_state
 		set_light(0)
 	update_held_icon()
+
+/obj/item/device/oxycandle/Destroy()
+	QDEL_NULL(air_contents)
+	STOP_PROCESSING(SSprocessing, src)
+	. = ..()


### PR DESCRIPTION
Apparently, I missed adding clean destroy to `oxycandle`. This adds it!