### PR TITLE
Additional Reagent Fixes

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -1,9 +1,13 @@
+#define CELLS 8
+#define CELLSIZE (32/CELLS)
+
 /obj/item/weapon/reagent_containers
 	name = "Container"
 	desc = "..."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = null
 	w_class = 2
+	var/list/center_of_mass = list("x" = 16,"y" = 16)
 	var/amount_per_transfer_from_this = 5
 	var/possible_transfer_amounts = list(5,10,15,25,30)
 	var/volume = 30
@@ -59,7 +63,22 @@
 	if(can_operate(M) && do_surgery(M, user, src))
 		return
 
-/obj/item/weapon/reagent_containers/afterattack(var/obj/target, var/mob/user, var/proximity)
+/obj/item/weapon/reagent_containers/afterattack(var/atom/target, var/mob/user, var/proximity, var/params)
+
+	if(proximity && params && istype(target, /obj/structure/table) && center_of_mass && center_of_mass.len)
+		//Places the item on a grid
+		var/list/mouse_control = params2list(params)
+
+		var/mouse_x = text2num(mouse_control["icon-x"])
+		var/mouse_y = text2num(mouse_control["icon-y"])
+
+		if(isnum(mouse_x) || isnum(mouse_y))
+			var/cell_x = max(0, min(CELLS-1, round(mouse_x/CELLSIZE)))
+			var/cell_y = max(0, min(CELLS-1, round(mouse_y/CELLSIZE)))
+
+			pixel_x = (CELLSIZE * (0.5 + cell_x)) - center_of_mass["x"]
+			pixel_y = (CELLSIZE * (0.5 + cell_y)) - center_of_mass["y"]
+
 	if(!proximity || !is_open_container())
 		return
 	if(is_type_in_list(target,can_be_placed_into))
@@ -234,3 +253,6 @@
 	playsound(src, 'sound/effects/pour.ogg', 25, 1)
 	user << "<span class='notice'>You transfer [trans] units of the solution to [target].</span>"
 	return 1
+
+#undef CELLS
+#undef CELLSIZE

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -17,8 +17,10 @@
 	var/list/reagent_volumes = list()
 	var/list/reagent_names = list()
 
+	center_of_mass = null
+
 /obj/item/weapon/reagent_containers/borghypo/medical
-	reagent_ids = list("bicaridine", "inaprovaline", "dexalin", "tramadol", "spaceacillin", "anti_toxin")
+	reagent_ids = list("bicaridine", "kelotane", "anti_toxin", "dexalin", "inaprovaline", "tramadol", "spaceacillin")
 
 /obj/item/weapon/reagent_containers/borghypo/rescue
 	reagent_ids = list("tricordrazine", "inaprovaline", "tramadol")

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -11,6 +11,7 @@
 	w_class = 1
 	slot_flags = SLOT_EARS
 	volume = 5
+	center_of_mass = null
 
 	afterattack(var/obj/target, var/mob/user, var/flag)
 		if(!target.reagents || !flag) return

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -1,6 +1,3 @@
-#define CELLS 8
-#define CELLSIZE (32/CELLS)
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Food.
 ////////////////////////////////////////////////////////////////////////////////
@@ -9,33 +6,3 @@
 	possible_transfer_amounts = null
 	volume = 50 //Sets the default container amount for all food items.
 	var/filling_color = "#FFFFFF" //Used by sandwiches.
-
-	var/list/center_of_mass = list() // Used for table placement
-
-/obj/item/weapon/reagent_containers/food/Initialize()
-	. = ..()
-	if (isnull(center_of_mass) && !pixel_x && !pixel_y)
-		src.pixel_x = rand(-6.0, 6) //Randomizes postion
-		src.pixel_y = rand(-6.0, 6)
-
-/obj/item/weapon/reagent_containers/food/afterattack(atom/A, mob/user, proximity, params)
-	if(proximity && params && istype(A, /obj/structure/table) && center_of_mass.len)
-		//Places the item on a grid
-		var/list/mouse_control = params2list(params)
-
-		var/mouse_x = text2num(mouse_control["icon-x"])
-		var/mouse_y = text2num(mouse_control["icon-y"])
-
-		if(!isnum(mouse_x) || !isnum(mouse_y))
-			return
-
-		var/cell_x = max(0, min(CELLS-1, round(mouse_x/CELLSIZE)))
-		var/cell_y = max(0, min(CELLS-1, round(mouse_y/CELLSIZE)))
-
-		pixel_x = (CELLSIZE * (0.5 + cell_x)) - center_of_mass["x"]
-		pixel_y = (CELLSIZE * (0.5 + cell_y)) - center_of_mass["y"]
-
-	. = ..()
-
-#undef CELLS
-#undef CELLSIZE

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -14,10 +14,13 @@
 	possible_transfer_amounts = null
 	flags = OPENCONTAINER
 	slot_flags = SLOT_BELT
+	center_of_mass = null
 	var/armorcheck = 1
 
 /obj/item/weapon/reagent_containers/hypospray/attack(var/mob/M, var/mob/user, target_zone)
+
 	. = ..()
