### PR TITLE
Vampire Blood Drain Tweak

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -73,7 +73,7 @@
 
 		// Alive and not of empty mind.
 		if (T.stat < 2 && T.client)
-			blood = min(10, T.vessel.get_reagent_amount("blood"))
+			blood = min(15, T.vessel.get_reagent_amount("blood"))
 			vampire.blood_total += blood
 			vampire.blood_usable += blood
 

--- a/html/changelogs/Kaedwuff - Vampyresucc.yml
+++ b/html/changelogs/Kaedwuff - Vampyresucc.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Vampires now receive slightly more blood for their suck, thus making game progression not so slow."


### PR DESCRIPTION
Simple change - Vampires now receive 15 blood per 25 instead of 10, thus reducing some of the sluggishness of the game mode's progression.

https://forums.aurorastation.org/viewtopic.php?f=18&t=12126 Feedback thread.