### PR TITLE
Fixes zombie juice turning people into zombies right away

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -158,7 +158,11 @@
 		return
 	if(target.internal_organs_by_name["zombie"])
 		to_chat(user, "<span class='danger'>You feel that \the [target] has been already infected!</span>")
-	if(prob(25))
+
+	var/infection_chance = 80
+	var/armor = target.run_armor_check(zone,"melee")
+	stun_chance -= armor
+	if(prob(stun_chance))
 		if(target.reagents)
 			target.reagents.add_reagent("trioxin", 10)
 

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -161,8 +161,8 @@
 
 	var/infection_chance = 80
 	var/armor = target.run_armor_check(zone,"melee")
-	stun_chance -= armor
-	if(prob(stun_chance))
+	infection_chance -= armor
+	if(prob(infection_chance))
 		if(target.reagents)
 			target.reagents.add_reagent("trioxin", 10)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -812,6 +812,9 @@
 			if(!H.internal_organs_by_name["brain"])	//destroying the brain stops trioxin from bringing the dead back to life
 				return
 
+			if(H && H.stat != DEAD)
+				return
+
 			for(var/datum/language/L in H.languages)
 				H.remove_language(L.name)
 


### PR DESCRIPTION
I deleted this line by accident, this should make the transformation not instant anymore. Also, it adds an armor check to being infected by the zombie attacks.