### PR TITLE
Hostile AI fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -33,7 +33,7 @@
 		return null
 
 	var/atom/T = null
-	var/lowest_health = 100
+	var/lowest_health = 1000 // Max you can get
 	stop_automated_movement = 0
 
 	for(var/atom/A in targets)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -33,7 +33,7 @@
 		return null
 
 	var/atom/T = null
-	var/lowest_health = 1000 // Max you can get
+	var/lowest_health = INFINITY // Max you can get
 	stop_automated_movement = 0
 
 	for(var/atom/A in targets)
@@ -192,6 +192,8 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 		if(HOSTILE_STANCE_IDLE)
 			targets = ListTargets(10)
 			target_mob = FindTarget()
+			if(isnull(target_mob))
+				DestroySurroundings()
 
 		if(HOSTILE_STANCE_ATTACK)
 			if(destroy_surroundings)


### PR DESCRIPTION
- When I made an update to hostile AI, I have not seen this stupid bug. This one variable makes them ignore people with full health. I urge to merge it ASAP as carps and spiders won't attack people with 100 health. fixes #4836 

- Also this makes hostile mobs to destroy surroundings if there is no-one to attack. 