### PR TITLE
Cyborg Fixes

### DIFF
--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -230,18 +230,27 @@
 		/obj/item/weapon/disk,
 		/obj/item/device/analyzer/plant_analyzer,//For farmbot construction
 		/obj/item/weapon/material/minihoe,//Farmbots and xenoflora
-		/obj/item/weapon/computer_hardware
+		/obj/item/weapon/computer_hardware,
+		/obj/item/weapon/slimepotion,
+		/obj/item/weapon/slimepotion2,
+		/obj/item/weapon/slimesteroid,
+		/obj/item/weapon/slimesteroid2,
+		/obj/item/slime_extract,
+		/obj/item/mecha_parts
 		)
 
 /obj/item/weapon/gripper/chemistry //A gripper designed for chemistry, to allow borgs to work efficiently in the lab
-	name = "chemistry gripper"
+	name = "medical gripper"
 	icon_state = "gripper-sci"
 	desc = "A specialised grasping tool designed for working in chemistry and pharmaceutical labs"
 
 	can_hold = list(
+		/obj/item/weapon/reagent_containers/blood,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge,
 		/obj/item/weapon/reagent_containers/glass,
 		/obj/item/weapon/reagent_containers/pill,
 		/obj/item/weapon/reagent_containers/spray,
+		/obj/item/weapon/reagent_containers/personal_inhaler_cartridge,
 		/obj/item/weapon/storage/pill_bottle,
 		/obj/item/weapon/hand_labeler,
 		/obj/item/stack/material/phoron

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -121,6 +121,11 @@ var/global/list/robot_modules = list(
 		else if(F.times_used)
 			F.times_used--
 
+	var/obj/item/weapon/reagent_containers/syringe/S = locate() in src.modules
+	if(S && S.mode == 2)
+		S.mode = 0
+		S.update_icon()
+
 	if(!synths || !synths.len)
 		return
 
@@ -242,6 +247,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/device/reagent_scanner/adv(src)
 	src.modules += new /obj/item/weapon/autopsy_scanner(src) // an autopsy scanner
+	src.modules += new /obj/item/weapon/personal_inhaler/cyborg(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("pacid", 250)
 	src.emag.name = "Polyacid spray"
@@ -303,6 +309,9 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
 	src.modules += new /obj/item/weapon/inflatable_dispenser(src) // Allows usage of inflatables. Since they are basically robotic alternative to EMTs, they should probably have them.
 	src.modules += new /obj/item/device/gps(src) // for coordinating with medical suit health sensors console
+	src.modules += new /obj/item/weapon/personal_inhaler/cyborg(src)
+	src.modules += new /obj/item/weapon/gripper/chemistry(src)
+
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("pacid", 250)
 	src.emag.name = "Polyacid spray"
@@ -736,12 +745,15 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/gripper/research(src)
 	src.modules += new /obj/item/weapon/gripper/no_use/loader(src)
 	src.modules += new /obj/item/device/robotanalyzer(src)
+	src.modules += new /obj/item/device/multitool(src)
 	src.modules += new /obj/item/weapon/card/robot(src)
 	src.modules += new /obj/item/weapon/wrench(src)
 	src.modules += new /obj/item/weapon/screwdriver(src)
 	src.modules += new /obj/item/weapon/crowbar(src)
 	src.modules += new /obj/item/weapon/scalpel(src)
 	src.modules += new /obj/item/weapon/circular_saw(src)
+	src.modules += new /obj/item/weapon/hemostat(src)
+	src.modules += new /obj/item/weapon/retractor(src)
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/weapon/gripper/chemistry(src)
@@ -750,16 +762,18 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/extinguisher(src)
 	src.modules += new /obj/item/weapon/storage/bag/plants(src)
 	src.modules += new /obj/item/weapon/pen/robopen(src)
+	src.modules += new /obj/item/weapon/storage/bag/slimes(src)
+	src.modules += new /obj/item/device/slime_scanner(src)
+	src.modules += new /obj/item/weapon/weldingtool/experimental(src)
+
+
+	var/datum/matter_synth/wire = new /datum/matter_synth/wire(15)
+	synths += wire
+	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
+	C.synths = list(wire)
+	src.modules += C
+
 	src.emag = new /obj/item/weapon/hand_tele(src)
-
-	var/datum/matter_synth/nanite = new /datum/matter_synth/nanite(10000)
-	synths += nanite
-
-	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
-	N.uses_charge = 1
-	N.charge_costs = list(1000)
-	N.synths = list(nanite)
-	src.modules += N
 
 /obj/item/weapon/robot_module/syndicate
 	name = "syndicate robot module"

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -18,7 +18,7 @@
 	var/list/reagent_names = list()
 
 /obj/item/weapon/reagent_containers/borghypo/medical
-	reagent_ids = list("bicaridine", "inaprovaline", "dexalin", "tramadol", "spaceacillin", "anti_toxin")
+	reagent_ids = list("bicaridine", "inaprovaline", "dexalin", "tramadol", "spaceacillin", "anti_toxin", "kelotane")
 
 /obj/item/weapon/reagent_containers/borghypo/rescue
 	reagent_ids = list("tricordrazine", "inaprovaline", "tramadol")
@@ -121,7 +121,7 @@
 	recharge_time = 3
 	volume = 60
 	possible_transfer_amounts = list(5, 10, 20, 30)
-	reagent_ids = list("beer", "kahlua", "whiskey", "wine", "vodka", "gin", "rum", "tequilla", "vermouth", "cognac", "ale", "mead", "water", "sugar", "ice", "tea", "icetea", "cola", "spacemountainwind", "dr_gibb", "space_up", "tonic", "sodawater", "lemon_lime", "orangejuice", "limejuice", "watermelonjuice")
+	reagent_ids = list("beer", "kahlua", "whiskey", "wine", "vodka", "gin", "rum", "tequilla", "vermouth", "cognac", "ale", "mead", "water", "sugar", "ice", "tea", "icetea", "cola", "spacemountainwind", "dr_gibb", "space_up", "tonic", "sodawater", "lemon_lime", "orangejuice", "limejuice", "watermelonjuice", "xuizijuice", "sarezhiwine" )
 
 /obj/item/weapon/reagent_containers/borghypo/service/attack(var/mob/M, var/mob/user)
 	return

--- a/code/modules/reagents/reagent_containers/inhaler_advanced.dm
+++ b/code/modules/reagents/reagent_containers/inhaler_advanced.dm
@@ -194,3 +194,12 @@
 		flags ^= OPENCONTAINER
 		update_icon()
 		return
+
+/obj/item/weapon/personal_inhaler/cyborg
+	name = "cyborg inhaler"
+	desc = "A large, bulky inhaler design that injects the entire contents of the loaded cartridge via an aerosol system in a single button press. For cyborgs."
+	icon_state = "pi_combat"
+	w_class = 3
+	transfer_amount = 60
+	origin_tech = null
+	eject_when_empty = TRUE

--- a/html/changelogs/burgerbb-cyborg_fixes.yml
+++ b/html/changelogs/burgerbb-cyborg_fixes.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Broken cyborg syringes can now be repaired inside the cyborg charger."
+  - balance: "Science Cyborgs now have multitools, wires, and a welder, instead of NanoPaste. Missing Hemostat and Retractor for cyborgifcation were also added. A slime bag and slime scanner were also added. Science Grippers can now carry slime cores, slime potions, and Exosuit parts."
+  - bugfix: "Added missing Kelotane from borg hypospray. Medical cyborgs have their own inhalers. Medical crippers can now grab blood packs, chem dispensers, and inhaler cartridges."
+  - bugfix: "Service Cyborgs can now produce Sarezhi Wine and Xuxzi Juice in their shakers."
+  


### PR DESCRIPTION
# Overview
Cyborgs were missing a lot of things they should be able to do, such as carry slime cores or mech parts, for the science module. The medical module hypospray was missing kelotane, for some reason.

## Changelog
- Broken cyborg syringes can now be repaired inside the cyborg charger.
(If you accidentally broke a syringe as a cyborg, there was no way to repair it unless you had a module reset.)
- Science Cyborgs now have multitools, wires, and a welder, instead of NanoPaste. Missing Hemostat and Retractor for cyborgifcation were also added. A slime bag and slime scanner were also added. Science Grippers can now carry slime cores, slime potions, and Exosuit parts.
(Nanopaste is incredibly fucking OP for a cyborg to have, especially when it regenerates. Even then, I think the charge check is broken and you can have unlimited nanopaste. Literally in XenoBiology, I could tank slimes/creatures easily and just give myself nanopaste and all would be fine. I know it feels like that should be in development, but this is honestly a bugfix that is needed. The science cyborg needs the hemostat, retractor, and multitool in order to perform cyborgication as well as some IPC related repairs. The welder tool and wires replace the nanopaste for repairs and assembly.)
- Added missing Kelotane from borg hypospray. Medical cyborgs have their own inhalers. Medical crippers can now grab blood packs, chem dispensers, and inhaler cartridges.
(Medical borgs didn't have kelotane for some reason in their hyposprays)
 - Service Cyborgs can now produce Sarezhi Wine and Xuxzi Juice in their shakers.
(For the Unathi, I guess.)