### PR TITLE
Removes Roboticist's Bluespace Toolbelt

### DIFF
--- a/html/changelogs/lordfowl.yml
+++ b/html/changelogs/lordfowl.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: LordFowl
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Removes the toolbelt in robotics that could fit anything."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -32501,7 +32501,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/weapon/storage/belt,
 /obj/item/weapon/storage/toolbox/electrical,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/device/multitool,
@@ -32510,6 +32509,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/head/welding,
 /obj/item/clothing/head/welding,
+/obj/item/weapon/storage/belt/utility,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
 "bhL" = (


### PR DESCRIPTION
There was a toolbelt in robotics that was using the generic belt class, meaning that it had no item restrictions and thus could fit _any_ item that was w_class 3 or less. This replaces it with an empty toolbelt (Which can only fit tools).
