### PR TITLE
Fix Phantom Globals

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -58,7 +58,7 @@
 		long_message = "[time_stamp()]: [text]",
 		level = level,
 		category = "GAME",
-		additional_data = list("_ckey" = html_encode(ckey), "_admin_key" = html_encode(admin_key), "_target" = html_encode(target))
+		additional_data = list("_ckey" = html_encode(ckey), "_admin_key" = html_encode(admin_key), "_target" = html_encode(ckey_target))
 	)
 
 /proc/log_vote(text)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -435,7 +435,7 @@
 	return ..()
 
 /obj/structure/cult/pylon/bullet_act(var/obj/item/projectile/Proj)
-	attackpylon(user, Proj.damage, Proj)
+	attackpylon(Proj.firer, Proj.damage, Proj)
 
 //Explosions will usually cause instant shattering, or heavy damage
 //Class 3 or lower blast is sometimes survivable. 2 or higher will always shatter

--- a/code/game/machinery/kitchen/cooking_machines/_mixer.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_mixer.dm
@@ -45,7 +45,7 @@ fundamental differences
 			return
 		else
 			selected_option = choice
-			user << "<span class='notice'>You prepare \the [src] to make \a [selected_option].</span>"
+			usr << "<span class='notice'>You prepare \the [src] to make \a [selected_option].</span>"
 			var/datum/cooking_item/CI = cooking_objs[1]
 			CI.combine_target = selected_option
 

--- a/code/game/objects/items/airbubble.dm
+++ b/code/game/objects/items/airbubble.dm
@@ -322,7 +322,7 @@
 		update_icon()
 		STOP_PROCESSING(SSfast_process, src)
 	else
-		to_chat(user, "<span class='warning'>[src] already has no tank.</span>")
+		to_chat(usr, "<span class='warning'>[src] has no tank.</span>")
 
 // Handle most of things: restraining, cutting restrains, attaching tank.
 /obj/structure/closet/airbubble/attackby(W as obj, mob/user as mob)

--- a/code/game/objects/items/weapons/landmines.dm
+++ b/code/game/objects/items/weapons/landmines.dm
@@ -20,7 +20,7 @@
 	set name = "Hide"
 	set category = "Object"
 
-	if(use_check(user, USE_DISALLOW_SILICONS))
+	if(use_check(usr, USE_DISALLOW_SILICONS))
 		return
 
 	layer = TURF_LAYER+0.2

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -317,7 +317,7 @@
 /obj/item/weapon/tray/throw_impact(atom/hit_atom)
 	spill(null, src.loc)
 
-/obj/item/weapon/tray/throw_at(/var/atom/target, var/throw_range, var/throw_speed, /var/mob/user)
+/obj/item/weapon/tray/throw_at(atom/target, throw_range, throw_speed, mob/user)
 	safedrop = 1//we dont want the tray to spill when thrown, it will spill on impact instead
 	..()
 

--- a/code/game/objects/structures/therapy.dm
+++ b/code/game/objects/structures/therapy.dm
@@ -52,7 +52,7 @@
 		on = 1
 		shock()
 		icon_state = "echair1"
-	user << "<span class='notice'>You switch [on ? "on" : "off"] [src].</span>"
+	usr << "<span class='notice'>You switch [on ? "on" : "off"] [src].</span>"
 
 /obj/structure/bed/chair/e_chair/proc/shock()
 	if(!on)
@@ -154,7 +154,7 @@
 	if(!do_mob(user, H, 10 SECONDS))
 		return
 
-	if((!user in view(1,target)))
+	if(!(user in view(1, loc)))
 		return
 
 	var/response = alert(H, "Do you believe in hypnosis?", "Willpower", "Yes", "No")
@@ -279,10 +279,10 @@
 		usr << "<span class='warning'>The subject cannot have abiotic items on.</span>"
 		return
 	if(locked)
-		user << "<span class='warning'>The pod is currently locked!</span>"
+		usr << "<span class='warning'>The pod is currently locked!</span>"
 		return
 	if(!ishuman(usr))
