### PR TITLE
Fixes Vending Machines unable to take stock

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -23,6 +23,7 @@
 	icon_state = "boozeomat"        //////////////18 drink entities below, plus the glasses, in case someone wants to edit the number of bottles
 	icon_deny = "boozeomat-deny"
 	vend_id = "booze"
+	restock_items = 1
 	products = list(
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/gin = 5,
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey = 5,
@@ -93,6 +94,7 @@
 		/obj/item/device/assembly/timer = 2
 	)
 	product_ads = "Only the finest!;Have some tools.;The most robust equipment.;The finest gear in space!"
+	restock_items = 1
 
 /obj/machinery/vending/coffee
 	name = "Hot Drinks machine"
@@ -117,7 +119,6 @@
 		/obj/item/weapon/reagent_containers/food/drinks/tea = 20,
 		/obj/item/weapon/reagent_containers/food/drinks/h_chocolate = 22
 	)
-
 
 /obj/machinery/vending/snack
 	name = "Getmore Chocolate Corp"
@@ -160,7 +161,6 @@
 		/obj/item/weapon/reagent_containers/food/snacks/nathisnack = 24,
 		/obj/item/weapon/reagent_containers/food/snacks/koisbar_clean = 60
 	)
-
 
 /obj/machinery/vending/cola
 	name = "Robust Softdrinks"
@@ -218,6 +218,7 @@
 		/obj/item/weapon/cartridge/captain = 3,
 		/obj/item/weapon/cartridge/quartermaster = 10
 	)
+	restock_items = 1
 
 
 /obj/machinery/vending/cigarette
@@ -247,7 +248,6 @@
 		/obj/item/weapon/flame/lighter/random = 12,
 		/obj/item/weapon/spacecash/ewallet/lotto = 200
 	)
-
 
 /obj/machinery/vending/medical
 	name = "NanoMed Plus"
@@ -279,7 +279,6 @@
 	)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 
-
 //This one's from bay12
 /obj/machinery/vending/phoronresearch
 	name = "Toximate 3000"
@@ -295,6 +294,7 @@
 		/obj/item/device/assembly/prox_sensor = 6,
 		/obj/item/device/assembly/igniter = 6
 	)
+	restock_items = 1
 
 /obj/machinery/vending/wallmed1
 	name = "NanoMed"
@@ -349,7 +349,6 @@
 		/obj/item/weapon/handcuffs = 8,
 		/obj/item/weapon/grenade/chem_grenade/teargas = 4,
 		/obj/item/device/flash = 5,
-		/obj/item/weapon/reagent_containers/food/snacks/donut/normal = 12,
 		/obj/item/weapon/storage/box/evidence = 6,
 		/obj/item/device/holowarrant = 5
 	)
@@ -360,6 +359,7 @@
 		/obj/item/clothing/glasses/sunglasses = 2,
 		/obj/item/weapon/grenade/flashbang = 4
 	)
+	restock_items = 1
 
 /obj/machinery/vending/hydronutrients
 	name = "NutriMax"
@@ -384,6 +384,7 @@
 	contraband = list(
 		/obj/item/weapon/reagent_containers/glass/bottle/mutagen = 2
 	)
+	restock_items = 1
 
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 
@@ -524,9 +525,7 @@
 		/obj/item/clothing/shoes/sandal = 1,
 		/obj/item/weapon/staff = 2
 	)
-	contraband = list(
-		/obj/item/weapon/reagent_containers/glass/bottle/wizarditis = 1
-	)	//No one can get to the machine to hack it anyways; for the lulz - Microwave
+	restock_items = 1
 
 /obj/machinery/vending/dinnerware
 	name = "Dinnerware"
@@ -551,6 +550,7 @@
 		/obj/item/weapon/material/knife/butch = 2,
 		/obj/item/weapon/storage/toolbox/lunchbox/syndicate = 2
 	)
+	restock_items = 1
 
 /obj/machinery/vending/sovietsoda
 	name = "BODA"
@@ -594,6 +594,7 @@
 	premium = list(
 		/obj/item/clothing/gloves/yellow = 1
 	)
