### PR TITLE
Airbubble tweaks

### DIFF
--- a/code/game/objects/items/airbubble.dm
+++ b/code/game/objects/items/airbubble.dm
@@ -37,7 +37,8 @@
 	else
 		R = new /obj/structure/closet/airbubble(user.loc)
 	if(!used)
-		internal_tank = new /obj/item/weapon/tank/emergency_oxygen/double(src)
+		internal_tank = new /obj/item/weapon/tank/emergency_oxygen/engi(src)
+		internal_tank.air_contents.adjust_gas("oxygen", (42*ONE_ATMOSPHERE)/(R_IDEAL_GAS_EQUATION*T20C))
 	R.internal_tank = internal_tank
 	if(!isnull(internal_tank))
 		internal_tank.forceMove(R)
@@ -267,6 +268,12 @@
 	dump_contents()
 	var/datum/gas_mixture/t_air = get_turf_air()
 	t_air.merge(inside_air)
+
+// When we shoot bubble, make it rip.
+/obj/structure/closet/airbubble/bullet_act(var/obj/item/projectile/Proj)
+	..()
+	ripped = TRUE
+	update_icon()
 
 // Change valve on internal tank
 /obj/structure/closet/airbubble/verb/set_internals()

--- a/html/changelogs/Sindroman-airbubble-feature.yml
+++ b/html/changelogs/Sindroman-airbubble-feature.yml
@@ -3,5 +3,5 @@ author: PoZe
 delete-after: True
 
 changes:
-  - tweak: "Airbubble comes now with fully filled engineering extended airtank(6 liters max). Instead of double airtank(10 liters max). It lasts around the same time, even slightly longer(40 minutes)."
+  - tweak: "Airbubble comes now with fully filled engineering extended airtank(6 liters max). Instead of double emergency airtank(10 liters max). It lasts around the same time, even slightly longer(40 minutes)."
   - tweak: "Airbubble now gets ripped and leaks after being shot with projectile weapons."

--- a/html/changelogs/Sindroman-airbubble-feature.yml
+++ b/html/changelogs/Sindroman-airbubble-feature.yml
@@ -1,0 +1,7 @@
+author: PoZe
+
+delete-after: True
+
+changes:
+  - tweak: "Airbubble comes now with fully filled engineering extended airtank(6 liters max). Instead of double airtank(10 liters max). It lasts around the same time, even slightly longer(40 minutes)."
+  - tweak: "Airbubble now gets ripped and leaks after being shot with projectile weapons."


### PR DESCRIPTION
This PR does something I should have done at the end of airbubble release.

-  Changes default airtank from double emergency(10 liters) to engineering extended(6 liters) that is fully filled in with air. I have calculated that fully filled engineering tank would last as much as default filled double emergency. 

- Adds bullet act to make bubble rip and leak after being shot with projectiles.