### PR TITLE
Another vamp grab fix.

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -15,8 +15,8 @@
 		to_chat(src, "<span class='warning'>You must be grabbing a victim in your active hand to drain their blood.</span>")
 		return
 
-	if (G.state == GRAB_PASSIVE || G.state == GRAB_UPGRADING)
-		to_chat(src, "<span class='warning'>You must have the victim pinned to the ground to drain their blood.</span>")
+	if (G.state != GRAB_AGGRESSIVE)
+		to_chat(src, "<span class='warning'>You must have a strong grip on the victim to drain their blood.</span>")
 		return
 
 	var/mob/living/carbon/human/T = G.affecting

--- a/html/changelogs/Changelog - Grabharder.yml
+++ b/html/changelogs/Changelog - Grabharder.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Vampires must now neck grab before they can succ. Previous undocumented bugfixes have rendered this possible."


### PR DESCRIPTION
Vampires with this change can now only suck blood from someone they have in a neck grab. Apparently, this is the solution to people resisting without causing a bug. /shrug  

According to #4712 you should have time to neckgrab during the stucklock period.

We just have to train vampires to perform neckgrabs when they want to succ.

But Kaed, you say, doesn't **if (G.state == GRAB_PASSIVE || G.state == GRAB_UPGRADING)** mean the same thing as if **(G.state != GRAB_AGGRESSIVE)**?  Why did you change it?

Apparently not, because there are 5 grab states.

Hang on, this might not actually fix it.