### PR TITLE
More Medical Tweaks

### DIFF
--- a/html/changelogs/furrycactus - medical-tweaks.yml
+++ b/html/changelogs/furrycactus - medical-tweaks.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Fixed some flaws and oversights with the medical layout. The delivery chute in storage should work properly, chemistry and surgery were made less cramped, and some more sinks and disposals outlets were added."
+  - bugfix: "Re-added an Air Alarm to Chemistry."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -108,10 +108,6 @@
 	dir = 4;
 	icon_state = "body_scannerconsole"
 	},
-/obj/machinery/vending/wallmed2{
-	pixel_x = 0;
-	pixel_y = 28
-	},
 /turf/simulated/floor/tiled,
 /area/medical/icu)
 "aap" = (
@@ -123,6 +119,13 @@
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/ringer{
+	department = "Medbay";
+	id = "medbay_ringer";
+	pixel_x = 0;
+	pixel_y = 30;
+	req_access = list(5)
 	},
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
@@ -404,7 +407,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -1169,7 +1172,7 @@
 "acr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -2161,7 +2164,7 @@
 /area/maintenance/security_starboard)
 "aei" = (
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -2488,7 +2491,7 @@
 	pixel_y = 0
 	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -2781,24 +2784,48 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "afz" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor/plating,
+/area/hydroponics)
 "afA" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "afB" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "afC" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -2886,12 +2913,20 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "afO" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/watertank,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "afP" = (
 /obj/effect/landmark/start{
 	name = "Librarian"
@@ -3105,10 +3140,16 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "agq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/structure/table/standard,
+/obj/machinery/reagentgrinder{
+	pixel_y = 16
+	},
+/obj/effect/floor_decal/corner/green/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "agr" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -3348,13 +3389,8 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "agR" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "agS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -3647,27 +3683,15 @@
 /turf/simulated/floor/wood,
 /area/chapel/office)
 "ahu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
+/area/rnd/misc_lab)
 "ahv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4958,18 +4982,11 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/civ)
 "akb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "akc" = (
@@ -5144,16 +5161,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/atmos_control)
 "akp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/atmos_control)
@@ -5183,7 +5201,7 @@
 /area/maintenance/atmos_control)
 "aks" = (
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -5807,11 +5825,10 @@
 	name = "\improper Medical - Exam Room 2"
 	})
 "alB" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Rooms"
+	})
 "alC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -6059,28 +6076,27 @@
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "amb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4";
-	dir = 1;
-	d1 = 1;
-	d2 = 8
-	},
+/obj/structure/closet/crate/solar,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "amc" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Hard Storage"
+	},
+/obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "amd" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/shield_capacitor,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "ame" = (
@@ -6551,7 +6567,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "ane" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "anf" = (
@@ -7148,7 +7164,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -7195,14 +7211,14 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "aod" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "aoe" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engineering/storage)
@@ -7364,7 +7380,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -7857,15 +7873,12 @@
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "apr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/cable/green{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "aps" = (
@@ -8557,23 +8570,28 @@
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /obj/structure/table/standard,
 /obj/item/weapon/storage/bag/circuits/basic,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "aqE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "aqF" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
 /obj/machinery/firealarm/south,
-/obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "aqG" = (
@@ -13666,7 +13684,7 @@
 /area/maintenance/engineering)
 "ayI" = (
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -15109,6 +15127,9 @@
 	icon_state = "warningcorner";
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "aAZ" = (
@@ -15329,6 +15350,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
@@ -16238,32 +16264,43 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_airlock)
 "aCT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/machinery/light/small/emergency{
+	icon_state = "bulb1";
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
-	dir = 9
+	dir = 4
 	},
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/engineering/engine_airlock)
 "aCU" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/shower{
-	pixel_y = 16
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/engineering/engine_airlock)
 "aCV" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
-	dir = 5
-	},
-/obj/machinery/shower{
-	pixel_y = 16
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_airlock)
@@ -16277,22 +16314,23 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_airlock)
 "aCX" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "engine_airlock_control";
-	name = "Engine Access Console";
-	pixel_x = -26;
-	pixel_y = 0;
-	req_access = list(11);
-	req_one_access = null;
-	tag_exterior_door = "engine_airlock_exterior";
-	tag_interior_door = "engine_airlock_interior"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 1;
+	name = "Engineering Firelock"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_airlock)
 "aCY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16465,11 +16503,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
 "aDp" = (
@@ -17282,115 +17315,69 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "aEE" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	frequency = 1379;
+	icon_state = "door_closed";
+	id_tag = "engine_airlock_interior";
+	locked = 0;
+	name = "Engine Airlock Interior";
+	req_access = list(11)
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_airlock)
+"aEF" = (
 /obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_airlock)
+"aEG" = (
+/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
+	dir = 2;
+	frequency = 1379;
+	id = "tox_airlock_pump"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/engineering/engine_room)
-"aEF" = (
+/area/engineering/engine_airlock)
+"aEH" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "engine_airlock_interior";
-	locked = 1;
-	name = "Engine Interior Access";
+	icon_state = "door_closed";
+	id_tag = "engine_airlock_exterior";
+	locked = 0;
+	name = "Engine Airlock Exterior";
 	req_access = list(11)
 	},
-/obj/machinery/door/firedoor{
-	dir = 8;
-	name = "Firelock West"
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "engine_airlock_control";
-	name = "Engine Access Button";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access = list(11);
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/engineering/engine_airlock)
-"aEG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"aEI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"aEH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"aEI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"aEJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "engine_airlock_exterior";
-	locked = 1;
-	name = "Engine Exterior Access";
-	req_access = list(11)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "engine_airlock_control";
-	name = "Engine Access Button";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access = list(11);
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"aEK" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aEJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -17399,7 +17386,31 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
+/area/engineering/engine_airlock)
+"aEK" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	icon_state = "door_closed";
+	locked = 0;
+	name = "Engine Access";
+	req_one_access = list(11)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 1;
+	name = "Engineering Firelock"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
 "aEL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17417,6 +17428,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
@@ -17662,6 +17677,11 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 8
 	},
@@ -17680,9 +17700,18 @@
 	name = "Medical Voidsuits";
 	req_one_access = list(5)
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "aFf" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -17692,10 +17721,6 @@
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
@@ -17708,12 +17733,6 @@
 	dir = 6
 	},
 /obj/machinery/firealarm/north,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "aFh" = (
@@ -17721,11 +17740,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
@@ -18677,28 +18691,28 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_airlock)
 "aGG" = (
-/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_airlock)
+"aGH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
+/obj/structure/cable/green,
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"aGH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_airlock)
@@ -19973,27 +19987,46 @@
 "aIJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aIK" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aIL" = (
-/obj/machinery/suit_cycler/hos,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/banner,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aIM" = (
-/obj/structure/banner,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aIN" = (
@@ -21061,11 +21094,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -22219,11 +22247,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
 "aMt" = (
@@ -23044,11 +23067,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aNR" = (
@@ -23056,21 +23074,11 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aNS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -23083,11 +23091,6 @@
 	c_tag = "Engineering - Lobby Aft";
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aNU" = (
@@ -23096,22 +23099,12 @@
 	name = "Engineering Break Room";
 	sortType = "Engineering Break Room"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aNV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -23185,11 +23178,6 @@
 /area/crew_quarters/heads/hos)
 "aOe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
 "aOf" = (
@@ -24192,10 +24180,6 @@
 /obj/structure/closet/secure_closet/hos,
 /obj/item/device/multitool,
 /obj/item/weapon/reagent_containers/spray/pepper,
-/obj/item/clothing/suit/space/void/hos,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/head/helmet/space/void/hos,
-/obj/item/clothing/mask/breath,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aPL" = (
@@ -24215,11 +24199,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/south,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aPO" = (
@@ -24234,11 +24213,6 @@
 /obj/machinery/door/window/brigdoor/northleft{
 	req_access = list(58)
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /mob/living/simple_animal/hostile/commanded/dog/columbo,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
@@ -24251,11 +24225,6 @@
 	name = "Head of Security RC";
 	pixel_x = 0;
 	pixel_y = -30
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
@@ -25283,11 +25252,6 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aRq" = (
@@ -25610,7 +25574,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "aRR" = (
@@ -25630,7 +25593,6 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "aRS" = (
@@ -26048,10 +26010,6 @@
 	icon_state = "rwindow";
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/foyer)
 "aSF" = (
@@ -26065,15 +26023,6 @@
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/foyer)
@@ -26092,16 +26041,6 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aSH" = (
@@ -26114,15 +26053,6 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/foyer)
@@ -28869,7 +28799,7 @@
 	pixel_x = 0
 	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -29741,6 +29671,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aYI" = (
@@ -29755,6 +29688,9 @@
 	dir = 4
 	},
 /obj/structure/closet/walllocker/emerglocker/south,
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aYK" = (
@@ -29771,12 +29707,11 @@
 	},
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
 /obj/item/device/radio/intercom{
 	pixel_y = 27
 	},
 /obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Chemistry 1";
+	c_tag = "Medical - Chemistry";
 	dir = 2;
 	icon_state = "camera";
 	network = list("Medical")
@@ -29800,6 +29735,9 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/south,
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aYO" = (
@@ -29817,6 +29755,9 @@
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = -32
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -29895,6 +29836,9 @@
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=S2";
 	location = "S1"
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -29978,7 +29922,7 @@
 "aZc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -30358,7 +30302,15 @@
 	icon_state = "corner_white_full";
 	dir = 1
 	},
-/obj/item/clothing/glasses/science,
+/obj/item/weapon/storage/fancy/vials{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 1
+	},
+/obj/item/weapon/reagent_containers/dropper,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "aZV" = (
@@ -30527,7 +30479,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "bal" = (
-/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
 "bam" = (
@@ -30777,7 +30728,6 @@
 	req_one_access = list(24,11,55)
 	},
 /obj/item/bodybag/cryobag,
-/obj/structure/window/reinforced,
 /obj/item/weapon/storage/box/cdeathalarm_kit,
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
@@ -30991,7 +30941,11 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
-/obj/item/clothing/glasses/science,
+/obj/item/weapon/storage/fancy/vials{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/dropper,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bbd" = (
@@ -31001,7 +30955,6 @@
 	},
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
 /obj/item/device/radio/intercom{
 	pixel_y = 27
 	},
@@ -31017,9 +30970,15 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/item/weapon/storage/fancy/vials{
-	pixel_x = 0;
-	pixel_y = 0
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/box/beakers,
+/obj/item/clothing/glasses/science,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -31028,22 +30987,12 @@
 	icon_state = "corner_white_full";
 	dir = 1
 	},
-/obj/machinery/ringer{
-	department = "Chemistry";
-	id = "chemistry_ringer";
-	pixel_x = 30;
+/obj/machinery/smartfridge/secure/medbay{
+	density = 0;
+	name = "Dangerous Materials Storage";
+	pixel_x = 0;
 	pixel_y = 0;
 	req_access = list(33)
-	},
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/weapon/storage/box/pillbottles,
-/obj/item/weapon/storage/box/pillbottles,
-/obj/item/device/radio/headset/headset_med,
-/obj/item/device/radio/headset/headset_med,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -31923,6 +31872,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/vending/medical{
+	density = 0;
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
@@ -31935,19 +31885,20 @@
 /turf/simulated/floor/tiled,
 /area/medical/medbay)
 "bcG" = (
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
 /obj/machinery/door/window{
 	base_state = "left";
-	dir = 8;
-	icon_state = "right";
+	dir = 1;
+	icon_state = "left";
 	layer = 2.85;
 	name = "MediExpress - Storage";
 	req_access = list(66)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
@@ -31958,14 +31909,14 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
 /obj/structure/disposaloutlet{
 	dir = 8;
 	spread = 360;
 	spread_point = 2
-	},
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
@@ -31993,8 +31944,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -32964,6 +32916,7 @@
 /obj/effect/floor_decal/corner/lime/full{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "beg" = (
@@ -33277,7 +33230,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -33674,9 +33627,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bfk" = (
@@ -33758,8 +33708,10 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/vending/wallmed2{
-	pixel_x = 26
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -33808,7 +33760,10 @@
 /obj/structure/sink{
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bfw" = (
@@ -33853,6 +33808,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bfz" = (
@@ -34000,6 +33956,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/medical{
+	density = 0;
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/white,
@@ -34027,6 +33984,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bfM" = (
@@ -34049,7 +34007,7 @@
 /area/maintenance/maintcentral)
 "bfN" = (
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -34244,7 +34202,11 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
 /area/medical/medbay)
 "bgh" = (
 /obj/structure/table/rack{
@@ -34459,15 +34421,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bgz" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bgA" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/structure/table/standard,
-/obj/machinery/reagentgrinder,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bgB" = (
@@ -34492,12 +34453,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bgD" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 4
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/hand_labeler,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bgE" = (
@@ -34507,13 +34466,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -34684,6 +34643,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bgQ" = (
@@ -34703,16 +34663,16 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
 "bgR" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bgS" = (
@@ -35200,7 +35160,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/weapon/storage/belt,
 /obj/item/weapon/storage/toolbox/electrical,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/device/multitool,
@@ -35209,6 +35168,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/head/welding,
 /obj/item/clothing/head/welding,
+/obj/item/weapon/storage/belt/utility,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
 "bhL" = (
@@ -35396,17 +35356,23 @@
 "bib" = (
 /obj/structure/cable{
 	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 1
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/library)
+/area/maintenance/bar)
 "bic" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -35551,7 +35517,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/library)
+/area/maintenance/bar)
 "bin" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -36338,11 +36304,15 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/obj/machinery/disposal,
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled,
 /area/medical/medbay)
 "bjD" = (
 /obj/structure/table/standard,
@@ -36362,8 +36332,8 @@
 /obj/machinery/button/remote/blast_door{
 	id = "emtshutter";
 	name = "Garage Shutters Control";
-	pixel_x = 0;
-	pixel_y = -26;
+	pixel_x = -5;
+	pixel_y = -25;
 	req_access = list(5)
 	},
 /obj/effect/floor_decal/industrial/loading{
@@ -36373,18 +36343,14 @@
 /turf/simulated/floor/plating,
 /area/medical/emt)
 "bjF" = (
-/obj/structure/table/standard,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - EMT Quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "camera"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "bjG" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -36393,6 +36359,10 @@
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Cryogenics Control";
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
 	},
 /turf/simulated/floor/plating,
 /area/medical/cryo)
@@ -36814,6 +36784,9 @@
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
+	},
+/obj/machinery/computer/guestpass{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -37438,8 +37411,9 @@
 /area/medical/reception)
 "blY" = (
 /obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/medical/reception)
 "bma" = (
@@ -37453,10 +37427,7 @@
 /turf/simulated/floor/tiled,
 /area/medical/reception)
 "bmb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/junction/yjunction,
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 9
@@ -37592,7 +37563,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bmw" = (
@@ -37655,7 +37625,7 @@
 /area/maintenance/medbay)
 "bmL" = (
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -37851,7 +37821,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -38329,7 +38299,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bof" = (
@@ -41026,31 +40995,14 @@
 /turf/simulated/floor/holofloor/reinforced,
 /area/holodeck/alphadeck)
 "buL" = (
-/obj/machinery/camera/network/civilian_main{
-	c_tag = "Central Corridor - Medical EMT Entrance";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
+/obj/effect/floor_decal/corner/pink{
+	icon_state = "corner_white";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "buM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 8;
@@ -41059,11 +41011,11 @@
 	name = "MedBay Lockdown Shutters";
 	opacity = 0
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/door/airlock/glass_medical{
+	name = "EMT Quarters";
+	req_access = list(67)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "buS" = (
 /obj/machinery/door/firedoor,
@@ -41451,10 +41403,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bvR" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 8;
-	name = "Chapel";
-	sortType = "Chapel"
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Central Corridor - Medical EMT Entrance";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -41655,16 +41606,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bwl" = (
 /obj/structure/table/standard,
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
-	},
 /obj/machinery/newscaster{
 	pixel_y = 32
+	},
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
@@ -41702,13 +41654,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white_full";
 	dir = 1
-	},
-/obj/machinery/ringer{
-	department = "Medbay";
-	id = "medbay_ringer";
-	pixel_x = 0;
-	pixel_y = 30;
-	req_access = list(5)
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
@@ -42346,7 +42291,7 @@
 	name = "Chapel";
 	sortType = "Chapel"
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/corner/lime,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bxq" = (
@@ -42356,23 +42301,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/closet/secure_closet/medical_wall{
-	name = "Stabilization Kit";
+/obj/machinery/power/apc{
+	dir = 1;
+	is_critical = 1;
+	name = "north bump";
 	pixel_x = 0;
-	pixel_y = 32
+	pixel_y = 24
 	},
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/weapon/storage/pill_bottle/tramadol,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "bxr" = (
@@ -42444,7 +42383,9 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bxC" = (
@@ -42452,6 +42393,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bxE" = (
@@ -42902,9 +42844,6 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "byu" = (
@@ -42952,11 +42891,11 @@
 /area/medical/medbay)
 "byE" = (
 /obj/machinery/atmospherics/unary/freezer{
-	dir = 2;
+	dir = 8;
 	icon_state = "freezer"
 	},
 /obj/machinery/light/small{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/medical/cryo)
@@ -42988,6 +42927,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "byP" = (
@@ -43468,17 +43408,16 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/central_one)
 "bzC" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
 	name = "KEEP CLEAR: MEDICAL EXOSUIT PARKING";
 	pixel_x = 32;
 	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -43508,26 +43447,16 @@
 /area/medical/emt)
 "bzH" = (
 /obj/structure/table/standard,
-/obj/item/weapon/storage/belt/medical/emt,
-/obj/item/weapon/storage/belt/medical/emt,
-/obj/item/device/radio{
-	frequency = 1487;
-	name = "Medbay Emergency Radio Link";
-	pixel_x = 5;
-	pixel_y = 5
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/item/device/radio{
-	frequency = 1487;
-	name = "Medbay Emergency Radio Link";
-	pixel_x = 5;
-	pixel_y = 5
-	},
+/obj/item/weapon/storage/firstaid/o2,
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "bzJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -43549,11 +43478,13 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/light{
 	dir = 2;
 	icon_state = "tube1";
 	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
@@ -43848,9 +43779,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
 "bAx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -43858,22 +43786,33 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
 "bAy" = (
-/obj/structure/table/standard,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/scanning_module,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/mauve/full{
-	icon_state = "corner_white_full";
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
 "bAz" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
 "bAA" = (
@@ -43935,10 +43874,6 @@
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/medical/emt)
@@ -44031,10 +43966,6 @@
 /area/medical/medbay2)
 "bBc" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access = list(66)
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -44043,6 +43974,10 @@
 	id = "LCKDshutters";
 	name = "MedBay Lockdown Shutters";
 	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = list(66)
 	},
 /turf/simulated/floor/plating,
 /area/medical/genetics_cloning)
@@ -44277,17 +44212,7 @@
 /area/hallway/primary/central_one)
 "bBA" = (
 /obj/machinery/door/firedoor,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'BOMB RANGE";
-	name = "KEEP CLEAR: MEDICAL EXOSUIT PARKING";
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -44302,28 +44227,18 @@
 	name = "MedBay Lockdown Shutters";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Pre-Op Maintenance Access";
-	req_access = list(66)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/medical/medbay)
+/obj/machinery/door/airlock/medical{
+	name = "Cryogenic Storage";
+	req_access = list(5)
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/sleep/main)
 "bBF" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	icon_state = "map";
-	dir = 4
-	},
-/obj/item/weapon/wrench,
-/obj/machinery/power/apc/high{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 8;
+	icon_state = "freezer"
 	},
 /turf/simulated/floor/plating,
 /area/medical/cryo)
@@ -44689,6 +44604,12 @@
 	icon_state = "warningcorner";
 	dir = 4
 	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "KEEP CLEAR: MEDICAL EXOSUIT PARKING";
+	pixel_x = 32;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bCz" = (
@@ -44714,16 +44635,23 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bCE" = (
-/obj/machinery/light/small/emergency{
+/obj/structure/cryofeed{
+	icon_state = "cryo_rear";
+	dir = 2
+	},
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
 "bCF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/sleep/main)
 "bCH" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -44749,6 +44677,8 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green,
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bCL" = (
@@ -44786,6 +44716,7 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bCQ" = (
@@ -45095,107 +45026,55 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bDu" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bDv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/device/radio/intercom{
+	pixel_y = 27
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/vending/cola,
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Central Coridor - Camera 4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bDx" = (
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/civilian_main{
-	c_tag = "Central Corridor - Camera 3";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bDy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access = null;
-	req_one_access = list(12,66)
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/central_one)
+/area/crew_quarters/sleep/main)
 "bDz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/cryopod{
+	icon_state = "body_scanner_0";
+	dir = 2
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
 "bDE" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bDF" = (
@@ -45210,10 +45089,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bDG" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bDK" = (
@@ -45421,55 +45300,37 @@
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
-	name = "botany alarm";
 	pixel_x = 24;
 	req_one_access = list(24,11,55)
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "bEm" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/beakers,
+/obj/effect/floor_decal/corner/mauve/full{
+	icon_state = "corner_white_full";
 	dir = 8
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/rnd/lab)
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
 "bEn" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
 	},
-/turf/simulated/floor/plating,
-/area/rnd/lab)
+/obj/machinery/chemical_dispenser/full,
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
 "bEo" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
 	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/rnd/lab)
+/obj/machinery/chem_heater,
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
 "bEp" = (
-/obj/machinery/door/airlock/research{
-	name = "Materials";
-	req_access = list(47)
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -45477,12 +45338,29 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/white,
-/area/rnd/lab)
+/area/rnd/misc_lab)
 "bEq" = (
-/turf/simulated/wall,
-/area/rnd/lab)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
 "bEr" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -45490,18 +45368,27 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bEs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bEt" = (
-/obj/structure/cable/green{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -45510,7 +45397,13 @@
 /area/hallway/primary/central_one)
 "bEu" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/green{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -45519,40 +45412,23 @@
 /area/hallway/primary/central_one)
 "bEx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 10
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bEA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
 "bEB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -45602,6 +45478,7 @@
 	icon_state = "tube1";
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bEH" = (
@@ -45796,8 +45673,9 @@
 "bFh" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
-	dir = 8
+	dir = 9
 	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "bFi" = (
@@ -45810,77 +45688,93 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "bFj" = (
-/turf/simulated/wall/r_wall,
-/area/outpost/research/chemistry)
-"bFk" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/beakers,
-/obj/effect/floor_decal/corner/mauve/full{
-	icon_state = "corner_white_full";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
-"bFl" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/chemical_dispenser/full,
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
-"bFm" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
-"bFn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j1"
-	},
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
-"bFo" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"bFk" = (
+/obj/structure/sign/nosmoking_1{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
-	dir = 5
+	dir = 9
 	},
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
+/obj/structure/table/standard,
+/obj/item/weapon/storage/fancy/vials,
+/obj/item/weapon/reagent_containers/dropper,
 /turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
-"bFp" = (
-/obj/machinery/disposal,
-/obj/item/device/radio/intercom{
-	pixel_x = 27
-	},
-/obj/structure/disposalpipe/trunk{
+/area/rnd/misc_lab)
+"bFl" = (
+/obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/mauve/full{
-	icon_state = "corner_white_full";
-	dir = 1
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
+"bFm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
+/area/rnd/misc_lab)
+"bFn" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
+"bFo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
+"bFp" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/firealarm/east,
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
 "bFq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -45922,29 +45816,38 @@
 /turf/simulated/wall,
 /area/library)
 "bFx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 8
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/library)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 "bFB" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/library)
+/area/maintenance/bar)
 "bFD" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -45957,10 +45860,12 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
@@ -46121,84 +46026,74 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "bGi" = (
-/obj/structure/sign/nosmoking_1{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
+/obj/structure/table/standard,
+/obj/machinery/reagentgrinder,
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_x = -30;
 	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/mauve/full,
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
+"bGj" = (
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Chemistry Laboratory";
+	dir = 1;
+	network = list("Research")
 	},
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
-	dir = 9
+	dir = 10
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/fancy/vials,
-/obj/item/weapon/reagent_containers/dropper,
+/obj/machinery/chem_master,
 /turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
-"bGj" = (
-/obj/structure/bed/chair/office/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
+/area/rnd/misc_lab)
 "bGk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
+/area/rnd/misc_lab)
 "bGm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/table/standard,
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
+"bGn" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/mauve/full{
+	icon_state = "corner_white_full";
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
-"bGn" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/machinery/firealarm/east,
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
+/area/rnd/misc_lab)
 "bGo" = (
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Central Corridor - Camera 1";
 	dir = 4
+	},
+/obj/machinery/computer/guestpass{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -46663,14 +46558,13 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "bHp" = (
-/obj/effect/floor_decal/corner/green/full{
-	icon_state = "corner_white_full";
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Division Maintenance";
+	req_access = list(47);
+	req_one_access = null
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/folder/purple,
-/obj/item/weapon/pen,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "bHq" = (
 /obj/structure/table/standard,
@@ -46704,20 +46598,16 @@
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/chemistry)
 "bHs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Division Maintenance";
+	req_access = list(47);
+	req_one_access = null
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/rnd/misc_lab)
 "bHt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -46818,11 +46708,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bHB" = (
@@ -46911,9 +46796,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bHG" = (
@@ -46934,26 +46816,17 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bHI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=CS2";
 	location = "CS1"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bHR" = (
@@ -46977,6 +46850,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bIf" = (
@@ -47134,21 +47008,15 @@
 /turf/simulated/wall,
 /area/outpost/research/chemistry)
 "bIw" = (
-/obj/machinery/door/airlock/research{
-	name = "Miscellaneous Research Room";
-	req_one_access = list(7)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/outpost/research/chemistry)
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "bIx" = (
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -47157,7 +47025,6 @@
 /area/hallway/primary/central_one)
 "bIy" = (
 /obj/machinery/light,
-/obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bIz" = (
@@ -47190,8 +47057,13 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bII" = (
-/turf/simulated/floor/tiled/dark,
-/area/library)
+/obj/structure/table/standard,
+/obj/random/loot,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "bIL" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/medical,
@@ -47270,13 +47142,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white_full";
 	dir = 4
-	},
-/obj/machinery/ringer{
-	department = "Medbay";
-	id = "medbay_ringer";
-	pixel_x = 0;
-	pixel_y = -30;
-	req_access = list(5)
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
@@ -47386,12 +47251,18 @@
 /turf/simulated/floor/plating,
 /area/rnd/misc_lab)
 "bJf" = (
-/turf/simulated/floor/plating,
-/area/rnd/misc_lab)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
 "bJg" = (
-/obj/machinery/atmospherics/unary/freezer,
-/turf/simulated/floor/plating,
-/area/rnd/misc_lab)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
 "bJh" = (
 /obj/machinery/atmospherics/unary/heater,
 /obj/effect/floor_decal/industrial/warning{
@@ -47508,79 +47379,47 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "bJq" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Library"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/hallway/primary/central_one)
+/turf/simulated/floor/tiled,
+/area/library)
 "bJr" = (
-/obj/machinery/door/firedoor,
+/turf/simulated/wall,
+/area/crew_quarters/sleep/main)
+"bJs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/cryo)
-"bJs" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Cryogenic Storage"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
+/turf/simulated/floor/plating,
+/area/library)
 "bJt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bJu" = (
 /turf/simulated/wall,
 /area/crew_quarters/locker/locker_toilet)
 "bJv" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/turf/simulated/floor/plating,
+/area/hydroponics)
 "bJK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -47654,7 +47493,7 @@
 "bJR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -47687,9 +47526,7 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bJU" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/structure/table/standard,
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
@@ -47704,35 +47541,28 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bJW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/telesci)
-"bJX" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
+"bJX" = (
+/obj/structure/closet/bombcloset,
+/obj/effect/floor_decal/corner/mauve/full{
+	icon_state = "corner_white_full";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
@@ -47761,11 +47591,9 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bJZ" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/rnd/misc_lab)
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
 "bKa" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -47773,9 +47601,14 @@
 /turf/simulated/floor/plating,
 /area/rnd/misc_lab)
 "bKb" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/floor/plating,
-/area/rnd/misc_lab)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 4;
+	status = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
 "bKc" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -47818,20 +47651,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "bKf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/turf/simulated/floor/tiled/dark,
+/area/library)
 "bKg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -47849,56 +47673,56 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "bKh" = (
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
-"bKi" = (
-/obj/structure/closet/secure_closet/scientist,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
+/obj/machinery/disposal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
-"bKj" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/structure/disposalpipe/trunk,
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
 	pixel_x = -22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"bKi" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"bKj" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/library)
 "bKk" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/sleep/main)
 "bKl" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/mime,
+/obj/machinery/light_switch{
+	pixel_y = 28
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/main)
 "bKm" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled,
@@ -47912,24 +47736,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bKo" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/obj/structure/flora/pottedplant/random,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "bKp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -47950,39 +47762,39 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/locker/locker_toilet)
 "bKs" = (
-/obj/structure/toilet{
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/biogenerator,
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
 "bKx" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
 /turf/simulated/floor/wood,
 /area/library)
 "bKA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "bKD" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/library)
+/area/maintenance/bar)
 "bKF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48084,8 +47896,17 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bKS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bKT" = (
@@ -48147,25 +47968,33 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "bKY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp,
+/obj/machinery/newscaster{
+	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/turf/simulated/floor/tiled/dark,
+/area/library)
 "bKZ" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Librarian"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/library)
+"bLa" = (
+/obj/structure/curtain/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
-"bLa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/turf/simulated/floor/wood,
+/area/library)
 "bLb" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/effect/floor_decal/corner/mauve{
@@ -48175,40 +48004,34 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "bLc" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/landmark{
-	name = "JoinLateCryo"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
+/turf/simulated/floor/wood,
+/area/library)
 "bLd" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/landmark{
-	name = "JoinLateCryo"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/sleep/main)
 "bLe" = (
-/obj/machinery/computer/cryopod{
-	pixel_x = 32
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/mime,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/effect/landmark{
-	name = "JoinLateCryo"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/main)
 "bLf" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -48243,18 +48066,26 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/locker/locker_toilet)
 "bLi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/effect/floor_decal/corner/green/full{
+	icon_state = "corner_white_full";
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "bLj" = (
-/obj/machinery/light{
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "bLs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48374,8 +48205,19 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bLC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
@@ -48383,11 +48225,9 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bLE" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 6
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Telescience"
 	},
-/obj/structure/closet/bombcloset,
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bLF" = (
@@ -48401,11 +48241,10 @@
 /turf/simulated/floor/plating,
 /area/rnd/misc_lab)
 "bLG" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/rnd/misc_lab)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
 "bLH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -48490,22 +48329,23 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "bLN" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
+/obj/machinery/door/window/southright{
+	name = "Library Desk";
+	req_access = list(37)
 	},
-/obj/machinery/firealarm/south,
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/library)
 "bLO" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
+/obj/structure/table/wood,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/turf/simulated/floor/wood,
+/area/library)
 "bLP" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/floor_decal/corner/mauve/full{
@@ -48515,12 +48355,12 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "bLQ" = (
-/obj/machinery/cryopod{
-	icon_state = "body_scanner_0";
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
+/obj/structure/window/reinforced,
+/turf/simulated/floor/wood,
+/area/library)
 "bLR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -48537,14 +48377,23 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bLT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bLU" = (
@@ -48560,16 +48409,15 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/locker/locker_toilet)
 "bLW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
-"bLX" = (
-/obj/machinery/door/airlock{
-	name = "Unit 2"
+/obj/effect/floor_decal/corner/green/full,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"bLX" = (
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
 "bMi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -48674,30 +48522,65 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bMv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	icon_state = "pipe-y";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bMw" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
-	dir = 6
+	dir = 10
 	},
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bMx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
 	},
-/obj/structure/window/reinforced/tinted,
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/rnd/misc_lab)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
 "bMy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted{
@@ -48712,13 +48595,20 @@
 /turf/simulated/floor/plating,
 /area/rnd/misc_lab)
 "bMz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Autopsy Room";
-	req_access = list(47)
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/area/rnd/telesci)
 "bMA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
@@ -48782,12 +48672,13 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/locker/locker_toilet)
 "bMH" = (
-/obj/machinery/camera/network/civilian_main{
-	c_tag = "Main Level - Restrooms";
-	dir = 8
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/hydroseeds{
+	prices = list();
+	restock_items = 1
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
 "bML" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48798,8 +48689,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+/turf/simulated/floor/tiled/ramp{
+	icon_state = "ramptop";
+	dir = 1
+	},
+/area/maintenance/bar)
 "bMM" = (
 /obj/structure/closet/hydrant{
 	pixel_x = -32
@@ -48878,17 +48772,53 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "bMX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "telescience";
+	name = "Containment Blast Doors";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/northleft,
+/obj/machinery/door/window/southright,
+/turf/simulated/floor/reinforced,
 /area/rnd/telesci)
 "bMY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "telescience";
+	name = "Containment Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
 /area/rnd/telesci)
 "bMZ" = (
 /obj/effect/floor_decal/corner/mauve{
@@ -48934,42 +48864,42 @@
 /turf/simulated/floor/plating,
 /area/rnd/misc_lab)
 "bNe" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "MiscBlast";
-	name = "Misc Science Blast Doors";
-	opacity = 0
+/obj/structure/table/wood,
+/obj/machinery/librarypubliccomp{
+	pixel_y = 8
 	},
-/turf/simulated/floor/reinforced,
-/area/rnd/misc_lab)
+/turf/simulated/floor/carpet,
+/area/library)
 "bNf" = (
-/obj/item/stack/material/steel{
-	amount = -5;
-	description_info = "A non-stack of non-metal. You're not sure how it exists or why it's stable.";
-	name = "Non-sheet of non-steel";
-	origin_tech = "materials=-1"
-	},
-/turf/simulated/floor/plating,
-/area/rnd/misc_lab)
-"bNg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 2;
+/obj/structure/cable/green{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	icon_state = "intact-scrubbers";
+	dir = 5
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/research_port)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/library)
+"bNg" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/library)
 "bNh" = (
 /obj/structure/crematorium{
 	_wifi_id = "chapel_crema"
@@ -49001,7 +48931,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/camera/network/civilian_main{
-	c_tag = "Aft Corridor - Camera 1";
+	c_tag = "Aft Corridor - Camera 3";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -49014,11 +48944,14 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/locker/locker_toilet)
 "bNm" = (
-/obj/machinery/door/airlock{
-	name = "Unit 3"
+/obj/effect/floor_decal/corner/green{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "bNn" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -49030,7 +48963,7 @@
 /obj/structure/closet/crate,
 /obj/random/loot,
 /turf/simulated/floor/plating,
-/area/maintenance/library)
+/area/maintenance/bar)
 "bNr" = (
 /obj/structure/table/rack{
 	dir = 1
@@ -49215,9 +49148,8 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bNI" = (
-/obj/machinery/optable,
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/turf/simulated/floor/reinforced,
+/area/rnd/telesci)
 "bNJ" = (
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/white,
@@ -49232,8 +49164,11 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
 "bNL" = (
-/turf/simulated/floor/tiled/dark,
-/area/chapel/office)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/library)
 "bNM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -49270,13 +49205,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bNP" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Showers"
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Hydroponics - West";
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "bNW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -49380,7 +49318,7 @@
 "bOh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -49408,11 +49346,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/telesci)
 "bOk" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/reinforced,
 /area/rnd/telesci)
 "bOl" = (
 /obj/effect/floor_decal/corner/mauve/full{
@@ -49425,14 +49362,9 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
 "bOm" = (
-/obj/effect/floor_decal/corner/mauve/full,
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/obj/machinery/telepad,
+/turf/simulated/floor/reinforced,
+/area/rnd/telesci)
 "bOn" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
@@ -49449,12 +49381,18 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "bOp" = (
-/turf/simulated/floor/reinforced,
-/area/rnd/misc_lab)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/library)
 "bOq" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/reinforced,
-/area/rnd/misc_lab)
+/obj/structure/table/wood,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/library)
 "bOr" = (
 /obj/machinery/air_sensor{
 	frequency = 1439;
@@ -49528,13 +49466,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bOy" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	icon_state = "shower";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "bOz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -49603,25 +49538,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/telesci)
 "bOU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Miscellaneous Research Room";
-	req_one_access = list(7,29)
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/telesci)
-"bOV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/research_port)
+/turf/simulated/floor/reinforced,
+/area/rnd/telesci)
+"bOV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/library)
 "bOW" = (
 /obj/machinery/button/windowtint{
 	id = "chapel";
@@ -49655,7 +49584,6 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor/carpet,
 /area/chapel/office)
 "bOY" = (
@@ -49675,23 +49603,14 @@
 "bPb" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "chapel"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/window/reinforced/polarized{
-	id = "chapel"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "chapel"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "chapel"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/chapel/office)
+/area/library)
 "bPc" = (
 /obj/machinery/station_map{
 	dir = 8;
@@ -49700,27 +49619,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bPd" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "bPe" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+/obj/structure/table/stone/marble,
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	pixel_y = 4
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/locker/locker_toilet)
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "bPg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -50099,7 +50009,7 @@
 	c_tag = "Engineering - Aft Maint EVA";
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/asteroid/ash/rocky,
 /area/maintenance/medbay)
 "bPT" = (
 /obj/item/stack/tile/floor,
@@ -50197,66 +50107,49 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bQe" = (
-/obj/structure/table/reinforced,
-/obj/item/glass_jar,
-/obj/item/device/eftpos{
-	eftpos_name = "Kitchen EFTPOS scanner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
 	},
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/button/remote/blast_door{
 	id = "kitchenshutters01";
-	name = "Canteen Shutters Control";
-	pixel_x = 0;
-	pixel_y = 28;
+	name = "Kitchen Shutters Control";
+	pixel_x = -32;
+	pixel_y = 0;
 	req_access = list(28)
-	},
-/obj/machinery/camera/network/civilian_east{
-	c_tag = "Kitchen - Canteen";
-	c_tag_order = 999;
-	dir = 2;
-	network = list("Service")
-	},
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bQf" = (
-/obj/machinery/vending/dinnerware,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+/obj/effect/landmark/start{
+	name = "Chef"
 	},
-/obj/machinery/firealarm/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bQg" = (
-/obj/machinery/ringer{
-	department = "Kitchen";
-	id = "kitchen_ringer";
-	pixel_x = 0;
-	pixel_y = 30;
-	req_access = list(28)
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/table/stone/marble,
+/obj/item/weapon/reagent_containers/glass/beaker/bowl,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bQh" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/stone/marble,
+/obj/item/weapon/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/item/weapon/reagent_containers/food/condiment/peppermill{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bQi" = (
 /obj/structure/table/stone/marble,
@@ -50277,10 +50170,16 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bQl" = (
-/obj/structure/table/stone/marble,
-/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "kitchenshutters02";
+	name = "Kitchen Shutters"
+	},
+/obj/item/weapon/reagent_containers/food/snacks/mint,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/bar)
 "bQp" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -50305,7 +50204,7 @@
 	name = "Engineering External Access";
 	req_access = list(13)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/asteroid/ash/rocky,
 /area/maintenance/medbay)
 "bQs" = (
 /obj/effect/decal/cleanable/generic,
@@ -50379,91 +50278,36 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "bQy" = (
-/obj/structure/grille,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/window/phoronreinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "MiscBlast";
-	name = "Misc Science Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/rnd/misc_lab)
-"bQz" = (
-/obj/structure/grille,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/window/phoronreinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "MiscBlast";
-	name = "Misc Science Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/rnd/misc_lab)
-"bQA" = (
-/obj/structure/grille,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
 	dir = 4
 	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/window/phoronreinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
+/obj/machinery/alarm{
 	dir = 4;
-	icon_state = "pdoor0";
-	id = "MiscBlast";
-	name = "Misc Science Blast Doors";
-	opacity = 0
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
+/turf/simulated/floor/wood,
+/area/library)
+"bQz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/rnd/misc_lab)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/library)
+"bQA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/library)
 "bQB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chaplain Office's Maintenance";
@@ -50493,42 +50337,37 @@
 /area/hallway/primary/aft)
 "bQF" = (
 /obj/item/weapon/stool/padded,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
 /area/hallway/primary/aft)
 "bQG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 6
-	},
+/obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/door/blast/shutters{
-	density = 1;
 	dir = 8;
-	icon_state = "shutter1";
 	id = "kitchenshutters01";
-	name = "Kitchen Shutters";
-	opacity = 1
+	name = "Kitchen Shutters"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/obj/machinery/smartfridge/foodheater,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bQH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bQI" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/disposalpipe/segment,
+/obj/structure/table/stone/marble,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bQO" = (
@@ -50542,11 +50381,9 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
 "bQQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/structure/table/rack,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "bQS" = (
 /obj/structure/table/reinforced/steel,
 /obj/machinery/recharger,
@@ -50639,37 +50476,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "bRb" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/research_port)
+/obj/structure/bookcase/libraryspawn/nonfiction,
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/carpet,
+/area/library)
 "bRc" = (
 /obj/structure/closet/wardrobe/chaplain_black,
 /obj/item/weapon/storage/fancy/crayons,
 /turf/simulated/floor/wood,
 /area/chapel/office)
 "bRd" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/newscaster{
+	pixel_y = -32
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
+/obj/machinery/vending/battlemonsters,
 /turf/simulated/floor/wood,
-/area/chapel/office)
+/area/library)
 "bRe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50684,19 +50506,13 @@
 /turf/simulated/floor/wood,
 /area/chapel/office)
 "bRg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/lapvend,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
 	},
-/obj/structure/flora/pottedplant/random,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green,
 /turf/simulated/floor/wood,
-/area/chapel/office)
+/area/library)
 "bRh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -50716,28 +50532,26 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bRj" = (
-/obj/effect/floor_decal/industrial/loading{
-	icon_state = "loadingarea";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/obj/item/weapon/stool/padded,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/hallway/primary/aft)
 "bRk" = (
 /obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 6
-	},
+/obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/door/blast/shutters{
-	density = 1;
 	dir = 8;
-	icon_state = "shutter1";
 	id = "kitchenshutters01";
-	name = "Kitchen Shutters";
-	opacity = 1
+	name = "Kitchen Shutters"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/obj/item/toy/figure/chef,
+/obj/machinery/ringer_button{
+	id = "kitchen_ringer";
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bRl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -50746,56 +50560,28 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bRm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/landmark/start{
+	name = "Chef"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bRn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/structure/table/stone/marble,
+/obj/item/weapon/material/kitchen/rollingpin,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bRo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 2;
-	name = "Kitchen";
-	req_access = list(28);
-	req_one_access = null
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/table/stone/marble,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bRp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bRx" = (
@@ -50895,21 +50681,15 @@
 /turf/simulated/wall,
 /area/hydroponics)
 "bRN" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/sign/botany{
+/obj/machinery/computer/guestpass{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bRO" = (
-/obj/structure/table/reinforced,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
-/obj/item/toy/figure/chef,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/stone/marble,
+/obj/item/weapon/storage/box/produce,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bRP" = (
@@ -50925,22 +50705,14 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bRQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/stone/marble,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bRS" = (
 /obj/structure/table/stone/marble,
-/obj/machinery/microwave{
-	pixel_y = 8
-	},
+/obj/item/weapon/material/knife,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bRU" = (
@@ -50949,19 +50721,6 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/research_port)
 "bRV" = (
-/obj/structure/table/standard,
-/obj/item/device/flashlight/lamp,
-/obj/item/stack/tile/floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/maintenance/research_port)
-"bRW" = (
-/obj/item/weapon/paper,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/maintenance/research_port)
-"bRX" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -50972,11 +50731,41 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 2;
-	name = "Hydroponics";
-	sortType = "Hydroponics"
+	name = "Library";
+	sortType = "Library"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/cargo)
+/area/maintenance/research_port)
+"bRW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"bRX" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "bSk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51029,23 +50818,17 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bSp" = (
-/obj/structure/table/stone/marble,
-/obj/item/weapon/reagent_containers/glass/beaker/bowl,
-/obj/item/weapon/reagent_containers/glass/beaker,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bSt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 1
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bSu" = (
@@ -51152,10 +50935,7 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "bST" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bSU" = (
@@ -51177,70 +50957,117 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bSW" = (
-/obj/machinery/alarm{
-	name = "freezer alarm";
-	pixel_y = 32;
-	target_temperature = 278
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "kitchenshutters01";
+	name = "Kitchen Shutters"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bSX" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	departmentType = 1;
+	name = "Kitchen Requests Console";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bSY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
-/area/crew_quarters/kitchen)
-"bSZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
-/area/crew_quarters/kitchen)
-"bTa" = (
-/obj/machinery/door/firedoor,
-/obj/structure/plasticflaps/airtight,
-/obj/machinery/door/airlock/freezer{
-	name = "Kitchen cold room";
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/ringer{
+	department = "Kitchen";
+	id = "kitchen_ringer";
+	pixel_x = 0;
+	pixel_y = -30;
 	req_access = list(28)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
 	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"bSZ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer{
-	name = "freezer storage tiles";
-	temperature = 253.15
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Kitchen - West";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"bTa" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bTb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -51252,20 +51079,42 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bTc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bTd" = (
-/obj/structure/table/stone/marble,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/button/remote/blast_door{
+	id = "kitchenshutters02";
+	name = "Kitchen Shutters Control";
+	pixel_x = 0;
+	pixel_y = -32;
+	req_access = list(28)
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -51336,13 +51185,18 @@
 	},
 /area/crew_quarters/kitchen)
 "bTD" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	icon_state = "sink_alt";
-	pixel_x = -20
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/bar)
 "bTE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -51431,13 +51285,17 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bTZ" = (
-/obj/structure/kitchenspike,
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+/obj/structure/closet/gmcloset,
+/obj/item/weapon/flame/lighter/zippo,
+/obj/machinery/requests_console{
+	department = "Bar";
+	departmentType = 1;
+	name = "Bar Requests Console";
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "bUb" = (
 /obj/machinery/gibber,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -51447,44 +51305,67 @@
 	},
 /area/crew_quarters/kitchen)
 "bUd" = (
-/obj/structure/table/stone/marble,
-/obj/item/weapon/material/knife/butch,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	pixel_y = 5
+	},
+/obj/structure/table/wood,
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Bar - Counter"
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "bUe" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/table/wood,
+/obj/machinery/chemical_dispenser/bar_alc/full{
+	pixel_y = 10
+	},
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/camera/network/civilian_east{
-	c_tag = "Kitchen - Southwest";
-	c_tag_order = 999;
-	dir = 1;
-	network = list("Service")
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "bUg" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Kitchen";
-	req_access = list(28);
-	req_one_access = null
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/multi_tile,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/door/airlock/glass{
+	name = "Bar";
+	req_access = list(25)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "bUh" = (
-/obj/structure/window/reinforced/polarized{
-	id = "theatre"
+/obj/structure/toilet{
+	icon_state = "toilet00";
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
+/obj/machinery/button/remote/airlock{
+	id = "main_unit_1";
+	name = "Door Bolt Control";
+	pixel_x = 5;
+	pixel_y = 25;
+	req_access = null;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "bUi" = (
-/obj/structure/window/reinforced/polarized{
-	id = "theatre"
+/obj/machinery/door/airlock/freezer{
+	id_tag = "main_unit_1";
+	name = "Unit 1"
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/bar)
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "bUj" = (
 /obj/effect/landmark/costume/gladiator,
 /obj/structure/table/rack,
@@ -51535,8 +51416,16 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bUC" = (
-/obj/structure/closet/gmcloset,
-/obj/item/weapon/flame/lighter/zippo,
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Bar - Backroom";
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bUE" = (
@@ -51596,26 +51485,16 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bUX" = (
-/obj/machinery/firealarm/north,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/structure/table/wood,
-/obj/machinery/chemical_dispenser/coffeemaster/full{
-	pixel_x = 2;
-	pixel_y = 8
+/obj/structure/shotgun_rack/double{
+	pixel_x = -32;
+	pixel_y = 0;
+	pixel_z = 0
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bUY" = (
-/obj/structure/table/wood,
-/obj/machinery/chemical_dispenser/bar_alc/full{
-	pixel_y = 10
-	},
-/obj/structure/shotgun_rack/double{
-	pixel_z = 30
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
@@ -51765,21 +51644,19 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bVR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (EAST)";
-	icon_state = "spline_fancy";
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm/east,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "bVS" = (
 /obj/structure/cable{
@@ -51892,21 +51769,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bWg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/weapon/stool/padded,
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 5
 	},
-/turf/simulated/floor/tiled/ramp/bottom{
-	icon_state = "rampbot";
-	dir = 4
-	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bWh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -51934,8 +51808,16 @@
 /turf/simulated/wall,
 /area/quartermaster/lobby)
 "bWu" = (
-/obj/structure/noticeboard{
-	pixel_y = 32
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/ramp/bottom{
 	icon_state = "rampbot";
@@ -51947,29 +51829,37 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/bed/chair/wood{
+	icon_state = "wooden_chair";
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWA" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 3;
-	icon_state = "spline_plain"
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWC" = (
-/turf/simulated/floor/carpet,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "bWF" = (
 /turf/simulated/floor/tiled/dark,
@@ -52015,8 +51905,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWL" = (
-/obj/structure/table/wood,
-/obj/item/weapon/flame/candle,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWO" = (
@@ -52095,7 +51984,7 @@
 /area/quartermaster/lobby)
 "bWX" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /obj/machinery/autolathe,
 /turf/simulated/floor/tiled,
@@ -52170,10 +52059,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bXk" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 8;
+	icon_state = "spline_plain"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bXm" = (
 /obj/structure/table/rack,
@@ -52275,11 +52165,8 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bXL" = (
-/obj/structure/table/rack,
-/obj/item/toy/katana,
-/obj/item/toy/cultsword,
-/obj/item/toy/sword,
-/turf/simulated/floor/carpet,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bXM" = (
 /obj/structure/cable{
@@ -52535,8 +52422,7 @@
 /obj/machinery/camera/network/civilian_east{
 	c_tag = "Bar - East";
 	c_tag_order = 999;
-	dir = 8;
-	network = list("Service")
+	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
@@ -52567,18 +52453,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "bYE" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Civilian (Main Level) Substation";
-	req_one_access = list(11,24)
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/maintenance/substation/civilian_west)
 "bYF" = (
 /obj/structure/cable{
@@ -52588,7 +52463,7 @@
 	pixel_x = 0
 	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -52624,6 +52499,9 @@
 	dir = 9
 	},
 /obj/item/device/multitool,
+/obj/machinery/computer/guestpass{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
 "bYJ" = (
@@ -52791,8 +52669,14 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bZf" = (
-/obj/structure/bed/chair/comfy/red,
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 10
+	},
+/obj/machinery/computer/guestpass{
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bZh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -52805,21 +52689,18 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bZj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 1
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 6
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bZl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 1
 	},
-/obj/structure/curtain/black,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "bZm" = (
 /obj/structure/cable{
@@ -52902,9 +52783,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bZw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bZy" = (
@@ -53001,15 +52881,12 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bZO" = (
-/obj/structure/bed/chair/wood{
-	dir = 4;
-	icon_state = "wooden_chair"
+/obj/structure/table/wood,
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Bar - Booths";
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bZV" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -53140,8 +53017,7 @@
 "cah" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Cargo Bay";
-	req_access = null;
-	req_one_access = list(31,48)
+	req_access = list(31)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -53158,10 +53034,8 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
 "cak" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 6
-	},
+/obj/structure/table/wood,
+/obj/machinery/light,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "cal" = (
@@ -53290,7 +53164,7 @@
 /area/quartermaster/lobby)
 "cav" = (
 /obj/machinery/door/airlock/glass_mining{
-	name = "Warehouse";
+	name = "Equipment Storage";
 	req_access = list(31)
 	},
 /obj/machinery/door/firedoor,
@@ -53452,20 +53326,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "caW" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/light/small/emergency{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
@@ -53540,8 +53416,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass_mining{
 	name = "Break Room";
-	req_access = null;
-	req_one_access = list(31,48)
+	req_access = list(31)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -53615,8 +53490,23 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
 "cbi" = (
-/turf/simulated/wall,
-/area/quartermaster/mail_room)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "cbj" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -53705,7 +53595,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Maintenance";
-	req_access = list(31,48)
+	req_access = list(31)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
@@ -53919,7 +53809,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/brown/full{
 	icon_state = "corner_white_full";
@@ -54019,7 +53909,7 @@
 	},
 /obj/machinery/firealarm/west,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/break_room)
@@ -54060,9 +53950,14 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
 "ccu" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "ccv" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -54233,22 +54128,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "ccP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
 "ccQ" = (
 /obj/structure/disposalpipe/up{
 	icon_state = "pipe-u";
@@ -54471,10 +54353,6 @@
 	pixel_x = 0;
 	pixel_y = -32
 	},
-/obj/machinery/camera/network/supply{
-	c_tag = "Cargo - Break Room";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/break_room)
 "cdq" = (
@@ -54599,12 +54477,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_mining{
 	name = "Break Room";
-	req_access = null;
-	req_one_access = list(31,48)
+	req_access = list(31)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/quartermaster/break_room)
 "cdC" = (
@@ -55866,6 +55743,8 @@
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
 /obj/item/stack/flag/purple,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 1
@@ -55878,9 +55757,6 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/mining,
-/obj/item/clothing/head/helmet/space/void/mining,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "cgc" = (
@@ -55927,6 +55803,8 @@
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
 /obj/item/stack/flag/red,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 6
@@ -55940,9 +55818,6 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/mining,
-/obj/item/clothing/head/helmet/space/void/mining,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "cgi" = (
@@ -56008,6 +55883,8 @@
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
 /obj/item/stack/flag/green,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 6
@@ -56016,9 +55893,6 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/mining,
-/obj/item/clothing/head/helmet/space/void/mining,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "cgr" = (
@@ -56062,6 +55936,8 @@
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
 /obj/item/stack/flag/yellow,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 6
@@ -56070,9 +55946,6 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/mining,
-/obj/item/clothing/head/helmet/space/void/mining,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "cgy" = (
@@ -57705,15 +57578,6 @@
 	pixel_x = 5;
 	pixel_y = -30
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "cnW" = (
@@ -57820,20 +57684,36 @@
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
 "coh" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/belt/medical/emt,
+/obj/item/weapon/storage/belt/medical/emt,
+/obj/item/device/radio{
+	frequency = 1487;
+	name = "Medbay Emergency Radio Link";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	frequency = 1487;
+	name = "Medbay Emergency Radio Link";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/device/gps{
+	gpstag = "MED1"
+	},
+/obj/item/device/gps{
+	gpstag = "MED0"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "coi" = (
 /obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/toxin{
+/obj/item/weapon/storage/firstaid/adv{
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/weapon/storage/firstaid/o2,
-/obj/machinery/light{
-	dir = 4;
-	status = 2
-	},
+/obj/item/weapon/storage/firstaid/fire,
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "coj" = (
@@ -57847,44 +57727,39 @@
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "cok" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Maintenance";
-	req_access = list(35)
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"col" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"com" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hydroponics)
-"col" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white_full";
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = 27
-	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
-"com" = (
-/obj/effect/floor_decal/industrial/loading,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/door/window{
-	dir = 2;
-	name = "Hydroponics Delivery";
-	req_access = list(35)
-	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/area/maintenance/library)
 "con" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
@@ -57900,13 +57775,12 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "coo" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/structure/closet/secure_closet/hydroponics,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "cop" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
@@ -57991,28 +57865,19 @@
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "cox" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 5
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = null;
+	req_one_access = list(12,66)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "coy" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
@@ -58044,14 +57909,8 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "coB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/turf/simulated/wall,
+/area/chapel/main)
 "coC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -58134,54 +57993,36 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "coO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"coP" = (
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 1
 	},
-/obj/effect/landmark/start{
-	name = "Gardener"
-	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
-"coP" = (
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/chem_disp_cartridge,
-/obj/item/weapon/reagent_containers/chem_disp_cartridge,
-/obj/item/weapon/reagent_containers/chem_disp_cartridge,
-/obj/item/weapon/reagent_containers/chem_disp_cartridge,
-/obj/item/weapon/reagent_containers/chem_disp_cartridge,
-/obj/item/weapon/reagent_containers/chem_disp_cartridge,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/tiled/ramp/bottom{
+	icon_state = "rampbot";
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/area/chapel/main)
 "coQ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/disposal,
-/obj/effect/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "coR" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "coT" = (
 /obj/structure/table/standard,
 /obj/machinery/door/window{
@@ -58201,30 +58042,26 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "coU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"coV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/hydroponics)
-"coV" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/hydroponics)
+/area/chapel/main)
 "coW" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white_full"
@@ -58249,35 +58086,33 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "coY" = (
-/obj/effect/floor_decal/corner/green{
-	dir = 10
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "chapel"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "chapel"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "chapel"
+	},
+/turf/simulated/floor/plating,
+/area/chapel/office)
 "coZ" = (
-/obj/effect/floor_decal/corner/green{
-	dir = 10
-	},
-/obj/machinery/chem_master,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "cpa" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 1
 	},
-/obj/structure/table/standard,
-/obj/machinery/reagentgrinder{
-	pixel_y = 16
-	},
-/obj/item/weapon/storage/fancy/vials,
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white_full";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "cpb" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/structure/window/reinforced{
@@ -58287,11 +58122,12 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "cpc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/bed/chair/wood{
+	icon_state = "wooden_chair";
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "cpd" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
@@ -58334,26 +58170,24 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "cpk" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Hydroponics Garden";
-	req_access = list(35)
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "chapel"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/structure/window/reinforced/polarized{
+	id = "chapel"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "chapel"
+	},
+/turf/simulated/floor/plating,
+/area/chapel/office)
 "cpm" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/holofloor/wood,
-/area/hydroponics)
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "cpo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -58367,37 +58201,43 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "cpt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "chapdoor";
+	name = "Chaplain's Office";
+	req_access = list(22)
+	},
+/turf/simulated/floor/wood,
+/area/chapel/office)
 "cpu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
-"cpv" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/item/weapon/reagent_containers/glass/bucket/wood,
-/turf/simulated/floor/holofloor/wood,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"cpv" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "cpC" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/machinery/light{
@@ -58425,13 +58265,19 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "cpL" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/camera/network/service{
-	c_tag = "Hydroponics - East";
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "cpN" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/machinery/alarm{
@@ -58442,19 +58288,13 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "cpR" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/weapon/reagent_containers/glass/bucket/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/holofloor/wood,
-/area/hydroponics)
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
 "cpT" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white_full"
-	},
-/turf/simulated/floor/tiled,
-/area/hydroponics)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "cpU" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
@@ -58483,11 +58323,15 @@
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "cpY" = (
-/obj/item/device/radio/intercom{
-	pixel_y = -26
+/obj/structure/flora/pottedplant/random,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/structure/cable/green,
+/turf/simulated/floor/wood,
+/area/chapel/office)
 "cpZ" = (
 /obj/machinery/status_display{
 	pixel_x = 0;
@@ -58496,27 +58340,50 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "cqa" = (
-/turf/simulated/floor/grass,
-/area/hydroponics)
-"cqb" = (
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood,
+/area/chapel/office)
+"cqb" = (
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 2
 	},
-/turf/simulated/floor/holofloor/wood,
-/area/hydroponics)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/ramp/bottom{
+	icon_state = "rampbot";
+	dir = 8
+	},
+/area/chapel/main)
 "cqd" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "cqe" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/item/device/radio/intercom{
@@ -58525,13 +58392,20 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "cqf" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/status_display{
-	pixel_x = 0;
-	pixel_y = -32
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Chapel - Main";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "cqg" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/alarm{
@@ -58546,13 +58420,16 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "cqi" = (
-/obj/structure/flora/pottedplant/random,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 2
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "cqj" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -58723,13 +58600,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "cqB" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Cryo - Main Level";
+	dir = 2
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/cryo)
 "cqF" = (
 /obj/machinery/cryopod{
 	icon_state = "body_scanner_0";
@@ -58738,11 +58614,9 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
 "cqH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/cryo)
 "cqI" = (
 /obj/structure/table/standard,
 /obj/structure/noticeboard{
@@ -58763,6 +58637,12 @@
 /obj/structure/table/standard,
 /obj/item/weapon/packageWrap,
 /obj/item/weapon/packageWrap,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "cqO" = (
@@ -58803,12 +58683,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "cqY" = (
 /turf/simulated/wall,
-/area/crew_quarters/sleep/cryo)
+/area/quartermaster/mail_room)
 "cqZ" = (
 /obj/structure/table/steel,
 /obj/item/weapon/screwdriver{
@@ -60286,26 +60165,35 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "cuH" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "cuI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
+/obj/structure/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/ramp{
+	icon_state = "ramptop";
+	dir = 4
+	},
 /area/hallway/primary/central_one)
 "cuK" = (
 /obj/machinery/camera/network/civilian_main{
@@ -60326,36 +60214,35 @@
 /turf/simulated/floor/plating,
 /area/library)
 "cuN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/library)
+/obj/effect/floor_decal/corner/green,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 "cuO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled/ramp{
+	icon_state = "ramptop";
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/glass{
-	name = "Library"
-	},
-/turf/simulated/floor/wood,
-/area/library)
+/area/hallway/primary/central_one)
 "cuP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Library"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 "cuQ" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -60381,65 +60268,45 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "cuW" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/simulated/floor/carpet,
-/area/library)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 "cuX" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/turf/simulated/floor/wood,
-/area/library)
-"cuY" = (
-/obj/structure/table/wood,
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
 	dir = 8
 	},
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
 	},
-/obj/item/weapon/barcodescanner,
-/turf/simulated/floor/wood,
-/area/library)
-"cuZ" = (
-/obj/structure/table/wood,
-/obj/machinery/librarycomp{
-	pixel_y = 8
-	},
-/obj/machinery/requests_console{
-	department = "Library";
-	departmentType = 1;
-	name = "Library Requests Console";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/library)
-"cva" = (
-/obj/machinery/libraryscanner,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	pixel_y = 27
+/turf/simulated/floor/plating,
+/area/crew_quarters/sleep/main)
+"cuY" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"cuZ" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"cva" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Cryogenics - Main Level";
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
 "cvb" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -60458,12 +60325,14 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cvc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/item/device/radio/intercom{
-	pixel_y = 27
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/dark,
-/area/library)
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
 "cvd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -60474,24 +60343,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/library)
 "cve" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -60501,11 +60362,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "cvh" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/watertank,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/firealarm/east,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "cvj" = (
 /obj/structure/table/wood,
 /obj/machinery/door/window/westright{
@@ -60555,13 +60420,13 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "cvu" = (
-/obj/structure/table/wood,
-/obj/machinery/door/window/westleft{
-	name = "Library Desk";
-	req_access = list(37)
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
 "cvv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -60589,12 +60454,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/library)
 "cvy" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "cvz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -60605,30 +60468,30 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cvA" = (
-/obj/structure/table/wood,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/recharger,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
 "cvB" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/wood,
 /area/library)
 "cvC" = (
-/obj/structure/table/wood,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+/obj/structure/table/standard,
+/obj/item/weapon/storage/fancy/vials,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
 	},
-/obj/item/device/flashlight/lamp/green,
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
 "cvD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/southright{
@@ -60641,12 +60504,20 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cvE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hydroponics)
 "cvF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -60654,11 +60525,16 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cvG" = (
-/obj/structure/table/wood,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/effect/floor_decal/corner/green/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "cvH" = (
 /obj/machinery/bookbinder,
 /turf/simulated/floor/wood,
@@ -60670,16 +60546,10 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cvJ" = (
-/obj/structure/table/wood,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/machinery/librarypubliccomp{
-	pixel_y = 8
-	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "cvL" = (
 /obj/structure/table/wood,
 /obj/machinery/librarypubliccomp{
@@ -60688,11 +60558,13 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cvN" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/library)
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "cvP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -60703,23 +60575,25 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cvT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/library)
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "cvU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "cvV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -60731,13 +60605,11 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cvZ" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -25
-	},
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "cwa" = (
 /obj/structure/bookcase/libraryspawn/religion,
 /turf/simulated/floor/carpet,
@@ -60783,31 +60655,31 @@
 /turf/simulated/floor/plating,
 /area/library)
 "cwm" = (
-/obj/machinery/camera/network/service{
-	c_tag = "Library - West";
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/effect/floor_decal/corner/green,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "cwn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hydroponics)
 "cwq" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/corner/green/full,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "cwu" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4;
-	status = 0
-	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled,
+/area/maintenance/bar)
 "cwv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -60815,9 +60687,10 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cww" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "cwy" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green,
@@ -60849,15 +60722,23 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cwE" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+/obj/machinery/door/airlock/multi_tile/glass{
+	autoclose = 1;
+	dir = 2;
+	id_tag = "RobMechBay";
+	req_access = list(29)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "cwI" = (
 /obj/structure/bookcase/libraryspawn/reference,
 /turf/simulated/floor/carpet,
@@ -60893,19 +60774,32 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "cwR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
 	},
-/turf/simulated/floor/carpet,
-/area/library)
-"cwS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor/plating,
+/area/hydroponics)
+"cwS" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hydroponics)
 "cwU" = (
 /obj/structure/table/wood,
 /obj/item/weapon/deck/cards,
@@ -60935,26 +60829,18 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cwZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/machinery/appliance/cooker/fryer,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "cxa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+/obj/structure/table/stone/marble,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/microwave{
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/carpet,
-/area/library)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "cxb" = (
 /obj/machinery/door/airlock{
 	name = "Adult Section"
@@ -60969,16 +60855,10 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cxc" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/chem_master/condimaster,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "cxe" = (
 /obj/structure/bookcase/libraryspawn/nonfiction,
 /turf/simulated/floor/carpet,
@@ -60988,17 +60868,31 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "cxi" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2;
+	icon_state = "door_closed";
+	name = "Hydroponics";
+	req_access = list(35)
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "cxj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -61010,12 +60904,11 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "cxl" = (
-/obj/machinery/papershredder,
-/obj/machinery/newscaster{
-	pixel_y = -32
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/area/crew_quarters/kitchen)
 "cxm" = (
 /obj/structure/table/wood,
 /obj/item/weapon/paper_bin,
@@ -61026,10 +60919,9 @@
 /turf/simulated/floor/wood,
 /area/library)
 "cxo" = (
-/obj/machinery/appliance/cooker/oven,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "cxp" = (
@@ -61037,15 +60929,25 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "cxq" = (
-/obj/machinery/appliance/cooker/fryer,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/stone/marble,
+/obj/item/weapon/material/knife/hook,
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Kitchen - East";
+	dir = 8;
+	network = list("Civilian Main","Capt_Office")
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "cxw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
 /area/crew_quarters/kitchen)
 "cxx" = (
 /obj/machinery/door/window/eastright{
@@ -61066,14 +60968,19 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "cxC" = (
-/obj/effect/landmark/start{
-	name = "Chef"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "cxF" = (
-/obj/structure/table/stone/marble,
-/obj/item/weapon/material/knife,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "cxJ" = (
@@ -61248,28 +61155,16 @@
 /obj/machinery/camera/network/civilian_east{
 	c_tag = "Kitchen - Northeast";
 	c_tag_order = 999;
-	dir = 2;
-	network = list("Service")
+	dir = 2
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "grC" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/kitchenspike,
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	is_critical = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "grD" = (
 /obj/structure/disposalpipe/segment{
@@ -61277,8 +61172,8 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
-	req_access = list(28);
-	req_one_access = null
+	req_access = null;
+	req_one_access = list(12,28)
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -61314,17 +61209,14 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "grS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
 /area/crew_quarters/kitchen)
 "grT" = (
 /obj/structure/window/reinforced{
@@ -61375,8 +61267,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "grY" = (
-/obj/machinery/smartfridge/secure{
-	req_one_access = list(35,28,25)
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "kitchenshutters01";
+	name = "Kitchen Shutters"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
@@ -61436,20 +61332,8 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "gsr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
 "gss" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/closet/secure_closet/freezer/kitchen,
@@ -61494,19 +61378,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "gsB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(28)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
 "gsC" = (
 /obj/machinery/light/small{
@@ -61571,12 +61450,6 @@
 	},
 /obj/item/weapon/storage/box/kitchen,
 /obj/item/weapon/storage/box/gloves,
-/obj/machinery/camera/network/civilian_east{
-	c_tag = "Kitchen - Pantry";
-	c_tag_order = 999;
-	dir = 8;
-	network = list("Service")
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "gsR" = (
@@ -61596,42 +61469,35 @@
 	},
 /area/crew_quarters/kitchen)
 "gsU" = (
-/obj/machinery/button/remote/blast_door{
-	id = "kitchenshutters02";
-	name = "Kitchen Shutters Control";
-	pixel_x = 0;
-	pixel_y = -28;
-	req_access = list(28);
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/structure/table/wood,
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "gsV" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "gsW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
-"gsX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/bar)
+"gsX" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/bar)
 "gsY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -61645,28 +61511,27 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "gsZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "kitchenshutters02";
-	name = "Kitchen Shutters"
+/obj/effect/landmark/start{
+	name = "Bartender"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "gta" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "kitchenshutters02";
-	name = "Kitchen Shutters"
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/weapon/reagent_containers/food/snacks/mint,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "gtb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -61681,9 +61546,25 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "gtc" = (
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/mirror{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "gti" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -61722,28 +61603,8 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "gtl" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "barshutters01";
-	name = "Bar Shutters Control";
-	pixel_x = 28;
-	pixel_y = 8;
-	req_access = list(25)
-	},
-/obj/item/device/radio/intercom{
-	desc = "Talk... listen through this.";
-	name = "Station Intercom (Brig Radio)";
-	pixel_x = 0;
-	pixel_y = 25;
-	wires = 7
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
@@ -61751,18 +61612,11 @@
 /turf/simulated/floor/tiled/ramp,
 /area/crew_quarters/bar)
 "gtn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/ramp,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "gto" = (
 /obj/structure/flora/pottedplant/random,
@@ -61884,12 +61738,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "gtA" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
 	},
+/obj/machinery/computer/arcade/battle,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "gtB" = (
@@ -61984,8 +61837,7 @@
 /obj/machinery/camera/network/civilian_east{
 	c_tag = "Bar - North";
 	c_tag_order = 999;
-	dir = 2;
-	network = list("Service")
+	dir = 2
 	},
 /obj/machinery/atm{
 	pixel_x = 0;
@@ -62018,49 +61870,49 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "gtQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 9
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/sign/double/barsign{
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "gtS" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/computer/guestpass{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "gtT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (EAST)";
-	icon_state = "spline_fancy";
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 3;
-	icon_state = "spline_plain"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "gtU" = (
 /obj/machinery/light/small{
@@ -62101,38 +61953,18 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "gtZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Bar - West";
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "gua" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "gub" = (
@@ -62192,31 +62024,11 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "gue" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/status_display/supply_display{
-	pixel_x = 32;
-	pixel_y = 0
-	},
 /obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 1
+	dir = 9;
+	icon_state = "spline_plain"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "guf" = (
 /obj/item/device/radio/intercom{
@@ -62276,13 +62088,10 @@
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/machinery/camera/network/civilian_east{
-	c_tag = "Bar - West";
-	c_tag_order = 999;
-	dir = 4;
-	network = list("Service")
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
 	},
-/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "guw" = (
@@ -62300,30 +62109,21 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "guy" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 27
+/obj/effect/floor_decal/spline/plain{
+	dir = 10;
+	icon_state = "spline_plain"
 	},
-/turf/simulated/floor/tiled/ramp/bottom,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "guz" = (
 /turf/simulated/floor/tiled/ramp/bottom,
 /area/crew_quarters/bar)
 "guB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "guC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "guD" = (
 /obj/structure/disposalpipe/segment{
@@ -62345,7 +62145,7 @@
 	req_one_access = list(12,25)
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/bar)
+/area/crew_quarters/bar)
 "guF" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 4
@@ -62360,26 +62160,20 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "guG" = (
-/obj/item/weapon/material/ashtray/bronze,
-/obj/item/weapon/flame/lighter/random,
-/obj/structure/table/wood/gamblingtable,
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "guH" = (
-/obj/item/weapon/lipstick/random,
-/obj/structure/table/wood/gamblingtable,
+/obj/structure/table/wood,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "guI" = (
-/obj/structure/window/reinforced{
+/obj/structure/bed/chair/comfy/black{
 	dir = 8
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "guJ" = (
 /obj/machinery/door/firedoor,
@@ -62389,7 +62183,7 @@
 	req_one_access = list(12,25)
 	},
 /turf/simulated/floor/wood,
-/area/maintenance/bar)
+/area/crew_quarters/bar)
 "guL" = (
 /obj/item/clothing/mask/smokable/cigarette,
 /obj/structure/table/wood/gamblingtable,
@@ -62511,7 +62305,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/maintenance/bar)
+/area/crew_quarters/bar)
 "gve" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -62568,6 +62362,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "gvw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -62579,10 +62377,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "gvB" = (
@@ -62593,16 +62387,9 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/bar)
 "jNC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/firealarm/east,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "jXF" = (
 /obj/structure/grille,
@@ -62790,15 +62577,12 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
-/obj/item/weapon/storage/fancy/vials{
-	pixel_x = 0;
-	pixel_y = 0
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/box/beakers,
+/obj/item/clothing/glasses/science,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "xDL" = (
@@ -62853,16 +62637,15 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/syringes{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/machinery/smartfridge/secure/medbay{
+	density = 0;
+	name = "Dangerous Materials Storage";
+	pixel_x = 0;
+	pixel_y = 0;
+	req_access = list(33)
 	},
-/obj/item/weapon/storage/box/beakers,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
+/obj/structure/sign/nosmoking_1{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -62880,12 +62663,7 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/syringes{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/box/beakers,
+/obj/machinery/chem_heater,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "xDY" = (
@@ -63090,19 +62868,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "xEr" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/structure/closet/wardrobe/chemistry_white,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -63394,13 +63166,13 @@
 /turf/simulated/floor/tiled,
 /area/medical/reception)
 "xEX" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -63471,12 +63243,13 @@
 /turf/simulated/floor/tiled,
 /area/medical/reception)
 "xFh" = (
-/obj/structure/sign/nosmoking_1{
-	pixel_x = -32
-	},
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -63837,6 +63610,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "xGb" = (
@@ -64058,7 +63832,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/medical/gen_treatment)
+/area/medical/cryo)
 "xGr" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/disposalpipe/segment{
@@ -64097,12 +63871,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "xGv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "xGw" = (
@@ -64197,22 +63973,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "xGE" = (
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -24
-	},
 /obj/structure/bed/chair{
 	dir = 4
 	},
@@ -64262,6 +64022,7 @@
 "xGI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "xGJ" = (
@@ -64298,7 +64059,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "xGN" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -64309,6 +64069,7 @@
 	name = "Cryogenics Control Room";
 	req_access = list(66)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/medical/cryo)
 "xGP" = (
@@ -64352,18 +64113,19 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "xGX" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
 	pixel_x = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/medical/cryo)
@@ -64424,7 +64186,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/medical/surgeryobs)
+/area/medical/cryo)
 "xHg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -64499,41 +64261,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "xHo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/cryopod{
+	icon_state = "body_scanner_0";
+	dir = 2
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
 "xHp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/ramp,
+/area/crew_quarters/sleep/main)
 "xHq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "xHr" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "xHs" = (
@@ -64624,23 +64375,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "xHA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/landmark{
+	name = "JoinLateCryo"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
 "xHB" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "xHC" = (
@@ -64686,8 +64428,8 @@
 /area/maintenance/medbay)
 "xHI" = (
 /obj/structure/table/standard,
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
+/obj/effect/floor_decal/corner/lime/full{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
@@ -64804,327 +64546,32 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "xIy" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/structure/closet/crate,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"xIz" = (
-/obj/structure/closet/crate,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"xIA" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"xIB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"xIC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"xID" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIE" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/structure/sign/nosmoking_1{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIF" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Hard Storage"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIG" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIH" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/structure/sign/nosmoking_1{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xII" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"xIK" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIL" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIM" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIN" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIO" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIP" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIQ" = (
-/obj/structure/table/rack,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"xIR" = (
-/obj/structure/table/rack,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"xIS" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIT" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIU" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
-"xIV" = (
-/obj/structure/closet/crate/solar,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIW" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIX" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24;
-	req_one_access = list(24,11,55)
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/power/port_gen/pacman,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xIY" = (
+"xIz" = (
 /obj/random/junk,
 /obj/structure/reagent_dispensers/extinguisher,
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
-"xIZ" = (
+"xIA" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/civ)
-"xJa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xJb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/shieldgen,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xJc" = (
-/obj/machinery/shieldwallgen,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"xJd" = (
+"xIB" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
-"xJe" = (
+"xIC" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"xJf" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "engine_airlock_control";
-	name = "Engine Access Console";
-	pixel_x = 26;
-	pixel_y = 0;
-	req_access = list(11);
-	req_one_access = null;
-	tag_exterior_door = "engine_airlock_exterior";
-	tag_interior_door = "engine_airlock_interior"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
-"xJg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
-"xJh" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 2
-	},
-/obj/machinery/firealarm/south,
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"xJi" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/structure/closet/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
-"xJj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
-"xJk" = (
+"xID" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"xJl" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"xJm" = (
-/obj/structure/grille,
+"xIE" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/foyer)
-"xJn" = (
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access = null;
-	req_one_access = list(12,66)
-	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -65133,13 +64580,18 @@
 	name = "MedBay Lockdown Shutters";
 	opacity = 0
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = null;
+	req_one_access = list(12,66)
+	},
+/turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"xJo" = (
+"xIF" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"xJp" = (
+"xIG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -65149,7 +64601,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"xJq" = (
+"xIH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -65164,7 +64616,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"xJr" = (
+"xII" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/table/glass,
 /obj/structure/disposalpipe/segment{
@@ -65172,14 +64624,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJs" = (
+"xIJ" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/ringer{
+	department = "Chemistry";
+	id = "chemistry_ringer";
+	pixel_x = -30;
+	pixel_y = 0;
+	req_access = list(33)
+	},
+/obj/machinery/chem_heater,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xIK" = (
 /obj/structure/bed/chair/comfy/beige,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"xJt" = (
+"xIL" = (
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"xJu" = (
+"xIM" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -65189,7 +64656,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJv" = (
+"xIN" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
@@ -65197,31 +64664,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJw" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/smartfridge/secure/medbay{
-	density = 1;
-	name = "Dangerous Materials Storage";
-	pixel_x = 0;
-	pixel_y = 0;
-	req_access = list(33)
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"xJx" = (
+"xIO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"xJy" = (
+"xIP" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -65245,44 +64695,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/medbreak)
-"xJz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"xJA" = (
+"xIQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"xJB" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"xJC" = (
+"xIR" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xJD" = (
+"xIS" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xJE" = (
+"xIT" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJF" = (
+"xIU" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/vending/snack,
 /obj/machinery/light{
@@ -65291,38 +64727,33 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJG" = (
+"xIV" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/machinery/firealarm/west,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"xJH" = (
-/obj/effect/floor_decal/corner/mauve/full,
+"xIW" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
 /obj/structure/table/standard,
-/obj/machinery/button/remote/blast_door{
-	id = "CHE3shutters";
-	name = "Desk Shutter Control";
-	pixel_x = 6;
-	pixel_y = 0;
-	req_access = list(33)
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "CHE2shutters";
-	name = "Window Shutter Control";
-	pixel_x = -6;
-	pixel_y = 0;
-	req_access = list(33)
-	},
+/obj/machinery/reagentgrinder,
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 2
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"xJI" = (
+"xIX" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
@@ -65331,47 +64762,63 @@
 /obj/item/weapon/packageWrap,
 /obj/item/weapon/packageWrap,
 /obj/item/device/destTagger,
+/obj/machinery/light{
+	dir = 2;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/obj/item/weapon/hand_labeler,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"xJJ" = (
+"xIY" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
 	},
-/obj/structure/closet/wardrobe/chemistry_white,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Chemistry 2";
-	dir = 1;
-	icon_state = "camera";
-	network = list("Medical")
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"xJK" = (
-/obj/effect/floor_decal/corner/mauve/full{
-	icon_state = "corner_white_full";
-	dir = 4
-	},
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/item/device/radio/headset/headset_med,
+/obj/item/device/radio/headset/headset_med,
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 2
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"xJL" = (
+"xIZ" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/closet/wardrobe/chemistry_white,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xJa" = (
+/obj/effect/floor_decal/corner/mauve/full{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xJb" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Medication Closet";
 	pixel_x = -32;
 	pixel_y = 0
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
 /obj/item/weapon/storage/pill_bottle/dermaline,
 /obj/item/weapon/storage/pill_bottle/tramadol,
@@ -65383,17 +64830,17 @@
 /area/medical/biostorage{
 	name = "\improper Medical - Exam Room 2"
 	})
-"xJM" = (
+"xJc" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xJN" = (
+"xJd" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xJO" = (
+"xJe" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/alarm{
 	dir = 4;
@@ -65406,7 +64853,7 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJP" = (
+"xJf" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/cable/green{
 	d1 = 2;
@@ -65418,15 +64865,7 @@
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJQ" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
-"xJR" = (
+"xJg" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -65452,7 +64891,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"xJS" = (
+"xJh" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Medication Closet";
@@ -65468,22 +64907,22 @@
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"xJT" = (
+"xJi" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xJU" = (
+"xJj" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xJV" = (
+"xJk" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xJW" = (
+"xJl" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
@@ -65500,24 +64939,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJX" = (
+"xJm" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xJY" = (
+"xJn" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xJZ" = (
+"xJo" = (
 /turf/simulated/wall,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKa" = (
+"xJp" = (
 /obj/structure/flora/pottedplant/random,
 /obj/effect/floor_decal/corner/lime/full{
 	icon_state = "corner_white_full";
@@ -65527,34 +64966,23 @@
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKb" = (
+"xJq" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKc" = (
+"xJr" = (
 /turf/simulated/wall,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKd" = (
+"xJs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKe" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/medical/reception)
-"xKf" = (
+"xJt" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
 	id_tag = null;
@@ -65565,90 +64993,133 @@
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/medical/reception)
-"xKg" = (
-/obj/structure/disposalpipe/junction,
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"xKh" = (
+"xJu" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKi" = (
+"xJv" = (
 /turf/simulated/wall,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKj" = (
-/obj/structure/sign/nosmoking_1{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"xKk" = (
+"xJw" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKl" = (
+"xJx" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKm" = (
-/obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/vending/wallmed2{
-	pixel_x = 28
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"xKn" = (
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 4
-	},
+"xJy" = (
+/obj/effect/floor_decal/corner/lime,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"xKo" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
+"xJz" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/structure/flora/pottedplant/random,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xJA" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/cryo)
+"xJB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/emergency{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKp" = (
+"xJC" = (
+/obj/structure/table/standard,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
+	dir = 2;
 	icon_state = "pipe-c"
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/roller{
+	pixel_y = 4
+	},
+/obj/item/roller{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKq" = (
+"xJD" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xJE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "Stabilization Kit";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/weapon/storage/pill_bottle/tramadol,
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xJF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/closet/secure_closet/medical_wall{
@@ -65665,45 +65136,7 @@
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	is_critical = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"xKs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"xKt" = (
+"xJG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -65723,7 +65156,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKu" = (
+"xJH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -65744,160 +65177,328 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/glass_medical{
-	name = "EMT Quarters";
-	req_access = list(67)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"xKw" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/glass_medical{
-	name = "EMT Quarters";
-	req_access = list(67)
-	},
+"xJI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKx" = (
+"xJJ" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKy" = (
+"xJK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"xKz" = (
-/obj/machinery/firealarm/south,
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"xKA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKB" = (
+"xJL" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/medical/cryo)
+"xJM" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKC" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/weapon/crowbar/red,
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"xKD" = (
+"xJN" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
+/obj/structure/sign/nosmoking_1{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKE" = (
+"xJO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/medical/medbay)
-"xKF" = (
+"xJP" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/substation/medical)
-"xKG" = (
-/obj/structure/table/standard,
-/obj/machinery/vending/wallmed2{
-	pixel_x = 28
+"xJQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/item/weapon/storage/firstaid/adv{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/r_n_d/destructive_analyzer,
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_x = -30;
+	pixel_y = 0
 	},
-/obj/item/weapon/storage/firstaid/fire,
 /turf/simulated/floor/tiled/dark,
+/area/rnd/lab)
+"xJR" = (
+/obj/machinery/light/small,
+/obj/machinery/button/remote/blast_door{
+	id = "emtshutter";
+	name = "Garage Shutters Control";
+	pixel_x = 0;
+	pixel_y = -26;
+	req_access = list(5)
+	},
+/obj/effect/floor_decal/industrial/loading{
+	icon_state = "loadingarea";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/medical/emt)
-"xKH" = (
-/obj/structure/table/standard,
+"xJS" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/camera/network/medbay{
-	c_tag = "Medical - EMT Quarters";
-	dir = 1;
+	c_tag = "Medical - EMT Garage";
+	dir = 8;
 	icon_state = "camera"
 	},
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/gps{
-	gpstag = "MED1"
-	},
-/obj/item/device/gps{
-	gpstag = "MED0"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/medical/emt)
-"xKI" = (
-/obj/structure/disposalpipe/segment{
+"xJT" = (
+/obj/structure/cryofeed{
+	icon_state = "cryo_rear";
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xJU" = (
+/obj/structure/cryofeed{
+	icon_state = "cryo_rear";
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xJV" = (
+/obj/structure/cryofeed{
+	icon_state = "cryo_rear";
+	dir = 2
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xJW" = (
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = 24
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/sleep/main)
+"xJX" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/library)
-"xKJ" = (
-/obj/machinery/light/small/emergency,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/area/medical/cryo)
+"xJY" = (
+/obj/machinery/power/apc/high{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 4;
+/obj/structure/cable/green{
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/library)
-"xKK" = (
+/area/medical/cryo)
+"xJZ" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/rnd/misc_lab)
+"xKa" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/rnd/misc_lab)
+"xKb" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/rnd/misc_lab)
+"xKc" = (
+/obj/machinery/door/airlock/research{
+	name = "Materials";
+	req_access = list(47)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
+"xKd" = (
+/turf/simulated/wall,
+/area/rnd/misc_lab)
+"xKe" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"xKf" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/ramp,
+/area/crew_quarters/sleep/main)
+"xKg" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/medical/cryo)
+"xKh" = (
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled/white,
+/area/rnd/xenobiology/xenoflora)
+"xKi" = (
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/white,
+/area/rnd/xenobiology/xenoflora)
+"xKj" = (
+/obj/machinery/disposal,
+/obj/item/device/radio/intercom{
+	pixel_x = 27
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
+"xKk" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/sleep/main)
+"xKl" = (
+/obj/effect/landmark{
+	name = "JoinLateCryo"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKm" = (
+/obj/effect/landmark{
+	name = "JoinLateCryo"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKn" = (
+/obj/effect/landmark{
+	name = "JoinLateCryo"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKo" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKp" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -65910,7 +65511,335 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
+"xKq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"xKr" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"xKs" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Cryogenic Storage"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = null;
+	req_one_access = list(12,66)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/crew_quarters/sleep/main)
+"xKA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"xKB" = (
+/obj/machinery/light,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/main)
+"xKC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = list(66)
+	},
+/turf/simulated/floor/plating,
+/area/medical/surgeryobs)
+"xKD" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"xKE" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"xKF" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"xKG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"xKH" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Gardener"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xKI" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
+"xKJ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = null;
+	req_one_access = list(12,66)
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"xKK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 "xKL" = (
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"xKM" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xKN" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
+"xKO" = (
+/obj/machinery/requests_console{
+	department = "Hydroponics";
+	departmentType = 2;
+	name = "Hydroponics Requests Console";
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
+"xKP" = (
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
+"xKQ" = (
+/obj/machinery/vending/hydroseeds{
+	prices = list();
+	restock_items = 1
+	},
+/obj/machinery/firealarm/east,
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
+"xKR" = (
+/obj/structure/table/standard,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xKS" = (
+/obj/structure/table/standard,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xKT" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xKU" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -65919,91 +65848,2722 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/maintenance/bar)
+"xKV" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
-"xKM" = (
-/obj/structure/cryofeed{
-	icon_state = "cryo_rear";
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/disposal,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
-"xKN" = (
-/obj/structure/cryofeed{
-	icon_state = "cryo_rear";
-	dir = 1
+/area/medical/surgeryobs)
+"xKW" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
-"xKO" = (
-/obj/structure/cryofeed{
-	icon_state = "cryo_rear";
+/area/rnd/telesci)
+"xKX" = (
+/turf/simulated/floor/tiled,
+/area/library)
+"xKY" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
-"xKP" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/maintenance/library)
-"xKQ" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/research_port)
-"xKR" = (
-/obj/structure/disposalpipe/segment{
+/area/library)
+"xKZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/closet/walllocker/emerglocker/north,
+/turf/simulated/floor/plating,
+/area/library)
+"xLa" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hydroponics)
+"xLb" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/hydroponics)
+"xLc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hydroponics)
+"xLd" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/spraybottles,
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
+"xLe" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
+"xLf" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
+"xLg" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xLh" = (
+/obj/machinery/vending/hydronutrients,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xLi" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/mauve/full{
+	icon_state = "corner_white_full";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
-"xKS" = (
+/area/rnd/telesci)
+"xLj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Library";
+	departmentType = 1;
+	name = "Library Requests Console";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"xLk" = (
+/obj/machinery/door/window/westright{
+	dir = 4;
+	name = "Library Door";
+	req_access = list(37)
+	},
+/obj/structure/table/wood,
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/wood,
+/area/library)
+"xLl" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/library)
+"xLm" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"xLn" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"xLo" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xLp" = (
+/obj/effect/floor_decal/corner/green/full{
+	icon_state = "corner_white_full";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xLq" = (
+/obj/machinery/door/window{
+	base_state = "left";
+	dir = 1;
+	icon_state = "left";
+	name = "Hydroponics Backroom";
+	req_access = list(35)
+	},
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xLr" = (
+/obj/machinery/vending/hydroseeds{
+	prices = list();
+	restock_items = 1
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/bar)
+"xLs" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
+"xLt" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
+"xLu" = (
+/obj/structure/closet/bombcloset,
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
+"xLv" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
+"xLw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/library)
+"xLx" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/library)
+"xLy" = (
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Library Desk";
+	req_access = list(37)
+	},
+/obj/structure/table/wood,
+/turf/simulated/floor/wood,
+/area/library)
+"xLz" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/library)
+"xLA" = (
+/obj/effect/floor_decal/corner/green/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xLB" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/standard,
 /obj/machinery/camera/network/civilian_main{
-	c_tag = "Aft Corridor - Camera 2";
+	c_tag = "Hydroponics - East";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
-"xKT" = (
-/obj/structure/reagent_dispensers/watertank,
+/area/hydroponics)
+"xLC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
+"xLD" = (
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
-/area/maintenance/research_port)
-"xKU" = (
+/area/hydroponics)
+"xLE" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
+"xLF" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/wood,
+/area/library)
+"xLG" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/library)
+"xLH" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/hydronutrients,
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
+"xLI" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Gardener"
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xLJ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xLK" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"xLL" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/machinery/door/window{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
+	name = "Hydroponics Backroom";
+	req_access = list(35)
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xLM" = (
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/corner/green/full{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xLN" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/junk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xLO" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
+"xLP" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
+"xLQ" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
+"xLR" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/telesci)
+"xLS" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"xLT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/wood,
+/area/library)
+"xLU" = (
 /obj/machinery/camera/network/civilian_main{
-	c_tag = "Aft Corridor - Camera 3";
+	c_tag = "Library - North"
+	},
+/turf/simulated/floor/carpet,
+/area/library)
+"xLV" = (
+/turf/simulated/floor/tiled,
+/area/library)
+"xLW" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/seed_extractor,
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
+"xLX" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/green/full{
+	icon_state = "corner_white_full";
+	dir = 8
+	},
+/obj/item/weapon/reagent_containers/chem_disp_cartridge,
+/obj/item/weapon/reagent_containers/chem_disp_cartridge,
+/obj/item/weapon/reagent_containers/chem_disp_cartridge,
+/obj/item/weapon/reagent_containers/chem_disp_cartridge,
+/obj/item/weapon/reagent_containers/chem_disp_cartridge,
+/obj/item/weapon/reagent_containers/chem_disp_cartridge,
+/obj/item/weapon/reagent_containers/chem_disp_cartridge,
+/obj/item/weapon/reagent_containers/chem_disp_cartridge,
+/obj/item/weapon/reagent_containers/chem_disp_cartridge,
+/obj/item/weapon/reagent_containers/chem_disp_cartridge,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xLY" = (
+/obj/machinery/chemical_dispenser,
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xLZ" = (
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMa" = (
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMb" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMc" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMd" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMe" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Division Maintenance";
+	req_access = list(47);
+	req_one_access = null
+	},
+/turf/simulated/floor/plating,
+/area/rnd/telesci)
+"xMf" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "telescience";
+	name = "Containment Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/rnd/telesci)
+"xMg" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/wood,
+/area/library)
+"xMh" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"xMi" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"xMj" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/library)
+"xMk" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	icon_state = "door_closed";
+	name = "Library"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/library)
+"xMl" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xKV" = (
-/obj/effect/landmark/dungeon_spawn,
-/turf/unsimulated/chasm_mask,
-/area/mine/unexplored)
-"xKW" = (
+"xMm" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMn" = (
+/obj/effect/floor_decal/corner/green/full{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMo" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMp" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMq" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMs" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/bed/chair/office/dark,
+/obj/effect/landmark/start{
+	name = "Gardener"
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMt" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/item/weapon/storage/fancy/vials,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMu" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xMv" = (
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Telescience Test Chamber 02";
+	dir = 4;
+	network = list("Research")
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/telesci)
+"xMw" = (
+/turf/simulated/floor/reinforced,
+/area/rnd/telesci)
+"xMx" = (
+/turf/simulated/floor/reinforced,
+/area/rnd/telesci)
+"xMy" = (
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Telescience Test Chamber 01";
+	dir = 4;
+	network = list("Research")
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/telesci)
+"xMz" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/library)
+"xMA" = (
+/obj/effect/landmark/start{
+	name = "Librarian"
+	},
+/obj/structure/bed/chair/office/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/library)
+"xMB" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"xMC" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/library)
+"xMD" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/library)
+"xME" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light,
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"xMF" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/status_display{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = -26
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"xMG" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"xMH" = (
+/obj/machinery/disposal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMJ" = (
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMK" = (
+/obj/effect/floor_decal/corner/green/full,
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xML" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMM" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/machinery/light,
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 4;
+	name = "Hydroponics";
+	sortType = "Hydroponics"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMN" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMO" = (
+/obj/effect/floor_decal/corner/green/full{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled,
+/area/hydroponics)
+"xMP" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(35)
+	},
+/turf/simulated/floor/plating,
+/area/hydroponics)
+"xMQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMR" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xMS" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xMT" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xMU" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xMV" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xMW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/telesci)
+"xMX" = (
+/obj/machinery/light/small/emergency{
+	icon_state = "bulb1";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"xMY" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/library)
+"xMZ" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/wood,
+/area/library)
+"xNa" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/library)
+"xNb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/window{
+	dir = 1;
+	req_one_access = list(35)
+	},
+/obj/machinery/door/window{
+	dir = 2;
+	icon_state = "left";
+	req_one_access = list(28)
+	},
+/turf/simulated/floor/tiled/white,
+/area/hydroponics)
+"xNc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/smartfridge/secure,
+/turf/simulated/floor/tiled/white,
+/area/hydroponics)
+"xNd" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/telesci)
+"xNe" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"xNf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"xNg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/library)
+"xNh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/wood,
+/area/library)
+"xNi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"xNj" = (
+/obj/structure/table/stone/marble,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/appliance/mixer/candy{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNk" = (
+/obj/structure/table/stone/marble,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNl" = (
+/obj/machinery/appliance/cooker/oven,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNm" = (
+/obj/structure/table/stone/marble,
+/obj/machinery/appliance/mixer/cereal{
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNn" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNo" = (
+/obj/structure/table/stone/marble,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNp" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
+/area/crew_quarters/kitchen)
+"xNq" = (
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
+/area/crew_quarters/kitchen)
+"xNr" = (
+/obj/structure/plasticflaps/airtight,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/freezer_maint{
+	req_access = list(28)
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
+"xNs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet,
+/area/library)
+"xNt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/library)
+"xNu" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNv" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNx" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNy" = (
+/obj/structure/table/stone/marble,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNz" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
+/area/crew_quarters/kitchen)
+"xNA" = (
+/obj/machinery/gibber,
+/obj/machinery/firealarm/east,
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
+/area/crew_quarters/kitchen)
+"xNB" = (
+/obj/structure/table/wood,
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/wood,
+/area/library)
+"xNC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/carpet,
+/area/library)
+"xND" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/library)
+"xNE" = (
+/obj/effect/landmark/start{
+	name = "Chef"
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNG" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/stone/marble,
+/obj/item/weapon/material/knife/butch,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNH" = (
+/obj/structure/reagent_dispensers/cookingoil,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
+/area/crew_quarters/kitchen)
+"xNI" = (
+/obj/structure/kitchenspike,
+/obj/machinery/alarm/cold{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
+/area/crew_quarters/kitchen)
+"xNJ" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "civilian_eva_outer";
+	locked = 1;
+	name = "Engineering External Access";
+	req_access = list(13)
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xNK" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"xNL" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/library)
+"xNM" = (
+/obj/structure/table/stone/marble,
+/obj/item/weapon/material/knife,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/library)
+"xNO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/library)
+"xNP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet,
+/area/library)
+"xNQ" = (
+/obj/structure/bookcase/libraryspawn/reference,
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Library - South";
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/library)
+"xNR" = (
+/obj/item/weapon/stool/padded,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/hallway/primary/aft)
+"xNS" = (
+/obj/effect/landmark/start{
+	name = "Chef"
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	name = "Kitchen";
+	sortType = "Kitchen"
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xNW" = (
+/obj/structure/plasticflaps/airtight,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/freezer{
+	name = "Kitchen Freezer";
+	req_access = list(28)
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
+"xNX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
+/area/crew_quarters/kitchen)
+"xNY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNZ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access = list(12,37,66)
+	},
+/turf/simulated/floor/plating,
+/area/library)
+"xOa" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/stone/marble,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xOb" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xOc" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xOd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xOe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"xOf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"xOg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"xOh" = (
+/obj/item/weapon/stool/padded,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/primary/aft)
+"xOi" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "kitchenshutters01";
+	name = "Kitchen Shutters"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xOj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xOk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xOl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xOm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xOn" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"xOo" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -28
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/primary/aft)
+"xOp" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	icon_state = "pipe-y";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xOq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xOr" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xOs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xOt" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"xOu" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/crew_quarters/bar)
+"xOv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "kitchenshutters02";
+	name = "Kitchen Shutters"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xOw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/device/destTagger,
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/packageWrap,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "kitchenshutters02";
+	name = "Kitchen Shutters"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xOx" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/crew_quarters/bar)
+"xOy" = (
+/obj/machinery/door/firedoor/multi_tile,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Kitchen";
+	req_access = list(28);
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xOz" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood,
+/area/maintenance/bar)
+"xOA" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xOB" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xOC" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood,
+/area/maintenance/bar)
+"xOD" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xOE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xOF" = (
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 5
+	},
+/obj/structure/flora/pottedplant/random,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"xOG" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"xOH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"xOI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/chapel/main)
+"xOJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"xOK" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"xOL" = (
+/obj/structure/table/wood,
+/obj/machinery/chemical_dispenser/coffeemaster/full{
+	pixel_y = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
+"xOM" = (
+/obj/machinery/vending/boozeomat{
+	density = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
+"xON" = (
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "kitchenshutters02";
+	name = "Kitchen Shutters Control";
+	pixel_x = 6;
+	pixel_y = 0;
+	req_access = list(25)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "barshutters01";
+	name = "Bar Shutters Control";
+	pixel_x = -6;
+	pixel_y = 0;
+	req_access = list(25)
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
+"xOO" = (
+/obj/machinery/firealarm/east,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xOP" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Bar - Bathroom"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
+"xOQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xOR" = (
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/weapon/flame/candle,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"xOS" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"xOT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Bartender"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xOU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
+"xOV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
+"xOW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
+"xOX" = (
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Bar";
+	sortType = "Bar"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xOY" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xOZ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
+"xPa" = (
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/weapon/storage/bible,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"xPb" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"xPc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Chapel"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"xPd" = (
+/obj/machinery/light{
+	dir = 4;
+	status = 2
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"xPe" = (
+/obj/structure/table/wood,
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/book/manual/barman_recipes,
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xPf" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xPg" = (
+/obj/machinery/door/airlock/freezer{
+	id_tag = "main_unit_2";
+	name = "Unit 2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
+"xPh" = (
+/obj/structure/toilet{
+	icon_state = "toilet00";
+	dir = 8
+	},
+/obj/machinery/button/remote/airlock{
+	id = "main_unit_2";
+	name = "Door Bolt Control";
+	pixel_x = 5;
+	pixel_y = 25;
+	req_access = null;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
+"xPi" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/chapel/office)
+"xPj" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"xPk" = (
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/weapon/flame/candle,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"xPl" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"xPm" = (
+/obj/structure/sign/double/barsign,
+/turf/simulated/wall,
+/area/crew_quarters/bar)
+"xPn" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xPo" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
+"xPp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 2;
+	name = "Chapel Office";
+	sortType = "Chapel Office"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"xPq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"xPr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"xPs" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Chaplain Office's Maintenance";
+	req_one_access = list(22)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/chapel/office)
+"xPt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/chapel/office)
+"xPu" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/chapel/office)
+"xPv" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"xPw" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 6;
+	icon_state = "spline_plain"
+	},
+/obj/structure/flora/pottedplant/random,
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"xPx" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"xPy" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/machinery/computer/arcade/orion_trail,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xPz" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xPA" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Bar - Northeast"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xPB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xPC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
+"xPD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
+"xPE" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
+"xPF" = (
+/obj/machinery/door/airlock/freezer{
+	id_tag = "main_unit_3";
+	name = "Unit 3"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
+"xPG" = (
+/obj/structure/toilet{
+	icon_state = "toilet00";
+	dir = 8
+	},
+/obj/machinery/button/remote/airlock{
+	id = "main_unit_3";
+	name = "Door Bolt Control";
+	pixel_x = 5;
+	pixel_y = 25;
+	req_access = null;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
+"xPH" = (
+/turf/simulated/floor/tiled/ramp/bottom,
+/area/maintenance/bar)
+"xPI" = (
+/obj/machinery/disposal,
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor/wood,
+/area/chapel/office)
+"xPJ" = (
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/wood,
+/area/chapel/office)
+"xPK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/carpet,
+/area/chapel/main)
+"xPL" = (
+/obj/machinery/light,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"xPM" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"xPN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/chapel/main)
+"xPO" = (
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/ramp/bottom{
+	icon_state = "rampbot";
+	dir = 4
+	},
+/area/crew_quarters/bar)
+"xPP" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xPQ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xPR" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xPS" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xPT" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xPU" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"xPV" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xPW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xPX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xPY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xPZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
+"xQa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access = list(12,25,66)
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/bar)
+"xQb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xQc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/ramp/bottom{
+	icon_state = "rampbot";
+	dir = 8
+	},
+/area/maintenance/bar)
+"xQd" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/device/piano{
+	force_piano = 1;
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 9;
+	icon_state = "spline_plain"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"xQe" = (
+/obj/structure/bed/chair/wood{
+	icon_state = "wooden_chair";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQf" = (
+/obj/structure/bed/chair/wood{
+	icon_state = "wooden_chair";
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Bartender"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQg" = (
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQh" = (
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQi" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/tiled/ramp/bottom{
+	icon_state = "rampbot";
+	dir = 1
+	},
+/area/crew_quarters/bar)
+"xQj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xQk" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atm{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKX" = (
-/obj/machinery/camera/network/civilian_east{
-	c_tag = "Bar - Theater Supplies";
-	c_tag_order = 999;
-	dir = 4;
-	network = list("Service")
+"xQl" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
-"xKY" = (
+"xQm" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"xQn" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQo" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQp" = (
+/obj/structure/table/rack,
+/obj/random/arcade,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xQr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKZ" = (
+"xQs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -66028,21 +68588,64 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/lobby)
-"xLa" = (
+"xQt" = (
 /obj/effect/floor_decal/industrial/loading,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLb" = (
+"xQu" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/spline/plain{
+	dir = 10;
+	icon_state = "spline_plain"
+	},
+/obj/structure/flora/pottedplant/random{
+	pixel_x = 16;
+	pixel_y = 16
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"xQv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/spline/plain{
+	dir = 6;
+	icon_state = "spline_plain"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"xQw" = (
+/obj/structure/table/rack,
+/obj/random/arcade,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xQy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLc" = (
+"xQz" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLd" = (
+"xQA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -66059,25 +68662,104 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLe" = (
+"xQB" = (
+/obj/structure/table/rack,
+/obj/random/arcade,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xQD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLf" = (
+"xQE" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xQF" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLg" = (
+"xQG" = (
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/ramp/bottom{
+	icon_state = "rampbot";
+	dir = 4
+	},
+/area/crew_quarters/bar)
+"xQH" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQI" = (
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Bar -Theatre";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQJ" = (
+/obj/structure/table/rack,
+/obj/random/arcade,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xQL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLh" = (
+"xQM" = (
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xQO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -66100,14 +68782,29 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/lobby)
-"xLi" = (
+"xQP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xLj" = (
+"xQQ" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQR" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xQS" = (
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
+"xQT" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -66119,17 +68816,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLk" = (
+"xQU" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/bar)
+"xQV" = (
+/obj/structure/table/rack,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/crew_quarters/bar)
+"xQW" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLl" = (
+"xQX" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -66147,21 +68853,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLm" = (
+"xQY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLn" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 8
-	},
-/obj/structure/closet/walllocker/emerglocker/west,
-/turf/simulated/floor/wood,
+"xQZ" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
-"xLo" = (
+"xRa" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
+"xRb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -66184,13 +68892,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLp" = (
+"xRc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLq" = (
+"xRd" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
 	dir = 4;
@@ -66199,15 +68907,17 @@
 /obj/effect/large_stock_marker,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLr" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"xLs" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/research_port)
-"xLt" = (
+"xRe" = (
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
+"xRf" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/bar)
+"xRg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -66225,14 +68935,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLu" = (
+"xRh" = (
 /obj/effect/floor_decal/corner/brown/full{
 	icon_state = "corner_white_full";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLv" = (
+"xRi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66259,7 +68969,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLw" = (
+"xRj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -66277,18 +68987,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLx" = (
+"xRk" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/large_stock_marker,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLy" = (
+"xRl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access = list(12,25,66)
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/bar)
+"xRm" = (
 /turf/simulated/wall,
 /area/quartermaster/break_room)
-"xLz" = (
+"xRn" = (
 /turf/simulated/wall,
 /area/quartermaster/break_room)
-"xLA" = (
+"xRo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -66304,13 +69021,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xLB" = (
-/turf/simulated/wall,
-/area/quartermaster/mail_room)
-"xLC" = (
-/turf/simulated/wall,
-/area/quartermaster/mail_room)
-"xLD" = (
+"xRp" = (
 /obj/machinery/disposal{
 	name = "mailing disposal unit"
 	},
@@ -66319,7 +69030,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xLE" = (
+"xRq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -66329,21 +69040,41 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xLF" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
+"xRr" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = null;
+	req_one_access = list(12,66)
+	},
 /turf/simulated/floor/tiled,
 /area/maintenance/bar)
-"xLG" = (
+"xRs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLH" = (
+"xRt" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xRu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66361,7 +69092,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLI" = (
+"xRv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66378,7 +69109,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLJ" = (
+"xRw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66395,11 +69126,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLK" = (
+"xRx" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/ramp/bottom{
+	icon_state = "rampbot";
+	dir = 4
+	},
 /area/maintenance/bar)
-"xLL" = (
+"xRy" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -66407,14 +69141,14 @@
 /obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLM" = (
+"xRz" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xLN" = (
+"xRA" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Disposals Maintenance";
 	req_one_access = list(12,50)
@@ -66431,14 +69165,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"xLO" = (
+"xRB" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xLP" = (
+"xRC" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
 	dir = 2
@@ -66453,15 +69187,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLQ" = (
+"xRD" = (
 /obj/structure/disposalpipe/sortjunction/untagged,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLR" = (
+"xRE" = (
 /obj/structure/ladder/up,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLS" = (
+"xRF" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -66475,7 +69209,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/break_room)
-"xLT" = (
+"xRG" = (
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
@@ -66491,18 +69225,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xLU" = (
+"xRH" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLV" = (
+"xRI" = (
 /obj/structure/ladder,
 /turf/simulated/open,
 /area/maintenance/disposal)
-"xLW" = (
+"xRJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66516,7 +69250,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLX" = (
+"xRK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66532,14 +69266,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLY" = (
+"xRL" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLZ" = (
+"xRM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66554,26 +69288,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMa" = (
+"xRN" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMb" = (
+"xRO" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMc" = (
+"xRP" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMd" = (
+"xRQ" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
 	dir = 1
@@ -66581,15 +69315,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMe" = (
+"xRR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMf" = (
+"xRS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMg" = (
+"xRT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66601,14 +69335,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMh" = (
+"xRU" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
 	dir = 2
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMi" = (
+"xRV" = (
 /obj/structure/disposalpipe/up{
 	icon_state = "pipe-u";
 	dir = 8
@@ -66625,33 +69359,30 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMj" = (
+"xRW" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall,
 /area/maintenance/bar)
-"xMk" = (
+"xRX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMl" = (
+"xRY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/meter{
 	name = "Scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/machinery/meter{
-	name = "Air supply"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"xMn" = (
+"xRZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMo" = (
+"xSa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xSb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -66660,14 +69391,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMp" = (
+"xSc" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMq" = (
+"xSd" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -66679,7 +69410,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMr" = (
+"xSe" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -66687,25 +69418,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"xMt" = (
+"xSf" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66723,7 +69436,28 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMu" = (
+"xSg" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/ramp/bottom{
+	icon_state = "rampbot";
+	dir = 4
+	},
+/area/maintenance/bar)
+"xSh" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66741,7 +69475,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMv" = (
+"xSi" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66759,7 +69493,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMw" = (
+"xSj" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66777,20 +69511,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMx" = (
+"xSk" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMy" = (
+"xSl" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMz" = (
+"xSm" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -66802,23 +69536,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMA" = (
-/obj/structure/table/rack,
-/obj/random/loot,
-/obj/machinery/light/small/emergency,
+"xSn" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMB" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/structure/table/rack,
-/obj/random/loot,
+"xSo" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMC" = (
+"xSp" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xSq" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xSr" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xSs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -66829,7 +69567,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/quartermaster/break_room)
-"xMD" = (
+"xSt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/standard,
 /obj/item/weapon/packageWrap,
@@ -66842,19 +69580,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xME" = (
+"xSu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMF" = (
+"xSv" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMG" = (
+"xSw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -66865,11 +69603,11 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/quartermaster/mail_room)
-"xMH" = (
+"xSx" = (
 /obj/structure/sign/drop,
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xMI" = (
+"xSy" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -66882,7 +69620,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMJ" = (
+"xSz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -66894,7 +69632,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMK" = (
+"xSA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66904,7 +69642,7 @@
 /obj/effect/floor_decal/corner/brown/full,
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xML" = (
+"xSB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66918,7 +69656,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMM" = (
+"xSC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66931,20 +69669,16 @@
 /obj/structure/noticeboard{
 	pixel_y = -32
 	},
-/obj/machinery/camera/network/supply{
-	c_tag = "Cargo - Mail Room";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMN" = (
+"xSD" = (
 /obj/structure/disposalpipe/junction/yjunction,
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMO" = (
+"xSE" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -66958,18 +69692,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMP" = (
+"xSF" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMQ" = (
+"xSG" = (
 /obj/structure/closet/crate,
 /obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"xMR" = (
+"xSH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
 	name = "Mail Maintenance";
@@ -66978,7 +69712,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMS" = (
+"xSI" = (
 /obj/structure/disposaloutlet{
 	dir = 1;
 	name = "mail outlet";
@@ -66989,7 +69723,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/mail_room)
-"xMT" = (
+"xSJ" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
 	name = "Sorting Office";
@@ -66997,7 +69731,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMU" = (
+"xSK" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -67005,7 +69739,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMV" = (
+"xSL" = (
 /obj/structure/disposaloutlet{
 	dir = 1;
 	spread = 360;
@@ -67018,7 +69752,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMW" = (
+"xSM" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -67026,7 +69760,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMX" = (
+"xSN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -67046,7 +69780,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMY" = (
+"xSO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -67064,7 +69798,7 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMZ" = (
+"xSP" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -67074,25 +69808,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNa" = (
+"xSQ" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xNb" = (
+"xSR" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
 /area/maintenance/disposal)
-"xNc" = (
+"xSS" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xNd" = (
+"xST" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -67106,7 +69840,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNe" = (
+"xSU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -67124,7 +69858,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNf" = (
+"xSV" = (
 /obj/structure/disposalpipe/tagger/partial{
 	dir = 8;
 	icon_state = "pipe-tagger-partial";
@@ -67143,7 +69877,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNg" = (
+"xSW" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67161,7 +69895,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNh" = (
+"xSX" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67178,7 +69912,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNi" = (
+"xSY" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67192,7 +69926,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNj" = (
+"xSZ" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67209,7 +69943,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNk" = (
+"xTa" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67228,7 +69962,7 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNl" = (
+"xTb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -67248,7 +69982,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNm" = (
+"xTc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -67268,7 +70002,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNn" = (
+"xTd" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -67280,7 +70014,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xNo" = (
+"xTe" = (
 /obj/machinery/conveyor{
 	dir = 9;
 	icon_state = "conveyor0";
@@ -67289,10 +70023,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNp" = (
+"xTf" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNq" = (
+"xTg" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -67307,7 +70041,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xNr" = (
+"xTh" = (
 /obj/machinery/mineral/output,
 /obj/machinery/conveyor{
 	dir = 9;
@@ -67317,7 +70051,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNs" = (
+"xTi" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "mining_internal"
@@ -67325,13 +70059,13 @@
 /obj/machinery/mineral/output,
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNt" = (
+"xTj" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNu" = (
+"xTk" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNv" = (
+"xTl" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -67346,7 +70080,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xNw" = (
+"xTm" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
@@ -67357,7 +70091,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNx" = (
+"xTn" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/brown{
@@ -67370,19 +70104,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xNy" = (
+"xTo" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNz" = (
+"xTp" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNA" = (
+"xTq" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNB" = (
+"xTr" = (
 /obj/machinery/mineral/processing_unit_console{
 	pixel_y = 32
 	},
@@ -67396,7 +70130,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNC" = (
+"xTs" = (
 /obj/machinery/mineral/processing_unit_console{
 	pixel_y = 32
 	},
@@ -67410,12 +70144,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xND" = (
+"xTt" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNE" = (
+"xTu" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 9
@@ -67426,12 +70160,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNF" = (
+"xTv" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNG" = (
+"xTw" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 9
@@ -67442,12 +70176,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNH" = (
+"xTx" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNI" = (
+"xTy" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 9
@@ -67458,7 +70192,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNJ" = (
+"xTz" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
@@ -69956,7 +72690,7 @@ aaa
 aaa
 aaa
 aaa
-xKV
+aaa
 aaa
 aaa
 aaa
@@ -74294,8 +77028,8 @@ aab
 aab
 aab
 aab
-aaa
-aaa
+aab
+aab
 aaa
 aaa
 aaa
@@ -74551,10 +77285,10 @@ aab
 aab
 aab
 aab
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
+aab
 aaa
 aaa
 aaa
@@ -74809,12 +77543,12 @@ aab
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
+aab
+aab
+aab
 aaa
 aaa
 aaa
@@ -80426,7 +83160,7 @@ azD
 aAX
 aCQ
 amT
-amT
+aGE
 aCQ
 aKd
 aLO
@@ -80680,11 +83414,11 @@ auS
 awy
 auS
 azE
-akY
-xJf
+anf
+aCR
 aEE
-aEE
-akY
+aCR
+aCR
 akY
 akY
 akY
@@ -80937,10 +83671,10 @@ auT
 awz
 auT
 azF
-aCR
-aCR
+anf
+aCS
 aEF
-aCR
+aGF
 aCR
 aKe
 aLP
@@ -81194,7 +83928,7 @@ auU
 awA
 ayh
 azG
-aCR
+anf
 aCT
 aEG
 aGG
@@ -81451,10 +84185,10 @@ auV
 awB
 ayi
 azH
-aCR
+anf
 aCU
 aEH
-xJh
+aCU
 aCR
 aKg
 aLP
@@ -81708,7 +84442,7 @@ atq
 awC
 anb
 azI
-aCR
+anf
 aCV
 aEI
 aGH
@@ -81965,10 +84699,10 @@ auW
 awD
 ayj
 azJ
-aCR
-aCR
+anf
+aCW
 aEJ
-aCR
+aGI
 aCR
 aKi
 aKi
@@ -82225,8 +84959,8 @@ auX
 arQ
 aCX
 aEK
-xJi
-arQ
+aCX
+aIl
 aKj
 aLS
 aNI
@@ -82462,9 +85196,9 @@ aab
 aab
 aab
 aab
+aab
+aab
 aiK
-ajv
-ajv
 ajv
 ako
 aiK
@@ -82480,9 +85214,9 @@ awF
 ayl
 att
 aAY
-xJg
+att
 aEL
-xJj
+att
 aIm
 aKk
 aKk
@@ -82719,10 +85453,10 @@ aab
 aab
 aab
 aab
+aab
+aab
 aiK
 ajw
-xIA
-xIB
 akp
 ale
 alX
@@ -82741,7 +85475,7 @@ aCY
 aEM
 aGJ
 aIn
-xJk
+xID
 aLT
 aKi
 aKi
@@ -82976,12 +85710,12 @@ aab
 aab
 aab
 aab
+aab
+aab
 aiK
 ajv
 akq
-alY
-alY
-alY
+aiK
 alY
 alY
 alY
@@ -83233,16 +85967,16 @@ aab
 aab
 aab
 aab
+aab
+aab
 aiK
 ajv
 akq
-alY
-xID
-xIK
-xIS
-xIV
-ama
-anc
+aiK
+alZ
+alZ
+alZ
+apq
 aqD
 alY
 atu
@@ -83490,14 +86224,14 @@ aab
 aab
 aab
 aab
+aab
+aab
 aiK
 ajx
 akq
-alY
-xIE
-xIL
-xIT
-and
+aiK
+ama
+anc
 aod
 apr
 aqE
@@ -83747,16 +86481,16 @@ aab
 aab
 aab
 aab
+aab
+aab
 aiK
 ajv
 akq
-alY
-xIF
-xIM
+aiK
 amb
-xIW
+and
 aoe
-xJa
+and
 and
 arU
 atw
@@ -84004,16 +86738,16 @@ aaa
 aab
 aab
 aab
+aab
+aab
 aiK
 ajv
 akq
-alY
-xIG
-xIN
+aiK
 amc
 and
+aof
 and
-xJb
 aqF
 alY
 atx
@@ -84261,17 +86995,17 @@ aaa
 aab
 aab
 aab
+aab
+aab
 aiK
 ajv
 akq
-alY
-xIH
-xIO
+aiK
 amd
 ane
-ane
-xJc
 aog
+amd
+aqG
 alY
 aty
 ava
@@ -84518,17 +87252,17 @@ aaa
 aaa
 aab
 aab
+aab
+aab
 aiK
 ajv
 akq
-alY
-xII
-xIP
-amc
-xIX
-alZ
-alZ
-alZ
+aiK
+ame
+ane
+aog
+aps
+aqG
 alY
 atz
 avc
@@ -84775,11 +87509,11 @@ aaa
 aaa
 aab
 aab
+aab
+aab
 aiK
 aiK
 akr
-aiK
-aiK
 aiK
 aiK
 anf
@@ -85032,12 +87766,12 @@ aaa
 aaa
 aab
 aab
+aab
+aab
 aiK
 ajv
 akq
 ajv
-ajv
-xIQ
 aiK
 ang
 ang
@@ -85289,12 +88023,12 @@ aaa
 aaa
 aab
 aab
+aab
+aab
 aiK
 ajw
 akq
 ajv
-ajv
-xIR
 aiK
 ang
 ang
@@ -85546,11 +88280,11 @@ aab
 aab
 aab
 aab
+aab
+aab
 aiK
-xIy
+ajy
 akq
-ajv
-ajv
 ajv
 aiK
 ang
@@ -85803,11 +88537,11 @@ aab
 aab
 aab
 aab
+aab
+aab
 aiL
-xIz
+ajv
 aks
-xIC
-xIJ
 alf
 aiK
 ang
@@ -86060,9 +88794,9 @@ aab
 aab
 aab
 agC
-agC
-agC
-agC
+ahb
+ahV
+aiK
 aiK
 akt
 alg
@@ -86084,7 +88818,7 @@ aGT
 aIx
 aKn
 aDj
-xJl
+aDj
 aPv
 aRk
 aSA
@@ -87884,7 +90618,7 @@ aDi
 aKt
 aDi
 aNV
-aDj
+aDk
 aRp
 aSG
 aUs
@@ -87893,7 +90627,7 @@ aXc
 aBr
 aZI
 aPz
-xJo
+xIF
 aKl
 bdG
 bgm
@@ -88198,7 +90932,7 @@ aKl
 aKl
 aKl
 aKl
-aKl
+beT
 aKl
 bdF
 aKl
@@ -88400,7 +91134,7 @@ aDk
 aDk
 aPD
 aRr
-xJm
+aSF
 aUt
 aIB
 aXe
@@ -88442,10 +91176,10 @@ bIZ
 bIZ
 bIZ
 bIZ
-aKi
-aKi
-aKi
-aKi
+aKl
+baJ
+aKl
+baJ
 beR
 baJ
 baJ
@@ -88693,16 +91427,16 @@ bDW
 bHg
 bIr
 bJa
-bJT
-bKP
-bLz
-bMu
+xLi
+xLs
 bLD
-bNF
-bOi
-bOS
-bPs
-aKi
+bLD
+xMe
+aKl
+aKl
+aKl
+aKl
+aKl
 beR
 baJ
 bRF
@@ -88726,7 +91460,7 @@ baJ
 baJ
 baJ
 baJ
-xLs
+bpG
 aLT
 aKj
 baJ
@@ -88951,15 +91685,15 @@ bHh
 bEd
 bJa
 bJU
-bKQ
-bLA
 bLD
-bLD
-bNG
-bOj
-bOT
-bOj
-aKi
+xLE
+xLO
+bJa
+bJa
+bJa
+bJa
+bJa
+aKl
 bQw
 bQW
 bRG
@@ -89162,7 +91896,7 @@ awX
 ayE
 aAa
 aBu
-aDm
+aDn
 aFc
 aHc
 aDm
@@ -89208,15 +91942,15 @@ bHi
 bIs
 bJb
 bJV
+xLt
 bKR
-bLB
-bLD
-bLD
-bNF
-bOj
-bOj
-bOj
-aKi
+xLP
+xMf
+xMv
+bNI
+bNI
+bJa
+aKl
 beR
 aKl
 bdF
@@ -89249,7 +91983,7 @@ bRJ
 bRJ
 cda
 cdj
-xMQ
+xSG
 bRJ
 ciP
 ciY
@@ -89420,7 +92154,7 @@ ayE
 aAb
 aBv
 aDm
-aFl
+aFd
 aHd
 aDm
 aKy
@@ -89469,11 +92203,11 @@ bKS
 bLC
 bMv
 bMX
+xMw
+bNI
+bNI
 bJa
-bJa
-bJa
-bJa
-aKi
+aKl
 beR
 aKl
 aKl
@@ -89483,7 +92217,7 @@ aKl
 aKl
 aKl
 aKl
-aKl
+bQW
 aKl
 aKl
 aKl
@@ -89722,15 +92456,15 @@ bsf
 bIt
 bJd
 bJX
-bKR
+xLu
 bLD
-bLD
+xLQ
 bMY
-bLD
+xMx
 bOk
 bOU
-bPt
-baJ
+bJa
+aKl
 beR
 aKl
 bRH
@@ -89975,28 +92709,28 @@ bDf
 bvL
 bvL
 bvL
-bvL
-bvL
 bJa
-bJY
-bKT
+bJa
+bJa
+bJa
+bJa
 bLE
 bMw
-bMZ
-bNH
-bOl
 bJa
-bPu
-baJ
-bQx
-baJ
-baJ
-baJ
+bJa
+bJa
+bJa
+bJa
+aKl
+beR
+aKl
+aKl
+aKl
 baJ
 baJ
 baJ
 bUn
-xKT
+bSD
 baJ
 baJ
 baJ
@@ -90227,37 +92961,37 @@ byi
 byi
 byi
 byi
-bCo
 bDg
 bEh
 bFd
 bGd
 bHk
-bIu
-bIu
-bIu
-bIu
-bIu
-bIu
-bIu
-bIu
-bIu
 bJa
-bPu
-bPW
-beR
-bQX
-baJ
+bJT
+xKW
+bKP
+bLz
+bMu
+xLR
+bNF
+xMy
+xMW
+xNd
+bJa
+aKl
+bOh
+blz
+blz
 bRV
-bSE
-bTm
-baJ
-baJ
-baJ
-baJ
-bRJ
-bVS
-bSI
+blz
+blz
+blz
+blz
+blz
+blz
+xPp
+blz
+ccF
 bSI
 bSI
 bSI
@@ -90484,36 +93218,36 @@ byj
 bzr
 bzr
 bzr
-bzr
 bDh
 bEi
 bFe
 bGe
 bHl
-bIu
-bJe
+bJa
+bJV
+bLD
 bJZ
-bKU
-bLF
+bLA
+bLD
 bMx
-bNa
+bMX
 bNI
 bOm
-bIu
-bPv
+bNI
+bJa
+aKl
 baJ
-bOh
-bQY
-baJ
-bPU
-bSF
-bND
-bTL
-bUo
-bUJ
-bVi
-bRJ
-bVT
+aKl
+aKl
+xOe
+aKl
+aKl
+aKl
+aKl
+aKl
+aKl
+xPq
+aKl
 bWm
 bWm
 bWm
@@ -90740,37 +93474,37 @@ bxa
 byk
 bzs
 bAt
-bBp
 bCp
 bDi
 bEj
 bFf
 bGf
 bHm
-bIu
+bJa
+bJV
 bJf
-bKa
-bKV
-bKb
-bMy
-bKh
-bKh
-bKh
-bMz
-bPt
+bLD
+bLB
+bLD
+bMx
+bNF
+bNI
+bNI
+bNI
+bJa
+aKl
 baJ
-aKi
-bOg
-bRI
+aKl
+aKl
 bRW
-bSG
-bSH
-bTM
-bND
-bUK
-bVj
-bRJ
-bVT
+aKl
+aKl
+aKl
+aKl
+aKl
+aKl
+xPr
+aKl
 bWm
 bWF
 bWF
@@ -90997,37 +93731,37 @@ bxb
 byl
 bzt
 bAu
-bBq
 bCq
 bDj
 bEk
-ajM
+xKh
 bGg
 bHn
-bIu
+bJa
+xKI
 bJg
 bKb
-bJf
+xLv
 bLG
 bMz
-bNb
-bKh
-bOn
-bIu
-bIu
-bIu
-aKi
-bOg
+bJa
+bJa
+bJa
+bJa
+bJa
+beT
 baJ
-bPV
-bSH
-bTn
-bTN
-bUp
-bUL
-bVk
-bRJ
-bVT
+baJ
+baJ
+xOf
+baJ
+beT
+bMD
+bMD
+bMD
+bMD
+xPs
+bMD
 bWm
 bWF
 bWT
@@ -91254,37 +93988,37 @@ bxc
 byl
 bzr
 bzr
-bBr
-bCr
-bDk
 bzr
+bzr
+bzr
+xKi
 bFh
-bCo
 bHo
-bIu
-bJh
-bKb
-bJf
-bLH
-bIu
-bNc
-bNJ
-bOo
-bIu
-aaa
-aaa
-aKi
-bOg
-bRJ
-bRJ
-bRJ
-bRJ
-bRJ
-bRJ
-bRJ
-bRJ
-bRJ
-bVU
+bJa
+bJa
+bJa
+bJa
+bJa
+bJa
+bJa
+bJa
+bPJ
+bPJ
+bPJ
+bPJ
+bPJ
+bPJ
+bPJ
+bPJ
+xOg
+bPJ
+bPJ
+bMD
+bOW
+bPy
+bPY
+bRf
+bRc
 bWm
 bWG
 bWF
@@ -91308,10 +94042,10 @@ bZA
 cdA
 cdG
 cdP
-xNn
-xNq
-xNv
-xNx
+xTd
+xTg
+xTl
+xTn
 ceM
 cfb
 cfp
@@ -91470,7 +94204,7 @@ aos
 aqS
 asf
 atO
-xJe
+xIC
 axb
 aii
 afr
@@ -91511,37 +94245,37 @@ bxd
 bym
 bzu
 bAv
-bBs
-bCs
-bDl
 bEl
 bFi
-bGh
+bzr
+bzr
+bzr
+bzr
 bHp
-bIu
-bJi
-bKc
-bKW
-bLI
-bIu
-bIu
-bIu
-bIu
-bIu
-bIu
-bIu
-bIu
-bQZ
-bRK
+bPJ
+bPJ
+bPJ
+bPJ
+bPJ
+bPJ
+bPJ
+bPJ
+xMX
+bMi
+bFv
+bFv
+bFv
+bFv
+bFv
 bRX
-bSI
-bSI
-bSI
-bSI
-bSI
-bSI
-bSI
-bVV
+bMD
+bMD
+bMD
+bOX
+bPz
+bPZ
+xPt
+xPI
 bWm
 bWF
 bWU
@@ -91770,35 +94504,35 @@ bvN
 bvN
 bvN
 bvN
-bvN
-bvN
-bFj
-bFj
-bFj
-bFj
-bJj
-bKd
-bKX
-bLJ
 bIu
-bNd
 bIu
-bOp
-bOp
-bOp
-bOp
+bIu
+bIu
+bIu
+bPJ
+bFv
+bFv
+bFv
+bFv
+bFv
+bFv
+bFv
+bFv
+bFv
+bFv
+xNB
 bQy
-bRa
-bRL
+cwY
+bFv
 cok
-bRL
-bRL
-bRL
-bRL
-bRL
-bRL
-bRL
-bRL
+bMD
+bNh
+bOs
+bOY
+bPA
+bOY
+bQC
+xPJ
 bWm
 bWF
 bWF
@@ -92024,38 +94758,38 @@ bvN
 bxe
 byn
 bzv
-bAw
 bBt
-bCt
+xJQ
 bDm
+xJZ
 bEm
 bFk
 bGi
-bHq
-bFj
-bJk
-bKe
+bIu
+bPJ
+bFv
+bGG
 bKY
-bLK
-bMA
-bMA
-bMA
+cvx
+bFv
+cwX
+bKx
 bOq
-bOq
-bPw
-bOp
-bQz
-bdJ
-bRL
+cvH
+bFv
+cwD
+cwQ
+xNN
+bFv
 col
-coy
-aeD
-coW
-cpi
-cpr
-cpC
-cpN
-bVl
+bMD
+bNi
+bOt
+bOZ
+aht
+bQa
+bQD
+bOY
 bWm
 bWF
 bWF
@@ -92282,36 +95016,36 @@ bxf
 byo
 bzw
 bAx
-bBu
 bCu
 bDn
+xKa
 bEn
 bFl
 bGj
-bHr
-bIv
-bJl
+bIu
+bPJ
+bFv
 bKf
 bKZ
-bLL
-bMB
+cvw
+bFv
 bNe
-bNK
-bOr
-bOp
-bOp
-bPX
+afV
+bGA
+xNe
+bFv
+cwD
 bQz
-bdJ
-coj
+xNO
+bFv
 com
-coz
-coM
-coX
-cpj
+bMD
+bNj
+bOu
+bOY
 cqa
-cqa
-cqa
+xPi
+xPu
 cpY
 bWm
 bWm
@@ -92324,7 +95058,7 @@ bWm
 bWm
 bWm
 cae
-xLt
+xRg
 caN
 bWm
 cbt
@@ -92539,37 +95273,37 @@ bxg
 byp
 bzx
 bAy
-bBv
 bCv
 bDo
+xKb
 bEo
 bFm
 bGk
 bHs
 bIw
-bJm
-bKg
+bFv
+bFv
 bLa
-bLM
-bMA
-bMA
-bMA
-bOq
-bOq
-bPx
-bOp
-bQz
-bdJ
-bRL
-con
-coA
-agQ
+bFv
+bFv
+bNe
+afV
+bGA
+xNf
+bFv
+bFv
+bFv
+cxb
+bFv
+com
+bMD
+bMD
 coY
 cpk
 cpt
-cqa
-cqa
-cpZ
+coY
+cpk
+bMD
 bWm
 bWH
 bWV
@@ -92796,37 +95530,37 @@ bxh
 byq
 bzy
 bAz
-bBw
 bCw
 bDp
+xKc
 bEp
 bFn
 ahu
-bHt
+bIu
 bFj
-bJn
+bFv
 bKh
-bKh
+xLw
 bLN
-bIu
+xLS
 bNf
-bIu
+xMz
 bOp
-bOp
-bOp
-bOp
+xNg
+xNs
+xNC
 bQA
-bdJ
-bRL
+xNP
+xNZ
 coo
 coB
 coO
 coZ
-akF
+coZ
 cpu
-cqa
-cqa
-cqa
+xPj
+xPv
+xPK
 bWm
 bWI
 bWW
@@ -92839,7 +95573,7 @@ cii
 bZC
 caf
 caw
-xLy
+xRm
 ciA
 cbv
 cbN
@@ -93052,44 +95786,44 @@ bvN
 bxi
 byr
 bzz
-bAA
 bBx
 bCx
 bDq
+xKd
 bEq
 bFo
 bGm
-bHu
+bIu
 bFj
-bJo
-bKh
-bKh
+bFv
+xLj
+xLx
 bLO
-bIu
-bIu
-bIu
-bIu
-bIu
-bIu
-bIu
-bIu
+xLT
+xMg
+xMA
+xMY
+xNh
+bGy
+cxg
+bGy
 bRb
-bRL
-cop
-coC
+bFv
+bPJ
+coB
 coP
 cpa
 cpm
 cpv
-cpG
+cpm
 cpR
 cqb
 bWm
 bWX
 bXo
-xKY
-xLb
-xLe
+xQr
+xQy
+xQD
 bYJ
 bYJ
 bYJ
@@ -93311,41 +96045,41 @@ bys
 bzA
 bzA
 bzA
-bzA
 bDr
-bvN
+bIu
+xKj
 bFp
 bGn
-bHv
-bFj
-bJp
-bKi
-bLb
-bLP
 bIu
+bFj
+bFv
+bKi
+afS
+cvB
+bGy
 bNg
-btm
-baK
+cwX
+xMZ
 bOV
-baK
-baK
-btm
-bAi
-bRL
-ajN
-coF
+bGy
+cxg
+bGy
+cxe
+bFv
+bPJ
+coB
 coQ
-cpb
-cqh
-cqh
-cqh
-cqh
+xOF
+xOR
+xPa
+xPk
+xPw
 cqi
 bWm
 cql
 bXp
 cqs
-xLc
+xQz
 bYo
 cqs
 bXp
@@ -93353,7 +96087,7 @@ bXp
 bXt
 ciq
 cit
-xLz
+xRn
 ciC
 cbx
 cbx
@@ -93368,7 +96102,7 @@ cdY
 cjx
 cdQ
 cdQ
-xNz
+xTp
 cfv
 ceS
 ceS
@@ -93566,36 +96300,36 @@ bvN
 bxk
 aYx
 bcr
-aYx
 bcr
 aYx
 bDs
-bvN
-bFj
-bFj
-bFj
-bFj
 bIu
 bIu
 bIu
 bIu
 bIu
-bdJ
-aLT
-bMD
-bMD
-bMD
-bMD
-bQB
-bMD
-bRL
-ajO
-coF
+xKJ
+bFv
+xLk
+xLy
+xLF
+xLU
+bNg
+cwX
+cwX
+bOV
+bGy
+cwa
+bGy
+xNQ
+bFv
+bPJ
+coB
 coR
-bSO
+xOG
 agR
-bSO
-bSO
+agR
+agR
 cpT
 cqd
 bWm
@@ -93831,42 +96565,42 @@ bEr
 aZN
 bGo
 bHw
-baW
+xKK
 bJq
-baK
-baK
-baK
-bMC
-bCe
-xKQ
-bMD
-bOW
-bPy
-bPY
-bOY
-bRc
-bRL
-cos
-coF
-bSL
+bGy
+bGy
+bGy
+bGA
+xMh
+xMB
+afT
+bOV
+bGy
+cwa
+bGy
+cwI
+bFv
+bPJ
+coB
+coQ
 cpc
-bSL
-aet
-cpI
-bSQ
-cqe
+cpc
+cpc
+cpc
+cpc
+cqi
 bWm
 bWm
 cqp
-xKZ
+xQs
 bXP
 bXP
 bXP
-xLh
+xQO
 bWm
-xLk
+xQW
 cir
-xLu
+xRh
 cbe
 ciE
 cby
@@ -94088,29 +96822,29 @@ baW
 bFq
 baW
 bHx
-bIx
-cqY
-cqY
-cqY
-cqY
-cqY
-bMD
-bMD
-bMD
-bOX
-bPz
-bPZ
-bOY
+aYx
+xKX
+bGy
+bGy
+bGy
+bGA
+xMi
+xMC
+bGA
+xNi
+xNt
+xND
+xNK
 bRd
-bRL
-cot
-coG
-abE
-cpd
-cpo
-cpo
-cpo
-cpU
+bFv
+bPJ
+coB
+coQ
+cpc
+cpc
+cpc
+cpc
+cpc
 cqf
 bWm
 bXa
@@ -94141,7 +96875,7 @@ cej
 cez
 cfl
 cdQ
-xNB
+xTr
 cfL
 cfL
 cge
@@ -94345,55 +97079,55 @@ aYx
 aVI
 aYx
 bHy
-aYx
-bJr
+bIy
+xKY
 bKj
 bLc
 bLQ
-xKM
-bMD
-bNh
-bOs
-bOY
-bPA
-bOY
-bQC
-bRe
-bRL
-cou
-coH
-adu
-adz
-bSL
-afd
-afy
-bSQ
-cqg
+bGy
+bNg
+bGA
+bGy
+afR
+afW
+afU
+bGy
+bOJ
+bFv
+bPJ
+coB
+xOt
+cpc
+cpc
+cpc
+cpc
+cpc
+xPL
 bWm
 bWm
-xKW
-xLa
+xQk
+xQt
 bXR
 bYr
 bYL
 bYr
-xLj
-xLl
-xLo
-xLv
+xQT
+xQX
+xRb
+xRi
 cbf
 cbf
-xLS
+xRF
 cbS
 cbS
 cbS
-xMC
+xSs
 cbf
 cbf
-xMX
+xSN
 cdQ
 cjh
-xNr
+xTh
 cfk
 cfy
 cey
@@ -94601,56 +97335,56 @@ bzB
 bvP
 aZQ
 bGp
-bHz
-bIz
+bHy
+aYx
 bJs
-bKk
-bLd
-bLQ
-xKN
-bMD
-bNi
-bOt
-bOZ
-aht
-bQa
-bQD
-bRf
-bPH
-cox
-coK
-coT
-cpf
-bVt
-bVt
-bVt
-cpV
-cqh
+cwX
+bGA
+cvr
+bGy
+xMj
+cxj
+afP
+cwy
+cwL
+cwU
+afU
+cxm
+bFv
+bPJ
+coB
+coQ
+cpc
+cpc
+cpc
+cpc
+cpc
+cqi
 bWm
 cqo
 cqq
 bXt
 bXS
+xQE
+xQL
 bXp
-xLg
 bXp
-bXp
-xLm
-xLp
-xLw
-xLA
+xQY
+xRc
+xRj
+xRo
 cbg
 bQO
 cbT
 ccs
 ccN
-xMD
-xMK
-cbi
+xSt
+xSA
+cqY
 cdO
 cdQ
-xNo
-xNs
+xTe
+xTi
 cfk
 cfy
 cey
@@ -94860,62 +97594,62 @@ btH
 aYx
 bHA
 bIA
-bJr
-bKl
-bLe
-bLQ
-xKO
-bMD
-bNj
-bOu
-bPa
-bPC
-bQb
-bQb
+bJs
+cwX
+cwX
+cvB
+bGy
+bNg
+bNL
+bGy
+afW
+afR
+afW
+bGy
 bRg
-bPH
-cow
-coK
+bFv
+bPJ
+coB
 coU
-cqh
-cqh
-cqh
+xOH
+xOS
+xPb
 cpL
-cqh
-cqi
+xPx
+xPM
 bWm
 bXd
 cqq
 bXu
 bXT
-xLf
+xQF
 bYM
 bZb
 bWm
 cqL
-xLq
-xLx
-xLB
+xRd
+xRk
+cqY
 cbh
 cbz
 cbU
 cct
 cct
-xME
-xML
-cbi
-xMY
+xSu
+xSB
+cqY
+xSO
 ciW
-xNp
-xNt
+xTf
+xTj
 cdQ
 ciW
 cdQ
 cdQ
-xNC
-xNE
-xNG
-xNI
+xTs
+xTu
+xTw
+xTy
 cjy
 aQk
 aab
@@ -95115,36 +97849,36 @@ buK
 buK
 aZQ
 bGq
-bHB
-bIB
-cqY
-cqY
-cqY
-cqY
-cqY
-bMD
-bMD
-bMD
+bHy
+aYx
+xKZ
+xLl
+xLz
+xLG
+xLV
+xMk
+xMD
+xNa
 bPb
-bPD
-bQc
-bMD
-bMD
-bPH
+bPb
+bPb
+xNL
+bFv
+bFv
 cox
-coK
+coB
 coV
-cpX
-cpX
-cpX
-cpX
-cpX
-cqj
+xOI
+coB
+xPc
+coB
+coV
+xPN
 bWm
 bWm
 cqr
 bXv
-xLd
+xQA
 bYs
 cqr
 bXv
@@ -95152,27 +97886,27 @@ bWm
 bWm
 bWm
 bWm
-xLC
-cbi
+cqY
+cqY
 cbA
 cbU
-ccu
 cct
+ccP
 cct
-xMM
-cbi
+xSC
+cqY
 cdO
 cdQ
 cdQ
-xNu
-xNw
-xNy
-xNA
+xTk
+xTm
+xTo
+xTq
 ciW
-xND
-xNF
-xNH
-xNJ
+xTt
+xTv
+xTx
+xTz
 ckI
 aQk
 aab
@@ -95377,28 +98111,28 @@ aYx
 aVI
 bKm
 bLf
-bLS
-bME
 bNk
-bNM
-bOv
 bLU
-bPE
+xMl
+bRh
+bLU
+bLU
+bLU
 bLU
 bQE
 grR
 bRN
-bSk
+bLU
 bST
-bTy
 bLf
 bLU
 bLU
+gtX
 bLU
 bLU
 bLU
-bME
-xKU
+cqk
+bRN
 bRh
 bXw
 bXV
@@ -95409,18 +98143,18 @@ cqw
 cqz
 cqI
 cqN
-xLD
-cbi
-xLT
+xRp
+cqY
+xRG
 cbW
 cct
 cct
 cct
-xMN
-xMR
-xMZ
-xNd
-bSx
+xSD
+xSH
+xSP
+xST
+cdQ
 cdQ
 cdQ
 cdQ
@@ -95633,49 +98367,49 @@ bHD
 bGs
 bJt
 bKn
-bLg
+bTY
+bQd
+bQd
 bLT
-bLT
-bLT
-bNN
-bOw
-bLT
-bPF
+bRi
+bQd
+bQd
+bSU
 bQd
 bQd
 bRi
 bQd
+bSU
+bWd
+bTY
+xOJ
+bQd
 bSl
 bSU
 bQd
-bTY
-bQd
-bSU
-bQd
-bQd
-bQd
 bQd
 bWd
+bQd
 bRi
 bQd
 bXW
 bYu
 cib
-xLi
+xQP
 cqv
 cqA
-cqH
+cqA
 cqO
 cqV
-cbi
-cbi
+cqY
+cqY
 cbX
-xMo
-xMx
-xMF
-xMO
-cbi
-cbi
+xSb
+xSk
+xSv
+xSE
+cqY
+cqY
 cdO
 bSx
 avT
@@ -95895,45 +98629,45 @@ bLU
 bLU
 bLU
 bNO
-bOx
-bPc
-bPG
 bLU
 bLU
-bLU
-bLU
-xKS
 bSV
-gsL
+bLU
+bLU
+bLU
+bLU
+bSV
+xOn
 bLf
+xOK
 bUy
-bSV
+xPd
+xPl
+bOx
+bLU
+xPU
 bLU
 bLU
-bWe
 bLU
-gtX
-bLU
-bYO
 bLU
 bLU
 guu
 bLf
 bLU
-cqB
+bLU
 guP
 bYO
-xLE
-cbi
+xRq
+cqY
 cbB
 cbY
 ccv
 ccv
 ccv
 cbY
-xMS
-cbi
-xNe
+xSI
+cqY
+xSU
 bSx
 aab
 aab
@@ -96144,53 +98878,53 @@ buK
 aZQ
 bGr
 bHF
-aYC
-bJu
-bJu
-bJu
-bJu
-bJu
-bNl
-bJu
-bJu
-bJu
-bPI
+aYx
+xLa
+cpX
+cpX
+cpX
+cpX
+cpX
+cqj
+bRL
+bPH
+bPH
+bPH
 bQF
-bQF
-bQF
+xNR
 bRj
-bPI
-bPI
-bPI
-bPI
-bPI
+xOh
+xOo
+bUz
+bUz
 bUz
 bUz
 bUz
 bUz
 bVO
 gtY
-bUz
-bUz
+xQd
+xQl
+xQu
 bVO
 bVO
 bUz
 bUz
+xQU
+xQZ
 bUz
 bUz
-bUz
-bUz
-xLF
-cbi
+xRr
+cqY
 cbC
-cbi
+cqY
 ccw
 ccS
-xMG
-cbi
+xSw
+cqY
 cbC
-cbi
-xNf
+cqY
+xSV
 bSx
 aab
 aab
@@ -96400,54 +99134,54 @@ buK
 buK
 bFs
 aYx
-bHG
+bHB
 aYx
-bJu
+xLb
 bKo
-bLh
-bLV
-bMF
-bKq
-bJu
+cqh
+cqh
+cqh
+cqh
+bKo
+bRL
 bOy
-bOy
+xNu
 bPI
-gru
 bQG
 bRk
 grY
-bPI
+xOi
 bSW
-gsM
-gsT
-bPI
+bUz
 gtj
 gtq
-gty
+xPe
 bUz
+bUz
+xPO
 bWu
 bWg
-bUz
-bUz
-bWu
+xQm
+xQv
 bVP
+xQG
 bUz
-bZe
-guF
-cqR
-guQ
+bUz
+bUz
+bUz
+bUz
 bUz
 bPK
 cbF
-xLU
+xRH
 cbF
 ccx
 ccT
 cbF
 cbF
-xMT
+xSJ
 cbF
-xNg
+xSW
 bSx
 aab
 aab
@@ -96658,41 +99392,41 @@ bvP
 aZQ
 cuQ
 cve
-bIz
+aYx
 bJv
-bKp
+cqh
 bLi
-bLW
-bMG
+bSO
+bSO
 bLW
 bNP
-bOz
+bRL
 bPd
-bPI
+xNv
 bQe
-bQH
-bRl
-grZ
-bPI
+bPd
+bPd
+bPd
+xOj
 bSX
-bTA
-bTZ
-bPI
+bUz
 bUW
 bVx
 gtz
-bUz
+xPm
+xPy
+gtH
 gtQ
 gtZ
-guh
-bXy
+gtH
+gtH
 gtH
 gtH
 guv
 bZf
 guG
-guL
-guR
+guG
+guG
 bUz
 bPL
 cbE
@@ -96700,11 +99434,11 @@ cbE
 cbE
 cbE
 cbE
-xMH
+xSx
 cbE
 cbE
 cbE
-xNh
+xSX
 bSx
 aab
 aab
@@ -96892,7 +99626,7 @@ bcx
 bdT
 bfh
 aYx
-xJG
+xIV
 bjr
 bcx
 bdT
@@ -96914,54 +99648,54 @@ aYx
 aYx
 cuK
 aYx
-bHG
-bIC
-bJu
-bKq
+bHB
+bIy
+bJv
+xLm
 bLj
-bKq
-bKq
-bKq
-bJu
-bOA
+xLH
+bMH
+xMm
+xME
+bRL
 bPe
-bPI
+bPd
 bQf
 bQH
 bRm
-gsa
-bPI
+bQH
+xOk
 bSY
-gsN
-bTZ
-bPI
-bUC
-bVy
-gtA
 bUz
-gtL
+bTZ
+xOT
+bUC
+bUz
+gtA
+xPP
+xPV
 gua
-bYa
-bYa
-bYa
-bYa
-bZu
-bZf
+gua
+gua
+gua
+xQH
+bVa
+xQQ
 guH
-bZM
-guS
+guH
+guH
 bUz
 bPL
-xLM
-xLV
+xRz
+xRI
 ccc
 ccz
 ccV
 cdh
-xMP
+xSF
 cdC
-xNa
-xNi
+xSQ
+xSY
 bSx
 aab
 aab
@@ -97117,8 +99851,8 @@ aah
 aah
 abG
 aah
-xIU
-xIY
+xIy
+xIz
 abK
 aaV
 are
@@ -97166,59 +99900,59 @@ bxn
 bcy
 bcy
 bBz
-bcy
-bDt
+baW
+baW
 bEs
-bGs
-bGs
+xKq
+xKA
 bHI
 aYx
-bJu
-bKr
-bJu
+bJv
+cqh
+bLj
 bLX
-bJu
+bLX
 bNm
-bFv
-bFv
-bFv
-bPI
+xMF
+bRL
+xNj
+bPd
 bQg
 bQI
 bRn
 bRO
-bPI
+bPd
 bSZ
-bTB
-bUb
-bPI
+bUz
 bUz
 gtr
 bUz
 bUz
+xPz
+xPQ
 gtS
-bWh
-bWv
-bWK
-bWK
-gus
+xQe
+bWw
 bVa
-bWC
-bWC
-bZN
+bWw
+bWw
+bVa
+xQR
+guH
+guH
 cak
-gvc
-xLG
+bUz
+xRs
 cbE
 cbD
-xMd
-xMp
+xRQ
+xSc
 ccf
 ccf
 ccf
-xMU
+xSK
 cbE
-xNj
+xSZ
 bSx
 aab
 aaa
@@ -97400,82 +100134,82 @@ aHt
 aVW
 aXt
 aYF
-aZT
+aVI
 aYx
-bcz
+aYx
 aYx
 bfj
 aYx
-bcz
-xJQ
-bcz
 aYx
-bcz
+blU
 aYx
-bcz
-bcz
+aYx
+aYx
+aYx
+aYx
+xJy
 bcz
 xFF
-xKn
 buL
+bvR
 bxo
 byt
 bzC
 bAB
 bBA
+bCy
 aYx
 aXt
-bEt
 aYx
-aYx
-aYx
-aYx
-bJu
+blU
+xKG
+xKL
+bJv
+cqh
+bLj
 bKs
-bJu
-bKs
-bJu
-bNn
-bFv
-cwO
-cwX
-bPI
+xLW
+bNm
+cqg
+bRL
+xNk
+bPd
 bQh
-bQH
+xNM
 bRo
-bQh
-bPI
+xOa
+bPd
 bTa
-bPI
-bPI
-bPI
+xOu
+xOL
+bXE
 bUX
-bVz
-gtB
-gtK
+bUE
+bWj
 bVa
 bWh
-bWv
-bWL
 bWK
-gus
+bWK
+bVa
+bWK
+bWK
 bVa
 guB
 guI
+guI
+guI
 bUz
-bUz
-bUz
-caW
-xLN
-xLW
+xRt
+xRA
+xRJ
 ags
-xMq
+xSd
 ccf
 ccf
 ccf
-xMV
-xNb
-xNk
+xSL
+xSR
+xTa
 bSx
 aab
 aab
@@ -97675,64 +100409,64 @@ xFy
 xFG
 xFK
 bxs
+bvS
 buM
-xKw
 bxs
+bAC
 bAC
 bxs
 aVI
-aXq
 bEu
-cuL
-cwW
-cwW
+aVI
+bRL
+cou
 cxi
-bFv
-bFv
-bFv
-bFv
-bFv
-bFv
-bFv
-cwP
-cwY
-bPI
-bQi
-grx
+xLc
+xLn
+xLA
+bVt
+bVt
+xMn
+xMG
+bRL
+xNl
+bPd
+bPd
+bPd
 bRp
-gsb
-bSn
-bTb
+bPd
+bPd
+bTa
 bTD
 bUd
-bPI
+xOU
 bUY
-bVz
-bUE
+gtC
 bWj
 bVa
-gub
+bWh
+bWK
+bWK
 bVa
-bVa
-bVa
-bVa
+bWK
+bWK
 bVa
 bZw
-bVa
-xLn
-guT
 bUz
-xLH
+bUz
+bUz
+bUz
+xRu
 cbE
-xLX
-xMe
-xMr
+xRK
+xRR
+xSe
 ccf
 ccf
 ccf
-xMW
+xSM
 cbE
-xNl
+xTb
 bSx
 aab
 aab
@@ -97917,10 +100651,10 @@ aYH
 bfJ
 xDI
 xDO
+xIJ
 xDV
-xJw
 bfl
-xJH
+bgy
 bhX
 bjt
 bkx
@@ -97930,65 +100664,65 @@ bkx
 xFn
 xFz
 bfA
-xFL
+xJz
 bxs
-xKo
-xKx
+xJB
+bvW
 byu
 xGK
+xGK
 bxs
-bCz
 bDu
 bEt
 cuN
-cwX
+adu
 afA
 afB
 cvy
-bGy
+cvy
 cvN
 cvZ
-bGy
-bFv
-cwD
-cwQ
+cvy
+xMo
+xMH
+bRL
 cwZ
-bPI
-bQj
-bQH
-bQH
-bRP
-bSo
+bPd
+bPd
+bPd
+bPd
+bPd
+bPd
 bTc
-bTE
+bUz
 bUe
-bPI
-bUZ
 bXE
-gtC
+bUB
+gtD
 bWj
 bVa
 bWh
-bXB
-bXB
+xQf
+bXg
 bVa
-bXB
-bXB
-bZw
-bXB
+bXg
+bXg
 bVa
-cal
+guB
+guG
+guG
+guG
 bUz
-xLI
-xLO
-xLY
-xMf
+xRv
+xRB
+xRL
+xRS
 agr
-xMy
-xMI
+xSl
+xSy
 cdt
 cdD
-xNc
+xSS
 cdO
 bSx
 aab
@@ -98178,7 +100912,7 @@ bjV
 bjV
 bjV
 xEq
-xJR
+xJg
 xEx
 bky
 xES
@@ -98189,54 +100923,54 @@ xFA
 bsx
 xFM
 bxs
-xKp
-xKy
+xJC
+xJI
 bzD
-bjE
+xGL
+xJR
 bxs
-bCA
-aXt
+xKe
 bEt
-cuN
-aeG
-bGA
-cvr
-bKA
-bGy
-cwa
-cwa
-bGy
-bFv
-cwD
+xKr
+coT
+xKH
+xKM
+bSL
+bSL
+bSL
+xLI
+bSL
+xMp
+xMI
 cwR
 cxa
-bPI
-bQk
-bQH
-bQH
-bRQ
-bSp
-bTd
-bTF
-bQH
-bUF
-bUB
+bPd
+bQg
+bQI
+bRn
+bRO
+bPd
+bTa
+bUz
+xOM
 bXE
-gtD
+bUB
+bVQ
 bWj
 bVa
 bWh
-bWK
+bVa
+bVa
 bWL
 bVa
-bWK
-bWK
-bZw
-bWL
 bVa
+bVa
+guB
+guH
+guH
 bZO
 bUz
-xLJ
+xRw
 cbE
 cbE
 cbE
@@ -98433,8 +101167,8 @@ aZU
 xDQ
 xDW
 bfn
-xJz
 bgA
+xIW
 bfJ
 bju
 xEU
@@ -98446,12 +101180,12 @@ bre
 bsx
 xFN
 bxs
-xKq
-xKz
-bxs
+xJD
+xJJ
+byu
 bAE
+xJS
 bxs
-bCB
 bDv
 cuH
 bFx
@@ -98459,51 +101193,51 @@ afz
 cvh
 afO
 bKA
-bGy
-bGy
-bGy
+xLo
+xLB
+xLJ
 cwm
-bFv
-bFv
-bFv
-cxb
-bPI
-bPI
+bVt
+xMJ
+bJv
+xNm
+bPd
+bQh
 bRS
-bQH
+bRo
 bRQ
-cxC
-bQH
-cxC
-bQH
+bPd
+bTa
+xOv
+bUB
 gsZ
-bVb
-bXE
-bVQ
+bUB
+gtE
 bWj
 bVa
+bWh
 bWw
-bWK
-bWK
+bWw
 bVa
-bWK
-bWL
-bZw
-bXg
+bWw
+bWw
 bVa
-guU
+guB
+guH
+guH
+cak
 bUz
 caX
-xLP
-xLZ
-xMg
+xRC
+xRM
+xRT
 ccB
-xMz
-xMJ
+xSm
+xSz
 cdv
 cdv
 cdv
-xNm
+xTc
 bSx
 aab
 aab
@@ -98690,7 +101424,7 @@ bbc
 ajI
 xDX
 xIg
-xJA
+xIQ
 bgB
 bfJ
 bjv
@@ -98703,58 +101437,58 @@ bre
 bsx
 bbr
 bxs
-xKr
-xKA
+xJE
+xJK
 bxs
-bAG
 bxs
-akI
-cuG
+bxs
+bxs
+aUB
 cuI
 cuO
-cuV
-cvt
-cvt
-cvz
+bRL
+bRL
+bRL
+bRL
 cvE
-cvP
+cpX
+cpX
 cwn
-cwn
-cwv
+bSL
 cwE
 cwS
 cxc
-cxj
-bPI
-bRS
-bQH
-bRQ
-cxz
-cxF
+bPd
+xNE
+bPd
+xNS
+bPd
+bPd
+bTa
 bQl
-bQH
+bUB
 gta
-bVc
-bVd
-bUE
+bUB
+gtF
 bWj
 bVa
 bWh
-bXg
-bXg
+bWK
+bWK
 bVa
-bXg
-bXg
-bZw
+bWK
+bWK
 bVa
-bVa
-guV
+guB
+guI
+guI
+guI
 bUz
 gvo
-xLQ
-xMa
-xMh
-xMs
+xRD
+xRN
+xRU
+gvw
 bSv
 bSx
 bSx
@@ -98941,14 +101675,14 @@ aTj
 aPU
 aJs
 aLc
-aCj
+aYO
 bfJ
 bbd
 xDP
 bjV
 bfo
 bgC
-xJI
+xIX
 bfJ
 xEy
 xEK
@@ -98962,56 +101696,56 @@ xFO
 bxs
 bxq
 bvW
-xGS
+coh
 byv
 bxs
-akJ
+bxs
 bDx
 bEx
 cuP
 cuW
-bGy
-bGy
-bGA
-cvF
-cvT
-afP
-afU
-bGy
-cwI
-bGy
-cxe
-bGy
-bPI
+bRL
+xKN
+xLd
+cpb
+cqh
+xLK
+xLX
+bSO
+xMK
+xNb
+xNn
+xNw
+xNF
 cxo
-bQH
-nfj
-bQH
-bQH
-bQH
-bQH
-gtb
+xNT
+cxo
+xOl
+xOp
+xOw
 bUB
 bXE
-gtE
+bUB
+bUE
 bWj
 bVa
 bWh
+bWK
+bWK
 bVa
-bVa
-bVa
-bVa
+bWK
+bWK
 bVa
 bZw
-bVa
-bVa
-bZO
+bUz
+bUz
+bUz
 bUz
 bSv
-xLR
+xRE
 bQp
-xMi
-xMt
+xRV
+xSf
 bSv
 bSx
 aaa
@@ -99203,9 +101937,9 @@ bfJ
 bbe
 bcC
 xDW
-xJx
-xJB
+xIO
 bgD
+xIY
 bfJ
 bjw
 bcL
@@ -99215,60 +101949,60 @@ boU
 xEU
 brg
 bsB
-xFP
+xFO
 bxs
-xKs
+xJF
 xIx
-xKB
-xKD
-bxs
-bxs
-bxs
+xJM
+xJN
+bJr
+bJr
 bDy
-bFv
+xKk
+xKs
 cuX
-bGA
-bGA
-bGA
-bGA
+bJr
+xKO
+xLe
+xLp
 cvT
 cwq
-cwy
-bGy
-cwI
-bGy
-cxe
-bGy
-bPI
-cxp
-bQH
-bRQ
+xLY
+xMq
+xML
+xNc
+bPd
+xNx
+bPd
+bPd
+xNU
+bPd
 bSp
 bTd
-bTF
-bQH
-bPI
-gtk
-bVC
-gtF
-bWj
-chS
-bWO
-bXh
-bYS
-guq
-bXh
-bYS
-bZh
-bXB
-bVa
-guU
 bUz
-xLK
+xON
+bXE
+bUB
+bUE
+bWj
+bVa
+bWh
+bXg
+bXg
+bVa
+bXg
+bXg
+bVa
+guB
+guG
+guG
+guG
+bUz
+xRx
 bSx
 bSx
-xMj
-gvw
+xRW
+xSg
 bSx
 bSx
 aaa
@@ -99455,18 +102189,18 @@ aTj
 aPU
 axP
 aLc
-aCj
+aYO
 bfJ
 apV
 xDR
 xDZ
 xEf
-bgC
-xJJ
+xEr
+xIZ
 bfJ
 xEz
+bkA
 blY
-xKe
 xEW
 xFg
 xEU
@@ -99474,59 +102208,59 @@ bre
 bsx
 xFQ
 bxs
-xKt
+xJG
 bxt
 byz
-bvW
-bvW
-xKH
-bxs
+bjF
+bJr
+xJT
 bDz
-bFv
+xKl
+xKt
 cuY
-cvj
+bJr
 cvu
 cvA
-bKx
-cvT
-cwq
-cwq
-bGy
-cwI
-bGy
-cxg
-bGy
-bPI
+xLq
+xLC
+xLL
+xLZ
+xMr
+xMM
+bRL
+xNo
+xNy
+xNG
 cxq
-bQH
-bRQ
+xNV
+xOb
 cxC
-bQH
-cxC
+xOq
+xOx
 gsU
-bPI
+xOV
 gtl
-gtt
 gtG
 gtL
+chS
+xPW
+bYa
+bYa
+bYa
+bYa
+bZu
 bVa
-guc
-bXi
-bXi
-bXi
-bXi
-bXi
-bZw
-bWL
-bVa
-guV
+guB
+guH
+guH
+guH
 bUz
 bSv
 bSv
 cbG
-xMk
-xMu
-gul
+xRX
+xSh
+xSn
 bSx
 aaa
 aaa
@@ -99719,11 +102453,11 @@ bcD
 xEa
 xEg
 bgE
-xJK
+xJa
 bfJ
 bjx
-bcL
 bcN
+bcL
 bnG
 boV
 bqe
@@ -99731,59 +102465,59 @@ brh
 bsC
 btK
 bxs
-xKu
+xJH
 bxr
-xKC
-coi
-xKG
 bzH
-bxs
-cbl
-bFv
+coi
+bJr
+bCE
+bDz
+xKm
+xKu
 cuZ
-afP
-bGy
-cvB
+bJr
+xKP
+xLf
 cvG
-cvT
-afU
-afV
-bGy
-cwI
-bGy
-cxg
-cxk
+xLD
+xLM
+xMa
+xMs
+xMN
 bPI
-grz
-bQH
-bRQ
-cxz
+bPI
+bPI
+bPI
+bPI
+xNW
+bPI
+bPd
 cxF
-bQl
+bTD
 gsV
-bPI
-bUz
-gtu
-bUz
-gtM
-bWA
-gud
-bXG
-bXG
-bXG
-bXG
-guw
-bZj
-bXg
+xOW
+bUB
+gtB
+gtL
 bVa
-guY
+bWh
+bVa
+bVa
+bVa
+bVa
+bVa
+bVa
+guB
+guH
+guH
+cak
 bUz
-xLL
+xRy
 bSv
-xMb
-xMl
-xMv
-xMA
+xRO
+xRY
+xSi
+xSo
 bSx
 aaa
 aaa
@@ -99979,8 +102713,8 @@ bgF
 bfJ
 bfJ
 bjy
-bcL
-xKf
+bcN
+xJt
 bjy
 bah
 bah
@@ -99988,59 +102722,59 @@ bqf
 xFH
 bjy
 bxs
+buS
+bxs
+bxs
+bxs
+bJr
+xJU
+bDz
+xKn
 xKv
-bxs
-bxs
-bxs
-bxs
-bxs
-bxs
-xKI
-bFv
 cva
-bGy
-bGy
+bJr
+xKQ
 cvC
-cvH
+cpb
 cvU
 cww
 agq
-cww
-cxj
-bGA
-bGA
-bGA
+xMt
+xMO
 bPI
-grA
-bQH
-bRQ
-bQH
-bQH
-bQH
+bTB
+xNz
+xNH
+cxl
+xNX
+bPI
+bPd
+cxF
+bUz
 gsW
 bUg
-gtm
-gtv
-gtH
-bVa
-bWA
-bWP
-bWC
-bWC
-bWC
-bWC
-gux
-bZj
-bVa
-bVa
-guZ
+gsW
 bUz
-gul
+xPA
+xPR
+bWA
+bZV
+bZV
+bZV
+bZV
+bZV
+bZV
+bZj
+guI
+guI
+guI
+bUz
+bQQ
 bSv
 cbG
-xMm
-xMw
-xMB
+xRZ
+xSj
+xSp
 bSx
 aaa
 aaa
@@ -100234,70 +102968,70 @@ xEb
 bfr
 bgG
 bie
-xJS
+xJh
 xEA
 bmb
-xKg
 xEX
-xKj
+xFh
+bwd
 bqg
 bri
 bsD
 bee
 bfp
 xGg
+bfx
 xGE
-xGM
 bgg
-bxw
-bPJ
-bPJ
+bJr
+xJV
+xHo
 xHA
-bFv
-cvb
-cvl
-cvv
-cvD
-cvI
-cvV
-cwh
-bGy
-afR
-afW
-afU
-bGy
-cxl
+xKw
+cuY
+bJr
+bRL
+bRL
+bRL
+bRL
+bRL
+bRL
+bRL
+xMP
 bPI
-grB
+xNp
+cxl
+cxl
+cxl
 grS
-gsc
+bPI
 bSt
 akb
-bSt
+xOy
 gsX
-bSt
+xOX
 gtn
-gtw
+gtn
 bVR
-gtN
+gsX
 gtT
 gue
 bXk
-bWC
 bXk
-bYA
+bXk
+bXk
 guy
-bZw
-bZy
-bZV
-gva
+xQS
+guC
+guC
+guC
 bUz
 bSx
 bSx
-xMc
-xMn
+xRP
+xSa
 gvm
-gul
+xSq
 bSx
 aaa
 aaa
@@ -100483,7 +103217,7 @@ aTm
 aPU
 axP
 aLc
-aCj
+aYO
 bxw
 xDL
 bcF
@@ -100494,8 +103228,8 @@ bif
 xEB
 xEM
 bmc
-aWo
 bnI
+xFi
 xFi
 xFi
 chs
@@ -100505,56 +103239,56 @@ bwa
 xGl
 byB
 bzJ
-xKE
+xJO
 bBD
 bCF
-bCF
-xKJ
-bFv
-bFv
-cvm
-bFv
-bFv
+xHp
+bEA
+xKx
+xKB
+bJr
+xKR
+xLg
 cvJ
-afS
-cwj
-afP
-cwy
-cwL
-cwU
-afU
-bOJ
+guN
+bSv
+xMb
+bQp
+bPL
 bPI
+xNq
+xNA
+xNI
 grC
 cxw
-fii
+bPI
 jNC
-gsA
+bPd
 gsr
-bPI
-bPI
-bUz
-bUz
-bUz
-bUz
-bUz
-bUz
-bUz
-bXJ
-bUz
-bUz
-bUz
+xOO
+xOY
+xPf
+xPn
+xPB
+xPS
+xPX
+xQg
+xQn
+bVa
+bVa
+bVa
+xQM
 bZl
-bUz
-bUz
-bUz
+guC
+guC
+xRe
 bUz
 bSv
 bRz
 bSv
 bRx
 cbj
-gul
+xSr
 bSx
 aaa
 aab
@@ -100763,49 +103497,49 @@ xGm
 byC
 bfI
 bjC
-bxw
-bPJ
-bPJ
-bEA
-bFv
+bJr
+xJW
+xKf
+xKo
+xKy
 cvc
-cvn
+bJr
 bII
-bFv
-cvL
-afQ
-cwj
-bGy
-afW
-afR
-afW
-bGy
-cxm
-bPI
-bQQ
-cxx
-wQE
-bSu
-gsB
-gsP
-bPI
-bUH
-gto
-bSw
 bSv
-bUz
+bSv
+caE
+bSv
+xMc
+bSx
+bPL
+bPI
+xNr
+bPI
+bPI
+bPI
+bPI
+bPI
+bPI
+gsB
+bJu
+bJu
+bJu
+bJu
+bJu
+xPC
+bJu
 bWC
-bWC
-xKX
-bWC
-bWC
-bWC
+xQh
+xQo
+bVa
+bVa
+xQI
 guz
 guC
-guJ
-bSv
-bSv
-bSv
+guC
+xRa
+xRf
+xRl
 caE
 bQp
 bSv
@@ -101020,49 +103754,49 @@ bxx
 btY
 bxy
 bxy
-bxy
-bxy
-bxy
-bPO
-bFv
-cvd
-bHR
-cvw
-bFv
-cvL
-afT
-cwk
+bJr
+bJr
+bJr
+bJr
+xKz
+bJr
+bJr
+xKS
+bSv
+bSv
+bSv
+bSv
 cwu
-cwA
-bGA
-bGA
-bGA
-bOC
-bPI
-xKR
-grT
-jXF
-gss
-gsC
-gsQ
-bPI
+bSx
+bPL
+bSx
+bSv
+gul
+gul
+bQQ
+bSv
+bSv
+bSx
+bSv
+bJu
+xOP
 gtc
-bSv
-bSv
-bSw
+gtc
+gtc
+xPD
+bJu
+bWC
 bUz
-gtU
-guf
-bXm
+bUz
 bXL
-bYg
-bYC
+bXL
 bUz
-guD
 bUz
-guN
-xLr
-caE
+bUz
+bUz
+bUz
+bUz
+bUz
 bRz
 bSv
 cbH
@@ -101278,54 +104012,54 @@ xGF
 xGN
 bjG
 xGX
-xHe
-bxy
-grr
-bFv
-bGG
-cvo
-cvx
-bFv
-bFv
-bFv
-cwl
-bFv
-cwB
-cwW
-cwW
-cxi
-bFv
-bPI
-grD
-grU
-bPI
-bPI
-bPI
-bPI
-bPI
-bSv
-bSw
-bSw
-bSw
-bUz
-bUz
-bUz
-bUz
-bUz
-bUz
-bUz
-bUz
-guE
-bUz
+xJX
+xKg
 bSx
-bQp
-bSx
-bSx
-bSx
-bSx
-bQp
 cbj
-ccX
+bSv
+bSx
+xKT
+xLh
+xLr
+bSv
+bSv
+xMd
+bSx
+bPL
+bSx
+bSv
+bSv
+bSv
+bSv
+bSv
+bQQ
+bSx
+bSv
+bJu
+bKq
+xOZ
+bKq
+xPo
+xPE
+bJu
+xPY
+xQi
+bVa
+bVa
+bVa
+bVa
+bUz
+gul
+xQV
+bNq
+bSv
+caE
+bSv
+bSv
+bSv
+bSx
+ccD
+bZz
 bSx
 aaa
 aab
@@ -101511,7 +104245,7 @@ aik
 aPU
 awc
 aLc
-aCj
+aYQ
 bad
 bab
 xDT
@@ -101535,54 +104269,54 @@ xGG
 bxy
 byE
 bBF
+xJY
 xHe
-bxy
-bPO
-bFv
-bFv
-bFv
-bFv
-bFv
+bSx
+caW
+bSv
+bSx
+bSx
+bSx
 bKD
-xHQ
-xKL
-bML
-bML
-bML
-bML
-bML
-grs
 grv
-grE
+xLN
+grv
+grv
+xMQ
+bYh
+bYh
+bYh
+bYh
+bYh
 bPQ
+gul
 bSx
-bSw
-bTj
-bTj
+bSv
+bJu
 bUi
+bJu
+xPg
+bJu
+xPF
+bJu
+xPZ
+bUz
+xQp
+xQw
+xQB
+xQJ
+bUz
 bSv
-bTj
-bTj
+bSv
+bSv
+bSv
 bSv
 bSx
-bRA
-bYh
-bYh
-bYh
-bYh
-bYh
-gsY
-bZm
-grv
-grv
-grv
-grv
-grv
-grv
-grv
-grv
-gvn
-gvB
+bSx
+bSx
+bQp
+cbj
+ccX
 bSx
 aab
 aab
@@ -101794,52 +104528,52 @@ bxy
 bxy
 bxy
 bxy
-bEC
+bSx
 bFB
+grv
 bML
-bML
-bML
-bML
+xKU
+grv
 bib
-bil
+grv
 bim
-bMj
-xKP
-bMi
+bSx
+gvB
+guN
 bNq
 bNq
-bMj
+bSx
 bSx
 bSx
 bRy
-bSx
-gst
-bTj
-bTj
-bUh
-bSv
-bVg
-bVg
-bSv
-bSx
-bRy
-bWR
 gul
-guo
 bSx
+xOr
+bJu
+bUh
+bJu
+xPh
+bJu
+xPG
+bJu
+xQa
+bUz
+bUz
+bUz
+bUz
+bUz
+bUz
+bSv
+bSv
+bSv
+bSv
+bSv
+bSv
+bSv
+bSv
 bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
+cbj
+bSv
 bSx
 aab
 aab
@@ -102025,7 +104759,7 @@ aTr
 aPU
 axP
 aLc
-aCj
+aYO
 bad
 aao
 bzS
@@ -102042,18 +104776,18 @@ bqn
 bro
 bsH
 btR
-bry
-xFq
+bxy
+xJA
 xGq
-xGH
-bvi
-bvi
-bvi
+xJL
+bxy
+bxy
+bxy
 xHf
+bxy
 bvi
 bvi
-bvi
-bvi
+xKC
 aZW
 aZW
 aZW
@@ -102063,41 +104797,41 @@ bin
 biL
 biL
 biL
-bMj
-bMj
-bMj
+bSx
+bSx
+bSx
 aaa
 bSx
 bRy
 bSx
-bTj
-bTj
-bTj
-bUh
-bSw
-bVg
-bVg
+bSx
 bSv
-gtO
-bRy
+bJu
+bJu
+bJu
+bJu
+bJu
+bJu
+bJu
+xQb
+xQj
+xQq
+xQx
+xQC
+xQK
+xQN
+grv
+grv
+grv
+grv
+grv
+grv
+grv
+grv
+grv
+gvn
+gvB
 bSx
-bSx
-bSx
-bSx
-aaa
-aaa
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-aab
 aab
 aab
 aab
@@ -102299,7 +105033,7 @@ xFp
 brp
 bsI
 btP
-bvi
+bxy
 xGi
 bxz
 byF
@@ -102310,7 +105044,7 @@ bCH
 bgU
 bEE
 bFD
-bFD
+xKD
 bhf
 bIL
 xHJ
@@ -102326,35 +105060,35 @@ aaa
 aaa
 bSx
 bRy
-bSx
-bTj
-bTj
-bTj
-bUi
+xOc
 bSv
-bVg
-bVg
-bSw
-bSx
+bSv
+bSv
+bSv
+bSv
+bSv
+bSv
+xPH
+xPT
 bRy
+bWR
+gul
+guo
 bSx
-aaa
-aaa
-aaa
-aab
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-aab
-aab
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
 aab
 aab
 aab
@@ -102539,7 +105273,7 @@ aTs
 aPU
 axP
 aLc
-aCj
+aYO
 bad
 bad
 bad
@@ -102556,7 +105290,7 @@ xFq
 xGH
 bsJ
 btY
-bvi
+bxy
 bwh
 xGr
 bxA
@@ -102584,20 +105318,20 @@ aaa
 bSx
 bRy
 bSx
-bSw
-bTj
-gsR
-bUh
-bSw
-bTj
-bTj
-bSv
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
 bSx
 bRy
 bSx
-aaa
-aaa
-aaa
+bSx
+bSx
+bSx
 aab
 aab
 aab
@@ -102803,7 +105537,7 @@ alA
 apQ
 aLW
 aTA
-xJL
+xJb
 bbs
 aqb
 bml
@@ -102841,14 +105575,14 @@ aaa
 bSx
 bRy
 bSx
-bSx
-gsH
-bSx
-bSx
-bSx
-bSx
-bSx
-gsH
+bSw
+bTj
+xOz
+bSv
+bTj
+bTj
+bSv
+bSv
 bSx
 bRy
 bSx
@@ -103053,7 +105787,7 @@ aCa
 aPU
 aWd
 aLc
-aCj
+aYO
 xDG
 bbo
 any
@@ -103075,13 +105809,13 @@ bwj
 bfy
 byI
 bfL
-bzR
+bfL
 bgP
 bCK
 bDE
 xHB
-bxA
-bxA
+xHB
+xKE
 aZW
 aZW
 aZW
@@ -103096,18 +105830,18 @@ biL
 aaR
 aaa
 bSx
-grV
+bRy
 bSx
-gsw
+gst
+bTj
+xOA
 bSv
-bTI
-bUj
-bUk
-bUk
-bVD
-bSw
+bVg
+bVg
+bSv
+bSv
 bSx
-grV
+xQc
 bSx
 aab
 aab
@@ -103338,9 +106072,9 @@ bdV
 bDF
 bdV
 bxA
-bxA
-bxA
-bxA
+xKF
+xHB
+xKV
 aZW
 xHO
 aZW
@@ -103355,15 +106089,15 @@ aaa
 bSx
 bRy
 bSx
-gsx
+bTj
+bTj
+xOB
 bSw
-bSw
-bRz
+bVg
+bVg
 bSv
-bSw
-bSw
-bSw
-bSx
+bSv
+gtO
 bRy
 bSx
 aab
@@ -103567,7 +106301,7 @@ aTv
 aUE
 aWe
 aLc
-aCj
+aYO
 baf
 bbq
 anA
@@ -103575,12 +106309,12 @@ apU
 apU
 aUI
 aZV
-xJT
+xJi
 bbz
 bcS
 bem
 bfH
-xKk
+xJw
 brs
 bmf
 beh
@@ -103610,16 +106344,16 @@ bNX
 aaR
 aaa
 bSx
-bRy
-wXX
+grV
+bSx
+bTj
+bTj
+xOC
 bSv
+bVg
+bVg
+bSw
 bSv
-bTJ
-bUk
-bUI
-bVh
-bVE
-bUk
 bSx
 bRy
 bSx
@@ -103802,7 +106536,7 @@ aah
 aah
 abn
 abK
-xJd
+xIB
 aaV
 asL
 asL
@@ -103830,9 +106564,9 @@ auy
 alA
 aqH
 aPQ
-xJC
-xJM
-xJU
+xIR
+xJc
+xJj
 bbA
 bcT
 ben
@@ -103849,7 +106583,7 @@ bgx
 bdV
 xHa
 bCL
-bDG
+xGv
 bdV
 brd
 bGN
@@ -103869,14 +106603,14 @@ aab
 bSx
 bRy
 bSx
-bSy
-bTk
-bTK
-bSx
-bSx
-bSx
-bSx
-bSx
+bSw
+bTj
+xOD
+bSw
+bTj
+bTj
+bSv
+bSw
 bSx
 bRy
 bSx
@@ -104081,8 +106815,8 @@ axP
 axP
 aWg
 aLc
-aCj
-alB
+aYO
+axP
 alF
 anB
 apW
@@ -104106,7 +106840,7 @@ xGI
 bAT
 bBM
 xHg
-xHr
+xGI
 bEJ
 xGI
 xGI
@@ -104124,18 +106858,18 @@ bNZ
 aaR
 aab
 bSx
+xNY
+bSx
+bSx
+gsH
+bSx
+bSx
+bSx
+bSx
+bSx
+gsH
+bSx
 bRy
-bSx
-bSx
-bSx
-bSx
-bSx
-oox
-tmB
-eCI
-owR
-xDz
-gti
 bSx
 aab
 aab
@@ -104347,7 +107081,7 @@ ari
 aOH
 aZY
 bbw
-xJX
+xJm
 bcV
 ber
 bhd
@@ -104381,18 +107115,18 @@ chQ
 aaR
 aab
 bSx
-grW
-bYh
-bYh
-bYh
-bYh
-gsY
-gti
+bRy
+bSx
+gsw
 bSv
-bSv
-bSv
-bSv
-bSv
+bTI
+bUj
+bUk
+bUk
+bVD
+bSw
+bSx
+grV
 bSx
 aab
 aab
@@ -104572,7 +107306,7 @@ ajV
 adI
 ahB
 ahB
-xIZ
+xIA
 aad
 ars
 asL
@@ -104596,7 +107330,7 @@ aUF
 axP
 aXB
 aYV
-alB
+axP
 alF
 aoJ
 apW
@@ -104638,18 +107372,18 @@ biL
 aaR
 aab
 bSx
+bRy
 bSx
+gsx
+bSw
+bSw
+bRz
+bSv
+bSw
+bSw
+bSw
 bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
-bSx
+bRy
 bSx
 aab
 aab
@@ -104857,15 +107591,15 @@ alE
 amf
 aoK
 aoK
-xJy
-xJD
-xJN
-xJV
-xJY
-xKb
+xIP
+xIS
+xJd
+xJk
+xJn
+xJq
 bet
-xKh
-xKl
+xJu
+xJx
 brw
 bme
 xFV
@@ -104894,20 +107628,20 @@ biL
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+bSx
+bRy
+wXX
+bSv
+bSv
+bTJ
+bUk
+bUI
+bVh
+bVE
+bUk
+bSx
+bRy
+bSx
 aab
 aab
 aaa
@@ -105113,7 +107847,7 @@ aYX
 alE
 amz
 aoL
-xJs
+xIK
 aQo
 alE
 aaa
@@ -105151,20 +107885,20 @@ biL
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+bSx
+bRy
+bSx
+bSy
+bTk
+bTK
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bRy
+bSx
 aab
 aab
 aaa
@@ -105369,8 +108103,8 @@ cuE
 aYY
 alE
 amA
-xJp
-xJt
+xIG
+xIL
 aQp
 alE
 aaa
@@ -105403,25 +108137,25 @@ bok
 xHY
 bok
 bok
-bOc
+bok
 biL
-bPg
-bPR
-bQq
 aab
 aab
 aab
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-aab
+bSx
+bRy
+bSx
+bSx
+bSx
+bSx
+bSx
+bRA
+bYh
+bYh
+bYh
+bYh
+gti
+bSx
 aab
 aaa
 aaa
@@ -105660,25 +108394,25 @@ bok
 xHZ
 xIb
 xIc
-bOd
-bOR
-bPh
-bPS
-bQr
-aab
-acs
+xMR
+biL
 aab
 aab
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-aaa
+bSx
+grW
+xOd
+xOm
+xOs
+xOE
+xOQ
+gti
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
 aaa
 aaa
 aaa
@@ -105883,16 +108617,16 @@ cuE
 aYY
 alE
 amC
-xJq
+xIH
 aNb
 aRO
 alE
 alE
 alE
-xJZ
-xKc
+xJo
+xJr
 bfB
-xKi
+xJv
 biB
 bbi
 bcW
@@ -105917,25 +108651,25 @@ xHH
 bio
 biL
 biL
+xMS
 biL
-biL
-bPi
-bPR
-bQq
 aab
 aab
-aaa
+aab
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
+bSx
 aab
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
 aaa
 aaa
 aaa
@@ -106140,13 +108874,13 @@ cuE
 aYZ
 alE
 amD
-xJr
-xJu
+xII
+xIM
 aRS
 aXx
-xJO
+xJe
 alE
-xKa
+xJp
 bcZ
 bfC
 bir
@@ -106159,7 +108893,7 @@ bub
 bub
 bub
 bub
-xKF
+xJP
 chC
 bDK
 xHw
@@ -106173,9 +108907,9 @@ biL
 bKF
 biL
 biL
-aab
-aab
-aab
+blj
+xMT
+biL
 aab
 aab
 aab
@@ -106401,8 +109135,8 @@ aoO
 aOF
 aRT
 aXC
-xJP
-xJW
+xJf
+xJl
 bbC
 bda
 bfD
@@ -106430,9 +109164,9 @@ bJK
 bLs
 bMm
 biL
-aab
-aab
-aab
+blj
+xMU
+biL
 aab
 aab
 aab
@@ -106652,16 +109386,16 @@ cul
 cuu
 cuE
 aZa
-xJn
+xIE
 anv
 aoP
-xJv
+xIN
 anv
-xJE
+xIT
 baa
 alE
 bbD
-xKd
+xJs
 bfE
 bit
 biD
@@ -106687,12 +109421,12 @@ biL
 biL
 bMn
 biL
-aab
-aab
-aab
-aab
-aab
-aab
+bok
+xMV
+biL
+bPg
+bPR
+bQq
 aaa
 aaa
 aaa
@@ -106914,7 +109648,7 @@ anw
 apt
 aOG
 aTz
-xJF
+xIU
 aYg
 alE
 bcR
@@ -106944,12 +109678,12 @@ bKH
 bJL
 bMo
 biL
-aab
-aaa
-aab
-aaa
-aaa
-aaa
+xMu
+bOd
+bOR
+bPh
+bPS
+xNJ
 aaa
 aaa
 aaa
@@ -107201,12 +109935,12 @@ bJL
 bok
 bMo
 biL
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
+biL
+biL
+biL
+bPi
+bPR
+bQq
 aaa
 aaa
 aaa
@@ -107705,7 +110439,7 @@ bub
 ajL
 xHj
 xHx
-xKK
+xKp
 bEQ
 bEQ
 bIg
@@ -108720,7 +111454,7 @@ blf
 bmI
 xFe
 bpw
-xKm
+xFw
 bbu
 bmw
 buk

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -30778,6 +30778,7 @@
 	},
 /obj/item/bodybag/cryobag,
 /obj/structure/window/reinforced,
+/obj/item/weapon/storage/box/cdeathalarm_kit,
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
 "baH" = (

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -35341,27 +35341,31 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/central_one)
 "bhX" = (
-/obj/effect/floor_decal/corner/mauve/full,
-/obj/structure/table/standard,
-/obj/machinery/button/remote/blast_door{
-	id = "CHE3shutters";
-	name = "Desk Shutter Control";
-	pixel_x = 6;
-	pixel_y = 0;
-	req_access = list(33)
-	},
-/obj/machinery/button/remote/blast_door{
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/sign/chemistry,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
 	id = "CHE2shutters";
-	name = "Window Shutter Control";
-	pixel_x = -6;
-	pixel_y = 0;
-	req_access = list(33)
+	name = "Chemistry Window Shutters";
+	opacity = 0
 	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 2
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced,
+/turf/simulated/floor/plating,
 /area/medical/chemistry)
 "bhY" = (
 /obj/machinery/optable,
@@ -65263,6 +65267,29 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "xJH" = (
+/obj/effect/floor_decal/corner/mauve/full,
+/obj/structure/table/standard,
+/obj/machinery/button/remote/blast_door{
+	id = "CHE3shutters";
+	name = "Desk Shutter Control";
+	pixel_x = 6;
+	pixel_y = 0;
+	req_access = list(33)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "CHE2shutters";
+	name = "Window Shutter Control";
+	pixel_x = -6;
+	pixel_y = 0;
+	req_access = list(33)
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xJI" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
@@ -65273,7 +65300,7 @@
 /obj/item/device/destTagger,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"xJI" = (
+"xJJ" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 10
@@ -65287,7 +65314,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"xJJ" = (
+"xJK" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 4
@@ -65304,17 +65331,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"xJK" = (
-/turf/simulated/wall,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
 "xJL" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
 "xJM" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xJN" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/alarm{
 	dir = 4;
@@ -65327,7 +65354,7 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJN" = (
+"xJO" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/cable/green{
 	d1 = 2;
@@ -65339,7 +65366,7 @@
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJO" = (
+"xJP" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
@@ -65347,37 +65374,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"xJP" = (
-/turf/simulated/wall/r_wall,
-/area/medical/reception)
 "xJQ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/sign/chemistry,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "CHE2shutters";
-	name = "Chemistry Window Shutters";
-	opacity = 0
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/window/phoronreinforced,
-/turf/simulated/floor/plating,
-/area/medical/reception)
-"xJR" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -65402,29 +65399,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"xJS" = (
-/turf/simulated/wall/r_wall,
-/area/medical/reception)
-"xJT" = (
-/turf/simulated/wall/r_wall,
-/area/medical/reception)
-"xJU" = (
-/turf/simulated/wall/r_wall,
-/area/medical/reception)
-"xJV" = (
-/turf/simulated/wall/r_wall,
-/area/medical/reception)
-"xJW" = (
-/turf/simulated/wall/r_wall,
-/area/medical/reception)
-"xJX" = (
-/turf/simulated/wall/r_wall,
-/area/medical/reception)
-"xJY" = (
-/turf/simulated/wall/r_wall,
-/area/medical/reception)
-"xJZ" = (
+/area/medical/chemistry)
+"xJR" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Medication Closet";
@@ -65440,22 +65416,22 @@
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"xKa" = (
+"xJS" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKb" = (
+"xJT" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKc" = (
+"xJU" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKd" = (
+"xJV" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
@@ -65472,24 +65448,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xKe" = (
+"xJW" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKf" = (
+"xJX" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKg" = (
+"xJY" = (
 /turf/simulated/wall,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKh" = (
+"xJZ" = (
 /obj/structure/flora/pottedplant/random,
 /obj/effect/floor_decal/corner/lime/full{
 	icon_state = "corner_white_full";
@@ -65499,23 +65475,23 @@
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKi" = (
+"xKa" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKj" = (
+"xKb" = (
 /turf/simulated/wall,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKk" = (
+"xKc" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKl" = (
+"xKd" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -65526,7 +65502,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/reception)
-"xKm" = (
+"xKe" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
 	id_tag = null;
@@ -65542,7 +65518,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/reception)
-"xKn" = (
+"xKf" = (
 /obj/structure/disposalpipe/junction,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -65550,33 +65526,33 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"xKo" = (
+"xKg" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKp" = (
+"xKh" = (
 /turf/simulated/wall,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKq" = (
+"xKi" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"xKr" = (
+"xKj" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKs" = (
+"xKk" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKt" = (
+"xKl" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 5
@@ -65586,7 +65562,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
-"xKu" = (
+"xKm" = (
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 4
@@ -65600,133 +65576,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"xKv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/sign/greencross,
-/turf/simulated/floor/plating,
-/area/medical/emt)
-"xKw" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/structure/flora/pottedplant/random,
-/turf/simulated/floor/tiled/white,
-/area/medical/emt)
-"xKx" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 2;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/emt)
-"xKy" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/emt)
-"xKz" = (
-/obj/structure/flora/pottedplant/random,
-/turf/simulated/floor/tiled/white,
-/area/medical/emt)
-"xKA" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/emt)
-"xKB" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/emt)
-"xKC" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Lobby 2";
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 2;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/emt)
-"xKD" = (
-/obj/structure/flora/pottedplant/random,
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/emt)
-"xKE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "entrance_shutters";
-	name = "Entrance Lockdown Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/medical/emt)
-"xKF" = (
+"xKn" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/firstaid/adv,
 /obj/machinery/alarm{
@@ -65738,14 +65588,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKG" = (
+"xKo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKH" = (
+"xKp" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -65753,14 +65603,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKI" = (
+"xKq" = (
 /obj/structure/bed/chair/office/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKJ" = (
+"xKr" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/weapon/crowbar/red,
@@ -65773,7 +65623,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKK" = (
+"xKs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -65782,10 +65632,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"xKL" = (
+"xKt" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/substation/medical)
-"xKM" = (
+"xKu" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -65798,72 +65648,72 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"xKN" = (
+"xKv" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
-"xKO" = (
+"xKw" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
-"xKP" = (
+"xKx" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
-"xKQ" = (
+"xKy" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"xKR" = (
+"xKz" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"xKS" = (
+"xKA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"xKT" = (
+"xKB" = (
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Aft Corridor - Camera 2";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xKU" = (
+"xKC" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled,
 /area/maintenance/research_port)
-"xKV" = (
+"xKD" = (
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Aft Corridor - Camera 3";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xKW" = (
+"xKE" = (
 /obj/effect/landmark/dungeon_spawn,
 /turf/unsimulated/chasm_mask,
 /area/mine/unexplored)
-"xKX" = (
+"xKF" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atm{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKY" = (
+"xKG" = (
 /obj/machinery/camera/network/civilian_east{
 	c_tag = "Bar - Theater Supplies";
 	c_tag_order = 999;
@@ -65872,11 +65722,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
-"xKZ" = (
+"xKH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLa" = (
+"xKI" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -65901,21 +65751,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/lobby)
-"xLb" = (
+"xKJ" = (
 /obj/effect/floor_decal/industrial/loading,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLc" = (
+"xKK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLd" = (
+"xKL" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLe" = (
+"xKM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -65932,25 +65782,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLf" = (
+"xKN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLg" = (
+"xKO" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLh" = (
+"xKP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLi" = (
+"xKQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -65973,14 +65823,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/lobby)
-"xLj" = (
+"xKR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xLk" = (
+"xKS" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -65992,7 +65842,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLl" = (
+"xKT" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 6
@@ -66002,7 +65852,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLm" = (
+"xKU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -66020,13 +65870,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLn" = (
+"xKV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLo" = (
+"xKW" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 8
@@ -66034,7 +65884,7 @@
 /obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"xLp" = (
+"xKX" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -66057,13 +65907,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLq" = (
+"xKY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLr" = (
+"xKZ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
 	dir = 4;
@@ -66072,15 +65922,15 @@
 /obj/effect/large_stock_marker,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLs" = (
+"xLa" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLt" = (
+"xLb" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"xLu" = (
+"xLc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -66098,14 +65948,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLv" = (
+"xLd" = (
 /obj/effect/floor_decal/corner/brown/full{
 	icon_state = "corner_white_full";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLw" = (
+"xLe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66132,7 +65982,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLx" = (
+"xLf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -66150,18 +66000,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLy" = (
+"xLg" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/large_stock_marker,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLz" = (
+"xLh" = (
 /turf/simulated/wall,
 /area/quartermaster/break_room)
-"xLA" = (
+"xLi" = (
 /turf/simulated/wall,
 /area/quartermaster/break_room)
-"xLB" = (
+"xLj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -66177,13 +66027,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xLC" = (
+"xLk" = (
 /turf/simulated/wall,
 /area/quartermaster/mail_room)
-"xLD" = (
+"xLl" = (
 /turf/simulated/wall,
 /area/quartermaster/mail_room)
-"xLE" = (
+"xLm" = (
 /obj/machinery/disposal{
 	name = "mailing disposal unit"
 	},
@@ -66192,7 +66042,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xLF" = (
+"xLn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -66202,21 +66052,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xLG" = (
+"xLo" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/maintenance/bar)
-"xLH" = (
+"xLp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLI" = (
+"xLq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66234,7 +66084,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLJ" = (
+"xLr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66251,7 +66101,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLK" = (
+"xLs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66268,11 +66118,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLL" = (
+"xLt" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLM" = (
+"xLu" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -66280,14 +66130,14 @@
 /obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLN" = (
+"xLv" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xLO" = (
+"xLw" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Disposals Maintenance";
 	req_one_access = list(12,50)
@@ -66304,14 +66154,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"xLP" = (
+"xLx" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xLQ" = (
+"xLy" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
 	dir = 2
@@ -66326,15 +66176,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLR" = (
+"xLz" = (
 /obj/structure/disposalpipe/sortjunction/untagged,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLS" = (
+"xLA" = (
 /obj/structure/ladder/up,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLT" = (
+"xLB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -66348,7 +66198,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/break_room)
-"xLU" = (
+"xLC" = (
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
@@ -66364,18 +66214,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xLV" = (
+"xLD" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLW" = (
+"xLE" = (
 /obj/structure/ladder,
 /turf/simulated/open,
 /area/maintenance/disposal)
-"xLX" = (
+"xLF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66389,7 +66239,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLY" = (
+"xLG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66405,14 +66255,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLZ" = (
+"xLH" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMa" = (
+"xLI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66427,26 +66277,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMb" = (
+"xLJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMc" = (
+"xLK" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMd" = (
+"xLL" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMe" = (
+"xLM" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
 	dir = 1
@@ -66454,15 +66304,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMf" = (
+"xLN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMg" = (
+"xLO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMh" = (
+"xLP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66474,14 +66324,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMi" = (
+"xLQ" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
 	dir = 2
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMj" = (
+"xLR" = (
 /obj/structure/disposalpipe/up{
 	icon_state = "pipe-u";
 	dir = 8
@@ -66498,33 +66348,33 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMk" = (
+"xLS" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall,
 /area/maintenance/bar)
-"xMl" = (
+"xLT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMm" = (
+"xLU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/meter{
 	name = "Scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMn" = (
+"xLV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/meter{
 	name = "Air supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMo" = (
+"xLW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMp" = (
+"xLX" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -66533,14 +66383,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMq" = (
+"xLY" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMr" = (
+"xLZ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -66552,7 +66402,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMs" = (
+"xMa" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -66560,7 +66410,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMt" = (
+"xMb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66578,7 +66428,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMu" = (
+"xMc" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66596,7 +66446,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMv" = (
+"xMd" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66614,7 +66464,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMw" = (
+"xMe" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66632,7 +66482,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMx" = (
+"xMf" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66650,20 +66500,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMy" = (
+"xMg" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMz" = (
+"xMh" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMA" = (
+"xMi" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -66675,13 +66525,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMB" = (
+"xMj" = (
 /obj/structure/table/rack,
 /obj/random/loot,
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMC" = (
+"xMk" = (
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -66691,7 +66541,7 @@
 /obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMD" = (
+"xMl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -66702,7 +66552,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/quartermaster/break_room)
-"xME" = (
+"xMm" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/standard,
 /obj/item/weapon/packageWrap,
@@ -66715,19 +66565,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMF" = (
+"xMn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMG" = (
+"xMo" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMH" = (
+"xMp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -66738,11 +66588,11 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/quartermaster/mail_room)
-"xMI" = (
+"xMq" = (
 /obj/structure/sign/drop,
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xMJ" = (
+"xMr" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -66755,7 +66605,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMK" = (
+"xMs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -66767,7 +66617,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xML" = (
+"xMt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66777,7 +66627,7 @@
 /obj/effect/floor_decal/corner/brown/full,
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMM" = (
+"xMu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66791,7 +66641,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMN" = (
+"xMv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66810,14 +66660,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMO" = (
+"xMw" = (
 /obj/structure/disposalpipe/junction/yjunction,
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMP" = (
+"xMx" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -66831,18 +66681,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMQ" = (
+"xMy" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMR" = (
+"xMz" = (
 /obj/structure/closet/crate,
 /obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"xMS" = (
+"xMA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
 	name = "Mail Maintenance";
@@ -66851,7 +66701,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMT" = (
+"xMB" = (
 /obj/structure/disposaloutlet{
 	dir = 1;
 	name = "mail outlet";
@@ -66862,7 +66712,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/mail_room)
-"xMU" = (
+"xMC" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
 	name = "Sorting Office";
@@ -66870,7 +66720,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMV" = (
+"xMD" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -66878,7 +66728,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMW" = (
+"xME" = (
 /obj/structure/disposaloutlet{
 	dir = 1;
 	spread = 360;
@@ -66891,7 +66741,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMX" = (
+"xMF" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -66899,7 +66749,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMY" = (
+"xMG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -66919,7 +66769,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMZ" = (
+"xMH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66937,7 +66787,7 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNa" = (
+"xMI" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -66947,25 +66797,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNb" = (
+"xMJ" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xNc" = (
+"xMK" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
 /area/maintenance/disposal)
-"xNd" = (
+"xML" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xNe" = (
+"xMM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66979,7 +66829,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNf" = (
+"xMN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66997,7 +66847,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNg" = (
+"xMO" = (
 /obj/structure/disposalpipe/tagger/partial{
 	dir = 8;
 	icon_state = "pipe-tagger-partial";
@@ -67016,7 +66866,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNh" = (
+"xMP" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67034,7 +66884,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNi" = (
+"xMQ" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67051,7 +66901,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNj" = (
+"xMR" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67065,7 +66915,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNk" = (
+"xMS" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67082,7 +66932,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNl" = (
+"xMT" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67101,7 +66951,7 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNm" = (
+"xMU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -67121,7 +66971,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNn" = (
+"xMV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -67141,7 +66991,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xNo" = (
+"xMW" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -67153,7 +67003,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xNp" = (
+"xMX" = (
 /obj/machinery/conveyor{
 	dir = 9;
 	icon_state = "conveyor0";
@@ -67162,10 +67012,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNq" = (
+"xMY" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNr" = (
+"xMZ" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -67180,7 +67030,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xNs" = (
+"xNa" = (
 /obj/machinery/mineral/output,
 /obj/machinery/conveyor{
 	dir = 9;
@@ -67190,7 +67040,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNt" = (
+"xNb" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "mining_internal"
@@ -67198,13 +67048,13 @@
 /obj/machinery/mineral/output,
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNu" = (
+"xNc" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNv" = (
+"xNd" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNw" = (
+"xNe" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -67219,7 +67069,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xNx" = (
+"xNf" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
@@ -67230,7 +67080,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNy" = (
+"xNg" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/brown{
@@ -67243,19 +67093,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xNz" = (
+"xNh" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNA" = (
+"xNi" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNB" = (
+"xNj" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNC" = (
+"xNk" = (
 /obj/machinery/mineral/processing_unit_console{
 	pixel_y = 32
 	},
@@ -67269,7 +67119,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xND" = (
+"xNl" = (
 /obj/machinery/mineral/processing_unit_console{
 	pixel_y = 32
 	},
@@ -67283,12 +67133,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNE" = (
+"xNm" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNF" = (
+"xNn" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 9
@@ -67299,12 +67149,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNG" = (
+"xNo" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNH" = (
+"xNp" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 9
@@ -67315,12 +67165,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNI" = (
+"xNq" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNJ" = (
+"xNr" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 9
@@ -67331,7 +67181,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNK" = (
+"xNs" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
@@ -69829,7 +69679,7 @@ aaa
 aaa
 aaa
 aaa
-xKW
+xKE
 aaa
 aaa
 aaa
@@ -88599,7 +88449,7 @@ baJ
 baJ
 baJ
 baJ
-xLt
+xLb
 aLT
 aKj
 baJ
@@ -89122,7 +88972,7 @@ bRJ
 bRJ
 cda
 cdj
-xMR
+xMz
 bRJ
 ciP
 ciY
@@ -89869,7 +89719,7 @@ baJ
 baJ
 baJ
 bUn
-xKU
+xKC
 baJ
 baJ
 baJ
@@ -91181,10 +91031,10 @@ bZA
 cdA
 cdG
 cdP
-xNo
-xNr
-xNw
-xNy
+xMW
+xMZ
+xNe
+xNg
 ceM
 cfb
 cfp
@@ -92197,7 +92047,7 @@ bWm
 bWm
 bWm
 cae
-xLu
+xLc
 caN
 bWm
 cbt
@@ -92712,7 +92562,7 @@ cii
 bZC
 caf
 caw
-xLz
+xLh
 ciA
 cbv
 cbN
@@ -92960,9 +92810,9 @@ cqb
 bWm
 bWX
 bXo
-xKZ
-xLc
-xLf
+xKH
+xKK
+xKN
 bYJ
 bYJ
 bYJ
@@ -93218,7 +93068,7 @@ bWm
 cql
 bXp
 cqs
-xLd
+xKL
 bYo
 cqs
 bXp
@@ -93226,7 +93076,7 @@ bXp
 bXt
 ciq
 cit
-xLA
+xLi
 ciC
 cbx
 cbx
@@ -93241,7 +93091,7 @@ cdY
 cjx
 cdQ
 cdQ
-xNA
+xNi
 cfv
 ceS
 ceS
@@ -93711,7 +93561,7 @@ baK
 baK
 bMC
 bCe
-xKR
+xKz
 bMD
 bOW
 bPy
@@ -93731,15 +93581,15 @@ cqe
 bWm
 bWm
 cqp
-xLa
+xKI
 bXP
 bXP
 bXP
-xLi
+xKQ
 bWm
-xLl
+xKT
 cir
-xLv
+xLd
 cbe
 ciE
 cby
@@ -94014,7 +93864,7 @@ cej
 cez
 cfl
 cdQ
-xNC
+xNk
 cfL
 cfL
 cge
@@ -94223,7 +94073,7 @@ bJr
 bKj
 bLc
 bLQ
-xKN
+xKv
 bMD
 bNh
 bOs
@@ -94244,29 +94094,29 @@ bSQ
 cqg
 bWm
 bWm
-xKX
-xLb
+xKF
+xKJ
 bXR
 bYr
 bYL
 bYr
-xLk
-xLm
-xLp
-xLw
+xKS
+xKU
+xKX
+xLe
 cbf
 cbf
-xLT
+xLB
 cbS
 cbS
 cbS
-xMD
+xMl
 cbf
 cbf
-xMY
+xMG
 cdQ
 cjh
-xNs
+xNa
 cfk
 cfy
 cey
@@ -94480,7 +94330,7 @@ bJs
 bKk
 bLd
 bLQ
-xKO
+xKw
 bMD
 bNi
 bOt
@@ -94505,25 +94355,25 @@ cqq
 bXt
 bXS
 bXp
-xLh
+xKP
 bXp
 bXp
-xLn
-xLq
-xLx
-xLB
+xKV
+xKY
+xLf
+xLj
 cbg
 bQO
 cbT
 ccs
 ccN
-xME
-xML
+xMm
+xMt
 cbi
 cdO
 cdQ
-xNp
-xNt
+xMX
+xNb
 cfk
 cfy
 cey
@@ -94737,7 +94587,7 @@ bJr
 bKl
 bLe
 bLQ
-xKP
+xKx
 bMD
 bNj
 bOu
@@ -94761,34 +94611,34 @@ bXd
 cqq
 bXu
 bXT
-xLg
+xKO
 bYM
 bZb
 bWm
 cqL
-xLr
-xLy
-xLC
+xKZ
+xLg
+xLk
 cbh
 cbz
 cbU
 cct
 cct
-xMF
-xMM
+xMn
+xMu
 cbi
-xMZ
+xMH
 ciW
-xNq
-xNu
+xMY
+xNc
 cdQ
 ciW
 cdQ
 cdQ
-xND
-xNF
-xNH
-xNJ
+xNl
+xNn
+xNp
+xNr
 cjy
 aQk
 aab
@@ -95017,7 +94867,7 @@ bWm
 bWm
 cqr
 bXv
-xLe
+xKM
 bYs
 cqr
 bXv
@@ -95025,27 +94875,27 @@ bWm
 bWm
 bWm
 bWm
-xLD
+xLl
 cbi
 cbA
 cbU
 ccu
 cct
 cct
-xMN
+xMv
 cbi
 cdO
 cdQ
 cdQ
-xNv
-xNx
-xNz
-xNB
+xNd
+xNf
+xNh
+xNj
 ciW
-xNE
-xNG
-xNI
-xNK
+xNm
+xNo
+xNq
+xNs
 ckI
 aQk
 aab
@@ -95271,7 +95121,7 @@ bLU
 bLU
 bLU
 bME
-xKV
+xKD
 bRh
 bXw
 bXV
@@ -95282,17 +95132,17 @@ cqw
 cqz
 cqI
 cqN
-xLE
+xLm
 cbi
-xLU
+xLC
 cbW
 cct
 cct
 cct
-xMO
-xMS
-xNa
-xNe
+xMw
+xMA
+xMI
+xMM
 bSx
 cdQ
 cdQ
@@ -95534,7 +95384,7 @@ bQd
 bXW
 bYu
 cib
-xLj
+xKR
 cqv
 cqA
 cqH
@@ -95543,10 +95393,10 @@ cqV
 cbi
 cbi
 cbX
-xMp
-xMy
-xMG
-xMP
+xLX
+xMg
+xMo
+xMx
 cbi
 cbi
 cdO
@@ -95775,7 +95625,7 @@ bLU
 bLU
 bLU
 bLU
-xKT
+xKB
 bSV
 gsL
 bLf
@@ -95796,7 +95646,7 @@ bLU
 cqB
 guP
 bYO
-xLF
+xLn
 cbi
 cbB
 cbY
@@ -95804,9 +95654,9 @@ ccv
 ccv
 ccv
 cbY
-xMT
+xMB
 cbi
-xNf
+xMN
 bSx
 aab
 aab
@@ -96053,17 +95903,17 @@ bUz
 bUz
 bUz
 bUz
-xLG
+xLo
 cbi
 cbC
 cbi
 ccw
 ccS
-xMH
+xMp
 cbi
 cbC
 cbi
-xNg
+xMO
 bSx
 aab
 aab
@@ -96312,15 +96162,15 @@ guQ
 bUz
 bPK
 cbF
-xLV
+xLD
 cbF
 ccx
 ccT
 cbF
 cbF
-xMU
+xMC
 cbF
-xNh
+xMP
 bSx
 aab
 aab
@@ -96573,11 +96423,11 @@ cbE
 cbE
 cbE
 cbE
-xMI
+xMq
 cbE
 cbE
 cbE
-xNi
+xMQ
 bSx
 aab
 aab
@@ -96825,16 +96675,16 @@ bZM
 guS
 bUz
 bPL
-xLN
-xLW
+xLv
+xLE
 ccc
 ccz
 ccV
 cdh
-xMQ
+xMy
 cdC
-xNb
-xNj
+xMJ
+xMR
 bSx
 aab
 aab
@@ -97081,17 +96931,17 @@ bWC
 bZN
 cak
 gvc
-xLH
+xLp
 cbE
 cbD
-xMe
-xMq
+xLM
+xLY
 ccf
 ccf
 ccf
-xMV
+xMD
 cbE
-xNk
+xMS
 bSx
 aab
 aaa
@@ -97280,7 +97130,7 @@ aYx
 bfj
 aYx
 bcz
-xJO
+xJP
 bcz
 aYx
 bcz
@@ -97289,7 +97139,7 @@ bcz
 bcz
 bcz
 xFF
-xKu
+xKm
 buL
 bxo
 byt
@@ -97339,16 +97189,16 @@ bUz
 bUz
 bUz
 caW
-xLO
-xLX
+xLw
+xLF
 ags
-xMr
+xLZ
 ccf
 ccf
 ccf
-xMW
-xNc
-xNl
+xME
+xMK
+xMT
 bSx
 aab
 aab
@@ -97537,7 +97387,7 @@ bfJ
 bfJ
 xEe
 xEp
-xJP
+bfJ
 bah
 bkw
 xER
@@ -97546,7 +97396,7 @@ bkw
 xFm
 xFy
 xFG
-xKv
+xFK
 bxs
 bvS
 buM
@@ -97592,20 +97442,20 @@ bVa
 bVa
 bZw
 bVa
-xLo
+xKW
 guT
 bUz
-xLI
+xLq
 cbE
-xLY
-xMf
-xMs
+xLG
+xLN
+xMa
 ccf
 ccf
 ccf
-xMX
+xMF
 cbE
-xNm
+xMU
 bSx
 aab
 aab
@@ -97793,8 +97643,8 @@ xDO
 xDV
 xJw
 bfl
+xJH
 bhX
-xJQ
 bjt
 bkx
 bkx
@@ -97803,7 +97653,7 @@ bkx
 xFn
 xFz
 bfA
-xKw
+xFL
 bxs
 bvT
 bvW
@@ -97852,16 +97702,16 @@ bXB
 bVa
 cal
 bUz
-xLJ
-xLP
-xLZ
-xMg
+xLr
+xLx
+xLH
+xLO
 agr
-xMz
-xMJ
+xMh
+xMr
 cdt
 cdD
-xNd
+xML
 cdO
 bSx
 aab
@@ -98051,7 +97901,7 @@ bjV
 bjV
 bjV
 xEq
-xJR
+xJQ
 xEx
 bky
 xES
@@ -98060,7 +97910,7 @@ bnD
 bnD
 xFA
 bsx
-xKx
+xFM
 bxs
 biw
 bvW
@@ -98109,7 +97959,7 @@ bWL
 bVa
 bZO
 bUz
-xLK
+xLs
 cbE
 cbE
 cbE
@@ -98308,7 +98158,7 @@ xDW
 bfn
 xJz
 bgA
-xJS
+bfJ
 bju
 xEU
 xET
@@ -98317,7 +98167,7 @@ xEU
 xFo
 bre
 bsx
-xKy
+xFN
 bxs
 bvU
 bvW
@@ -98367,16 +98217,16 @@ bVa
 guU
 bUz
 caX
-xLQ
-xMa
-xMh
+xLy
+xLI
+xLP
 ccB
-xMA
-xMK
+xMi
+xMs
 cdv
 cdv
 cdv
-xNn
+xMV
 bSx
 aab
 aab
@@ -98565,7 +98415,7 @@ xDX
 xIg
 xJA
 bgB
-xJT
+bfJ
 bjv
 xEJ
 blV
@@ -98574,10 +98424,10 @@ boT
 xEU
 bre
 bsx
-xKz
+bbr
 bxs
-xKF
-xKG
+xKn
+xKo
 bxs
 bAG
 bxs
@@ -98624,10 +98474,10 @@ bVa
 guV
 bUz
 gvo
-xLR
+xLz
+xLJ
+xLQ
 xMb
-xMi
-xMt
 bSv
 bSx
 bSx
@@ -98821,8 +98671,8 @@ xDP
 bjV
 bfo
 bgC
-xJH
-xJU
+xJI
+bfJ
 xEy
 xEK
 blW
@@ -98831,7 +98681,7 @@ xFg
 xEU
 bre
 bsx
-xKA
+xFO
 bxs
 bxq
 xGD
@@ -98881,10 +98731,10 @@ bVa
 bZO
 bUz
 bSv
-xLS
+xLA
 bQp
-xMj
-xMu
+xLR
+xMc
 bSv
 bSx
 aaa
@@ -99079,7 +98929,7 @@ xDW
 xJx
 xJB
 bgD
-xJV
+bfJ
 bjw
 bcL
 blX
@@ -99088,10 +98938,10 @@ boU
 xEU
 brg
 bsB
-xKB
+xFP
 bxs
 xIx
-xKH
+xKp
 bvW
 byv
 bxs
@@ -99137,10 +98987,10 @@ bXB
 bVa
 guU
 bUz
-xLL
+xLt
 bSx
 bSx
-xMk
+xLS
 gvw
 bSx
 bSx
@@ -99335,21 +99185,21 @@ xDR
 xDZ
 xEf
 bgC
-xJI
-xJW
+xJJ
+bfJ
 xEz
 blY
-xKl
+xKd
 xEW
 xFg
 xEU
 bre
 bsx
-xKC
+xFQ
 bxs
 bvY
 bxt
-xKI
+xKq
 bjF
 bxs
 bPJ
@@ -99397,8 +99247,8 @@ bUz
 bSv
 bSv
 cbG
-xMl
-xMv
+xLT
+xMd
 gul
 bSx
 aaa
@@ -99592,8 +99442,8 @@ bcD
 xEa
 xEg
 bgE
-xJJ
-xJX
+xJK
+bfJ
 bjx
 bcL
 bcN
@@ -99602,11 +99452,11 @@ boV
 bqe
 brh
 bsC
-xKD
+btK
 bxs
 xGf
 bxr
-xKJ
+xKr
 bzH
 bxs
 bCE
@@ -99651,12 +99501,12 @@ bXg
 bVa
 guY
 bUz
-xLM
+xLu
 bSv
-xMc
-xMm
-xMw
-xMB
+xLK
+xLU
+xMe
+xMj
 bSx
 aaa
 aaa
@@ -99850,16 +99700,16 @@ bdW
 bqC
 bgF
 bfJ
-xJY
+bfJ
 bjy
 bcL
-xKm
+xKe
 bjy
 bah
 bah
 bqf
 xFH
-xKE
+bjy
 bxs
 buS
 bxs
@@ -99911,9 +99761,9 @@ bUz
 gul
 bSv
 cbG
-xMn
-xMx
-xMC
+xLV
+xMf
+xMk
 bSx
 aaa
 aaa
@@ -100107,12 +99957,12 @@ xEb
 bfr
 bgG
 bie
-xJZ
+xJR
 xEA
 bmb
-xKn
+xKf
 xEX
-xKq
+xKi
 bqg
 bri
 bsD
@@ -100167,8 +100017,8 @@ gva
 bUz
 bSx
 bSx
-xMd
-xMo
+xLL
+xLW
 gvm
 gul
 bSx
@@ -100378,7 +100228,7 @@ bwa
 xGl
 byB
 bzJ
-xKK
+xKs
 bBD
 bCF
 xHp
@@ -100669,7 +100519,7 @@ bSv
 bUz
 bWC
 bWC
-xKY
+xKG
 bWC
 bWC
 bWC
@@ -100912,7 +100762,7 @@ bGA
 bGA
 bOC
 bPI
-xKS
+xKA
 grT
 jXF
 gss
@@ -100934,7 +100784,7 @@ bUz
 guD
 bUz
 guN
-xLs
+xLa
 caE
 bRz
 bSv
@@ -101677,7 +101527,7 @@ bib
 bil
 bim
 bMj
-xKQ
+xKy
 bMi
 bNq
 bNq
@@ -103448,12 +103298,12 @@ apU
 apU
 aUI
 aZV
-xKa
+xJS
 bbz
 bcS
 bem
 bfH
-xKr
+xKj
 brs
 bmf
 beh
@@ -103704,8 +103554,8 @@ alA
 aqH
 aPQ
 xJC
-xJK
-xKb
+xJL
+xJT
 bbA
 bcT
 ben
@@ -104220,7 +104070,7 @@ ari
 aOH
 aZY
 bbw
-xKe
+xJW
 bcV
 ber
 bhd
@@ -104732,13 +104582,13 @@ aoK
 aoK
 xJy
 xJD
-xJL
-xKc
-xKf
-xKi
+xJM
+xJU
+xJX
+xKa
 bet
-xKo
-xKs
+xKg
+xKk
 brw
 bme
 xFV
@@ -105762,10 +105612,10 @@ aRO
 alE
 alE
 alE
-xKg
-xKj
+xJY
+xKb
 bfB
-xKp
+xKh
 biB
 bbi
 bcW
@@ -106017,9 +105867,9 @@ xJr
 xJu
 aRS
 aXx
-xJM
+xJN
 alE
-xKh
+xJZ
 bcZ
 bfC
 bir
@@ -106032,7 +105882,7 @@ bub
 bub
 bub
 bub
-xKL
+xKt
 chC
 bDK
 xHw
@@ -106274,8 +106124,8 @@ aoO
 aOF
 aRT
 aXC
-xJN
-xKd
+xJO
+xJV
 bbC
 bda
 bfD
@@ -106534,7 +106384,7 @@ xJE
 baa
 alE
 bbD
-xKk
+xKc
 bfE
 bit
 biD
@@ -107578,7 +107428,7 @@ bub
 ajL
 xHj
 xHx
-xKM
+xKu
 bEQ
 bEQ
 bIg
@@ -108593,7 +108443,7 @@ blf
 bmI
 xFe
 bpw
-xKt
+xKl
 bbu
 bmw
 buk

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -36374,20 +36374,12 @@
 /area/medical/emt)
 "bjF" = (
 /obj/structure/table/standard,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - EMT Quarters";
-	dir = 1;
-	icon_state = "camera"
-	},
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/radio{
-	pixel_x = -5
-	},
-/obj/item/device/gps{
-	gpstag = "MED1"
-	},
-/obj/item/device/gps{
-	gpstag = "MED0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
@@ -41044,7 +41036,21 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "buM" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
 /obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 8;
@@ -41053,11 +41059,11 @@
 	name = "MedBay Lockdown Shutters";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/glass_medical{
-	name = "EMT Quarters";
-	req_access = list(67)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/medical/emt)
 "buS" = (
 /obj/machinery/door/firedoor,
@@ -42344,14 +42350,29 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bxq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/sign/nosmoking_1{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "Stabilization Kit";
+	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/weapon/storage/pill_bottle/tramadol,
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "bxr" = (
@@ -43915,6 +43936,10 @@
 	icon_state = "rwindow";
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/medical/emt)
 "bAO" = (
@@ -45100,19 +45125,28 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bDx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Central Corridor - Camera 3";
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -45484,13 +45518,20 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bEx" = (
-/obj/machinery/camera/network/civilian_main{
-	c_tag = "Central Corridor - Camera 3";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -57780,22 +57821,18 @@
 /area/janitor)
 "coh" = (
 /obj/structure/bed/chair/office/light,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "coi" = (
 /obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/gps{
-	gpstag = "MED1"
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/item/device/radio{
-	pixel_x = -5
-	},
-/obj/item/device/gps{
-	gpstag = "MED0"
+/obj/item/weapon/storage/firstaid/o2,
+/obj/machinery/light{
+	dir = 4;
+	status = 2
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
@@ -64146,9 +64183,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "xGD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "Pill Cabinet";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/pill_bottle/tramadol,
+/obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/item/weapon/storage/pill_bottle/spaceacillin,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
@@ -64581,20 +64625,18 @@
 /area/maintenance/medbay)
 "xHA" = (
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/light/small/emergency,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
@@ -64758,17 +64800,7 @@
 /turf/simulated/wall,
 /area/medical/main_storage)
 "xIx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "xIy" = (
@@ -65333,9 +65365,23 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "xJL" = (
-/turf/simulated/wall,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "Medication Closet";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
+/obj/item/weapon/storage/pill_bottle/dermaline,
+/obj/item/weapon/storage/pill_bottle/tramadol,
+/obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
 	})
 "xJM" = (
 /turf/simulated/wall,
@@ -65343,6 +65389,11 @@
 	name = "\improper Medical - Exam Room 1"
 	})
 "xJN" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xJO" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/alarm{
 	dir = 4;
@@ -65355,7 +65406,7 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJO" = (
+"xJP" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/cable/green{
 	d1 = 2;
@@ -65367,7 +65418,7 @@
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJP" = (
+"xJQ" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
@@ -65375,7 +65426,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"xJQ" = (
+"xJR" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -65401,7 +65452,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"xJR" = (
+"xJS" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Medication Closet";
@@ -65417,11 +65468,6 @@
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"xJS" = (
-/turf/simulated/wall,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
 "xJT" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
@@ -65433,6 +65479,11 @@
 	name = "\improper Medical - Exam Room 1"
 	})
 "xJV" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xJW" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
@@ -65449,24 +65500,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
-"xJW" = (
+"xJX" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xJX" = (
+"xJY" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xJY" = (
+"xJZ" = (
 /turf/simulated/wall,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xJZ" = (
+"xKa" = (
 /obj/structure/flora/pottedplant/random,
 /obj/effect/floor_decal/corner/lime/full{
 	icon_state = "corner_white_full";
@@ -65476,23 +65527,23 @@
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKa" = (
+"xKb" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKb" = (
+"xKc" = (
 /turf/simulated/wall,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKc" = (
+"xKd" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKd" = (
+"xKe" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -65503,7 +65554,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/reception)
-"xKe" = (
+"xKf" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
 	id_tag = null;
@@ -65519,7 +65570,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/reception)
-"xKf" = (
+"xKg" = (
 /obj/structure/disposalpipe/junction,
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -65527,33 +65578,33 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"xKg" = (
+"xKh" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"xKh" = (
+"xKi" = (
 /turf/simulated/wall,
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"xKi" = (
+"xKj" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"xKj" = (
-/turf/simulated/wall,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
 "xKk" = (
 /turf/simulated/wall,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
 "xKl" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xKm" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 5
@@ -65563,7 +65614,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
-"xKm" = (
+"xKn" = (
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 4
@@ -65577,54 +65628,205 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"xKn" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/adv,
+"xKo" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKq" = (
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "Medication Closet";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
+/obj/item/weapon/storage/pill_bottle/dermaline,
+/obj/item/weapon/storage/pill_bottle/tramadol,
+/obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 6
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	is_critical = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKo" = (
+"xKs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_medical{
+	name = "EMT Quarters";
+	req_access = list(67)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKw" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/glass_medical{
+	name = "EMT Quarters";
+	req_access = list(67)
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKp" = (
-/obj/machinery/hologram/holopad,
+"xKx" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKq" = (
-/obj/structure/bed/chair/office/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+"xKz" = (
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKA" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKr" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/weapon/crowbar/red,
-/obj/machinery/light{
-	dir = 4;
-	status = 2
-	},
-/obj/machinery/vending/wallmed2{
-	pixel_x = 28
+"xKB" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"xKs" = (
+"xKC" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/crowbar/red,
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKD" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -65633,10 +65835,69 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"xKt" = (
+"xKF" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/substation/medical)
-"xKu" = (
+"xKG" = (
+/obj/structure/table/standard,
+/obj/machinery/vending/wallmed2{
+	pixel_x = 28
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/fire,
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKH" = (
+/obj/structure/table/standard,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - EMT Quarters";
+	dir = 1;
+	icon_state = "camera"
+	},
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/device/gps{
+	gpstag = "MED1"
+	},
+/obj/item/device/gps{
+	gpstag = "MED0"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"xKJ" = (
+/obj/machinery/light/small/emergency,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"xKK" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -65649,72 +65910,87 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"xKv" = (
+"xKL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"xKM" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
-"xKw" = (
+"xKN" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
-"xKx" = (
+"xKO" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
-"xKy" = (
+"xKP" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"xKz" = (
+"xKQ" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"xKA" = (
+"xKR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"xKB" = (
+"xKS" = (
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Aft Corridor - Camera 2";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xKC" = (
+"xKT" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled,
 /area/maintenance/research_port)
-"xKD" = (
+"xKU" = (
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Aft Corridor - Camera 3";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xKE" = (
+"xKV" = (
 /obj/effect/landmark/dungeon_spawn,
 /turf/unsimulated/chasm_mask,
 /area/mine/unexplored)
-"xKF" = (
+"xKW" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atm{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKG" = (
+"xKX" = (
 /obj/machinery/camera/network/civilian_east{
 	c_tag = "Bar - Theater Supplies";
 	c_tag_order = 999;
@@ -65723,11 +65999,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
-"xKH" = (
+"xKY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKI" = (
+"xKZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -65752,21 +66028,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/lobby)
-"xKJ" = (
+"xLa" = (
 /obj/effect/floor_decal/industrial/loading,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKK" = (
+"xLb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKL" = (
+"xLc" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKM" = (
+"xLd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -65783,25 +66059,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKN" = (
+"xLe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKO" = (
+"xLf" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKP" = (
+"xLg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKQ" = (
+"xLh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -65824,14 +66100,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/lobby)
-"xKR" = (
+"xLi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xKS" = (
+"xLj" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -65843,7 +66119,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKT" = (
+"xLk" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 6
@@ -65853,7 +66129,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKU" = (
+"xLl" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -65871,13 +66147,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKV" = (
+"xLm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKW" = (
+"xLn" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 8
@@ -65885,7 +66161,7 @@
 /obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"xKX" = (
+"xLo" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -65908,13 +66184,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKY" = (
+"xLp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xKZ" = (
+"xLq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
 	dir = 4;
@@ -65923,15 +66199,15 @@
 /obj/effect/large_stock_marker,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLa" = (
+"xLr" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLb" = (
+"xLs" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"xLc" = (
+"xLt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -65949,14 +66225,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLd" = (
+"xLu" = (
 /obj/effect/floor_decal/corner/brown/full{
 	icon_state = "corner_white_full";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLe" = (
+"xLv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -65983,7 +66259,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLf" = (
+"xLw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -66001,18 +66277,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLg" = (
+"xLx" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/large_stock_marker,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xLh" = (
+"xLy" = (
 /turf/simulated/wall,
 /area/quartermaster/break_room)
-"xLi" = (
+"xLz" = (
 /turf/simulated/wall,
 /area/quartermaster/break_room)
-"xLj" = (
+"xLA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -66028,13 +66304,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xLk" = (
+"xLB" = (
 /turf/simulated/wall,
 /area/quartermaster/mail_room)
-"xLl" = (
+"xLC" = (
 /turf/simulated/wall,
 /area/quartermaster/mail_room)
-"xLm" = (
+"xLD" = (
 /obj/machinery/disposal{
 	name = "mailing disposal unit"
 	},
@@ -66043,7 +66319,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xLn" = (
+"xLE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -66053,21 +66329,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
-"xLo" = (
+"xLF" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/maintenance/bar)
-"xLp" = (
+"xLG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLq" = (
+"xLH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66085,7 +66361,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLr" = (
+"xLI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66102,7 +66378,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLs" = (
+"xLJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66119,11 +66395,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLt" = (
+"xLK" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLu" = (
+"xLL" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -66131,14 +66407,14 @@
 /obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLv" = (
+"xLM" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xLw" = (
+"xLN" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Disposals Maintenance";
 	req_one_access = list(12,50)
@@ -66155,14 +66431,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"xLx" = (
+"xLO" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xLy" = (
+"xLP" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
 	dir = 2
@@ -66177,15 +66453,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLz" = (
+"xLQ" = (
 /obj/structure/disposalpipe/sortjunction/untagged,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLA" = (
+"xLR" = (
 /obj/structure/ladder/up,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLB" = (
+"xLS" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -66199,7 +66475,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/break_room)
-"xLC" = (
+"xLT" = (
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
@@ -66215,18 +66491,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xLD" = (
+"xLU" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLE" = (
+"xLV" = (
 /obj/structure/ladder,
 /turf/simulated/open,
 /area/maintenance/disposal)
-"xLF" = (
+"xLW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66240,7 +66516,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLG" = (
+"xLX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66256,14 +66532,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLH" = (
+"xLY" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLI" = (
+"xLZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66278,26 +66554,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLJ" = (
+"xMa" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLK" = (
+"xMb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLL" = (
+"xMc" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLM" = (
+"xMd" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
 	dir = 1
@@ -66305,15 +66581,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLN" = (
+"xMe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLO" = (
+"xMf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLP" = (
+"xMg" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66325,14 +66601,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLQ" = (
+"xMh" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
 	dir = 2
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLR" = (
+"xMi" = (
 /obj/structure/disposalpipe/up{
 	icon_state = "pipe-u";
 	dir = 8
@@ -66349,33 +66625,33 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLS" = (
+"xMj" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall,
 /area/maintenance/bar)
-"xLT" = (
+"xMk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLU" = (
+"xMl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/meter{
 	name = "Scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLV" = (
+"xMm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/meter{
 	name = "Air supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLW" = (
+"xMn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xLX" = (
+"xMo" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -66384,14 +66660,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xLY" = (
+"xMp" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xLZ" = (
+"xMq" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -66403,7 +66679,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMa" = (
+"xMr" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -66411,7 +66687,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMb" = (
+"xMs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66429,7 +66705,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMc" = (
+"xMt" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66447,7 +66723,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMd" = (
+"xMu" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66465,7 +66741,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMe" = (
+"xMv" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66483,7 +66759,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMf" = (
+"xMw" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66501,20 +66777,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMg" = (
+"xMx" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMh" = (
+"xMy" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMi" = (
+"xMz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -66526,13 +66802,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMj" = (
+"xMA" = (
 /obj/structure/table/rack,
 /obj/random/loot,
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMk" = (
+"xMB" = (
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -66542,7 +66818,7 @@
 /obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMl" = (
+"xMC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -66553,7 +66829,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/quartermaster/break_room)
-"xMm" = (
+"xMD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/standard,
 /obj/item/weapon/packageWrap,
@@ -66566,19 +66842,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMn" = (
+"xME" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMo" = (
+"xMF" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMp" = (
+"xMG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -66589,11 +66865,11 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/quartermaster/mail_room)
-"xMq" = (
+"xMH" = (
 /obj/structure/sign/drop,
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xMr" = (
+"xMI" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -66606,7 +66882,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMs" = (
+"xMJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -66618,7 +66894,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMt" = (
+"xMK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66628,7 +66904,7 @@
 /obj/effect/floor_decal/corner/brown/full,
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMu" = (
+"xML" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66642,7 +66918,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMv" = (
+"xMM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66661,14 +66937,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMw" = (
+"xMN" = (
 /obj/structure/disposalpipe/junction/yjunction,
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMx" = (
+"xMO" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -66682,18 +66958,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"xMy" = (
+"xMP" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMz" = (
+"xMQ" = (
 /obj/structure/closet/crate,
 /obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"xMA" = (
+"xMR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
 	name = "Mail Maintenance";
@@ -66702,7 +66978,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMB" = (
+"xMS" = (
 /obj/structure/disposaloutlet{
 	dir = 1;
 	name = "mail outlet";
@@ -66713,7 +66989,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/mail_room)
-"xMC" = (
+"xMT" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
 	name = "Sorting Office";
@@ -66721,7 +66997,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMD" = (
+"xMU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -66729,7 +67005,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xME" = (
+"xMV" = (
 /obj/structure/disposaloutlet{
 	dir = 1;
 	spread = 360;
@@ -66742,7 +67018,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMF" = (
+"xMW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -66750,7 +67026,7 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
-"xMG" = (
+"xMX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -66770,7 +67046,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMH" = (
+"xMY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66788,7 +67064,7 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMI" = (
+"xMZ" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -66798,25 +67074,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMJ" = (
+"xNa" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xMK" = (
+"xNb" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
 /area/maintenance/disposal)
-"xML" = (
+"xNc" = (
 /obj/structure/sign/securearea{
 	name = "\improper CAUTION: TRASH COMPACTOR";
 	pixel_x = 0
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
-"xMM" = (
+"xNd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -66830,7 +67106,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMN" = (
+"xNe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66848,7 +67124,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMO" = (
+"xNf" = (
 /obj/structure/disposalpipe/tagger/partial{
 	dir = 8;
 	icon_state = "pipe-tagger-partial";
@@ -66867,7 +67143,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMP" = (
+"xNg" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66885,7 +67161,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMQ" = (
+"xNh" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66902,7 +67178,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMR" = (
+"xNi" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66916,7 +67192,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMS" = (
+"xNj" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66933,7 +67209,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMT" = (
+"xNk" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66952,7 +67228,7 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMU" = (
+"xNl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66972,7 +67248,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMV" = (
+"xNm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -66992,7 +67268,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xMW" = (
+"xNn" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -67004,7 +67280,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xMX" = (
+"xNo" = (
 /obj/machinery/conveyor{
 	dir = 9;
 	icon_state = "conveyor0";
@@ -67013,10 +67289,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xMY" = (
+"xNp" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xMZ" = (
+"xNq" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -67031,7 +67307,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xNa" = (
+"xNr" = (
 /obj/machinery/mineral/output,
 /obj/machinery/conveyor{
 	dir = 9;
@@ -67041,7 +67317,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNb" = (
+"xNs" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "mining_internal"
@@ -67049,13 +67325,13 @@
 /obj/machinery/mineral/output,
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNc" = (
+"xNt" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNd" = (
+"xNu" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNe" = (
+"xNv" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -67070,7 +67346,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xNf" = (
+"xNw" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
@@ -67081,7 +67357,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNg" = (
+"xNx" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/brown{
@@ -67094,19 +67370,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"xNh" = (
+"xNy" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNi" = (
+"xNz" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNj" = (
+"xNA" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
-"xNk" = (
+"xNB" = (
 /obj/machinery/mineral/processing_unit_console{
 	pixel_y = 32
 	},
@@ -67120,7 +67396,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNl" = (
+"xNC" = (
 /obj/machinery/mineral/processing_unit_console{
 	pixel_y = 32
 	},
@@ -67134,12 +67410,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNm" = (
+"xND" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNn" = (
+"xNE" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 9
@@ -67150,12 +67426,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNo" = (
+"xNF" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNp" = (
+"xNG" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 9
@@ -67166,12 +67442,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNq" = (
+"xNH" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNr" = (
+"xNI" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 9
@@ -67182,7 +67458,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"xNs" = (
+"xNJ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled,
@@ -69680,7 +69956,7 @@ aaa
 aaa
 aaa
 aaa
-xKE
+xKV
 aaa
 aaa
 aaa
@@ -88450,7 +88726,7 @@ baJ
 baJ
 baJ
 baJ
-xLb
+xLs
 aLT
 aKj
 baJ
@@ -88973,7 +89249,7 @@ bRJ
 bRJ
 cda
 cdj
-xMz
+xMQ
 bRJ
 ciP
 ciY
@@ -89720,7 +89996,7 @@ baJ
 baJ
 baJ
 bUn
-xKC
+xKT
 baJ
 baJ
 baJ
@@ -91032,10 +91308,10 @@ bZA
 cdA
 cdG
 cdP
-xMW
-xMZ
-xNe
-xNg
+xNn
+xNq
+xNv
+xNx
 ceM
 cfb
 cfp
@@ -92048,7 +92324,7 @@ bWm
 bWm
 bWm
 cae
-xLc
+xLt
 caN
 bWm
 cbt
@@ -92563,7 +92839,7 @@ cii
 bZC
 caf
 caw
-xLh
+xLy
 ciA
 cbv
 cbN
@@ -92811,9 +93087,9 @@ cqb
 bWm
 bWX
 bXo
-xKH
-xKK
-xKN
+xKY
+xLb
+xLe
 bYJ
 bYJ
 bYJ
@@ -93069,7 +93345,7 @@ bWm
 cql
 bXp
 cqs
-xKL
+xLc
 bYo
 cqs
 bXp
@@ -93077,7 +93353,7 @@ bXp
 bXt
 ciq
 cit
-xLi
+xLz
 ciC
 cbx
 cbx
@@ -93092,7 +93368,7 @@ cdY
 cjx
 cdQ
 cdQ
-xNi
+xNz
 cfv
 ceS
 ceS
@@ -93562,7 +93838,7 @@ baK
 baK
 bMC
 bCe
-xKz
+xKQ
 bMD
 bOW
 bPy
@@ -93582,15 +93858,15 @@ cqe
 bWm
 bWm
 cqp
-xKI
+xKZ
 bXP
 bXP
 bXP
-xKQ
+xLh
 bWm
-xKT
+xLk
 cir
-xLd
+xLu
 cbe
 ciE
 cby
@@ -93865,7 +94141,7 @@ cej
 cez
 cfl
 cdQ
-xNk
+xNB
 cfL
 cfL
 cge
@@ -94074,7 +94350,7 @@ bJr
 bKj
 bLc
 bLQ
-xKv
+xKM
 bMD
 bNh
 bOs
@@ -94095,29 +94371,29 @@ bSQ
 cqg
 bWm
 bWm
-xKF
-xKJ
+xKW
+xLa
 bXR
 bYr
 bYL
 bYr
-xKS
-xKU
-xKX
-xLe
+xLj
+xLl
+xLo
+xLv
 cbf
 cbf
-xLB
+xLS
 cbS
 cbS
 cbS
-xMl
+xMC
 cbf
 cbf
-xMG
+xMX
 cdQ
 cjh
-xNa
+xNr
 cfk
 cfy
 cey
@@ -94331,7 +94607,7 @@ bJs
 bKk
 bLd
 bLQ
-xKw
+xKN
 bMD
 bNi
 bOt
@@ -94356,25 +94632,25 @@ cqq
 bXt
 bXS
 bXp
-xKP
+xLg
 bXp
 bXp
-xKV
-xKY
-xLf
-xLj
+xLm
+xLp
+xLw
+xLA
 cbg
 bQO
 cbT
 ccs
 ccN
-xMm
-xMt
+xMD
+xMK
 cbi
 cdO
 cdQ
-xMX
-xNb
+xNo
+xNs
 cfk
 cfy
 cey
@@ -94588,7 +94864,7 @@ bJr
 bKl
 bLe
 bLQ
-xKx
+xKO
 bMD
 bNj
 bOu
@@ -94612,34 +94888,34 @@ bXd
 cqq
 bXu
 bXT
-xKO
+xLf
 bYM
 bZb
 bWm
 cqL
-xKZ
-xLg
-xLk
+xLq
+xLx
+xLB
 cbh
 cbz
 cbU
 cct
 cct
-xMn
-xMu
+xME
+xML
 cbi
-xMH
-ciW
 xMY
-xNc
+ciW
+xNp
+xNt
 cdQ
 ciW
 cdQ
 cdQ
-xNl
-xNn
-xNp
-xNr
+xNC
+xNE
+xNG
+xNI
 cjy
 aQk
 aab
@@ -94868,7 +95144,7 @@ bWm
 bWm
 cqr
 bXv
-xKM
+xLd
 bYs
 cqr
 bXv
@@ -94876,27 +95152,27 @@ bWm
 bWm
 bWm
 bWm
-xLl
+xLC
 cbi
 cbA
 cbU
 ccu
 cct
 cct
-xMv
+xMM
 cbi
 cdO
 cdQ
 cdQ
-xNd
-xNf
-xNh
-xNj
+xNu
+xNw
+xNy
+xNA
 ciW
-xNm
-xNo
-xNq
-xNs
+xND
+xNF
+xNH
+xNJ
 ckI
 aQk
 aab
@@ -95122,7 +95398,7 @@ bLU
 bLU
 bLU
 bME
-xKD
+xKU
 bRh
 bXw
 bXV
@@ -95133,17 +95409,17 @@ cqw
 cqz
 cqI
 cqN
-xLm
+xLD
 cbi
-xLC
+xLT
 cbW
 cct
 cct
 cct
-xMw
-xMA
-xMI
-xMM
+xMN
+xMR
+xMZ
+xNd
 bSx
 cdQ
 cdQ
@@ -95385,7 +95661,7 @@ bQd
 bXW
 bYu
 cib
-xKR
+xLi
 cqv
 cqA
 cqH
@@ -95394,10 +95670,10 @@ cqV
 cbi
 cbi
 cbX
-xLX
-xMg
 xMo
 xMx
+xMF
+xMO
 cbi
 cbi
 cdO
@@ -95626,7 +95902,7 @@ bLU
 bLU
 bLU
 bLU
-xKB
+xKS
 bSV
 gsL
 bLf
@@ -95647,7 +95923,7 @@ bLU
 cqB
 guP
 bYO
-xLn
+xLE
 cbi
 cbB
 cbY
@@ -95655,9 +95931,9 @@ ccv
 ccv
 ccv
 cbY
-xMB
+xMS
 cbi
-xMN
+xNe
 bSx
 aab
 aab
@@ -95904,17 +96180,17 @@ bUz
 bUz
 bUz
 bUz
-xLo
+xLF
 cbi
 cbC
 cbi
 ccw
 ccS
-xMp
+xMG
 cbi
 cbC
 cbi
-xMO
+xNf
 bSx
 aab
 aab
@@ -96163,15 +96439,15 @@ guQ
 bUz
 bPK
 cbF
-xLD
+xLU
 cbF
 ccx
 ccT
 cbF
 cbF
-xMC
+xMT
 cbF
-xMP
+xNg
 bSx
 aab
 aab
@@ -96424,11 +96700,11 @@ cbE
 cbE
 cbE
 cbE
-xMq
+xMH
 cbE
 cbE
 cbE
-xMQ
+xNh
 bSx
 aab
 aab
@@ -96676,16 +96952,16 @@ bZM
 guS
 bUz
 bPL
-xLv
-xLE
+xLM
+xLV
 ccc
 ccz
 ccV
 cdh
-xMy
+xMP
 cdC
-xMJ
-xMR
+xNa
+xNi
 bSx
 aab
 aab
@@ -96932,17 +97208,17 @@ bWC
 bZN
 cak
 gvc
-xLp
+xLG
 cbE
 cbD
-xLM
-xLY
+xMd
+xMp
 ccf
 ccf
 ccf
-xMD
+xMU
 cbE
-xMS
+xNj
 bSx
 aab
 aaa
@@ -97131,7 +97407,7 @@ aYx
 bfj
 aYx
 bcz
-xJP
+xJQ
 bcz
 aYx
 bcz
@@ -97140,7 +97416,7 @@ bcz
 bcz
 bcz
 xFF
-xKm
+xKn
 buL
 bxo
 byt
@@ -97190,16 +97466,16 @@ bUz
 bUz
 bUz
 caW
-xLw
-xLF
+xLN
+xLW
 ags
-xLZ
+xMq
 ccf
 ccf
 ccf
-xME
-xMK
-xMT
+xMV
+xNb
+xNk
 bSx
 aab
 aab
@@ -97399,8 +97675,8 @@ xFy
 xFG
 xFK
 bxs
-bvS
 buM
+xKw
 bxs
 bAC
 bxs
@@ -97443,20 +97719,20 @@ bVa
 bVa
 bZw
 bVa
-xKW
+xLn
 guT
 bUz
-xLq
+xLH
 cbE
-xLG
-xLN
-xMa
+xLX
+xMe
+xMr
 ccf
 ccf
 ccf
-xMF
+xMW
 cbE
-xMU
+xNl
 bSx
 aab
 aab
@@ -97656,8 +97932,8 @@ xFz
 bfA
 xFL
 bxs
-bvT
-bvW
+xKo
+xKx
 byu
 xGK
 bxs
@@ -97703,16 +97979,16 @@ bXB
 bVa
 cal
 bUz
-xLr
-xLx
-xLH
+xLI
 xLO
+xLY
+xMf
 agr
-xMh
-xMr
+xMy
+xMI
 cdt
 cdD
-xML
+xNc
 cdO
 bSx
 aab
@@ -97902,7 +98178,7 @@ bjV
 bjV
 bjV
 xEq
-xJQ
+xJR
 xEx
 bky
 xES
@@ -97913,8 +98189,8 @@ xFA
 bsx
 xFM
 bxs
-biw
-bvW
+xKp
+xKy
 bzD
 bjE
 bxs
@@ -97960,7 +98236,7 @@ bWL
 bVa
 bZO
 bUz
-xLs
+xLJ
 cbE
 cbE
 cbE
@@ -98170,8 +98446,8 @@ bre
 bsx
 xFN
 bxs
-bvU
-bvW
+xKq
+xKz
 bxs
 bAE
 bxs
@@ -98218,16 +98494,16 @@ bVa
 guU
 bUz
 caX
-xLy
-xLI
 xLP
+xLZ
+xMg
 ccB
-xMi
-xMs
+xMz
+xMJ
 cdv
 cdv
 cdv
-xMV
+xNm
 bSx
 aab
 aab
@@ -98427,8 +98703,8 @@ bre
 bsx
 bbr
 bxs
-xKn
-xKo
+xKr
+xKA
 bxs
 bAG
 bxs
@@ -98475,10 +98751,10 @@ bVa
 guV
 bUz
 gvo
-xLz
-xLJ
 xLQ
-xMb
+xMa
+xMh
+xMs
 bSv
 bSx
 bSx
@@ -98685,9 +98961,9 @@ bsx
 xFO
 bxs
 bxq
-xGD
-coh
+bvW
 xGS
+byv
 bxs
 akJ
 bDx
@@ -98732,10 +99008,10 @@ bVa
 bZO
 bUz
 bSv
-xLA
-bQp
 xLR
-xMc
+bQp
+xMi
+xMt
 bSv
 bSx
 aaa
@@ -98941,14 +99217,14 @@ brg
 bsB
 xFP
 bxs
+xKs
 xIx
-xKp
-bvW
-byv
+xKB
+xKD
 bxs
-aUB
+bxs
+bxs
 bDy
-aUB
 bFv
 cuX
 bGA
@@ -98988,10 +99264,10 @@ bXB
 bVa
 guU
 bUz
-xLt
+xLK
 bSx
 bSx
-xLS
+xMj
 gvw
 bSx
 bSx
@@ -99190,7 +99466,7 @@ xJJ
 bfJ
 xEz
 blY
-xKd
+xKe
 xEW
 xFg
 xEU
@@ -99198,14 +99474,14 @@ bre
 bsx
 xFQ
 bxs
-bvY
+xKt
 bxt
-xKq
-bjF
+byz
+bvW
+bvW
+xKH
 bxs
-bPJ
 bDz
-bPJ
 bFv
 cuY
 cvj
@@ -99248,8 +99524,8 @@ bUz
 bSv
 bSv
 cbG
-xLT
-xMd
+xMk
+xMu
 gul
 bSx
 aaa
@@ -99455,14 +99731,14 @@ brh
 bsC
 btK
 bxs
-xGf
+xKu
 bxr
-xKr
+xKC
+coi
+xKG
 bzH
 bxs
-bCE
 cbl
-bPJ
 bFv
 cuZ
 afP
@@ -99502,12 +99778,12 @@ bXg
 bVa
 guY
 bUz
-xLu
+xLL
 bSv
-xLK
-xLU
-xMe
-xMj
+xMb
+xMl
+xMv
+xMA
 bSx
 aaa
 aaa
@@ -99704,7 +99980,7 @@ bfJ
 bfJ
 bjy
 bcL
-xKe
+xKf
 bjy
 bah
 bah
@@ -99712,14 +99988,14 @@ bqf
 xFH
 bjy
 bxs
-buS
+xKv
 bxs
 bxs
 bxs
 bxs
-bPJ
-cbl
-bPJ
+bxs
+bxs
+xKI
 bFv
 cva
 bGy
@@ -99762,9 +100038,9 @@ bUz
 gul
 bSv
 cbG
-xLV
-xMf
-xMk
+xMm
+xMw
+xMB
 bSx
 aaa
 aaa
@@ -99958,12 +100234,12 @@ xEb
 bfr
 bgG
 bie
-xJR
+xJS
 xEA
 bmb
-xKf
+xKg
 xEX
-xKi
+xKj
 bqg
 bri
 bsD
@@ -99975,7 +100251,7 @@ xGM
 bgg
 bxw
 bPJ
-xHo
+bPJ
 xHA
 bFv
 cvb
@@ -100018,8 +100294,8 @@ gva
 bUz
 bSx
 bSx
-xLL
-xLW
+xMc
+xMn
 gvm
 gul
 bSx
@@ -100229,11 +100505,11 @@ bwa
 xGl
 byB
 bzJ
-xKs
+xKE
 bBD
 bCF
-xHp
-bEA
+bCF
+xKJ
 bFv
 bFv
 cvm
@@ -100520,7 +100796,7 @@ bSv
 bUz
 bWC
 bWC
-xKG
+xKX
 bWC
 bWC
 bWC
@@ -100763,7 +101039,7 @@ bGA
 bGA
 bOC
 bPI
-xKA
+xKR
 grT
 jXF
 gss
@@ -100785,7 +101061,7 @@ bUz
 guD
 bUz
 guN
-xLa
+xLr
 caE
 bRz
 bSv
@@ -101269,7 +101545,7 @@ bFv
 bFv
 bKD
 xHQ
-bML
+xKL
 bML
 bML
 bML
@@ -101528,7 +101804,7 @@ bib
 bil
 bim
 bMj
-xKy
+xKP
 bMi
 bNq
 bNq
@@ -102527,7 +102803,7 @@ alA
 apQ
 aLW
 aTA
-apU
+xJL
 bbs
 aqb
 bml
@@ -103299,12 +103575,12 @@ apU
 apU
 aUI
 aZV
-xJS
+xJT
 bbz
 bcS
 bem
 bfH
-xKj
+xKk
 brs
 bmf
 beh
@@ -103555,8 +103831,8 @@ alA
 aqH
 aPQ
 xJC
-xJL
-xJT
+xJM
+xJU
 bbA
 bcT
 ben
@@ -104071,7 +104347,7 @@ ari
 aOH
 aZY
 bbw
-xJW
+xJX
 bcV
 ber
 bhd
@@ -104583,13 +104859,13 @@ aoK
 aoK
 xJy
 xJD
-xJM
-xJU
-xJX
-xKa
+xJN
+xJV
+xJY
+xKb
 bet
-xKg
-xKk
+xKh
+xKl
 brw
 bme
 xFV
@@ -105613,10 +105889,10 @@ aRO
 alE
 alE
 alE
-xJY
-xKb
+xJZ
+xKc
 bfB
-xKh
+xKi
 biB
 bbi
 bcW
@@ -105868,9 +106144,9 @@ xJr
 xJu
 aRS
 aXx
-xJN
+xJO
 alE
-xJZ
+xKa
 bcZ
 bfC
 bir
@@ -105883,7 +106159,7 @@ bub
 bub
 bub
 bub
-xKt
+xKF
 chC
 bDK
 xHw
@@ -106125,8 +106401,8 @@ aoO
 aOF
 aRT
 aXC
-xJO
-xJV
+xJP
+xJW
 bbC
 bda
 bfD
@@ -106385,7 +106661,7 @@ xJE
 baa
 alE
 bbD
-xKc
+xKd
 bfE
 bit
 biD
@@ -107429,7 +107705,7 @@ bub
 ajL
 xHj
 xHx
-xKu
+xKK
 bEQ
 bEQ
 bIg
@@ -108444,7 +108720,7 @@ blf
 bmI
 xFe
 bpw
-xKl
+xKm
 bbu
 bmw
 buk

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -62,10 +62,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "aal" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled,
-/area/assembly/robotics)
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "rich_command_outer";
+	locked = 1;
+	name = "Engineering External Access";
+	req_access = list(13)
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/security_starboard)
 "aam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warning{
@@ -87,31 +94,47 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "aao" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/floor_decal/corner/beige/full,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 10
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/body_scanconsole{
+	dir = 4;
+	icon_state = "body_scannerconsole"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/obj/machinery/vending/wallmed2{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/medical/icu)
 "aap" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "rich_command_outer";
-	locked = 1;
-	name = "Engineering External Access";
-	req_access = list(13)
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/bodyscanner{
+	dir = 8;
+	icon_state = "body_scanner_0"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/icu)
 "aaq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warning{
@@ -3106,9 +3129,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
 "agt" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled,
-/area/maintenance/research_port)
+/obj/machinery/light/small/emergency,
+/turf/simulated/open,
+/area/maintenance/disposal)
 "agu" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3381,6 +3404,22 @@
 "aha" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/drone_fabrication)
+"ahb" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "ahc" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -3862,6 +3901,19 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
+"ahV" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "ahW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	icon_state = "intact";
@@ -4629,6 +4681,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/atmos_control)
+"ajy" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/atmos_control)
 "ajz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance Access";
@@ -5083,6 +5143,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/atmos_control)
+"akp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/atmos_control)
 "akq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5302,13 +5376,27 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
 "akL" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light{
+	dir = 2;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
 "akM" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/medbay)
 "akN" = (
 /obj/structure/morgue{
 	icon_state = "morgue1";
@@ -5515,9 +5603,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/atmos_control)
 "ali" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/civ)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/loading{
+	icon_state = "loadingarea";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/icu)
 "alj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -5697,73 +5802,87 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "alA" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/turf/simulated/wall,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
 "alB" = (
-/obj/random/junk,
-/obj/structure/reagent_dispensers/extinguisher,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
 "alC" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/greencross,
 /turf/simulated/floor/plating,
-/area/maintenance/engineering)
+/area/hallway/primary/starboard)
 "alD" = (
 /turf/simulated/floor/tiled,
 /area/security/main)
 "alE" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/research_port)
+/turf/simulated/wall,
+/area/crew_quarters/medbreak)
 "alF" = (
-/obj/structure/table/wood,
-/obj/item/device/flashlight/lamp{
-	pixel_y = 10
+/turf/simulated/floor/tiled/ramp{
+	icon_state = "ramptop";
+	dir = 1
 	},
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/turf/simulated/floor/carpet,
-/area/chapel/office)
+/area/hallway/primary/starboard)
 "alG" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Cargo Bay";
-	req_access = null;
-	req_one_access = list(31,48)
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "Stabilization Kit";
+	pixel_x = -32;
+	pixel_y = 0
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/weapon/storage/pill_bottle/tramadol,
+/obj/effect/floor_decal/corner/pink{
+	icon_state = "corner_white";
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Intensive Care Unit";
+	dir = 4;
+	icon_state = "camera"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/icu)
 "alH" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/glass_mining{
-	name = "Break Room";
-	req_access = null;
-	req_one_access = list(31,48)
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/quartermaster/break_room)
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/primary/starboard)
 "alI" = (
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
@@ -5939,20 +6058,60 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/storage)
-"amf" = (
+"amb" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /obj/structure/cable/green{
+	icon_state = "1-4";
+	dir = 1;
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8
 	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"amc" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"amd" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"ame" = (
+/obj/machinery/shield_gen,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"amf" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_mining{
-	name = "Break Room";
-	req_access = null;
-	req_one_access = list(31,48)
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "medlounge"
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/break_room)
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "medlounge"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "medlounge"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/medbreak)
 "amg" = (
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -6143,88 +6302,62 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/security_starboard)
 "amz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/flora/pottedplant/random,
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass_mining{
-	name = "Mining";
-	req_access = null;
-	req_one_access = list(31,48)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/refinery)
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/medbreak)
 "amA" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Maintenance";
-	req_access = list(31,48)
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/cargo)
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/medbreak)
 "amB" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Disposals Maintenance";
-	req_one_access = list(12,50)
+/obj/machinery/vending/cigarette,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Staff Smoking Lounge"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/disposal)
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/medbreak)
 "amC" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/newscaster{
-	pixel_x = 0;
-	pixel_y = -32
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/camera/network/supply{
-	c_tag = "Cargo - Break Room";
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/break_room)
+/turf/simulated/floor/plating,
+/area/crew_quarters/medbreak)
 "amD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/standard,
-/obj/item/device/destTagger,
-/obj/effect/floor_decal/corner/brown{
-	dir = 10
-	},
-/obj/machinery/light,
-/obj/structure/noticeboard{
-	pixel_y = -32
-	},
-/obj/machinery/camera/network/supply{
-	c_tag = "Cargo - Mail Room";
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/donut,
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
+/area/crew_quarters/medbreak)
 "amE" = (
-/obj/machinery/camera/network/civilian_main{
-	c_tag = "Aft Corridor - Camera 3";
-	dir = 4
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/item/weapon/stool/padded,
+/obj/machinery/ringer{
+	department = "Medbay";
+	id = "medbay_ringer";
+	pixel_x = 0;
+	pixel_y = 30;
+	req_access = list(5)
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
+/area/crew_quarters/medbreak)
 "amF" = (
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled,
@@ -6417,6 +6550,10 @@
 "and" = (
 /turf/simulated/floor/plating,
 /area/engineering/storage)
+"ane" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
 "anf" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/engine_monitoring)
@@ -6551,78 +6688,113 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "anv" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/civilian_main{
-	c_tag = "Aft Corridor - Camera 1";
-	dir = 4
+/obj/effect/floor_decal/corner/white/diagonal,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"anw" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/bar_soft/full,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Break Room"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
-"anw" = (
-/obj/machinery/camera/network/civilian_main{
-	c_tag = "Aft Corridor - Camera 2";
+/area/crew_quarters/medbreak)
+"anx" = (
+/obj/structure/bed,
+/obj/effect/floor_decal/corner/pink{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/bedsheet/medical,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/icu)
+"any" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "ExamR2"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "ExamR2"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "ExamR2"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"anz" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/polarized{
+	id = "ExamR2"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "ExamR2"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"anA" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/polarized{
+	id = "ExamR2"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "ExamR2"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "ExamR2"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"anB" = (
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
-"anx" = (
-/obj/structure/table/standard,
-/obj/structure/noticeboard{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
-"any" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
-"anz" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/supply{
-	c_tag = "Cargo - Disposals, Upper";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"anA" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Warehouse";
-	req_access = list(31)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"anB" = (
-/obj/structure/closet/secure_closet/hos,
-/obj/item/device/multitool,
-/obj/item/weapon/reagent_containers/spray/pepper,
-/obj/item/clothing/suit/space/void/hos,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/head/helmet/space/void/hos,
-/obj/item/clothing/mask/breath,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
+/turf/simulated/floor/tiled/white,
+/area/hallway/primary/starboard)
 "anC" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7022,6 +7194,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
+"aod" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"aoe" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"aof" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
 "aog" = (
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor/plating,
@@ -7325,76 +7515,77 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aoI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
-"aoJ" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
-"aoK" = (
-/obj/machinery/suit_cycler/hos,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
-"aoL" = (
-/obj/structure/banner,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
-"aoM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
-"aoN" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
-"aoO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
-"aoP" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/firealarm/south,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/turf/simulated/floor/tiled/white,
+/area/hallway/primary/starboard)
+"aoJ" = (
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/primary/starboard)
+"aoK" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "medlounge"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "medlounge"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/medbreak)
+"aoL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
+/area/crew_quarters/medbreak)
+"aoM" = (
+/obj/effect/floor_decal/corner/pink{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/icu)
+"aoN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/medbreak)
+"aoO" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/item/weapon/stool/padded,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"aoP" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
 "aoQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -7653,26 +7844,47 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
-"apt" = (
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+"apq" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access = list(58)
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"apr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/mob/living/simple_animal/hostile/commanded/dog/columbo,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"aps" = (
+/obj/machinery/shield_gen/external,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"apt" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/drinkingglasses{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
 "apu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -7877,45 +8089,118 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "apO" = (
-/obj/machinery/photocopier,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security RC";
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
-"apP" = (
-/obj/structure/table/wood,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/weapon/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = -30
-	},
-/obj/machinery/power/apc{
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/door/blast/shutters{
+	density = 0;
 	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = null;
+	req_one_access = list(12,66)
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Waiting Room"
+	})
+"apP" = (
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Port 1";
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"apQ" = (
+/obj/structure/table/standard,
+/obj/machinery/computer/med_data/laptop,
+/turf/simulated/floor/carpet/blue,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"apR" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/medical/icu)
+"apS" = (
+/obj/structure/table/standard,
+/obj/item/device/radio{
+	anchored = 1;
+	broadcasting = 0;
+	canhear_range = 1;
+	frequency = 1487;
+	icon = 'icons/obj/items.dmi';
+	icon_state = "red_phone";
+	listening = 1;
+	name = "Examination Room Emergency Phone";
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"apT" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"apU" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"apV" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"apW" = (
+/turf/simulated/floor/tiled/white,
+/area/hallway/primary/starboard)
+"apX" = (
+/obj/effect/floor_decal/corner/pink{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "apY" = (
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
@@ -7932,6 +8217,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"aqa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"aqb" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "aqc" = (
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
@@ -8247,6 +8551,55 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
+"aqD" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/storage/bag/circuits/basic,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"aqE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"aqF" = (
+/obj/machinery/firealarm/south,
+/obj/machinery/shieldgen,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"aqG" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"aqH" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/medical{
+	id_tag = "EXdoor2";
+	name = "Examination Room 2";
+	req_one_access = list(5)
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
 "aqI" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
@@ -8544,6 +8897,48 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"ari" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/hallway/primary/starboard)
+"arj" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Rooms"
+	})
+"ark" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	autoclose = 1;
+	dir = 2;
+	id_tag = null;
+	name = "Psychiatry Waiting Room";
+	req_access = null
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Waiting Room"
+	})
+"arl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/medbreak)
 "arm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -8560,6 +8955,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
+"arn" = (
+/obj/structure/flora/pottedplant/random,
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
+	dir = 8
+	},
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "aro" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -9453,6 +9857,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"asD" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = -2
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "asE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11241,6 +11668,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"avz" = (
+/obj/structure/flora/pottedplant/random,
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 27
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "avA" = (
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/blue{
@@ -11570,6 +12008,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"awc" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "awd" = (
@@ -13193,6 +13637,14 @@
 "ayE" = (
 /turf/simulated/wall,
 /area/maintenance/substation/engineering)
+"ayF" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/hologram/holopad,
+/mob/living/simple_animal/cat/fluff/Runtime{
+	name = "Bones"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/cmo)
 "ayG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14643,6 +15095,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"aAY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_monitoring)
 "aAZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -14855,6 +15323,14 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
+/area/maintenance/substation/engineering)
+"aBu" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "aBv" = (
 /obj/structure/cable/green,
@@ -15582,6 +16058,20 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
+"aCE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
 "aCF" = (
 /obj/machinery/atm{
 	pixel_y = 32
@@ -15727,6 +16217,82 @@
 "aCR" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/engine_airlock)
+"aCS" = (
+/obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
+	id_tag = "engine_room_airlock";
+	name = "Engine Room Airlock";
+	pixel_x = -24;
+	tag_airpump = "engine_airlock_pump";
+	tag_chamber_sensor = "eng_al_c_snsr";
+	tag_exterior_door = "engine_airlock_exterior";
+	tag_exterior_sensor = "eng_al_ext_snsr";
+	tag_interior_door = "engine_airlock_interior";
+	tag_interior_sensor = "eng_al_int_snsr"
+	},
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_airlock)
+"aCT" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 9
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aCU" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aCV" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 5
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aCW" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aCX" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "engine_airlock_control";
+	name = "Engine Access Console";
+	pixel_x = -26;
+	pixel_y = 0;
+	req_access = list(11);
+	req_one_access = null;
+	tag_exterior_door = "engine_airlock_exterior";
+	tag_interior_door = "engine_airlock_interior"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_monitoring)
 "aCY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15882,6 +16448,29 @@
 /area/engineering/foyer)
 "aDm" = (
 /turf/simulated/wall/r_wall,
+/area/ai_monitored/storage/eva)
+"aDn" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/r_wall,
+/area/ai_monitored/storage/eva)
+"aDo" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "E.V.A. Maintenance";
+	req_access = list(12,18)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
 "aDp" = (
 /obj/structure/sign/securearea,
@@ -16692,6 +17281,145 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"aEE" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
+"aEF" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "engine_airlock_interior";
+	locked = 1;
+	name = "Engine Interior Access";
+	req_access = list(11)
+	},
+/obj/machinery/door/firedoor{
+	dir = 8;
+	name = "Firelock West"
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "engine_airlock_control";
+	name = "Engine Access Button";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access = list(11);
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aEG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aEH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aEI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aEJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "engine_airlock_exterior";
+	locked = 1;
+	name = "Engine Exterior Access";
+	req_access = list(11)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "engine_airlock_control";
+	name = "Engine Access Button";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access = list(11);
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aEK" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_monitoring)
+"aEL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_monitoring)
 "aEM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -16930,6 +17658,77 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
+"aFc" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"aFd" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"aFe" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Voidsuits";
+	req_one_access = list(5)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"aFf" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"aFg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/firealarm/north,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
+"aFh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/blue/full{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
 "aFi" = (
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -17848,6 +18647,71 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"aGE" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
+"aGF" = (
+/obj/machinery/airlock_sensor{
+	frequency = 1379;
+	id_tag = "eng_al_c_snsr";
+	pixel_x = -25;
+	pixel_y = 0
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Engine Airlock";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_airlock)
+"aGG" = (
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aGH" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"aGI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/closet/hydrant{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
 "aGJ" = (
 /obj/machinery/light,
 /obj/structure/closet/emcloset,
@@ -18838,6 +19702,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"aIl" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_airlock)
 "aIm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(11)
@@ -19094,6 +19968,32 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/hos)
+"aIJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/hos)
+"aIK" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/hos)
+"aIL" = (
+/obj/machinery/suit_cycler/hos,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/hos)
+"aIM" = (
+/obj/structure/banner,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aIN" = (
@@ -20157,6 +21057,18 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
+"aKH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
 "aKI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21009,6 +21921,40 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
+"aLW" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/button/remote/airlock{
+	id = "EXdoor2";
+	name = "Office Door Control";
+	pixel_x = 36;
+	pixel_y = -14;
+	req_access = list(5)
+	},
+/obj/machinery/button/windowtint{
+	id = "ExamR2";
+	pixel_x = 28;
+	pixel_y = -14;
+	req_access = list(5)
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Examination Room 2";
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
 "aLX" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
@@ -21265,6 +22211,18 @@
 /obj/item/weapon/stamp/hos{
 	pixel_x = -5;
 	pixel_y = 7
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
+"aMs" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -21605,6 +22563,26 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"aNb" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Staff Smoking Lounge";
+	req_access = list(66)
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	icon_state = "vault";
+	dir = 5
+	},
+/area/crew_quarters/medbreak)
 "aNc" = (
 /obj/machinery/status_display{
 	pixel_x = 0;
@@ -22057,6 +23035,86 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/chief)
+"aNQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"aNR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"aNS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"aNT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Lobby Aft";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"aNU" = (
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 8;
+	name = "Engineering Break Room";
+	sortType = "Engineering Break Room"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"aNV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
 "aNW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -22123,6 +23181,15 @@
 "aOd" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/skills,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
+"aOe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
 "aOf" = (
@@ -22424,6 +23491,66 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"aOF" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"aOG" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/coffee/full,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"aOH" = (
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/medical{
+	id_tag = "EXdoor1";
+	name = "Examination Room 1";
+	req_one_access = list(5)
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"aOI" = (
+/obj/structure/table/standard,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/pen,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"aOJ" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
 "aOK" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -23061,6 +24188,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
+"aPK" = (
+/obj/structure/closet/secure_closet/hos,
+/obj/item/device/multitool,
+/obj/item/weapon/reagent_containers/spray/pepper,
+/obj/item/clothing/suit/space/void/hos,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/head/helmet/space/void/hos,
+/obj/item/clothing/mask/breath,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/hos)
 "aPL" = (
 /obj/item/device/radio/intercom{
 	pixel_y = -28
@@ -23073,6 +24210,85 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
+"aPN" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/firealarm/south,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/hos)
+"aPO" = (
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list(58)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/commanded/dog/columbo,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/hos)
+"aPP" = (
+/obj/machinery/photocopier,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	name = "Head of Security RC";
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/hos)
+"aPQ" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "ExamR2"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "ExamR2"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "ExamR2"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "ExamR2"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
 "aPR" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -23257,18 +24473,73 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"aQj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "aQk" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/airless{
 	icon_state = "asteroidplating"
 	},
 /area/outpost/mining_main/eva)
+"aQl" = (
+/obj/effect/floor_decal/corner/lime/full,
+/turf/simulated/floor/tiled/white,
+/area/hallway/primary/starboard)
 "aQm" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner,
 /turf/simulated/floor/airless{
 	icon_state = "asteroidplating"
 	},
 /area/outpost/mining_main/eva)
+"aQn" = (
+/obj/effect/floor_decal/corner/lime/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/primary/starboard)
+"aQo" = (
+/obj/structure/table/glass,
+/obj/item/weapon/material/ashtray/bronze,
+/obj/machinery/button/windowtint{
+	id = "medlounge";
+	pixel_x = -4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/medbreak)
+"aQp" = (
+/obj/structure/bed/chair/comfy/beige{
+	dir = 8
+	},
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/medbreak)
+"aQq" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/medbreak)
 "aQr" = (
 /obj/item/device/t_scanner,
 /obj/structure/table/steel,
@@ -24006,6 +25277,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
+"aRp" = (
+/obj/structure/bed/chair/office/dark,
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
 "aRq" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -24286,6 +25570,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"aRO" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/crew_quarters/medbreak)
 "aRP" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -24295,6 +25594,58 @@
 	icon_state = "asteroidplating"
 	},
 /area/outpost/mining_main/eva)
+"aRQ" = (
+/obj/effect/floor_decal/sign/ex,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"aRR" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/corner/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"aRS" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/donkpockets,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"aRT" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
 "aRU" = (
 /obj/structure/closet,
 /obj/item/clothing/head/ushanka,
@@ -24531,6 +25882,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
+"aSs" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/o2{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/o2,
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
+	dir = 8
+	},
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
 "aSt" = (
 /obj/item/modular_computer/console/preset/engineering,
 /obj/machinery/light_switch{
@@ -24671,6 +26036,96 @@
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
+"aSE" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/foyer)
+"aSF" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/foyer)
+"aSG" = (
+/obj/structure/table/reinforced/steel,
+/obj/machinery/door/window/brigdoor/northleft{
+	name = "Engineering Desk";
+	req_access = list(32)
+	},
+/obj/machinery/door/firedoor{
+	dir = 1;
+	name = "Engineering Firelock"
+	},
+/obj/machinery/ringer_button{
+	id = "engie_ringer";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"aSH" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/foyer)
 "aSI" = (
 /obj/machinery/conveyor{
 	backwards = 1;
@@ -24693,6 +26148,30 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
+"aSL" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	is_critical = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
 "aSM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24885,6 +26364,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
+"aTd" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/fire,
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
 "aTe" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -25023,6 +26519,27 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"aTp" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/adv,
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 27
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Main Storage";
+	dir = 8;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
 "aTq" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/toy/figure/secofficer{
@@ -25110,6 +26627,45 @@
 	icon_state = "asteroidplating"
 	},
 /area/outpost/mining_main/eva)
+"aTx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"aTy" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Waiting Room"
+	})
+"aTz" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/vending/cola,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"aTA" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
 "aTB" = (
 /obj/structure/table/rack{
 	dir = 1
@@ -25820,6 +27376,86 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"aUG" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"aUH" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"aUI" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/firealarm/east,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"aUJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"aUK" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "ExamR1"
+	},
+/turf/simulated/floor/plating,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
 "aUL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -26199,6 +27835,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
+"aVC" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/port)
 "aVD" = (
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -26333,6 +27976,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
+"aVS" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 "aVT" = (
 /obj/machinery/station_map{
 	pixel_y = 32
@@ -26456,6 +28105,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"aWh" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
 "aWi" = (
 /obj/structure/track{
 	icon_state = "track13"
@@ -26468,10 +28135,69 @@
 	icon_state = "asteroidplating"
 	},
 /area/outpost/mining_main/eva)
+"aWj" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/firstaid/regular,
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
+"aWk" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
+"aWl" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
+"aWm" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/machinery/requests_console{
+	department = "Psychiatrist's Desk";
+	departmentType = 1;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
 "aWn" = (
 /obj/structure/sign/drop,
 /turf/simulated/wall,
 /area/outpost/mining_main/eva)
+"aWo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "aWp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -27346,6 +29072,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"aXx" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/standard,
+/obj/machinery/microwave{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
 "aXy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -27415,6 +29150,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"aXC" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
 "aXD" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -27708,6 +29453,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/janitor)
+"aYg" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
 "aYh" = (
 /obj/machinery/button/remote/blast_door{
 	id = "mopinator";
@@ -27991,9 +29741,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aYI" = (
@@ -28008,9 +29755,6 @@
 	dir = 4
 	},
 /obj/structure/closet/walllocker/emerglocker/south,
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aYK" = (
@@ -28020,14 +29764,42 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"aYL" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/device/radio/intercom{
+	pixel_y = 27
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Chemistry 1";
+	dir = 2;
+	icon_state = "camera";
+	network = list("Medical")
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"aYM" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
 "aYN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/firealarm/south,
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aYO" = (
@@ -28045,9 +29817,6 @@
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = -32
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -28069,6 +29838,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"aYS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/ramp,
+/area/medical/medbay2)
 "aYT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28112,9 +29895,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=S2";
 	location = "S1"
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -28394,6 +30174,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/janitor)
+"aZx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/ramp,
+/area/medical/medbay2)
 "aZy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -28572,15 +30358,67 @@
 	icon_state = "corner_white_full";
 	dir = 1
 	},
-/obj/item/weapon/storage/fancy/vials{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/glasses/science,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
+"aZV" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/medical,
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
 "aZW" = (
 /turf/simulated/wall,
 /area/medical/surgeryprep)
+"aZX" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/flora/pottedplant/random,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"aZY" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"aZZ" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/flora/pottedplant/random,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"baa" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
 "bab" = (
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
@@ -28603,6 +30441,25 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled,
 /area/medical/icu)
+"bac" = (
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/effect/floor_decal/sign/cmo,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "bad" = (
 /turf/simulated/wall,
 /area/medical/icu)
@@ -28618,9 +30475,61 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"bag" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
 "bah" = (
 /turf/simulated/wall,
 /area/medical/reception)
+"bai" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
+"baj" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/door/airlock/medical{
+	name = "Examination Room 2";
+	req_one_access = list(5)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"bak" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"bal" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
 "bam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -28852,6 +30761,25 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"baG" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/rxglasses,
+/obj/item/weapon/cane,
+/obj/item/weapon/cane,
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	req_one_access = list(24,11,55)
+	},
+/obj/item/bodybag/cryobag,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
 "baH" = (
 /turf/simulated/wall,
 /area/storage/tech)
@@ -29062,10 +30990,7 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
-/obj/item/weapon/storage/fancy/vials{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/glasses/science,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bbd" = (
@@ -29091,22 +31016,33 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/item/weapon/storage/box/beakers,
+/obj/item/weapon/storage/fancy/vials{
+	pixel_x = 0;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bbf" = (
-/obj/machinery/disposal,
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 1
 	},
-/obj/structure/disposalpipe/trunk,
 /obj/machinery/ringer{
 	department = "Chemistry";
 	id = "chemistry_ringer";
 	pixel_x = 30;
 	pixel_y = 0;
 	req_access = list(33)
+	},
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/item/device/radio/headset/headset_med,
+/obj/item/device/radio/headset/headset_med,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1";
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -29124,6 +31060,19 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled,
 /area/medical/medbay)
+"bbi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "bbj" = (
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "O- Blood Locker";
@@ -29145,67 +31094,61 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
 "bbk" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/beige/full,
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
-	},
-/obj/machinery/body_scanconsole{
-	dir = 4;
-	icon_state = "body_scannerconsole"
-	},
-/turf/simulated/floor/tiled,
-/area/medical/icu)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "bbl" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 4
 	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"bbm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/ringer{
-	department = "Medbay";
-	id = "medbay_ringer";
-	pixel_x = 0;
-	pixel_y = 30;
-	req_access = list(5)
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 10
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"bbn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/bodyscanner{
-	dir = 8;
-	icon_state = "body_scanner_0"
-	},
-/turf/simulated/floor/tiled,
-/area/medical/icu)
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "bbo" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "bbp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 2;
-	icon_state = "tube1";
-	pixel_y = 0
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "bbq" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
@@ -29218,6 +31161,209 @@
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
+"bbs" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "ExamR2"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "ExamR2"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "ExamR2"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "ExamR2"
+	},
+/turf/simulated/floor/plating,
+/area/medical/biostorage{
+	name = "\improper Medical - Exam Room 2"
+	})
+"bbt" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"bbu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"bbv" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "Medication Closet";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
+/obj/item/weapon/storage/pill_bottle/dermaline,
+/obj/item/weapon/storage/pill_bottle/tramadol,
+/obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bbw" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bbx" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/firealarm/east,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bby" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Psychiatry Wing"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Waiting Room"
+	})
+"bbz" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "ExamR1"
+	},
+/turf/simulated/floor/plating,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bbA" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/medical,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bbB" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/requests_console{
+	department = "Medical Bay";
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bbC" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"bbD" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
 "bbE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29441,6 +31587,27 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
+"bcb" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Main Storage";
+	req_access = list(66)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
 "bcc" = (
 /turf/simulated/wall/r_wall,
 /area/storage/tech)
@@ -29681,6 +31848,44 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
+"bcA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
+"bcB" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/obj/machinery/button/windowtint{
+	id = "ExamR1";
+	pixel_x = -14;
+	pixel_y = 28;
+	req_access = list(5)
+	},
+/obj/machinery/button/remote/airlock{
+	id = "EXdoor1";
+	name = "Office Door Control";
+	pixel_x = -14;
+	pixel_y = 36;
+	req_access = list(5)
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
 "bcC" = (
 /obj/machinery/chem_master,
 /obj/effect/floor_decal/corner/mauve{
@@ -29709,7 +31914,6 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bcE" = (
@@ -29730,36 +31934,40 @@
 /turf/simulated/floor/tiled,
 /area/medical/medbay)
 "bcG" = (
+/obj/machinery/door/window{
+	base_state = "left";
+	dir = 8;
+	icon_state = "right";
+	layer = 2.85;
+	name = "MediExpress - Storage";
+	req_access = list(66)
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/floor_decal/corner/lime{
-	dir = 10
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay)
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
 "bcH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/beige{
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 8;
+	spread = 360;
+	spread_point = 2
+	},
+/obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
-	dir = 10
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/loading{
-	icon_state = "loadingarea";
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/medical/icu)
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
 "bcI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -29771,6 +31979,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
+"bcJ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "bcK" = (
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
@@ -29789,6 +32015,24 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/medical/reception)
+"bcM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "bcN" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/disposalpipe/segment{
@@ -29796,6 +32040,225 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/reception)
+"bcO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"bcP" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j1s";
+	name = "CMO's Office";
+	sortType = "CMO's Office"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"bcQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j1s";
+	name = "Medical Bay";
+	sortType = "Medical Bay"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"bcR" = (
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/obj/structure/flora/pottedplant/random,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Psych Stairway"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"bcS" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "ExamR1"
+	},
+/turf/simulated/floor/plating,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bcT" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bcU" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/bed/chair,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bcV" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bcW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"bcX" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bcY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"bcZ" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"bda" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
 "bdb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -30033,6 +32496,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
+"bdw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "bdx" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -30314,6 +32795,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
+"bdU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "bdV" = (
 /turf/simulated/wall,
 /area/medical/surgerywing)
@@ -30335,38 +32833,58 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"bdZ" = (
-/obj/structure/closet/secure_closet/medical_wall{
-	name = "Stabilization Kit";
-	pixel_x = -32;
-	pixel_y = 0
+"bdX" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/weapon/storage/pill_bottle/tramadol,
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Intensive Care Unit";
-	dir = 4;
-	icon_state = "camera"
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/icu)
+/area/medical/medbay2)
+"bdY" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"bdZ" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "bea" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -30398,6 +32916,297 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
+"bed" = (
+/obj/effect/floor_decal/sign/c2,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"bee" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/roller{
+	pixel_y = 4
+	},
+/obj/item/roller{
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"bef" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/lime/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"beg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/table/standard,
+/obj/item/roller{
+	pixel_y = 4
+	},
+/obj/item/roller{
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"beh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/masks{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/gloves,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"bei" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"bej" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/medical/medbay2)
+"bek" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/machinery/firealarm/east,
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"bel" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/medbay2)
+"bem" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "ExamR1"
+	},
+/turf/simulated/floor/plating,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"ben" = (
+/obj/item/device/radio{
+	anchored = 1;
+	broadcasting = 0;
+	canhear_range = 1;
+	frequency = 1487;
+	icon = 'icons/obj/items.dmi';
+	icon_state = "red_phone";
+	listening = 1;
+	name = "Examination Room Emergency Phone";
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Examination Office 1";
+	dir = 4;
+	icon_state = "camera"
+	},
+/obj/structure/table/standard,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"beo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/medical/genetics_cloning)
+"bep" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/medical/genetics_cloning)
+"beq" = (
+/obj/item/weapon/folder/white,
+/obj/item/weapon/pen,
+/obj/structure/table/standard,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"ber" = (
+/obj/item/weapon/paper_bin{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/structure/table/standard,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bes" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bet" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/door/airlock/medical{
+	name = "Examination Room 1";
+	req_one_access = list(5)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
 "beu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -30903,25 +33712,56 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
+"bfm" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Cloning Laboratory";
+	req_access = list(66)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/genetics_cloning)
 "bfn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bfo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bfp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/grey{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/computer/guestpass{
+	pixel_x = -28;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
+/area/medical/medbay)
+"bfq" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/vending/wallmed2{
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "bfr" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -30963,6 +33803,69 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
+"bfv" = (
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/corner/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bfw" = (
+/obj/machinery/button/windowtint{
+	id = "OR1";
+	pixel_x = 0;
+	pixel_y = 26;
+	req_access = list(66)
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"bfx" = (
+/obj/effect/floor_decal/corner/grey{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"bfy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bfz" = (
+/obj/machinery/bodyscanner{
+	dir = 8;
+	icon_state = "body_scanner_0"
+	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
+/area/medical/gen_treatment)
 "bfA" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -30970,9 +33873,161 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
+"bfB" = (
+/obj/machinery/door/airlock/medical{
+	name = "Psychiatric Wing";
+	req_access = list(5)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"bfC" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"bfD" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"bfE" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"bfF" = (
+/obj/structure/stairs/east,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"bfG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Port 2";
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"bfH" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "ExamR1"
+	},
+/turf/simulated/floor/plating,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"bfI" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/vending/medical{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "bfJ" = (
 /turf/simulated/wall/r_wall,
 /area/medical/chemistry)
+"bfK" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/bed/chair/comfy/teal{
+	dir = 4;
+	icon_state = "comfychair_preview"
+	},
+/obj/machinery/firealarm/west,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bfL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
 "bfM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -31181,6 +34236,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
+"bgg" = (
+/obj/structure/flora/pottedplant/random,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "bgh" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -31221,6 +34285,13 @@
 /obj/item/weapon/circuitboard/arcade/orion_trail,
 /turf/simulated/floor/plating,
 /area/storage/tech)
+"bgk" = (
+/obj/machinery/computer/med_data/laptop,
+/obj/structure/table/standard,
+/turf/simulated/floor/carpet/blue,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
 "bgl" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -31414,18 +34485,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bgC" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/device/destTagger,
-/obj/machinery/light{
-	dir = 2;
-	icon_state = "tube1";
-	pixel_y = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -31439,14 +34500,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bgE" = (
-/obj/effect/floor_decal/corner/mauve/full{
-	icon_state = "corner_white_full";
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -31454,9 +34507,12 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -31522,6 +34578,23 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
+"bgI" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/icu)
 "bgJ" = (
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
@@ -31567,24 +34640,285 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
 "bgN" = (
-/obj/structure/bed,
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bgO" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bgP" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bgQ" = (
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/bedsheet/medical,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/bed/roller,
+/obj/machinery/ringer{
+	department = "Medbay";
+	id = "medbay_ringer";
+	pixel_x = 30;
+	pixel_y = 0;
+	req_access = list(5)
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
+"bgR" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bgS" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
 "bgT" = (
-/turf/simulated/wall,
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/CMO,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - CMO's Office"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/cmo)
+"bgU" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/iv_drip,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bgV" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bgW" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bgX" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bgY" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/coffee/full,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
+"bgZ" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bha" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bhb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = list(5)
+	},
+/obj/effect/floor_decal/corner/white/diagonal,
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
+"bhc" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/polarized{
+	id = "CMO"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "CMO"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "CMO"
+	},
+/obj/structure/cable/green,
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "CMO"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/cmo)
+"bhd" = (
+/turf/simulated/floor/carpet/blue,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
+"bhe" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"bhf" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/surgeryprep)
+"bhg" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Pre/Post-OP";
+	req_access = list(66)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
+"bhh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"bhi" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
 "bhj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31707,6 +35041,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
+"bhx" = (
+/obj/machinery/firealarm/east,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
 "bhy" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -31943,6 +35284,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
+"bhT" = (
+/obj/effect/floor_decal/corner/mauve/full{
+	icon_state = "corner_white_full";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 "bhU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31993,36 +35341,90 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/central_one)
 "bhX" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/sign/chemistry,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
+/obj/effect/floor_decal/corner/mauve/full,
+/obj/structure/table/standard,
+/obj/machinery/button/remote/blast_door{
+	id = "CHE3shutters";
+	name = "Desk Shutter Control";
+	pixel_x = 6;
+	pixel_y = 0;
+	req_access = list(33)
+	},
+/obj/machinery/button/remote/blast_door{
 	id = "CHE2shutters";
-	name = "Chemistry Window Shutters";
-	opacity = 0
+	name = "Window Shutter Control";
+	pixel_x = -6;
+	pixel_y = 0;
+	req_access = list(33)
 	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 4
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 2
 	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/window/phoronreinforced,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "bhY" = (
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
+"bhZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
+"bia" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
+"bib" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"bic" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/polarized{
+	id = "CMO"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "CMO"
+	},
+/obj/structure/cable/green,
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "CMO"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/cmo)
+"bid" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
 "bie" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -32065,6 +35467,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
+"bih" = (
+/obj/structure/table/rack,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
 "bii" = (
 /obj/machinery/button/remote/blast_door{
 	id = "ICUshutters";
@@ -32079,6 +35489,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
+"bij" = (
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
 "bik" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -32090,35 +35508,268 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
-"bim" = (
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 6
+"bil" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/icu)
-"bis" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"bim" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"bin" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = list(12)
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"bio" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"bip" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"bit" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/flora/pottedplant/random,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+"biq" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 10
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Starboard 1";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"bir" = (
+/obj/effect/floor_decal/corner/lime/full,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"bis" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"bit" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"biu" = (
+/obj/structure/stairs/east,
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"biv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/main_storage)
+"biw" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"bix" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Port 4";
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"biy" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "ExamR1"
+	},
+/turf/simulated/floor/plating,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
+	})
+"biz" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "ExamR1"
+	},
+/turf/simulated/floor/plating,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"biA" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "ExamR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "ExamR1"
+	},
+/turf/simulated/floor/plating,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"biB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"biC" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"biD" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
 	})
 "biE" = (
 /obj/structure/table/glass,
@@ -32131,17 +35782,41 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
-"biG" = (
+"biF" = (
+/obj/structure/table/glass,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Medical Officer's Office"
+	},
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/structure/closet/secure_closet/CMO,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - CMO's Office"
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
+"biG" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
 "biH" = (
 /obj/item/modular_computer/console/preset/medical,
 /obj/effect/floor_decal/corner/paleblue{
@@ -32158,6 +35833,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
+"biJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/medical/medbay2)
 "biK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32484,6 +36165,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
+"bjs" = (
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Starboard 3";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "bjt" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -32614,42 +36309,159 @@
 /turf/simulated/floor/tiled,
 /area/medical/icu)
 "bjB" = (
-/turf/simulated/wall,
-/area/medical/main_storage)
-"bjC" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Starboard 2";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
+"bjC" = (
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Port 3";
 	dir = 8
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"bjD" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/crowbar/red,
+/obj/machinery/vending/wallmed2{
+	pixel_x = 28
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"bjE" = (
+/obj/machinery/light/small,
+/obj/machinery/button/remote/blast_door{
+	id = "emtshutter";
+	name = "Garage Shutters Control";
+	pixel_x = 0;
+	pixel_y = -26;
+	req_access = list(5)
+	},
+/obj/effect/floor_decal/industrial/loading{
+	icon_state = "loadingarea";
+	dir = 8
+	},
 /turf/simulated/floor/plating,
-/area/medical/icu)
-"bjJ" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/firealarm/east,
+/area/medical/emt)
+"bjF" = (
+/obj/structure/table/standard,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - EMT Quarters";
+	dir = 1;
+	icon_state = "camera"
+	},
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/device/radio{
+	pixel_x = -5
+	},
+/obj/item/device/gps{
+	gpstag = "MED1"
+	},
+/obj/item/device/gps{
+	gpstag = "MED0"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"bjG" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bjK" = (
-/turf/simulated/floor/tiled/ramp,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Cryogenics Control";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/cryo)
+"bjH" = (
+/obj/machinery/power/smes/buildable{
+	charge = 0;
+	RCon_tag = "Substation - Medical Main"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"bjI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Substation Access";
+	req_access = list(5);
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled,
 /area/medical/medbay2)
+"bjJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Pre-Op 2";
+	dir = 1
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
+"bjK" = (
+/obj/effect/floor_decal/corner/lime/full,
+/obj/effect/floor_decal/sign/gtr,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
 "bjO" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	icon_state = "warningcorner_dust";
@@ -32709,14 +36521,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
-"bjU" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/hologram/holopad,
-/mob/living/simple_animal/cat/fluff/Runtime{
-	name = "Bones"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
@@ -32995,6 +36799,17 @@
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
+"bkt" = (
+/obj/structure/sign/nosmoking_1{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/reagent_containers/spray,
+/turf/simulated/floor/tiled/white,
+/area/assembly/robotics)
 "bku" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -33117,77 +36932,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"bkJ" = (
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bkK" = (
-/obj/structure/closet/secure_closet/medical_wall{
-	name = "Medication Closet";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
-/obj/item/weapon/storage/pill_bottle/dermaline,
-/obj/item/weapon/storage/pill_bottle/tramadol,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/item/weapon/storage/pill_bottle/dylovene,
-/obj/item/weapon/storage/pill_bottle/dylovene,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bkL" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bkM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bkN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bkP" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet/medical,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
 "bkR" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -33201,65 +36945,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/outpost/mining_main/eva)
-"bkS" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/requests_console{
-	department = "Medical Bay";
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bkU" = (
-/obj/structure/flora/pottedplant/random,
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 8
-	},
-/obj/machinery/firealarm/north,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bkV" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = -2
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bkW" = (
-/obj/structure/flora/pottedplant/random,
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 27
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "bkY" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	icon_state = "warningcorner_dust";
@@ -33756,19 +37441,28 @@
 /area/medical/reception)
 "blY" = (
 /obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/medical/reception)
+"bma" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2;
+	id_tag = null;
+	name = "Medical Reception";
+	req_access = list(5)
 	},
+/obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled,
 /area/medical/reception)
 "bmb" = (
-/obj/effect/floor_decal/corner/lime{
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 9
-	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -33888,82 +37582,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"bmm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bmp" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bmq" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/bed/chair,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bmr" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bms" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
 "bmu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -33977,6 +37595,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bmw" = (
@@ -34697,138 +38316,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"bnS" = (
-/obj/item/device/radio{
-	anchored = 1;
-	broadcasting = 0;
-	canhear_range = 1;
-	frequency = 1487;
-	icon = 'icons/obj/items.dmi';
-	icon_state = "red_phone";
-	listening = 1;
-	name = "Examination Room Emergency Phone";
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Examination Office 1";
-	dir = 4;
-	icon_state = "camera"
-	},
-/obj/structure/table/standard,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bnT" = (
-/obj/item/weapon/folder/white,
-/obj/item/weapon/pen,
-/obj/structure/table/standard,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bnU" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/obj/structure/table/standard,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bnV" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bnW" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/door/airlock/medical{
-	name = "Examination Room 1";
-	req_one_access = list(5)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bnX" = (
-/obj/effect/floor_decal/sign/ex,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bnY" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "bnZ" = (
 /obj/effect/floor_decal/sign/p,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -34845,6 +38332,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "bof" = (
@@ -35376,54 +38864,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/gen_treatment)
-"bpd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bpf" = (
-/obj/machinery/computer/med_data/laptop,
-/obj/structure/table/standard,
-/turf/simulated/floor/carpet/blue,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bph" = (
-/turf/simulated/floor/carpet/blue,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bpi" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"bpl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "bpm" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -35484,30 +38924,6 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/cmo)
-"bpx" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/firstaid/regular,
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"bpy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
 "bpA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -35737,6 +39153,16 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
+"bpW" = (
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled,
+/area/assembly/robotics)
+"bpX" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled,
+/area/assembly/robotics)
 "bpY" = (
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Central Corridor - Camera 5";
@@ -35890,25 +39316,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/gen_treatment)
-"bqo" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"bqq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bqw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/ramp,
-/area/medical/medbay2)
 "bqC" = (
 /obj/machinery/smartfridge/secure/medbay{
 	density = 1;
@@ -35925,19 +39332,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
-"bqE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"bqF" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
 "bqH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -36340,27 +39734,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
-"brA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/structure/sink{
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "brB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"brD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -36383,135 +39757,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
-"brH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"brI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"brJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"brK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"brL" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Main Storage";
-	req_access = list(66)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"brM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"brO" = (
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/table/standard,
-/obj/machinery/door/window{
-	base_state = "left";
-	dir = 1;
-	icon_state = "left";
-	layer = 2.85;
-	name = "MediExpress - Storage";
-	req_access = list(66)
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"brP" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/disposaloutlet{
-	dir = 8;
-	spread = 360;
-	spread_point = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
 "brQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -36965,11 +40210,24 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
 "bsJ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "GTRshutters";
+	name = "General Treatment Room Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/medical/gen_treatment)
 "bsK" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -36987,39 +40245,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"bsN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bsO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "bsS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37034,180 +40259,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bsT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	icon_state = "pipe-j1s";
-	name = "CMO's Office";
-	sortType = "CMO's Office"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bsU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	icon_state = "pipe-j1s";
-	name = "Medical Bay";
-	sortType = "Medical Bay"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bsV" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bsW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bsY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"btc" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"btd" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"bte" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"btf" = (
-/obj/effect/floor_decal/sign/c2,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
@@ -37582,20 +40633,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
-"btM" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/roller{
-	pixel_y = 4
-	},
-/obj/item/roller{
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "btP" = (
 /obj/machinery/vending/medical{
 	density = 0;
@@ -37616,43 +40653,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
-"btT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/masks{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/box/gloves,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "btU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/machinery/disposal,
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -37726,66 +40729,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/medbay2)
-"bud" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/medical/medbay2)
 "bue" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/medical/medbay2)
-"buh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/medical/genetics_cloning)
-"bui" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/medical/genetics_cloning)
-"buj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_medical{
-	name = "Cloning Laboratory";
-	req_access = list(66)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/genetics_cloning)
 "buk" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -38127,29 +41076,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"buW" = (
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/machinery/computer/guestpass{
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"buY" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "bva" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/power/apc{
@@ -38192,9 +41118,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/gen_treatment)
-"bve" = (
-/turf/simulated/wall,
-/area/medical/surgeryobs)
 "bvg" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
@@ -38203,6 +41126,9 @@
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/tiled,
 /area/medical/icu)
+"bvi" = (
+/turf/simulated/wall,
+/area/medical/surgeryobs)
 "bvq" = (
 /obj/effect/floor_decal/corner/lime/full,
 /turf/simulated/floor/tiled/white,
@@ -38577,8 +41503,7 @@
 	pixel_y = 23
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
@@ -38586,16 +41511,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "bvX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/light_switch{
 	pixel_x = 7;
 	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
@@ -38623,20 +41547,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "bwa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -38729,13 +41646,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
-"bwk" = (
-/obj/structure/sink{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
 "bwl" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/lime{
@@ -38747,47 +41657,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
-"bwm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"bwn" = (
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/button/windowtint{
-	id = "OR1";
-	pixel_x = 0;
-	pixel_y = 26;
-	req_access = list(66)
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgerywing)
 "bwo" = (
 /obj/structure/table/standard,
 /obj/item/weapon/bonesetter,
 /obj/item/weapon/bonegel,
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 5
-	},
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Operating Room 1";
 	dir = 2
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
@@ -38795,22 +41675,29 @@
 /obj/structure/table/standard,
 /obj/item/weapon/surgicaldrill,
 /obj/item/weapon/FixOVein,
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 5
-	},
 /obj/machinery/vending/wallmed2{
 	pixel_x = 0;
 	pixel_y = 28
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bwq" = (
 /obj/structure/table/standard,
 /obj/item/weapon/retractor,
-/obj/effect/floor_decal/corner/grey/full{
+/obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white_full";
 	dir = 1
+	},
+/obj/machinery/ringer{
+	department = "Medbay";
+	id = "medbay_ringer";
+	pixel_x = 0;
+	pixel_y = 30;
+	req_access = list(5)
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
@@ -39443,24 +42330,23 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bxo" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
+	name = "Chapel";
+	sortType = "Chapel"
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bxq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "bxr" = (
@@ -39488,20 +42374,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"bxv" = (
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "bxw" = (
 /turf/simulated/wall,
 /area/medical/medbay)
@@ -39554,21 +42426,20 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/rack,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bxE" = (
 /obj/structure/table/standard,
 /obj/item/weapon/cautery,
 /obj/item/weapon/hemostat,
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1";
 	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
@@ -39995,14 +42866,18 @@
 /turf/simulated/floor/plating,
 /area/rnd/lab)
 "byt" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'BOMB RANGE";
-	name = "KEEP CLEAR: MEDICAL EXOSUIT PARKING";
-	pixel_x = 32;
-	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -40028,19 +42903,6 @@
 /obj/machinery/computer/crew,
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"byy" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/weapon/crowbar/red,
-/obj/machinery/light{
-	dir = 4;
-	status = 2
-	},
-/obj/machinery/vending/wallmed2{
-	pixel_x = 28
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
 "byz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -40049,7 +42911,10 @@
 /area/medical/emt)
 "byB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "byC" = (
@@ -40060,22 +42925,15 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "byE" = (
-/obj/machinery/body_scanconsole{
-	dir = 4;
-	icon_state = "body_scannerconsole"
-	},
-/obj/effect/floor_decal/corner/beige/full,
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
-	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/unary/freezer{
 	dir = 2;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "freezer"
 	},
-/turf/simulated/floor/tiled,
-/area/medical/gen_treatment)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/cryo)
 "byF" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -40106,37 +42964,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
-"byM" = (
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/bed/roller,
-/obj/machinery/ringer{
-	department = "Medbay";
-	id = "medbay_ringer";
-	pixel_x = 30;
-	pixel_y = 0;
-	req_access = list(5)
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/icu)
 "byP" = (
 /obj/structure/table/standard,
 /obj/item/weapon/scalpel,
 /obj/item/weapon/circular_saw{
 	pixel_y = 8
 	},
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24;
 	req_one_access = list(24,11,55)
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
@@ -40606,6 +43448,12 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "KEEP CLEAR: MEDICAL EXOSUIT PARKING";
+	pixel_x = 32;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bzD" = (
@@ -40632,39 +43480,33 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/emt)
+"bzH" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/belt/medical/emt,
+/obj/item/weapon/storage/belt/medical/emt,
+/obj/item/device/radio{
+	frequency = 1487;
+	name = "Medbay Emergency Radio Link";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	frequency = 1487;
+	name = "Medbay Emergency Radio Link";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
 "bzJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	icon_state = "map-scrubbers";
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"bzK" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/vending/medical{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bzP" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/bed/chair/comfy/teal{
-	dir = 4;
-	icon_state = "comfychair_preview"
-	},
-/obj/machinery/firealarm/west,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
 "bzR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -40672,7 +43514,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bzS" = (
@@ -40695,18 +43536,36 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bzY" = (
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
-	},
 /obj/structure/sink/kitchen{
 	dir = 8;
 	icon_state = "sink_alt";
 	name = "Surgical sink";
 	pixel_x = 20
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
+"bzZ" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
 "bAa" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
@@ -41053,16 +43912,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/emt)
-"bAM" = (
-/obj/machinery/atmospherics/unary/freezer{
-	dir = 2;
-	icon_state = "freezer"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/medical/cryo)
 "bAO" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
@@ -41083,26 +43932,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
-"bAQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
 "bAT" = (
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/curtain/open/medical{
 	name = "Operating Room 1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bAV" = (
@@ -41117,6 +43957,65 @@
 	temperature = 278
 	},
 /area/medical/surgerywing)
+"bAX" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = list(12);
+	req_one_access = null
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"bAY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Break Room";
+	req_access = list(5)
+	},
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
+"bBc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = list(66)
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/medical/genetics_cloning)
 "bBd" = (
 /turf/simulated/floor/plating,
 /area/turbolift/command_sub)
@@ -41357,7 +44256,8 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -41407,40 +44307,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
-"bBJ" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"bBK" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
 "bBL" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	icon_state = "map-scrubbers";
 	dir = 1
@@ -41454,13 +44321,14 @@
 	c_tag = "Medical - Combined Surgery Central";
 	dir = 2
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bBM" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/firealarm/east,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bBO" = (
@@ -41469,21 +44337,52 @@
 	temperature = 278
 	},
 /area/medical/surgerywing)
-"bBX" = (
-/obj/structure/bed/chair{
-	dir = 1
+"bBR" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Lobby 2";
-	dir = 1
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/light{
-	dir = 2;
-	icon_state = "tube1";
-	pixel_y = 0
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Medbay Subgrid";
+	name_tag = "Medbay Subgrid"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"bBS" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
 "bCa" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -41813,29 +44712,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
-"bCI" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"bCJ" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
 "bCK" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -41846,7 +44722,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "bCL" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -41854,6 +44729,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bCM" = (
@@ -41898,6 +44774,38 @@
 	temperature = 278
 	},
 /area/medical/surgerywing)
+"bCS" = (
+/obj/machinery/power/smes/buildable{
+	charge = 0;
+	RCon_tag = "Substation - Medical Main"
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"bCT" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
+"bCU" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
 "bCX" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -42244,36 +45152,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"bDB" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/iv_drip,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"bDC" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"bDD" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
 "bDE" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -42293,15 +45171,22 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bDG" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bDK" = (
 /turf/simulated/wall,
 /area/maintenance/substation/medical)
+"bDL" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
 "bDO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -42673,25 +45558,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
-"bEG" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
 "bEH" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/cmo)
 "bEJ" = (
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/curtain/open/medical{
 	name = "Operating Room 2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bEN" = (
@@ -43027,27 +45907,6 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
-"bFE" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"bFF" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
 "bFI" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -43372,17 +46231,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/library)
-"bGI" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
 "bGJ" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -43408,10 +46256,6 @@
 /turf/simulated/floor/plating,
 /area/medical/surgerywing)
 "bGO" = (
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 10
-	},
 /obj/machinery/button/windowtint{
 	id = "OR2";
 	pixel_x = 0;
@@ -43421,20 +46265,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/table/standard,
-/obj/item/device/radio{
-	anchored = 1;
-	broadcasting = 0;
-	canhear_range = 7;
-	frequency = 1487;
-	icon = 'icons/obj/items.dmi';
-	icon_state = "red_phone";
-	listening = 1;
-	name = "Surgery Emergency Phone";
-	pixel_x = 5;
-	pixel_y = 5
+/obj/structure/table/rack,
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 10
 	},
-/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bGQ" = (
@@ -43443,7 +46278,7 @@
 /obj/item/weapon/circular_saw{
 	pixel_y = 8
 	},
-/obj/effect/floor_decal/corner/grey{
+/obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 6
 	},
@@ -44084,39 +46919,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/library)
-"bHT" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/medical/surgeryprep)
-"bHU" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Pre/Post-OP";
-	req_access = list(66)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
 "bHY" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
@@ -44129,9 +46931,26 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/rack,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
+"bIf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
 "bIg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -44290,6 +47109,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
+"bIy" = (
+/obj/machinery/light,
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 "bIz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -44327,25 +47151,6 @@
 /obj/item/weapon/bedsheet/medical,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
-"bIM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
-"bIN" = (
-/obj/machinery/firealarm/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
 "bIQ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
@@ -44357,19 +47162,31 @@
 /area/crew_quarters/heads/cmo)
 "bIR" = (
 /obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner"
-	},
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 10
-	},
 /obj/item/device/radio/intercom{
 	dir = 1;
 	name = "Station Intercom (General)";
 	pixel_x = 0;
 	pixel_y = -24
+	},
+/obj/item/device/radio{
+	anchored = 1;
+	broadcasting = 0;
+	canhear_range = 7;
+	frequency = 1487;
+	icon = 'icons/obj/items.dmi';
+	icon_state = "red_phone";
+	listening = 1;
+	name = "Surgery Emergency Phone";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner"
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
@@ -44377,13 +47194,13 @@
 /obj/structure/table/standard,
 /obj/item/weapon/bonesetter,
 /obj/item/weapon/bonegel,
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 10
-	},
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Operating Room 2";
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
@@ -44391,25 +47208,43 @@
 /obj/structure/table/standard,
 /obj/item/weapon/surgicaldrill,
 /obj/item/weapon/FixOVein,
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 10
-	},
 /obj/machinery/vending/wallmed2{
 	pixel_x = 0;
 	pixel_y = -28
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
 "bIU" = (
 /obj/structure/table/standard,
 /obj/item/weapon/retractor,
-/obj/effect/floor_decal/corner/grey/full{
+/obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white_full";
 	dir = 4
 	},
+/obj/machinery/ringer{
+	department = "Medbay";
+	id = "medbay_ringer";
+	pixel_x = 0;
+	pixel_y = -30;
+	req_access = list(5)
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
+"bIV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
 "bIW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/machinery/meter{
@@ -45102,20 +47937,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"bKE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "bKF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -45654,6 +48475,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
+"bLR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/sleep/main)
 "bLS" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -45905,6 +48735,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/locker/locker_toilet)
+"bMH" = (
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Main Level - Restrooms";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "bML" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -46111,6 +48948,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/office)
+"bNk" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Aft Corridor - Camera 1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
 "bNl" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -46336,6 +49185,9 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
+"bNL" = (
+/turf/simulated/floor/tiled/dark,
+/area/chapel/office)
 "bNM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -46747,6 +49599,17 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
+/turf/simulated/floor/carpet,
+/area/chapel/office)
+"bOX" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp{
+	pixel_y = 10
+	},
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor/carpet,
 /area/chapel/office)
 "bOY" = (
@@ -49184,6 +52047,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"bWX" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/machinery/autolathe,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
 "bWY" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -49212,6 +52082,23 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"bXe" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4;
+	name = "Firelock East"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "bXg" = (
 /obj/structure/bed/chair/wood{
 	icon_state = "wooden_chair";
@@ -49548,6 +52435,22 @@
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"bYp" = (
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
+"bYq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "bYr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -49677,6 +52580,33 @@
 /obj/item/device/multitool,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"bYJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"bYK" = (
+/obj/machinery/door/firedoor{
+	dir = 4;
+	name = "Firelock East"
+	},
+/obj/machinery/door/airlock/glass_mining{
+	id_tag = "cargodoor";
+	name = "Cargo Office";
+	req_access = list(50)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "bYL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -49778,6 +52708,22 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"bYZ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
+"bZa" = (
+/obj/machinery/status_display{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "bZb" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -49787,6 +52733,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"bZc" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
 "bZe" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
@@ -49891,6 +52841,14 @@
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"bZr" = (
+/obj/machinery/conveyor{
+	backwards = 0;
+	dir = 2;
+	id = "cargo_crates"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "bZu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -49958,6 +52916,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"bZE" = (
+/obj/machinery/firealarm/east,
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/camera/network/supply{
+	c_tag = "Cargo - MULE Storage";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "bZG" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -50122,6 +53091,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"cah" = (
+/obj/machinery/door/airlock/glass_mining{
+	name = "Cargo Bay";
+	req_access = null;
+	req_one_access = list(31,48)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
 "cak" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
@@ -50253,6 +53242,25 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"cav" = (
+/obj/machinery/door/airlock/glass_mining{
+	name = "Warehouse";
+	req_access = list(31)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
 "caw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -50374,6 +53382,29 @@
 /obj/effect/large_stock_marker,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"caU" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "caW" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j1";
@@ -50457,6 +53488,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"cbc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Break Room";
+	req_access = null;
+	req_one_access = list(31,48)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/quartermaster/break_room)
 "cbd" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -50480,6 +53528,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
+/area/quartermaster/break_room)
+"cbf" = (
+/turf/simulated/wall,
 /area/quartermaster/break_room)
 "cbg" = (
 /obj/structure/disposalpipe/segment,
@@ -50517,6 +53568,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
+"cbi" = (
+/turf/simulated/wall,
+/area/quartermaster/mail_room)
 "cbj" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -50531,6 +53585,28 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"cbk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
@@ -50573,6 +53649,17 @@
 "cbt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/cargo)
+"cbu" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Maintenance";
+	req_access = list(31,48)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
@@ -50757,6 +53844,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
+"cbV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/meter{
+	name = "Air supply"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "cbW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -50764,6 +53862,22 @@
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
+"cbX" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/floor_decal/corner/brown/full{
+	icon_state = "corner_white_full";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
@@ -50775,6 +53889,39 @@
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
 /area/quartermaster/mail_room)
+"cbZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/disposal)
+"cca" = (
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/obj/structure/ladder,
+/turf/simulated/open,
+/area/maintenance/disposal)
+"ccb" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/disposal)
 "ccc" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -50785,6 +53932,10 @@
 /area/maintenance/disposal)
 "ccf" = (
 /turf/simulated/open,
+/area/maintenance/disposal)
+"ccg" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
 "cci" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -50807,6 +53958,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"ccm" = (
+/obj/structure/weightlifter,
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/landmark/start{
+	name = "Shaft Miner"
+	},
+/obj/machinery/firealarm/west,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/break_room)
 "ccn" = (
 /turf/simulated/floor/carpet,
 /area/quartermaster/break_room)
@@ -50843,6 +54013,10 @@
 "cct" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
+"ccu" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
 "ccv" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -50864,6 +54038,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/mail_room)
+"ccx" = (
+/obj/structure/disposalpipe/segment,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"ccy" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/disposal)
 "ccz" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -50984,6 +54176,71 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
+"ccO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"ccP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"ccQ" = (
+/obj/structure/disposalpipe/up{
+	icon_state = "pipe-u";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	icon_state = "up-supply";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	icon_state = "up-scrubbers";
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "12-0"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating{
+	roof_type = null
+	},
+/area/maintenance/bar)
+"ccR" = (
+/obj/machinery/disposal{
+	name = "External Disposals"
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 10
+	},
+/obj/structure/sign/deathsposal{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/disposal)
 "ccS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -51002,6 +54259,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"ccU" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/disposal)
 "ccV" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -51059,6 +54323,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/break_room)
+"cdf" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
+"cdg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/maintenance/disposal)
 "cdh" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -51141,6 +54419,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/break_room)
+"cdp" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/newscaster{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/camera/network/supply{
+	c_tag = "Cargo - Break Room";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/break_room)
 "cdq" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -51167,6 +54457,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
+"cdu" = (
+/turf/simulated/floor/tiled/airless{
+	icon_state = "asteroidfloor"
+	},
+/area/maintenance/disposal)
+"cdv" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "cdw" = (
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
@@ -51240,6 +54547,54 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"cdB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Break Room";
+	req_access = null;
+	req_one_access = list(31,48)
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/break_room)
+"cdC" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/supply{
+	c_tag = "Cargo - Disposals, Upper";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"cdD" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"cdE" = (
+/obj/machinery/door/window/southright,
+/turf/simulated/floor/tiled/airless{
+	icon_state = "asteroidfloor"
+	},
+/area/maintenance/disposal)
+"cdF" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless{
+	icon_state = "asteroidfloor"
+	},
+/area/maintenance/disposal)
 "cdG" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -51435,6 +54790,23 @@
 "cdQ" = (
 /turf/simulated/wall,
 /area/outpost/mining_main/refinery)
+"cdR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mining";
+	req_access = null;
+	req_one_access = list(31,48)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "cdS" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -51456,6 +54828,22 @@
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
+"cdU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/camera/network/mining{
+	c_tag = "Mining - Locker Room"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
@@ -51535,6 +54923,17 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
+"cdZ" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
 "cea" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -51612,6 +55011,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
+"ceh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 2
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
 "cei" = (
 /obj/machinery/mineral/stacking_machine,
 /turf/simulated/floor/plating,
@@ -51687,6 +55098,26 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"cev" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 2
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"cex" = (
+/obj/machinery/mineral/rigpress,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
 "cey" = (
@@ -52385,6 +55816,27 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
+"cgb" = (
+/obj/structure/table/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/stack/flag/purple,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
 "cgc" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -52423,6 +55875,28 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
+"cgh" = (
+/obj/structure/table/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/stack/flag/red,
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "cgi" = (
@@ -52484,6 +55958,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
+"cgq" = (
+/obj/structure/table/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/stack/flag/green,
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
 "cgr" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/brown{
@@ -52519,6 +56010,23 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
+"cgx" = (
+/obj/structure/table/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/stack/flag/yellow,
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
 "cgy" = (
@@ -52733,13 +56241,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
-"cgY" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
+"cgZ" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
 "chg" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
@@ -52772,31 +56277,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"cht" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"chu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "chw" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -52820,6 +56300,72 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/rdoffice)
+"chx" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
+"chy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"chA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Medbay Subgrid";
+	name_tag = "Medbay Subgrid"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
 "chB" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -52943,10 +56489,6 @@
 /obj/structure/table/standard,
 /obj/item/weapon/cautery,
 /obj/item/weapon/hemostat,
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -52957,6 +56499,10 @@
 	dir = 4;
 	icon_state = "tube1";
 	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
@@ -52974,14 +56520,6 @@
 /obj/random/loot,
 /turf/simulated/floor/tiled,
 /area/maintenance/medbay)
-"chR" = (
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 8
-	},
-/obj/structure/flora/pottedplant/random,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
 "chS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
@@ -52992,18 +56530,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
-"chW" = (
-/obj/machinery/bodyscanner{
-	dir = 8;
-	icon_state = "body_scanner_0"
-	},
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
-/area/medical/gen_treatment)
 "chX" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -53065,6 +56591,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/lobby)
+"cif" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "cih" = (
 /obj/machinery/conveyor{
 	dir = 9;
@@ -53082,6 +56617,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"cij" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "cik" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall,
@@ -53099,6 +56646,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/quartermaster/lobby)
+"cin" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "cip" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -53247,6 +56800,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/break_room)
+"ciG" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/start{
+	name = "Cargo Technician"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/quartermaster/office)
 "ciH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -53443,6 +57006,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
+"cjE" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/status_display/supply_display{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
 "cjG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -53482,6 +57056,20 @@
 "cjN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"cjO" = (
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/machinery/mineral/processing_unit_console{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
@@ -53938,13 +57526,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
-"cnE" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plating,
-/area/medical/cryo)
 "cnI" = (
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
@@ -54066,6 +57647,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
+"cnV" = (
+/obj/structure/table/wood,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/weapon/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = -30
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/hos)
 "cnW" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/item/weapon/tank/emergency_oxygen/engi,
@@ -54170,20 +57774,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
 "coh" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/belt/medical/emt,
-/obj/item/weapon/storage/belt/medical/emt,
-/obj/item/device/radio{
-	frequency = 1487;
-	name = "Medbay Emergency Radio Link";
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/device/radio{
-	frequency = 1487;
-	name = "Medbay Emergency Radio Link";
-	pixel_x = 5;
-	pixel_y = 5
+/obj/structure/bed/chair/office/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
@@ -54339,6 +57932,27 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
+"cow" = (
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
 "cox" = (
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
@@ -54417,18 +58031,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
-"coD" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
 "coF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54921,6 +58523,16 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hydroponics)
+"cqk" = (
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Aft Corridor - Camera 1";
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
 "cql" = (
 /obj/machinery/firealarm/north,
 /obj/structure/table/standard,
@@ -54949,6 +58561,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"cqn" = (
+/obj/item/modular_computer/console/preset/supply,
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "cqo" = (
 /obj/item/modular_computer/console/preset/supply,
 /obj/effect/floor_decal/corner/brown{
@@ -55031,6 +58655,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
+"cqw" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
 "cqz" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
@@ -55054,6 +58685,26 @@
 	dir = 8;
 	pixel_x = 25;
 	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"cqF" = (
+/obj/machinery/cryopod{
+	icon_state = "body_scanner_0";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/cryo)
+"cqH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"cqI" = (
+/obj/structure/table/standard,
+/obj/structure/noticeboard{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
@@ -55082,6 +58733,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
+"cqP" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/cryo)
 "cqR" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 4
@@ -57039,13 +60700,6 @@
 /obj/structure/bookcase/libraryspawn/religion,
 /turf/simulated/floor/carpet,
 /area/library)
-"cwf" = (
-/obj/structure/sign/securearea{
-	name = "\improper CAUTION: TRASH COMPACTOR";
-	pixel_x = 0
-	},
-/turf/simulated/wall/r_wall,
-/area/maintenance/disposal)
 "cwh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -57122,20 +60776,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/library)
-"cwx" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/roller{
-	pixel_y = 4
-	},
-/obj/item/roller{
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/reception)
 "cwy" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green,
@@ -57408,6 +61048,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
+"cxP" = (
+/obj/structure/sign/drop,
+/turf/simulated/wall/r_wall,
+/area/maintenance/disposal)
 "cxQ" = (
 /obj/structure/table/rack{
 	dir = 1
@@ -57426,276 +61070,6 @@
 /obj/item/weapon/crowbar,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"cBt" = (
-/obj/effect/floor_decal/industrial/loading,
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"cOi" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"cQr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "mail_chute"
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
-"cRj" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"cYM" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"dbQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"diD" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner"
-	},
-/obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 27
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgerywing)
-"dmA" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"dnQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"dpM" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/maintenance/bar)
-"drP" = (
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"dsE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"duy" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"dvg" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"dzP" = (
-/obj/structure/table/standard,
-/obj/item/roller{
-	pixel_y = 4
-	},
-/obj/item/roller{
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"dBc" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"dJL" = (
-/obj/structure/table/rack,
-/obj/random/loot,
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"dLZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
-"dTQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"dVI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"dWo" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/eva)
-"dXk" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "ICUshutters";
-	name = "Intensive Care Unit Shutters";
-	opacity = 0
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/medical/icu)
-"epT" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Medbay Substation";
-	req_one_access = list(11,24,5)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/medical)
-"eyg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/sign/greencross,
-/turf/simulated/floor/plating,
-/area/medical/reception)
 "eCI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -57708,101 +61082,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"eDF" = (
-/obj/effect/floor_decal/corner/lime/full,
-/obj/effect/floor_decal/sign/gtr,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"eEV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"eSy" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white_full";
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/item/device/radio/intercom{
-	dir = 0;
-	name = "Station Intercom (General)";
-	pixel_x = 27
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
-"eWc" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "CHE2shutters";
-	name = "Chemistry Window Shutters";
-	opacity = 0
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/medical/chemistry)
-"eXU" = (
-/obj/machinery/door/airlock/medical{
-	autoclose = 0;
-	icon_state = "door_open";
-	id_tag = null;
-	name = "Intensive Care Unit";
-	req_access = list(66)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/medical/icu)
 "fii" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -57814,282 +61093,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
-"fmW" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
-"fnz" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/mauve/full{
-	icon_state = "corner_white_full";
-	dir = 8
-	},
-/obj/item/weapon/storage/box/beakers,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"foK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"fxb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Combined Operating Theatre";
-	req_access = list(45)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgerywing)
-"fyv" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/refinery)
-"fAO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"fBF" = (
-/obj/machinery/door/firedoor/multi_tile,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"fBO" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"fCh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"fCk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"fDN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"fFC" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/medical/icu)
-"fKg" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/adv{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/firstaid/adv,
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 27
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Main Storage";
-	dir = 8;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"fKy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"fOa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"fWU" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"gbo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/medical/icu)
-"gbw" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Psychiatry";
-	sortType = "Psychiatry"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"gcq" = (
-/obj/structure/reagent_dispensers/extinguisher,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"gcu" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/simulated/floor/plating,
-/area/medical/cryo)
-"gcW" = (
-/obj/effect/floor_decal/plaque{
-	desc = "Charlie Dove Memorial Hall<br>With an endless capacity for kindness, she used her skills as a doctor to better the lives of everyone she met. She was the 4th victim murdered by the notorious Odin Killer, and will be missed.<br>December 2416 - June 2460"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"geE" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"ggj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/quartermaster/break_room)
-"ghF" = (
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/refinery)
-"gne" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/machinery/meter{
-	name = "Air supply"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"gnU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
-"gql" = (
-/obj/structure/disposalpipe/segment,
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
 "grp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58256,38 +61259,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"grH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"grI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
 "grR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -58472,23 +61443,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/bar)
-"gsy" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/smartfridge/secure/medbay{
-	density = 0;
-	name = "Dangerous Materials Storage";
-	pixel_x = 0;
-	pixel_y = 0;
-	req_access = list(33)
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "gsA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -59516,6 +62470,19 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"gve" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
 "gvm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -59580,109 +62547,252 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"gHb" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/research_port)
-"gLH" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"gvD" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/bar)
+"jNC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Cryogenics Control Room";
-	req_access = list(66)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/crew_quarters/kitchen)
+"jXF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/medical/cryo)
-"gNO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/area/crew_quarters/kitchen)
+"nfj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
-/area/medical/gen_treatment)
-"gOP" = (
-/obj/machinery/door/airlock{
-	name = "Changing Room"
+/area/crew_quarters/kitchen)
+"oox" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
-"gRJ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/table/rack,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"owR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/reagent_dispensers/extinguisher,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"tmB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/table/rack,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"wQE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/kitchen)
+"wXX" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xDz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xDB" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgerywing)
-"gTr" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/security_starboard)
+"xDC" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
-"gVs" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
+"xDD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/security_starboard)
+"xDE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/security_starboard)
+"xDF" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"xDG" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/gen_treatment)
-"gXa" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgerywing)
-"gYD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/effect/floor_decal/corner/beige/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/loading{
-	icon_state = "loadingarea";
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/vending/cola,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"xDH" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled,
-/area/medical/gen_treatment)
-"haU" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled,
-/area/medical/reception)
-"hcb" = (
-/obj/machinery/light/small/emergency{
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "CHE2shutters";
+	name = "Chemistry Window Shutters";
+	opacity = 0
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
 	dir = 8
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/outpost/mining_main/refinery)
-"hdn" = (
+/area/medical/chemistry)
+"xDI" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/mauve/full{
+	icon_state = "corner_white_full";
+	dir = 8
+	},
+/obj/item/weapon/storage/fancy/vials{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xDL" = (
+/obj/machinery/disposal{
+	name = "MediExpress - Storage"
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled,
+/area/medical/medbay)
+"xDO" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/chem_master,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xDP" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xDQ" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/chemical_dispenser/full,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xDR" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xDT" = (
 /obj/effect/floor_decal/corner/beige/full{
 	icon_state = "corner_white_full";
 	dir = 4
@@ -59696,145 +62806,77 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/icu)
-"heY" = (
+"xDV" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/box/beakers,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xDW" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/machinery/chemical_dispenser/full,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"hjD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"hla" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/brown{
+"xDX" = (
+/obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"hlg" = (
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/vending/cola,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
-"hmA" = (
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Temporary Morgue";
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/morgue{
-	icon_state = "morgue1";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark{
-	name = "cooled dark floor";
-	temperature = 278
-	},
-/area/medical/temp_morgue)
-"hnv" = (
 /obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/item/weapon/storage/firstaid/toxin,
-/obj/effect/floor_decal/corner/lime{
+/obj/item/weapon/storage/box/beakers,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xDY" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/science,
+/obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	is_critical = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"hoM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/area/medical/chemistry)
+"xDZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xEa" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"hoR" = (
-/turf/simulated/floor/tiled/dark{
-	name = "cooled dark floor";
-	temperature = 278
-	},
-/area/medical/temp_morgue)
-"hzv" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "mining_internal"
-	},
-/obj/machinery/mineral/output,
-/turf/simulated/floor/plating,
-/area/outpost/mining_main/refinery)
-"hOC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/light{
-	dir = 2;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xEb" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"hTM" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+"xEd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -59842,508 +62884,132 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/substation/medical)
-"inc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"irc" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"irn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/ramp,
-/area/medical/medbay2)
-"iuN" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 4
-	},
+/area/maintenance/maintcentral)
+"xEe" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"iIC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"iMx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"iNY" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"iOJ" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"iTM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"iXc" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"jhE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"jnz" = (
-/obj/structure/ladder/up,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"jtP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/wrapping_paper,
-/obj/effect/floor_decal/corner/brown/full,
-/turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
-"jwK" = (
-/obj/structure/flora/pottedplant/random,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"jEY" = (
-/obj/machinery/conveyor{
-	dir = 9;
-	icon_state = "conveyor0";
-	id = "mining_internal";
-	reversed = 1
-	},
-/turf/simulated/floor/plating,
-/area/outpost/mining_main/refinery)
-"jNC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/crew_quarters/kitchen)
-"jQT" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/iv_drip,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgerywing)
-"jRc" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"jXF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/kitchen)
-"kgh" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/weapon/storage/box/pillbottles,
-/obj/item/weapon/storage/box/pillbottles,
-/obj/item/device/radio/headset/headset_med,
-/obj/item/device/radio/headset/headset_med,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"kgI" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
-"kja" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"kqA" = (
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/obj/structure/table/rack,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"kqR" = (
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"kug" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/chem_master,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"kyC" = (
-/turf/simulated/floor/plating,
-/area/outpost/mining_main/refinery)
-"kGG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"kIa" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/structure/flora/pottedplant/random,
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"kJC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"kKv" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
-"kLa" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/firstaid/fire,
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"kLC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"kPP" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
-	dir = 2;
+	dir = 8;
 	icon_state = "shutter0";
-	id = "CHE3shutters";
-	name = "Chemistry Desk Shutter";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Chemistry Desk";
-	req_access = list(33)
+/obj/structure/grille,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "CHE2shutters";
+	name = "Chemistry Window Shutters";
+	opacity = 0
 	},
-/obj/machinery/ringer_button{
-	id = "chemistry_ringer";
-	pixel_x = 5;
-	pixel_y = 5
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/structure/noticeboard{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/chemistry)
+"xEf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"kSb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+"xEg" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xEh" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
+/turf/simulated/floor/plating,
+/area/medical/icu)
+"xEi" = (
+/obj/machinery/sleeper{
+	icon_state = "sleeper_0";
+	dir = 4
 	},
-/obj/structure/table/standard,
-/obj/item/roller{
-	pixel_y = 4
-	},
-/obj/item/roller{
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"kWE" = (
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"lfd" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"lho" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"llb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/area/medical/icu)
+"xEj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"llI" = (
-/obj/structure/sign/nosmoking_1{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
+/area/medical/icu)
+"xEk" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"lnp" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
+/area/medical/icu)
+"xEo" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"lpE" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"lpG" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/bar)
-"lqM" = (
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"ltv" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/status_display/supply_display{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/eva)
-"lCC" = (
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/gen_treatment)
-"lDe" = (
+/area/maintenance/maintcentral)
+"xEp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -60373,164 +63039,384 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/plating,
 /area/medical/chemistry)
-"lFh" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"lIz" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/floor_decal/corner/brown{
+"xEq" = (
+/obj/item/weapon/stool/padded,
+/obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
-	dir = 9
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/red{
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xEr" = (
+/obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
-	dir = 6
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/eva)
-"lQg" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/ore_box,
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/refinery)
-"lUb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"maz" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wardrobe/chemistry_white,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xEs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xEt" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
-"mbs" = (
-/turf/simulated/floor/plating,
-/area/medical/emt)
-"mgS" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"mhg" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
+/obj/machinery/alarm{
 	dir = 8;
-	id = "OR1"
+	pixel_x = 25;
+	pixel_y = 0
 	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "OR1"
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"xEu" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "CHE3shutters";
+	name = "Chemistry Desk Shutter";
+	opacity = 0
 	},
-/turf/simulated/floor/plating,
-/area/medical/surgerywing)
-"mmG" = (
-/obj/machinery/mineral/processing_unit_console{
-	pixel_y = 32
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Chemistry Desk"
 	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining_internal";
-	name = "mining conveyor"
+/obj/machinery/ringer_button{
+	id = "chemistry_ringer";
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/effect/floor_decal/corner/brown/full{
-	icon_state = "corner_white_full";
+/obj/structure/table/reinforced,
+/obj/structure/noticeboard{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xEx" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xEy" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/standard,
+/obj/item/device/radio/intercom{
+	pixel_y = 27
+	},
+/turf/simulated/floor/tiled,
+/area/medical/reception)
+"xEz" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/ringer{
+	department = "Medbay";
+	id = "medbay_ringer";
+	pixel_x = 0;
+	pixel_y = 30;
+	req_access = list(5)
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/outpost/mining_main/refinery)
-"mtB" = (
-/obj/effect/floor_decal/corner/brown{
+/area/medical/reception)
+"xEA" = (
+/obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
-	dir = 9
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/refinery)
-"mEE" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xEB" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xEC" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xED" = (
+/obj/machinery/door/airlock/medical{
+	autoclose = 0;
+	icon_state = "door_open";
+	id_tag = null;
+	name = "Intensive Care Unit";
+	req_access = list(66)
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"mEF" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/area/medical/icu)
+"xEE" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "ICUshutters";
+	name = "Intensive Care Unit Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"mIF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/medical/icu)
+"xEJ" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/standard,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor{
-	dir = 4;
-	name = "Firelock East"
+/obj/item/roller{
+	pixel_y = 4
 	},
-/obj/machinery/door/blast/shutters{
-	density = 1;
-	dir = 4;
-	icon_state = "shutter1";
-	id = "cargo_cockblock";
-	name = "Cargo";
-	opacity = 1
+/obj/item/roller{
+	pixel_y = 4
 	},
-/turf/simulated/floor/plating,
-/area/quartermaster/lobby)
-"mRk" = (
+/turf/simulated/floor/tiled,
+/area/medical/reception)
+"xEK" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/medical/reception)
-"mTc" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+"xEL" = (
+/obj/effect/floor_decal/corner/pink{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"mUk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/area/medical/medbay)
+"xEM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/light/small/emergency{
-	icon_state = "bulb1";
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"mWw" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xEN" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xEO" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/effect/floor_decal/sign/icu,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xER" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/medical/reception)
+"xES" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xET" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xEU" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xEV" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/item/device/radio{
+	anchored = 1;
+	broadcasting = 0;
+	canhear_range = 1;
+	frequency = 1487;
+	icon = 'icons/obj/items.dmi';
+	icon_state = "red_phone";
+	listening = 1;
+	name = "Reception Emergency Phone";
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled,
+/area/medical/reception)
+"xEW" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled,
+/area/medical/reception)
+"xEX" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xEY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/light{
+	dir = 2;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xEZ" = (
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xFa" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xFe" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/item/device/radio/intercom{
+	dir = 0;
+	name = "Station Intercom (General)";
+	pixel_x = 27
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/cmo)
+"xFg" = (
 /obj/machinery/door/window{
 	base_state = "left";
 	dir = 2;
@@ -60542,175 +63428,74 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/medical/reception)
-"nfj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
-"ngo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
-"ngR" = (
-/obj/effect/floor_decal/corner/brown/full{
-	icon_state = "corner_white_full";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"nif" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Mail Maintenance";
-	req_access = list(50)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"npk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/light/small/emergency,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
-"nud" = (
-/obj/machinery/disposal{
-	name = "MediExpress - Storage"
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled,
-/area/medical/medbay)
-"nBa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"nEB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
-"nEE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
+"xFh" = (
 /obj/structure/sign/nosmoking_1{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"nGb" = (
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"nGz" = (
-/obj/structure/sign/drop,
-/turf/simulated/wall/r_wall,
-/area/maintenance/disposal)
-"nKK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	pixel_x = -32
 	},
 /obj/machinery/light{
-	dir = 2;
 	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"nOo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"nYV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/area/medical/medbay)
+"xFi" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"nYY" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xFk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xFm" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/sign/greencross,
+/turf/simulated/floor/plating,
+/area/medical/reception)
+"xFn" = (
+/obj/effect/floor_decal/corner/pink{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xFo" = (
+/obj/effect/floor_decal/plaque{
+	desc = "Charlie Dove Memorial Hall<br>With an endless capacity for kindness, she used her skills as a doctor to better the lives of everyone she met. She was the 4th victim murdered by the notorious Odin Killer, and will be missed.<br>December 2416 - June 2460"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xFp" = (
 /obj/machinery/sleeper{
 	icon_state = "sleeper_0";
 	dir = 8
@@ -60724,485 +63509,106 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/gen_treatment)
-"oab" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
-"obO" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"ocq" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
-"ofm" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"ogS" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/large_stock_marker,
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"oip" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/weapon/tape_roll,
-/obj/item/weapon/tape_roll,
-/obj/item/weapon/tape_roll,
-/obj/item/weapon/tape_roll,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/machinery/requests_console{
-	department = "Psychiatrist's Desk";
-	departmentType = 1;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"okG" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"olp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"omx" = (
+"xFq" = (
+/obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 8
+	icon_state = "rwindow";
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/medical/medbay2)
-"oox" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/table/rack,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"opk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"opA" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"oqb" = (
-/obj/machinery/disposal{
-	name = "mailing disposal unit"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
-"oqI" = (
-/obj/machinery/power/terminal{
+	icon_state = "rwindow";
 	dir = 8
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Medical Substation";
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/medical)
-"oro" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark{
-	name = "cooled dark floor";
-	temperature = 278
-	},
-/area/medical/temp_morgue)
-"orx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"ovA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
-"owR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/reagent_dispensers/extinguisher,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"oyB" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
-"oAG" = (
-/obj/structure/disposalpipe/tagger/partial{
-	dir = 8;
-	icon_state = "pipe-tagger-partial";
-	tag = "Sorting Office"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"oBd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"oEo" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 1
 	},
-/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"oEX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
-"oFF" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 2;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"oFJ" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/full{
-	icon_state = "corner_white_full";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
-"oLn" = (
-/obj/structure/ladder,
-/turf/simulated/open,
-/area/maintenance/disposal)
-"oNt" = (
-/obj/item/weapon/stool/padded,
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"oRZ" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/bodybags,
-/obj/item/weapon/storage/box/rxglasses,
-/obj/item/weapon/cane,
-/obj/item/weapon/cane,
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24;
-	req_one_access = list(24,11,55)
-	},
-/obj/item/bodybag/cryobag,
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"oSF" = (
+/area/medical/gen_treatment)
+"xFr" = (
+/turf/simulated/floor/tiled/ramp,
+/area/medical/medbay2)
+"xFw" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
-"oUr" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
+"xFy" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
 	},
-/obj/structure/table/rack,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"oWF" = (
-/obj/structure/curtain,
 /turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
-"peG" = (
-/obj/effect/floor_decal/industrial/loading{
-	icon_state = "loadingarea";
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/medical/emt)
-"pjW" = (
-/turf/simulated/wall,
-/area/quartermaster/break_room)
-"ppQ" = (
-/obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"pqr" = (
-/obj/structure/disposalpipe/sortjunction/untagged,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"prN" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/standard,
-/obj/item/weapon/packageWrap,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown{
+/area/medical/reception)
+"xFz" = (
+/obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
-"pxo" = (
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xFA" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/item/weapon/pen,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/brown/full{
-	icon_state = "corner_white_full";
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xFB" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
+	},
+/obj/effect/floor_decal/corner/beige/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/loading{
+	icon_state = "loadingarea";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
-"pyh" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/syringes{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 10
 	},
-/obj/item/clothing/glasses/science,
-/obj/effect/floor_decal/corner/mauve{
+/turf/simulated/floor/tiled,
+/area/medical/gen_treatment)
+"xFD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"xFF" = (
+/obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"pBT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/brown{
-	dir = 10
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
-"pBU" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/o2{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/firstaid/o2,
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 8
-	},
-/obj/machinery/firealarm/north,
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"pDO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
-"pEO" = (
-/obj/machinery/mineral/output,
-/obj/machinery/conveyor{
-	dir = 9;
-	icon_state = "conveyor0";
-	id = "mining_internal";
-	reversed = 1
-	},
-/turf/simulated/floor/plating,
-/area/outpost/mining_main/refinery)
-"pIL" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"pLP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"pQW" = (
+/area/hallway/primary/central_one)
+"xFG" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
 	id_tag = "CONS2door";
@@ -61222,58 +63628,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
-"pRK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"pTt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"qbe" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"qbi" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"qgR" = (
+"xFH" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
 	id_tag = "main_door";
@@ -61293,7 +63648,208 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
-"qgS" = (
+"xFI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/medical/gen_treatment)
+"xFK" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/sign/greencross,
+/turf/simulated/floor/plating,
+/area/medical/reception)
+"xFL" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/structure/flora/pottedplant/random,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xFM" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 2;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xFN" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xFO" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xFP" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xFQ" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Lobby 2";
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 2;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"xFU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xFV" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xFW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 2;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"xFX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/vending/medical{
+	density = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"xFY" = (
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/medical/temp_morgue)
+"xGa" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"xGb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/medical/temp_morgue)
+"xGc" = (
+/obj/structure/morgue{
+	icon_state = "morgue1";
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/medical/temp_morgue)
+"xGe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xGf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xGg" = (
 /obj/effect/floor_decal/corner/grey{
 	icon_state = "corner_white";
 	dir = 9
@@ -61315,80 +63871,199 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"qia" = (
-/obj/machinery/alarm/cold{
-	dir = 1;
-	pixel_y = -22
+"xGh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/morgue{
-	icon_state = "morgue1";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark{
-	name = "cooled dark floor";
-	temperature = 278
-	},
-/area/medical/temp_morgue)
-"qul" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/turf/simulated/floor/tiled/white,
+/area/medical/gen_treatment)
+"xGi" = (
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
+	dir = 8
+	},
+/obj/structure/flora/pottedplant/random,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"xGj" = (
+/obj/structure/table/standard,
+/obj/item/device/radio/intercom{
+	pixel_y = 27
+	},
+/obj/item/device/radio{
+	anchored = 1;
+	broadcasting = 0;
+	canhear_range = 7;
+	frequency = 1487;
+	icon = 'icons/obj/items.dmi';
+	icon_state = "red_phone";
+	listening = 1;
+	name = "Surgery Emergency Phone";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner"
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"xGk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
-"quw" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
+"xGl" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	icon_state = "pipe-y";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"quz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/area/medical/medbay)
+"xGm" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xGn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/gen_treatment)
+"xGo" = (
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
-"qzp" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/ringer{
-	department = "Medbay";
-	id = "medbay_ringer";
-	pixel_x = 0;
-	pixel_y = 30;
-	req_access = list(5)
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/medical/reception)
-"qFn" = (
+/area/medical/gen_treatment)
+"xGp" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/loading,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - General Treatment 2";
+	dir = 8;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/gen_treatment)
+"xGq" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/gen_treatment)
+"xGr" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"xGs" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"xGt" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "OR1"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "OR1"
+	},
+/turf/simulated/floor/plating,
+/area/medical/surgerywing)
+"xGu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"xGv" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"xGw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -61404,85 +64079,124 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay2)
-"qGO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+"xGy" = (
+/obj/machinery/alarm/cold{
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/morgue{
+	icon_state = "morgue1";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access = list(12)
+/area/medical/temp_morgue)
+"xGz" = (
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Temporary Morgue";
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/morgue{
+	icon_state = "morgue1";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/medical/temp_morgue)
+"xGA" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/morgue{
+	icon_state = "morgue1";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/medical/temp_morgue)
+"xGB" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"qLW" = (
-/obj/structure/table/rack,
-/obj/machinery/light/small{
-	dir = 4;
+/area/maintenance/research_port)
+"xGC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
-"qNc" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
-"rbe" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Sorting Office";
-	sortType = "Sorting Office"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/bar)
-"rcr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"rdq" = (
-/obj/structure/disposalpipe/segment,
+/area/maintenance/research_port)
+"xGD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xGE" = (
+/obj/effect/floor_decal/corner/grey{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -24
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xGF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"rrd" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
+/area/medical/gen_treatment)
+"xGG" = (
+/obj/machinery/body_scanconsole{
+	dir = 4;
+	icon_state = "body_scannerconsole"
 	},
-/obj/effect/floor_decal/sign/icu,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"rvl" = (
+/obj/effect/floor_decal/corner/beige/full,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 2;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled,
+/area/medical/gen_treatment)
+"xGH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -61493,13 +64207,38 @@
 	icon_state = "rwindow";
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/gen_treatment)
-"rwV" = (
+"xGI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"xGJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
+"xGK" = (
+/turf/simulated/floor/plating,
+/area/medical/emt)
+"xGL" = (
+/obj/effect/floor_decal/industrial/loading{
+	icon_state = "loadingarea";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/medical/emt)
+"xGM" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
@@ -61509,7 +64248,246 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"rAl" = (
+"xGN" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Cryogenics Control Room";
+	req_access = list(66)
+	},
+/turf/simulated/floor/plating,
+/area/medical/cryo)
+"xGP" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/iv_drip,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"xGQ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
+"xGS" = (
+/obj/structure/table/standard,
+/obj/item/roller{
+	pixel_y = 4
+	},
+/obj/item/roller{
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xGW" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"xGX" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/plating,
+/area/medical/cryo)
+"xGZ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Combined Operating Theatre";
+	req_access = list(45)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"xHa" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"xHb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xHc" = (
+/obj/structure/disposalpipe/down{
+	icon_state = "pipe-d";
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/drop{
+	pixel_y = 32
+	},
+/turf/simulated/open,
+/area/maintenance/medbay)
+"xHe" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plating,
+/area/medical/cryo)
+"xHf" = (
+/obj/structure/disposaloutlet{
+	icon_state = "outlet";
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/surgeryobs)
+"xHg" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"xHh" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/drinkingglasses{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/donkpockets,
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
+"xHi" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Medical Substation";
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/medical)
+"xHj" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	name = "Psychiatry";
+	sortType = "Psychiatry"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xHk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xHl" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = null;
+	req_one_access = list(12,66)
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xHo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"xHp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"xHq" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"xHr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgerywing)
+"xHs" = (
 /obj/structure/closet/crate/freezer{
 	name = "Various Blood Packs"
 	},
@@ -61532,330 +64510,25 @@
 	temperature = 278
 	},
 /area/medical/surgerywing)
-"rDP" = (
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"rEu" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/icu)
-"rIP" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/medical/gen_treatment)
-"rKm" = (
-/obj/structure/disposalpipe/junction/yjunction,
-/obj/effect/floor_decal/corner/brown{
-	dir = 10
-	},
+"xHt" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
-"rSU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/sign/greencross,
-/turf/simulated/floor/plating,
-/area/medical/reception)
-"rUV" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgerywing)
-"saK" = (
-/obj/structure/disposaloutlet{
-	dir = 1;
-	spread = 360;
-	spread_point = 2
-	},
-/obj/structure/disposalpipe/trunk,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"shM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/green{
-	d1 = 2;
+/area/medical/medbay2)
+"xHu" = (
+/obj/structure/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/gen_treatment)
-"snS" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 2;
-	use_power = 1
+	icon_state = "4-8";
+	pixel_x = 0
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"srm" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"svt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"sDJ" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall,
-/area/maintenance/disposal)
-"sHz" = (
+"xHv" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/research_port)
-"sIm" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
-"sJx" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"sVQ" = (
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
-"tbZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"thq" = (
-/obj/structure/cryofeed{
-	icon_state = "cryo_rear";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
-"tij" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"tmB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/table/rack,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"tsg" = (
-/obj/structure/sign/electricshock,
-/turf/simulated/wall,
-/area/maintenance/bar)
-"ttI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/vending/medical{
-	density = 0;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"tww" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/reception)
-"txO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/gen_treatment)
-"tzW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgerywing)
-"tDD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/quartermaster/mail_room)
-"tFi" = (
-/obj/structure/disposalpipe/up{
-	icon_state = "pipe-u";
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "12-0"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
-/obj/machinery/atmospherics/pipe/zpipe/up/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"tFP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"tRw" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atm{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"tTJ" = (
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"tUu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -61863,366 +64536,23 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"tWi" = (
-/obj/machinery/mineral/processing_unit_console{
-	pixel_y = 32
+/area/maintenance/substation/medical)
+"xHw" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Medbay Substation";
+	req_one_access = list(11,24,5)
 	},
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/refinery)
-"tXU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/machinery/meter{
-	name = "Scrubbers"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"tZA" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "CHE2shutters";
-	name = "Chemistry Window Shutters";
-	opacity = 0
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/medical/chemistry)
-"ufe" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
-"ufj" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/morgue{
-	icon_state = "morgue1";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark{
-	name = "cooled dark floor";
-	temperature = 278
-	},
-/area/medical/temp_morgue)
-"uga" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table/standard,
-/obj/item/device/radio{
-	anchored = 1;
-	broadcasting = 0;
-	canhear_range = 1;
-	frequency = 1487;
-	icon = 'icons/obj/items.dmi';
-	icon_state = "red_phone";
-	listening = 1;
-	name = "Reception Emergency Phone";
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/reception)
-"uiA" = (
-/obj/structure/disposaloutlet{
-	icon_state = "outlet";
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/medical/surgeryobs)
-"uqm" = (
-/obj/structure/disposalpipe/down{
-	icon_state = "pipe-d";
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/drop{
-	pixel_y = 32
-	},
-/turf/simulated/open,
-/area/maintenance/medbay)
-"utc" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"uQH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"uSR" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"uVG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/medical/gen_treatment)
-"uXm" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"uZI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
-"vcx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/lime/full{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"vfU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"vnl" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	icon_state = "4-8";
+	pixel_x = 0
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/bar)
-"vnH" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/eva)
-"vpw" = (
-/obj/structure/closet/secure_closet/medical_wall{
-	name = "Pill Cabinet";
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/item/weapon/storage/pill_bottle/tramadol,
-/obj/item/weapon/storage/pill_bottle/dylovene,
-/obj/item/weapon/storage/pill_bottle/spaceacillin,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"vus" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
-"vyF" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"vAr" = (
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/refinery)
-"vEZ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/loading,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - General Treatment 2";
-	dir = 8;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled,
-/area/medical/gen_treatment)
-"vFt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"vGv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"vIw" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgerywing)
-"vOX" = (
+/area/maintenance/substation/medical)
+"xHx" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -62244,82 +64574,1079 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"vPN" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+"xHA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/small/emergency,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"xHB" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"xHC" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/vending/cola,
+/turf/simulated/floor/tiled,
+/area/medical/medbay2)
+"xHD" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/standard,
+/obj/machinery/microwave{
+	pixel_x = -2;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
-"vTp" = (
+/area/medical/medbay2)
+"xHF" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xHG" = (
+/obj/structure/reagent_dispensers/extinguisher,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xHH" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xHI" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"xHJ" = (
+/obj/structure/curtain,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
+"xHN" = (
+/obj/machinery/door/airlock{
+	name = "Changing Room"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
+"xHO" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryprep)
+"xHQ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"xHY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xHZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xIb" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xIc" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 2;
+	use_power = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
+"xId" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"xIe" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"xIg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xIw" = (
+/turf/simulated/wall,
+/area/medical/main_storage)
+"xIx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xIy" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
 /obj/structure/closet/crate,
 /obj/random/loot,
 /turf/simulated/floor/plating,
-/area/maintenance/cargo)
-"wbn" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
+/area/maintenance/atmos_control)
+"xIz" = (
+/obj/structure/closet/crate,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/atmos_control)
+"xIA" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/atmos_control)
+"xIB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/atmos_control)
+"xIC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/atmos_control)
+"xID" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIE" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIF" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Hard Storage"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIG" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIH" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xII" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/atmos_control)
+"xIK" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIL" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIM" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIN" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIO" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIP" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIQ" = (
+/obj/structure/table/rack,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/atmos_control)
+"xIR" = (
+/obj/structure/table/rack,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/atmos_control)
+"xIS" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIT" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIU" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/security_starboard)
+"xIV" = (
+/obj/structure/closet/crate/solar,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIX" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	req_one_access = list(24,11,55)
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/power/port_gen/pacman,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xIY" = (
+/obj/random/junk,
+/obj/structure/reagent_dispensers/extinguisher,
+/turf/simulated/floor/plating,
+/area/maintenance/security_starboard)
+"xIZ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/civ)
+"xJa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xJb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/shieldgen,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xJc" = (
+/obj/machinery/shieldwallgen,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage)
+"xJd" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/security_starboard)
+"xJe" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
+"xJf" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "engine_airlock_control";
+	name = "Engine Access Console";
+	pixel_x = 26;
+	pixel_y = 0;
+	req_access = list(11);
+	req_one_access = null;
+	tag_exterior_door = "engine_airlock_exterior";
+	tag_interior_door = "engine_airlock_interior"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
+"xJg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_monitoring)
+"xJh" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 2
+	},
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"xJi" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_monitoring)
+"xJj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_monitoring)
+"xJk" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"xJl" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/foyer)
+"xJm" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/foyer)
+"xJn" = (
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access = null;
+	req_one_access = list(12,66)
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
+"xJo" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"xJp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/medbreak)
+"xJq" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/medbreak)
+"xJr" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"xJs" = (
+/obj/structure/bed/chair/comfy/beige,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/medbreak)
+"xJt" = (
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/medbreak)
+"xJu" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"xJv" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"xJw" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/smartfridge/secure/medbay{
+	density = 1;
+	name = "Dangerous Materials Storage";
+	pixel_x = 0;
+	pixel_y = 0;
+	req_access = list(33)
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xJx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xJy" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	id = "medlounge"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "medlounge"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "medlounge"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/medbreak)
+"xJz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xJA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xJB" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xJC" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xJD" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xJE" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"xJF" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/vending/snack,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"xJG" = (
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/firealarm/west,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"xJH" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/device/destTagger,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xJI" = (
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/closet/wardrobe/chemistry_white,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Chemistry 2";
+	dir = 1;
+	icon_state = "camera";
+	network = list("Medical")
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xJJ" = (
+/obj/effect/floor_decal/corner/mauve/full{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"xJK" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xJL" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xJM" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"xJN" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"xJO" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"xJP" = (
+/turf/simulated/wall/r_wall,
+/area/medical/reception)
+"xJQ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/sign/chemistry,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "CHE2shutters";
+	name = "Chemistry Window Shutters";
+	opacity = 0
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced,
+/turf/simulated/floor/plating,
+/area/medical/reception)
+"xJR" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "CHE3shutters";
+	name = "Chemistry Desk Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Chemistry Desk";
+	req_access = list(33)
+	},
+/obj/machinery/ringer_button{
+	id = "chemistry_ringer";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/table/reinforced,
+/obj/structure/noticeboard{
+	pixel_x = 32;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/surgerywing)
-"wcb" = (
-/obj/machinery/hologram/holopad,
+/area/medical/reception)
+"xJS" = (
+/turf/simulated/wall/r_wall,
+/area/medical/reception)
+"xJT" = (
+/turf/simulated/wall/r_wall,
+/area/medical/reception)
+"xJU" = (
+/turf/simulated/wall/r_wall,
+/area/medical/reception)
+"xJV" = (
+/turf/simulated/wall/r_wall,
+/area/medical/reception)
+"xJW" = (
+/turf/simulated/wall/r_wall,
+/area/medical/reception)
+"xJX" = (
+/turf/simulated/wall/r_wall,
+/area/medical/reception)
+"xJY" = (
+/turf/simulated/wall/r_wall,
+/area/medical/reception)
+"xJZ" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "Medication Closet";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
+/obj/item/weapon/storage/pill_bottle/dermaline,
+/obj/item/weapon/storage/pill_bottle/tramadol,
+/obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xKa" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xKb" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xKc" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xKd" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Break Room";
+	req_access = list(5)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/medbreak)
+"xKe" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
 	})
-"wel" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+"xKf" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xKg" = (
+/turf/simulated/wall,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"xKh" = (
+/obj/structure/flora/pottedplant/random,
+/obj/effect/floor_decal/corner/lime/full{
+	icon_state = "corner_white_full";
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"xKi" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xKj" = (
+/turf/simulated/wall,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"xKk" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"xKl" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
 /area/medical/reception)
-"wgN" = (
-/obj/structure/bed/chair{
+"xKm" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2;
+	id_tag = null;
+	name = "Medical Reception";
+	req_access = list(5)
+	},
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/medical/reception)
+"xKn" = (
+/obj/structure/disposalpipe/junction,
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
-"wrl" = (
+"xKo" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xKp" = (
+/turf/simulated/wall,
+/area/medical/med_office{
+	name = "\improper Medical - Psych Stairway"
+	})
+"xKq" = (
+/obj/structure/sign/nosmoking_1{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xKr" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xKs" = (
+/turf/simulated/wall,
+/area/medical/exam_room{
+	name = "\improper Medical - Exam Room 1"
+	})
+"xKt" = (
+/obj/effect/floor_decal/corner/paleblue{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/vending/wallmed2{
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"xKu" = (
+/obj/effect/floor_decal/corner/pink{
+	icon_state = "corner_white";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/pink{
+	icon_state = "corner_white";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"xKv" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "LCKDshutters";
+	name = "MedBay Lockdown Shutters";
+	opacity = 0
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
+	icon_state = "rwindow";
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/structure/window/reinforced,
+/obj/structure/sign/greencross,
 /turf/simulated/floor/plating,
-/area/quartermaster/break_room)
-"wwA" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/area/medical/emt)
+"xKw" = (
+/obj/effect/floor_decal/corner/lime{
+	icon_state = "corner_white";
+	dir = 1
 	},
-/obj/machinery/door/airlock/glass_mining{
-	name = "Mail Sorting";
-	req_access = list(50)
+/obj/structure/flora/pottedplant/random,
+/turf/simulated/floor/tiled/white,
+/area/medical/emt)
+"xKx" = (
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
-"wxQ" = (
+/obj/machinery/light{
+	dir = 2;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/emt)
+"xKy" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -62330,213 +65657,226 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"wAc" = (
-/obj/machinery/light{
+/area/medical/emt)
+"xKz" = (
+/obj/structure/flora/pottedplant/random,
+/turf/simulated/floor/tiled/white,
+/area/medical/emt)
+"xKA" = (
+/obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
-"wAo" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
+/turf/simulated/floor/tiled/white,
+/area/medical/emt)
+"xKB" = (
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/newscaster{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"wIQ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 4;
-	status = 2
+/area/medical/emt)
+"xKC" = (
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/effect/large_stock_marker,
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"wJR" = (
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Lobby 2";
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 2;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/emt)
+"xKD" = (
+/obj/structure/flora/pottedplant/random,
+/obj/effect/floor_decal/corner/pink{
+	icon_state = "corner_white";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/emt)
+"xKE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "entrance_shutters";
+	name = "Entrance Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/medical/emt)
+"xKF" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/adv,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
-"wKI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgerywing)
-"wNz" = (
-/obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/effect/floor_decal/sign/cmo,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+"xKH" = (
+/obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"wQE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKI" = (
+/obj/structure/bed/chair/office/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/kitchen)
-"wXX" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"wYw" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/syringes{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/science,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"xbY" = (
-/obj/structure/disposaloutlet{
-	dir = 1;
-	name = "mail outlet";
-	spread_point = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/mail_room)
-"xjb" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id = "GTRshutters";
-	name = "General Treatment Room Shutters";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/gen_treatment)
-"xob" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal,
 /turf/simulated/floor/tiled/dark,
-/area/maintenance/disposal)
-"xuY" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper_0";
-	dir = 4
+/area/medical/emt)
+"xKJ" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/crowbar/red,
+/obj/machinery/light{
+	dir = 4;
+	status = 2
 	},
-/obj/effect/floor_decal/corner/pink{
-	icon_state = "corner_white";
-	dir = 9
+/obj/machinery/vending/wallmed2{
+	pixel_x = 28
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/icu)
-"xAl" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"xCL" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/quartermaster/mail_room)
-"xDz" = (
+/turf/simulated/floor/tiled/dark,
+/area/medical/emt)
+"xKK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay)
+"xKL" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/substation/medical)
+"xKM" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/structure/closet/crate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/maintenance/bar)
-"xIy" = (
+/area/maintenance/medbay)
+"xKN" = (
+/obj/structure/cryofeed{
+	icon_state = "cryo_rear";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/cryo)
+"xKO" = (
+/obj/structure/cryofeed{
+	icon_state = "cryo_rear";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/cryo)
+"xKP" = (
+/obj/structure/cryofeed{
+	icon_state = "cryo_rear";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/cryo)
+"xKQ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"xKR" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"xKS" = (
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"xIJ" = (
-/turf/simulated/wall,
-/area/quartermaster/mail_room)
-"xIT" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/table/standard,
-/obj/item/device/radio/intercom{
-	pixel_y = 27
+/obj/structure/closet/walllocker/emerglocker/north,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xKT" = (
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Aft Corridor - Camera 2";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/medical/reception)
-"xNM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/area/hallway/primary/aft)
+"xKU" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled,
+/area/maintenance/research_port)
+"xKV" = (
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Aft Corridor - Camera 3";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
-"xTf" = (
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"xKW" = (
+/obj/effect/landmark/dungeon_spawn,
+/turf/unsimulated/chasm_mask,
+/area/mine/unexplored)
+"xKX" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xKY" = (
+/obj/machinery/camera/network/civilian_east{
+	c_tag = "Bar - Theater Supplies";
+	c_tag_order = 999;
+	dir = 4;
+	network = list("Service")
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"xKZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLa" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -62561,47 +65901,211 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/lobby)
-"xUH" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 10
+"xLb" = (
+/obj/effect/floor_decal/industrial/loading,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLd" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
 	},
-/obj/structure/closet/wardrobe/chemistry_white,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"xUY" = (
-/obj/effect/floor_decal/corner/mauve{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLg" = (
+/obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
-	dir = 5
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLi" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4;
+	name = "Firelock East"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 1;
+	dir = 4;
+	icon_state = "shutter1";
+	id = "cargo_cockblock";
+	name = "Cargo";
+	opacity = 1
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/lobby)
+"xLj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
+"xLk" = (
+/obj/machinery/door/firedoor/multi_tile,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLl" = (
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLm" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLn" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLo" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 8
+	},
+/obj/structure/closet/walllocker/emerglocker/west,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xLp" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"xVE" = (
-/obj/structure/morgue{
-	icon_state = "morgue1";
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLq" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/dark{
-	name = "cooled dark floor";
-	temperature = 278
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLr" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 4;
+	status = 2
 	},
-/area/medical/temp_morgue)
-"xXW" = (
+/obj/effect/large_stock_marker,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLs" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xLt" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
+"xLu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLv" = (
+/obj/effect/floor_decal/corner/brown/full{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -62628,2022 +66132,231 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
-"xYf" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/medical/icu)
-"ybr" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
-"ygv" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/port)
-"ygw" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
-"ygx" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
-"ygy" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/sign/greencross,
-/turf/simulated/floor/plating,
-/area/hallway/primary/starboard)
-"ygG" = (
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access = null;
-	req_one_access = list(12,66)
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medbreak)
-"ygJ" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/item/device/radio/intercom{
-	pixel_y = 27
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Chemistry";
-	dir = 2;
-	icon_state = "camera";
-	network = list("Medical")
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"ygK" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
-	},
-/obj/structure/sink/kitchen{
-	name = "chemistry sink";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"ygM" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/hallway/primary/starboard)
-"ygN" = (
-/turf/simulated/floor/tiled/ramp{
-	icon_state = "ramptop";
-	dir = 1
-	},
-/area/hallway/primary/starboard)
-"ygO" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "medlounge"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "medlounge"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "medlounge"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/medbreak)
-"ygP" = (
-/obj/structure/flora/pottedplant/random,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"ygQ" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"ygR" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Staff Smoking Lounge"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"ygS" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/medbreak)
-"ygT" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/donut,
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"ygU" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/item/weapon/stool/padded,
-/obj/machinery/ringer{
-	department = "Medbay";
-	id = "medbay_ringer";
-	pixel_x = 0;
-	pixel_y = 30;
-	req_access = list(5)
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"ygW" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/bar_soft/full,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Break Room"
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"ygZ" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "ExamR2"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "ExamR2"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "ExamR2"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yha" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized{
-	id = "ExamR2"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "ExamR2"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yhb" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized{
-	id = "ExamR2"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "ExamR2"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "ExamR2"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yhc" = (
-/turf/simulated/wall,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yhd" = (
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/hallway/primary/starboard)
-"yhe" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/hallway/primary/starboard)
-"yhf" = (
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/hallway/primary/starboard)
-"yhh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"yhi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"yhj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"yhk" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/medbreak)
-"yhl" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/table/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yhm" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/item/weapon/stool/padded,
+"xLx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yhn" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yho" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/drinkingglasses{
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yhq" = (
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Port 1";
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"yhr" = (
-/obj/structure/table/standard,
-/obj/machinery/computer/med_data/laptop,
-/turf/simulated/floor/carpet/blue,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yhs" = (
-/obj/structure/table/standard,
-/obj/item/device/radio{
-	anchored = 1;
-	broadcasting = 0;
-	canhear_range = 1;
-	frequency = 1487;
-	icon = 'icons/obj/items.dmi';
-	icon_state = "red_phone";
-	listening = 1;
-	name = "Examination Room Emergency Phone";
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yht" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yhv" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/medical{
-	id_tag = "EXdoor2";
-	name = "Examination Room 2";
-	req_one_access = list(5)
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yhy" = (
-/turf/simulated/floor/tiled/white,
-/area/hallway/primary/starboard)
-"yhz" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "medlounge"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "medlounge"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/medbreak)
-"yhA" = (
-/obj/structure/bed/chair/comfy/beige,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"yhB" = (
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"yhC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"yhD" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Staff Smoking Lounge";
-	req_access = list(66)
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled{
-	icon_state = "vault";
-	dir = 5
-	},
-/area/crew_quarters/medbreak)
-"yhE" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yhF" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yhG" = (
-/obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yhH" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/coffee/full,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yhJ" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/obj/machinery/button/remote/airlock{
-	id = "EXdoor2";
-	name = "Office Door Control";
-	pixel_x = 36;
-	pixel_y = -14;
-	req_access = list(5)
-	},
-/obj/machinery/button/windowtint{
-	id = "ExamR2";
-	pixel_x = 28;
-	pixel_y = -14;
-	req_access = list(5)
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Examination Room 2";
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yhK" = (
-/obj/structure/table/standard,
-/obj/item/weapon/folder/white,
-/obj/item/weapon/pen,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yhL" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yhM" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yhN" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "ExamR2"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "ExamR2"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "ExamR2"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "ExamR2"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yhO" = (
-/obj/effect/floor_decal/corner/lime/full,
-/turf/simulated/floor/tiled/white,
-/area/hallway/primary/starboard)
-"yhP" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/hallway/primary/starboard)
-"yhQ" = (
-/obj/effect/floor_decal/corner/lime/full{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/hallway/primary/starboard)
-"yhR" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	id = "medlounge"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "medlounge"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "medlounge"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/medbreak)
-"yhS" = (
-/obj/structure/table/glass,
-/obj/item/weapon/material/ashtray/bronze,
-/obj/machinery/button/windowtint{
-	id = "medlounge";
-	pixel_x = -4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"yhT" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 8
-	},
-/obj/machinery/firealarm/south,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"yhU" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -28
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/medbreak)
-"yhV" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/crew_quarters/medbreak)
-"yhW" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/donkpockets,
 /turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yhX" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/area/quartermaster/lobby)
+"xLy" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/large_stock_marker,
+/turf/simulated/floor/tiled,
+/area/quartermaster/lobby)
+"xLz" = (
+/turf/simulated/wall,
+/area/quartermaster/break_room)
+"xLA" = (
+/turf/simulated/wall,
+/area/quartermaster/break_room)
+"xLB" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yhY" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yhZ" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/vending/cola,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yib" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yic" = (
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin{
-	pixel_x = -1;
-	pixel_y = 7
-	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yid" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yie" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/firealarm/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yig" = (
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/medical{
-	id_tag = "EXdoor1";
-	name = "Examination Room 1";
-	req_one_access = list(5)
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yih" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "ExamR1"
-	},
-/turf/simulated/floor/plating,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yim" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/table/standard,
-/obj/machinery/microwave{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yin" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mail Sorting";
+	req_access = list(50)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yio" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yip" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/vending/snack,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yiq" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/closet/secure_closet/medical_wall{
-	name = "Medication Closet";
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
-/obj/item/weapon/storage/pill_bottle/dermaline,
-/obj/item/weapon/storage/pill_bottle/tramadol,
-/obj/item/weapon/storage/pill_bottle/dylovene,
-/obj/item/weapon/storage/pill_bottle/dylovene,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yir" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yis" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yit" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/bed,
-/obj/item/weapon/bedsheet/medical,
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yiu" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/flora/pottedplant/random,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yiw" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
+/area/quartermaster/mail_room)
+"xLC" = (
+/turf/simulated/wall,
+/area/quartermaster/mail_room)
+"xLD" = (
+/turf/simulated/wall,
+/area/quartermaster/mail_room)
+"xLE" = (
+/obj/machinery/disposal{
+	name = "mailing disposal unit"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/disposal,
 /turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yix" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yiy" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yiz" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yiA" = (
-/obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Medical Officer's Office"
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
-"yiC" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/door/airlock/medical{
-	name = "Examination Room 2";
-	req_one_access = list(5)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yiD" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "ExamR2"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "ExamR2"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "ExamR2"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "ExamR2"
-	},
-/turf/simulated/floor/plating,
-/area/medical/biostorage{
-	name = "\improper Medical - Exam Room 2"
-	})
-"yiE" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/closet/secure_closet/medical_wall{
-	name = "Medication Closet";
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
-/obj/item/weapon/storage/pill_bottle/dermaline,
-/obj/item/weapon/storage/pill_bottle/tramadol,
-/obj/item/weapon/storage/pill_bottle/dylovene,
-/obj/item/weapon/storage/pill_bottle/dylovene,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yiH" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_medical{
-	name = "Break Room";
-	req_access = list(5)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/medbreak)
-"yiJ" = (
-/turf/simulated/wall,
-/area/crew_quarters/medbreak)
-"yiK" = (
-/obj/structure/sign/nosmoking_1{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/structure/table/standard,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/hand_labeler,
-/obj/item/weapon/reagent_containers/spray,
-/turf/simulated/floor/tiled/white,
-/area/assembly/robotics)
-"yiL" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "ExamR1"
-	},
-/turf/simulated/floor/plating,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yiN" = (
-/obj/structure/flora/pottedplant/random,
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yiO" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yiP" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
-	},
+/area/hallway/primary/aft)
+"xLF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yiQ" = (
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 1
-	},
-/obj/structure/flora/pottedplant/random,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Psych Stairway"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yiR" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 2;
-	id_tag = null;
-	name = "Medical Reception";
-	req_access = list(5)
-	},
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
 	},
 /turf/simulated/floor/tiled,
-/area/medical/reception)
-"yiS" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "ExamR1"
-	},
-/turf/simulated/floor/plating,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yiU" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yiV" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yiW" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yiX" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/machinery/firealarm/east,
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yiY" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "ExamR1"
-	},
-/turf/simulated/floor/plating,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yiZ" = (
-/obj/machinery/door/airlock/medical{
-	name = "Psychiatric Wing";
-	req_access = list(5)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yja" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjb" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjc" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjd" = (
-/obj/structure/stairs/east,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yje" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Port 2";
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"yjf" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "ExamR1"
-	},
-/turf/simulated/floor/plating,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yjg" = (
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
-/obj/machinery/button/windowtint{
-	id = "ExamR1";
-	pixel_x = -14;
-	pixel_y = 28;
-	req_access = list(5)
-	},
-/obj/machinery/button/remote/airlock{
-	id = "EXdoor1";
-	name = "Office Door Control";
-	pixel_x = -14;
-	pixel_y = 36;
-	req_access = list(5)
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yjh" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Starboard 1";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"yji" = (
-/turf/simulated/wall,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjj" = (
-/obj/effect/floor_decal/corner/lime/full,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjk" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjl" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjm" = (
-/obj/structure/stairs/east,
-/turf/simulated/floor/tiled/white,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjn" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized{
-	id = "CMO"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "CMO"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "CMO"
-	},
-/obj/structure/cable/green,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "CMO"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/cmo)
-"yjo" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized{
-	id = "CMO"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "CMO"
-	},
-/obj/structure/cable/green,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "CMO"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/cmo)
-"yjq" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Port 4";
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"yjr" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "ExamR1"
-	},
-/turf/simulated/floor/plating,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yjt" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "ExamR1"
-	},
-/turf/simulated/floor/plating,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yju" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "ExamR1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "ExamR1"
-	},
-/turf/simulated/floor/plating,
-/area/medical/exam_room{
-	name = "\improper Medical - Exam Room 1"
-	})
-"yjv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjw" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjy" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjz" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/medical/med_office{
-	name = "\improper Medical - Psych Stairway"
-	})
-"yjA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/medical/medbay2)
-"yjB" = (
-/obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Starboard 3";
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"yjC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/main_storage)
-"yjD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/firealarm/west,
-/turf/simulated/floor/tiled/white,
-/area/medical/gen_treatment)
-"yjE" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"yjF" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Starboard 2";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
-"yjG" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
-"yjH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
-"yjI" = (
-/obj/machinery/light/small,
-/obj/machinery/button/remote/blast_door{
-	id = "emtshutter";
-	name = "Garage Shutters Control";
-	pixel_x = 0;
-	pixel_y = -26;
-	req_access = list(5)
-	},
-/obj/effect/floor_decal/industrial/loading{
-	icon_state = "loadingarea";
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/medical/emt)
-"yjJ" = (
-/obj/structure/table/standard,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - EMT Quarters";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/emt)
-"yjK" = (
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Port 3";
-	dir = 8
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"yjL" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Cryogenics Control";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/medical/cryo)
-"yjM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+/area/hallway/primary/aft)
+"xLG" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access = list(12);
-	req_one_access = null
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
+	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/substation/medical)
-"yjN" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/substation/medical)
-"yjO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access = list(66)
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "LCKDshutters";
-	name = "MedBay Lockdown Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/medical/genetics_cloning)
-"yjP" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Medbay Subgrid";
-	name_tag = "Medbay Subgrid"
-	},
-/obj/structure/cable/green,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/turf/simulated/floor/tiled,
+/area/maintenance/bar)
+"xLH" = (
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
-/area/maintenance/substation/medical)
-"yjU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/area/maintenance/bar)
+"xLI" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"yjV" = (
-/obj/machinery/power/smes/buildable{
-	charge = 0;
-	RCon_tag = "Substation - Medical Main"
-	},
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/medical)
-"yka" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xLJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"ykb" = (
+/area/maintenance/bar)
+"xLK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xLL" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xLM" = (
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/obj/structure/table/rack,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xLN" = (
+/obj/structure/sign/securearea{
+	name = "\improper CAUTION: TRASH COMPACTOR";
+	pixel_x = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/maintenance/disposal)
+"xLO" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Disposals Maintenance";
+	req_one_access = list(12,50)
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/disposal)
+"xLP" = (
+/obj/structure/sign/securearea{
+	name = "\improper CAUTION: TRASH COMPACTOR";
+	pixel_x = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/maintenance/disposal)
+"xLQ" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"ykc" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"ykd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/medbay)
-"yke" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical - Pre-Op 2";
-	dir = 1
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryprep)
-"ykf" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
-"ykg" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/machinery/autolathe,
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"ykh" = (
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
-"yki" = (
+/area/maintenance/bar)
+"xLR" = (
+/obj/structure/disposalpipe/sortjunction/untagged,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xLS" = (
+/obj/structure/ladder/up,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xLT" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/turf/simulated/floor/plating,
+/area/quartermaster/break_room)
+"xLU" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/corner/brown/full{
 	icon_state = "corner_white_full";
@@ -64651,759 +66364,307 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/mail_room)
-"ykj" = (
-/obj/structure/weightlifter,
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 5
+"xLV" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 10
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xLW" = (
+/obj/structure/ladder,
+/turf/simulated/open,
+/area/maintenance/disposal)
+"xLX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/effect/landmark/start{
-	name = "Shaft Miner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/firealarm/west,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/break_room)
-"ykk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/camera/network/mining{
-	c_tag = "Mining - Locker Room"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/eva)
-"ykl" = (
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xLY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/closet/walllocker/emerglocker/north,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
-"ykm" = (
-/obj/machinery/camera/network/civilian_east{
-	c_tag = "Bar - Theater Supplies";
-	c_tag_order = 999;
-	dir = 4;
-	network = list("Service")
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
-"ykn" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 8
-	},
-/obj/structure/closet/walllocker/emerglocker/west,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"yko" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/structure/closet/crate,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"ykp" = (
-/obj/structure/closet/crate,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"ykq" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"ykr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"yks" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"ykt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"yku" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykv" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/structure/sign/nosmoking_1{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykw" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Hard Storage"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykx" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"yky" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/structure/sign/nosmoking_1{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykz" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"ykB" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykC" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykD" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykE" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykF" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykG" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykH" = (
-/obj/structure/table/rack,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"ykI" = (
-/obj/structure/table/rack,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/atmos_control)
-"ykJ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykK" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykL" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4";
-	dir = 1;
-	d1 = 1;
-	d2 = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykM" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykN" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykO" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykP" = (
-/obj/structure/closet/crate/solar,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykS" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24;
-	req_one_access = list(24,11,55)
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/power/port_gen/pacman,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/shieldgen,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ykZ" = (
-/obj/machinery/shieldwallgen,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"yla" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/bag/circuits/basic,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ylb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"ylc" = (
-/obj/machinery/firealarm/south,
-/obj/machinery/shieldgen,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
-"yld" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
-"yle" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/engineering)
-"ylf" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "engine_airlock_control";
-	name = "Engine Access Console";
-	pixel_x = 26;
-	pixel_y = 0;
-	req_access = list(11);
-	req_one_access = null;
-	tag_exterior_door = "engine_airlock_exterior";
-	tag_interior_door = "engine_airlock_interior"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
-"ylg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
-	},
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"ylh" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"yli" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 5
-	},
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"ylj" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "engine_airlock_control";
-	name = "Engine Access Console";
-	pixel_x = -26;
-	pixel_y = 0;
-	req_access = list(11);
-	req_one_access = null;
-	tag_exterior_door = "engine_airlock_exterior";
-	tag_interior_door = "engine_airlock_interior"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
-"ylk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
-"yll" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "E.V.A. Maintenance";
-	req_access = list(12,18)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/ai_monitored/storage/eva)
-"ylm" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
-"yln" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "engine_airlock_interior";
-	locked = 1;
-	name = "Engine Interior Access";
-	req_access = list(11)
-	},
-/obj/machinery/door/firedoor{
-	dir = 8;
-	name = "Firelock West"
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "engine_airlock_control";
-	name = "Engine Access Button";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access = list(11);
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"ylo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"ylp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"ylq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"ylr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "engine_airlock_exterior";
-	locked = 1;
-	name = "Engine Exterior Access";
-	req_access = list(11)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "engine_airlock_control";
-	name = "Engine Access Button";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access = list(11);
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"yls" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
-"ylt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
-"ylu" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/full{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"ylv" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Medical Voidsuits";
-	req_one_access = list(5)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"ylw" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
 	pixel_x = 0;
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
 /turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"ylx" = (
-/obj/machinery/light{
-	dir = 1
+/area/maintenance/disposal)
+"xLZ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/machinery/firealarm/north,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
+/obj/machinery/disposal,
 /turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"yly" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/area/maintenance/disposal)
+"xMa" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue/full{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"ylz" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/machinery/light/small/emergency{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engineering/engine_room)
-"ylA" = (
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
+/area/maintenance/bar)
+"xMb" = (
+/obj/structure/disposalpipe/segment,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMc" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"ylB" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light{
-	icon_state = "tube1";
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMd" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMe" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMh" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMi" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
 	dir = 2
 	},
-/obj/machinery/firealarm/south,
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"ylC" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
-"ylD" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMj" = (
+/obj/structure/disposalpipe/up{
+	icon_state = "pipe-u";
 	dir = 8
 	},
-/obj/structure/closet/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
-"ylE" = (
 /obj/structure/cable{
-	d1 = 1;
+	icon_state = "12-0"
+	},
+/obj/structure/cable{
 	d2 = 2;
-	icon_state = "1-2";
+	icon_state = "0-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
-"ylF" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
+/obj/machinery/atmospherics/pipe/zpipe/up/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMk" = (
+/obj/structure/sign/electricshock,
+/turf/simulated/wall,
+/area/maintenance/bar)
+"xMl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/meter{
+	name = "Scrubbers"
 	},
-/obj/structure/cable/green{
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/meter{
+	name = "Air supply"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMp" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "mail_chute"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
+"xMq" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMr" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMs" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMy" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"ylG" = (
+/area/quartermaster/mail_room)
+"xMz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMA" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -65412,290 +66673,669 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"ylH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"ylI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"ylJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Lobby Aft";
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"ylK" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 8;
-	name = "Engineering Break Room";
-	sortType = "Engineering Break Room"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"ylL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"ylM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"ylN" = (
-/obj/structure/bed/chair/office/dark,
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"ylO" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/plating,
-/area/engineering/foyer)
-"ylP" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/foyer)
-"ylQ" = (
-/obj/structure/table/reinforced/steel,
-/obj/machinery/door/window/brigdoor/northleft{
-	name = "Engineering Desk";
-	req_access = list(32)
-	},
-/obj/machinery/door/firedoor{
-	dir = 1;
-	name = "Engineering Firelock"
-	},
-/obj/machinery/ringer_button{
-	id = "engie_ringer";
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
-"ylR" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/foyer)
-"ylS" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/foyer)
-"ylT" = (
-/obj/effect/landmark/dungeon_spawn,
-/turf/unsimulated/chasm_mask,
-/area/mine/unexplored)
-"ylU" = (
+/area/maintenance/bar)
+"xMB" = (
 /obj/structure/table/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/stack/flag/purple,
+/obj/random/loot,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMC" = (
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/table/rack,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMD" = (
+/obj/structure/grille,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/quartermaster/break_room)
+"xME" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/standard,
+/obj/item/weapon/packageWrap,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
-	dir = 6
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
+"xMF" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
+"xMG" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
+"xMH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/quartermaster/mail_room)
+"xMI" = (
+/obj/structure/sign/drop,
+/turf/simulated/wall/r_wall,
+/area/maintenance/disposal)
+"xMJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/light/small/emergency{
+	icon_state = "bulb1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMK" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xML" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/wrapping_paper,
+/obj/effect/floor_decal/corner/brown/full,
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
+"xMM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
+"xMN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/obj/item/device/destTagger,
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/obj/machinery/light,
+/obj/structure/noticeboard{
+	pixel_y = -32
+	},
+/obj/machinery/camera/network/supply{
+	c_tag = "Cargo - Mail Room";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
+"xMO" = (
+/obj/structure/disposalpipe/junction/yjunction,
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
+"xMP" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/full{
+	icon_state = "corner_white_full";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/mail_room)
+"xMQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMR" = (
+/obj/structure/closet/crate,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/cargo)
+"xMS" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Mail Maintenance";
+	req_access = list(50)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMT" = (
+/obj/structure/disposaloutlet{
+	dir = 1;
+	name = "mail outlet";
+	spread_point = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/mail_room)
+"xMU" = (
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Sorting Office";
+	sortType = "Sorting Office"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMW" = (
+/obj/structure/disposaloutlet{
+	dir = 1;
+	spread = 360;
+	spread_point = 2
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/disposal)
+"xMY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xMZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNa" = (
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNb" = (
+/obj/structure/sign/securearea{
+	name = "\improper CAUTION: TRASH COMPACTOR";
+	pixel_x = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/maintenance/disposal)
+"xNc" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/maintenance/disposal)
+"xNd" = (
+/obj/structure/sign/securearea{
+	name = "\improper CAUTION: TRASH COMPACTOR";
+	pixel_x = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/maintenance/disposal)
+"xNe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNg" = (
+/obj/structure/disposalpipe/tagger/partial{
+	dir = 8;
+	icon_state = "pipe-tagger-partial";
+	tag = "Sorting Office"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"xNo" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/mining,
-/obj/item/clothing/head/helmet/space/void/mining,
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/eva)
-"ylV" = (
-/obj/structure/table/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/stack/flag/red,
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
+"xNp" = (
+/obj/machinery/conveyor{
+	dir = 9;
+	icon_state = "conveyor0";
+	id = "mining_internal";
+	reversed = 1
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"xNq" = (
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"xNr" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/machinery/status_display{
+	pixel_x = -32
 	},
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
-	dir = 9
+	dir = 6
 	},
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/mining,
-/obj/item/clothing/head/helmet/space/void/mining,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"ylW" = (
-/obj/structure/table/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/stack/flag/green,
+"xNs" = (
+/obj/machinery/mineral/output,
+/obj/machinery/conveyor{
+	dir = 9;
+	icon_state = "conveyor0";
+	id = "mining_internal";
+	reversed = 1
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"xNt" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining_internal"
+	},
+/obj/machinery/mineral/output,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"xNu" = (
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"xNv" = (
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"xNw" = (
+/obj/structure/closet/secure_closet/miner,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
-	dir = 6
+	dir = 9
+	},
+/obj/machinery/status_display/supply_display{
+	pixel_x = -32
 	},
 /obj/effect/floor_decal/corner/green{
 	icon_state = "corner_white";
-	dir = 9
+	dir = 6
 	},
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/mining,
-/obj/item/clothing/head/helmet/space/void/mining,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
-"ylX" = (
-/obj/structure/table/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/stack/flag/yellow,
+"xNx" = (
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"xNy" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
-	dir = 6
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
-	dir = 9
+	dir = 6
 	},
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/mining,
-/obj/item/clothing/head/helmet/space/void/mining,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
+"xNz" = (
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"xNA" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"xNB" = (
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/refinery)
+"xNC" = (
+/obj/machinery/mineral/processing_unit_console{
+	pixel_y = 32
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining_internal";
+	name = "mining conveyor"
+	},
+/obj/effect/floor_decal/corner/brown/full{
+	icon_state = "corner_white_full";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"xND" = (
+/obj/machinery/mineral/processing_unit_console{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"xNE" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/ore_box,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"xNF" = (
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"xNG" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/ore_box,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"xNH" = (
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"xNI" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/ore_box,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"xNJ" = (
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
+"xNK" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/ore_box,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 
 (1,1,1) = {"
 aaa
@@ -68189,7 +69829,7 @@ aaa
 aaa
 aaa
 aaa
-ylT
+xKW
 aaa
 aaa
 aaa
@@ -78914,9 +80554,9 @@ awy
 auS
 azE
 akY
-ylf
-ylm
-ylz
+xJf
+aEE
+aEE
 akY
 akY
 akY
@@ -79172,7 +80812,7 @@ auT
 azF
 aCR
 aCR
-yln
+aEF
 aCR
 aCR
 aKe
@@ -79428,9 +81068,9 @@ awA
 ayh
 azG
 aCR
-ylg
-ylo
-ylA
+aCT
+aEG
+aGG
 aCR
 aKf
 aLQ
@@ -79685,9 +81325,9 @@ awB
 ayi
 azH
 aCR
-ylh
-ylp
-ylB
+aCU
+aEH
+xJh
 aCR
 aKg
 aLP
@@ -79942,9 +81582,9 @@ awC
 anb
 azI
 aCR
-yli
-ylq
-ylC
+aCV
+aEI
+aGH
 aCR
 aKh
 aLR
@@ -80200,7 +81840,7 @@ ayj
 azJ
 aCR
 aCR
-ylr
+aEJ
 aCR
 aCR
 aKi
@@ -80456,9 +82096,9 @@ awE
 ayk
 auX
 arQ
-ylj
-yls
-ylD
+aCX
+aEK
+xJi
 arQ
 aKj
 aLS
@@ -80712,10 +82352,10 @@ auY
 awF
 ayl
 att
-yld
-ylk
-ylt
-ylE
+aAY
+xJg
+aEL
+xJj
 aIm
 aKk
 aKk
@@ -80954,9 +82594,9 @@ aab
 aab
 aiK
 ajw
-ykq
-ykr
-ykt
+xIA
+xIB
+akp
 ale
 alX
 alX
@@ -80974,7 +82614,7 @@ aCY
 aEM
 aGJ
 aIn
-alE
+xJk
 aLT
 aKi
 aKi
@@ -81470,13 +83110,13 @@ aiK
 ajv
 akq
 alY
-yku
-ykB
-ykJ
-ykP
+xID
+xIK
+xIS
+xIV
 ama
 anc
-yla
+aqD
 alY
 atu
 ava
@@ -81727,13 +83367,13 @@ aiK
 ajx
 akq
 alY
-ykv
-ykC
-ykK
+xIE
+xIL
+xIT
 and
-ykT
-ykW
-ylb
+aod
+apr
+aqE
 arT
 atv
 avb
@@ -81984,12 +83624,12 @@ aiK
 ajv
 akq
 alY
-ykw
-ykD
-ykL
-ykQ
-ykU
-ykX
+xIF
+xIM
+amb
+xIW
+aoe
+xJa
 and
 arU
 atw
@@ -82241,13 +83881,13 @@ aiK
 ajv
 akq
 alY
-ykx
-ykE
-ykM
+xIG
+xIN
+amc
 and
 and
-ykY
-ylc
+xJb
+aqF
 alY
 atx
 ava
@@ -82498,12 +84138,12 @@ aiK
 ajv
 akq
 alY
-yky
-ykF
-ykN
-ykR
-ykV
-ykZ
+xIH
+xIO
+amd
+ane
+ane
+xJc
 aog
 alY
 aty
@@ -82755,10 +84395,10 @@ aiK
 ajv
 akq
 alY
-ykz
-ykG
-ykO
-ykS
+xII
+xIP
+amc
+xIX
 alZ
 alZ
 alZ
@@ -83270,7 +84910,7 @@ ajv
 akq
 ajv
 ajv
-ykH
+xIQ
 aiK
 ang
 ang
@@ -83527,7 +85167,7 @@ ajw
 akq
 ajv
 ajv
-ykI
+xIR
 aiK
 ang
 ang
@@ -83780,7 +85420,7 @@ aab
 aab
 aab
 aiK
-yko
+xIy
 akq
 ajv
 ajv
@@ -84037,10 +85677,10 @@ aab
 aab
 aab
 aiL
-ykp
+xIz
 aks
-yks
-ykA
+xIC
+xIJ
 alf
 aiK
 ang
@@ -84317,7 +85957,7 @@ aGT
 aIx
 aKn
 aDj
-ylF
+xJl
 aPv
 aRk
 aSA
@@ -84344,7 +85984,7 @@ ajK
 aLT
 baJ
 baJ
-gHb
+xGB
 baJ
 bAh
 bBi
@@ -84574,7 +86214,7 @@ aGU
 aIy
 aKo
 aMd
-ylG
+aNQ
 aPw
 aRl
 aSB
@@ -84601,7 +86241,7 @@ btm
 btm
 btm
 btm
-sHz
+xGC
 btm
 bAi
 aKl
@@ -84831,7 +86471,7 @@ aGV
 aGW
 aKp
 aMe
-ylH
+aNR
 aPx
 aDi
 aSC
@@ -85088,7 +86728,7 @@ aGW
 aGW
 aKq
 aMe
-ylI
+aNS
 aPy
 aRm
 aSD
@@ -85345,7 +86985,7 @@ aGX
 aIz
 aKq
 aMe
-ylJ
+aNT
 aPz
 aPz
 aPz
@@ -85602,10 +87242,10 @@ aGW
 aGW
 aKr
 aMe
-ylK
+aNU
 aPA
 aRn
-ylO
+aSE
 aUr
 aDk
 aXc
@@ -85859,10 +87499,10 @@ aGY
 aIA
 aKs
 aMf
-ylL
+aNS
 aPB
 aRo
-ylP
+aSF
 aUs
 aDk
 aXc
@@ -86116,17 +87756,17 @@ aDi
 aDi
 aKt
 aDi
-ylM
+aNV
 aDj
-ylN
-ylQ
+aRp
+aSG
 aUs
 aDk
 aXc
 aBr
 aZI
 aPz
-alE
+xJo
 aKl
 bdG
 bgm
@@ -86376,7 +88016,7 @@ aMg
 aNW
 aPC
 aRq
-ylR
+aSH
 aUs
 aDk
 aXc
@@ -86633,7 +88273,7 @@ aDk
 aDk
 aPD
 aRr
-ylS
+xJm
 aUt
 aIB
 aXe
@@ -86959,7 +88599,7 @@ baJ
 baJ
 baJ
 baJ
-alE
+xLt
 aLT
 aKj
 baJ
@@ -87394,9 +89034,9 @@ avr
 awX
 ayE
 aAa
-yle
+aBu
 aDm
-ylu
+aFc
 aHc
 aDm
 aKx
@@ -87482,7 +89122,7 @@ bRJ
 bRJ
 cda
 cdj
-vTp
+xMR
 bRJ
 ciP
 ciY
@@ -87910,7 +89550,7 @@ ayE
 aAc
 aBw
 aDm
-ylv
+aFe
 aHe
 aDm
 aHe
@@ -88167,7 +89807,7 @@ ayE
 aAd
 aBx
 aDm
-ylw
+aFf
 aHf
 aID
 aKz
@@ -88229,7 +89869,7 @@ baJ
 baJ
 baJ
 bUn
-agt
+xKU
 baJ
 baJ
 baJ
@@ -88424,7 +90064,7 @@ ayE
 aAe
 aBy
 aDm
-ylx
+aFg
 aFj
 aFj
 aFj
@@ -88680,8 +90320,8 @@ akD
 akD
 akD
 aBz
-yll
-yly
+aDo
+aFh
 aHg
 aHg
 aKA
@@ -89462,7 +91102,7 @@ aPI
 aRv
 aSP
 aDm
-ygv
+aVC
 aXl
 aVz
 aZM
@@ -89541,10 +91181,10 @@ bZA
 cdA
 cdG
 cdP
-lIz
-vnH
-ltv
-dWo
+xNo
+xNr
+xNw
+xNy
 ceM
 cfb
 cfp
@@ -89703,7 +91343,7 @@ aos
 aqS
 asf
 atO
-alC
+xJe
 axb
 aii
 afr
@@ -90312,7 +91952,7 @@ cdl
 ciM
 ciN
 cdP
-ykk
+cdU
 ceb
 ceq
 ceG
@@ -90557,16 +92197,16 @@ bWm
 bWm
 bWm
 cae
-grH
+xLu
 caN
 bWm
 cbt
-pjW
-pjW
-pjW
-pjW
-pjW
-pjW
+cbf
+cbf
+cbf
+cbf
+cbf
+cbf
 cdH
 cdP
 cdV
@@ -90578,10 +92218,10 @@ cff
 cfs
 cfG
 cfR
-ylU
-ylV
-ylW
-ylX
+cgb
+cgh
+cgq
+cgx
 cgD
 aQk
 aab
@@ -90814,16 +92454,16 @@ bYW
 bZp
 bWm
 bWm
-anA
+cav
 bWm
 bWm
-amA
-pjW
-ykj
+cbu
+cbf
+ccm
 ccH
 cdd
 cdm
-pjW
+cbf
 cdI
 cdQ
 cdQ
@@ -91000,7 +92640,7 @@ aIH
 aKE
 aMp
 aOc
-anB
+aPK
 aHl
 aST
 aUA
@@ -91019,7 +92659,7 @@ bks
 blR
 bjg
 boM
-aal
+bpX
 aZM
 bsp
 btE
@@ -91072,7 +92712,7 @@ cii
 bZC
 caf
 caw
-pjW
+xLz
 ciA
 cbv
 cbN
@@ -91080,7 +92720,7 @@ cbx
 cbx
 ccI
 cdn
-pjW
+cbf
 cdJ
 cdQ
 cdW
@@ -91272,11 +92912,11 @@ bco
 bgq
 bhR
 bjn
-yiK
+bkt
 blR
 bjg
 boN
-aal
+bpX
 aZM
 bsq
 btE
@@ -91318,18 +92958,18 @@ cpG
 cpR
 cqb
 bWm
-ykg
+bWX
 bXo
-mEE
-mEE
-lUb
-mEE
-mEE
-mEE
+xKZ
+xLc
+xLf
+bYJ
+bYJ
+bYJ
 bZD
 cip
 cax
-alH
+cbc
 ciB
 cbw
 cbO
@@ -91337,9 +92977,9 @@ cco
 ccJ
 cde
 cdo
-amf
+cdB
 cdK
-amz
+cdR
 cdX
 cef
 ceu
@@ -91578,7 +93218,7 @@ bWm
 cql
 bXp
 cqs
-qbi
+xLd
 bYo
 cqs
 bXp
@@ -91586,22 +93226,22 @@ bXp
 bXt
 ciq
 cit
-pjW
+xLA
 ciC
 cbx
 cbx
 cbx
 cbx
 cbx
-amC
-pjW
+cdp
+cbf
 cdL
 cdQ
 cdY
 cjx
 cdQ
 cdQ
-fyv
+xNA
 cfv
 ceS
 ceS
@@ -91767,11 +93407,11 @@ ajE
 aDt
 aFq
 aHp
-aoI
-aoM
-aoN
-aoO
-aoP
+aIJ
+aKH
+aMs
+aOe
+aPN
 aHl
 aSU
 aUB
@@ -91851,7 +93491,7 @@ cbR
 ccL
 ccn
 cdq
-pjW
+cbf
 cdM
 cdQ
 cjf
@@ -92024,11 +93664,11 @@ ajE
 atX
 aFr
 aHq
-aoJ
+aIK
 aKI
 aMt
 aMu
-apt
+aPO
 aHl
 aSU
 aUB
@@ -92071,7 +93711,7 @@ baK
 baK
 bMC
 bCe
-alE
+xKR
 bMD
 bOW
 bPy
@@ -92091,15 +93731,15 @@ cqe
 bWm
 bWm
 cqp
-xTf
+xLa
 bXP
 bXP
 bXP
-mIF
+xLi
 bWm
-ykh
+xLl
 cir
-ngR
+xLv
 cbe
 ciE
 cby
@@ -92108,7 +93748,7 @@ ccq
 ccL
 ccn
 cdr
-pjW
+cbf
 cdN
 cdQ
 cei
@@ -92281,11 +93921,11 @@ aBD
 aDr
 aFr
 aHr
-aoK
+aIL
 aKJ
 aMu
 aMu
-apO
+aPP
 aHl
 amr
 aUB
@@ -92330,7 +93970,7 @@ cqY
 bMD
 bMD
 bMD
-alF
+bOX
 bPz
 bPZ
 bOY
@@ -92355,9 +93995,9 @@ bXQ
 cia
 bWm
 bZG
-alG
+cah
 bZG
-pjW
+cbf
 ciF
 cby
 cbR
@@ -92365,7 +94005,7 @@ ccr
 ccL
 ccn
 cds
-pjW
+cbf
 cdN
 cdQ
 cjg
@@ -92374,7 +94014,7 @@ cej
 cez
 cfl
 cdQ
-mmG
+xNC
 cfL
 cfL
 cge
@@ -92538,11 +94178,11 @@ aBE
 aDu
 aFs
 aHs
-aoL
+aIM
 aKK
 aMv
 aOf
-apP
+cnV
 aHl
 amr
 aUB
@@ -92583,7 +94223,7 @@ bJr
 bKj
 bLc
 bLQ
-thq
+xKN
 bMD
 bNh
 bOs
@@ -92604,29 +94244,29 @@ bSQ
 cqg
 bWm
 bWm
-tRw
-cBt
+xKX
+xLb
 bXR
 bYr
 bYL
 bYr
-fBF
-hla
-duy
-xXW
-pjW
-pjW
-wrl
+xLk
+xLm
+xLp
+xLw
+cbf
+cbf
+xLT
 cbS
 cbS
 cbS
-ggj
-pjW
-pjW
-eEV
+xMD
+cbf
+cbf
+xMY
 cdQ
 cjh
-pEO
+xNs
 cfk
 cfy
 cey
@@ -92840,7 +94480,7 @@ bJs
 bKk
 bLd
 bLQ
-thq
+xKO
 bMD
 bNi
 bOt
@@ -92865,25 +94505,25 @@ cqq
 bXt
 bXS
 bXp
-ofm
+xLh
 bXp
 bXp
-ofm
-iNY
-nOo
-wwA
+xLn
+xLq
+xLx
+xLB
 cbg
 bQO
 cbT
 ccs
 ccN
-prN
-jtP
-xIJ
+xME
+xML
+cbi
 cdO
 cdQ
-jEY
-hzv
+xNp
+xNt
 cfk
 cfy
 cey
@@ -93097,7 +94737,7 @@ bJr
 bKl
 bLe
 bLQ
-thq
+xKP
 bMD
 bNj
 bOu
@@ -93107,7 +94747,7 @@ bQb
 bQb
 bRg
 bPH
-ykf
+cow
 coK
 coU
 cqh
@@ -93121,34 +94761,34 @@ bXd
 cqq
 bXu
 bXT
-lqM
+xLg
 bYM
 bZb
 bWm
 cqL
-wIQ
-ogS
-xIJ
+xLr
+xLy
+xLC
 cbh
 cbz
 cbU
 cct
 cct
-oEX
-pBT
-xIJ
-jhE
+xMF
+xMM
+cbi
+xMZ
 ciW
-kyC
-kyC
+xNq
+xNu
 cdQ
 ciW
 cdQ
 cdQ
-tWi
-mtB
-vAr
-ghF
+xND
+xNF
+xNH
+xNJ
 cjy
 aQk
 aab
@@ -93377,7 +95017,7 @@ bWm
 bWm
 cqr
 bXv
-rcr
+xLe
 bYs
 cqr
 bXv
@@ -93385,27 +95025,27 @@ bWm
 bWm
 bWm
 bWm
-xIJ
-xIJ
+xLD
+cbi
 cbA
 cbU
-xCL
+ccu
 cct
 cct
-amD
-xIJ
+xMN
+cbi
 cdO
 cdQ
 cdQ
-kyC
-hcb
-kyC
-kyC
+xNv
+xNx
+xNz
+xNB
 ciW
-lQg
-lQg
-lQg
-lQg
+xNE
+xNG
+xNI
+xNK
 ckI
 aQk
 aab
@@ -93612,7 +95252,7 @@ bKm
 bLf
 bLS
 bME
-anv
+bNk
 bNM
 bOv
 bLU
@@ -93631,28 +95271,28 @@ bLU
 bLU
 bLU
 bME
-amE
+xKV
 bRh
 bXw
 bXV
 bYt
 bYN
 bLf
-any
+cqw
 cqz
-anx
+cqI
 cqN
-oqb
-xIJ
-pxo
+xLE
+cbi
+xLU
 cbW
 cct
 cct
 cct
-rKm
-nif
-ppQ
-fCk
+xMO
+xMS
+xNa
+xNe
 bSx
 cdQ
 cdQ
@@ -93894,21 +95534,21 @@ bQd
 bXW
 bYu
 cib
-pDO
+xLj
 cqv
 cqA
-gnU
+cqH
 cqO
 cqV
-xIJ
-xIJ
-yki
-cQr
-vPN
-vPN
-oFJ
-xIJ
-xIJ
+cbi
+cbi
+cbX
+xMp
+xMy
+xMG
+xMP
+cbi
+cbi
 cdO
 bSx
 avT
@@ -94135,7 +95775,7 @@ bLU
 bLU
 bLU
 bLU
-anw
+xKT
 bSV
 gsL
 bLf
@@ -94156,17 +95796,17 @@ bLU
 cqB
 guP
 bYO
-vus
-xIJ
+xLF
+cbi
 cbB
 cbY
 ccv
 ccv
 ccv
 cbY
-xbY
-xIJ
-tFP
+xMT
+cbi
+xNf
 bSx
 aab
 aab
@@ -94413,17 +96053,17 @@ bUz
 bUz
 bUz
 bUz
-dpM
-xIJ
+xLG
+cbi
 cbC
-xIJ
+cbi
 ccw
 ccS
-tDD
-xIJ
+xMH
+cbi
 cbC
-xIJ
-oAG
+cbi
+xNg
 bSx
 aab
 aab
@@ -94602,7 +96242,7 @@ ahr
 aRA
 aTb
 aHt
-ygw
+aVS
 aXt
 aYx
 aZQ
@@ -94672,15 +96312,15 @@ guQ
 bUz
 bPK
 cbF
-dmA
+xLV
 cbF
-gql
+ccx
 ccT
 cbF
 cbF
-rbe
+xMU
 cbF
-pLP
+xNh
 bSx
 aab
 aab
@@ -94933,11 +96573,11 @@ cbE
 cbE
 cbE
 cbE
-nGz
+xMI
 cbE
 cbE
 cbE
-dbQ
+xNi
 bSx
 aab
 aab
@@ -95125,7 +96765,7 @@ bcx
 bdT
 bfh
 aYx
-bcx
+xJG
 bjr
 bcx
 bdT
@@ -95185,16 +96825,16 @@ bZM
 guS
 bUz
 bPL
-cwf
-oLn
+xLN
+xLW
 ccc
 ccz
 ccV
 cdh
-mEF
-anz
-cwf
-vFt
+xMQ
+cdC
+xNb
+xNj
 bSx
 aab
 aab
@@ -95350,8 +96990,8 @@ aah
 aah
 abG
 aah
-alA
-alB
+xIU
+xIY
 abK
 aaV
 are
@@ -95393,9 +97033,9 @@ bcy
 bcy
 bbb
 bcy
+bcy
 bvQ
 bxn
-bcy
 bcy
 bcy
 bBz
@@ -95441,17 +97081,17 @@ bWC
 bZN
 cak
 gvc
-dnQ
+xLH
 cbE
 cbD
-opA
-lfd
+xMe
+xMq
 ccf
 ccf
 ccf
-obO
+xMV
 cbE
-iIC
+xNk
 bSx
 aab
 aaa
@@ -95639,24 +97279,24 @@ bcz
 aYx
 bfj
 aYx
-ocq
-blU
+bcz
+xJO
 bcz
 aYx
 bcz
 aYx
 bcz
 bcz
-sVQ
 bcz
+xFF
+xKu
 buL
-bvR
 bxo
 byt
 bzC
 bAB
 bBA
-bCy
+aYx
 aXt
 bEt
 aYx
@@ -95699,16 +97339,16 @@ bUz
 bUz
 bUz
 caW
-amB
-nYV
+xLO
+xLX
 ags
-coD
+xMr
 ccf
 ccf
 ccf
-saK
-sDJ
-svt
+xMW
+xNc
+xNl
 bSx
 aab
 aab
@@ -95891,26 +97531,26 @@ aVI
 aXq
 aYG
 bfJ
-eWc
-lDe
+xDH
+xEp
 bfJ
-tZA
-lDe
 bfJ
+xEe
+xEp
+xJP
 bah
 bkw
-tww
+xER
 bah
 bkw
-rSU
-quw
-pQW
-eyg
+xFm
+xFy
+xFG
+xKv
 bxs
 bvS
 buM
 bxs
-bAC
 bAC
 bxs
 aVI
@@ -95952,20 +97592,20 @@ bVa
 bVa
 bZw
 bVa
-ykn
+xLo
 guT
 bUz
-hoM
+xLI
 cbE
-opk
-fAO
-qbe
+xLY
+xMf
+xMs
 ccf
 ccf
 ccf
-obO
+xMX
 cbE
-pTt
+xNm
 bSx
 aab
 aab
@@ -96148,27 +97788,27 @@ aVX
 aXv
 aYH
 bfJ
-fnz
-kug
-gsy
+xDI
+xDO
+xDV
+xJw
 bfl
-bgy
 bhX
+xJQ
 bjt
 bkx
 bkx
 bnC
 bkx
-rDP
-kWE
+xFn
+xFz
 bfA
-kIa
+xKw
 bxs
 bvT
 bvW
 byu
-mbs
-mbs
+xGK
 bxs
 bCz
 bDu
@@ -96212,16 +97852,16 @@ bXB
 bVa
 cal
 bUz
-pRK
-cwf
-xob
-fAO
+xLJ
+xLP
+xLZ
+xMg
 agr
-iXc
-mUk
+xMz
+xMJ
 cdt
-opA
-cwf
+cdD
+xNd
 cdO
 bSx
 aab
@@ -96405,27 +98045,27 @@ aHS
 aXw
 aYI
 bfJ
-ygJ
-kqR
+aYL
+xDP
 bjV
 bjV
-oNt
-kPP
-xUY
+bjV
+xEq
+xJR
+xEx
 bky
-wel
+xES
 bnD
 bnD
 bnD
-uXm
+xFA
 bsx
-oFF
+xKx
 bxs
-yjE
+biw
 bvW
 bzD
-peG
-yjI
+bjE
 bxs
 bCA
 aXt
@@ -96469,13 +98109,13 @@ bWL
 bVa
 bZO
 bUz
-pRK
+xLK
 cbE
 cbE
 cbE
 cbE
 cbE
-nGz
+cxP
 cbE
 cbE
 cbE
@@ -96663,25 +98303,25 @@ aLc
 aYJ
 bfJ
 aZU
-heY
-wYw
+xDQ
+xDW
 bfn
+xJz
 bgA
-bfJ
+xJS
 bju
-kja
-lho
-kja
-kja
-gcW
+xEU
+xET
+xEU
+xEU
+xFo
 bre
 bsx
-wxQ
+xKy
 bxs
 bvU
 bvW
 bxs
-bAE
 bAE
 bxs
 bCB
@@ -96727,16 +98367,16 @@ bVa
 guU
 bUz
 caX
-vyF
-olp
-orx
+xLQ
+xMa
+xMh
 ccB
-lFh
-lFh
-lFh
-lFh
-lFh
-dsE
+xMA
+xMK
+cdv
+cdv
+cdv
+xNn
 bSx
 aab
 aab
@@ -96921,24 +98561,24 @@ aYK
 bfJ
 bbc
 ajI
-kgh
-bfo
+xDX
+xIg
+xJA
 bgB
-bfJ
+xJT
 bjv
-cwx
+xEJ
 blV
-uga
+xEV
 boT
-kja
+xEU
 bre
 bsx
-bbr
+xKz
 bxs
-bvV
-wJR
+xKF
+xKG
 bxs
-bzE
 bAG
 bxs
 akI
@@ -96984,10 +98624,10 @@ bVa
 guV
 bUz
 gvo
-pqr
-gql
-uSR
-xIy
+xLR
+xMb
+xMi
+xMt
 bSv
 bSx
 bSx
@@ -97174,29 +98814,29 @@ aTj
 aPU
 aJs
 aLc
-aYO
+aCj
 bfJ
 bbd
-kqR
+xDP
 bjV
-bfp
+bfo
 bgC
-bfJ
-xIT
-mRk
+xJH
+xJU
+xEy
+xEK
 blW
-haU
-mWw
-kja
+xEW
+xFg
+xEU
 bre
 bsx
-srm
+xKA
 bxs
-nEE
 bxq
-vpw
-drP
-dzP
+xGD
+coh
+xGS
 bxs
 akJ
 bDx
@@ -97241,10 +98881,10 @@ bVa
 bZO
 bUz
 bSv
-jnz
+xLS
 bQp
-tFi
-foK
+xMj
+xMu
 bSv
 bSx
 aaa
@@ -97435,23 +99075,23 @@ aCj
 bfJ
 bbe
 bcC
-pyh
-bfp
+xDW
+xJx
+xJB
 bgD
-bfJ
+xJV
 bjw
 bcL
 blX
 bnE
 boU
-kja
+xEU
 brg
 bsB
-dBc
+xKB
 bxs
-bvX
-dvg
-bvW
+xIx
+xKH
 bvW
 byv
 bxs
@@ -97497,10 +99137,10 @@ bXB
 bVa
 guU
 bUz
-sJx
+xLL
 bSx
 bSx
-tsg
+xMk
 gvw
 bSx
 bSx
@@ -97688,29 +99328,29 @@ aTj
 aPU
 axP
 aLc
-aYO
+aCj
 bfJ
-ygK
-inc
-dVI
-tbZ
-xUH
-bfJ
-qzp
-bkA
+apV
+xDR
+xDZ
+xEf
+bgC
+xJI
+xJW
+xEz
 blY
-haU
-mWw
-kja
+xKl
+xEW
+xFg
+xEU
 bre
 bsx
-bBX
+xKC
 bxs
 bvY
 bxt
-byz
-drP
-yjJ
+xKI
+bjF
 bxs
 bPJ
 bDz
@@ -97757,8 +99397,8 @@ bUz
 bSv
 bSv
 cbG
-dTQ
-iTM
+xMl
+xMv
 gul
 bSx
 aaa
@@ -97949,25 +99589,25 @@ aCj
 bfJ
 bbf
 bcD
-fWU
-xAl
+xEa
+xEg
 bgE
-bfJ
+xJJ
+xJX
 bjx
-bcN
 bcL
+bcN
 bnG
 boV
 bqe
 brh
 bsC
-btK
+xKD
 bxs
-vfU
+xGf
 bxr
-byy
-coh
-coi
+xKJ
+bzH
 bxs
 bCE
 cbl
@@ -98011,12 +99651,12 @@ bXg
 bVa
 guY
 bUz
-kqA
+xLM
 bSv
-lpG
-tXU
-kLC
-dJL
+xMc
+xMm
+xMw
+xMB
 bSx
 aaa
 aaa
@@ -98200,7 +99840,7 @@ aPZ
 aRI
 aTj
 aPU
-ybr
+xId
 aLc
 aYN
 bfJ
@@ -98210,18 +99850,18 @@ bdW
 bqC
 bgF
 bfJ
+xJY
 bjy
-bcN
-yiR
+bcL
+xKm
 bjy
 bah
 bah
 bqf
-qgR
-bjy
+xFH
+xKE
 bxs
 buS
-bxs
 bxs
 bxs
 bxs
@@ -98271,9 +99911,9 @@ bUz
 gul
 bSv
 cbG
-gne
-vnl
-oUr
+xMn
+xMx
+xMC
 bSx
 aaa
 aaa
@@ -98463,29 +100103,29 @@ aCj
 bxw
 bbg
 bcE
-pIL
+xEb
 bfr
 bgG
 bie
-tTJ
-nGb
+xJZ
+xEA
 bmb
-iOJ
-llI
+xKn
+xEX
+xKq
 bqg
 bri
 bsD
-btM
-buW
-qgS
-bxv
-wgN
-rwV
-jwK
+bee
+bfp
+xGg
+xGE
+xGM
+bgg
 bxw
 bPJ
-nEB
-npk
+xHo
+xHA
 bFv
 cvb
 cvl
@@ -98527,8 +100167,8 @@ gva
 bUz
 bSx
 bSx
-lpG
-dTQ
+xMd
+xMo
 gvm
 gul
 bSx
@@ -98716,32 +100356,32 @@ aTm
 aPU
 axP
 aLc
-aYO
+aCj
 bxw
-nud
+xDL
 bcF
-pIL
+xEb
 bfs
 bgH
 bif
-kJC
-rdq
+xEB
+xEM
 bmc
+aWo
 bnI
-uQH
-uQH
+xFi
+xFi
 chs
-uQH
-uQH
-uQH
+xFi
+xFi
 bwa
-kGG
+xGl
 byB
 bzJ
-byB
+xKK
 bBD
 bCF
-quz
+xHp
 bEA
 bFv
 bFv
@@ -98976,26 +100616,26 @@ aLc
 aCj
 bxw
 bbh
-bcG
-yhq
+akM
+apP
 bft
-oBd
+xEs
 big
-lpE
-pIL
+xEC
+xEb
 bmd
-pIL
-yje
+xEb
+bfG
 bqi
 brk
 bsE
 bsE
-buY
+bfq
 bwb
-wAo
+xGm
 byC
-bzK
-yjK
+bfI
+bjC
 bxw
 bPJ
 bPJ
@@ -99029,7 +100669,7 @@ bSv
 bUz
 bWC
 bWC
-ykm
+xKY
 bWC
 bWC
 bWC
@@ -99232,21 +100872,21 @@ aWb
 aLe
 aYP
 bad
-fFC
-xYf
+xEh
+bgI
 bad
-fFC
-xYf
+xEh
+bgI
 bad
 bad
-iuN
+xEN
 bme
-hOC
+xEY
 bry
 bpa
 btY
 bru
-bry
+bru
 bry
 bwc
 bxx
@@ -99272,7 +100912,7 @@ bGA
 bGA
 bOC
 bPI
-ykl
+xKS
 grT
 jXF
 gss
@@ -99294,7 +100934,7 @@ bUz
 guD
 bUz
 guN
-akL
+xLs
 caE
 bRz
 bSv
@@ -99490,28 +101130,28 @@ aLc
 aYK
 bad
 bvh
-bcH
-bdZ
-xuY
+ali
+alG
+xEi
 bgJ
 bii
-eXU
-rrd
+xED
+xEO
 bmf
-cOi
+xEZ
 bry
 bqk
-gYD
+xFB
 bqm
-yjD
+bqm
 bva
-shM
-gNO
-txO
-gLH
-yjL
-gcu
-cnE
+xGh
+xGn
+xGF
+xGN
+bjG
+xGX
+xHe
 bxy
 grr
 bFv
@@ -99742,12 +101382,12 @@ aQe
 azb
 aik
 aPU
-ygx
+awc
 aLc
-aYQ
+aCj
 bad
 bab
-hdn
+xDT
 bea
 bzS
 bgK
@@ -99763,12 +101403,12 @@ bsG
 btX
 bvb
 bwe
-lCC
-byE
+xGo
+xGG
 bxy
-bAM
+byE
 bBF
-cnE
+xHe
 bxy
 bPO
 bFv
@@ -99777,7 +101417,7 @@ bFv
 bFv
 bFv
 bKD
-oyB
+xHQ
 bML
 bML
 bML
@@ -100006,7 +101646,7 @@ bad
 bbj
 bcI
 beb
-gbo
+xEj
 bgL
 bik
 bjA
@@ -100016,12 +101656,12 @@ bnM
 boY
 bqm
 brn
-uVG
+xFI
 btX
 bvc
 bwf
-vEZ
-chW
+xGp
+bfz
 bxy
 bxy
 bxy
@@ -100033,11 +101673,11 @@ bML
 bML
 bML
 bML
-bKE
-qul
-uZI
+bib
+bil
+bim
 bMj
-akM
+xKQ
 bMi
 bNq
 bNq
@@ -100258,41 +101898,41 @@ aTr
 aPU
 axP
 aLc
-aYO
+aCj
 bad
-bbk
+aao
 bzS
 bec
-rEu
+xEk
 bgM
-rEu
-dXk
+xEk
+xEE
 bkI
 bmd
-lnp
+xFa
 boZ
 bqn
 bro
 bsH
 btR
 bry
-rvl
-rIP
-gVs
-bve
-bve
-bve
-uiA
-bve
-bve
-bve
-bve
+xFq
+xGq
+xGH
+bvi
+bvi
+bvi
+xHf
+bvi
+bvi
+bvi
+bvi
 aZW
 aZW
 aZW
 aZW
 aZW
-qGO
+bin
 biL
 biL
 biL
@@ -100462,7 +102102,7 @@ aab
 aab
 aab
 aab
-aao
+xDB
 aar
 aaw
 aad
@@ -100513,43 +102153,43 @@ aBX
 aRK
 aBX
 aPU
-wAc
+xIe
 aLc
 aCj
 bad
-bbl
+aap
 bcK
-byM
+bgQ
 bfu
-bgN
-bim
-bjC
-bkJ
+anx
+aoM
+apR
+apX
 bmf
 bnN
 bpa
-nYY
+xFp
 brp
 bsI
 btP
-bve
-chR
+bvi
+xGi
 bxz
 byF
-bzP
+bfK
 bAO
 bBI
 bCH
-bDB
+bgU
 bEE
 bFD
 bFD
-bHT
+bhf
 bIL
-oWF
+xHJ
 bIL
 aZW
-fDN
+xHY
 biL
 bMM
 bNr
@@ -100719,14 +102359,14 @@ aab
 aab
 aab
 aab
-aap
+aal
 aas
 aax
 aaF
-gTr
+xDC
 aaQ
-ovA
-xNM
+xDD
+xDE
 aad
 aah
 aah
@@ -100772,7 +102412,7 @@ aTs
 aPU
 axP
 aLc
-aYO
+aCj
 bad
 bad
 bad
@@ -100781,30 +102421,30 @@ bad
 bad
 bad
 bad
-bkK
+aqa
 bmf
 bnO
 bry
-rvl
-gVs
-xjb
+xFq
+xGH
+bsJ
 btY
-bve
+bvi
 bwh
-jRc
+xGr
 bxA
 bxA
 bxA
-bBJ
-bCI
-bDC
-bDC
-bFE
-bGI
-bHU
-bIM
-ngo
-yke
+bgN
+bgR
+bgV
+bgV
+bgZ
+bhe
+bhg
+bhi
+bhZ
+bjJ
 aZW
 bKF
 bMk
@@ -100976,7 +102616,7 @@ aab
 aab
 aab
 aab
-aao
+xDB
 aar
 aay
 aad
@@ -101032,36 +102672,36 @@ aLc
 aCj
 auy
 auy
-yhc
-yhr
-yhJ
-yib
-yiq
-yiD
-bkL
+alA
+apQ
+aLW
+aTA
+apU
+bbs
+aqb
 bml
 bnP
-pIL
-pIL
+xEb
+xEb
 brq
 bsK
-eDF
+bjK
 bvg
 bwi
-cYM
+xGs
 byH
-mTc
-mTc
-oab
-bCJ
-bDD
-bEG
-bFF
+xGW
+xGW
+bgO
+bgS
+bgW
+bgX
+bha
 bGJ
-bHT
-bIN
-kgI
-sIm
+bhf
+bhx
+bia
+bid
 aZW
 bKF
 biL
@@ -101286,39 +102926,39 @@ aCa
 aPU
 aWd
 aLc
-aYO
-hlg
+aCj
+xDG
 bbo
-ygZ
-yhs
-yhK
-yic
-yir
-yiC
-bkM
-bmm
-iMx
-bpd
-bqq
-bqq
-irc
-vcx
-llb
+any
+apS
+aOI
+aUG
+aWh
+baj
+bak
+bbt
+aQj
+aTx
+aWo
+aWo
+bcJ
+bef
+xGa
 bwj
-bwm
+bfy
 byI
+bfL
 bzR
-bAQ
-bBK
+bgP
 bCK
 bDE
-geE
+xHB
 bxA
 bxA
 aZW
 aZW
 aZW
-gOP
+xHN
 aZW
 bKF
 biL
@@ -101543,30 +103183,30 @@ aTu
 aUE
 aWe
 aLc
-kKv
+xDF
 bae
-bbp
-yha
-yht
-yhL
-yid
-yis
-yiD
-bkN
+akL
+anz
+apT
+aOJ
+aUH
+aYM
+bbs
+btU
 bwd
 bft
-vGv
-yjq
-pIL
+xFk
+bix
+xEb
 bmd
-kSb
-bve
-bwk
+beg
+bvi
+bfv
 bxA
 bxA
 bxA
 bdV
-fxb
+xGZ
 bdV
 bDF
 bdV
@@ -101575,7 +103215,7 @@ bxA
 bxA
 bxA
 aZW
-qNc
+xHO
 aZW
 bKF
 biL
@@ -101800,24 +103440,24 @@ aTv
 aUE
 aWe
 aLc
-aYO
+aCj
 baf
 bbq
-yhb
-yhM
-yhM
-yie
-yit
-bgT
-yiL
-yiS
-yiY
-yjf
-bgT
+anA
+apU
+apU
+aUI
+aZV
+xKa
+bbz
+bcS
+bem
+bfH
+xKr
 brs
 bmf
-btT
-bve
+beh
+bvi
 bwl
 bxB
 bxB
@@ -101825,16 +103465,16 @@ bzT
 bdV
 bBL
 bCM
-gXa
+xHq
 bdV
 bFI
 bxB
 bxB
-cRj
+xHI
 aZW
-qLW
+bih
 aZW
-fDN
+xHY
 biL
 bJL
 bNv
@@ -102035,7 +103675,7 @@ aah
 aah
 abn
 abK
-alA
+xJd
 aaV
 asL
 asL
@@ -102060,27 +103700,27 @@ aXz
 aYT
 auy
 auy
-yhc
-yhv
-yhN
-bgT
-bgT
-bgT
-bkP
-bmp
-bnS
-bpf
-yjr
+alA
+aqH
+aPQ
+xJC
+xJK
+xKb
+bbA
+bcT
+ben
+bgk
+biy
 bwd
-bsN
-btU
+bcM
+bei
 bdV
 bfk
-mhg
-mhg
+xGt
+xGt
 bgx
 bdV
-rUV
+xHa
 bCL
 bDG
 bdV
@@ -102314,41 +103954,41 @@ axP
 axP
 aWg
 aLc
-aYO
-axP
-ygN
-yhd
-yhy
-yhO
-yih
-yiu
-yiE
-bis
-bmq
-bnT
-yjg
-yjt
+aCj
+alB
+alF
+anB
+apW
+aQl
+aUK
+aZX
+bbv
+aZY
+bcU
+beq
+bcB
+biz
 brt
-bsO
+bcO
 btV
 bdV
-bwn
+bfw
 bxC
-wKI
-wKI
+xGI
+xGI
 bAT
 bBM
-vIw
-wbn
+xHg
+xHr
 bEJ
-wKI
-wKI
+xGI
+xGI
 bHZ
 bGO
 bdV
 blg
 bok
-fDN
+xHY
 biL
 bJL
 bNx
@@ -102572,40 +104212,40 @@ aOE
 aOE
 aXA
 aYU
-ygy
-ygM
-yhe
-yhP
-yhP
-yig
-bis
-wcb
-cgY
-bmr
-bnU
-bph
-yjt
+alC
+alH
+aoI
+ari
+ari
+aOH
+aZY
+bbw
+xKe
+bcV
+ber
+bhd
+biz
 bwd
 bmf
-fOa
+xFU
 bdV
-diD
-tzW
+xGj
+xGu
 bgz
-jQT
+xGP
 bdV
 bdV
 bAV
 bdV
 bdV
-jQT
+xGP
 bgz
-tzW
+xGu
 bIR
 bdV
 blh
 bok
-fDN
+xHY
 biL
 bMQ
 bNu
@@ -102805,7 +104445,7 @@ ajV
 adI
 ahB
 ahB
-ali
+xIZ
 aad
 ars
 asL
@@ -102829,35 +104469,35 @@ aUF
 axP
 aXB
 aYV
-axP
-ygN
-yhf
-yhy
-yhQ
-yih
-bit
-bjJ
-bkS
-bms
-bnV
-bpi
-yju
+alB
+alF
+aoJ
+apW
+aQn
+aUK
+aZZ
+bbx
+bbB
+bcX
+bes
+bip
+biA
 bwd
 bmf
 btW
 bdV
 bwo
-tzW
+xGu
 bhY
 bzW
 bdV
 bkD
 bBO
-rAl
+xHs
 bdV
 bzW
 bhY
-tzW
+xGu
 bIS
 bdV
 bli
@@ -103086,25 +104726,25 @@ cue
 cuE
 cuE
 aYW
-yiJ
-ygO
-yhz
-yhz
-yhR
-bgT
-bgT
-bgT
-bgT
-bgT
-bnW
-bgT
-bgT
+alE
+amf
+aoK
+aoK
+xJy
+xJD
+xJL
+xKc
+xKf
+xKi
+bet
+xKo
+xKs
 brw
 bme
-fBO
+xFV
 bdV
 bwp
-gRJ
+xGv
 bgz
 bgz
 bAV
@@ -103114,12 +104754,12 @@ bBO
 bAV
 bgz
 bgz
-gRJ
+xGv
 bIT
 bdV
 blj
 bok
-fDN
+xHY
 biL
 bMR
 blg
@@ -103343,22 +104983,22 @@ cuf
 cuo
 cuE
 aYX
-yiJ
-ygP
-yhh
-yhA
-yhS
-yiJ
+alE
+amz
+aoL
+xJs
+aQo
+alE
 aaa
 boj
-bkU
+arn
 bmu
-bnX
-yjh
-bjK
+aRQ
+biq
+xFr
 brx
 bsS
-nKK
+xFW
 bdV
 bwq
 bxE
@@ -103600,22 +105240,22 @@ cug
 cup
 cuE
 aYY
-yiJ
-ygQ
-yhi
-yhB
-yhT
-yiJ
+alE
+amA
+xJp
+xJt
+aQp
+alE
 aaa
 boj
-bkV
+asD
 bmv
-bnY
-bpl
-irn
-tij
-bsT
-ttI
+aRR
+aUJ
+aYS
+xFD
+bcP
+xFX
 bdV
 bdV
 bdV
@@ -103633,7 +105273,7 @@ bdV
 bdV
 bok
 bok
-fDN
+xHY
 bok
 bok
 bOc
@@ -103857,30 +105497,30 @@ cuh
 cuq
 cuE
 aYY
-yiJ
-ygR
-yhj
-yhC
-yhU
-yiJ
+alE
+amB
+aoN
+arl
+aQq
+alE
 aaa
 boj
-bkW
+avz
 bmw
 bnZ
 bpm
-bqw
+aZx
 brz
-bsU
-brD
+bcQ
+brB
 bvq
-yjF
+bjB
 bxF
 byQ
-yjG
-yjM
-yjP
-yjV
+bzZ
+bAX
+bBR
+bCS
 bEN
 bDK
 blj
@@ -103890,9 +105530,9 @@ bok
 bok
 bok
 bok
-tUu
-okG
-snS
+xHZ
+xIb
+xIc
 bOd
 bOR
 bPh
@@ -104114,40 +105754,40 @@ cui
 cur
 cuE
 aYY
-yiJ
-ygS
-yhk
-yhD
-yhV
-yiJ
-yiJ
-yiJ
-yji
-yji
-yiZ
-yji
-yjv
-brA
-bsV
+alE
+amC
+xJq
+aNb
+aRO
+alE
+alE
+alE
+xKg
+xKj
+bfB
+xKp
+biB
+bbi
+bcW
 bua
 bvr
-ufe
-qFn
-fmW
-yjH
+xGk
+xGw
+xGJ
+xGQ
 bDK
 chB
-oqI
-hTM
+xHi
+xHv
 bDK
-mgS
+xHF
 bok
 bok
 bok
 bok
 bok
-utc
-hjD
+xHH
+bio
 biL
 biL
 biL
@@ -104371,33 +106011,33 @@ cuj
 cus
 cuE
 aYZ
-yiJ
-ygT
-yhl
-yhE
-yhW
-yim
-yiw
-yiJ
-yiN
-yiU
-yja
-yjj
-yjw
-brB
-bsW
+alE
+amD
+xJr
+xJu
+aRS
+aXx
+xJM
+alE
+xKh
+bcZ
+bfC
+bir
+biC
+bbk
+bcY
 bue
 bub
 bub
 bub
 bub
 bub
-yjN
+xKL
 chC
 bDK
-epT
+xHw
 bDK
-gcq
+xHG
 bok
 bok
 biL
@@ -104609,7 +106249,7 @@ aqf
 arw
 asN
 auy
-ygx
+awc
 axP
 azo
 aAJ
@@ -104628,36 +106268,36 @@ cut
 cut
 cuC
 aYY
-yiJ
-ygU
-yhm
-yhF
-yhX
-yin
-yix
-yiH
-yiO
-yiV
-yjb
-yjk
-yjy
-cht
-chu
-omx
+alE
+amE
+aoO
+aOF
+aRT
+aXC
+xJN
+xKd
+bbC
+bda
+bfD
+bis
+biD
+bbl
+bdw
+bej
 bvs
 bvs
 bvs
 bvs
 bvs
 bub
-yjU
+chy
 bok
-yka
+xHu
 biL
 biL
 biL
-utc
-ykd
+xHH
+bIV
 bJK
 bJK
 bLs
@@ -104885,35 +106525,35 @@ cul
 cuu
 cuE
 aZa
-ygG
-yhY
-yhn
-yhG
-yhY
-yio
-yiy
-yiJ
-yiP
-yiW
-yjc
-yjl
-yjy
-brD
-bsY
-bud
+xJn
+anv
+aoP
+xJv
+anv
+xJE
+baa
+alE
+bbD
+xKk
+bfE
+bit
+biD
+brB
+bdU
+bel
 bvs
 bvs
 bvs
 bvs
 bvs
 bub
-yjU
+chy
 bok
-yka
+xHu
 biL
 blj
 biL
-ykc
+bIf
 biL
 biL
 biL
@@ -105131,7 +106771,7 @@ aab
 aab
 aab
 aGb
-ygx
+awc
 aLh
 ctt
 cuE
@@ -105142,20 +106782,20 @@ cuE
 cuE
 cuE
 aZb
-yiJ
-ygW
-yho
-yhH
-yhZ
-yip
-yiz
-yiJ
-yiQ
-yiX
-yjd
-yjm
-yjz
-brD
+alE
+anw
+apt
+aOG
+aTz
+xJF
+aYg
+alE
+bcR
+bek
+bfF
+biu
+biG
+brB
 bsS
 bub
 bvs
@@ -105164,9 +106804,9 @@ bvs
 bvs
 bvs
 bub
-yjU
+chy
 bok
-yka
+xHu
 biL
 blj
 bok
@@ -105399,11 +107039,11 @@ aQt
 aiZ
 aXD
 aYY
-yiJ
-yiJ
-yiJ
-yiJ
-yiJ
+alE
+alE
+alE
+alE
+alE
 bEH
 bEH
 bEH
@@ -105411,9 +107051,9 @@ bEH
 bEH
 bEH
 bEH
-yjA
+biJ
 brF
-bsY
+bdU
 buc
 bvs
 bvs
@@ -105421,13 +107061,13 @@ bvs
 bvs
 bvs
 bub
-yjU
+chy
 bok
-yka
+xHu
 biL
 bli
 bok
-nBa
+bhh
 biL
 bJL
 bJL
@@ -105667,20 +107307,20 @@ bjS
 blb
 chg
 bof
-yjn
-yjB
-brD
-bsY
-bud
+bhc
+bjs
+brB
+bdU
+bel
 bvs
 bvs
 bvs
 bvs
 bvs
 bub
-yjU
+chy
 bok
-yka
+xHu
 biL
 bok
 bok
@@ -105916,18 +107556,18 @@ aXF
 aXF
 bbF
 aXF
-dLZ
+xEd
 aRV
 bEH
-yiA
+biF
 bGM
 blc
 bmE
 bog
 bps
-wNz
-brH
-btc
+bac
+bbm
+bdX
 bub
 bub
 bub
@@ -105936,15 +107576,15 @@ bub
 bub
 bub
 ajL
-gbw
-vOX
-ykb
+xHj
+xHx
+xKM
 bEQ
 bEQ
 bIg
 biL
 bok
-oEo
+bij
 bLu
 bLt
 biL
@@ -106176,16 +107816,16 @@ aXF
 bew
 aRV
 bEH
-biG
+bgT
 bGM
-bjU
+ayF
 bmF
 boh
-yjo
+bic
 bqD
-brI
-btd
-buh
+bbn
+bdY
+beo
 bvt
 bwt
 bxG
@@ -106193,7 +107833,7 @@ byR
 bAa
 byU
 chE
-fKy
+xHk
 bmK
 biL
 biL
@@ -106431,7 +108071,7 @@ bao
 bbH
 aXF
 bex
-maz
+xEo
 bEH
 biH
 bGM
@@ -106439,10 +108079,10 @@ bIQ
 bmF
 boh
 bpu
-oSF
-brD
-bte
-bui
+xFw
+brB
+bdZ
+bep
 bvu
 bwu
 bvu
@@ -106696,17 +108336,17 @@ bHY
 bmH
 boh
 bpu
-oSF
-brJ
-btf
-buj
+xFw
+bbp
+bed
+bfm
 bvv
 bwv
 bxH
 bxH
 bAc
-yjO
-fCh
+bBc
+xHb
 bok
 bmK
 biL
@@ -106951,10 +108591,10 @@ cod
 bjX
 blf
 bmI
-eSy
+xFe
 bpw
-oSF
-brK
+xKt
+bbu
 bmw
 buk
 bvw
@@ -106963,7 +108603,7 @@ bxI
 byT
 bAd
 byU
-uqm
+xHc
 bok
 byY
 biL
@@ -107210,9 +108850,9 @@ bEH
 bEH
 bEH
 bEH
-bjB
-brL
-bjB
+xIw
+bcb
+xIw
 btj
 bvx
 btj
@@ -107463,17 +109103,17 @@ bfN
 bhj
 biK
 biK
-grI
-bjB
-pBU
-bpx
-bqE
-brM
-bjB
+aCE
+xIw
+aSs
+aWj
+bag
+bcA
+xIw
 bul
 bvy
-hoR
-ufj
+xFY
+xGA
 btj
 byV
 bok
@@ -107721,16 +109361,16 @@ aQt
 aQt
 aQt
 byX
-bjB
-hnv
-bpy
-bqF
-yjC
-bjB
-hoR
-oro
-hoR
-qia
+xIw
+aSL
+aWk
+bai
+biv
+xIw
+xFY
+xGb
+xFY
+xGy
 btj
 byW
 bAe
@@ -107978,16 +109618,16 @@ bds
 aiZ
 aQt
 byY
-bjB
-kLa
-bsJ
-bqo
-brO
-bjB
+xIw
+aTd
+aWl
+bal
+bcG
+xIw
 bum
 bvz
 bwz
-hmA
+xGz
 btj
 byX
 biL
@@ -108235,16 +109875,16 @@ aRV
 biM
 aQt
 bmK
-bjB
-fKg
-oip
-oRZ
-brP
-bjB
-xVE
-xVE
-hoR
-ufj
+xIw
+aTp
+aWm
+baG
+bcH
+xIw
+xGc
+xGc
+xFY
+xGA
 btj
 byY
 byV
@@ -108492,12 +110132,12 @@ bhk
 biN
 aQt
 bmK
-bjB
-bjB
-bjB
-bjB
-bjB
-bjB
+xIw
+xIw
+xIw
+xIw
+xIw
+xIw
 btj
 btj
 btj


### PR DESCRIPTION
Made some fixes to the new Medical layout.
- Chemistry was made a bit less cramped, and given two disposals outlet; one for each Chemistry station.
- EMT Bay was shrunk a little bit, since they don't need space for two mechs.
- Extra sinks, disposals outlets, and smaller NanoMed machines were added around the department.
- Surgery also made a bit less cramped, also made the floor decal blue instead of grey. 
- Adjusted the space for the delivery chute in storage so that the crates don't get stuck.
- Re-added the missing Air Alarm in Chemistry.

Screenshots:
https://i.imgur.com/6b11Xro.png
https://i.imgur.com/kYZxMcC.png
https://i.imgur.com/vaiOtul.png
https://i.imgur.com/IL0cjVG.png