### PR TITLE
Enabling Diona whitelist for nymph 

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/progression.dm
+++ b/code/modules/mob/living/carbon/alien/diona/progression.dm
@@ -1,11 +1,9 @@
 /mob/living/carbon/alien/diona/confirm_evolution()
 
 	//Whitelist requirement for evolution experimentally removed
-	/*
 	if(!is_alien_whitelisted(src, "Diona") && config.usealienwhitelist)
 		src << alert("You are currently not whitelisted to play as a full diona.")
 		return null
-	*/
 
 	var/response = alert(src, "A worker gestalt is a large, slow, and durable humanoid form. You will lose the ability to ventcrawl and devour animals, but you will gain hand-like tendrils and the ability to wear things.You have enough biomass, are you certain you're ready to form a new gestalt?","Confirm Gestalt","Growth!","Patience...")
 	if(response != "Growth!") return  //Hit the wrong key...again.

--- a/html/changelogs/Sidndorman-nymph.yml
+++ b/html/changelogs/Sidndorman-nymph.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Whitelist check is again enabled for nympth when they evolve into Gestalts. For some reason it was diabled experimentally bizzillion seconds ago."


### PR DESCRIPTION
Apparently Diona's nymph ability to grow into worker Gestalt whitelist check was disabled. This PR enabled it back, also a lore request.