### PR TITLE
Fixes the long-standing RCON bug.

### DIFF
--- a/html/changelogs/rcon_fix.yml
+++ b/html/changelogs/rcon_fix.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: flimango
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed RCON tags."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -188,7 +188,7 @@
 "aB" = (
 /obj/machinery/power/smes/buildable{
 	charge = 2e+006;
-	RCon_tag = "\[ENG.2] Tesla - Containment"
+	RCon_tag = "Tesla - Containment"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -1848,7 +1848,7 @@
 /area/outpost/engineering/power)
 "dZ" = (
 /obj/machinery/power/smes/buildable/outpost_substation{
-	RCon_tag = "\[ENG.2] Tesla - Grid"
+	RCon_tag = "Tesla - Grid"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -12496,13 +12496,13 @@
 /area/medical/virology)
 "wq" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "\[F.4] Medical Substation Bypass"
+	RCon_tag = "Medical Sublevel Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)
 "wr" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - \[F.4] Medical"
+	RCon_tag = "Substation - Medical Sublevel"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -14986,7 +14986,7 @@
 /area/maintenance/sublevel)
 "AR" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - \[F.4] Research"
+	RCon_tag = "Substation - Research Sublevel"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -15000,7 +15000,7 @@
 /area/maintenance/sublevel)
 "AS" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "\[F.4] Research Substation Bypass"
+	RCon_tag = "Research Sublevel Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/sublevel)

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -964,7 +964,7 @@
 "abY" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
-	RCon_tag = "Substation - \[F.3] Security"
+	RCon_tag = "Substation - Security Main"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -978,7 +978,7 @@
 /area/maintenance/substation/security)
 "abZ" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "\[F.3] Security Substation Bypass"
+	RCon_tag = "Security Main Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
@@ -5531,7 +5531,7 @@
 	charge = 2e+006;
 	input_attempt = 1;
 	output_attempt = 1;
-	RCon_tag = "Substation - \[ATM] Atmospherics"
+	RCon_tag = "Substation - Atmospherics"
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
@@ -6748,7 +6748,7 @@
 	input_level = 500000;
 	output_attempt = 1;
 	output_level = 500000;
-	RCon_tag = "\[ENG.1] Supermatter - Grid"
+	RCon_tag = "Supermatter - Grid"
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -8644,7 +8644,7 @@
 	input_level = 100000;
 	output_attempt = 1;
 	output_level = 200000;
-	RCon_tag = "\[ENG.1] Supermatter - Containment"
+	RCon_tag = "Supermatter - Containment"
 	},
 /obj/structure/cable/orange{
 	icon_state = "0-2"
@@ -13835,7 +13835,7 @@
 "aAc" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
-	RCon_tag = "Substation - \[F.3] Engineering"
+	RCon_tag = "Substation - Engineering Main"
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -13849,7 +13849,7 @@
 /area/maintenance/substation/engineering)
 "aAd" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "\[F.3] Engineering Substation Bypass"
+	RCon_tag = "Engineering Main Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
@@ -29288,7 +29288,7 @@
 "bao" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
-	RCon_tag = "Substation - \[F.3] Command"
+	RCon_tag = "Substation - Command Main"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -30000,7 +30000,7 @@
 /area/maintenance/substation/command)
 "bbH" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "\[F.3] Command Substation Bypass"
+	RCon_tag = "Command Main Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/command)
@@ -37519,7 +37519,7 @@
 "boy" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
-	RCon_tag = "Substation - \[F.3] Research"
+	RCon_tag = "Substation - Research Main"
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -38246,7 +38246,7 @@
 /area/maintenance/substation/research)
 "bpK" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "\[F.3] Research Substation Bypass"
+	RCon_tag = "Research Main Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
@@ -47335,14 +47335,14 @@
 /area/crew_quarters/heads/cmo)
 "bEN" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "\[F.3] Medical Substation Bypass"
+	RCon_tag = "Medical Main Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "bEO" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
-	RCon_tag = "Substation - \[F.3] Medical"
+	RCon_tag = "Substation - Medical Main"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -55484,7 +55484,7 @@
 /area/maintenance/substation/civilian_west)
 "bYG" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "\[F.3] Civilian Substation Bypass"
+	RCon_tag = "Civilian Main Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian_west)
@@ -55651,7 +55651,7 @@
 "bYV" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
-	RCon_tag = "Substation - \[F.3] Civilian"
+	RCon_tag = "Substation - Civilian Main"
 	},
 /obj/structure/cable/green{
 	d2 = 2;

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -432,7 +432,7 @@
 	},
 /obj/machinery/power/smes/buildable{
 	charge = 0;
-	RCon_tag = "\[SOL.3] Solar - Fore TComms"
+	RCon_tag = "Solar - Fore TComms"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/foresolar)
@@ -3237,7 +3237,7 @@
 	},
 /obj/machinery/power/smes/buildable{
 	charge = 0;
-	RCon_tag = "\[SOL.2] Solar - Port TComms"
+	RCon_tag = "Solar - Port TComms"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
@@ -8644,7 +8644,7 @@
 	},
 /obj/machinery/power/smes/buildable{
 	charge = 0;
-	RCon_tag = "\[SOL.1] Solar - Aft TComms"
+	RCon_tag = "Solar - Aft TComms"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
@@ -17991,7 +17991,7 @@
 "Hr" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
-	RCon_tag = "Substation - \[F.1] Civilian"
+	RCon_tag = "Substation - Civilian Surface"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -18166,7 +18166,7 @@
 /area/maintenance/substation/civilian_east)
 "HD" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "\[F.1] Civilian Substation Bypass"
+	RCon_tag = "Civilian Surface Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian_east)

--- a/maps/aurora/aurora-7_roof.dmm
+++ b/maps/aurora/aurora-7_roof.dmm
@@ -2152,7 +2152,7 @@
 "es" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
-	RCon_tag = "\[SOL.4] Solar - Roof"
+	RCon_tag = "Solar - Roof"
 	},
 /obj/structure/cable{
 	d2 = 8;


### PR DESCRIPTION
Fixes all Substation SMES, Solar SMES, Grid SMES, Containment SMES, and Substation Bypass RCON tags to actually work. 

Tested (briefly) on a local server and worked properly.

Fixes #4218 and fixes #4495.