### PR TITLE
Less Stupid Fireaxes

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -205,8 +205,8 @@
 			P.die_off()
 
 /obj/item/weapon/material/twohanded/fireaxe/pre_attack(var/mob/living/target, var/mob/living/user)	
-	if(istype(target))	
-		cleave(user, target)	
+	if(istype(target))
+		cleave(user, target)
 	..()
 
 //spears, bay edition

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -192,7 +192,6 @@
 
 /obj/item/weapon/material/twohanded/fireaxe/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 2.5)
 	..()
 	if(A && wielded)
 		if(istype(A,/obj/structure/window))
@@ -205,6 +204,7 @@
 			P.die_off()
 
 /obj/item/weapon/material/twohanded/fireaxe/pre_attack(var/mob/living/target, var/mob/living/user)
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 2.5)
 	if(istype(target))
 		cleave(user, target)
 	..()

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -204,7 +204,7 @@
 			var/obj/effect/plant/P = A
 			P.die_off()
 
-/obj/item/weapon/material/twohanded/fireaxe/pre_attack(var/mob/living/target, var/mob/living/user)	
+/obj/item/weapon/material/twohanded/fireaxe/pre_attack(var/mob/living/target, var/mob/living/user)
 	if(istype(target))
 		cleave(user, target)
 	..()

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -204,6 +204,11 @@
 			var/obj/effect/plant/P = A
 			P.die_off()
 
+/obj/item/weapon/material/twohanded/fireaxe/pre_attack(var/mob/living/target, var/mob/living/user)	
+	if(istype(target))	
+		cleave(user, target)	
+	..()
+
 //spears, bay edition
 /obj/item/weapon/material/twohanded/spear
 	icon_state = "spearglass0"

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -188,9 +188,11 @@
 	force_wielded = 30
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	applies_material_colour = 0
+	can_embed = 0
 
-/obj/item/weapon/material/twohanded/fireaxe/afterattack(atom/A as mob|obj|turf|area, mob/user as mob, proximity)
+/obj/item/weapon/material/twohanded/fireaxe/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 2.5)
 	..()
 	if(A && wielded)
 		if(istype(A,/obj/structure/window))
@@ -201,11 +203,6 @@
 		else if(istype(A,/obj/effect/plant))
 			var/obj/effect/plant/P = A
 			P.die_off()
-
-/obj/item/weapon/material/twohanded/fireaxe/pre_attack(var/mob/living/target, var/mob/living/user)
-	if(istype(target))
-		cleave(user, target)
-	..()
 
 //spears, bay edition
 /obj/item/weapon/material/twohanded/spear

--- a/html/changelogs/Kaedwuff - Fireaxe.yml
+++ b/html/changelogs/Kaedwuff - Fireaxe.yml
@@ -34,4 +34,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Fireaxes have stopped being weapons of mass destruction - they no longer cleave during attacks. You also attack slower and no longer embed the weapon during attacks."
+  - tweak: "Fireaxes now attack much slower, but also no longer embed constantly in everyone you attack, or everyone nearby the general vicinity of your attack."

--- a/html/changelogs/Kaedwuff - Fireaxe.yml
+++ b/html/changelogs/Kaedwuff - Fireaxe.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Fireaxes have stopped being weapons of mass destruction - they no longer cleave during attacks. You also attack slower and no longer embed the weapon during attacks."


### PR DESCRIPTION
Due to unchecked feature creep, the fireaxe had become a horrible object to use as a weapon.  It tends to randomly embed in people that were not your actual target.  "It's funny to watch" is not enough justification for me to leave it like that, so I've changed it.

Changes
-Fireaxes have had embedding turned off.  It's really obnoxious and no one has fun with it, especially since embedding code is largely garbage and there's no logical reason someone should be able to run off with a 10+ pound axe lodged in their neck.  There are better balancing forces.
-Fireaxes are heavy, slow weapons.  No longer can you spam them, as there is a 2 second delay between attacks. They are still strong, and can still kill people, but you can't run after people anymore, hacking at them like you're holding a rubber hatchet bigger than your arm.

https://forums.aurorastation.org/topic/11061-less-stupid-fireaxes/