### PR TITLE
ERT Sidegrade

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -5,6 +5,7 @@
 	extended_round_description = "Revolutionaries - Remove the heads of staff from power. Convert other crewmembers to your cause using the 'Convert Bourgeoise' verb. Protect your leaders."
 	required_players = 4
 	required_enemies = 3
+	ert_disabled = 1
 	auto_recall_shuttle = 0
 	end_on_antag_death = 0
 //	shuttle_delay = 3

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -195,7 +195,7 @@
 		slot_l_hand_str = "syndicate-helm-green",
 		slot_r_hand_str = "syndicate-helm-green"
 		)
-	armor = list(melee = 62, bullet = 50, laser = 50,energy = 35, bomb = 10, bio = 2, rad = 0)
+	armor = list(melee = 65, bullet = 60, laser = 60, energy = 40, bomb = 20, bio = 50, rad = 25)
 
 //Commander
 /obj/item/clothing/head/helmet/ert/command

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -7,13 +7,14 @@
 	desc = "A suit worn by the commander of an Emergency Response Team. Has blue highlights. Armoured and space ready."
 	suit_type = "ERT commander"
 	icon_state = "ert_commander_rig"
-	emp_protection = 35
+	emp_protection = 30
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/ert
 
 	req_access = list(access_cent_specops)
 
-	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 100, rad = 100)
+	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 40, bio = 100, rad = 100)
+	slowdown = 1
 	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/device/t_scanner, /obj/item/weapon/rcd, /obj/item/weapon/crowbar, \
 	/obj/item/weapon/screwdriver, /obj/item/weapon/weldingtool, /obj/item/weapon/wirecutters, /obj/item/weapon/wrench, /obj/item/device/multitool, \
 	/obj/item/device/radio, /obj/item/device/analyzer,/obj/item/weapon/storage/briefcase/inflatable, /obj/item/weapon/melee/baton, /obj/item/weapon/gun, \
@@ -32,8 +33,9 @@
 	desc = "A suit worn by the engineering division of an Emergency Response Team. Has orange highlights. Armoured and space ready."
 	suit_type = "ERT engineer"
 	icon_state = "ert_engineer_rig"
-	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 100, rad = 100)
-	emp_protection = 30
+	armor = list(melee = 50, bullet = 40, laser = 20, energy = 15, bomb = 40, bio = 100, rad = 100)
+	slowdown = 0
+	emp_protection = 20
 
 	glove_type = /obj/item/clothing/gloves/rig/eva
 
@@ -51,7 +53,9 @@
 	desc = "A suit worn by the medical division of an Emergency Response Team. Has white highlights. Armoured and space ready."
 	suit_type = "ERT medic"
 	icon_state = "ert_medical_rig"
-	emp_protection = 30
+	armor = list(melee = 50, bullet = 40, laser = 20, energy = 15, bomb = 30, bio = 100, rad = 100)
+	slowdown = 0
+	emp_protection = 20
 
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
@@ -59,7 +63,7 @@
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/healthscanner,
 		/obj/item/rig_module/chem_dispenser/injector,
-		/obj/item/rig_module/actuators
+		/obj/item/rig_module/actuators/combat
 		)
 
 /obj/item/weapon/rig/ert/security
@@ -67,7 +71,7 @@
 	desc = "A suit worn by the security division of an Emergency Response Team. Has red highlights. Armoured and space ready."
 	suit_type = "ERT security"
 	icon_state = "ert_security_rig"
-	emp_protection = 30
+	emp_protection = 25
 
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
@@ -75,7 +79,7 @@
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/grenade_launcher,
 		/obj/item/rig_module/mounted/egun,
-		/obj/item/rig_module/actuators
+		/obj/item/rig_module/actuators/combat
 		)
 
 /obj/item/weapon/rig/ert/janitor
@@ -83,6 +87,9 @@
 	desc = "A suit worn by the janitoral division of an Emergency Response Team. Has purple highlights. Armoured and space ready."
 	suit_type = "ERT janitor"
 	icon_state = "ert_janitor_rig"
+	armor = list(melee = 50, bullet = 40, laser = 20, energy = 15, bomb = 30, bio = 100, rad = 100)
+	emp_protection = 20
+	slowdown = 0
 
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
@@ -90,7 +97,7 @@
 		/obj/item/rig_module/fabricator/sign,
 		/obj/item/rig_module/grenade_launcher/cleaner,
 		/obj/item/rig_module/device/decompiler,
-		/obj/item/rig_module/actuators
+		/obj/item/rig_module/actuators/combat
 		)
 
 /obj/item/weapon/rig/ert/assetprotection
@@ -99,6 +106,7 @@
 	suit_type = "heavy asset protection"
 	icon_state = "asset_protection_rig"
 	armor = list(melee = 60, bullet = 60, laser = 60,energy = 40, bomb = 50, bio = 100, rad = 100)
+	slowdown = 0
 	siemens_coefficient = 0
 	emp_protection = 50
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -448,7 +448,7 @@
 	desc = "A high-quality armor vest in a fetching tan. It is surprisingly flexible and light, even with the added webbing and armor plating."
 	icon_state = "mercwebvest"
 	item_state = "mercwebvest"
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 40, bomb = 40, bio = 0, rad = 0)
+	armor = list(melee = 60, bullet = 60, laser = 60, energy = 40, bomb = 40, bio = 25, rad = 25)
 
 //ert related armor
 
@@ -458,8 +458,8 @@
 	icon_state = "ert_soldier"
 	item_state = "ert_soldier"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 40, bomb = 20, bio = 0, rad = 0)
