### PR TITLE
Cigarette Fixes

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -25,6 +25,10 @@
 #define REAGENTS_BURNING_TEMP_LOW_DAMAGE 0.00005 //Damage per celcius per unit below the REAGENTS_BURNING_TEMP_LOW define per unit.
 #define REAGENTS_BURNING_TEMP_LOW_DAMAGE_CAP 20 //Maximum amount of burn damage to deal due to low temperature reagents.
 
+#define REAGENTS_BODYTEMP 0.002 //Increase in body temperature per unit per celcius above current body temperature.
+#define REAGENTS_BODYTEMP_MIN 0.25 //Minimum amount of increase to actually increase body temperature. The increase is also rounded to this value.
+#define REAGENTS_BODYTEMP_MAX 10 //Maximum allowed increase in body temperature (K) per unit.
+
 #define CHEM_SYNTH_ENERGY 500 // How much energy does it take to synthesize 1 unit of chemical, in Joules.
 
 // Some on_mob_life() procs check for alien races.

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -11,21 +11,21 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 	var/list/chemical_reagents
 
 	var/tmp/list/processing_holders = list()
-	
+
 /datum/controller/subsystem/chemistry/proc/has_valid_specific_heat(var/datum/reagent/R) //Used for unit tests. Same as check_specific_heat but returns a boolean instead.
 
 	if(R.specific_heat > 0)
-		return TRUE	
+		return TRUE
 
 	if(chemical_reagents[R.id].specific_heat > 0) //Don't think this will happen but you never know.
 		return TRUE
-		
+
 	var/datum/chemical_reaction/recipe = find_recipe_by_result(R.id)
 	if(recipe)
 		for(var/chem in recipe.required_reagents)
 			if(!has_valid_specific_heat(chemical_reagents[chem]))
 				return FALSE
-				
+
 		return TRUE
 	else
 		return R.fallback_specific_heat > 0
@@ -63,7 +63,7 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 /datum/controller/subsystem/chemistry/proc/find_recipe_by_result(var/result_id)
 	for(var/key in chemical_reactions_clean)
 		var/datum/chemical_reaction/CR = chemical_reactions_clean[key]
-		if(CR.result == result_id && CR.result_amount > 0)
+		if(CR.result == result_id && CR.result_amount > 0 && !ignore_specific_heat)
 			return CR
 
 /datum/controller/subsystem/chemistry/stat_entry()

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -29,7 +29,11 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 
 		return TRUE
 	else
-		return R.fallback_specific_heat > 0
+		if(R.fallback_specific_heat > 0)
+			return TRUE
+		else
+			log_ss("chemistry", "ERROR: [R.type] does not have a valid specific heat ([R.specific_heat]) or a valid fallback specific heat ([R.fallback_specific_heat]) assigned!")
+			return FALSE
 
 /datum/controller/subsystem/chemistry/proc/check_specific_heat(var/datum/reagent/R)
 

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -63,7 +63,7 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 /datum/controller/subsystem/chemistry/proc/find_recipe_by_result(var/result_id)
 	for(var/key in chemical_reactions_clean)
 		var/datum/chemical_reaction/CR = chemical_reactions_clean[key]
-		if(CR.result == result_id && CR.result_amount > 0 && !ignore_specific_heat)
+		if(CR.result == result_id && CR.result_amount > 0 && !CR.ignore_specific_heat)
 			return CR
 
 /datum/controller/subsystem/chemistry/stat_entry()

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -70,7 +70,7 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 /datum/controller/subsystem/chemistry/proc/find_recipe_by_result(var/result_id)
 	for(var/key in chemical_reactions_clean)
 		var/datum/chemical_reaction/CR = chemical_reactions_clean[key]
-		if(CR.result == result_id && CR.result_amount > 0 && !CR.ignore_specific_heat)
+		if(CR.result == result_id && CR.result_amount > 0)
 			return CR
 
 /datum/controller/subsystem/chemistry/stat_entry()

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -24,7 +24,8 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 	if(recipe)
 		for(var/chem in recipe.required_reagents)
 			if(!has_valid_specific_heat(chemical_reagents[chem]))
