### PR TITLE
Revenge of detective trenchcoats

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -109,6 +109,24 @@
 	display_name = "trenchcoat, grey"
 	path = /obj/item/clothing/suit/storage/toggle/trench/grey
 
+/datum/gear/suit/det_trenchcoat_brown
+	display_name = "brown trenchcoat (Detective)"
+	description = "A rugged canvas trenchcoat, designed and created by TX Fabrication Corp. The coat is externally impact resistant - perfect for your next act of autodefenestration!"
+	path = /obj/item/clothing/suit/storage/toggle/det_trench
+	allowed_roles = list("Detective")
+
+/datum/gear/suit/det_trenchcoat_black
+	display_name = "black trenchcoat (Detective)"
+	description = "A rugged canvas trenchcoat, designed and created by TX Fabrication Corp. The coat is externally impact resistant - perfect for your next act of autodefenestration!"
+	path = /obj/item/clothing/suit/storage/toggle/det_trench/black
+	allowed_roles = list("Detective")
+
+/datum/gear/suit/det_trenchcoat_techni
+	display_name = "technicolor trenchcoat (Detective)"
+	description = "A 23rd-century multi-purpose trenchcoat. It's fibres are hyper-absorbent. Can be painted into any color."
+	path = /obj/item/clothing/suit/storage/toggle/det_trench/technicolor
+	allowed_roles = list("Detective")
+
 /datum/gear/suit/ian
 	display_name = "worn shirt"
 	description = "A worn out, curiously comfortable t-shirt with a picture of Ian."

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -137,11 +137,13 @@
 	siemens_coefficient = 0.7
 
 /obj/item/clothing/suit/storage/toggle/det_trench/black
+	name = "black trenchcoat"
 	icon_state = "detective2"
 	icon_open = "detective2_open"
 	icon_closed = "detective2"
 
 /obj/item/clothing/suit/storage/toggle/det_trench/technicolor
+	name = "black trenchcoat"
 	desc = "A 23rd-century multi-purpose trenchcoat. It's fibres are hyper-absorbent."
 	icon_state = "suit_detective_black"
 	item_state = "suit_detective_black"

--- a/html/changelogs/Sindorman-trench.yml
+++ b/html/changelogs/Sindorman-trench.yml
@@ -1,0 +1,7 @@
+author: PoZe
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed names for black and technicolor detective armoured trenchcoats"
+  - rscadd: "Detective armoured trenchcoats are avaliable in loadout section of character setup. (Only for detectives)"


### PR DESCRIPTION
As per players request, this add detective trench coats to the character loadout section of character setup.
Summary:

- Adds brown, black, technicolor detective armoured trenchcoats to loadout.

- Fixes names for detective black and technicolor trenchcoats.