-	slowdown = 0
+	armor = list(melee = 65, bullet = 60, laser = 60, energy = 40, bomb = 40, bio = 25, rad = 25)
+	slowdown = 1
 
 /obj/item/clothing/suit/storage/vest/heavy/ert/commander
 	name = "ERT commander's plate carrier"

--- a/code/modules/reagents/dispenser/dispenser_presets.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets.dm
@@ -27,33 +27,21 @@
 	name = "medicine dispenser"
 	spawn_cartridges = list(
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/inaprov,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ryetalyn,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/paracetamol,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tramadol,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/oxycodone,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sterilizine,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/leporazine,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/kelotane,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/dermaline,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/dexalin,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/dexalin_p,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tricord,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/dylovene,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/synaptizine,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/hyronalin,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/arithrazine,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/alkysine,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/imidazoline,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/peridaxon,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/bicaridine,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/hyperzine,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/rezadone,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/spaceacillin,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ethylredox,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cryoxadone,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sleeptox,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/chloral,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cryoxadone,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/clonexadone
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/water,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/carbon,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/acetone,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/silicon
 		)
 
 /obj/machinery/chemical_dispenser/bar_soft

--- a/html/changelogs/paradoxspace-gogopowerrangers.yml
+++ b/html/changelogs/paradoxspace-gogopowerrangers.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: ParadoxSpace
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Adds a dartgun, two netguns, and a gravity gun to the ERT base."
+  - tweak: "Adds a slowdown to ERT commander and ERT security suits. Lowers armor levels of other hardsuits. Raises armor levels and adds slowdown to non-hardsuit armor."
+  - rscdel: "Deletes combat injectors from ERT base (pray to your Gods), and deletes some chemicals from the dispenser."
+  - bugfix: "Disables ERT on the Revolution gamemode."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -9174,7 +9174,6 @@
 /obj/item/ammo_magazine/mc9mmt/rubber,
 /obj/item/weapon/gun/projectile/automatic/wt550,
 /obj/item/weapon/gun/projectile/automatic/wt550,
-/obj/item/weapon/gun/projectile/automatic/wt550,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -9182,6 +9181,7 @@
 /area/centcom/specops)
 "vm" = (
 /obj/structure/table/rack,
+/obj/item/weapon/gun/energy/ionrifle,
 /obj/item/weapon/gun/energy/ionrifle,
 /turf/unsimulated/floor{
 	icon_state = "vault";
@@ -9216,10 +9216,10 @@
 "vp" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/flashbangs,
-/obj/item/weapon/storage/box/flashbangs,
 /obj/item/weapon/storage/box/emps,
 /obj/item/weapon/storage/box/frags,
 /obj/item/weapon/storage/box/smokebombs,
+/obj/item/weapon/storage/box/teargas,
 /obj/item/weapon/gun/launcher/grenade,
 /turf/unsimulated/floor{
 	icon_state = "vault";
@@ -10355,6 +10355,8 @@
 /obj/item/weapon/storage/belt/security/tactical,
 /obj/item/weapon/storage/belt/security/tactical,
 /obj/item/taperoll/police,
+/obj/item/weapon/legcuffs,
+/obj/item/weapon/legcuffs,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -10916,6 +10918,7 @@
 /obj/item/clothing/glasses/welding/superior,
 /obj/item/clothing/glasses/welding/superior,
 /obj/structure/table/reinforced/steel,
+/obj/item/weapon/ladder_mobile,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -11290,8 +11293,6 @@
 /obj/item/rig_module/device/rcd,
 /obj/item/rig_module/chem_dispenser/injector,
 /obj/item/rig_module/chem_dispenser/injector,
-/obj/item/rig_module/chem_dispenser/combat,
-/obj/item/rig_module/chem_dispenser/combat,
 /obj/item/rig_module/mounted/egun,
 /obj/item/rig_module/mounted/egun,
 /obj/machinery/light{
@@ -11542,7 +11543,6 @@
 /obj/item/clothing/mask/balaclava,
 /obj/item/clothing/mask/balaclava,
 /obj/item/clothing/mask/balaclava,
-/obj/item/clothing/accessory/holster/waist,
 /obj/item/clothing/accessory/holster/waist,
 /obj/item/clothing/accessory/holster/waist,
 /turf/unsimulated/floor{
@@ -11935,6 +11935,10 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/chemdart,
+/obj/item/ammo_magazine/chemdart,
+/obj/item/weapon/gun/projectile/dartgun,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 8
@@ -12435,6 +12439,8 @@
 /obj/item/clothing/accessory/storage/white_vest,
 /obj/item/clothing/accessory/storage/white_vest,
 /obj/item/clothing/accessory/storage/white_vest,
+/obj/item/weapon/gun/energy/net,
+/obj/item/weapon/gun/energy/net,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -22763,6 +22769,20 @@
 	icon_state = "cult"
 	},
 /area/wizard_station)
+"YV" = (
+/obj/structure/table/rack,
+/obj/item/weapon/gun/energy/gravity_gun,
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 8
+	},
+/area/centcom/specops)
+"YW" = (
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 8
+	},
+/area)
 
 (1,1,1) = {"
 aa
@@ -53244,7 +53264,7 @@ qt
 qt
 qt
 ve
-vs
+YV
 vs
 vH
 vs


### PR DESCRIPTION
As in the changelog. Basically, fucks ERT.
Removes the combat injectors and hyperzine from the chemical dispenser. 
Gives all suits but the J-ERT, E-ERT, and M-ERT suits a 1 slowdown. 
Replaces their actuators with combat actuators.
Reduces armor levels of those three suits. Raises armor values of non-hardsuit armor.  
Removes ERT on the Revolution gamemode.
Gives ERT two netguns, a dartgun, and a gravity gun.

https://forums.aurorastation.org/viewtopic.php?f=21&t=12133