-		user << "<span class='warning'>The subject does not fit!</span>"
+		usr << "<span class='warning'>The subject does not fit!</span>"
 		return
 	usr.pulling = null
 	usr.client.perspective = EYE_PERSPECTIVE

--- a/code/modules/cciaa/cciaa.dm
+++ b/code/modules/cciaa/cciaa.dm
@@ -232,7 +232,7 @@
 	if (!customname)
 		usr << "<span class='warning'>Cancelled.</span>"
 		return
-	var/announce = alert(user, "Do you wish to announce the fax being sent?", "Announce Fax", "Yes", "No")
+	var/announce = alert(usr, "Do you wish to announce the fax being sent?", "Announce Fax", "Yes", "No")
 	if(announce == "Yes")
 		announce = 1
 

--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -56,7 +56,7 @@
 	var/list/langs = S.secondary_langs.Copy()
 	for (var/L in all_languages)
 		var/datum/language/lang = all_languages[L]
-		if (!(lang.flags & RESTRICTED) && (!config.usealienwhitelist || is_alien_whitelisted(user, L) || !(lang.flags & WHITELISTED)))
+		if (!(lang.flags & RESTRICTED) && (!config.usealienwhitelist || is_alien_whitelisted(pref.client.mob, L) || !(lang.flags & WHITELISTED)))
 			langs |= L
 
 	var/list/bad_langs = pref.alternate_languages - langs

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -554,7 +554,7 @@ All custom items with worn sprites must follow the contained sprite system: http
 
 	F.take_damage(5)
 	src << "<span class='warning'>You feel a stabbing pain in your chest!</span>"
-	playsound(user, 'sound/effects/Heart Beat.ogg', 20, 1)
+	playsound(src, 'sound/effects/Heart Beat.ogg', 20, 1)	// shouldn't this be only to src?
 
 
 /obj/item/clothing/accessory/badge/fluff/caleb_badge //Worn Badge - Caleb Greene - notmegatron
@@ -1373,7 +1373,7 @@ All custom items with worn sprites must follow the contained sprite system: http
 			desc = "A grey t-shirt with a stylistic white, faded depiction of the Parthenon on it. It has been cut in half, displaying the inside, with sections clearly labelled in small font."
 
 	usr.update_inv_w_uniform()
