### PR TITLE
Fixes examine of suits

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -72,7 +72,7 @@
 		var/tie_msg
 		if(istype(wear_suit,/obj/item/clothing/suit))
 			var/obj/item/clothing/suit/U = wear_suit
-			if(U.accessories.len)
+			if(LAZYLEN(U.accessories))
 				tie_msg += ". Attached to it is [lowertext(english_list(U.accessories))]"
 
 		if(wear_suit.blood_DNA)


### PR DESCRIPTION
This fixes examine of suits that do not have accessories attached which was introduced by #5058

accessories can be `null` which causes runtime, LAZYLEN checks for it

This doesn't require changelog