### PR TITLE
Moving emitters

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -82,7 +82,7 @@
 	if (C == user)
 		user.visible_message("[user] climbs on \the [src].","You climb on \the [src].")
 	else
-		visible_message("<span class='notice'>\The [C] has been laid on \the [src] by [user].</span>", 3)
+		visible_message("<span class='notice'>\The [C] has been laid on \the [src] by [user].</span>")
 	if (C.client)
 		C.client.perspective = EYE_PERSPECTIVE
 		C.client.eye = src

--- a/html/changelogs/Sindorman-dresser.yml
+++ b/html/changelogs/Sindorman-dresser.yml
@@ -1,0 +1,6 @@
+author: PoZe
+
+delete-after: True
+
+changes:
+  - maptweak: "Veding machines at Centcomm don't charge money for their products. Hail NanoTrasen!"

--- a/html/changelogs/fixessurgerytable.yml
+++ b/html/changelogs/fixessurgerytable.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: LordFowl
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes the number 3 being broadcasted from surgery tables."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -8133,13 +8133,20 @@
 	},
 /area/centcom/living)
 "atb" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/snack{
+	name = "Free Chocolate Corp";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/centcom/living)
 "atc" = (
 /obj/machinery/vending/cola,
+/obj/machinery/vending/cola{
+	name = "Free Robust Softdrinks";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -12573,7 +12580,7 @@
 /area/centcom/specops)
 "aBL" = (
 /obj/machinery/vending/snack{
-	name = "hacked Getmore Chocolate Corp";
+	name = "Free Chocolate Corp";
 	prices = list()
 	},
 /turf/unsimulated/floor{
@@ -12672,7 +12679,7 @@
 /area/centcom/specops)
 "aBY" = (
 /obj/machinery/vending/cola{
-	name = "Robust Softdrinks";
+	name = "Free Robust Softdrinks";
 	prices = list()
 	},
 /turf/unsimulated/floor{
@@ -12739,7 +12746,7 @@
 /area/shuttle/specops/centcom)
 "aCh" = (
 /obj/machinery/vending/cigarette{
-	name = "cigarette machine";
+	name = "Free Cigarette Machine";
 	prices = list()
 	},
 /turf/unsimulated/floor{
@@ -15939,7 +15946,10 @@
 	},
 /area/centcom/holding)
 "aJv" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	name = "Free Hot Drinks machine";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "green";
 	dir = 4
@@ -16190,7 +16200,10 @@
 	},
 /area/centcom/holding)
 "aJW" = (
-/obj/machinery/vending/cigarette,
+/obj/machinery/vending/cigarette{
+	name = "Free Cigarette Machine";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "green";
 	dir = 4
@@ -18517,7 +18530,8 @@
 	icon_state = "floor"
 	},
 /obj/machinery/vending/snack{
-	can_move = 0
+	name = "Free Chocolate Corp";
+	prices = list()
 	},
 /turf/unsimulated/floor{
 	icon_state = "wood_siding4"
@@ -18614,7 +18628,8 @@
 	icon_state = "floor"
 	},
 /obj/machinery/vending/cola{
-	can_move = 0
+	name = "Free Robust Softdrinks";
+	prices = list()
 	},
 /turf/unsimulated/floor{
 	icon_state = "wood_siding8"
@@ -20553,6 +20568,10 @@
 /area/tdome)
 "aTh" = (
 /obj/machinery/vending/cigarette,
+/obj/machinery/vending/cigarette{
+	name = "Free Cigarette Machine";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "redbluefull";
 	dir = 8
@@ -20592,6 +20611,10 @@
 /area/tdome/tdomeobserve)
 "aTm" = (
 /obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	name = "Free Hot Drinks machine";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "redbluefull";
 	dir = 8
@@ -20678,7 +20701,10 @@
 	},
 /area/tdome/tdomeobserve)
 "aTx" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/snack{
+	name = "Free Chocolate Corp";
+	prices = list()
+	},
 /turf/unsimulated/floor{
 	icon_state = "redbluefull";
 	dir = 8

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -4053,6 +4053,7 @@
 	icon_state = "tube1";
 	dir = 1
 	},
+/obj/machinery/power/emitter,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
@@ -4063,6 +4064,7 @@
 	dir = 5;
 	icon_state = "camera"
 	},
+/obj/machinery/power/emitter,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
@@ -4275,6 +4277,7 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
+/obj/machinery/power/emitter,
 /turf/simulated/floor{
 	icon_state = "plating"
 	},
@@ -27245,6 +27248,21 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
+"Wm" = (
+/obj/machinery/power/emitter,
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/outpost/engineering/storage)
+"Wn" = (
+/obj/structure/particle_accelerator/end_cap{
+	icon_state = "end_cap";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "plating"
+	},
+/area/outpost/engineering/storage)
 
 (1,1,1) = {"
 aa
@@ -40448,7 +40466,7 @@ gC
 fT
 fy
 iv
-iy
+Wm
 jq
 jO
 ku
@@ -40706,9 +40724,9 @@ hp
 fy
 iw
 iW
-jr
+jq
+Wn
 jP
-kv
 iA
 aa
 aa
@@ -41475,7 +41493,7 @@ fT
 gE
 fT
 fy
-iy
+kv
 iY
 iY
 iY

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -80471,8 +80471,8 @@ ajv
 akq
 aiK
 alZ
-alZ
-alZ
+and
+and
 apq
 aqD
 alY


### PR DESCRIPTION
A player asked to move around emitters from storage and add more spare to Tesla. This fixes #4778 . So the list of changes:

- Deleted two spare emitters from SM storage room, leaving it with 1 spare.

- Added 4 spare emitters to Tesla storage. 

- Moved Tesla machinery around in Tesla storage, making room to walk around.