### PR TITLE
More alternative job titles

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -199,6 +199,7 @@
 	selection_color = "#dddddd"
 	access = list(access_janitor, access_maint_tunnels, access_engine, access_research, access_sec_doors, access_medical)
 	minimal_access = list(access_janitor, access_maint_tunnels, access_engine, access_research, access_sec_doors, access_medical)
+	alt_titles = list("Custodial Technician")
 
 	bag_type = /obj/item/weapon/storage/backpack
 	satchel_type = /obj/item/weapon/storage/backpack/satchel_norm
@@ -255,7 +256,7 @@
 	selection_color = "#dddddd"
 	access = list(access_library, access_maint_tunnels)
 	minimal_access = list(access_library)
-
+	alt_titles = list("Curator", "Archivist")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)
@@ -284,7 +285,7 @@
 	economic_modifier = 7
 	access = list(access_lawyer, access_sec_doors, access_maint_tunnels, access_heads)
 	minimal_access = list(access_lawyer, access_sec_doors, access_heads)
-
+	alt_titles = list("Human Resources Representative", "Corporate Lawyer")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)

--- a/code/game/jobs/job/outsider/merchant.dm
+++ b/code/game/jobs/job/outsider/merchant.dm
@@ -14,6 +14,7 @@
 	ideal_character_age = 30
 	create_record = 0
 	account_allowed = 0
+	alt_titles = list("Trader", "Materials Seller", "Arms Dealer", "Retail Food Delivery")
 
 	access = list(access_merchant)
 	minimal_access = list(access_merchant)

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -54,7 +54,7 @@
 	economic_modifier = 7
 	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch)
-	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher")
+	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher", "Hardware Engineer", "Toxins Researcher")
 
 	minimal_player_age = 14
 

--- a/html/changelogs/VTCobaltblood - more-job-titles.yml
+++ b/html/changelogs/VTCobaltblood - more-job-titles.yml
@@ -23,7 +23,7 @@
 #################################
 
 # Your name.  
-author: N3X15
+author: VTCobaltblood
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/VTCobaltblood - more-job-titles.yml
+++ b/html/changelogs/VTCobaltblood - more-job-titles.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: Scientists can now be Toxin Researchers and Hardware Engineers.
+  - rscadd: Merchants can now be Traders, Material Sellers, Arms Dealers and Retail Food Delivery.
+  - rscadd: Janitors can now be Custodial Technicians.
+  - rscadd: Librarians can now be Curators and Archivists.
+  - rscadd: IAA can now be Human Resources Representatives and Corporate Lawyers.


### PR DESCRIPTION
Janitors can be Custodial Technicians; Scientists can be Hardware Engineers (R&D and circuitry basically) and Toxin Researchers; Librarians can be Curators and Archivists; Merchants can be Arms Dealers, Traders, Material Sellers and Retail Food Delivery; IAA can be Human Resources Representatives and Corporate Lawyers. I'm most conflicted about the IAA title alternatives, and ready to remove them. If this gets approved, I'll also work on making Hardware Engineers not wear labcoats.