### PR TITLE
[WIP] Infestation Overhaul

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -62,6 +62,7 @@
 	var/station_area = 0
 	var/centcomm_area = 0
 	var/has_weird_power = FALSE	// If TRUE, SSmachinery will not use the inlined power checks and will call powered() and use_power() on this area.
+	var/no_events = 1 //This area is not affected by station events.
 
 // Don't move this to Initialize(). Things in here need to run before SSatoms does.
 /area/New()
@@ -406,7 +407,7 @@ var/list/mob/living/forced_ambiance_list = new
 
 //A useful proc for events.
 //This returns a random area of the station which is meaningful. Ie, a room somewhere
-/proc/random_station_area()
+/proc/random_station_area(var/filter_players = FALSE)
 	var/list/possible = list()
 	for(var/Y in the_station_areas)
 		if(!Y)
@@ -420,11 +421,25 @@ var/list/mob/living/forced_ambiance_list = new
 			continue
 		if (istype(A, /area/constructionsite))
 			continue
+		if (istype(A, /area/turbolift))
+			continue
 
 		//Although hostile mobs instadying to turrets is fun
 		//If there's no AI they'll just be hit with stunbeams all day and spam the attack logs.
 		if (istype(A, /area/turret_protected) || LAZYLEN(A.turret_controls))
 			continue
+
+		var/should_continue = FALSE
+		if(filter_players)
+			for(var/mob/living/carbon/human/H in human_mob_list)
+				if(!H.client)
+					continue
+				if(A == get_area(H))
+					should_continue = TRUE
+					break
+
+			if(should_continue)
+				continue
 
 		possible += A
 

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -165,7 +165,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				50,		list(ASSIGNMENT_SECURITY = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Moderate Spider Infestation",/datum/event/spider_infestation/moderate,50,	list(ASSIGNMENT_SECURITY = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Viral Infection",			/datum/event/viral_infection, 			0,		list(ASSIGNMENT_MEDICAL = 12), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Major Vermin Infestation",	/datum/event/infestation, 				60,	list(ASSIGNMENT_JANITOR = 15, ASSIGNMENT_SECURITY = 15))
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Moderate Vermin Infestation",	/datum/event/infestation, 				60,	list(ASSIGNMENT_JANITOR = 15, ASSIGNMENT_SECURITY = 15))
 	)
 
 /datum/event_container/major
@@ -178,6 +178,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",		/datum/event/spacevine, 		75,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_GARDENER = 20), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Viral Infection",	/datum/event/viral_infection,	20,	list(ASSIGNMENT_MEDICAL =  15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Spider Infestation",/datum/event/spider_infestation, 25, list(ASSIGNMENT_SECURITY = 10, ASSIGNMENT_MEDICAL = 5), 1)
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Major Vermin Infestation",	/datum/event/infestation, 60,	list(ASSIGNMENT_SECURITY = 15))
 	)
 
 #undef ASSIGNMENT_ANY

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -1,216 +1,85 @@
-//Infestation event now has two modes.
-//Mundane event spawns some creatures in a place, and tells you which and where.
-//Moderate event spawns twice the amount of two types of creatures, in two places. And tells you where but not what spawns
-
-
-#define LOC_KITCHEN 0
-#define LOC_ATMOS 1
-#define LOC_INCIN 2
-#define LOC_CHAPEL 3
-#define LOC_LIBRARY 4
-#define LOC_HYDRO 5
-#define LOC_VAULT 6
-#define LOC_CONSTR 7
-#define LOC_TECH 8
-#define LOC_ARMORY 9
-#define LOC_DORMS 10
-#define LOC_FITNESS 11
-#define LOC_HOLODECK 12
-#define LOC_DISPOSAL 13
-#define LOC_CARGO 14
-#define LOC_MEETING 15
-#define LOC_LOCKER 16
-#define LOC_XENO 17
-
-
-#define VERM_MICE 0
-#define VERM_LIZARDS 1
-#define VERM_SPIDERS 2
-#define VERM_DIYAAB 3
-#define VERM_BATS 4
-#define VERM_YITHIAN 5
-#define VERM_TINDALOS 6
-
 /datum/event/infestation
 	announceWhen = 10
 	endWhen = 11
