### PR TITLE
Fixes Particle Accelerators not functioning when hacked to level 3.

### DIFF
--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -26,6 +26,10 @@
 	movement_range = 15
 	energy = 15
 
+// Can only be obtained by hacking the machine
+/obj/effect/accelerated_particle/powerful
+	movement_range = 20
+	energy = 50
 
 /obj/effect/accelerated_particle/New(loc, dir = 2)
 	src.forceMove(loc)

--- a/code/modules/power/singularity/particle_accelerator/particle_emitter.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_emitter.dm
@@ -38,6 +38,9 @@
 				A = new/obj/effect/accelerated_particle(T, dir)
 			if(2)
 				A = new/obj/effect/accelerated_particle/strong(T, dir)
+			if(3)
+			// Level 3 is extra strong, only obtained by hacking
+				A = new/obj/effect/accelerated_particle/powerful(T, dir)
 		if(A)
 			A.set_dir(src.dir)
 			return 1

--- a/html/changelogs/POSIXCompliant-BugFixPALevelThree.yml
+++ b/html/changelogs/POSIXCompliant-BugFixPALevelThree.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: POSIXCompliant
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes Particle Accelerators not working when hacked to particle strength level 3. Strength 3 works now, though it is not necessarily a good idea."


### PR DESCRIPTION
* Fixes an existing bug in which a PA hacked to level three will turn on and then fail to fire any particles.
* Bug was caused by a missing firing check and a missing particle definition; both have been added.
* Resulting behavior in playtesting: PA fires particles suitable for level three generation when hacked to level three.

#### IC newscaster changelog description
A spokesman for Nanotrasen's Engineering Division made a statement on Particle Accelerators yesterday morning, noting that after a careful review of accelerator electronics, a long-standing blueprint issue preventing accelerators from reaching their maximum charge rates has been rectified. Standard-issue particle accelerators should now be able to reach maximum, level three charge rates, though they remain disabled by default.

The spokesman went on to note that maximum charge rates were and are not intended for general station use, and are only within standard protocol for nine specialized power research stations in the Nanotrasen corporate body. All of these stations already have the setting enabled. Accelerator users who attempt to circumvent procedure and modify ("hack") default-configuration Accelerators to allow level three settings are fully liable for any consequence, accident, injury, structural damage or death caused by this action, and will be prosecuted in this vein to the fullest extent of the law.