### PR TITLE
Nerfs Zombie Powder / Parapen.

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -62,7 +62,6 @@
 	if(!ismob(M))
 		return
 	user << "<span class='warning'>You stab [M] with the pen.</span>"
-//	M << "\red You feel a tiny prick!" //That's a whole lot of meta!
 	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been stabbed with [name]  by [user.name] ([user.ckey])</font>")
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to stab [M.name] ([M.ckey])</font>")
 	msg_admin_attack("[user.name] ([user.ckey]) Used the [name] to stab [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)",ckey=key_name(user),ckey_target=key_name(M))
@@ -88,12 +87,13 @@
 
 	. = ..()
 
-	if(M.can_inject(user,1))
-		if(reagents.total_volume)
-			if(M.reagents)
-				var/contained_reagents = reagents.get_reagents()
-				var/trans = reagents.trans_to_mob(M, 30, CHEM_BLOOD)
-				admin_inject_log(user, M, src, contained_reagents, trans)
+	if(M.can_inject(user,1) && reagents.total_volume && M.reagents)
+		var/contained_reagents = reagents.get_reagents()
+		var/trans = reagents.trans_to_mob(M, 30, CHEM_BLOOD)
+		admin_inject_log(user, M, src, contained_reagents, trans)
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			H.custom_pain("You feel a tiny prick.")
 
 /*
  * Sleepy Pens

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -206,11 +206,11 @@
 /datum/reagent/toxin/zombiepowder
 	name = "Zombie Powder"
 	id = "zombiepowder"
-	description = "A strong neurotoxin that puts the subject into a death-like state."
+	description = "A strong neurotoxin that puts the subject into a death-like state after a short period."
 	reagent_state = SOLID
 	color = "#669900"
 	metabolism = REM
-	strength = 3
+	strength = 1
 	taste_description = "death"
 
 /datum/reagent/toxin/zombiepowder/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -218,11 +218,18 @@
 	var/mob/living/carbon/human/H = M
 	if(istype(H) && (H.species.flags & NO_SCAN))
 		return
-	M.status_flags |= FAKEDEATH
-	M.adjustOxyLoss(3 * removed)
-	M.Weaken(10)
-	M.silent = max(M.silent, 10)
-	M.tod = worldtime2text()
+
+	if(!dose && volume)
+		M.emote("deathgasp")
+
+	if(dose <= 5)
+		M.adjustHalLoss(removed*20)
+	else
+		M.status_flags |= FAKEDEATH
+		M.adjustOxyLoss(1 * removed)
+		M.Weaken(10)
+		M.silent = max(M.silent, 10)
+		M.tod = worldtime2text()
 
 /datum/reagent/toxin/zombiepowder/Destroy()
 	if(holder && holder.my_atom && ismob(holder.my_atom))

--- a/html/changelogs/burgerbb - stunsbgone.yml
+++ b/html/changelogs/burgerbb - stunsbgone.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Parapens now display a message upon injection."
+  - balance: "Zombie powder takes 5 seconds to kick in, and now plays a fake deathgasp message."


### PR DESCRIPTION
# Overview
Aurorastation is trying to move away from stun based combat, so it only makes sense to nerf one of the largest, cheapest, and most reliable stuns in the game: Parapen. Parapen contains zombie powder, which stuns you instantly without any notification at all towards the victim or the people around them. It's very strange that this 3 TC tool has gone unnoticed for so long. If I make a PR that introduces a 3TC one time use stun baton that stuns someone for 19 seconds, it would get denied because of powercreep.

## Changes
Zombie powder is now changed. It takes 5 seconds and at least 5 units to kick in. During it kicking in, it will deal a total of 100 pain damage in those 5 seconds so simulate death. Once it kicks in, it plays a custom deathgasp message and does the normal effects. As an added bonus, it only deals 1 toxin and 1 oxy damage per unit as opposed to 3 for both, so it can be used to fake your own death without killing you.

Parapen is now changed as well. It notifies the victim that they feel an undirected tiny prick, much like a changeling stealth sting.

## Fun Chart
```
Aurorastation's Sleepy Pen:
	No injection message.
	Instant:
		19 second stun.
		19 second mute.
		30 oxyloss.
		18 second dizziness.
		24 second confusion.
	
/tg/station's Sleepy Pen:
	No injection message.
	Instant:
		Stamina loss.
		17 Second Mute.

	5 second delay: 
		19 second confusion.
		19 second dizziness.
	
	10 second delay:
		20 second sleep.
```

## Feedback Thread
https://forums.aurorastation.org/viewtopic.php?f=21&t=12060

## WIP
Needs to be tested and feedback gathered.