### PR TITLE
Fixes being able to use dna injectors on species without dna

### DIFF
--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -124,6 +124,9 @@
 		user << "<span class='warning'>Apparently it didn't work...</span>"
 		return
 
+	if(H.species && H.species.flags & NO_SCAN)
+		return
+
 	// Used by admin log.
 	var/injected_with_monkey = ""
 	if((buf.types & DNA2_BUF_SE) && (block ? (GetState() && block == MONKEYBLOCK) : GetState(MONKEYBLOCK)))

--- a/html/changelogs/alberyk-genetics.yml
+++ b/html/changelogs/alberyk-genetics.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed DNA injectors working on species without DNA."


### PR DESCRIPTION
What the title says, you could use those in ipc and etc to change their name and give them hair, as well other strange results.