+
 	var/mob/living/carbon/human/H = M
 	if(istype(H))
 		user.visible_message("<span class='warning'>[user] is trying to inject \the [M] with \the [src]!</span>","<span class='notice'>You are trying to inject \the [M] with \the [src].</span>")
@@ -29,6 +32,9 @@
 
 	if (!istype(M))
 		return ..()
+
+	if(!proximity)
+		return
 
 	if(!reagents.total_volume)
 		to_chat(user,"<span class='warning'>\The [src] is empty.</span>")
@@ -45,7 +51,7 @@
 		var/trans = reagents.trans_to_mob(M, amount_per_transfer_from_this, CHEM_BLOOD)
 		admin_inject_log(user, M, src, contained, trans)
 		to_chat(user,"<span class='notice'>[trans] units injected. [reagents.total_volume] units remaining in \the [src].</span>")
-		
+
 	update_icon()
 
 	return
@@ -66,13 +72,12 @@
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/attack(mob/M as mob, mob/user as mob)
 	. = ..()
-	if(reagents.total_volume <= 0) //Prevents autoinjectors to be refilled.
-		flags &= ~OPENCONTAINER
-	return .
+	update_icon()
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/update_icon()
 	if(reagents.total_volume > 0)
 		icon_state = "[initial(icon_state)]1"
+		flags &= ~OPENCONTAINER
 	else
 		icon_state = "[initial(icon_state)]0"
 
@@ -112,7 +117,7 @@
 
 /obj/item/weapon/reagent_containers/hypospray/combat
 	name = "combat hypospray"
-	desc = "A hypospray loaded with combat stimulants."
+	desc = "A hypospray loaded with combat stimulants. Its needle has the ability to bypass armor."
 	item_state = "combat_hypo"
 	icon_state = "combat_hypo"
 	volume = 20

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -13,11 +13,15 @@
 	possible_transfer_amounts = null
 	flags = OPENCONTAINER
 	slot_flags = SLOT_BELT
+	center_of_mass = null
 
-/obj/item/weapon/reagent_containers/inhaler/afterattack(var/mob/living/carbon/human/H, var/mob/user, proximity)
+/obj/item/weapon/reagent_containers/inhaler/afterattack(var/mob/living/carbon/human/H, var/mob/user, var/proximity)
 
 	if (!istype(H))
 		return ..()
+
+	if(!proximity)
+		return
 
 	if(!reagents.total_volume)
 		to_chat(user,"<span class='warning'>\The [src] is empty.</span>")
@@ -57,7 +61,7 @@
 			to_chat(user,"<span class='notice'>You and the target need to be standing still in order to inject \the [src].</span>")
 			return
 
-		user.visible_message("<span class='notice'>[user] injects [H] with the [src].</span>","<span class='notice'>You stick the [src] in [H]'s mouth and press the injection button.</span>")
+		user.visible_message("<span class='notice'>[user] injects [H] with the [src].</span>","<span class='notice'>You stick \the [src] in [H]'s mouth and press the injection button.</span>")
 
 	if(H.reagents)
 		var/contained = reagentlist()
@@ -71,14 +75,13 @@
 	return
 
 /obj/item/weapon/reagent_containers/inhaler/attack(mob/M as mob, mob/user as mob)
-	..()
-	if(reagents.total_volume <= 0) //Prevents autoinjectors to be refilled.
-		flags &= ~OPENCONTAINER
-	return
+	. = ..()
+	update_icon()
 
 /obj/item/weapon/reagent_containers/inhaler/update_icon()
 	if(reagents.total_volume > 0)
 		icon_state = "[initial(icon_state)]1"
+		flags &= ~OPENCONTAINER
 	else
 		icon_state = "[initial(icon_state)]0"
 

--- a/code/modules/reagents/reagent_containers/inhaler_advanced.dm
+++ b/code/modules/reagents/reagent_containers/inhaler_advanced.dm
@@ -16,6 +16,7 @@
 	slot_flags = SLOT_BELT
 	origin_tech = list(TECH_BIO = 2, TECH_MATERIAL = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 250)
+	center_of_mass = null
 
 /obj/item/weapon/reagent_containers/personal_inhaler_cartridge/examine(var/mob/user)
 	if(!..(user, 2))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -24,6 +24,7 @@
 	var/image/filling //holds a reference to the current filling overlay
 	var/visible_name = "a syringe"
 	var/time = 30
+	center_of_mass = null
 
 /obj/item/weapon/reagent_containers/syringe/on_reagent_change()
 	update_icon()

--- a/html/changelogs/burgerbb-mass_reagent_fixes.yml
+++ b/html/changelogs/burgerbb-mass_reagent_fixes.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed hypospray and inhalers being able to inject at a distance."
+  - bugfix: "Fixed food unable to be placed specifically. Applied specific placing code to most reagent containers."
+  - bugfix: "Added missing kelotane reagent to borg hypospray."


### PR DESCRIPTION
# Overview
- Fixes #5162
- Fixes food unable to be placed specifically. Applied the specific placing code to all reagent containers, except for syringes, hypospray, and inhalers.
- Fixes missing Kelotane reagent for borg hypospray.