-				return FALSE
+				log_ss("chemistry", "ERROR: [recipe.type] has an improper recipe!")
+				return R.fallback_specific_heat > 0
 
 		return TRUE
 	else

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -49,8 +49,10 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 		var/result_amount = recipe.result_amount
 		for(var/chem in recipe.required_reagents)
 			var/chem_specific_heat = check_specific_heat(chemical_reagents[chem])
-			if(!chem_specific_heat)
+			if(chem_specific_heat <= 0)
 				log_ss("chemistry", "ERROR: [R.type] does not have a specific heat value set, and there is no associated recipe for it! Please fix this by giving it a specific_heat value!")
+				final_heat = 0
+				break
 			final_heat += chem_specific_heat * (recipe.required_reagents[chem]/result_amount)
 
 		if(final_heat > 0)

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -25,7 +25,7 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 			if(!has_valid_specific_heat(chemical_reagents[chem]))
 				return FALSE
 
-	if(R.fallback_specific_heat)
+	if(R.fallback_specific_heat > 0)
 		return TRUE
 
 	return FALSE

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -52,7 +52,7 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 			chemical_reagents[R.id].specific_heat = final_heat
 			return final_heat
 
-	if(R.fallback_specific_heat)
+	if(R.fallback_specific_heat > 0)
 		chemical_reagents[R.id].specific_heat = R.fallback_specific_heat
 		return R.fallback_specific_heat
 

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -12,10 +12,11 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 
 	var/tmp/list/processing_holders = list()
 	
-/datum/controller/subsystem/chemistry/proc/has_valid_specific_heat(var/datum/reagent/R) //Used for unit tests
+/datum/controller/subsystem/chemistry/proc/has_valid_specific_heat(var/datum/reagent/R) //Used for unit tests. Same as check_specific_heat but returns a boolean instead.
 
 	if(R.specific_heat > 0)
 		return TRUE	
+
 	if(chemical_reagents[R.id].specific_heat > 0) //Don't think this will happen but you never know.
 		return TRUE
 		
@@ -24,11 +25,10 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 		for(var/chem in recipe.required_reagents)
 			if(!has_valid_specific_heat(chemical_reagents[chem]))
 				return FALSE
-
-	if(R.fallback_specific_heat > 0)
+				
 		return TRUE
-
-	return FALSE
+	else
+		return R.fallback_specific_heat > 0
 
 /datum/controller/subsystem/chemistry/proc/check_specific_heat(var/datum/reagent/R)
 

--- a/code/game/objects/items/bees_items.dm
+++ b/code/game/objects/items/bees_items.dm
@@ -43,6 +43,7 @@
 	id = "honey"
 	description = "A golden yellow syrup, loaded with sugary sweetness."
 	color = "#FFFF00"
+	fallback_specific_heat = 0.75
 
 /obj/item/weapon/book/manual/hydroponics_beekeeping
 	name = "The Ins and Outs of Apiculture - A Precise Art"

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -106,7 +106,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/smokable/process()
 
-	if(reagents && reagents.total_volume)
+	if(reagents && reagents.total_volume && burn_rate)
 		if(!initial_volume)
 			initial_volume = reagents.total_volume
 		var/mob/living/carbon/human/C = loc

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -81,19 +81,9 @@
 
 	dose = min(dose + removed, max_dose)
 
-	//Not based on science, based on balance.
-
-	world << "VOLUME: [volume]"
-	world << "REMOVED: [removed]"
-	world << "SPECIFIC HEAT: [specific_heat]"
-	world << "THERMAL ENERGY: [thermal_energy]"
-
-	/*
-	var/body_temp = M.bodytemperature
-	var/removed_var = removed
-	world << "OKAY: [chem_temp] [body_temp] [removed_var]"
-	world << "CHANGE: [Clamp((get_temperature() - M.bodytemperature) * removed * 0.002,-10 * removed, 10 * removed)]"
-	*/
+	var/bodytempchange = Clamp((get_temperature() - M.bodytemperature) * removed * REAGENTS_BODYTEMP,-REAGENTS_BODYTEMP_MAX * removed, REAGENTS_BODYTEMP_MAX * removed)
+	if(abs(bodytempchange) >= REAGENTS_BODYTEMP_MIN)
+		M.bodytemperature += round(bodytempchange,REAGENTS_BODYTEMP_MIN)
 
 	for(var/datum/reagent/R in M.bloodstr.reagent_list)
 		if(istype(R, conflicting_reagent))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -82,7 +82,18 @@
 	dose = min(dose + removed, max_dose)
 
 	//Not based on science, based on balance.
