### PR TITLE
Beepsky fix

### DIFF
--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -595,7 +595,7 @@
 
 /mob/living/bot/secbot/attackby(var/obj/item/O, var/mob/user)
 	..()
-	if(istype(O, /obj/item/weapon/card/id))
+	if(istype(O, /obj/item/weapon/card/id) || istype(O, /obj/item/weapon/pen) || istype(O, /obj/item/device/pda))
 		return
 
 	target = user

--- a/html/changelogs/Sindorman-beepsky-fix.yml
+++ b/html/changelogs/Sindorman-beepsky-fix.yml
@@ -1,0 +1,6 @@
+author: PoZe
+
+delete-after: True
+
+changes:
+  - bugfix: "Beepsky/ED209 will no longer arrest you for using pen or PDA on it"


### PR DESCRIPTION
- Beepsky will no longer arrest people for using pen or PDA on it