### PR TITLE
Science sublevel QOL changes

### DIFF
--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -13902,6 +13902,15 @@
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/tiled,
 /area/outpost/research/isolation_monitoring)
+"ayZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 9
+	},
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/tiled,
+/area/rnd/mixing)
 "aza" = (
 /obj/structure/table/standard,
 /obj/item/weapon/scalpel,
@@ -15582,6 +15591,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"aBQ" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1379;
+	id_tag = "toxinsairlock_pump"
+	},
+/turf/simulated/floor/plating,
+/area/rnd/mixing)
 "aBR" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -23768,6 +23785,7 @@
 	icon_state = "intact-supply";
 	dir = 6
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "aPq" = (
@@ -23882,6 +23900,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
+"aPC" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/rnd/mixing)
 "aPD" = (
 /turf/unsimulated/chasm_mask,
 /area/crew_quarters/sleep/medical)
@@ -24220,6 +24245,30 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/medical)
+"aQk" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "toxinsairlock_outer";
+	locked = 1;
+	name = "Toxins External Access";
+	req_access = list(10,13)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/rnd/mixing)
 "aQl" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -24491,6 +24540,19 @@
 /obj/item/weapon/reagent_containers/food/drinks/jar,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"aQK" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1379;
+	id_tag = "toxinsairlock_pump"
+	},
+/turf/simulated/floor/plating,
+/area/rnd/mixing)
 "aQL" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24948,6 +25010,71 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/xenobiology/cells/delta)
+"aRI" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1379;
+	id_tag = "toxinsairlock_airlock";
+	pixel_x = 0;
+	pixel_y = -35;
+	tag_airpump = "toxinsairlock_pump";
+	tag_chamber_sensor = "toxinsairlock_sensor";
+	tag_exterior_door = "toxinsairlock_outer";
+	tag_interior_door = "toxinsairlock_inner"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1379;
+	id_tag = "toxinsairlock_sensor";
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/turf/simulated/floor/plating,
+/area/rnd/mixing)
+"aRJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "toxinsairlock_airlock";
+	name = "interior access button";
+	pixel_x = -25;
+	pixel_y = -25;
+	req_one_access = list(13,65)
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled,
+/area/rnd/mixing)
+"aRK" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8;
+	name = "Distro to Canisters";
+	target_pressure = 150
+	},
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/rnd/mixing)
 "aRM" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/disposalpipe/segment{
@@ -28381,15 +28508,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
-"aYD" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
-	},
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled,
-/area/rnd/mixing)
 "aYE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -28668,59 +28786,6 @@
 	},
 /turf/simulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"aZi" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "toxinsairlock_outer";
-	locked = 1;
-	name = "Toxins External Access";
-	req_access = list(10,13)
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/rnd/mixing)
-"aZj" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1379;
-	id_tag = "toxinsairlock_pump"
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
-	id_tag = "toxinsairlock_airlock";
-	pixel_x = 0;
-	pixel_y = -35;
-	tag_airpump = "toxinsairlock_pump";
-	tag_chamber_sensor = "toxinsairlock_sensor";
-	tag_exterior_door = "toxinsairlock_outer";
-	tag_interior_door = "toxinsairlock_inner"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1379;
-	id_tag = "toxinsairlock_sensor";
-	pixel_x = 0;
-	pixel_y = -25
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/rnd/mixing)
 "aZk" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -28736,46 +28801,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/rnd/mixing)
-"aZl" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "toxinsairlock_airlock";
-	name = "interior access button";
-	pixel_x = 0;
-	pixel_y = -25;
-	req_one_access = list(13,65)
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/machinery/meter,
-/turf/simulated/floor/tiled,
-/area/rnd/mixing)
-"aZm" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning/cee{
-	icon_state = "warningcee";
-	dir = 8
-	},
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8;
-	name = "Distro to Canisters";
-	target_pressure = 150
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
@@ -45630,7 +45655,7 @@ aWH
 aYo
 akG
 aba
-aZg
+aZh
 asB
 aZC
 atE
@@ -45885,10 +45910,10 @@ aWI
 aWI
 aXP
 aVT
-aba
-aba
-aZh
-asB
+aQq
+aQq
+aQk
+aQq
 aZC
 atE
 aaa
@@ -46142,9 +46167,9 @@ aWJ
 aXs
 aXQ
 aVT
-aba
 aQq
-aZi
+aBQ
+aQK
 aQq
 aZD
 atE
@@ -46399,9 +46424,9 @@ aWK
 aXt
 aXR
 aVT
-aba
 aQq
-aZj
+aPC
+aRI
 aQq
 aZE
 aQq
@@ -46913,9 +46938,9 @@ aWM
 aXv
 aXS
 aQq
-aYD
+ayZ
 aYS
-aZl
+aRJ
 aQq
 aZE
 aQq
@@ -47172,7 +47197,7 @@ aXT
 aQq
 aYE
 aYT
-aZm
+aRK
 aQq
 aZE
 aQq


### PR DESCRIPTION
Expands the toxins airlock to allow moving equipment, targets, etc. out onto the range without issue. Also fixes minor mapping errors in the area.

![image](https://user-images.githubusercontent.com/22651198/46817061-e5667480-cd43-11e8-9c40-04b59b15ee20.png)


Adds an AI pad to xenobiology, because Burger removed it/failed to add it in his changes.

![image](https://user-images.githubusercontent.com/22651198/46817071-ed261900-cd43-11e8-9e85-0f73efe47161.png)
