### PR TITLE
HOP disposal pipe fix

### DIFF
--- a/html/changelogs/Sindorman-disposal.yml
+++ b/html/changelogs/Sindorman-disposal.yml
@@ -1,0 +1,12 @@
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "HOP office disposal system is properly connected, so it can receive delivery and send trash properly."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -19828,9 +19828,6 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "aJC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 10


### PR DESCRIPTION
This removes pipe that was in same tile as sorting pipe, making HOP office cut off from disposals system. Fixes #3854 

Damn that was my first bug I posted on Aurora, it took one year for someone to fix it, found it accidentally out of curiosity. 