### PR TITLE
Mapping Fixes

### DIFF
--- a/html/changelogs/ben10083 - Mapping Fixes.yml
+++ b/html/changelogs/ben10083 - Mapping Fixes.yml
@@ -34,5 +34,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - bugfix: "Removed duplicate Warden's stamp"
-  - spellcheck: "Fixed camera name of Journalist's office"
+  - maptweak: "Removed the duplicate stamp and fixes the name of the camera in the journalists office".

--- a/html/changelogs/ben10083 - Mapping Fixes.yml
+++ b/html/changelogs/ben10083 - Mapping Fixes.yml
@@ -34,4 +34,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - maptweak: "Removed the duplicate stamp and fixes the name of the camera in the journalists office".
+  - maptweak: "Removed the duplicate stamp and fixes the name of the camera in the journalists office."

--- a/html/changelogs/ben10083 - Mapping Fixes.yml
+++ b/html/changelogs/ben10083 - Mapping Fixes.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Removed duplicate Warden's stamp"
+  - spellcheck: "Fixed camera name of Journalist's office"

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -15960,9 +15960,6 @@
 	dir = 8
 	},
 /obj/structure/table/standard,
-/obj/item/weapon/stamp{
-	name = "warden's rubber stamp"
-	},
 /obj/item/weapon/folder/sec,
 /obj/item/weapon/stamp{
 	name = "warden's rubber stamp"
@@ -63631,7 +63628,7 @@
 /area/journalistoffice)
 "cus" = (
 /obj/machinery/camera/network/civilian_main{
-	c_tag = "Starboard Corridor - Store";
+	c_tag = "Starboard Corridor - Journalist's Office";
 	dir = 1
 	},
 /obj/item/device/radio/intercom{


### PR DESCRIPTION
(First one was accidentally based off development)

Removed duplicate Warden's Stamp and fixed camera name of Journalist's Office.
