### PR TITLE
Fixed vueui resources not working

### DIFF
--- a/code/modules/vueui/ui.dm
+++ b/code/modules/vueui/ui.dm
@@ -230,13 +230,13 @@ main ui datum.
   */
 /datum/vueui/Topic(href, href_list)
 	update_status()
+	if(status < STATUS_INTERACTIVE || user != usr)
+		return
 	if(href_list["vueuiforceresource"])
 		if(user.client)
 			user.client << browse_rsc(file("vueui/dist/app.js"), "vueui.js")
 			user.client << browse_rsc(file("vueui/dist/app.css"), "vueui.css")
 		open()
-	if(status < STATUS_INTERACTIVE || user != usr)
-		return
 	if(href_list["vueuistateupdate"])
 		var/rdata = json_decode(href_list["vueuistateupdate"])
 		var/ndata = rdata["state"]

--- a/code/modules/vueui/ui.dm
+++ b/code/modules/vueui/ui.dm
@@ -126,7 +126,7 @@ main ui datum.
 			<header-[header]></header-[header]>
 		</div>
 		<div id="app">
-
+			Javascript file has failed to load. <a href="?src=\ref[src]&vueuiforceresource=1">Click here to force load resources</a>
 		</div>
 		[debugtxt]
 		<noscript>
@@ -230,6 +230,11 @@ main ui datum.
   */
 /datum/vueui/Topic(href, href_list)
 	update_status()
+	if(href_list["vueuiforceresource"])
+		if(user.client)
+			user.client << browse_rsc(file("vueui/dist/app.js"), "vueui.js")
+			user.client << browse_rsc(file("vueui/dist/app.css"), "vueui.css")
+		open()
 	if(status < STATUS_INTERACTIVE || user != usr)
 		return
 	if(href_list["vueuistateupdate"])

--- a/html/changelogs/Karolis2011 - vueui fixes.yml
+++ b/html/changelogs/Karolis2011 - vueui fixes.yml
@@ -1,0 +1,5 @@
+author: Karolis2011
+delete-after: True
+
+changes: 
+  - bugfix: Added a reliable way to manually force send resources to client if asset manager fails.

--- a/vueui/src/assets/global.scss
+++ b/vueui/src/assets/global.scss
@@ -145,3 +145,7 @@ input, textarea, button, select, .button {
 .uiTitleFluff {
     display: none;
 }
+
+.csserror {
+    display: none;
+}

--- a/vueui/src/main.js
+++ b/vueui/src/main.js
@@ -45,7 +45,7 @@ window.__wtimetimer = window.setInterval(() => {
 
 new Vue({
   data: Store.state,
-  template: "<div><component v-if='componentName' :is='componentName'/><component v-if='templateString' :is='{template:templateString}'/></div>",
+  template: "<div><p class='csserror'>Javascript loaded, stylesheets has failed to load. <a href='javascript:void(0)'><vui-button :params='{ vueuiforceresource: 1}'>Click here to load.</vui-button></a></p><component v-if='componentName' :is='componentName'/><component v-if='templateString' :is='{template:templateString}'/></div>",
   computed: {
     componentName() {
       if(this.$root.$data.active.charAt(0) != "?") {


### PR DESCRIPTION
Fixes #5087 and fixes #5086 by adding clickable links to load resources if they seemingly failed to load due to asset manager. 
If CSS file fails to load it shows 
![paveikslas](https://user-images.githubusercontent.com/11229891/43693347-06d33a96-9936-11e8-8edf-d2d2667ddad9.png)
If JavaScript fails to load:
![paveikslas](https://user-images.githubusercontent.com/11229891/43693372-1c274716-9936-11e8-9801-2ad663182534.png)
If only JavaScript has failed to load
![paveikslas](https://user-images.githubusercontent.com/11229891/43693389-34d72498-9936-11e8-90f5-1e3ae20e7e15.png)

