### PR TITLE
Devour Fixes Pt. 5

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -170,7 +170,7 @@
 // Flags for the eat_types variable, a bitfield of what can or can't be eaten
 // Note that any given mob can be more than one type
 #define TYPE_ORGANIC      1	// Almost any creature under /mob/living/carbon and most simple animals
-#define	TYPE_SYNTHETIC    2	// Everything under /mob/living/silicon, plus IPCs, viscerators
+#define TYPE_SYNTHETIC    2	// Everything under /mob/living/silicon, plus IPCs, viscerators
 #define TYPE_HUMANOID     4	// Humans, skrell, unathi, tajara, vaurca, diona, IPC, vox
 #define TYPE_WEIRD        8	// Slimes, constructs, demons, and other creatures of a magical or bluespace nature.
 #define TYPE_INCORPOREAL 16 // Mobs that don't really have any physical form to them.

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -167,12 +167,13 @@
 #define RESPAWN_ANIMAL 3000
 #define RESPAWN_MINISYNTH 6000
 
-//Flags for the eat_types variable, a bitfield of what can or can't be eaten
-//Note that any given mob can be more than one type
-#define TYPE_ORGANIC	1//Almost any creature under /mob/living/carbon and most simple animals
-#define	TYPE_SYNTHETIC	2//Everything under /mob/living/silicon, plus IPCs, viscerators
-#define TYPE_HUMANOID	4//Humans, skrell, unathi, tajara, vaurca, diona, IPC, vox
-#define TYPE_WEIRD		8//Slimes, constructs, demons, and other creatures of a magical or bluespace nature.
+// Flags for the eat_types variable, a bitfield of what can or can't be eaten
+// Note that any given mob can be more than one type
+#define TYPE_ORGANIC      1	// Almost any creature under /mob/living/carbon and most simple animals
+#define	TYPE_SYNTHETIC    2	// Everything under /mob/living/silicon, plus IPCs, viscerators
+#define TYPE_HUMANOID     4	// Humans, skrell, unathi, tajara, vaurca, diona, IPC, vox
+#define TYPE_WEIRD        8	// Slimes, constructs, demons, and other creatures of a magical or bluespace nature.
+#define TYPE_INCORPOREAL 16 // Mobs that don't really have any physical form to them.
 
 // Maximum number of chickens allowed at once.
 // If the number of chickens on the map exceeds this, laid eggs will not hatch.

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -104,25 +104,6 @@ var/global/list/syndicate_access = list(access_maint_tunnels, access_syndicate, 
 //Cloaking devices
 var/global/list/cloaking_devices = list()
 
-// Devour types (these are typecaches). Only simple_animals check these, other types are handled specially.
-/var/list/mtl_synthetic = list(
-	/mob/living/simple_animal/hostile/hivebot
-)
-
-/var/list/mtl_weird = list(
-	/mob/living/simple_animal/construct,
-	/mob/living/simple_animal/shade,
-	/mob/living/simple_animal/slime,
-	/mob/living/simple_animal/hostile/faithless
-)
-
-// Actual human mobs are delibrately not in this list as they are handled elsewhere.
-/var/list/mtl_humanoid = list(
-	/mob/living/simple_animal/hostile/pirate,
-	/mob/living/simple_animal/hostile/russian,
-	/mob/living/simple_animal/hostile/syndicate
-)
-
 //////////////////////////
 /////Initial Building/////
 //////////////////////////
@@ -229,16 +210,6 @@ var/global/list/cloaking_devices = list()
 		var/datum/poster/P = new T
 		poster_designs += P
 
-	// Some setup work for the eat-types lists.
-	mtl_synthetic = typecacheof(mtl_synthetic) + list(
-		/mob/living/simple_animal/hostile/retaliate/malf_drone,
-		/mob/living/simple_animal/hostile/viscerator,
-		/mob/living/simple_animal/spiderbot
-	)
-
-	mtl_weird = typecacheof(mtl_weird) + /mob/living/simple_animal/adultslime
-
-	mtl_humanoid = typecacheof(mtl_humanoid)
 
 	return 1
 

--- a/code/controllers/subsystems/mob.dm
+++ b/code/controllers/subsystems/mob.dm
@@ -51,8 +51,9 @@
 		/mob/living/simple_animal/spiderbot = TRUE
 	)
 
-	mtl_weird = typecacheof(mtl_weird) 
-	mtl_weird[/mob/living/simple_animal/adultslime] = TRUE
+	mtl_weird = typecacheof(mtl_weird) + list(
+		/mob/living/simple_animal/adultslime = TRUE
+	)
 
 	mtl_humanoid = typecacheof(mtl_humanoid)
 

--- a/code/controllers/subsystems/mob.dm
+++ b/code/controllers/subsystems/mob.dm
@@ -2,7 +2,7 @@
 
 /datum/controller/subsystem/mobs
 	name = "Mobs - Life"
-	flags = SS_NO_INIT
+	init_order = SS_INIT_MISC	// doesn't really matter when we init
 	priority = SS_PRIORITY_MOB
 
 	var/list/slept = list()
