### PR TITLE
Fix a custom item spawning bug

### DIFF
--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -305,8 +305,6 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 
 	UpdateFactionList(character)
 
-	equip_custom_items(character)
-
 	// AIs don't need a spawnpoint, they must spawn at an empty core
 	if(character.mind.assigned_role == "AI")
 
@@ -327,6 +325,8 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 
 	//Find our spawning point.
 	var/join_message = SSjobs.LateSpawn(character, rank)
+
+	equip_custom_items(character)
 
 	character.lastarea = get_area(loc)
 	// Moving wheelchair if they have one


### PR DESCRIPTION
Turns out if the game can't equip or put the custom item into an inventory, it will just throw the item into space due to the order of where the equip_custom_items is, this should fix this problem.