### PR TITLE
Multiple bugfixes

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -30,7 +30,7 @@
 /proc/game_log(category, text)
 	diary << "\[[time_stamp()]] [game_id] [category]: [text][log_end]"
 
-/proc/log_admin(text,level=5,ckey="",admin_key="",ckey_target="")
+/proc/log_admin(text,level=SEVERITY_NOTICE,ckey="",admin_key="",ckey_target="")
 	admin_log.Add(text)
 	if (config.log_admin)
 		game_log("ADMIN", text)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -478,8 +478,9 @@ var/list/admin_verbs_cciaa = list(
 		var/mob/abstract/observer/ghost = mob
 		if(ghost.can_reenter_corpse)
 			ghost.reenter_corpse()
+			log_admin("[src] reentered their corpose using aghost.",admin_key=key_name(src))
 		else
-			ghost << "<font color='red'>Error:  Aghost:  Can't reenter corpse, mentors that use adminHUD while aghosting are not permitted to enter their corpse again</font>"
+			ghost << "<font color='red'>Error: Aghost: Can't reenter corpse.</font>"
 			return
 
 		feedback_add_details("admin_verb","P") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -496,7 +497,7 @@ var/list/admin_verbs_cciaa = list(
 			if(!body.key)
 				body.key = "@[key]"	//Haaaaaaaack. But the people have spoken. If it breaks; blame adminbus
 		feedback_add_details("admin_verb","O") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
+		log_admin("[src] aghosted.",admin_key=key_name(src))
 
 /client/proc/invisimin()
 	set name = "Invisimin"
@@ -660,6 +661,7 @@ var/list/admin_verbs_cciaa = list(
 
 	var/list/traumas = subtypesof(/datum/brain_trauma)
 	var/result = input(usr, "Choose the brain trauma to apply","Traumatize") as null|anything in traumas
+	if(!result) return
 	var/permanent = alert("Do you want to make the trauma unhealable?", "Permanently Traumatize", "Yes", "No")
 	if(permanent == "Yes")
 		permanent = TRUE

--- a/html/changelogs/Arrow768-bugfixes.yml
+++ b/html/changelogs/Arrow768-bugfixes.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "NanoTrasen Engineers have fixed issues such as missing holopads, newscasters, vents and access errors throughout the station"
+  - maptweak: "The skylight has been readded to the psych wing."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -36957,6 +36957,9 @@
 	icon_state = "corner_white";
 	dir = 4
 	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "brx" = (
@@ -39381,6 +39384,9 @@
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 5
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
@@ -51417,6 +51423,7 @@
 	icon_state = "warning";
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
 "ccf" = (
@@ -51502,10 +51509,10 @@
 /area/quartermaster/mail_room)
 "ccz" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
 "ccB" = (
@@ -51700,7 +51707,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+	dir = 1;
+	external_pressure_bound = 102;
+	external_pressure_bound_default = 102;
+	icon_state = "map_vent_in";
+	pump_direction = 0
 	},
 /obj/machinery/light/small/emergency{
 	dir = 8
@@ -58798,6 +58809,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"gnU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
 "gql" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/junk,
@@ -58945,8 +58962,8 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
-	req_access = null;
-	req_one_access = list(12,28)
+	req_access = list(28);
+	req_one_access = null
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -61115,6 +61132,11 @@
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
+"lUb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
 "maz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -63187,6 +63209,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
+"xCL" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
 "xDz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -63531,6 +63557,9 @@
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/donut,
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
 "ygU" = (
@@ -64346,6 +64375,9 @@
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
@@ -91034,7 +91066,7 @@ ykg
 bXo
 mEE
 mEE
-mEE
+lUb
 mEE
 mEE
 mEE
@@ -93101,7 +93133,7 @@ xIJ
 xIJ
 cbA
 cbU
-cct
+xCL
 cct
 cct
 amD
@@ -93609,7 +93641,7 @@ cib
 pDO
 cqv
 cqA
-cqA
+gnU
 cqO
 cqV
 xIJ

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -1500,19 +1500,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"cN" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "cO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1562,35 +1549,6 @@
 	pixel_y = 16
 	},
 /turf/simulated/open,
-/area/maintenance/library)
-"cU" = (
-/obj/structure/disposalpipe/down{
-	icon_state = "pipe-d";
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/simulated/open,
-/area/maintenance/library)
-"cV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
-"cW" = (
-/obj/structure/disposalpipe/up{
-	icon_state = "pipe-u";
-	dir = 8
-	},
-/turf/simulated/floor/plating{
-	roof_type = null
-	},
 /area/maintenance/library)
 "cX" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
@@ -5265,9 +5223,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
-"ju" = (
-/turf/simulated/wall,
-/area/maintenance/library)
 "jv" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -5864,9 +5819,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
-"kw" = (
-/turf/simulated/wall,
-/area/medical/med_office)
 "kx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6043,14 +5995,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
-"kN" = (
-/obj/structure/lattice,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
-	},
-/turf/simulated/open,
-/area/medical/med_office)
 "kO" = (
 /obj/structure/curtain,
 /turf/simulated/floor/tiled/white,
@@ -6357,14 +6301,6 @@
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
-"lo" = (
-/obj/structure/lattice,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 2
-	},
-/turf/simulated/open,
-/area/medical/med_office)
 "lp" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
@@ -7033,6 +6969,10 @@
 /obj/effect/decal/remains,
 /turf/simulated/floor/plating,
 /area/security/training)
+"zY" = (
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/medical/psych)
 "FK" = (
 /obj/effect/landmark/dungeon_spawn,
 /turf/unsimulated/chasm_mask,
@@ -7055,17 +6995,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"GT" = (
-/obj/structure/lattice/catwalk,
-/turf/simulated/open,
-/area/medical/med_office)
-"Hl" = (
-/obj/structure/lattice,
-/turf/simulated/open,
-/area/medical/med_office)
-"Hm" = (
-/turf/simulated/open,
-/area/medical/med_office)
 "HV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -7208,6 +7137,16 @@
 	roof_type = null
 	},
 /area/maintenance/library)
+"PT" = (
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/psych)
 
 (1,1,1) = {"
 aa
@@ -44599,11 +44538,11 @@ hZ
 hZ
 hZ
 hZ
-ab
-ab
-aa
-aa
-aa
+hZ
+hZ
+hZ
+hZ
+hZ
 aa
 aa
 aa
@@ -44856,11 +44795,11 @@ kA
 kK
 kU
 hZ
-ab
-ab
-ab
-ab
-aa
+mr
+mr
+mr
+mr
+hZ
 aa
 aa
 aa
@@ -45113,11 +45052,11 @@ kB
 kL
 kL
 ke
-ab
-ab
-ab
-ab
-aa
+mr
+mr
+mr
+mr
+hZ
 aa
 aa
 aa
@@ -45370,11 +45309,11 @@ kB
 kM
 kV
 kg
-ab
-ab
-ab
-ab
-ab
+mr
+mr
+mr
+mr
+hZ
 aa
 aa
 aa
@@ -45627,13 +45566,13 @@ kC
 kO
 kO
 hZ
-ab
-ab
-ab
-ab
-ab
-ab
-aa
+zY
+zY
+zY
+zY
+hZ
+hZ
+hZ
 aa
 aa
 aa
@@ -45884,13 +45823,13 @@ kB
 kP
 kU
 kY
-ab
-ab
-ab
-ab
-ab
-ab
-aa
+mr
+mr
+mr
+mr
+zY
+mr
+hZ
 aa
 aa
 aa
@@ -46141,14 +46080,14 @@ kB
 kL
 kL
 kg
+mr
+mr
+mr
+mr
+zY
+mr
+hZ
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
 hZ
 hZ
 hZ
@@ -46393,19 +46332,19 @@ ab
 ab
 ab
 hZ
-jA
+PT
 kD
 kQ
 kV
 hZ
+mr
+mr
+mr
+mr
+zY
+mr
+hZ
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
 hZ
 mr
 mr
@@ -46655,14 +46594,14 @@ kE
 hZ
 hZ
 hZ
+mr
+mr
+mr
+mr
+zY
+mr
+hZ
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
 hZ
 mr
 mr


### PR DESCRIPTION
Changes the kitchen maint access. Fixes #5398.
Readds the psych-skylight.
Fixes insufficient logging of a admin command.
Adds newscasters to the medbay. Fixes #5375.
Adds a properly configured vent to disposals. Fixes #5374.
Adds missing holopads to cargo.