### PR TITLE
Fixes Midnight Rollovers

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -31,7 +31,7 @@ var/round_start_time
 
 var/real_round_start_time
 /proc/get_round_duration() //Real time since round has started, in ticks.
-	return real_round_start_time ? REALTIMEOFDAY - real_round_start_time : 0
+	return real_round_start_time ? (REALTIMEOFDAY - real_round_start_time) : 0
 
 /proc/get_round_duration_formatted()
 	var/duration = get_round_duration()
@@ -48,7 +48,8 @@ var/real_round_start_time
 /var/rollovercheck_last_timeofday = 0
 /proc/update_midnight_rollover()
 	if (world.timeofday < rollovercheck_last_timeofday) //TIME IS GOING BACKWARDS!
-		return midnight_rollovers++
+		midnight_rollovers += 1
+	rollovercheck_last_timeofday = world.timeofday
 	return midnight_rollovers
 
 //returns timestamp in a sql and ISO 8601 friendly format

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -392,7 +392,7 @@
 	if (SSticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 		dat += "Current Game Mode: <B>[SSticker.mode.name]</B><BR>"
-		dat += "Round Duration: <B>[round(world.time / 36000)]:[add_zero(world.time / 600 % 60, 2)]:[world.time / 100 % 6][world.time / 100 % 10]</B><BR>"
+		dat += "Round Duration: [get_round_duration_formatted()]"
 		dat += "<B>Emergency shuttle</B><BR>"
 		if (!emergency_shuttle.online())
 			dat += "<a href='?src=\ref[src];call_shuttle=1'>Call Shuttle</a><br>"

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -360,7 +360,7 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 
 	var/dat = "<html><body><center>"
 	dat += "<b>Welcome, [name].<br></b>"
-	dat += "Round Duration: [get_round_duration()]<br>"
+	dat += "Round Duration: [get_round_duration_formatted()]<br>"
 
 	if(emergency_shuttle) //In case Nanotrasen decides reposess CentComm's shuttles.
 		if(emergency_shuttle.going_to_centcom()) //Shuttle is going to centcomm, not recalled

--- a/html/changelogs/burgerbb - midnight rollover.yml
+++ b/html/changelogs/burgerbb - midnight rollover.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed midnight rollover times that resulted in funky round duration times, among other things."


### PR DESCRIPTION
The REAL_TIME define that I used that was left by our ancestors was not working properly as intended, so every time the server time struck midnight, it would fuck up the time. I fixed this by making it so that midnight checking actually works.

I bet you anything that the reason the server used our shitty method of keeping time (lag time) is because realtime kept doing this. The bug wasn't discovered before because REAL_TIME is only used by benchmarking, which means that this bug would never be found unless you started the server 20 seconds before midnight on debug mode.

Also fixes a few formatting bugs.