### PR TITLE
Fixes a bad fix

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -100,6 +100,7 @@
 	var/can_move = 1	//if you can wrench the machine out of place
 	var/vend_id = "generic"	//Id of the refill cartridge that has to be used
 	var/restock_items = 0	//If items can be restocked into the vending machine
+	var/list/restock_blocked_items = list() //Items that can not be restocked if restock_items is enabled
 
 /obj/machinery/vending/Initialize()
 	. = ..()
@@ -269,9 +270,16 @@
 			return
 
 	else if(!is_borg_item(W))
+		if(!restock_items)
+			user << "<span class='warning'>\the [src] can not be restocked manually!</span>"
+			return
+		for(var/path in restock_blocked_items)
+			if(istype(W,path))
+				user << "<span class='warning'>\the [src] does not accept this item!</span>"
+				return
 
 		for(var/datum/data/vending_product/R in product_records)
-			if(istype(W, R.product_path) && restock_items)
+			if(istype(W, R.product_path))
 				stock(R, user)
 				qdel(W)
 				return

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -23,7 +23,6 @@
 	icon_state = "boozeomat"        //////////////18 drink entities below, plus the glasses, in case someone wants to edit the number of bottles
 	icon_deny = "boozeomat-deny"
 	vend_id = "booze"
-	restock_items = 1
 	products = list(
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/gin = 5,
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey = 5,
@@ -359,6 +358,11 @@
 		/obj/item/clothing/glasses/sunglasses = 2,
 		/obj/item/weapon/grenade/flashbang = 4
 	)
+	restock_blocked_items = list(
+		/obj/item/weapon/storage/box/donut, 
+		/obj/item/weapon/storage/box/evidence,
+		/obj/item/device/flash
+		)
 	restock_items = 1
 
 /obj/machinery/vending/hydronutrients
@@ -384,7 +388,6 @@
 	contraband = list(
 		/obj/item/weapon/reagent_containers/glass/bottle/mutagen = 2
 	)
-	restock_items = 1
 
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 
@@ -481,6 +484,7 @@
 		/obj/item/seeds/wheatseed = 20,
 		/obj/item/seeds/whitebeetseed = 20
 	)
+	restock_items = 1
 
 /**
  *  Populate hydroseeds product_records
@@ -594,8 +598,13 @@
 	premium = list(
 		/obj/item/clothing/gloves/yellow = 1
 	)
+	restock_blocked_items = list(
+		/obj/item/stack/cable_coil,
+		/obj/item/weapon/weldingtool,
+		/obj/item/weapon/weldingtool/hugetank
+	)
 	restock_items = 1
-
+	
 /obj/machinery/vending/engivend
 	name = "Engi-Vend"
 	desc = "Spare tool vending. What? Did you expect some witty description?"
@@ -701,6 +710,11 @@
 	// There was an incorrect entry (cablecoil/power).  I improvised to cablecoil/heavyduty.
 	// Another invalid entry, /obj/item/weapon/circuitry.  I don't even know what that would translate to, removed it.
 	// The original products list wasn't finished.  The ones without given quantities became quantity 5.  -Sayu
+	restock_blocked_items = list(
+		/obj/item/stack/cable_coil/heavyduty,
+		/obj/item/weapon/weldingtool,
+		/obj/item/weapon/light/tube
+	)
 	restock_items = 1
 
 //This one's from bay12
@@ -728,6 +742,12 @@
 		/obj/item/weapon/crowbar = 5
 	)
 	//everything after the power cell had no amounts, I improvised.  -Sayu
+	restock_blocked_items = list(
+		/obj/item/stack/cable_coil,
+		/obj/item/device/flash,
+		/obj/item/weapon/light/tube,
+		/obj/item/weapon/tank/anesthetic
+	)
 	restock_items = 1
 
 //RECURSION

--- a/html/changelogs/Arrow768-fixBadFix.yml
+++ b/html/changelogs/Arrow768-fixBadFix.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes a bad bugfix that reintruduced the bug which allows to \"regenerate\" used items using the vending machines."


### PR DESCRIPTION
A recent "bugfix" reintroduced the bug that allows items that are in one or another way consumable to be restocked into the vending machines and to receive a "new" item for it.

For example:
A bartender vends a booze bottle from the vendor, uses it up, restocks it, vends it again and now the bottle is full again.

ToDo:
- [x] Test the restock exclude list