-	var/location
-	var/numlocs = 0
-	var/list/locstrings = list()
-	var/vermin
-	var/vermstring
-	var/spawn_area_type
-	var/list/turf/simulated/floor/turfs
-	no_fake = 1
+	var/area/chosen_area
+	var/event_name = "Unregistered Teleportation"
+	var/chosen_mob = "bluespace bears"
+	var/chosen_verb = "have teleported to"
+	var/list/chosen_mob_types = list()
 
 /datum/event/infestation/start()
-	locstrings = new/list(2)
-	choose_location()
-	spawn_creatures()
-	if (severity == EVENT_LEVEL_MODERATE)
-		choose_location()
-		spawn_creatures()
+	choose_area()
+	choose_mobs()
+	spawn_mobs()
 
+/datum/event/infestation/proc/choose_area()
+	chosen_area = random_station_area(TRUE)
 
+/datum/event/infestation/proc/choose_mobs()
 
+	var/list/possible_mobs = list(
+		"space bears" = 0,
+		"hivebots" = 0,
+		"space bats" = 0,
+		"lizards" = 0,
+		"mice" = 0,
+		"baby slimes" = 0
+	)
 
+	switch(severity)
+		if(EVENT_LEVEL_MUNDANE)
+			possible_mobs["mice"] = 1
+			possible_mobs["lizards"] = 1
+		if(EVENT_LEVEL_MODERATE)
+			possible_mobs["space bats"] = 1
+			possible_mobs["baby slimes"] = 1
+		if(EVENT_LEVEL_MAJOR)
+			possible_mobs["bluespace bears"] = 1
+			possible_mobs["hivebots"] = 1
 
-/datum/event/infestation/proc/choose_location()
+	chosen_mob = pickweight(possible_mobs)
 
-	location = rand(0,17)
-	turfs = list()
-	numlocs++
-	switch(location)
-		if(LOC_KITCHEN)
-			spawn_area_type = /area/crew_quarters/kitchen
-			locstrings[numlocs] = "the kitchen"
-		if(LOC_ATMOS)
-			spawn_area_type = /area/engineering/atmos
-			locstrings[numlocs] = "atmospherics"
-		if(LOC_INCIN)
-			spawn_area_type = /area/maintenance/disposal
-			locstrings[numlocs] = "waste disposal"
-		if(LOC_CHAPEL)
-			spawn_area_type = /area/chapel/main
-			locstrings[numlocs] = "the chapel"
-		if(LOC_LIBRARY)
-			spawn_area_type = /area/library
-			locstrings[numlocs] = "the library"
-		if(LOC_HYDRO)
-			spawn_area_type = /area/hydroponics
-			locstrings[numlocs] = "hydroponics"
-		if(LOC_VAULT)
-			spawn_area_type = /area/security/nuke_storage
-			locstrings[numlocs] = "the vault"
-		if(LOC_CONSTR)
-			spawn_area_type = /area/construction
-			locstrings[numlocs] = "the construction area"
-		if(LOC_TECH)
-			spawn_area_type = /area/storage/tech
-			locstrings[numlocs] = "technical storage"
-		if(LOC_ARMORY)
-			spawn_area_type = /area/security/armoury
-			locstrings[numlocs] = "the armoury"
-		if(LOC_DORMS)
-			spawn_area_type = /area/crew_quarters/sleep
-			locstrings[numlocs] = "the dormitories"
-		if(LOC_FITNESS)
-			spawn_area_type = /area/crew_quarters/fitness
-			locstrings[numlocs] = "the fitness room"
-		if(LOC_HOLODECK)
-			spawn_area_type = /area/holodeck/alphadeck
-			locstrings[numlocs] = "the holodeck"
-		if(LOC_DISPOSAL)
-			spawn_area_type = /area/quartermaster/office
-			locstrings[numlocs] = "the cargo disposals office"
-		if(LOC_CARGO)
-			spawn_area_type = /area/quartermaster/loading
-			locstrings[numlocs] = "the cargo bay"
-		if(LOC_MEETING)
-			spawn_area_type = /area/bridge/meeting_room
-			locstrings[numlocs] = "the command meeting room"
-		if(LOC_LOCKER)
-			spawn_area_type = /area/crew_quarters/locker
-			locstrings[numlocs] = "the locker room"
-		if(LOC_XENO)
-			spawn_area_type = /area/rnd/xenobiology
-			locstrings[numlocs] = "xenobiology"
+	switch(chosen_mob)
+		if("bluespace bears")
+			event_name = "Bluespace Bear Teleportation"
+			chosen_verb = "have teleported to"
+			chosen_mob_types +=	/mob/living/simple_animal/hostile/bear/spatial
+			chosen_mob_types +=	/mob/living/simple_animal/hostile/bear/spatial
+		if("hivebots")
+			event_name = "Minor Hivebot Invasion"
+			chosen_verb = "have invaded"
+			chosen_mob_types += /mob/living/simple_animal/hostile/hivebot/tele
+			chosen_mob_types += /mob/living/simple_animal/hostile/hivebot
+			chosen_mob_types += /mob/living/simple_animal/hostile/hivebot/range
+		if("space bats")
+			event_name = "Space Bat Nest"
+			chosen_verb = "have been breeding in"
+			for(var/i = 1, i < rand(3,5),i++)
+				chosen_mob_types += /mob/living/simple_animal/hostile/scarybat
+		if("lizards")
+			event_name = "Lizard Nest"
+			chosen_verb = "have been breeding in"
+			for(var/i = 1, i < rand(6,8),i++)
+				chosen_mob_types += /mob/living/simple_animal/lizard
+		if("mice")
+			event_name = "Mouse Nest"
+			chosen_verb = "have been breeding in"
+			var/list/rat_breeds = list(
+				/mob/living/simple_animal/mouse/gray = 4,
+				/mob/living/simple_animal/mouse/brown = 2,
+				/mob/living/simple_animal/mouse/white = 1
+			)
+			for(var/i = 1, i < rand(6,12),i++)
+				chosen_mob_types += pickweight(rat_breeds)
+		if("baby slimes")
+			event_name = "Slime Leak"
+			chosen_verb = "have leaked into"
+			for(var/i = 1, i < rand(2,4),i++)
+				chosen_mob_types += /mob/living/carbon/slime/
 
