### PR TITLE
Bugfixes

### DIFF
--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -3,7 +3,7 @@
 #define SS_INIT_SEEDS       22	// Plant controller setup.
 #define SS_INIT_MAPLOAD     21	// DMM parsing and load. Unless you know what you're doing, make sure this remains first.
 #define SS_INIT_JOBS        20
-#define SS_INIT_MAPFINALIZE 10	// Asteroid generation.
+#define SS_INIT_MAPFINALIZE 19	// Asteroid generation.
 #define SS_INIT_SHUTTLE     18	// Shuttle setup.
 #define SS_INIT_PARALLAX    17	// Parallax image cache generation. Must run before ghosts are able to join.
 #define SS_INIT_HOLOMAP     16

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -188,7 +188,7 @@
 	//Transfer 5% of current tank air contents to turf
 	var/datum/gas_mixture/air_transfer = ptank.air_contents.remove_ratio(0.02*(throw_amount/100))
 	//air_transfer.toxins = air_transfer.toxins * 5 // This is me not comprehending the air system. I realize this is retarded and I could probably make it work without fucking it up like this, but there you have it. -- TLE
-	new/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel(target,air_transfer.gas["phoron"],get_dir(loc,target))
+	new/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel(target,air_transfer.gas["phoron"]*15,get_dir(loc,target))
 	air_transfer.gas["phoron"] = 0
 	target.assume_air(air_transfer)
 	//Burn it based on transfered gas

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -284,7 +284,7 @@
 		return ..() //once open, behave like normal
 
 /obj/item/weapon/gun/projectile/automatic/rifle/l6_saw/update_icon()
-	icon_state = "l6[cover_open ? "open" : "closed"][ammo_magazine ? round(ammo_magazine.stored_ammo.len, 25) : "-empty"]"
+	icon_state = "l6[cover_open ? "open" : "closed"][ammo_magazine ? round(ammo_magazine.stored_ammo.len*2, 25) : "-empty"]"
 	if(wielded)
 		item_state = "l6closedmag-wielded"
 	else

--- a/html/changelogs/Arrow768-Bugfixes.yml
+++ b/html/changelogs/Arrow768-Bugfixes.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "NanoTrasen Engineers have reevaluated their design and changed the networks of the cams in the bar/kitchen/hydro/library to service."
+  - bugfix: "NanoTrasen Scientists have updated the L6-Saw to enalbe user to better determine how much ammunition remains."
+  - bugfix: "CCIA has provided additional monkey cubes to xenobio in the hopes of reducing incidents where xenobiologists feed themselfs to the slimes."
+  - tweak: "NanoTrasen Scientists have found a way to increase the burn duration of the flamethrower."
+

--- a/html/changelogs/Arrow768-Bugfixes.yml
+++ b/html/changelogs/Arrow768-Bugfixes.yml
@@ -36,6 +36,6 @@ delete-after: True
 changes: 
   - bugfix: "NanoTrasen Engineers have reevaluated their design and changed the networks of the cams in the bar/kitchen/hydro/library to service."
   - bugfix: "NanoTrasen Scientists have updated the L6-Saw to enalbe user to better determine how much ammunition remains."
-  - bugfix: "CCIA has provided additional monkey cubes to xenobio in the hopes of reducing incidents where xenobiologists feed themselfs to the slimes."
+  - bugfix: "CCIA has provided additional monkey cubes to xenobio in the hopes of reducing incidents where xenobiologists feed themselvs to the slimes."
   - tweak: "NanoTrasen Scientists have found a way to increase the burn duration of the flamethrower."
 

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -23997,6 +23997,8 @@
 "aQa" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/storage/box/monkeycubes,
+/obj/item/weapon/storage/box/monkeycubes,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "aQb" = (

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -30840,7 +30840,8 @@
 /obj/structure/table/standard,
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Hydroponics - East";
-	dir = 8
+	dir = 8;
+	network = list("Service")
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
@@ -33846,6 +33847,9 @@
 	pixel_x = 25;
 	pixel_y = 0
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -33929,6 +33933,9 @@
 /area/crew_quarters/kitchen)
 "bha" = (
 /obj/structure/kitchenspike,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -33968,13 +33975,18 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bhg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
 	name = "Kitchen";
 	sortType = "Kitchen"
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bhh" = (
@@ -33993,6 +34005,12 @@
 /obj/machinery/door/airlock/freezer{
 	name = "Kitchen Freezer";
 	req_access = list(28)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
@@ -34120,6 +34138,12 @@
 /area/janitor)
 "bhx" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -34624,11 +34648,11 @@
 /area/crew_quarters/kitchen)
 "bio" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bip" = (
@@ -34770,7 +34794,8 @@
 	},
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Kitchen - West";
-	dir = 1
+	dir = 1;
+	network = list("Service")
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -35974,9 +35999,6 @@
 	pixel_y = 5
 	},
 /obj/structure/table/wood,
-/obj/machinery/camera/network/civilian_main{
-	c_tag = "Bar - Counter"
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bkD" = (
@@ -36142,6 +36164,10 @@
 	pixel_x = -6;
 	pixel_y = 0;
 	req_access = list(25)
+	},
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Bar - Counter";
+	network = list("Service")
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
@@ -38682,6 +38708,13 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -38739,7 +38772,8 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/camera/network/civilian_main{
-	c_tag = "Bar - Northeast"
+	c_tag = "Bar - Northeast";
+	network = list("Service")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -46311,12 +46345,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"bBG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet,
-/area/library)
 "bBH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -47501,6 +47529,11 @@
 	dir = 1;
 	pixel_y = -25
 	},
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Library - East";
+	dir = 1;
+	network = list("Service")
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "bDN" = (
@@ -47737,7 +47770,7 @@
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Kitchen - East";
 	dir = 8;
-	network = list("Civilian Main","Capt_Office")
+	network = list("Service")
 	},
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -48143,7 +48176,8 @@
 	},
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Chapel - Office";
-	dir = 8
+	dir = 8;
+	network = list("Service")
 	},
 /turf/simulated/floor/wood,
 /area/chapel/office)
