### PR TITLE
nerfs force glove damage amplification to melee weapons.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -91,10 +91,10 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	var/power = force
 	if(HULK in user.mutations)
 		power *= 2
-	//if(istype(user, /mob/living/carbon/human)) //Removed.
-	//	var/mob/living/carbon/human/X = user
-	//	if(X.gloves && istype(X.gloves,/obj/item/clothing/gloves/force))
-	//		var/obj/item/clothing/gloves/force/G = X.gloves
-	//		power *= G.amplification
+	if(istype(user, /mob/living/carbon/human)) 
+		var/mob/living/carbon/human/X = user
+		if(X.gloves && istype(X.gloves,/obj/item/clothing/gloves/force))
+			var/obj/item/clothing/gloves/force/G = X.gloves
+			power *= G.amplification
 	return target.hit_with_weapon(src, user, power, hit_zone)
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -91,10 +91,10 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	var/power = force
 	if(HULK in user.mutations)
 		power *= 2
-	if(istype(user, /mob/living/carbon/human))
-		var/mob/living/carbon/human/X = user
-		if(X.gloves && istype(X.gloves,/obj/item/clothing/gloves/force))
-			var/obj/item/clothing/gloves/force/G = X.gloves
-			power *= G.amplification
+	//if(istype(user, /mob/living/carbon/human)) //Removed.
+	//	var/mob/living/carbon/human/X = user
+	//	if(X.gloves && istype(X.gloves,/obj/item/clothing/gloves/force))
+	//		var/obj/item/clothing/gloves/force/G = X.gloves
+	//		power *= G.amplification
 	return target.hit_with_weapon(src, user, power, hit_zone)
 

--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -16,7 +16,7 @@
 
 /datum/uplink_item/item/visible_weapons/forcegloves
 	name = "Force Gloves"
-	item_cost = 8
+	item_cost = 5
 	path = /obj/item/clothing/gloves/force/syndicate
 
 /datum/uplink_item/item/visible_weapons/energy_sword

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -188,7 +188,7 @@
 
 /obj/item/clothing/gloves/force/syndicate  //for syndies.  pda, *maybe* nuke team or ert.  up to you.  maybe just use the amp 2 variant.
 	name = "enhanced force gloves"
-	amplification = 2.5 //because *2.5 is kind of scary okay.  sometimes you want the scary effect.  sometimes not.
+	amplification = 1.5 // Nerfed, used to be 2.5. Sorry, duck, your legacy of terror ends.
 
 
 /obj/item/clothing/gloves/brassknuckles

--- a/html/changelogs/scheveningen-forcegloveschange.yml
+++ b/html/changelogs/scheveningen-forcegloveschange.yml
@@ -34,4 +34,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscdel: "Force gloves no longer amplify damage with melee weapons."
+  - balance: "Enhanced force gloves have a lowered amplification to melee damage."

--- a/html/changelogs/scheveningen-forcegloveschange.yml
+++ b/html/changelogs/scheveningen-forcegloveschange.yml
@@ -35,3 +35,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - balance: "Enhanced force gloves have a lowered amplification to melee damage."
+  - balance: "Force glove TC cost adjusted to compensate for the reduced power."

--- a/html/changelogs/scheveningen-forcegloveschange.yml
+++ b/html/changelogs/scheveningen-forcegloveschange.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Scheveningen
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Force gloves no longer amplify damage with melee weapons."


### PR DESCRIPTION
With the amount of high base damage melee weapons that exist in the game now, the game and the state of roleplay would benefit more with this trim back of the increasing power creep stemming from the combination potential of force gloves and the highest damaging weapons.

It's a roleplay server, anyway, insta-dying shouldn't become common.

Edit: After some feedback, the damage amp was reduced instead.