### PR TITLE
Cyborg component bugfix

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -39,8 +39,8 @@
 	wrapped.icon_state = brokenstate // Module-specific broken icons! Yay!
 
 	// The thing itself isn't there anymore, but some fried remains are.
-	installed = -1
 	uninstall()
+	installed = -1
 
 /datum/robot_component/proc/take_damage(brute, electronics, sharp, edge)
 	if(installed != 1) return

--- a/html/changelogs/Sindorman-bugfix.yml
+++ b/html/changelogs/Sindorman-bugfix.yml
@@ -1,0 +1,13 @@
+
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Destroyed cyborg components no longer just vanish"


### PR DESCRIPTION
- Cyborg components no longer vanish, because of one var being set improperly. Fixes #5000 