### PR TITLE
Adding more coffee to the coffee resupply canister

### DIFF
--- a/code/game/machinery/vending_items.dm
+++ b/code/game/machinery/vending_items.dm
@@ -47,7 +47,7 @@
 /obj/item/weapon/vending_refill/coffee
 	name = "coffee resupply canister"
 	vend_id = "coffee"
-	charges = 38
+	charges = 100
 
 /obj/item/weapon/vending_refill/snack
 	name = "snacks resupply canister"


### PR DESCRIPTION
Since the coffee machine needs 95 items to be full, i would say its fair that the coffee resupply canister has 100 items