@@ -50540,7 +50574,8 @@
 "bJk" = (
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Bar -Theatre";
-	dir = 8
+	dir = 8;
+	network = list("Service")
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -58961,6 +58996,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"dMP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "dTQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
@@ -59816,6 +59858,17 @@
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
+"hlL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Library - West";
+	dir = 4;
+	network = list("Service")
+	},
+/turf/simulated/floor/carpet,
+/area/library)
 "hmA" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Temporary Morgue";
@@ -60026,6 +60079,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
+"jba" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "jhE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60132,6 +60198,16 @@
 /obj/machinery/chem_master,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
+"kwG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
+/area/crew_quarters/kitchen)
 "kyC" = (
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/refinery)
@@ -60332,6 +60408,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"lpJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
+/area/crew_quarters/kitchen)
 "lqM" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
@@ -64320,15 +64405,8 @@
 /area/crew_quarters/sleep/main)
 "ykm" = (
 /obj/machinery/camera/network/civilian_main{
-	c_tag = "Library - North"
-	},
-/turf/simulated/floor/carpet,
-/area/library)
-"ykn" = (
-/obj/structure/bookcase/libraryspawn/reference,
-/obj/machinery/camera/network/civilian_main{
-	c_tag = "Library - South";
-	dir = 1
+	c_tag = "Library - North";
+	network = list("Service")
 	},
 /turf/simulated/floor/carpet,
 /area/library)
@@ -64343,7 +64421,8 @@
 	},
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Chapel - Main";
-	dir = 1
+	dir = 1;
+	network = list("Service")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -64354,7 +64433,8 @@
 	},
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Bar - West";
-	dir = 4
+	dir = 4;
+	network = list("Service")
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -89708,8 +89788,8 @@ bnQ
 bvn
 bvn
 bAU
-bBG
 bBY
+hlL
 bCP
 bDc
 bEl
@@ -90482,7 +90562,7 @@ bBa
 aWh
 bCo
 aWh
-ykn
+bDH
 bFv
 arj
 bEq
@@ -95880,7 +95960,7 @@ bEA
 bgI
 bgI
 bhg
-bgI
+dMP
 bio
 biD
 bjT
@@ -96136,7 +96216,7 @@ bfw
 bEC
 bfw
 bfw
-bhh
+jba
 bfw
 bip
 biF
@@ -96393,7 +96473,7 @@ bgX
 bqx
 bFB
 bEo
-bhh
+jba
 bih
 biq
 biJ
@@ -97162,8 +97242,8 @@ bzL
 bPI
 bjH
 bgP
-bgP
-bgP
+lpJ
+kwG
 boS
 bPI
 bir

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -15355,11 +15355,6 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/wall/r_wall,
 /area/storage/shields)
 "Cl" = (
@@ -15369,11 +15364,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled,
 /area/storage/shields)
 "Cm" = (
@@ -19368,22 +19358,6 @@
 	},
 /turf/unsimulated/chasm_mask,
 /area/solar/starboard)
-"Nl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled,
-/area/storage/shields)
 "NI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19497,30 +19471,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
-"RL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/wall/r_wall,
-/area/storage/shields)
-"SL" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/storage/shields)
 "Vk" = (
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
@@ -20006,6 +19956,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled,
 /area/storage/shields)
 "Wo" = (
@@ -20069,13 +20024,15 @@
 	name = "west bump";
 	pixel_x = -24
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/structure/cable/cyan,
 /turf/simulated/floor/tiled,
 /area/storage/shields)
 "Wt" = (
@@ -20131,10 +20088,20 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/firealarm/west,
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/storage/shields)
@@ -47493,7 +47460,7 @@ Wi
 Wi
 Wi
 Ck
-RL
+Wi
 Wi
 AU
 WL
@@ -48004,8 +47971,8 @@ iK
 oS
 Wi
 Bh
-SL
-Nl
+BA
+BR
 Cl
 WC
 Wi

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -15355,6 +15355,11 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/wall/r_wall,
 /area/storage/shields)
 "Cl" = (
@@ -15364,6 +15369,11 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/storage/shields)
 "Cm" = (
@@ -19358,6 +19368,22 @@
 	},
 /turf/unsimulated/chasm_mask,
 /area/solar/starboard)
+"Nl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/storage/shields)
 "NI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19471,6 +19497,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
+"RL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/wall/r_wall,
+/area/storage/shields)
+"SL" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/storage/shields)
 "Vk" = (
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
@@ -19956,11 +20006,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/tiled,
 /area/storage/shields)
 "Wo" = (
@@ -20024,15 +20069,13 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable/cyan,
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled,
 /area/storage/shields)
 "Wt" = (
@@ -20088,20 +20131,10 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/firealarm/west,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/storage/shields)
@@ -47460,7 +47493,7 @@ Wi
 Wi
 Wi
 Ck
-Wi
+RL
 Wi
 AU
 WL
@@ -47971,8 +48004,8 @@ iK
 oS
 Wi
 Bh
-BA
-BR
+SL
+Nl
 Cl
 WC
 Wi


### PR DESCRIPTION
A few bugfixes.

- Fixes the cam networks in the bar / library / chapel / kitchen / hydroponics
- Adds additional monkeys to xenobio
- Increases the amount of fuel thrown by the flamethrower
- Changes the L6 to use the correct icon states depending on the ammo
- Fixes messed up astroid tiles