### PR TITLE
Adds Antag Scaling Enforcement

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -7,6 +7,7 @@
 #define GAME_FAILURE_NO_ANTAGS             0x1
 #define GAME_FAILURE_NO_PLAYERS            0x2
 #define GAME_FAILURE_TOO_MANY_PLAYERS      0x4
+#define GAME_FAILURE_NO_ANTAGS_SCALED      0x8
 
 // Security levels.
 #define SEC_LEVEL_GREEN 0

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -13,6 +13,7 @@
 	config_tag = "changeling"
 	required_players = 10
 	required_enemies = 3
+	required_enemies_scale = 15 //There needs to be at least 1 antag every 15 players.
 	end_on_antag_death = 1
 	antag_scaling_coeff = 8
 	antag_tags = list(MODE_CHANGELING)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -3,7 +3,8 @@
 	round_description = "Some crewmembers are attempting to start a cult!"
 	extended_round_description = "The station has been infiltrated by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
 	config_tag = "cult"
-	required_players = 9
+	required_players = 10
 	required_enemies = 4
+	required_enemies_scale = 15 //There needs to be at least 1 antag for every 15 players.
 	end_on_antag_death = 1
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -7,6 +7,6 @@
 	required_enemies = 4
 	auto_recall_shuttle = 0
 	end_on_antag_death = 0
-//	shuttle_delay = 3
+	required_enemies_scale = 10 //There needs to be at least 1 antag every 10 players.
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST)
 	require_all_templates = 1

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -16,9 +16,11 @@
 	end_on_antag_death = 1
 	antag_tags = list(MODE_TRAITOR)
 	antag_scaling_coeff = 8
+	required_enemies_scale = 15 //There needs to be at least 1 antag every 15 players.
 
 /datum/game_mode/traitor/auto
 	name = "autotraitor"
 	config_tag = "autotraitor"
 	round_autoantag = 1
 	antag_scaling_coeff = 5
+	required_enemies_scale = 15 //There needs to be at least 1 starting antag every 15 players.

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -7,6 +7,7 @@
 	config_tag = "vampire"
 	required_players = 2
 	required_enemies = 1
+	required_enemies_scale = 15 //There needs to be at least 1 antag every 15 players.
 	end_on_antag_death = 0
 	antag_scaling_coeff = 8
 	antag_tags = list(MODE_VAMPIRE)

--- a/html/changelogs/burgerbb - antag scaling.yml
+++ b/html/changelogs/burgerbb - antag scaling.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed a potential issue that caused rounds to start without antagonists."
+  - rscadd: "There must be AT LEAST one antag for every fifteen players in order for secret changeling, cult, or vampire to start, and one antag for every ten players for revolution to start."
+  
+


### PR DESCRIPTION
# Overview
Currently, a single vampire can spawn in a crew of 25 people. This means that one vampire is expected to interact with at least 25 people.

The fact that this exists makes most gamemodes Extended 2.0. This PR changes it so this doesn't occur.

So, at least 1 antag per 15 players must exist in order for secret cult, changeling, and vampire to trigger. 1 antag per 10 players for secret rev to trigger.

As an example, if there were 15 players, and 2 antags, then vampire will be a possible secret option, because 2 antags per 15 players (2/15) is larger than 1 antag per 15 players (1/15).

If there were 16 players, and 1 antag, then vampire would not be a possible secret option because 1 antag per 16 players (1/16) is less than 1 antag per 15 players (1/15).

Fixes #5756
Fixes #5761 