### PR TITLE
Bugfixes: constructs, simple animals falling down and airlock runtimes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -798,7 +798,7 @@ About the new airlock wires panel:
 			src.do_animate("spark")
 			src.stat |= BROKEN
 			var/check = src.open(1)
-			src.visible_message("\The [H] slices \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]", "You slice \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]", "You hear something sparking.")
+			H.visible_message("\The [H] slices \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]", "You slice \the [src]'s controls[check ? ", ripping it open!" : ", breaking it!"]", "You hear something sparking.")
 			return
 	if(src.p_open)
 		user.set_machine(src)

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -197,8 +197,8 @@
 	health_prefix = "artificer"
 	response_harm = "viciously beaten"
 	harm_intent_damage = 5
-	melee_damage_lower = 5
-	melee_damage_upper = 5
+	melee_damage_lower = 10
+	melee_damage_upper = 10
 	attacktext = "rammed"
 	speed = 0
 	environment_smash = 1

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -666,12 +666,14 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 
 
 /mob/living/simple_animal/can_fall()
+	..()
 	if (stat != DEAD && flying)
 		return FALSE
 	else
 		return TRUE
 
 /mob/living/simple_animal/can_ztravel()
+	..()
 	if (stat != DEAD && flying)
 		return TRUE
 	else

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -666,14 +666,12 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 
 
 /mob/living/simple_animal/can_fall()
-	..()
 	if (stat != DEAD && flying)
 		return FALSE
-	else
-		return TRUE
+
+	return ..()
 
 /mob/living/simple_animal/can_ztravel()
-	..()
 	if (stat != DEAD && flying)
 		return TRUE
 	else


### PR DESCRIPTION
-fixes #5370
-fixes simple animals ignoring ladders and other things when falling down
-fixes a runtime when forcing airlocks open