### PR TITLE
Adjustments to Wizard Spells

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -109,7 +109,7 @@
 	if(changeling)
 		new_character.make_changeling()
 	if(vampire)
-		new_character.make_vampire(TRUE)
+		new_character.make_vampire()
 	if(active)
 		new_character.key = key		//now transfer the key to link the client to our new body
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -109,7 +109,7 @@
 	if(changeling)
 		new_character.make_changeling()
 	if(vampire)
-		new_character.make_vampire()
+		new_character.make_vampire(TRUE)
 	if(active)
 		new_character.key = key		//now transfer the key to link the client to our new body
 

--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -14,10 +14,12 @@
 
 	verbs += new/datum/game_mode/vampire/verb/vampire_help
 
-	for (var/datum/power/vampire/P in vampirepowers)
-		if (!P.blood_cost)
-			if (!(P in mind.vampire.purchased_powers))
+	for(var/datum/power/vampire/P in vampirepowers)
+		if(!(P in mind.vampire.purchased_powers))
+			if(!P.blood_cost)
 				mind.vampire.add_power(mind, P, 0)
+		else if(P.isVerb && P.verbpath)
+			verbs += P.verbpath
 
 	return 1
 

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -119,7 +119,7 @@
 	health -= Proj.get_structure_damage()
 	check_health()
 
-	return //I only added this to spite lohikar
+	return
 
 /obj/structure/closet/statue/attack_generic(var/mob/user, damage, attacktext, environment_smash)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -119,7 +119,7 @@
 	health -= Proj.get_structure_damage()
 	check_health()
 
-	return
+	return //I only added this to spite lohikar
 
 /obj/structure/closet/statue/attack_generic(var/mob/user, damage, attacktext, environment_smash)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -75,7 +75,7 @@
 /obj/structure/closet/statue/process()
 	timer -= 2
 
-	if (timer == 50)
+	if (timer == 10)
 		visible_message("<span class='notice'>\The [src]'s surface begins cracking and dissolving!</span>")
 
 	if (timer <= 0)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -3,7 +3,7 @@
 	universal_understand = 1
 
 /mob/statue_mob/send_emote()
-	src << "You are unable to emote while trapped as a statue."
+	src << "You are unable to move while trapped as a statue."
 
 /mob/statue_mob/say()
 	src << "You are unable to speak while trapped as a statue."
@@ -16,7 +16,7 @@
 	density = 1
 	anchored = 1
 	health = 0 //destroying the statue kills the mob within
-	var/timer = 240 //eventually the person will be freed
+	var/timer = 90 //eventually the person will be freed
 	var/mob/statue_mob/imprisoned = null //the temporary mob that is created when someone is put inside a statue
 
 /obj/structure/closet/statue/eternal
@@ -73,7 +73,7 @@
 	..()
 
 /obj/structure/closet/statue/process()
-	timer--
+	timer -= 2
 
 	if (timer == 50)
 		visible_message("<span class='notice'>\The [src]'s surface begins cracking and dissolving!</span>")

--- a/code/modules/spells/targeted/flesh_to_stone.dm
+++ b/code/modules/spells/targeted/flesh_to_stone.dm
@@ -1,16 +1,16 @@
 /spell/targeted/flesh_to_stone
 	name = "Flesh to Stone"
-	desc = "This spell turns a single person into an inert statue for a short period of time."
+	desc = "This spell turns a single person into an inert statue for a long period of time."
 	feedback = "FS"
 	school = "transmutation"
-	charge_max = 600
+	charge_max = 200
 	spell_flags = NEEDSCLOTHES | SELECTABLE
 	range = 5
 	max_targets = 1
 	invocation = "STAUN EI"
 	invocation_type = SpI_SHOUT
 	amt_stunned = 5
-	cooldown_min = 200
+	cooldown_min = 100
 	cast_sound = 'sound/magic/FleshToStone.ogg'
 
 	hud_state = "wiz_statue"

--- a/code/modules/spells/targeted/flesh_to_stone.dm
+++ b/code/modules/spells/targeted/flesh_to_stone.dm
@@ -1,11 +1,11 @@
 /spell/targeted/flesh_to_stone
 	name = "Flesh to Stone"
-	desc = "This spell turns a single person into an inert statue for a long period of time."
+	desc = "This spell turns a single person into an inert statue for a short period of time."
 	feedback = "FS"
 	school = "transmutation"
 	charge_max = 600
 	spell_flags = NEEDSCLOTHES | SELECTABLE
-	range = 3
+	range = 5
 	max_targets = 1
 	invocation = "STAUN EI"
 	invocation_type = SpI_SHOUT

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -97,7 +97,7 @@
 
 	newVars = list("health" = 50, "maxHealth" = 50)
 
-	protected_roles = list("Wizard","Changeling","Cultist","Vampire")
+	protected_roles = list("Wizard")
 
 	hud_state = "wiz_poly"
 

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -81,7 +81,7 @@
 
 /spell/targeted/shapeshift/baleful_polymorph
 	name = "Baleful Polymorth"
-	desc = "This spell transforms its target into a small, furry animal."
+	desc = "This spell transforms its target into a small, furry animal. Those practiced in the high arcane arts can block this spell with ease, however."
 	feedback = "BP"
 	possible_transformations = list(/mob/living/simple_animal/lizard,/mob/living/simple_animal/mouse,/mob/living/simple_animal/corgi, /mob/living/simple_animal/cat)
 

--- a/html/changelogs/Kaedwuff - Wizfixes.yml
+++ b/html/changelogs/Kaedwuff - Wizfixes.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "The wizard's Stone to Flesh spell now last less time, but is also slightly longer range. Also, the Veil no longer protects one from Baleful Polymorphs."


### PR DESCRIPTION
The Flesh to Stone spell has been slightly adjusted:
-It now lasts 90 seconds (1.5 minutes), instead of 480 (8 minutes)  
-To compensate, it has had its range slightly increased. (3 -> 5)

This makes it less of a last ditch defense and more of a general use disable, while also not forcing the player to endure 8 agonizing minutes of effectively being unconscious, possibly to be zapped right back into it the moment they break free if the wizard is still nearby.  Too many people ghost in frustration with the original implementation of this spell. 

Note that is is a full 30 seconds more than the actual cooldown of the spell.  It still remains viable as a re-applicable single target disable, only you can have periods in between statueing them where you can make demands/talk/threats etc.  You know, roleplay, instead of just leaving them helpless as a statue for a geological epoch.  When it lasted 8 minutes it was fairly viable to go around turning the entire security team into statues, or other shitty behavior.

Additionally:
The Baleful Polymorph spell is no longer silently blocked by numerous antag types.  Only wizards remain immune to it, largely because their shit is so intrinsically tied to irreplaceable clothing that it's kind of bullshit to have them all lose it because of one spell.  Changelings, cultists, and vampires, however, have no particular reason they need to be immune to it, and this behavior for the spell often causes confused wizards to be murdered.

Feedback Thread https://forums.aurorastation.org/viewtopic.php?f=18&t=11992