### PR TITLE
Bump flyway version on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     BYOND_MAJOR="512"
     BYOND_MINOR="1438"
     MACRO_COUNT=77
-    FLYWAY_BUILD="4.2.0"
+    FLYWAY_BUILD="5.1.4"
     NODE_VERSION=10
   matrix:
     - USE_MAP=aurora

--- a/install-flyway.sh
+++ b/install-flyway.sh
@@ -4,7 +4,7 @@ if [ -f "$HOME/flyway-${FLYWAY_BUILD}/flyway" ];
 then
   echo "Using cached Flyway directory."
 else
-  echo "Setting up Flyway."
+  echo "Setting up Flyway ${FLYWAY_BUILD}."
   cd "$HOME"
   curl "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_BUILD}/flyway-commandline-${FLYWAY_BUILD}.tar.gz" -o flyway.tar.gz
   tar -xf flyway.tar.gz


### PR DESCRIPTION
Flyway stopped hosting 4.1.2, which is why Travis builds are failing.