-	M.bodytemperature += Clamp( ((get_temperature() - (T0C + 20)) * removed * 0.002),-5*removed,5*removed)
+
+	world << "VOLUME: [volume]"
+	world << "REMOVED: [removed]"
+	world << "SPECIFIC HEAT: [specific_heat]"
+	world << "THERMAL ENERGY: [thermal_energy]"
+
+	/*
+	var/body_temp = M.bodytemperature
+	var/removed_var = removed
+	world << "OKAY: [chem_temp] [body_temp] [removed_var]"
+	world << "CHANGE: [Clamp((get_temperature() - M.bodytemperature) * removed * 0.002,-10 * removed, 10 * removed)]"
+	*/
 
 	for(var/datum/reagent/R in M.bloodstr.reagent_list)
 		if(istype(R, conflicting_reagent))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -130,6 +130,7 @@
 	reagent_state = LIQUID
 	color = "#C81040"
 	taste_description = "slime"
+	fallback_specific_heat = 1.2
 
 /datum/reagent/vaccine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(data)
@@ -153,6 +154,7 @@
 	reagent_state = LIQUID
 	color = "#0050F0"
 	taste_description = "slime"
+	fallback_specific_heat = 1.5
 
 /datum/reagent/antibodies/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(src.data)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -572,7 +572,7 @@
 	var/agony_amount = 1
 	var/discomfort_message = "<span class='danger'>Your insides feel uncomfortably hot!</span>"
 	var/slime_temp_adj = 10
-	specific_heat = 2
+	fallback_specific_heat = 2
 
 /datum/reagent/capsaicin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustToxLoss(0.5 * removed)
@@ -606,7 +606,7 @@
 	agony_amount = 4
 	discomfort_message = "<span class='danger'>You feel like your insides are burning!</span>"
 	slime_temp_adj = 15
-	specific_heat = 4
+	fallback_specific_heat = 4
 
 /datum/reagent/capsaicin/condensed/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 #define EYES_PROTECTED 1
@@ -3809,4 +3809,4 @@
 	description = "A delicious seasonal flavoring."
 	color = "#AE771C"
 	taste_description = "autumn bliss"
-	
+

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -669,7 +669,7 @@
 			M.custom_emote(2, "[pick("coughs!","coughs hysterically!","splutters!")]")
 		M.apply_effect(40, AGONY, 0)
 
-/datum/reagent/condensedcapsaicin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/capsaicin/condensed/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.species && (H.species.flags & NO_PAIN))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -606,6 +606,7 @@
 	agony_amount = 4
 	discomfort_message = "<span class='danger'>You feel like your insides are burning!</span>"
 	slime_temp_adj = 15
+	specific_heat = 4
 
 /datum/reagent/capsaicin/condensed/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 #define EYES_PROTECTED 1

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -568,11 +568,13 @@
 	color = "#B31008"
 	taste_description = "hot peppers"
 	taste_mult = 1.5
+	fallback_specific_heat = 2
+
 	var/agony_dose = 5
 	var/agony_amount = 1
 	var/discomfort_message = "<span class='danger'>Your insides feel uncomfortably hot!</span>"
 	var/slime_temp_adj = 10
-	fallback_specific_heat = 2
+
 
 /datum/reagent/capsaicin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustToxLoss(0.5 * removed)
@@ -594,6 +596,9 @@
 		M.bodytemperature += rand(0, 15) + slime_temp_adj
 	holder.remove_reagent("frostoil", 5)
 
+#define EYES_PROTECTED 1
+#define EYES_MECH 2
+
 /datum/reagent/capsaicin/condensed
 	name = "Condensed Capsaicin"
 	id = "condensedcapsaicin"
@@ -609,8 +614,6 @@
 	fallback_specific_heat = 4
 
 /datum/reagent/capsaicin/condensed/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
