### PR TITLE
More bugfixes

### DIFF
--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -4,53 +4,7 @@
 
 // #define EMPDEBUG 10
 
-proc/empulse(turf/epicenter, heavy_range, light_range, log=FALSE)
-	if(!epicenter) return
-
-	if(!istype(epicenter, /turf))
-		epicenter = get_turf(epicenter.loc)
-
-	if(log)
-		message_admins("EMP with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
-		log_game("EMP with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
-
-	if(heavy_range > 1)
-		var/obj/effect/overlay/pulse = new /obj/effect/overlay(epicenter)
-		pulse.icon = 'icons/effects/effects.dmi'
-		pulse.icon_state = "emppulse"
-		pulse.name = "emp pulse"
-		pulse.anchored = 1
-		QDEL_IN(pulse, 20)
-
-	if(heavy_range > light_range)
-		light_range = heavy_range
-
-	for(var/mob/M in range(heavy_range, epicenter))
-		M << 'sound/effects/EMPulse.ogg'
-
-	for(var/atom/T in range(light_range, epicenter))
-		#ifdef EMPDEBUG
-		var/time = world.timeofday
-		#endif
-		var/distance = get_dist(epicenter, T)
-		if(distance < 0)
-			distance = 0
-		if(distance < heavy_range)
-			T.emp_act(1)
-		else if(distance == heavy_range)
-			if(prob(50))
-				T.emp_act(1)
-			else
-				T.emp_act(2)
-		else if(distance <= light_range)
-			T.emp_act(2)
-		#ifdef EMPDEBUG
-		if((world.timeofday - time) >= EMPDEBUG)
-			log_and_message_admins("EMPDEBUG: [T.name] - [T.type] - took [world.timeofday - time]ds to process emp_act()!")
-		#endif
-	return 1
-
-proc/empulse_exclusive(turf/epicenter, heavy_range, light_range, log=FALSE, list/exclude)
+proc/empulse(turf/epicenter, heavy_range, light_range, list/exclude, log=FALSE)
 	if(!epicenter) return
 
 	if(!istype(epicenter, /turf))
@@ -93,3 +47,4 @@ proc/empulse_exclusive(turf/epicenter, heavy_range, light_range, log=FALSE, list
 		if((world.timeofday - time) >= EMPDEBUG)
 			log_and_message_admins("EMPDEBUG: [epicenter.name] - [epicenter.type] - took [world.timeofday - time]ds to process emp_act()!")
 		#endif
+	return 1

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -4,7 +4,7 @@
 
 // #define EMPDEBUG 10
 
-proc/empulse(turf/epicenter, heavy_range, light_range, log=0)
+proc/empulse(turf/epicenter, heavy_range, light_range, log=FALSE)
 	if(!epicenter) return
 
 	if(!istype(epicenter, /turf))
@@ -49,3 +49,47 @@ proc/empulse(turf/epicenter, heavy_range, light_range, log=0)
 			log_and_message_admins("EMPDEBUG: [T.name] - [T.type] - took [world.timeofday - time]ds to process emp_act()!")
 		#endif
 	return 1
+
+proc/empulse_exclusive(turf/epicenter, heavy_range, light_range, log=FALSE, list/exclude)
+	if(!epicenter) return
+
+	if(!istype(epicenter, /turf))
+		epicenter = get_turf(epicenter.loc)
+
+	if(log)
+		message_admins("EMP with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
+		log_game("EMP with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
+
+	if(heavy_range > 1)
+		var/obj/effect/overlay/pulse = new /obj/effect/overlay(epicenter)
+		pulse.icon = 'icons/effects/effects.dmi'
+		pulse.icon_state = "emppulse"
+		pulse.name = "emp pulse"
+		pulse.anchored = 1
+		QDEL_IN(pulse, 20)
+
+	for(var/mob/M in range(heavy_range, epicenter))
+		M << 'sound/effects/EMPulse.ogg'
+
+	for(var/atom/A in range(light_range, epicenter))
+		#ifdef EMPDEBUG
+		var/time = world.timeofday
+		#endif
+		if(exclude && (A in exclude))
+			continue
+		var/distance = get_dist(epicenter, A)
+		if(distance < 0)
+			distance = 0
+		if(distance < heavy_range)
+			A.emp_act(1)
+		else if(distance == heavy_range)
+			if(prob(50))
+				A.emp_act(1)
+			else
+				A.emp_act(2)
+		else if(distance <= light_range)
+			A.emp_act(2)
+		#ifdef EMPDEBUG
+		if((world.timeofday - time) >= EMPDEBUG)
+			log_and_message_admins("EMPDEBUG: [epicenter.name] - [epicenter.type] - took [world.timeofday - time]ds to process emp_act()!")
+		#endif

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -4,7 +4,7 @@
 
 // #define EMPDEBUG 10
 
-proc/empulse(turf/epicenter, heavy_range, light_range, log=FALSE, list/exclude=null)
+proc/empulse(turf/epicenter, heavy_range, light_range, log = FALSE, list/exclude = null)
 	if(!epicenter) return
 
 	if(!istype(epicenter, /turf))

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -4,7 +4,7 @@
 
 // #define EMPDEBUG 10
 
-proc/empulse(turf/epicenter, heavy_range, light_range, list/exclude, log=FALSE)
+proc/empulse(turf/epicenter, heavy_range, light_range, log=FALSE, list/exclude=null)
 	if(!epicenter) return
 
 	if(!istype(epicenter, /turf))
@@ -45,6 +45,6 @@ proc/empulse(turf/epicenter, heavy_range, light_range, list/exclude, log=FALSE)
 			A.emp_act(2)
 		#ifdef EMPDEBUG
 		if((world.timeofday - time) >= EMPDEBUG)
-			log_and_message_admins("EMPDEBUG: [epicenter.name] - [epicenter.type] - took [world.timeofday - time]ds to process emp_act()!")
+			log_and_message_admins("EMPDEBUG: [A.name] - [A.type] - took [world.timeofday - time]ds to process emp_act()!")
 		#endif
 	return 1

--- a/code/modules/spells/aoe_turf/disable_tech.dm
+++ b/code/modules/spells/aoe_turf/disable_tech.dm
@@ -19,11 +19,9 @@
 	hud_state = "wiz_tech"
 
 /spell/aoe_turf/disable_tech/cast(list/targets, mob/user)
-	var/list/ex = list()
-	ex += user
 
 	for(var/turf/target in targets)
-		empulse(get_turf(target), emp_heavy, emp_light, log = TRUE, exclude = ex)
+		empulse(get_turf(target), emp_heavy, emp_light, log = TRUE, exclude = list(user))
 	return
 
 /spell/aoe_turf/disable_tech/empower_spell()

--- a/code/modules/spells/aoe_turf/disable_tech.dm
+++ b/code/modules/spells/aoe_turf/disable_tech.dm
@@ -23,7 +23,7 @@
 	ex += user
 
 	for(var/turf/target in targets)
-		empulse_exclusive(get_turf(target), emp_heavy, emp_light, TRUE, ex)
+		empulse(get_turf(target), emp_heavy, emp_light, ex, TRUE)
 	return
 
 /spell/aoe_turf/disable_tech/empower_spell()

--- a/code/modules/spells/aoe_turf/disable_tech.dm
+++ b/code/modules/spells/aoe_turf/disable_tech.dm
@@ -23,7 +23,7 @@
 	ex += user
 
 	for(var/turf/target in targets)
-		empulse(get_turf(target), emp_heavy, emp_light, ex, TRUE)
+		empulse(get_turf(target), emp_heavy, emp_light, log = TRUE, exclude = ex)
 	return
 
 /spell/aoe_turf/disable_tech/empower_spell()

--- a/code/modules/spells/aoe_turf/disable_tech.dm
+++ b/code/modules/spells/aoe_turf/disable_tech.dm
@@ -10,7 +10,7 @@
 	range = 0
 	inner_radius = -1
 	cast_sound = 'sound/magic/Disable_Tech.ogg'
-	
+
 	cooldown_min = 200 //50 deciseconds reduction per rank
 
 	var/emp_heavy = 3
@@ -18,10 +18,12 @@
 
 	hud_state = "wiz_tech"
 
-/spell/aoe_turf/disable_tech/cast(list/targets)
+/spell/aoe_turf/disable_tech/cast(list/targets, mob/user)
+	var/list/ex = list()
+	ex += user
 
 	for(var/turf/target in targets)
-		empulse(get_turf(target), emp_heavy, emp_light)
+		empulse_exclusive(get_turf(target), emp_heavy, emp_light, TRUE, ex)
 	return
 
 /spell/aoe_turf/disable_tech/empower_spell()

--- a/html/changelogs/Sindorman-bugfixes.yml
+++ b/html/changelogs/Sindorman-bugfixes.yml
@@ -2,5 +2,5 @@ author: PoZe
 
 delete-after: True
 
-changes: 
-  - bugfix: "Wizard disable technology no longer affects caster(wizard), making wizard IPC not take damage. It does still damage other wizard IPC, who is not caster."
+changes:
+  - bugfix: "Wizard disable technology spell no longer affects the caster."

--- a/html/changelogs/Sindorman-bugfixes.yml
+++ b/html/changelogs/Sindorman-bugfixes.yml
@@ -1,0 +1,6 @@
+author: PoZe
+
+delete-after: True
+
+changes: 
+  - bugfix: "Wizard disable technology no longer affects caster(wizard), making wizard IPC not take damage. It does still damage other wizard IPC, who is not caster."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -10522,7 +10522,7 @@
 	},
 /area/centcom/specops)
 "axY" = (
-/obj/machinery/porta_turret,
+/obj/machinery/porta_turret/crescent,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -64691,6 +64691,15 @@
 "cqY" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep/cryo)
+"cqZ" = (
+/obj/structure/table/steel,
+/obj/item/weapon/screwdriver{
+	pixel_y = 16
+	},
+/obj/item/weapon/crowbar,
+/obj/item/weapon/wrench,
+/turf/simulated/floor/tiled/dark,
+/area/janitor)
 
 (1,1,1) = {"
 aaa
@@ -80756,7 +80765,7 @@ bbZ
 bdv
 beJ
 beJ
-cog
+cqZ
 bbZ
 cog
 aKi


### PR DESCRIPTION
- Made generic empulse_exclusive which takes list of atoms that needs to be excluded.

- Wizard `disable technology`(emp) spell uses empulse_exclusive with caster being excluded from being EMPed. This will allow IPC wizard not damage themselves with cast. But it will still damage other wizard IPCs. 

- Added screwdriver, crowbar and a wrench to janitor's closet. Fixed #4755

- Replaced turrets in ERT ready room with cencomm check turrets. Fixed #4742