### PR TITLE
Fixing the Food Tagging mechanic.

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -153,9 +153,20 @@
 
 	return 1
 
+/obj/item/weapon/reagent_containers/food/snacks
+	var/hide_rename_msg = FALSE
+
+/obj/item/weapon/reagent_containers/food/snacks/grown
+	hide_rename_msg = TRUE
+
+/obj/item/weapon/reagent_containers/food/snacks/icecream
+	hide_rename_msg = TRUE
+
 /obj/item/weapon/reagent_containers/food/snacks/examine(mob/user)
 	if(!..(user, 1))
 		return
+	if(!hide_rename_msg && name != initial(name))
+		user << "<span class='notice'>This looks like someone's personal recipe for \a [name].</span>"
 	if (coating)
 		user << "<span class='notice'>It's coated in [coating.name]!</span>"
 	if (bitecount==0)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -156,8 +156,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/examine(mob/user)
 	if(!..(user, 1))
 		return
-	if(name != initial(name))
-		user << "<span class='notice'>You know the item as [initial(name)], however a little piece of propped up paper indicates it's \a [name].</span>"
 	if (coating)
 		user << "<span class='notice'>It's coated in [coating.name]!</span>"
 	if (bitecount==0)

--- a/html/changelogs/Kaedwuff - Labels.yml
+++ b/html/changelogs/Kaedwuff - Labels.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Procedurally generated food items no longer spawn with a label on them explaining what they are to you. Additionally, renaming food items now just renames them, cutting out the 'tagging' mechanic entirely."

--- a/html/changelogs/Kaedwuff - Labels.yml
+++ b/html/changelogs/Kaedwuff - Labels.yml
@@ -34,4 +34,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "The food tagging mechanic from the game has been removed, and precedurally generated and renamed food items will no longer have a tag on them explaining what you supposedly know it's normally called."
+  - tweak: "Renaming a food item will now only add a tag that indicates it is a custom recipe, instead of propping a piece of paper on it and magically conveying knowledge of the original food item to the player." 
+  - bugfix: "The bug that caused produce and other things to be tagged as renamed has also been fixed."

--- a/html/changelogs/Kaedwuff - Labels.yml
+++ b/html/changelogs/Kaedwuff - Labels.yml
@@ -34,4 +34,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Procedurally generated food items no longer spawn with a label on them explaining what they are to you. Additionally, renaming food items now just renames them, cutting out the 'tagging' mechanic entirely."
+  - tweak: "The food tagging mechanic from the game has been removed, and precedurally generated and renamed food items will no longer have a tag on them explaining what you supposedly know it's normally called."

--- a/html/changelogs/Kaedwuff - Labels.yml
+++ b/html/changelogs/Kaedwuff - Labels.yml
@@ -34,5 +34,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Renaming a food item will now only add a tag that indicates it is a custom recipe, instead of propping a piece of paper on it and magically conveying knowledge of the original food item to the player." 
+  - tweak: "Renaming a food item will now only add a tag that indicates it is a renamed, instead of propping a piece of paper on it and magically conveying knowledge of the original food item to the player." 
   - bugfix: "The bug that caused produce and other things to be tagged as renamed has also been fixed."


### PR DESCRIPTION
Edit: In an attempt to compromise, I have returned the food tagging feature, but it now only indicates that the renamed is a personal recipe, rather than magically conveying knowledge of what the original item is called.

Also, I used to boolean variables to make produce and ice cream cones stop having the tag entirely.

![485b2266c53f9aed8b0cac0775d59558](https://user-images.githubusercontent.com/12869074/49848148-53a5d280-fd99-11e8-9d4f-d832fe42b081.png)


https://forums.aurorastation.org/topic/11133-removing-food-tags/