### PR TITLE
Blast doors and shutters fix

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -176,8 +176,9 @@
 	if(src.operating || (stat & BROKEN))
 		return
 	if(stat & NOPOWER)
-		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_close)
-		securitylock = 1
+		if(!density)
+			INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_close)
+			securitylock = 1
 	else if(securitylock)
 		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_open)
 		securitylock = 0

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -82,6 +82,8 @@
 // Parameters: None
 // Description: Closes the door. No checks are done inside this proc.
 /obj/machinery/door/blast/proc/force_close()
+	if(!density)
+		return 0
 	src.operating = 1
 	src.layer = closed_layer
 	flick(icon_state_closing, src)
@@ -175,10 +177,9 @@
 	..()
 	if(src.operating || (stat & BROKEN))
 		return
-	if(stat & NOPOWER)
-		if(!density)
-			INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_close)
-			securitylock = 1
+	if(stat & NOPOWER)		
+		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_close)
+		securitylock = 1
 	else if(securitylock)
 		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_open)
 		securitylock = 0

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -177,7 +177,7 @@
 	..()
 	if(src.operating || (stat & BROKEN))
 		return
-	if(stat & NOPOWER)		
+	if(stat & NOPOWER)
 		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_close)
 		securitylock = 1
 	else if(securitylock)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -82,7 +82,7 @@
 // Parameters: None
 // Description: Closes the door. No checks are done inside this proc.
 /obj/machinery/door/blast/proc/force_close()
-	if(!density)
+	if(density)
 		return 0
 	src.operating = 1
 	src.layer = closed_layer

--- a/html/changelogs/Sindorman-fixes.yml
+++ b/html/changelogs/Sindorman-fixes.yml
@@ -1,0 +1,12 @@
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Blast doors and shutters no longer glitch when APC has no power(Or during grid check event)."


### PR DESCRIPTION
- Fixes all blast doors and shutters(children of blast doors), they no longer glitch when area has no power. Fixes #5262 