### PR TITLE
More alternative job titles

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -12,7 +12,7 @@
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 	//alt_titles = list("Technical Assistant","Medical Intern","Research Assistant","Security Cadet", "Visitor")
-	alt_titles = list("Visitor")
+	alt_titles = list("Visitor", "Tourist")
 
 /datum/job/assistant/equip(var/mob/living/carbon/human/H)
 	if(!H)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -104,6 +104,7 @@
 	economic_modifier = 5
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
+	alt_titles = list("Supply Manager")
 
 	ideal_character_age = 40
 
@@ -130,6 +131,7 @@
 	selection_color = "#dddddd"
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
+	alt_titles = list("Deliveryman", "Deliverywoman")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -194,6 +196,7 @@
 	selection_color = "#dddddd"
 	access = list(access_janitor, access_maint_tunnels, access_engine, access_research, access_sec_doors, access_medical)
 	minimal_access = list(access_janitor, access_maint_tunnels, access_engine, access_research, access_sec_doors, access_medical)
+	alt_titles = list("Custodial Technician")
 
 	bag_type = /obj/item/weapon/storage/backpack
 	satchel_type = /obj/item/weapon/storage/backpack/satchel_norm
@@ -221,7 +224,7 @@
 	selection_color = "#dddddd"
 	access = list(access_journalist, access_maint_tunnels)
 	minimal_access = list(access_journalist, access_maint_tunnels)
-	alt_titles = list("Freelance Journalist")
+	alt_titles = list("Freelance Journalist", "News Publisher")
 	title_accesses = list("Corporate Reporter" = list(access_medical, access_sec_doors, access_research, access_engine))
 
 /datum/job/journalist/equip(var/mob/living/carbon/human/H, var/alt_title)
@@ -249,6 +252,7 @@
 	selection_color = "#dddddd"
 	access = list(access_library, access_maint_tunnels)
 	minimal_access = list(access_library)
+	alt_titles = list("Curator", "Archivist")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -131,7 +131,6 @@
 	selection_color = "#dddddd"
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
-	alt_titles = list("Deliveryman", "Deliverywoman")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -224,7 +223,7 @@
 	selection_color = "#dddddd"
 	access = list(access_journalist, access_maint_tunnels)
 	minimal_access = list(access_journalist, access_maint_tunnels)
-	alt_titles = list("Freelance Journalist", "News Publisher")
+	alt_titles = list("Freelance Journalist", "Newscaster Maintainer")
 	title_accesses = list("Corporate Reporter" = list(access_medical, access_sec_doors, access_research, access_engine))
 
 /datum/job/journalist/equip(var/mob/living/carbon/human/H, var/alt_title)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -251,7 +251,7 @@
 	selection_color = "#dddddd"
 	access = list(access_library, access_maint_tunnels)
 	minimal_access = list(access_library)
-	alt_titles = list("Curator", "Archivist")
+	alt_titles = list("Curator")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)

--- a/code/game/jobs/job/outsider/merchant.dm
+++ b/code/game/jobs/job/outsider/merchant.dm
@@ -17,6 +17,7 @@
 
 	access = list(access_merchant)
 	minimal_access = list(access_merchant)
+	alt_titles = list("Arms Dealer", "Trader", "Materials Shipper")
 
 	latejoin_at_spawnpoints = TRUE
 

--- a/code/game/jobs/job/outsider/merchant.dm
+++ b/code/game/jobs/job/outsider/merchant.dm
@@ -17,7 +17,7 @@
 
 	access = list(access_merchant)
 	minimal_access = list(access_merchant)
-	alt_titles = list("Arms Dealer", "Trader", "Materials Shipper")
+	alt_titles = list("Arms Dealer", "Materials Shipper")
 
 	latejoin_at_spawnpoints = TRUE
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -54,7 +54,7 @@
 	economic_modifier = 7
 	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch)
-	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher")
+	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher", "Hardware Engineer", "Toxins Researcher")
 
 	minimal_player_age = 14
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -110,7 +110,7 @@
 	access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_detective, access_weapons)
 	minimal_access = list(access_security, access_sec_doors, access_morgue, access_maint_tunnels, access_detective, access_weapons)
 	minimal_player_age = 7
-
+	alt_titles = list("Sleuth")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -110,7 +110,6 @@
 	access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_detective, access_weapons)
 	minimal_access = list(access_security, access_sec_doors, access_morgue, access_maint_tunnels, access_detective, access_weapons)
 	minimal_player_age = 7
-	alt_titles = list("Sleuth")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)

--- a/html/changelogs/vtcobaltblood-more-job-titles.yml
+++ b/html/changelogs/vtcobaltblood-more-job-titles.yml
@@ -1,0 +1,6 @@
+author: VTCobaltblood
+
+delete-after: True
+
+changes: 
+  - rscadd: "NanoTrasen is now hiring Custodial Technicians, Newscaster Maintainers, Supply Managers, Hardware Engineers and Toxins Researchers. Merchants now can have their specializations specified on their ID, and Aurora is now officially open for tourists."

--- a/html/changelogs/vtcobaltblood-more-job-titles.yml
+++ b/html/changelogs/vtcobaltblood-more-job-titles.yml
@@ -3,4 +3,4 @@ author: VTCobaltblood
 delete-after: True
 
 changes: 
-  - rscadd: "NanoTrasen is now hiring Custodial Technicians, Newscaster Maintainers, Supply Managers, Hardware Engineers and Toxins Researchers. Merchants now can have their specializations specified on their ID, and Aurora is now officially open for tourists."
+  - rscadd: "NanoTrasen is now hiring Custodial Technicians, Newscaster Maintainers, Supply Managers, Curators Hardware Engineers and Toxins Researchers. Merchants now can have their specializations specified on their ID, and Aurora is now officially open for tourists."


### PR DESCRIPTION
I stopped being a github unga bunga and did it again. List:
- Janitors can now be Custodial Technicians
- Scientists can additionally be Hardware Engineers (R&D and circuitry specialization) and Toxins Researchers
- Quartermasters can be Supply Managers
- Librarians can be Curators
- Journalists can additionally be Newscaster Maintainers
- Merchants can be Traders, Arms Dealers and Material Shippers
- Assistants can additionally be Tourists

Feedback: https://forums.aurorastation.org/viewtopic.php?f=21&t=12103 