### PR TITLE
Roof Solars Fix

### DIFF
--- a/html/changelogs/flimango-roof_solars_redo.yml
+++ b/html/changelogs/flimango-roof_solars_redo.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: flimango
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Remapped the surface solars cables to run internally."
+  - bugfix: "Fixed the surface solars to properly transfer power to the main grid and vice versa."

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -15891,9 +15891,7 @@
 /obj/structure/ladder/up{
 	pixel_y = 16
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes,
 /turf/simulated/floor/plating,
 /area/maintenance/arrivals)
 "DC" = (
@@ -44680,7 +44678,7 @@ NK
 NL
 NM
 NN
-NO
+NM
 NR
 DW
 Eh
@@ -44688,7 +44686,7 @@ Ek
 EU
 Ek
 FK
-NU
+NT
 Gn
 GB
 DW
@@ -44945,7 +44943,7 @@ Ek
 EV
 Ek
 FK
-NV
+NT
 Ek
 GE
 DW
@@ -45202,7 +45200,7 @@ EC
 EU
 Ek
 FK
-NW
+NT
 Ek
 ER
 DW
@@ -45719,11 +45717,11 @@ FM
 Gd
 NY
 GG
-NZ
+NY
 Hf
-Oa
-Ob
-Oc
+NY
+NY
+NY
 Od
 Ig
 DW

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -16080,6 +16080,11 @@
 	req_access = list(31)
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/loading)
 "DY" = (
@@ -16168,6 +16173,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
@@ -16376,6 +16386,11 @@
 /area/quartermaster/loading)
 "EA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "EB" = (
@@ -16529,6 +16544,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
@@ -16806,6 +16826,11 @@
 "Fp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "Fq" = (
@@ -17035,6 +17060,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
@@ -17301,6 +17331,11 @@
 "Gd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "Ge" = (
