### PR TITLE
Affordable burritos

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -951,14 +951,12 @@ I said no!
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/tortilla,
 		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
 		/obj/item/weapon/reagent_containers/food/snacks/meatball
 	)
 	reagents = list("spacespice" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/burrito
 
 /datum/recipe/burrito_vegan
-	fruit = list("carrot" = 1, "cabbage" = 1)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/tortilla,
 		/obj/item/weapon/reagent_containers/food/snacks/tofu
@@ -966,7 +964,7 @@ I said no!
 	result = /obj/item/weapon/reagent_containers/food/snacks/burrito_vegan
 
 /datum/recipe/burrito_spicy
-	fruit = list("chili" = 2)
+	fruit = list("chili" = 1)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/burrito
 	)
@@ -980,7 +978,7 @@ I said no!
 	result = /obj/item/weapon/reagent_containers/food/snacks/burrito_cheese
 
 /datum/recipe/burrito_cheese_spicy
-	fruit = list("chili" = 2)
+	fruit = list("chili" = 1)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/burrito,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
@@ -988,7 +986,7 @@ I said no!
 	result = /obj/item/weapon/reagent_containers/food/snacks/burrito_cheese_spicy
 
 /datum/recipe/burrito_hell
-	fruit = list("chili" = 10)
+	fruit = list("chili" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/burrito_spicy
 	)

--- a/html/changelogs/OneOneThreeEight-Yotengoburrito.yml
+++ b/html/changelogs/OneOneThreeEight-Yotengoburrito.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Scheveningen
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Adjusts ingredient costs for burritos."
+  - tweak: "Burrito: Meatball requirement down from 3 to 2."
+  - tweak: "Vegan burrito: Removes the need for a carrot and a head of cabbage to make."
+  - tweak: "Burrito spicy and cheese spicy burrito: Chili requirement down from 2 to 1."
+  - tweak: "Burrito hell: Chili requirement down from 10 to 5."


### PR DESCRIPTION
This allows for aspiring microwave jockeys to produce various types of burritos en masse. Because chef isn't any fun unless you can make a lot of food of various types, and burritos happen to be the biggest offender in being too costly to be worth it.

This PR will hopefully make or break the difference present.

The differences:

Burrito: Meatball requirement down from 3 to 2.
Vegan burrito: Removes the need for a carrot and a head of cabbage to make.
Burrito spicy: Chili requirement down from 2 to 1.
Burrito cheese spicy: Chili requirement down from 2 to 1.
Burrito hell: Chili requirement down from 10 to 5.