### PR TITLE
Adjusts Stun Baton Cranial Agony

### DIFF
--- a/code/modules/clothing/head/collectable.dm
+++ b/code/modules/clothing/head/collectable.dm
@@ -48,7 +48,6 @@
 	desc = "A top hat worn by only the most prestigious hat collectors."
 	icon_state = "tophat"
 	item_state = "tophat"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/collectable/captain
 	name = "collectable captain's hat"
@@ -58,19 +57,16 @@
 		slot_l_hand_str = "caphat",
 		slot_r_hand_str = "caphat"
 		)
-	body_parts_covered = 0
 
 /obj/item/clothing/head/collectable/police
 	name = "collectable police officer's hat"
 	desc = "A Collectable Police Officer's Hat. This hat emphasizes that you are THE LAW."
 	icon_state = "policehelm"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/collectable/beret
 	name = "collectable beret"
 	desc = "A Collectable red Beret. It smells faintly of Garlic."
 	icon_state = "beret"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/collectable/welding
 	name = "collectable welding helmet"
@@ -97,7 +93,6 @@
 	name = "collectable pirate hat"
 	desc = "You'd make a great Dread Syndie Roberts!"
 	icon_state = "pirate"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/collectable/kitty
 	name = "collectable kitty ears"
@@ -109,7 +104,7 @@
 	name = "collectable rabbit ears"
 	desc = "Not as lucky as the feet!"
 	icon_state = "bunny"
-	body_parts_covered = 0
+	siemens_coefficient = 1.5
 
 /obj/item/clothing/head/collectable/wizard
 	name = "collectable wizard's hat"
@@ -120,13 +115,11 @@
 	name = "collectable hard hat"
 	desc = "WARNING! Offers no real protection, or luminosity, but it is damn fancy!"
 	icon_state = "hardhat0_yellow"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/collectable/HoS
 	name = "collectable HoS hat"
 	desc = "Now you can beat prisoners, set silly sentences and arrest for no reason too!"
 	icon_state = "hoscap"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/collectable/thunderdome
 	name = "collectable Thunderdome helmet"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -7,7 +7,6 @@
 		slot_r_hand_str = "helmet"
 		)
 	item_flags = THICKMATERIAL
-	body_parts_covered = HEAD
 	armor = list(melee = 50, bullet = 15, laser = 50,energy = 10, bomb = 25, bio = 0, rad = 0)
 	flags_inv = HIDEEARS|BLOCKHEADHAIR
 	cold_protection = HEAD
@@ -32,7 +31,6 @@
 	desc = "It's a special helmet issued to the Warden of a securiy force. Protects the head from impacts."
 	icon_state = "policehelm"
 	flags_inv = 0
-	body_parts_covered = 0
 
 /obj/item/clothing/head/helmet/warden/commissar
 	name = "commissar's cap"
@@ -45,7 +43,6 @@
 	icon_state = "hoscap"
 	armor = list(melee = 65, bullet = 30, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 	flags_inv = HIDEEARS
-	body_parts_covered = 0
 
 /obj/item/clothing/head/helmet/HoS/dermal
 	name = "dermal armour patch"
@@ -58,14 +55,12 @@
 	desc = "A stylish hat that both protects you from enraged former-crewmembers and gives you a false sense of authority."
 	icon_state = "hopcap"
 	flags_inv = 0
-	body_parts_covered = 0
 
 /obj/item/clothing/head/helmet/formalcaptain
 	name = "parade hat"
 	desc = "No one in a commanding position should be without a perfect, white hat of ultimate authority."
 	icon_state = "officercap"
 	flags_inv = 0
-	body_parts_covered = 0
 
 /obj/item/clothing/head/helmet/riot
 	name = "riot helmet"

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -15,7 +15,6 @@
 		slot_l_hand_str = "caphat",
 		slot_r_hand_str = "caphat"
 		)
-	body_parts_covered = 0
 
 /obj/item/clothing/head/caphat/cap
 	name = "captain's cap"
@@ -39,7 +38,6 @@
 	desc = "It's hood that covers the head. It keeps you warm during the space winters."
 	icon_state = "chaplain_hood"
 	flags_inv = BLOCKHAIR
-	body_parts_covered = HEAD
 
 //Chaplain
 /obj/item/clothing/head/nun_hood
@@ -47,14 +45,12 @@
 	desc = "Maximum piety in this star system."
 	icon_state = "nun_hood"
 	flags_inv = BLOCKHAIR
-	body_parts_covered = HEAD
 
 //Mime
 /obj/item/clothing/head/beret
 	name = "beret"
 	desc = "A beret, an artists favorite headwear."
 	icon_state = "beret"
-	body_parts_covered = 0
 
 //berets
 /obj/item/clothing/head/beret/sec
@@ -138,7 +134,6 @@
 	allowed = list(/obj/item/weapon/reagent_containers/food/snacks/candy_corn, /obj/item/weapon/pen)
 	armor = list(melee = 50, bullet = 5, laser = 25,energy = 10, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.7
-	body_parts_covered = 0
 
 /obj/item/clothing/head/det/grey
 	icon_state = "detective2"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -9,7 +9,6 @@
 		)
 	desc = "It's good to be emperor."
 	siemens_coefficient = 0.9