-#define EYES_PROTECTED 1
-#define EYES_MECH 2
 	var/eyes_covered = 0
 	var/mouth_covered = 0
 	var/no_pain = 0
@@ -666,9 +669,6 @@
 			M.custom_emote(2, "[pick("coughs!","coughs hysterically!","splutters!")]")
 		M.apply_effect(40, AGONY, 0)
 
-#undef EYES_PROTECTED
-#undef EYES_MECH
-
 /datum/reagent/condensedcapsaicin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -683,6 +683,9 @@
 	if(istype(M, /mob/living/carbon/slime))
 		M.bodytemperature += rand(15, 30)
 	holder.remove_reagent("frostoil", 5)
+
+#undef EYES_PROTECTED
+#undef EYES_MECH
 
 /datum/reagent/spacespice
 	name = "Space Spice"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -572,6 +572,7 @@
 	var/agony_amount = 1
 	var/discomfort_message = "<span class='danger'>Your insides feel uncomfortably hot!</span>"
 	var/slime_temp_adj = 10
+	specific_heat = 2
 
 /datum/reagent/capsaicin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustToxLoss(0.5 * removed)
@@ -605,7 +606,6 @@
 	agony_amount = 4
 	discomfort_message = "<span class='danger'>You feel like your insides are burning!</span>"
 	slime_temp_adj = 15
-	fallback_specific_heat = 2
 
 /datum/reagent/capsaicin/condensed/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 #define EYES_PROTECTED 1

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -527,6 +527,7 @@
 	reagent_state = SOLID
 	color = "#000000"
 	taste_description = "pepper"
+	fallback_specific_heat = 1.25
 
 /datum/reagent/enzyme
 	name = "Universal Enzyme"
@@ -537,6 +538,7 @@
 	overdose = REAGENTS_OVERDOSE
 	taste_description = "sweetness"
 	taste_mult = 0.7
+	fallback_specific_heat = 1
 
 /datum/reagent/frostoil
 	name = "Frost Oil"
@@ -603,6 +605,7 @@
 	agony_amount = 4
 	discomfort_message = "<span class='danger'>You feel like your insides are burning!</span>"
 	slime_temp_adj = 15
+	fallback_specific_heat = 2
 
 /datum/reagent/capsaicin/condensed/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 #define EYES_PROTECTED 1
@@ -688,6 +691,7 @@
 	color = "#e08702"
 	taste_description = "spices"
 	taste_mult = 1.5
+	fallback_specific_heat = 2
 
 /datum/reagent/browniemix
 	name = "Brownie Mix"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -581,6 +581,8 @@
 	var/list/withdrawal_traumas //List of withdrawl effects that the medication permanently adds during withdrawl, with the key being the brain trauma, and the value being the base percent chance to add.
 	var/list/suppressing_reagents = list() // List of reagents that suppress the withdrawal effects, with the key being the reagent and the vlue being the minimum dosage required to suppress.
 
+	fallback_specific_heat = 1.5
+	
 /datum/reagent/mental/affect_blood(var/mob/living/carbon/human/H, var/alien, var/removed)
 
 	if(!istype(H) || max_dose < min_dose || (world.time < data && volume > removed) || messagedelay == -1)
@@ -1136,6 +1138,7 @@
 	color = "#BF0000"
 	taste_description = "bitter metal"
 	overdose = 5
+	fallback_specific_heat = 1.2
 
 /datum/reagent/azoth/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
@@ -1222,6 +1225,7 @@
 	color = "#ffd700"
 	affects_dead = 1
 	taste_description = "eternal blissfulness"
+	fallback_specific_heat = 2
 
 /datum/reagent/elixir/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(ishuman(M))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -509,6 +509,8 @@
 	glass_name = "glass of beer"
 	glass_desc = "A freezing pint of beer"
 	glass_center_of_mass = list("x"=16, "y"=8)
+	
+	fallback_specific_heat = 1.2
 
 /* Drugs */
 
@@ -544,6 +546,7 @@
 	metabolism = REM * 0.25
 	overdose = REAGENTS_OVERDOSE
 	taste_description = "bitterness"
