### PR TITLE
Roof Solars Wiring Fix

### DIFF
--- a/html/changelogs/flimango-roof_power_bugfix.yml
+++ b/html/changelogs/flimango-roof_power_bugfix.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: flimango
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed roof solars wiring."

--- a/maps/aurora/aurora-7_roof.dmm
+++ b/maps/aurora/aurora-7_roof.dmm
@@ -2426,10 +2426,6 @@
 /turf/simulated/floor/airless,
 /area/mine/explored)
 "eM" = (
-/obj/structure/cable{
-	icon_state = "1-8";
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -2472,15 +2468,15 @@
 /area/mine/explored)
 "eP" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
 /turf/simulated/floor/airless,
@@ -2862,6 +2858,166 @@
 	dir = 1
 	},
 /turf/simulated/floor/reinforced/airless,
+/area/mine/explored)
+"fM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8";
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fP" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fR" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fS" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fT" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fU" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fW" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fX" = (
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/mine/explored)
+"fY" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 5
+	},
+/turf/simulated/floor/airless,
 /area/mine/explored)
 
 (1,1,1) = {"
@@ -27704,7 +27860,7 @@ el
 el
 el
 el
-el
+fM
 eM
 ah
 ah
@@ -27961,8 +28117,8 @@ em
 em
 em
 em
-em
-eN
+fN
+eb
 ah
 ah
 ah
@@ -28218,8 +28374,8 @@ ab
 ab
 ab
 ab
-ae
-eO
+fO
+ah
 ah
 ah
 ah
@@ -28466,7 +28622,7 @@ ag
 bG
 ag
 ag
-ah
+fe
 ea
 al
 ab
@@ -28475,8 +28631,8 @@ ab
 ab
 ab
 ab
-ae
-eO
+fP
+ah
 ah
 ah
 ah
@@ -28724,7 +28880,7 @@ dZ
 ec
 ec
 ec
-eb
+fE
 al
 ab
 ab
@@ -28732,8 +28888,8 @@ aa
 aa
 ab
 ab
-ae
-eO
+fQ
+ah
 ah
 ah
 ah
@@ -28989,8 +29145,8 @@ aa
 aa
 aa
 ab
-ae
-eO
+fR
+ah
 ah
 ah
 ah
@@ -29246,8 +29402,8 @@ aa
 aa
 aa
 aa
-ae
-eO
+fS
+ah
 ah
 ah
 ah
@@ -29503,8 +29659,8 @@ aa
 aa
 aa
 aa
-ae
-eO
+fT
+ah
 ah
 ah
 ah
@@ -29760,8 +29916,8 @@ aa
 aa
 aa
 aa
-ae
-eO
+fU
+ah
 ah
 ah
 ah
@@ -30017,8 +30173,8 @@ aa
 aa
 aa
 aa
-ae
-eO
+fV
+ah
 ah
 ah
 ah
@@ -30274,8 +30430,8 @@ ad
 ag
 ag
 ag
-fe
-eO
+fW
+ah
 ah
 ah
 ah
@@ -30531,8 +30687,8 @@ ae
 ah
 ah
 ah
+fX
 ah
-eO
 ah
 ah
 ah
@@ -30788,7 +30944,7 @@ ae
 ah
 ah
 ah
-ah
+fY
 eP
 eQ
 eQ

--- a/maps/aurora/aurora-7_roof.dmm
+++ b/maps/aurora/aurora-7_roof.dmm
@@ -2881,8 +2881,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	dir = 4
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/mine/explored)
@@ -2890,11 +2891,12 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/airless,
 /area/mine/explored)
 "fP" = (
@@ -2979,24 +2981,26 @@
 	icon_state = "warningcorner";
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/mine/explored)
 "fX" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/mine/explored)

--- a/maps/aurora/aurora-7_roof.dmm
+++ b/maps/aurora/aurora-7_roof.dmm
@@ -2870,6 +2870,11 @@
 /turf/simulated/floor/airless,
 /area/mine/explored)
 "fN" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -2879,11 +2884,6 @@
 	icon_state = "1-2";
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/airless,
 /area/mine/explored)
 "fO" = (
@@ -28631,7 +28631,7 @@ ab
 ab
 ab
 ab
-fP
+fO
 ah
 ah
 ah
@@ -28888,7 +28888,7 @@ aa
 aa
 ab
 ab
-fQ
+fO
 ah
 ah
 ah
@@ -29145,7 +29145,7 @@ aa
 aa
 aa
 ab
-fR
+fO
 ah
 ah
 ah
@@ -29402,7 +29402,7 @@ aa
 aa
 aa
 aa
-fS
+fO
 ah
 ah
 ah
@@ -29659,7 +29659,7 @@ aa
 aa
 aa
 aa
-fT
+fO
 ah
 ah
 ah
@@ -29916,7 +29916,7 @@ aa
 aa
 aa
 aa
-fU
+fO
 ah
 ah
 ah
@@ -30173,7 +30173,7 @@ aa
 aa
 aa
 aa
-fV
+fO
 ah
 ah
 ah

--- a/maps/aurora/aurora-7_roof.dmm
+++ b/maps/aurora/aurora-7_roof.dmm
@@ -2864,8 +2864,9 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	dir = 8
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/airless,
 /area/mine/explored)


### PR DESCRIPTION
Fixes roof solars wiring, as pictured, so that they don't transfer power between grids. Fixes #4311

![](https://puu.sh/B915d/b6ac69015e.png)

![](https://puu.sh/B90Q2/5f9ccd82c6.png)