### PR TITLE
Fix poweralarm on derelict shuttle

### DIFF
--- a/html/changelogs/arrow768-shuttle-teg.yml
+++ b/html/changelogs/arrow768-shuttle-teg.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "The derelict shuttle will no longer show up on the power monitoring console."

--- a/maps/dungeon_spawns/shuttle_unique.dmm
+++ b/maps/dungeon_spawns/shuttle_unique.dmm
@@ -322,6 +322,10 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crashed_ship)
 "aU" = (
@@ -339,7 +343,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crashed_ship)
 "aW" = (
-/obj/machinery/power/smes/buildable,
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crashed_ship)
 "aX" = (
@@ -413,10 +421,6 @@
 /obj/item/weapon/reagent_containers/blood/ripped,
 /turf/simulated/floor/tiled/white,
 /area/crashed_ship)
-"bh" = (
-/obj/machinery/power/rtg/advanced,
-/turf/simulated/floor/tiled/dark,
-/area/crashed_ship)
 "bi" = (
 /obj/structure/table/rack,
 /obj/item/clothing/head/helmet,
@@ -477,6 +481,7 @@
 "bs" = (
 /obj/machinery/power/rtg/advanced,
 /obj/machinery/light/small,
+/obj/structure/cable/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/crashed_ship)
 "bt" = (
@@ -543,6 +548,19 @@
 	icon_state = "propulsion_r"
 	},
 /turf/unsimulated/chasm_mask,
+/area/crashed_ship)
+"DG" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/crashed_ship)
 
 (1,1,1) = {"
@@ -1383,10 +1401,10 @@ aa
 aa
 ae
 aT
-ai
-ai
-ai
-ai
+DG
+DG
+DG
+DG
 bs
 ae
 aa
@@ -1418,9 +1436,9 @@ aa
 ae
 ae
 aW
-bh
-bh
-bh
+aW
+aW
+aW
 ae
 ae
 aa


### PR DESCRIPTION
Fixes the power alarm on the derelict shuttle by wiring the tegs to the apc.
Fixes #5277