### PR TITLE
Extra auto-dresser

### DIFF
--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -8133,13 +8133,20 @@
 	},
 /area/centcom/living)
 "atb" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/snack{
+	name = "Free Chocolate Corp";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/centcom/living)
 "atc" = (
 /obj/machinery/vending/cola,
+/obj/machinery/vending/cola{
+	name = "Free Robust Softdrinks";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -12573,7 +12580,7 @@
 /area/centcom/specops)
 "aBL" = (
 /obj/machinery/vending/snack{
-	name = "hacked Getmore Chocolate Corp";
+	name = "Free Chocolate Corp";
 	prices = list()
 	},
 /turf/unsimulated/floor{
@@ -12672,7 +12679,7 @@
 /area/centcom/specops)
 "aBY" = (
 /obj/machinery/vending/cola{
-	name = "Robust Softdrinks";
+	name = "Free Robust Softdrinks";
 	prices = list()
 	},
 /turf/unsimulated/floor{
@@ -12739,7 +12746,7 @@
 /area/shuttle/specops/centcom)
 "aCh" = (
 /obj/machinery/vending/cigarette{
-	name = "cigarette machine";
+	name = "Free Cigarette Machine";
 	prices = list()
 	},
 /turf/unsimulated/floor{
@@ -15939,7 +15946,10 @@
 	},
 /area/centcom/holding)
 "aJv" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	name = "Free Hot Drinks machine";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "green";
 	dir = 4
@@ -16190,7 +16200,10 @@
 	},
 /area/centcom/holding)
 "aJW" = (
-/obj/machinery/vending/cigarette,
+/obj/machinery/vending/cigarette{
+	name = "Free Cigarette Machine";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "green";
 	dir = 4
@@ -18517,7 +18530,8 @@
 	icon_state = "floor"
 	},
 /obj/machinery/vending/snack{
-	can_move = 0
+	name = "Free Chocolate Corp";
+	prices = list()
 	},
 /turf/unsimulated/floor{
 	icon_state = "wood_siding4"
@@ -18614,7 +18628,8 @@
 	icon_state = "floor"
 	},
 /obj/machinery/vending/cola{
-	can_move = 0
+	name = "Free Robust Softdrinks";
+	prices = list()
 	},
 /turf/unsimulated/floor{
 	icon_state = "wood_siding8"
@@ -20553,6 +20568,10 @@
 /area/tdome)
 "aTh" = (
 /obj/machinery/vending/cigarette,
+/obj/machinery/vending/cigarette{
+	name = "Free Cigarette Machine";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "redbluefull";
 	dir = 8
@@ -20592,6 +20611,10 @@
 /area/tdome/tdomeobserve)
 "aTm" = (
 /obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	name = "Free Hot Drinks machine";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "redbluefull";
 	dir = 8
@@ -20678,7 +20701,10 @@
 	},
 /area/tdome/tdomeobserve)
 "aTx" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/snack{
+	name = "Free Chocolate Corp";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "redbluefull";
 	dir = 8


### PR DESCRIPTION
- So Centcom has weird thing. It used to have autodresser not infront of the shuttle, and people would miss it. But there are also vending machine in the lobby, and with new way where autodressers are you cannot get ID to buy stuff from vendor. So I added one extra dresser in the door infront, which will solve people who wait 10-20 minutes for arrival shuttle(due to IC issues) when they are hungry.
![dresser](https://user-images.githubusercontent.com/25555314/40275195-9e6d69ac-5b9d-11e8-810a-cf975b8129b4.jpg)
