### PR TITLE
Fixed the Warden uniform being a Security Officer uniform in the character loadout.

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -188,7 +188,7 @@
 
 /datum/gear/suit/secjacketwarden
 	display_name = "navy security jacket (Warden)"
-	path = /obj/item/clothing/suit/security/navyofficer
+	path = /obj/item/clothing/suit/security/navywarden
 	allowed_roles = list("Head of Security", "Warden")
 
 /datum/gear/suit/secjackethos


### PR DESCRIPTION
While playing as a Warden I noticed I didn't get the uniform I selected in the loadout but instead got a Security Officer's uniform.
This pull request fixes the 'Uniform, NavyBlue (Warden)' in the character loadout actually being a duplicate 'Uniform, NavyBlue (Security Officer)'.