+	restock_items = 1
 
 /obj/machinery/vending/engivend
 	name = "Engi-Vend"
@@ -617,6 +618,7 @@
 	premium = list(
 		/obj/item/weapon/storage/belt/utility = 3
 	)
+	restock_items = 1
 
 /obj/machinery/vending/tacticool //Tried not to go overboard with the amount of fun security has access to.
 	name = "Tactical Express"
@@ -699,6 +701,7 @@
 	// There was an incorrect entry (cablecoil/power).  I improvised to cablecoil/heavyduty.
 	// Another invalid entry, /obj/item/weapon/circuitry.  I don't even know what that would translate to, removed it.
 	// The original products list wasn't finished.  The ones without given quantities became quantity 5.  -Sayu
+	restock_items = 1
 
 //This one's from bay12
 /obj/machinery/vending/robotics
@@ -725,6 +728,7 @@
 		/obj/item/weapon/crowbar = 5
 	)
 	//everything after the power cell had no amounts, I improvised.  -Sayu
+	restock_items = 1
 
 //RECURSION
 /obj/machinery/vending/vendors
@@ -747,5 +751,4 @@
 		/obj/item/weapon/vending_refill/hydro = 1,
 		/obj/item/weapon/vending_refill/cutlery = 1,
 		/obj/item/weapon/vending_refill/robo = 1
-
 	)

--- a/html/changelogs/burgerbb-vendorfix.yml
+++ b/html/changelogs/burgerbb-vendorfix.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed some non-public vendors refusing to accept items."
+  - maptweak: "Removed the additonal seed vendor due to redundancy."
+

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -2224,8 +2224,11 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aet" = (
+/obj/machinery/vending/hydroseeds{
+	prices = list();
+	restock_items = 1
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/smartfridge/seeds,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "aeu" = (
@@ -2316,6 +2319,27 @@
 	dir = 4
 	},
 /area/security/brig)
+"aeD" = (
+/obj/item/weapon/material/hatchet,
+/obj/item/weapon/material/minihoe,
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/table/standard,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/obj/item/watertank,
+/obj/item/weapon/screwdriver,
+/obj/item/weapon/wrench,
+/obj/item/weapon/shovel/spade,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "aeE" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2585,6 +2609,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"afd" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/hydronutrients,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "afe" = (
 /turf/simulated/wall/r_wall,
 /area/security/investigations)
@@ -2731,6 +2760,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"afy" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/seed_extractor,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "afC" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -63946,23 +63980,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"coL" = (
-/obj/item/weapon/material/hatchet,
-/obj/item/weapon/material/minihoe,
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/table/standard,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
 "coM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64254,24 +64271,6 @@
 /obj/item/weapon/reagent_containers/glass/bucket/wood,
 /turf/simulated/floor/holofloor/wood,
 /area/hydroponics)
-"cpx" = (
-/obj/machinery/vending/hydroseeds{
-	prices = list()
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
-"cpy" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
-"cpz" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/standard,
-/obj/item/watertank,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
 "cpC" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/machinery/light{
@@ -64295,11 +64294,6 @@
 /area/hydroponics)
 "cpI" = (
 /obj/machinery/biogenerator,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
-"cpJ" = (
-/obj/machinery/seed_extractor,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
@@ -89286,7 +89280,7 @@ bdJ
 bRL
 col
 coy
-coL
+aeD
 coW
 cpi
 cpr
@@ -91088,7 +91082,7 @@ coF
 bSL
 cpc
 bSL
-cpx
+aet
 cpI
 bSQ
 cqe
@@ -91345,8 +91339,8 @@ coG
 abE
 cpd
 cpo
-cpy
-cpJ
+cpo
+cpo
 cpU
 cqf
 bWm
@@ -91602,8 +91596,8 @@ coH
 adu
 adz
 bSL
-cpz
-aet
+afd
+afy
 bSQ
 cqg
 bRL


### PR DESCRIPTION
# Overview
Vending machines couldn't be restock due to a new variable being introduced that prevents vending machines from being restocked. Now, private vending machines such as seed storage units and booze-o-mats can now be restocked. Public ones like soda machines can't.

Tweaked the Garden to reflect this bug change.

Fixes #4743