### PR TITLE
Supermatter Tweaks

### DIFF
--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -8,7 +8,7 @@
 
 /obj/item/weapon/tape_roll/proc/take_charge(var/mob/user,var/amount)
 	charge -= amount
-	if(charge < 0)
+	if(charge <= 0)
 		to_chat(user,"<span class='notice'>You ran out of tape!</span>")
 		qdel(src)
 

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -4,6 +4,13 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "taperoll"
 	w_class = 1
+	var/charge = 10
+
+/obj/item/weapon/tape_roll/proc/take_charge(var/mob/user,var/amount)
+	charge -= amount
+	if(charge < 0)
+		to_chat(user,"<span class='notice'>You ran out of tape!</span>")
+		qdel(src)
 
 /obj/item/weapon/tape_roll/attack(var/mob/living/carbon/human/H, var/mob/user, var/target_zone)
 	if(istype(H))
@@ -31,6 +38,7 @@
 				return
 
 			playsound(src, 'sound/items/tape.ogg',25)
+			take_charge(user,1)
 			user.visible_message("<span class='danger'>\The [user] has taped up \the [H]'s eyes!</span>")
 			H.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses/blindfold/tape(H), slot_glasses)
 			H.update_inv_glasses()
@@ -50,6 +58,7 @@
 				return
 
 			playsound(src, 'sound/items/tape.ogg',25)
+			take_charge(user,1)
 			user.visible_message("<span class='danger'>\The [user] begins taping up \the [H]'s mouth!</span>")
 
 			if(!do_after(user, 30))
@@ -60,12 +69,14 @@
 				return
 
 			playsound(src, 'sound/items/tape.ogg',25)
+			take_charge(user,1)
 			user.visible_message("<span class='danger'>\The [user] has taped up \the [H]'s mouth!</span>")
 			H.equip_to_slot_or_del(new /obj/item/clothing/mask/muzzle/tape(H), slot_wear_mask)
 			H.update_inv_wear_mask()
 
 		else if(target_zone == "r_hand" || target_zone == "l_hand")
 			playsound(src, 'sound/items/tape.ogg',25)
+			take_charge(user,1)
 			var/obj/item/weapon/handcuffs/cable/tape/T = new(user)
 			if(!T.place_handcuffs(H, user))
 				user.unEquip(T)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -353,9 +353,11 @@
 /obj/machinery/power/supermatter/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 
 	if(istype(W,/obj/item/weapon/tape_roll))
+		var/obj/item/weapon/tape_roll/tape = W
 		playsound(src, 'sound/items/tape.ogg',25)
-		user.visible_message("<span class='notice'>\The [user] applies duct tape to the supermatter, repairing it.</span>")
+		user.visible_message("<span class='notice'>\The [user] applies duct tape to \the [src], repairing it.</span>")
 		damage -= 5
+		tape.take_charge(user,1)
 		return
 
 	user.visible_message("<span class=\"warning\">\The [user] touches \a [W] to \the [src] as a silence fills the room...</span>",\

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -351,6 +351,13 @@
 */
 
 /obj/machinery/power/supermatter/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
+
+	if(istype(W,/obj/item/weapon/tape_roll))
+		playsound(src, 'sound/items/tape.ogg',25)
+		user.visible_message("<span class='notice'>\The [user] applies duct tape to the supermatter, repairing it.</span>")
+		damage -= 5
+		return
+
 	user.visible_message("<span class=\"warning\">\The [user] touches \a [W] to \the [src] as a silence fills the room...</span>",\
 		"<span class=\"danger\">You touch \the [W] to \the [src] when everything suddenly goes silent.\"</span>\n<span class=\"notice\">\The [W] flashes into dust as you flinch away from \the [src].</span>",\
 		"<span class=\"warning\">Everything suddenly goes silent.</span>")

--- a/html/changelogs/burgerbb-supermatter_tweaks.yml
+++ b/html/changelogs/burgerbb-supermatter_tweaks.yml
@@ -35,3 +35,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Duct tape can now repair the supermatter."
+  - balance: "Duct tape now has 10 charges instead of unlimted use."

--- a/html/changelogs/burgerbb-supermatter_tweaks.yml
+++ b/html/changelogs/burgerbb-supermatter_tweaks.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Duct tape can now repair the supermatter."


### PR DESCRIPTION
# Overview
There are a lot of new engineer players lately, and right now I believe that setting up the supermatter in a safe and working manner is honestly a little difficult for the first timers.

I propose adding an additional way for new players to maintain the supermater. Hopefully we can finally become a new player friendly server.

Duct Tape was unlimited, now it is limited, with only 10 uses. It's still better than using cable cuffs, however I do not want to upset duct tape mains by reducing it to useless levels.