### PR TITLE
Adjusts maximum break thresholds + buffs maximum damage thresholds to limbs.

### DIFF
--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -7,7 +7,7 @@
 	limb_name = "chest"
 	icon_name = "torso"
 	max_damage = 100
-	min_broken_damage = 35
+	min_broken_damage = 45
 	w_class = 5
 	body_part = UPPER_TORSO
 	vital = 1
@@ -25,7 +25,7 @@
 	limb_name = "groin"
 	icon_name = "groin"
 	max_damage = 100
-	min_broken_damage = 35
+	min_broken_damage = 45
 	w_class = 4
 	body_part = LOWER_TORSO
 	vital = 1
@@ -40,8 +40,8 @@
 	limb_name = "l_arm"
 	name = "left arm"
 	icon_name = "l_arm"
-	max_damage = 50
-	min_broken_damage = 30
+	max_damage = 75
+	min_broken_damage = 40
 	w_class = 3
 	body_part = ARM_LEFT
 	parent_organ = "chest"
@@ -61,8 +61,8 @@
 	limb_name = "l_leg"
 	name = "left leg"
 	icon_name = "l_leg"
-	max_damage = 50
-	min_broken_damage = 30
+	max_damage = 75
+	min_broken_damage = 40
 	w_class = 3
 	body_part = LEG_LEFT
 	icon_position = LEFT
@@ -84,8 +84,8 @@
 	limb_name = "l_foot"
 	name = "left foot"
 	icon_name = "l_foot"
-	max_damage = 30
-	min_broken_damage = 15
+	max_damage = 50
+	min_broken_damage = 25
 	w_class = 2
 	body_part = FOOT_LEFT
 	icon_position = LEFT
@@ -114,8 +114,8 @@
 	limb_name = "l_hand"
 	name = "left hand"
 	icon_name = "l_hand"
-	max_damage = 30
-	min_broken_damage = 15
+	max_damage = 50
+	min_broken_damage = 25
 	w_class = 2
 	body_part = HAND_LEFT
 	parent_organ = "l_arm"
@@ -146,7 +146,7 @@
 	icon_name = "head"
 	name = "head"
 	max_damage = 75
-	min_broken_damage = 35
+	min_broken_damage = 50
 	w_class = 3
 	body_part = HEAD
 	vital = 1

--- a/html/changelogs/Scheveningen-Externalorganboogaloo2.yml
+++ b/html/changelogs/Scheveningen-Externalorganboogaloo2.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Buffed maximum damage threshold for external organs, and raised the thresholds for which limbs can be gored or removed by sharp force."


### PR DESCRIPTION
This is to make it much harder to remove someone's limbs as most weaponry is not actually meant to gore people's limbs in so few hits. Looking at you, glass spears.

You'll need more hits to get anywhere close to doing that, but you'll have pushed your foe to death by the time that happens. Which seems, dare I say it, realistic. I understand this is a trigger word for some members of the community, but this is also a balance issue where an insubstantial amount of effort can be focused on the limb with the least HP to cripple and easily execute someone.

As such, many thresholds for limb health have been raised. This doesn't make people that much tankier health-wise, if they take damage, they'll still bleed out or take substantial pain damage. People can just survive certain wounds without the risk of breaking a limb.

This will inadvertently probably allow people (sec and antags alike) to play more aggressively and for longer periods of time. Oh well, nobody likes fast-finishing combat anyway.