### PR TITLE
Slimes and Booze fixes

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -238,10 +238,7 @@
 
 /datum/reagent/water/affect_touch(var/mob/living/carbon/slime/S, var/alien, var/removed)
 	if(istype(S))
-		//Adult slimes have 200 HP, baby slimes have 100 HP.
-		//45u of water should kill a baby slime in 10 seconds.
-		//Wiki: Deals volume * 0.44 damage to slimes per second.
-		S.adjustToxLoss((volume/45) * (removed/REM) * 100 * (1/10))
+		S.adjustToxLoss( volume * (removed/REM) * 0.23 )
 		if(!S.client)
 			if(S.Target) // Like cats
 				S.Target = null

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -166,6 +166,7 @@
 	color = "#0064C877"
 	metabolism = REM * 2
 	ingest_met = REM * 10
+	touch_met = REM * 30
 	taste_description = "water"
 
 	glass_icon_state = "glass_clear"
@@ -235,10 +236,12 @@
 	if(istype(M) && !istype(M, /mob/abstract))
 		M.color = initial(M.color)
 
-/datum/reagent/water/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
-	if(istype(M, /mob/living/carbon/slime))
-		var/mob/living/carbon/slime/S = M
-		S.adjustToxLoss(8 * removed) // Babies have 150 health, adults have 200; So, 10 units and 13.5
+/datum/reagent/water/affect_touch(var/mob/living/carbon/slime/S, var/alien, var/removed)
+	if(istype(S))
+		//Adult slimes have 200 HP, baby slimes have 100 HP.
+		//45u of water should kill a baby slime in 10 seconds.
+		//Wiki: Deals volume * 0.44 damage to slimes per second.
+		S.adjustToxLoss((volume/45) * (removed/REM) * 100 * (1/10))
 		if(!S.client)
 			if(S.Target) // Like cats
 				S.Target = null

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -94,7 +94,7 @@
 	description = "An abstract type you shouldn't be able to see."
 	reagent_state = LIQUID
 	color = "#404030"
-	ingest_met = REM * 4
+	ingest_met = REM * 5
 
 	var/hydration_factor = 1 //How much hydration to add per unit.
 	var/nutriment_factor = 0.5 //How much nutrition to add per unit.
@@ -135,7 +135,7 @@
 /datum/reagent/alcohol/affect_ingest(mob/living/carbon/M, alien, removed)
 
 	if(alien != IS_DIONA)
-		M.intoxication += (strength / 100) * removed
+		M.intoxication += (strength / 100) * removed * 3.5
 
 		if (druggy != 0)
 			M.druggy = max(M.druggy, druggy)
@@ -155,7 +155,6 @@
 	name = "Ethanol"
 	id = "ethanol"
 	description = "A well-known alcohol with a variety of applications."
-	ingest_met = REM * 0.5
 	flammability_divisor = 10
 
 	taste_description = "pure alcohol"
@@ -202,7 +201,7 @@
 	description = "A fairly harmless alcohol that has intoxicating effects on certain species."
 	reagent_state = LIQUID
 	color = "#404030"
-	ingest_met = REM * 0.17 //Extremely slow metabolic rate means the liver will generally purge it faster than it can intoxicate you
+	ingest_met = REM * 0.5 //Extremely slow metabolic rate means the liver will generally purge it faster than it can intoxicate you
 	flammability_divisor = 7	//Butanol is a bit less flammable than ethanol
 
 	taste_description = "alcohol"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -311,7 +311,7 @@
 	description = "A compound used to clean things. Now with 50% more sodium hypochlorite!"
 	reagent_state = LIQUID
 	color = "#A5F0EE"
-	touch_met = 50
+	touch_met = REM * 10
 	taste_description = "sourness"
 
 /datum/reagent/space_cleaner/touch_obj(var/obj/O)
@@ -323,9 +323,6 @@
 			var/turf/simulated/S = T
 			S.dirt = 0
 		T.clean_blood()
-
-		for(var/mob/living/carbon/slime/M in T)
-			M.adjustToxLoss(rand(5, 10))
 
 /datum/reagent/space_cleaner/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.r_hand)
@@ -353,6 +350,20 @@
 			H.clean_blood(1)
 			return
 	M.clean_blood()
