### PR TITLE
Gives people with +DEBUG (maintainers & head admins) access to the profiler

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -66,6 +66,10 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 		C.holder = null
 	admins.Cut()
 
+	// Clears admins from the world config.
+	for (var/A in world.GetConfig("admin"))
+		world.SetConfig("APP/admin", A, null)
+
 	if(config.admin_legacy_system)
 		load_admin_ranks()
 

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -33,6 +33,9 @@ var/list/admin_datums = list()
 	rights = initial_rights
 	admin_datums[ckey] = src
 
+	if (rights & R_DEBUG)
+		world.SetConfig("APP/admin", ckey, "role=admin")
+
 /datum/admins/proc/associate(client/C)
 	if(istype(C))
 		owner = C


### PR DESCRIPTION
Bypass develop because with TGS3, the profiler is inaccessible via conventional means.

The profiler can be accessed by right clicking on the server's top bar, and looking under "Server".