### PR TITLE
Voting Fixes

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -31,24 +31,30 @@ var/round_start_time
 
 var/next_duration_update = 0
 var/last_round_duration = 0
-/proc/round_duration()
-	if(last_round_duration && world.time < next_duration_update)
-		return last_round_duration
 
-	var/mills = round_duration_in_ticks // 1/10 of a second, not real milliseconds but whatever
-	//var/secs = ((mills % 36000) % 600) / 10 //Not really needed, but I'll leave it here for refrence.. or something
-	if (!mills)
-		last_round_duration = "00:00"
-		next_duration_update = world.time + 1 MINUTE
-		return last_round_duration
-
-	var/mins = round((mills % 36000) / 600)
-	var/hours = round(mills / 36000)
+/proc/format_time_lazy(var/input)
+	var/mins = round((input % 36000) / 600)
+	var/hours = round(input / 36000)
 
 	mins = mins < 10 ? add_zero(mins, 1) : mins
 	hours = hours < 10 ? add_zero(hours, 1) : hours
 
-	last_round_duration = "[hours]:[mins]"
+	return "[hours]:[mins]"
+
+/proc/round_duration()
+
+	if(last_round_duration && world.time < next_duration_update)
+		return last_round_duration
+	
+	var/time_passed = world.time - round_start_time
+
+	if (time_passed <= 0)
+		last_round_duration = "00:00"
+		next_duration_update = world.time + 1 MINUTE
+		return last_round_duration
+
+	last_round_duration = format_time_lazy(time_passed)
+
 	next_duration_update = world.time + 1 MINUTES
 	return last_round_duration
 

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -214,15 +214,8 @@ var/datum/controller/subsystem/ticker/SSticker
 
 	else if (mode_finished)
 		post_game = 1
-
 		mode.cleanup()
-
-		//call a transfer shuttle vote
-		spawn(50)
-			if(!round_end_announced) // Spam Prevention. Now it should announce only once.
-				world << "<span class='danger'>The round has ended!</span>"
-				round_end_announced = 1
-			SSvote.autotransfer()
+		message_admins("<span class='warning'><b>Notice: The gamemode has finished.</b></span>")
 
 	return 1
 

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -21,6 +21,7 @@ var/datum/controller/subsystem/vote/SSvote
 	var/list/additional_text = list()
 	var/auto_muted = 0
 	var/last_transfer_vote = null
+	var/next_allowed_time = 0
 
 	var/list/round_voters = list()
 
@@ -29,6 +30,7 @@ var/datum/controller/subsystem/vote/SSvote
 
 /datum/controller/subsystem/vote/Initialize(timeofday)
 	next_transfer_time = config.vote_autotransfer_initial
+	next_allowed_time = config.transfer_timeout
 
 /datum/controller/subsystem/vote/fire(resumed = FALSE)
 	if (mode)
@@ -232,7 +234,6 @@ var/datum/controller/subsystem/vote/SSvote
 	if(!mode)
 		if(started_time != null && !(check_rights(R_ADMIN|R_MOD) || automatic))
 			// Transfer votes are their own little special snowflake
-			var/next_allowed_time = 0
 			if (vote_type == "crew_transfer")
 				if (config.vote_no_dead && !usr.client.holder)
 					if (isnewplayer(usr))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -756,7 +756,7 @@
 			stat("Map", current_map.full_name)
 			stat("Station Time", worldtime2text())
 			stat("Round Duration", round_duration())
-			stat("Last Transfer Vote", SSvote.last_transfer_vote ? time2text(SSvote.last_transfer_vote, "hh:mm") : "Never")
+			stat("Next Transfer Time:", SSvote.next_allowed_time ? format_time_lazy(SSvote.next_allowed_time) : "Never")
 
 		if(client.holder)
 			if(statpanel("Status"))

--- a/html/changelogs/burgerbb-voting_fixes.yml
+++ b/html/changelogs/burgerbb-voting_fixes.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "You can no longer vote before the 2 hour mark. The round duration's time is measured in REAL time, and not ticks."
+  - bugfix: "Fixed the game calling an annoying crew transfer vote and informing everyone when raiders/mercs/whatever left."

--- a/html/changelogs/burgerbb-voting_fixes.yml
+++ b/html/changelogs/burgerbb-voting_fixes.yml
@@ -36,3 +36,4 @@ delete-after: True
 changes: 
   - bugfix: "You can no longer vote before the 2 hour mark. The round duration's time is measured in REAL time, and not ticks."
   - bugfix: "Fixed the game calling an annoying crew transfer vote and informing everyone when raiders/mercs/whatever left."
+  - tweak: "Changes + fixes the 'next vote' time metric to be saner."


### PR DESCRIPTION
# Overview
Fixes a bug where players could vote 2-3 minutes before the 2 hour voting mark.
The game's duration time is measured in REAL time and not server ticks.
Fixes the game informing the server of a merc/raiders departure and calling an automatic vote.

I haven't truly tested this yet. Will test it tomorrow.