+
+
+	if(istype(M,/mob/living/carbon/slime))
+		var/mob/living/carbon/slime/S = M
+		//Adult slimes have 200 HP, baby slimes have 100 HP.
+		//20u of cleaner should kill a baby slime in 10 seconds.
+		//Wiki: Deals volume damage to slimes per second.
+		S.adjustToxLoss( (volume/20) * (removed/REM) * 100 * (1/10) )
+		if(!S.client)
+			if(S.Target) // Like cats
+				S.Target = null
+				++S.Discipline
+		if(dose == removed)
+			S.visible_message("<span class='warning'>[S]'s flesh sizzles where the water touches it!</span>", "<span class='danger'>Your flesh burns in the water!</span>")
 
 /datum/reagent/lube
 	name = "Space Lube"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -354,10 +354,7 @@
 
 	if(istype(M,/mob/living/carbon/slime))
 		var/mob/living/carbon/slime/S = M
-		//Adult slimes have 200 HP, baby slimes have 100 HP.
-		//20u of cleaner should kill a baby slime in 10 seconds.
-		//Wiki: Deals volume damage to slimes per second.
-		S.adjustToxLoss( (volume/20) * (removed/REM) * 100 * (1/10) )
+		S.adjustToxLoss( volume * (removed/REM) * 0.5 )
 		if(!S.client)
 			if(S.Target) // Like cats
 				S.Target = null

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -119,7 +119,7 @@
 	description = "Cardox is an mildly toxic, expensive, NanoTrasen designed cleaner intended to eliminate liquid phoron stains from suits."
 	reagent_state = LIQUID
 	color = "#EEEEEE"
-	metabolism = 0.6 // 100 seconds for 30 units to metabolise.
+	metabolism = 0.3 // 100 seconds for 30 units to metabolise.
 	taste_description = "cherry"
 	conflicting_reagent = /datum/reagent/toxin/phoron
 	strength = 1
@@ -268,7 +268,7 @@
 	reagent_state = SOLID
 	color = "#CCCCCC"
 	taste_description = "salty dirt"
-	metabolism = REM * 10
+	touch_met = REM * 10
 	breathe_mul = 0
 
 /datum/reagent/toxin/fertilizer/monoammoniumphosphate/touch_turf(var/turf/simulated/T)
@@ -301,12 +301,16 @@
 
 /datum/reagent/toxin/fertilizer/monoammoniumphosphate/affect_touch(var/mob/living/carbon/slime/S, var/alien, var/removed)
 	if(istype(S))
-		S.adjustToxLoss(8 * removed)
-		if(!S.client && S.Target)
-			S.Target = null
-			++S.Discipline
+		//Adult slimes have 200 HP, baby slimes have 100 HP.
+		//30u of extinguisher should kill a baby slime in 10 seconds.
+		//Wiki: Deals volume * 0.66 damage to slimes per second.
+		S.adjustToxLoss( (volume/30) * (removed/REM) * 100 * (1/10) )
+		if(!S.client)
+			if(S.Target) // Like cats
+				S.Target = null
+				++S.Discipline
 		if(dose == removed)
-			S.visible_message("<span class='warning'>[S]'s flesh sizzles where the liquid touches it!</span>", "<span class='danger'>Your flesh burns in the liquid!</span>")
+			S.visible_message("<span class='warning'>[S]'s flesh sizzles where the foam touches it!</span>", "<span class='danger'>Your flesh burns in the foam!</span>")
 
 /datum/reagent/toxin/plantbgone
 	name = "Plant-B-Gone"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -301,10 +301,7 @@
 
 /datum/reagent/toxin/fertilizer/monoammoniumphosphate/affect_touch(var/mob/living/carbon/slime/S, var/alien, var/removed)
 	if(istype(S))
-		//Adult slimes have 200 HP, baby slimes have 100 HP.
-		//30u of extinguisher should kill a baby slime in 10 seconds.
-		//Wiki: Deals volume * 0.66 damage to slimes per second.
-		S.adjustToxLoss( (volume/30) * (removed/REM) * 100 * (1/10) )
+		S.adjustToxLoss( volume * (removed/REM) * 0.23 )
 		if(!S.client)
 			if(S.Target) // Like cats
 				S.Target = null

--- a/html/changelogs/burgerbb - slimes and intoxication.yml
+++ b/html/changelogs/burgerbb - slimes and intoxication.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Alcohol now properly gets people drunk. Adjusted the metabolism rate of ethanol/butanol."
+  - balance: "Damage to slimes is now based on a percentage of the volume of that reagent on the slime, meaning more water kills slimes faster."


### PR DESCRIPTION
# Overview
Water was killing slimes super slowly because of an oversight. This fixes that oversight by making it so that the more water you spray on a slime, the faster you kill it. This applies to all slime killing chemicals.

Alcohol had little effect due to an overnerf by Skull. This fixes it so that drinking an entire bottle of whiskey is now like drinking an entire bottle of whiskey. Metabolism values for alcohol were also tweaked to process faster.

Fixes #5376