### PR TITLE
Bug fixes

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -755,7 +755,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			photo_data.photo.forceMove(src.loc)
 			if(!issilicon(user))
 				user.put_in_inactive_hand(photo_data.photo)
-		qdel(photo_data)
+		QDEL_NULL(photo_data)
 
 	if(istype(user.get_active_hand(), /obj/item/weapon/photo))
 		var/obj/item/photo = user.get_active_hand()

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -26,6 +26,10 @@
 	toggle()
 	..()
 
+/obj/structure/curtain/attack_ai(mob/user)
+	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Robots can open/close it, but not the AI.
+		attack_hand(user)
+
 /obj/structure/curtain/proc/toggle()
 	src.set_opacity(!src.opacity)
 	if(opacity)

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -177,7 +177,7 @@
 	pants["blue track pants"] = /obj/item/clothing/under/pants/track/blue
 	pants["green track pants"] = /obj/item/clothing/under/pants/track/green
 	pants["white track pants"] = /obj/item/clothing/under/pants/track/white
-	pants["red track pants"] = /obj/item/clothing/under/pants/track/blue
+	pants["red track pants"] = /obj/item/clothing/under/pants/track/red
 	pants["camo pants"] = /obj/item/clothing/under/pants/camo
 	pants["athletic shorts, black"] = /obj/item/clothing/under/shorts
 	pants["athletic shorts, red"] = /obj/item/clothing/under/shorts/red

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -266,6 +266,9 @@
 	qdel(src)
 
 /mob/living/bot/secbot/ed209/RangedAttack(var/atom/A)
+	if(!(target in view(7, src)))
+		walk_to(src, target, 6, move_to_delay)
+		return
 	if(last_shot + shot_delay > world.time)
 		src << "You are not ready to fire yet!"
 		return

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -80,6 +80,7 @@
 
 /mob/living/bot/secbot/turn_off()
 	..()
+	walk_to(src, src, 0, move_to_delay)
 	target = null
 	frustration = 0
 	mode = SECBOT_IDLE

--- a/html/changelogs/Sindorman-fixes.yml
+++ b/html/changelogs/Sindorman-fixes.yml
@@ -1,0 +1,8 @@
+author: PoZe
+
+delete-after: True
+
+changes:
+  - bugfix: "Beepsky/ED209 no longer move around when turned off"
+  - bugfix: "Red track pants now spawn the right item(instead of blue)"
+  - bugfix: "Cybrogs can now interact with curtains to open and close them."

--- a/html/changelogs/Sindorman-fixes.yml
+++ b/html/changelogs/Sindorman-fixes.yml
@@ -8,3 +8,4 @@ changes:
   - bugfix: "Cybrogs can now interact with curtains to open and close them."
   - bugfix: "Newscaster no longer keep photos after you remove it."
   - mapteak: "Bar now has full camera coverage and two emergency O2 wall lockers"
+  - bugfix: "ED209 no longer shoots far away, but gets closer into shooting range distance with its target"

--- a/html/changelogs/Sindorman-fixes.yml
+++ b/html/changelogs/Sindorman-fixes.yml
@@ -6,3 +6,5 @@ changes:
   - bugfix: "Beepsky/ED209 no longer move around when turned off"
   - bugfix: "Red track pants now spawn the right item(instead of blue)"
   - bugfix: "Cybrogs can now interact with curtains to open and close them."
+  - bugfix: "Newscaster no longer keep photos after you remove it."
+  - mapteak: "Bar now has full camera coverage and two emergency O2 wall lockers"

--- a/html/changelogs/Sindorman-fixes.yml
+++ b/html/changelogs/Sindorman-fixes.yml
@@ -7,5 +7,6 @@ changes:
   - bugfix: "Red track pants now spawn the right item(instead of blue)"
   - bugfix: "Cybrogs can now interact with curtains to open and close them."
   - bugfix: "Newscaster no longer keep photos after you remove it."
-  - mapteak: "Bar now has full camera coverage and two emergency O2 wall lockers"
+  - maptweak: "Bar and kitchen have emergency O2 wall lockers."
+  - maptweak: "Bar theater and Kitchen Pantry now have security cameras"
   - bugfix: "ED209 no longer shoots far away, but gets closer into shooting range distance with its target"

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -64231,6 +64231,12 @@
 	},
 /obj/item/weapon/storage/box/kitchen,
 /obj/item/weapon/storage/box/gloves,
+/obj/machinery/camera/network/civilian_east{
+	c_tag = "Kitchen - Pantry";
+	c_tag_order = 999;
+	dir = 8;
+	network = list("Service")
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "gsR" = (
@@ -65255,6 +65261,13 @@
 "gvD" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/bar)
+"jxb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/emerglocker/north,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "jNC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -65320,6 +65333,23 @@
 /obj/structure/reagent_dispensers/extinguisher,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"pTv" = (
+/obj/machinery/camera/network/civilian_east{
+	c_tag = "Bar - Theater Supplies";
+	c_tag_order = 999;
+	dir = 4;
+	network = list("Service")
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"tdT" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 8
+	},
+/obj/structure/closet/walllocker/emerglocker/west,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "tmB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -95618,7 +95648,7 @@ bVa
 bVa
 bZw
 bVa
-gtH
+tdT
 guT
 bUz
 cbj
@@ -98695,7 +98725,7 @@ bSv
 bUz
 bWC
 bWC
-bWC
+pTv
 bWC
 bWC
 bWC
@@ -98938,7 +98968,7 @@ bGA
 bGA
 bOC
 bPI
-bQQ
+jxb
 grT
 jXF
 gss


### PR DESCRIPTION
- Newscaster no longer keep photo in them after you take it out. Fixes #5216 
- Added missing cameras in the bar. Fixes #5207
- Added two emergency O2 wall lockers to the bar and kitchen. Fixes #5241 
- Fixed reference in red track pants(was referring to blue). Fixes #5276 
- Beepsky/ED209 now stop moving after they are being disabled. Fixes #5244 
- Cyborgs can not open/close curtains. Fixes #5284 
- ED 209 no longer fires from long distance, but gets closer if target is too far away to shoot.