-
-	for(var/areapath in typesof(spawn_area_type))
-		var/area/A = locate(areapath)
-		for(var/turf/simulated/floor/F in A.contents)
-			if(turf_clear(F))
-				turfs += F
-
-
-/datum/event/infestation/proc/spawn_creatures()
-	var/list/spawn_types = list()
-	var/max_number
-	vermin = rand(0,6)
-	switch(vermin)
-		if(VERM_MICE)
-			spawn_types = list(/mob/living/simple_animal/mouse/gray, /mob/living/simple_animal/mouse/brown, /mob/living/simple_animal/mouse/white)
-			max_number = 16
-			//Large quantities of mice aren't a potential lag issue since they decompose to
-			//inert skeletons now
-			vermstring = "mice"
-		if(VERM_LIZARDS)
-			spawn_types = list(/mob/living/simple_animal/lizard)
-			max_number = 12
-			vermstring = "lizards"
-		if(VERM_SPIDERS)
-			spawn_types = list(/obj/effect/spider/spiderling)
-			max_number = 5
-			vermstring = "spiders"
-		if (VERM_DIYAAB)
-			spawn_types = list(/mob/living/simple_animal/hostile/diyaab)
-			max_number = 4
-			vermstring = "strange creatures"
-		if (VERM_BATS)
-			spawn_types = list(/mob/living/simple_animal/hostile/scarybat)
-			max_number = 4
-			vermstring = "space bats"
-		if (VERM_YITHIAN)
-			spawn_types = list(/mob/living/simple_animal/yithian)
-			max_number = 7
-			vermstring = "strange creatures"
-		if (VERM_TINDALOS)
-			spawn_types = list(/mob/living/simple_animal/tindalos)
-			max_number = 7
-			vermstring = "strange creatures"
-
-
-	if (severity == EVENT_LEVEL_MODERATE)
-		max_number *= 2
-	var/num = rand(2,max_number)
-
-	while(turfs.len > 0 && num > 0)
-		var/turf/simulated/floor/T = pick(turfs)
-
-		turfs.Remove(T)
-		num--
-
-		if(vermin == VERM_SPIDERS)
-			var/obj/effect/spider/spiderling/S = new /obj/effect/spider/spiderling(T)
-			S.amount_grown = 1
-			S.growth_rate = (rand(50,300)/1000)//At most, they grow at 30% the usual rate. As low as 1/20th
-			if (severity == EVENT_LEVEL_MODERATE)
-				S.growth_rate *= 2//They grow faster on the higher severity event
-		else
-			var/spawn_type = pick(spawn_types)
-			new spawn_type(T)
+/datum/event/infestation/proc/spawn_mobs()
+	for(var/spawned_mob in chosen_mob_types)
+		new spawned_mob(chosen_area.random_space())
 
 /datum/event/infestation/announce()
