### PR TITLE
Map fixes

### DIFF
--- a/html/changelogs/Sindorman-fixes.yml
+++ b/html/changelogs/Sindorman-fixes.yml
@@ -1,0 +1,15 @@
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Deleted wrong pipe below medical break room, it shouldn't shoot trash anymore."
+  - maptweak: "Added one cryostatis bag into medica storage. And added a sink to the chemistry. Added disposal unit to EMT room."
+  - bugfix: "Chemistry windoors access is fixed."
+  - bugfix: "Regular ERT members no longer has access to Admin Shuttle(HAP) blast door remote button. ERT commander and CCIA are the only people whose ID has access to it."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -22653,7 +22653,7 @@
 	name = "Administration Shuttle";
 	pixel_x = 0;
 	pixel_y = 26;
-	req_access = list(101)
+	req_access = list(108)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -30973,7 +30973,8 @@
 	},
 /obj/machinery/door/window/brigdoor/northright{
 	dir = 8;
-	name = "Chemistry Desk"
+	name = "Chemistry Desk";
+	req_access = list(33)
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -39216,7 +39217,8 @@
 	pixel_y = 23
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
@@ -39224,15 +39226,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "bvX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/light_switch{
 	pixel_x = 7;
 	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
@@ -40092,6 +40095,9 @@
 /area/hallway/primary/central_one)
 "bxq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "bxr" = (
@@ -58284,6 +58290,10 @@
 /area/quartermaster/lobby)
 "dvg" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "dzP" = (
@@ -60891,7 +60901,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor/northright{
-	name = "Chemistry Desk"
+	name = "Chemistry Desk";
+	req_access = list(33)
 	},
 /obj/machinery/ringer_button{
 	id = "chemistry_ringer";
@@ -61339,15 +61350,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "nEE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "nGb" = (
@@ -61743,6 +61753,7 @@
 	pixel_x = 24;
 	req_one_access = list(24,11,55)
 	},
+/obj/item/bodybag/cryobag,
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
 "oSF" = (
@@ -63053,6 +63064,13 @@
 /obj/effect/large_stock_marker,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"wJR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
 "wKI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -63420,12 +63438,13 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/structure/sign/nosmoking_1{
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 1
+	},
+/obj/structure/sink/kitchen{
+	name = "chemistry sink";
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -64564,7 +64583,6 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -96630,7 +96648,7 @@ bsx
 bbr
 bxs
 bvV
-bvW
+wJR
 bxs
 bzE
 bAG


### PR DESCRIPTION
- ERT troopers no longer have access to Heavy Asset Protection shuttle blast door.

- Chemistry windoors access is fixed. Fixes #5388 

- Deleted rogue pipe next to medical break room. Fixes #5372 

- Chemistry has a sink, EMT room has a disposal unit now.

- Added a single cryostatis bag to medical storage. Now medbay has 6 bags in total on main level.