### PR TITLE
Fixes overlooked issues with the gun accuracy formula + fixes incidental nerfs dealt to guns.

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -111,13 +111,13 @@ obj/item/weapon/gun/energy/retro
 	fire_delay = 45
 	force = 10
 	w_class = 4
-	accuracy = -5 //shooting at the hip
-	scoped_accuracy = 0
+	accuracy = -3 // Unapologetic LWAP buffs.
+	scoped_accuracy = 3
 	can_turret = 1
 	turret_sprite_set = "sniper"
 
 	fire_delay_wielded = 35
-	accuracy_wielded = -3
+	accuracy_wielded = 0 // God have mercy on me if the LWAP returns to its previous state.
 
 	//action button for wielding
 	action_button_name = "Wield rifle"

--- a/code/modules/projectiles/guns/energy/rifle.dm
+++ b/code/modules/projectiles/guns/energy/rifle.dm
@@ -18,7 +18,7 @@
 	turret_is_lethal = 0
 
 	fire_delay_wielded = 1
-	accuracy_wielded = 0
+	accuracy_wielded = 2
 	sel_mode = 1
 
 	projectile_type = /obj/item/projectile/beam/stun
@@ -78,7 +78,7 @@
 	charge_cost = 400
 	max_shots = 5
 	fire_delay = 40
-	accuracy = -2
+	accuracy = -3
 	secondary_projectile_type = null
 	secondary_fire_sound = null
 	can_switch_modes = 0

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -115,7 +115,7 @@
 
 	//wielding information
 	fire_delay_wielded = 6
-	accuracy_wielded = 0
+	accuracy_wielded = 2
 
 	//action button for wielding
 	action_button_name = "Wield rifle"
@@ -373,8 +373,8 @@
 
 	//wielding information
 	fire_delay_wielded = 5
-	accuracy_wielded = 0
-	scoped_accuracy = 2
+	accuracy_wielded = 2
+	scoped_accuracy = 4 //This is a godly, synth terrorist-made weapon anyway. Let it be powerful.
 
 	action_button_name = "Wield rifle"
 
@@ -423,12 +423,12 @@
 	recoil = 3
 	fire_sound = 'sound/weapons/shotgun_shoot.ogg'
 
-	accuracy = -2
+	accuracy = -3
 	fire_delay = 10
 	recoil_wielded = 0
 
 	fire_delay_wielded = 6
-	accuracy_wielded = 0
+	accuracy_wielded = -1
 
 	firemodes = list(
 		list(mode_name="semiauto",       burst=1, fire_delay= 10,    move_delay=null, burst_accuracy=null, dispersion=null),

--- a/code/modules/projectiles/guns/projectile/improvised.dm
+++ b/code/modules/projectiles/guns/projectile/improvised.dm
@@ -141,7 +141,7 @@
 	desc = "A common sight in an amateur's workshop, a simple yet effective assembly made to chamber and fire .45 Rounds."
 	max_shells = 7
 	recoil = 2
-	accuracy = -2
+	accuracy = -1
 	fire_delay = 9
 	icon = 'icons/obj/improvised.dmi'
 	icon_state = "ipistol"
@@ -217,7 +217,7 @@
 	max_shells = 16
 	caliber = ".45"
 	sel_mode = 1
-	accuracy = -5
+	accuracy = -2 // Was previously -5, which was approximately a +60% chance to miss without accounting for distance. Alberyk, this never hit anything!
 	fire_delay = 5
 	burst = 3
 	burst_delay = 3

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -44,6 +44,8 @@
 	item_state = "shotgun"
 	max_shells = 4
 	w_class = ITEMSIZE_LARGE
+	recoil = 2
+	accuracy = -3
 	force = 10
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
@@ -59,6 +61,8 @@
 	var/has_wield_state = TRUE
 
 	action_button_name = "Wield shotgun"
+
+	accuracy_wielded = -1
 
 /obj/item/weapon/gun/projectile/shotgun/pump/can_wield()
 	return 1
@@ -131,6 +135,8 @@
 	handle_casings = CYCLE_CASINGS
 	max_shells = 2
 	w_class = 4
+	recoil = 2
+	accuracy = -2
 	force = 10
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -15,7 +15,7 @@
 	ammo_type = /obj/item/ammo_casing/a145
 	//+2 accuracy over the LWAP because only one shot
 	accuracy = -3
-	scoped_accuracy = 2
+	scoped_accuracy = 3
 	var/bolt_open = 0
 
 	fire_sound = 'sound/weapons/Gunshot_DMR.ogg'

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -182,7 +182,7 @@
 		return
 
 	//roll to-hit
-	miss_modifier = max(15*(distance-2) - round(15*accuracy) + miss_modifier, 0)
+	miss_modifier = max(20*(distance-2) - round(10*accuracy) + miss_modifier, 0)
 	var/hit_zone = get_zone_with_miss_chance(def_zone, target_mob, miss_modifier, ranged_attack=(distance > 1 || original != target_mob)) //if the projectile hits a target we weren't originally aiming at then retain the chance to miss
 
 	var/result = PROJECTILE_FORCE_MISS

--- a/html/changelogs/OneOneThreeEight-checkouttheseguns.yml
+++ b/html/changelogs/OneOneThreeEight-checkouttheseguns.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Scheveningen
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Fixes overlooked issues with the gun accuracy formula and how certain weapons were balanced, issues that were accidentally created due to a lack of understanding of the gun accuracy formula."
+  - balance: "Reverts half the nerfs dealt to the LWAP rifle."


### PR DESCRIPTION
This is what the equation was originally.

`miss_modifier = max(15*(distance-2) - round(15*accuracy) + miss_modifier, 0)`

The first part of the equation basically rounds out your distance and how far a projectile has already travelled from its initial spot. Afterward, it gives a 30% bonus against miss-chance regardless of range, just so you can actually hit something at point blank range. In most cases it will round out a positive number at longer ranges. We'll say 4 tiles is to be exact.

Therefore, we have a 30% chance to miss just by itself, as 15 is multiplied by the result 2 from the initial subtraction.

The second part of the equation calculates the gun's accuracy, from which the former is to subtract the latter.

If the latter gun accuracy variable is a positive number, you basically get a bonus to offset the penalty for distance. If it is negative, it gets a penalty instead.

This formula has been changed to bell curve and basically increase the range for almost all weapons without the accuracy modifier very slightly but it drops off substantially harder at a certain point.

I don't think this requires significant testing, personally, (As this is, in my opinion, something that is worthy of a proper hotfix that we shall say is not exactly very hot) but I can easily re-do all the work anyway if I'm required to run this through development instead.