@@ -16,8 +16,47 @@
 	var/list/ghost_darkness_images = list()	//this is a list of images for things ghosts should still be able to see when they toggle darkness
 	var/list/ghost_sightless_images = list()	//this is a list of images for things ghosts should still be able to see even without ghost sight
 
+	// Devour types (these are typecaches). Only simple_animals check these, other types are handled specially.
+	var/list/mtl_synthetic = list(
+		/mob/living/simple_animal/hostile/hivebot
+	)
+
+	var/list/mtl_weird = list(
+		/mob/living/simple_animal/construct,
+		/mob/living/simple_animal/shade,
+		/mob/living/simple_animal/slime,
+		/mob/living/simple_animal/hostile/faithless
+	)
+
+	// Actual human mobs are delibrately not in this list as they are handled elsewhere.
+	var/list/mtl_humanoid = list(
+		/mob/living/simple_animal/hostile/pirate,
+		/mob/living/simple_animal/hostile/russian,
+		/mob/living/simple_animal/hostile/syndicate
+	)
+
+	var/list/mtl_incorporeal = list(
+		/mob/living/simple_animal/hostile/carp/holodeck,
+		/mob/living/simple_animal/penguin/holodeck
+	)
+
 /datum/controller/subsystem/mobs/New()
 	NEW_SS_GLOBAL(SSmob)
+
+/datum/controller/subsystem/mobs/Initialize()
+	// Some setup work for the eat-types lists.
+	mtl_synthetic = typecacheof(mtl_synthetic) + list(
+		/mob/living/simple_animal/hostile/retaliate/malf_drone = TRUE,
+		/mob/living/simple_animal/hostile/viscerator = TRUE,
+		/mob/living/simple_animal/spiderbot = TRUE
+	)
+
+	mtl_weird = typecacheof(mtl_weird) 
+	mtl_weird[/mob/living/simple_animal/adultslime] = TRUE
+
+	mtl_humanoid = typecacheof(mtl_humanoid)
+
+	mtl_incorporeal = typecacheof(mtl_incorporeal)
 
 /datum/controller/subsystem/mobs/stat_entry()
 	..("P:[mob_list.len]")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1046,6 +1046,9 @@ proc/is_blind(A)
 	if (is_type_in_typecache(src, SSmob.mtl_weird))
 		. |= TYPE_WEIRD
 
+	if (is_type_in_typecache(src, SSmob.mtl_incorporeal))
+		. |= TYPE_INCORPOREAL
+
 	// If it's not TYPE_SYNTHETIC, TYPE_WEIRD or TYPE_INCORPOREAL, we can assume it's TYPE_ORGANIC.
 	if (!(. & (TYPE_SYNTHETIC|TYPE_WEIRD|TYPE_INCORPOREAL)))
 		. |= TYPE_ORGANIC
@@ -1053,8 +1056,6 @@ proc/is_blind(A)
 	if (is_type_in_typecache(src, SSmob.mtl_humanoid))
 		. |= TYPE_HUMANOID
 
-	if (is_type_in_typecache(src, SSmob.mtl_incorporeal))
-		. |= TYPE_INCORPOREAL
 
 /mob/living/proc/get_vessel(create = FALSE)
 	if (!create)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1040,18 +1040,21 @@ proc/is_blind(A)
 // It's not worth adding a proc for every single one of these types.
 /mob/living/simple_animal/find_type()
 	. = ..()
-	if (is_type_in_typecache(src, global.mtl_synthetic))
+	if (is_type_in_typecache(src, SSmob.mtl_synthetic))
 		. |= TYPE_SYNTHETIC
 
-	if (is_type_in_typecache(src, global.mtl_weird))
+	if (is_type_in_typecache(src, SSmob.mtl_weird))
 		. |= TYPE_WEIRD
 
-	// If it's not TYPE_SYNTHETIC or TYPE_WEIRD, we can assume it's TYPE_ORGANIC.
-	if (!(. & (TYPE_SYNTHETIC|TYPE_WEIRD)))
+	// If it's not TYPE_SYNTHETIC, TYPE_WEIRD or TYPE_INCORPOREAL, we can assume it's TYPE_ORGANIC.
+	if (!(. & (TYPE_SYNTHETIC|TYPE_WEIRD|TYPE_INCORPOREAL)))
 		. |= TYPE_ORGANIC
 
-	if (is_type_in_typecache(src, global.mtl_humanoid))
+	if (is_type_in_typecache(src, SSmob.mtl_humanoid))
 		. |= TYPE_HUMANOID
+
+	if (is_type_in_typecache(src, SSmob.mtl_incorporeal))
+		. |= TYPE_INCORPOREAL
 
 /mob/living/proc/get_vessel(create = FALSE)
 	if (!create)

--- a/html/changelogs/lohikar-inediblehardlight.yml
+++ b/html/changelogs/lohikar-inediblehardlight.yml
@@ -1,0 +1,4 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - bugfix: "Unathi can no longer chew on holograms."


### PR DESCRIPTION
- Fixes #4780.
- Fixes an issue where SA adult slimes were improperly considered organic mobs.
- Fixes an issue where viscerators, malf drones, and spiderbots were not considered synthetic mobs.