### PR TITLE
The last of the hydration/hunger fixes.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -123,16 +123,16 @@
 #define MOB_MINISCULE	1
 
 #define BASE_MAX_NUTRITION	400
-#define HUNGER_FACTOR		0.025 // Factor of how fast mob nutrition decreases. Moved here from chemistry define
+#define HUNGER_FACTOR		0.04 // Factor of how fast mob nutrition decreases over time.
 
 #define BASE_MAX_HYDRATION  600
-#define THIRST_FACTOR       0.05 // Factor of how fast mob hydration decreases. Moved here from chemistry define
+#define THIRST_FACTOR       0.02 // Factor of how fast mob hydration decreases over time.
 
-#define CREW_MINIMUM_HYDRATION 50	// The minimum amount of nutrition a crewmember will spawn with.
-#define CREW_MAXIMUM_HYDRATION 100	// Same as above, but maximum.
+#define CREW_MINIMUM_HYDRATION BASE_MAX_HYDRATION * CREW_HYDRATION_SLIGHTLYTHIRSTY	// The minimum amount of nutrition a crewmember will spawn with.
+#define CREW_MAXIMUM_HYDRATION BASE_MAX_HYDRATION * CREW_HYDRATION_HYDRATED	// Same as above, but maximum.
 
-#define CREW_MINIMUM_NUTRITION 50	// The minimum amount of nutrition a crewmember will spawn with.
-#define CREW_MAXIMUM_NUTRITION 100	// Same as above, but maximum.
+#define CREW_MINIMUM_NUTRITION BASE_MAX_NUTRITION * CREW_NUTRITION_SLIGHTLYHUNGRY	// The minimum amount of nutrition a crewmember will spawn with.
+#define CREW_MAXIMUM_NUTRITION BASE_MAX_NUTRITION * CREW_NUTRITION_FULL	// Same as above, but maximum.
 
 //Note that all of this is relative to nutrition/max nutrition
 #define CREW_NUTRITION_OVEREATEN 0.95

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -34,8 +34,8 @@
 
 /mob/living/carbon/Move(NewLoc, direct)
 	. = ..()
-	if(.)
 
+	if(.)
 		if(src.stat != 2)
 			if(src.nutrition)
 				adjustNutritionLoss(nutrition_loss*0.1)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1685,7 +1685,7 @@
 		var/regen = stamina_recovery * (1 - min(((oxyloss) / exhaust_threshold) + ((halloss) / exhaust_threshold), 1))
 		if (regen > 0)
 			stamina = min(max_stamina, stamina+regen)
-			adjustNutritionLoss(stamina_recovery*0.9)
+			adjustNutritionLoss(stamina_recovery*0.09)
 			adjustHydrationLoss(stamina_recovery*0.18)
 			if (client)
 				hud_used.move_intent.update_move_icon(src)

--- a/code/modules/mob/living/carbon/human/species/species_hud.dm
+++ b/code/modules/mob/living/carbon/human/species/species_hud.dm
@@ -55,6 +55,7 @@
 	equip_slots |= slot_legcuffed
 
 /datum/hud_data/diona