@@ -17582,6 +17617,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "GH" = (
@@ -17856,6 +17896,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "Hg" = (
@@ -18305,6 +18350,11 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "HV" = (
@@ -18319,6 +18369,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "HW" = (
@@ -18332,11 +18387,21 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "HX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
@@ -18359,6 +18424,11 @@
 	icon_state = "corner_white";
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "HZ" = (
@@ -18377,6 +18447,11 @@
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
@@ -18402,6 +18477,11 @@
 /obj/machinery/status_display/supply_display{
 	pixel_y = 32
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "Ib" = (
@@ -18416,6 +18496,11 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/loading)
@@ -18433,6 +18518,11 @@
 	dir = 6
 	},
 /obj/random/junk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/arrivals)
 "Id" = (
@@ -18960,11 +19050,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/arrivals)
 "IW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/random/junk,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -18987,11 +19072,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/arrivals)
 "IY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/down{
 	icon_state = "pipe-d";
 	dir = 1
@@ -20074,6 +20154,207 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
+"NJ" = (
+/obj/structure/cable{
+	icon_state = "12-0"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"NK" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"NL" = (
+/obj/random/junk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"NM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"NN" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"NO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"NP" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"NQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"NR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/arrivals)
+"NS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"NT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"NU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"NV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"NW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"NX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"NY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"NZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"Oa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"Ob" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"Oc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"Od" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
+"Oe" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/loading)
 
 (1,1,1) = {"
 aa
@@ -43886,14 +44167,14 @@ DD
 sU
 ag
 sU
-tt
+NP
 DX
 Ef
 EA
 ET
 Fp
 FI
-Ek
+NS
 Go
 GD
 DW
@@ -44138,19 +44419,19 @@ ag
 sU
 sU
 sU
-tt
+NJ
 tt
 sU
 sU
 sU
-tt
+NQ
 DW
 Eg
 EB
 EB
 EB
 FJ
-Ek
+NT
 Go
 GB
 DW
@@ -44395,19 +44676,19 @@ ag
 sU
 tt
 tt
-tt
-tu
-tt
-Bw
-tt
-tt
+NK
+NL
+NM
+NN
+NO
+NR
 DW
 Eh
 Ek
 EU
 Ek
 FK
-Ek
+NU
 Gn
 GB
 DW
@@ -44664,7 +44945,7 @@ Ek
 EV
 Ek
 FK
-Ek
+NV
 Ek
 GE
 DW
@@ -44921,7 +45202,7 @@ EC
 EU
 Ek
 FK
-Ek
+NW
 Ek
 ER
 DW
@@ -45178,7 +45459,7 @@ Ek
 EU
 Fq
 FL
-ED
+NX
 ED
 GF
 GR
@@ -45436,14 +45717,14 @@ Ek
 Fr
 FM
 Gd
-Gd
+NY
 GG
-Gd
+NZ
 Hf
-Gd
-Gd
-Gd
-FI
+Oa
+Ob
+Oc
+Od
 Ig
 DW
 ag
@@ -46728,7 +47009,7 @@ Hj
 Hv
 HH
 HR
-Hg
+Oe
 Ek
 Ip
 Iw
@@ -48025,7 +48306,7 @@ IR
 IT
 IW
 IY
-Jb
+tt
 sU
 aa
 aa

--- a/maps/aurora/aurora-7_roof.dmm
+++ b/maps/aurora/aurora-7_roof.dmm
@@ -2112,11 +2112,11 @@
 /turf/simulated/open,
 /area/maintenance/solarmaint)
 "eo" = (
-/obj/structure/lattice,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "11-2"
 	},
+/obj/structure/lattice/catwalk,
 /turf/simulated/open,
 /area/maintenance/solarmaint)
 "ep" = (

--- a/maps/aurora/aurora-7_roof.dmm
+++ b/maps/aurora/aurora-7_roof.dmm
@@ -854,8 +854,7 @@
 	icon_state = "warning";
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
@@ -2065,11 +2064,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/solarmaint)
 "ek" = (
@@ -2118,12 +2112,12 @@
 /turf/simulated/open,
 /area/maintenance/solarmaint)
 "eo" = (
+/obj/structure/lattice,
 /obj/structure/cable{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "11-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/open,
 /area/maintenance/solarmaint)
 "ep" = (
 /obj/random/loot,
@@ -2145,24 +2139,24 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/solarmaint)
 "es" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/smes/buildable{
 	charge = 0;
 	RCon_tag = "\[SOL.4] Solar - Roof"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/solarmaint)
@@ -2487,21 +2481,18 @@
 /turf/simulated/floor/airless,
 /area/mine/explored)
 "eP" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
 /turf/simulated/floor/airless,
 /area/mine/explored)
 "eQ" = (
@@ -3126,6 +3117,14 @@
 	dir = 1
 	},
 /turf/simulated/floor/airless,
+/area/mine/explored)
+"gc" = (
+/obj/random/glowstick,
+/turf/simulated/floor/reinforced/airless,
+/area/mine/explored)
+"gd" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/reinforced/airless,
 /area/mine/explored)
 
 (1,1,1) = {"
@@ -26418,17 +26417,17 @@ ab
 ac
 ac
 ab
-fM
-fN
-fO
-fP
-fQ
-fR
-fS
-fT
-fU
-fV
-fW
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+fe
+ah
+ah
 ah
 ah
 ah
@@ -26675,7 +26674,7 @@ ab
 ab
 ab
 ab
-eO
+ae
 ei
 ei
 ei
@@ -26685,7 +26684,7 @@ ei
 ei
 ah
 ah
-fX
+ah
 ah
 ah
 ah
@@ -26932,7 +26931,7 @@ ab
 ab
 ab
 ab
-eO
+ae
 ei
 en
 eq
@@ -26942,7 +26941,7 @@ eC
 ex
 eG
 ah
-fY
+ah
 ah
 ah
 ah
@@ -27189,7 +27188,7 @@ ab
 ab
 ab
 ad
-ee
+fe
 ej
 eo
 er
@@ -27199,7 +27198,7 @@ eD
 eF
 eH
 eN
-fZ
+ah
 ah
 ah
 ah
@@ -27456,7 +27455,7 @@ eE
 ex
 eI
 eL
-ga
+ah
 ah
 ah
 ah
@@ -27713,7 +27712,7 @@ ei
 ei
 eJ
 eL
-gb
+ah
 ah
 ah
 ah
@@ -27970,7 +27969,7 @@ el
 el
 bS
 eP
-eX
+ah
 ah
 ah
 ah
@@ -28218,15 +28217,15 @@ ab
 ab
 ae
 eL
+fg
+ai
+ai
+ai
+ai
+ai
+ai
+ff
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-eb
-eX
 ah
 ah
 ah
@@ -28482,7 +28481,7 @@ ab
 ab
 ab
 ab
-eK
+ae
 ah
 ah
 ah
@@ -28739,7 +28738,7 @@ ab
 ab
 ab
 ab
-eK
+ae
 ah
 ah
 ah
@@ -28996,7 +28995,7 @@ aa
 aa
 ab
 ab
-eK
+ae
 ah
 ah
 ah
@@ -29253,7 +29252,7 @@ aa
 aa
 aa
 ab
-eK
+ae
 ah
 ah
 ah
@@ -29510,7 +29509,7 @@ aa
 aa
 aa
 aa
-eK
+ae
 ah
 ah
 ah
@@ -29767,7 +29766,7 @@ aa
 aa
 aa
 aa
-eK
+ae
 ah
 ah
 ah
@@ -30024,7 +30023,7 @@ aa
 aa
 aa
 aa
-eK
+ae
 ah
 ah
 ah
@@ -30281,7 +30280,7 @@ aa
 aa
 aa
 aa
-eK
+ae
 ah
 ah
 ah
@@ -30538,7 +30537,7 @@ ad
 ag
 ag
 ag
-eO
+fe
 ah
 ah
 ah
@@ -30565,7 +30564,7 @@ ag
 fe
 ah
 ah
-ah
+gc
 al
 aa
 aa
@@ -30795,7 +30794,6 @@ ae
 ah
 ah
 ah
-eO
 ah
 ah
 ah
@@ -30821,8 +30819,9 @@ ah
 ah
 ah
 ah
-eU
 ah
+an
+gd
 al
 aa
 aa
@@ -31052,34 +31051,34 @@ ae
 ah
 ah
 ah
-eM
-eQ
-fn
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eS
-eQ
-eT
-eV
-fL
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+fg
+ai
+ff
+ah
+ah
+an
 al
 aa
 aa
@@ -31333,9 +31332,9 @@ ai
 ai
 am
 aa
-af
+ak
 ai
-eW
+ai
 ai
 am
 aa


### PR DESCRIPTION
This PR both fixes issue #4311, and also moves the cables to run internally, so that there's no ugly cables running across the roof, and so that carp can't break the window and vent half of maintenance. Images:

CURRENT LIVE:

![image](https://user-images.githubusercontent.com/32926873/43765690-65a65058-99e5-11e8-914d-710321bdb398.png)
![image](https://user-images.githubusercontent.com/32926873/43765703-6b4afe46-99e5-11e8-9074-8d058b8dc2b0.png)

CHANGED/FIXED:

![image](https://user-images.githubusercontent.com/32926873/43765759-8d9a506e-99e5-11e8-9371-02356d94af05.png)
![image](https://user-images.githubusercontent.com/32926873/43765762-9048cb38-99e5-11e8-92ed-902e919b6905.png)
![image](https://user-images.githubusercontent.com/32926873/43765769-928f8850-99e5-11e8-85aa-5cc4081a1a4c.png)
![image](https://user-images.githubusercontent.com/32926873/43765770-94b7b06c-99e5-11e8-8809-5de7be693650.png)

Tested on a local server with no issues. Removed all remaining instances of the bugged cables from both levels.