-	usr.visible_message("<span class='notice'>[user] fumbles with \the [src], changing the shirt..</span>",
+	usr.visible_message("<span class='notice'>[usr] fumbles with \the [src], changing the shirt..</span>",
 						"<span class='notice'>You change \the [src]'s style to be '[style]'.</span>")
 
 
@@ -1600,7 +1600,7 @@ All custom items with worn sprites must follow the contained sprite system: http
 		return
 
 	usr.visible_message("<span class='notice'>[usr] yanks apart \the [src]!</span>")
-	var/obj/item/fluff/jamie_tag/tag = new(get_turf(user))
+	var/obj/item/fluff/jamie_tag/tag = new(get_turf(usr))
 	usr.put_in_hands(tag)
 	src.separated = TRUE
 	src.update_icon()
@@ -2123,7 +2123,7 @@ obj/item/clothing/suit/storage/hooded/fluff/make_poncho //Raincoat Poncho - M.A.
 		return
 
 	else
-		usr.visible_message("<span class='notice'>With the flick of \the [user] wrists and the pinch of \his fingers, the glove's flames are extinguished.</span>")
+		usr.visible_message("<span class='notice'>With the flick of \the [usr] wrists and the pinch of \his fingers, the glove's flames are extinguished.</span>")
 		lit = FALSE
 		playsound(src.loc, 'sound/items/lighter_off.ogg', 75, 1)
 		update_icon()

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -700,7 +700,7 @@ var/list/asteroid_floor_smooth = list(
 				else
 					user << "<span class='notice'>You dug a big hole.</span>"
 
-			gets_dug()
+			gets_dug(user)
 			digging = 0
 			return
 
@@ -721,7 +721,7 @@ var/list/asteroid_floor_smooth = list(
 		user << "<span class='notice'> You dug a hole.</span>"
 		digging = 0
 
-		gets_dug()
+		gets_dug(user)
 
 	else if(istype(W,/obj/item/weapon/storage/bag/ore))
 		var/obj/item/weapon/storage/bag/ore/S = W
@@ -740,7 +740,7 @@ var/list/asteroid_floor_smooth = list(
 		..(W,user)
 	return
 
-/turf/simulated/floor/asteroid/proc/gets_dug()
+/turf/simulated/floor/asteroid/proc/gets_dug(mob/user)
 
 	add_overlay("asteroid_dug", TRUE)
 
@@ -799,7 +799,8 @@ var/list/asteroid_floor_smooth = list(
 		if(below)
 			var/area/below_area = below.loc		// Let's just assume that the turf is not in nullspace.
 			if(below_area.station_area)
-				user << "<span class='alert'>You strike metal!</span>"
+				if (user)
+					user << "<span class='alert'>You strike metal!</span>"
 				below.spawn_roof(ROOF_FORCE_SPAWN)
 			else
 				ChangeTurf(/turf/space)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -405,7 +405,6 @@
 		return wear_id.GetID()
 
 /mob/living/carbon/human/electrocute_act(var/shock_damage, var/obj/source, var/base_siemens_coeff = 1.0, var/def_zone = null, var/tesla_shock = 0, var/ground_zero)
-	var/hairvar = 0
 	var/list/damage_areas = list()
 	if(status_flags & GODMODE)	return 0	//godmode
 
@@ -416,11 +415,7 @@
 
 	if(!def_zone)
 		//The way this works is by damaging multiple areas in an "Arc" if no def_zone is provided. should be pretty easy to add more arcs if it's needed. though I can't imangine a situation that can apply.
-		if(istype(user, /mob/living/carbon/human))
-			if(h_style == "Floorlength Braid" || h_style == "Very Long Hair")
-				hairvar = 1
-		var/count = hairvar == 1 ? rand(1, 7) : rand(1, 6)
-		switch (count)
+		switch ((h_style == "Floorlength Braid" || h_style == "Very Long Hair") ? rand(1, 7) : rand(1, 6))
 			if(1)
 				damage_areas = list("l_hand", "l_arm", "chest", "r_arm", "r_hand")
 			if(2)

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -476,7 +476,7 @@
 	src.apply_damage(10,BRUTE)
 	playsound(src.loc, 'sound/weapons/bladeslice.ogg', 50, 1)
 	var/obj/item/weapon/arrow/quill/A = new /obj/item/weapon/arrow/quill(usr.loc)
-	A.throw_at(target, 10, 30, user)
+	A.throw_at(target, 10, 30, usr)
 	msg_admin_attack("[key_name_admin(src)] launched a quill at [key_name_admin(target)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)",ckey=key_name(src),ckey_target=key_name(target))
 
 

--- a/code/modules/mob/living/devour.dm
+++ b/code/modules/mob/living/devour.dm
@@ -42,7 +42,7 @@
 		var/mob/living/carbon/human/H = src
 		var/obj/item/blocked = H.check_mouth_coverage()
 		if(blocked)
-			user << "<span class='warning'>\The [blocked] is in the way!</span>"
+			src << "<span class='warning'>\The [blocked] is in the way!</span>"
 			return
 
 	//This check is exploit prevention.

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -149,7 +149,7 @@
 				var/new_y = P.starting.y + pick(0, 0, -1, 1, -2, 2, -2, 2, -2, 2, -3, 3, -3, 3)
 
 				// redirect the projectile
-				P.firer = user
+				P.firer = src
 				P.old_style_target(locate(new_x, new_y, P.z))
 
 			return -1 // complete projectile permutation

--- a/code/modules/mob/living/simple_animal/hostile/changeling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/changeling.dm
@@ -137,5 +137,5 @@
 
 	playsound(src.loc, 'sound/weapons/bloodyslice.ogg', 50, 1)
 	var/obj/item/weapon/bone_dart/A = new /obj/item/weapon/bone_dart(usr.loc)
-	A.throw_at(target, 10, 20, user)
+	A.throw_at(target, 10, 20, usr)
 	add_logs(src, target, "launched a bone dart at")

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -259,7 +259,7 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 /mob/living/simple_animal/hostile/RangedAttack(atom/A, params) //Player firing
 	if(ranged)
 		setClickCooldown(attack_delay)
-		target = A
+		target_mob = A
 		OpenFire(A)
 	..()
 

--- a/code/modules/projectiles/guns/energy/modular.dm
+++ b/code/modules/projectiles/guns/energy/modular.dm
@@ -162,11 +162,11 @@
 			modifier.degrade(1)
 	if((prob(A.damage)/burst))
 		if(prob(A.damage/2))
-			medium_fail(user)
+			medium_fail(ismob(loc) ? loc : null)
 		else
-			small_fail(user)
+			small_fail(ismob(loc) ? loc : null)
 
-	updatetype(user)
+	updatetype(ismob(loc) ? loc : null)
 	return A
 
 /obj/item/weapon/gun/energy/laser/prototype/proc/disassemble(var/mob/user)

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -9,9 +9,8 @@
 				AO.update_aiming_deferred()
 
 /obj/aiming_overlay/proc/trigger(var/perm)
-
-	if(user && user.client && (user.client.prefs.toggles_secondary & SAFETY_CHECK) && user.a_intent != I_HURT) //Check this first to save time.
-		user << "You refrain from firing, as you aren't on harm intent."
+	if(owner && owner.client && (owner.client.prefs.toggles_secondary & SAFETY_CHECK) && owner.a_intent != I_HURT) //Check this first to save time.
+		owner << "You refrain from firing, as you aren't on harm intent."
 		return
 	if(!owner || !aiming_with || !aiming_at || !locked)
 		return

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -108,6 +108,7 @@
 				for (var/j = 0, j < strength - 1, j++) //The number of separate splatters
 					spray_loop:
 						var/direction = pick(alldirs)
+						var/target
 						for (var/i = 1, i < strength, i++) //The distance the splatters will travel from random direction
 							switch (direction)
 								if (NORTH)

--- a/code/modules/spells/aoe_turf/knock.dm
+++ b/code/modules/spells/aoe_turf/knock.dm
@@ -49,9 +49,9 @@
 		for(var/obj/machinery/door/door in T.contents)
 			spawn door.cultify()
 
-	for(var/obj/O in range(1,user))
+	for(var/obj/O in range(1, holder))
 		O.cultify()
-	for(var/turf/T in range(1,user))
+	for(var/turf/T in range(1, holder))
 		var/atom/movable/overlay/animation = new /atom/movable/overlay(T)
 		animation.name = "conjure"
 		animation.density = 0
@@ -65,7 +65,6 @@
 		else
 			animation.icon_state = "cultfloor"
 			flick("cultfloor",animation)
-		spawn(10)
-			qdel(animation)
+		QDEL_IN(animation, 10)
 		T.cultify()
 	return


### PR DESCRIPTION
Removes the phantom global definitions that Fowl found.

Fixes:
- Game log in GELF not logging proper target.
- Pylon attacks not detecting the actual firer of a damaging bullet.
- A message in the mixer cooking machine.
- A message in airbubbles.
- A use_check sanity check in landmines.
- Some messages in psych therapy code.
- A view() checkk in psych therapy code.
- CCIA being unable to announce incoming faxes in some circumstances.
- Language whitelists potentially checking the whitelists of the last person to throw a tray in addition to the pref mob.
- Fixes some messages/sounds with some custom items.
- Fixes a message with digging into the asteroid.
- Fixes electrocution code not properly checking for absurdly long hair.
- Fixes a broken message in devour.
- Fixes a targeting issue with player-controlled hostile ranged mobs.
- Fixes failure behavior for modular RnD guns.
- Fixes an intent safety check on gun aim.
- Fixes the Harvester knock spell potentially not working.