-	if (severity == EVENT_LEVEL_MODERATE)
-		command_announcement.Announce("Bioscans indicate that large numbers of lifeforms have been breeding in [locstrings[1]] and [locstrings[2]]. Clear them out, before this starts to affect productivity.", "Vermin infestation", new_sound = 'sound/AI/vermin.ogg')
-	else
-		command_announcement.Announce("Bioscans indicate that [vermstring] have been breeding in [locstrings[1]]. Clear them out, before this starts to affect productivity.", "Vermin infestation", new_sound = 'sound/AI/vermin.ogg')
-
-
-#undef LOC_KITCHEN
-#undef LOC_ATMOS
-#undef LOC_INCIN
-#undef LOC_CHAPEL
-#undef LOC_LIBRARY
-#undef LOC_HYDRO
-#undef LOC_VAULT
-#undef LOC_CONSTR
-#undef LOC_TECH
-#undef LOC_ARMORY
-#undef LOC_DORMS
-#undef LOC_FITNESS
-#undef LOC_HOLODECK
-#undef LOC_DISPOSAL
-#undef LOC_CARGO
-#undef LOC_MEETING
-#undef LOC_LOCKER
-#undef LOC_XENO
-
-#undef VERM_MICE
-#undef VERM_LIZARDS
-#undef VERM_SPIDERS
-#undef VERM_DIYAAB
-#undef VERM_BATS
-#undef VERM_YITHIAN
-#undef VERM_TINDALOS
+	command_announcement.Announce("Bioscans indicate that [chosen_mob] [chosen_verb] [chosen_area.name]. Clear them out before this starts to affect productivity.", event_name, new_sound = 'sound/AI/vermin.ogg')

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -43,7 +43,7 @@
 	add_overlay("aslime-:33")
 
 
-/mob/living/simple_animal/slime/adult/death()
+/mob/living/simple_animal/adultslime/death()
 	var/mob/living/simple_animal/slime/S1 = new /mob/living/simple_animal/slime (src.loc)
 	S1.icon_state = "[src.colour] baby slime"
 	S1.icon_living = "[src.colour] baby slime"

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -489,7 +489,7 @@
 //Used to move to a new part of the station when it sees another bear, or it hasnt found any prey
 /mob/living/simple_animal/hostile/bear/spatial/proc/teleport()
 	if (stat == CONSCIOUS)
-		var/area/A = random_station_area()
+		var/area/A = random_station_area(TRUE) //Don't teleport to areas with players in them.
 		var/turf/target = A.random_space()
 
 		teleport_to(target)

--- a/html/changelogs/burgerbb-infestation_overhaul.yml
+++ b/html/changelogs/burgerbb-infestation_overhaul.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."


### PR DESCRIPTION
# Overview
Makes it so that the infestation overhaul is better coded and works better with any station. Instead of picking from a set of 8 areas (2 which don't exist) it picks from any of the station areas without players currently in them.

It also removes some of the more dumber spawns (yithians who exist in the sea, and diyaabs which I don't fucking know.), and replaces them with even dumber spawns such as BLUESPACE BEARS and HIVEBOTS.

## Details
Spawns are based on event severity. A minor severity spawns mice and lizards. A moderate one spawns space bats and baby slimes. A major one spawns bluespace bears and hivebots. The chosen spawns can be any area on the station, however some places are limited. The limitation is based on area as well as if there are any players currently present in the area. Don't want bluespace bears to teleport on people.

## WIP
Wasn't working last time I tested it, and I still need to edit that excel document.