+	fallback_specific_heat = 1.2
 
 /datum/reagent/serotrotium/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/mob/living/carbon/human/H = M
@@ -611,6 +614,7 @@
 	overdose = REAGENTS_OVERDOSE
 	metabolism = REM * 0.5
 	taste_description = "mushroom"
+	fallback_specific_heat = 1.2
 
 /datum/reagent/psilocybin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/mob/living/carbon/human/H = M
@@ -696,6 +700,7 @@
 	reagent_state = LIQUID
 	color = "#535E66"
 	taste_description = "slimey metal"
+	fallback_specific_heat = 3
 
 /datum/reagent/nanites/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	if(prob(10))
@@ -711,6 +716,7 @@
 	reagent_state = LIQUID
 	color = "#535E66"
 	taste_description = "sludge"
+	fallback_specific_heat = 2
 
 /datum/reagent/xenomicrobes/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	if(prob(10))

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -506,7 +506,6 @@
 	required_reagents = list("capsaicin" = 2)
 	catalysts = list("phoron" = 5)
 	result_amount = 1
-	ignore_specific_heat = TRUE
 
 /datum/chemical_reaction/coolant
 	name = "Coolant"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -35,8 +35,6 @@
 	var/mix_message = "The solution begins to bubble."
 	var/reaction_sound = 'sound/effects/bubbles.ogg'
 
-	var/ignore_specific_heat = FALSE
-
 	var/log_is_important = 0 // If this reaction should be considered important for logging. Important recipes message admins when mixed, non-important ones just log to file.
 /datum/chemical_reaction/proc/can_happen(var/datum/reagents/holder)
 	//check that all the required reagents are present
@@ -1303,7 +1301,6 @@
 	required_reagents = list("blood" = 1)
 	result_amount = 10
 	required = /obj/item/slime_extract/orange
-	ignore_specific_heat = TRUE
 
 /datum/chemical_reaction/slime/fire
 	name = "Slime fire"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -35,6 +35,8 @@
 	var/mix_message = "The solution begins to bubble."
 	var/reaction_sound = 'sound/effects/bubbles.ogg'
 
+	var/ignore_specific_heat = FALSE
+
 	var/log_is_important = 0 // If this reaction should be considered important for logging. Important recipes message admins when mixed, non-important ones just log to file.
 /datum/chemical_reaction/proc/can_happen(var/datum/reagents/holder)
 	//check that all the required reagents are present
@@ -504,6 +506,7 @@
 	required_reagents = list("capsaicin" = 2)
 	catalysts = list("phoron" = 5)
 	result_amount = 1
+	ignore_specific_heat = TRUE
 
 /datum/chemical_reaction/coolant
 	name = "Coolant"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1304,6 +1304,7 @@
 	required_reagents = list("blood" = 1)
 	result_amount = 10
 	required = /obj/item/slime_extract/orange
+	ignore_specific_heat = TRUE
 
 /datum/chemical_reaction/slime/fire
 	name = "Slime fire"

--- a/code/modules/reagents/Chemistry-Temperature.dm
+++ b/code/modules/reagents/Chemistry-Temperature.dm
@@ -26,15 +26,17 @@
 
 /datum/reagents/proc/get_temperature()
 	var/HC = get_heat_capacity()
-	if(HC)
-		return get_thermal_energy() / (HC)
+	var/TE = get_thermal_energy()
+	if(HC && TE)
+		return TE / HC
 	else
 		return T0C + 20
 
 /datum/reagent/proc/get_temperature()
 	var/HC = get_heat_capacity()
-	if(HC)
-		return get_thermal_energy() / (HC)
+	var/TE = get_thermal_energy()
+	if(HC && TE)
+		return TE / HC
 	else
 		return T0C + 20
 

--- a/html/changelogs/burgerbb - temperature fixes.yml
+++ b/html/changelogs/burgerbb - temperature fixes.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed a bug that would cause you, your friends, and your loved ones to combust into the power of a million suns when consuming some reagent, such as nicotine from cigarettes."


### PR DESCRIPTION
There was an issue with one of the travis checks that caused reagents with incorrect specific heat values to sneak into the game and cause havok. This fixes that.

Fixes #5594
Fixes #5593