+	has_hydration = 0
 	has_internals = 0
 	gear = list(
 		"i_clothing" =   list("loc" = ui_iclothing, "name" = "Uniform",      "slot" = slot_w_uniform, "state" = "center", "toggle" = 1),

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -335,6 +335,8 @@
 	sprint_cost_factor = 0.8
 	climb_coeff = 1.3
 
+	max_hydration_factor = -1
+
 /datum/species/diona/handle_sprint_cost(var/mob/living/carbon/H, var/cost)
 	var/datum/dionastats/DS = H.get_dionastats()
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1237,7 +1237,8 @@ proc/is_blind(A)
 	return TRUE
 
 /mob/proc/adjustHydrationLoss(var/amount)
-	if(max_nutrition <= 0)
+
+	if(max_hydration <= 0)
 		return FALSE
 	hydration = max(0,min(max_hydration,hydration - amount))
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -117,6 +117,8 @@
 	glass_name = "glass of coder fuckups"
 	glass_desc = "A glass of distilled maintainer tears."
 
+	var/blood_to_ingest_scale = 2
+
 /datum/reagent/alcohol/Destroy()
 	if (caffeine_mod)
 		QDEL_NULL(caffeine_mod)
@@ -128,8 +130,8 @@
 		L.adjust_fire_stacks((amount / (flammability_divisor || 1)) * (strength / 100))
 
 /datum/reagent/alcohol/affect_blood(mob/living/carbon/M, alien, removed)
-	M.adjustToxLoss(removed * 2)
-	affect_ingest(M,alien,removed * 2)
+	M.adjustToxLoss(removed * blood_to_ingest_scale * (strength/100) )
+	affect_ingest(M,alien,removed * blood_to_ingest_scale)
 	return
 
 /datum/reagent/alcohol/affect_ingest(mob/living/carbon/M, alien, removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -701,6 +701,7 @@
 	var/caffeine = 0 // strength of stimulant effect, since so many drinks use it
 	var/datum/modifier/modifier = null
 	unaffected_species = IS_MACHINE
+	var/blood_to_ingest_scale = 2
 
 /datum/reagent/drink/Destroy()
 	if (modifier)
@@ -708,8 +709,8 @@
 	return ..()
 
 /datum/reagent/drink/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.adjustToxLoss(removed) // Probably not a good idea; not very deadly though
-	digest(M,alien,removed * 2, FALSE)
+	M.adjustToxLoss(removed * blood_to_ingest_scale) // Probably not a good idea; not very deadly though
+	digest(M,alien,removed * blood_to_ingest_scale, FALSE)
 
 /datum/reagent/drink/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	digest(M,alien,removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -2463,6 +2463,9 @@
 	glass_desc = "A drink that is guaranteed to knock you silly."
 	glass_center_of_mass = list("x"=16, "y"=8)
 
+	blood_to_ingest_scale = 1
+	metabolism = REM * 5
+
 /datum/reagent/alcohol/ethanol/neurotoxin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	if(alien != IS_DIONA)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -1434,6 +1434,8 @@
 	glass_desc = "A healthy mixture of juices, guaranteed to keep you healthy until the next toolboxing takes place."
 	glass_center_of_mass = list("x"=16, "y"=8)
 
+	blood_to_ingest_scale = 1
+
 /datum/reagent/drink/doctor_delight/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	if(alien != IS_DIONA)
@@ -1450,6 +1452,7 @@
 	description = "Space age food, since August 25, 1958. Contains dried noodles, vegetables, and chemicals that boil in contact with water."
 	reagent_state = SOLID
 	nutrition = 1
+	hydration = 0
 	color = "#302000"
 	taste_description = "dry and cheap noodles"
 
@@ -1460,6 +1463,7 @@
 	reagent_state = LIQUID
 	color = "#302000"
 	nutrition = 5
+	hydration = 5
 	adj_temp = 5
 	taste_description = "wet and cheap noodles"
 
@@ -1470,6 +1474,7 @@
 	reagent_state = LIQUID
 	color = "#302000"
 	nutrition = 5
+	hydration = 5
 	taste_description = "wet and cheap noodles on fire"
 
 /datum/reagent/drink/hell_ramen/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
@@ -1485,6 +1490,7 @@
 	adj_temp = -5
 	taste_description = "ice"
 	taste_mult = 1.5
+	hydration = 8
 
 	glass_icon_state = "iceglass"
 	glass_name = "glass of ice"

--- a/html/changelogs/burgerbb - lastfix.yml
+++ b/html/changelogs/burgerbb - lastfix.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed a typo that caused hunger related hell to be unleashed upon players when sprinting a lot."
+  - bugfix: "Diona are no longer affected by thirst."
+  - tweak: "Adjusted starting hunger values so that people don't come to the station starving."
+  - tweak: "Increased the metabolism rate of Neurotoxin so it doesn't stun for 30 seconds when injected."

--- a/html/changelogs/burgerbb - lastfix.yml
+++ b/html/changelogs/burgerbb - lastfix.yml
@@ -37,4 +37,5 @@ changes:
   - bugfix: "Fixed a typo that caused hunger related hell to be unleashed upon players when sprinting a lot."
   - bugfix: "Diona are no longer affected by thirst."
   - tweak: "Adjusted starting hunger values so that people don't come to the station starving."
-  - tweak: "Increased the metabolism rate of Neurotoxin so it doesn't stun for 30 seconds when injected."
+  - tweak: "Increased the metabolism rate of Neurotoxin so it doesn't stun for 30 seconds when injected. Adjusted the injection strength of Doctor's Delight when injected."
+  - tweak: "Adjusted ramen and ice nutrition and hydration stats."


### PR DESCRIPTION
- Fixes #5387 via a typo.
- Reduces the strength of Neurotoxin (drink item) and Doctor's Delight (Drink Item) when injected.
- Dionaea are no longer affected by thirst
- Adjusted ice and ramen hydration/nutrition stats.