-	body_parts_covered = 0
 
 /obj/item/clothing/head/hairflower
 	name = "hair flower pin"
@@ -39,19 +38,16 @@
 	icon_state = "tophat"
 	item_state = "tophat"
 	siemens_coefficient = 0.9
-	body_parts_covered = 0
 
 /obj/item/clothing/head/redcoat
 	name = "redcoat's hat"
 	icon_state = "redcoat"
 	desc = "<i>'I guess it's a redhead.'</i>"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/mailman
 	name = "station cap"
 	icon_state = "mailman"
 	desc = "<i>Choo-choo</i>!"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/plaguedoctorhat
 	name = "plague doctor's hat"
@@ -59,7 +55,6 @@
 	icon_state = "plaguedoctor"
 	permeability_coefficient = 0.01
 	siemens_coefficient = 0.9
-	body_parts_covered = 0
 
 /obj/item/clothing/head/hasturhood
 	name = "hastur's hood"
@@ -73,7 +68,6 @@
 	desc = "It allows quick identification of trained medical personnel."
 	icon_state = "nursehat"
 	siemens_coefficient = 0.9
-	body_parts_covered = 0
 
 /obj/item/clothing/head/syndicatefake
 	name = "red space-helmet replica"
@@ -150,13 +144,11 @@
 	name = "pirate hat"
 	desc = "Yarr."
 	icon_state = "pirate"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/hgpiratecap
 	name = "pirate hat"
 	desc = "Yarr."
 	icon_state = "hgpiratecap"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/bandana
 	name = "pirate bandana"
@@ -167,7 +159,6 @@
 	name = "bowler-hat"
 	desc = "Gentleman, elite aboard!"
 	icon_state = "bowler"
-	body_parts_covered = 0
 
 //stylish bs12 hats
 
@@ -175,7 +166,6 @@
 	name = "bowler hat"
 	icon_state = "bowler_hat"
 	desc = "For the gentleman of distinction."
-	body_parts_covered = 0
 
 /obj/item/clothing/head/beaverhat
 	name = "beaver hat"
@@ -252,7 +242,6 @@
 		)
 	flags_inv = BLOCKHAIR
 	siemens_coefficient = 2.0 //why is it so conductive?!
-	body_parts_covered = 0
 
 /obj/item/clothing/head/orangebandana //themij: Taryn Kifer
 	name = "orange bandana"
@@ -304,7 +293,6 @@
 	name = "cowboy hat"
 	desc = "A wide-brimmed hat, in the prevalent style of the frontier."
 	icon_state = "cowboyhat"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/cowboy/wide
 	name = "wide-brimmed cowboy hat"
@@ -314,7 +302,6 @@
 	name = "sombrero"
 	desc = "You can practically taste the fiesta."
 	icon_state = "sombrero"
-	body_parts_covered = 0
 
 /obj/item/clothing/head/turban
 	name = "turban"
@@ -323,7 +310,6 @@
 	icon_state = "turban_black"
 	item_state = "turban_black"
 	flags_inv = BLOCKHEADHAIR
-	body_parts_covered = 0
 	contained_sprite = 1
 
 /obj/item/clothing/head/turban/blue

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -144,7 +144,6 @@
 	name = "kitty ears"
 	desc = "A pair of kitty ears. Meow!"
 	icon_state = "kitty"
-	body_parts_covered = 0
 	siemens_coefficient = 1.5
 	item_icons = list()
 

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -8,7 +8,6 @@
 		)
 	var/flipped = 0
 	siemens_coefficient = 0.9
-	body_parts_covered = 0
 
 /obj/item/clothing/head/soft/dropped()
 	src.icon_state = initial(icon_state)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -54,7 +54,8 @@ emp_act
 
 	switch (def_zone)
 		if("head")
-			agony_amount *= 1.50
+			eye_blurry += (rand(3,6) * siemens_coeff)
+			confused = max(confused, 5 * siemens_coeff)
 		if("l_hand", "r_hand")
 			var/c_hand
 			if (def_zone == "l_hand")

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -96,7 +96,7 @@
 	maim_bonus = 1
 
 /obj/item/organ/external/foot/removed()
-	if(owner) 
+	if(owner)
 		owner.drop_from_inventory(owner.shoes)
 	..()
 
@@ -148,7 +148,7 @@
 	max_damage = 75
 	min_broken_damage = 35
 	w_class = 3
-	body_part = HEAD
+	body_part = HEAD | FACE
 	vital = 1
 	parent_organ = "chest"
 	joint = "jaw"

--- a/html/changelogs/fowl-gudgot.yml
+++ b/html/changelogs/fowl-gudgot.yml
@@ -1,0 +1,7 @@
+author: Lord Fowl
+
+delete-after: True
+
+changes: 
+  - tweak: "Baton strikes directed to the head now disorientate instead of just causing 1.5x agony."
+  - tweak: "Most hats now cover the head and provide appropriate protections."


### PR DESCRIPTION
Adjusts the effect of a stun baton strike to the head. Instead of dealing 1.5x agony, it will now blur and disorientate the target.

Removes the arbitrary limitation on most hats that prevented them from actually covering the head. Their status as non-combat items should be represented by other values, as is standard for the rest of the clothing items.

Tweaks the head organ to also include the FACE as a body part applicable to def_zones. This may have some other trickle down effects, but should work normally.
