### PR TITLE
Fixes sandstone and allows soil plots to be moved.

### DIFF
--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -576,10 +576,11 @@
 		user << "You [anchored ? "wrench" : "unwrench"] \the [src]."
 
 	else if (mechanical == 0 && istype(O, /obj/item/weapon/shovel) )
-		new /obj/item/stack/material/sandstone{amount = 3}(loc)
-		user << "<span class='notice'>You remove the soil from the bed and dismantle the sandstone base.</span>"
-		playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
-		qdel(src)
+		if(do_after(user, 50))
+			new /obj/item/stack/material/sandstone{amount = 3}(loc)
+			user << "<span class='notice'>You remove the soil from the bed and dismantle the sandstone base.</span>"
+			playsound(src, 'sound/effects/stonedoor_openclose.ogg', 40, 1)
+			qdel(src)
 
 	else if(O.force && seed)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -565,7 +565,7 @@
 		qdel(O)
 		check_health()
 
-	else if(mechanical == 1 && iswrench(O))
+	else if(mechanical && iswrench(O))
 
 		//If there's a connector here, the portable_atmospherics setup can handle it.
 		if(locate(/obj/machinery/atmospherics/portables_connector/) in loc)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -575,7 +575,7 @@
 		anchored = !anchored
 		user << "You [anchored ? "wrench" : "unwrench"] \the [src]."
 
-	else if (mechanical == 0 && istype(O, /obj/item/weapon/shovel) )
+	else if (!mechanical && istype(O, /obj/item/weapon/shovel) )
 		if(do_after(user, 50))
 			new /obj/item/stack/material/sandstone{amount = 3}(loc)
 			user << "<span class='notice'>You remove the soil from the bed and dismantle the sandstone base.</span>"

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -565,7 +565,7 @@
 		qdel(O)
 		check_health()
 
-	else if(mechanical && iswrench(O))
+	else if(iswrench(O))
 
 		//If there's a connector here, the portable_atmospherics setup can handle it.
 		if(locate(/obj/machinery/atmospherics/portables_connector/) in loc)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -565,7 +565,7 @@
 		qdel(O)
 		check_health()
 
-	else if(iswrench(O))
+	else if(mechanical == 1 && iswrench(O))
 
 		//If there's a connector here, the portable_atmospherics setup can handle it.
 		if(locate(/obj/machinery/atmospherics/portables_connector/) in loc)
@@ -574,6 +574,12 @@
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 		anchored = !anchored
 		user << "You [anchored ? "wrench" : "unwrench"] \the [src]."
+
+	else if (mechanical == 0 && istype(O, /obj/item/weapon/shovel) )
+		new /obj/item/stack/material/sandstone{amount = 3}(loc)
+		user << "<span class='notice'>You remove the soil from the bed and dismantle the sandstone base.</span>"
+		playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
+		qdel(src)
 
 	else if(O.force && seed)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -346,7 +346,7 @@ var/list/name_to_material
 	return round(totalPhoron/100)
 */
 
-/material/stone
+/material/sandstone
 	name = "sandstone"
 	stack_type = /obj/item/stack/material/sandstone
 	icon_base = "stone"


### PR DESCRIPTION
- Removes mechanical flag in wrenching trays, which governs moving soil plots. Doesn't make sense they can't be moved. Redesign to sprite will eventually be done, into a sandstone-based planter box.

- Adds correct name to material list for sandstones, allows building of former items, as well as the planter box, which it's supposed to.