### PR TITLE
Revert "The Dangers of Teleportation (#5651)"

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -113,83 +113,9 @@
 		var/mob/living/L = teleatom
 		if(L.buckled)
 			C = L.buckled
-
 	if(force_teleport)
 		teleatom.forceMove(destturf)
 		playSpecials(destturf,effectout,soundout)
-		var/atom/impediment
-
-		if(destturf.density)
-			impediment = destturf
-
-		else
-			for(var/atom/movable/A in destturf)
-				if(A.density && A.anchored)
-					impediment = A
-					break
-
-		if(impediment)
-			var/turf/newdest
-			var/boominess = 0
-			for(var/turf/T in range(1, destturf))
-				if(!T.density)
-					for(var/atom/movable/A in T)
-						var/blocked = 0
-						if(A.density && A.opacity && A.anchored)
-							blocked = 1
-							break
-						if(!blocked)
-							newdest = T
-							break
-
-			if(istype(teleatom, /obj))
-				var/obj/O = teleatom
-				if(newdest)
-					O.forceMove(newdest)
-					O.ex_act(3)
-				else
-					O.crush_act()
-				boominess += max(0, O.w_class - 1)
-				if(O.density)
-					boominess += 5
-				if(O.opacity)
-					boominess += 10
-
-			if(istype(teleatom, /mob/living))
-				var/mob/living/L = teleatom
-				boominess += L.mob_size/4
-				if(istype(L, /mob/living/carbon/human))
-					var/mob/living/carbon/human/H = L
-					if(newdest)
-						var/list/organs_to_gib = list()
-						for(var/obj/item/organ/external/ext in H.organs)
-							if(!ext.vital) //ensures someone doesn't instantly die, allowing them to slowly die instead
-								organs_to_gib.Add(ext)
-
-						if(organs_to_gib.len)
-							var/obj/item/organ/external/E = pick(organs_to_gib)
-							to_chat(H, "<span class='danger'>You partially phase into \the [impediment], causing your [E.name] to violently dematerialize!</span>")
-							E.droplimb(0,DROPLIMB_BLUNT)
-
-						H.forceMove(newdest)
-					else
-						to_chat(H, "<span class='danger'>Your life flashes before your eyes as you phase into \the [impediment] before the universe suddenly and violently corrects itself!</span>")
-						H.gib()
-				else
-					if(newdest)
-						to_chat(L, "<span class='danger'>You partially phase into \the [impediment], causing a chunk of you to violently dematerialize!</span>")
-						L.adjustBruteLoss(40)
-						L.forceMove(newdest)
-					else
-						to_chat(L, "<span class='danger'>Your life flashes before your eyes as you phase into \the [impediment] before the universe suddenly and violently corrects itself!</span>")
-						L.gib()
-
-			if(!newdest)
-				boominess += 5
-
-			destturf.visible_message("<span class ='danger'>There is a sizable emission of energy as \the [teleatom] phases into \the [impediment]!</span>")
-			explosion(destturf, ((boominess > 10) ? 1 : 0), ((boominess > 5) ? (boominess/10) : 0), boominess/5, boominess/2)
-
 	else
 		if(teleatom.Move(destturf))
 			playSpecials(destturf,effectout,soundout)

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -149,28 +149,10 @@ Frequency:
 			else
 				L["[com.id] (Inactive)"] = com.locked
 	var/list/turfs = list(	)
-
 	for(var/turf/T in orange(10))
-		if(T.x>world.maxx-8 || T.x<8)
-			continue	//putting them at the edge is dumb
-
-		if(T.y>world.maxy-8 || T.y<8)
-			continue
-
-		if(T.density)
-			continue
-
-		var/breakcheck = 0
-		for(var/atom/movable/A in T)
-			if(A.density && A.opacity && A.anchored)
-				breakcheck = 1
-				break
-
-		if(breakcheck)
-			continue
-
+		if(T.x>world.maxx-8 || T.x<8)	continue	//putting them at the edge is dumb
+		if(T.y>world.maxy-8 || T.y<8)	continue
 		turfs += T
-
 	if(turfs.len)
 		L["None (Dangerous)"] = pick(turfs)
 	var/t1 = input(user, "Please select a teleporter to lock in on.", "Hand Teleporter") in L

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -754,15 +754,15 @@ Note that amputating the affected organ does in fact remove the infection from t
 				owner.visible_message(
 					"<span class='danger'>\The [owner]'s [src.name] flies off in an arc!</span>",\
 					"<span class='moderate'><b>Your [src.name] goes flying off!</b></span>",\
-					"<span class='danger'>You hear the terrible sound of [gore_sound].</span>")
+					"<span class='danger'>You hear a terrible sound of [gore_sound].</span>")
 		if(DROPLIMB_BURN)
 			var/gore = "[(status & ORGAN_ROBOT) ? "": " of burning flesh"]"
 			owner.visible_message(
 				"<span class='danger'>\The [owner]'s [src.name] flashes away into ashes!</span>",\
 				"<span class='moderate'><b>Your [src.name] flashes away into ashes!</b></span>",\
-				"<span class='danger'>You hear the crackling sound[gore].</span>")
+				"<span class='danger'>You hear a crackling sound[gore].</span>")
 		if(DROPLIMB_BLUNT)
-			var/gore = "[(status & ORGAN_ROBOT) ? "": " in a shower of gore"]"
+			var/gore = "[(status & ORGAN_ROBOT) ? "": " in shower of gore"]"
 			var/gore_sound = "[(status & ORGAN_ROBOT) ? "rending sound of tortured metal" : "sickening splatter of gore"]"
 			owner.visible_message(
 				"<span class='danger'>\The [owner]'s [src.name] explodes[gore]!</span>",\

--- a/html/changelogs/tehflamintaco.yml
+++ b/html/changelogs/tehflamintaco.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Teh Flamin' Taco
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Telescience no-longer causes harm when teleporting into objects."


### PR DESCRIPTION
This reverts commit c2953f306217ec44cb7981aaa74d9f7df0b54680.

This commit Unintentionally increases the skill ceiling of Telescience and Encourages Metagaming.

Those not using a perfect calculator and potentially, a map, or at the very least a dedicated list of coordinates, run the risk of injuring crew. Those with malicious intent can now also use it as a long range weapon, teleporting crates into people.

This has turned an already elitist science into even more of one, and was done during a time where Telescience Nerfs were already heated discussions, skipping over their discussions.

At the very least, this change needs to be reverted until those discussions finish.