### PR TITLE
Reduces the brain damage caused by cloning

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -110,7 +110,7 @@
 
 	//Get the clone body ready
 	H.setCloneLoss(H.maxHealth * (100 - config.health_threshold_crit) / 100) // We want to put them exactly at the crit level, so we deal this much clone damage
-	H.adjustBrainLoss(50, 55) // Even if healed to full health, it will have some brain damage
+	H.adjustBrainLoss(25, 55) // Even if healed to full health, it will have some brain damage
 	H.Paralyse(4)
 
 	//Here let's calculate their health so the pod doesn't immediately eject them!!!


### PR DESCRIPTION
This reduces the total brain damage caused by cloning, by around half, causing cloning to only trigger minor traumas instead of the big ones. Since, it seems that one of the main complains is that cloning can't really be properly done without a psych to fix the traumas, so this might allow cloning to happen more, since minor traumas are not so debilitating.