### PR TITLE
Fire Tweaks and Fixes

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -529,6 +529,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 					user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src].</span>")
 				else
 					user << "<span class='warning'>You burn yourself while lighting the lighter.</span>"
+					if(user.IgniteMob())
+						user.visible_message(span("danger","\The [user] accidentally sets themselves on fire!"))
+
 					if (user.l_hand == src)
 						user.apply_damage(2,BURN,"l_hand")
 					else
@@ -557,7 +560,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/weapon/flame/lighter/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M, /mob))
 		return
-	M.IgniteMob()
+
+	if(lit && M.IgniteMob())
+		M.visible_message(span("danger","\The [user] ignites \the [M] with \the [src]!"))
 
 	if(istype(M.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == "mouth" && lit)
 		var/obj/item/clothing/mask/smokable/cigarette/cig = M.wear_mask
@@ -571,10 +576,20 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	else
 		..()
 
+/obj/item/weapon/flame/lighter/throw_impact(mob/living/carbon/M as mob)
+	. = ..()
+	if(istype(M) && lit && M.IgniteMob())
+		M.visible_message(span("danger","\The [M] is ignited by \the [src]!"))
+
 /obj/item/weapon/flame/lighter/process()
 	var/turf/location = get_turf(src)
 	if(location)
 		location.hotspot_expose(700, 5)
+
+	if(lit && prob(10) && istype(src.loc,/mob/living/))
+		var/mob/living/M = src.loc
+		if(M.IgniteMob())
+			M.visible_message(span("danger","\The [M] is ignited by \the [src]!"))
 
 	if (istype(loc, /obj/item/weapon/storage))//A lighter shouldn't stay lit inside a closed container
 		lit = 0

--- a/code/game/objects/items/weapons/towel.dm
+++ b/code/game/objects/items/weapons/towel.dm
@@ -10,12 +10,24 @@
 	hitsound = 'sound/weapons/towelwhip.ogg'
 
 /obj/item/weapon/towel/attack_self(mob/living/user as mob)
-	user.visible_message("<span class='notice'>\The [user] uses \the [src] to towel themselves off.</span>")
-	playsound(user, 'sound/weapons/towelwipe.ogg', 25, 1)
-	if(user.fire_stacks > 0)
-		user.fire_stacks = (max(0, user.fire_stacks - 1.5))
-	else if(user.fire_stacks < 0)
-		user.fire_stacks = (min(0, user.fire_stacks + 1.5))
+	attack(user,user)
+
+/obj/item/weapon/towel/attack(mob/living/carbon/human/M as mob, mob/living/carbon/user as mob)
+	if(istype(M) && user.a_intent == I_HELP)
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		if(user.on_fire)
+			user.visible_message("<span class='warning'>\The [user] uses \the [src] to pat out \the [M]'s flames with \the [src]!</span>")
+			playsound(M, 'sound/weapons/towelwhip.ogg', 25, 1)
+			M.ExtinguishMob(-1)
+		else
+			user.visible_message("<span class='notice'>\The [user] starts drying \the [M] off with \the [src]...</span>")
+			if(do_mob(user, M, 3 SECONDS))
+				user.visible_message("<span class='notice'>\The [user] dries \the [M] off with \the [src].</span>")
+				playsound(M, 'sound/weapons/towelwipe.ogg', 25, 1)
+				M.adjust_fire_stacks(-Clamp(M.fire_stacks,-1.5,1.5))
+		return
+
+	. = ..()
 
 /obj/item/weapon/towel/random/Initialize()
 	. = ..()

--- a/code/modules/mining/mine_turf_types.dm
+++ b/code/modules/mining/mine_turf_types.dm
@@ -37,8 +37,7 @@
 			else
 				L.bodytemperature = min(L.bodytemperature + 150, 1000)
 		else
-			L.adjust_fire_stacks(15)
-			L.IgniteMob()
+			L.IgniteMob(15)
 			return 1
 	..()
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -230,21 +230,14 @@
 			else
 				M.visible_message("<span class='warning'>[M] tries to pat out [src]'s flames!</span>",
 				"<span class='warning'>You try to pat out [src]'s flames! Hot!</span>")
-				if(do_mob(M, src, 15))
-					src.fire_stacks -= 0.5
-					if (prob(10) && (M.fire_stacks <= 0))
-						M.fire_stacks += 1
-					M.IgniteMob()
-					if (M.on_fire)
+				if(do_mob(M, src, 1.5 SECONDS))
+					if (M.IgniteMob(prob(10)))
 						M.visible_message("<span class='danger'>The fire spreads from [src] to [M]!</span>",
 						"<span class='danger'>The fire spreads to you as well!</span>")
 					else
-						src.fire_stacks -= 0.5 //Less effective than stop, drop, and roll - also accounting for the fact that it takes half as long.
-						if (src.fire_stacks <= 0)
+						if (src.ExtinguishMob(1))
 							M.visible_message("<span class='warning'>[M] successfully pats out [src]'s flames.</span>",
 							"<span class='warning'>You successfully pat out [src]'s flames.</span>")
-							src.ExtinguishMob()
-							src.fire_stacks = 0
 		else
 			var/t_him = "it"
 			if (src.gender == MALE)
@@ -274,11 +267,13 @@
 				else
 					M.visible_message("<span class='notice'>[M] hugs [src] to make [t_him] feel better!</span>", \
 								"<span class='notice'>You hug [src] to make [t_him] feel better!</span>")
-				if(M.fire_stacks >= (src.fire_stacks + 3))
-					src.fire_stacks += 1
-					M.fire_stacks -= 1
-				if(M.on_fire)
-					src.IgniteMob()
+
+				if(M.on_fire && M.fire_stacks > 0 && src.fire_stacks <= 0)
+					var/fire_stacks_to_transfer = max(1,M.fire_stacks / 2)
+					if(!M.ExtinguishMob(fire_stacks_to_transfer))
+						src.IgniteMob(fire_stacks_to_transfer)
+						src.visible_message(span("danger","\The [src] catches on fire from \the [hugger]'s hug!"))
+
 			AdjustParalysis(-3)
 			AdjustStunned(-3)
 			AdjustWeakened(-3)
@@ -380,7 +375,6 @@
 		usr << "<span class='warning'>You are already sleeping</span>"
 		return
 	if(alert(src,"You sure you want to sleep for a while?","Sleep","Yes","No") == "Yes")
-		willfully_sleeping = 1
 		usr.sleeping = 20 //Short nap
 
 /mob/living/carbon/Collide(atom/A)

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -3,20 +3,19 @@
 
 	//drop && roll
 	if(on_fire && !buckled)
-		fire_stacks -= 1.2
+		ExtinguishMob(1.2)
 		Weaken(3)
 		spin(32,2)
 		visible_message(
 			"<span class='danger'>[src] rolls on the floor, trying to put themselves out!</span>",
 			"<span class='notice'>You stop, drop, and roll!</span>"
 			)
-		sleep(30)
+		sleep(3 SECONDS)
 		if(fire_stacks <= 0)
 			visible_message(
 				"<span class='danger'>[src] has successfully extinguished themselves!</span>",
 				"<span class='notice'>You extinguish yourself.</span>"
 				)
-			ExtinguishMob()
 		return
 
 	..()
@@ -199,7 +198,7 @@
 	return ..()
 
 /mob/living/carbon/escape_buckle()
-	
+
 	if(!buckled) return
 
 	if(!restrained())
@@ -217,4 +216,3 @@
 			visible_message("<span class='danger'>[usr] manages to unbuckle themself!</span>",
 							"<span class='notice'>You successfully unbuckle yourself.</span>")
 			buckled.user_unbuckle_mob(src)
-

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -63,8 +63,7 @@
 		if(DROWSY)
 			drowsyness = max(drowsyness, effect * BLOCKED_MULT(blocked))
 		if(INCINERATE)
-			adjust_fire_stacks(effect * BLOCKED_MULT(blocked))
-			IgniteMob()
+			IgniteMob(effect * BLOCKED_MULT(blocked))
 	updatehealth()
 	return 1
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -465,8 +465,7 @@ default behaviour is:
 	BITSET(hud_updateflag, HEALTH_HUD)
 	BITSET(hud_updateflag, STATUS_HUD)
 	BITSET(hud_updateflag, LIFE_HUD)
-	ExtinguishMob()
-	fire_stacks = 0
+	ExtinguishMobCompletely()
 
 /mob/living/proc/rejuvenate()
 	if(!isnull(reagents))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -257,24 +257,44 @@
 	spawn(1) updatehealth()
 	return 1
 
-/mob/living/proc/IgniteMob()
+/mob/living/proc/IgniteMob(var/fire_stacks_to_add = 0)
+
+	if(fire_stacks_to_add)
+		adjust_fire_stacks(fire_stacks_to_add)
+
 	if(fire_stacks > 0 && !on_fire)
 		on_fire = 1
 		set_light(light_range + MOB_FIRE_LIGHT_RANGE, light_power + MOB_FIRE_LIGHT_POWER)
 		update_fire()
+		return TRUE
 
-/mob/living/proc/ExtinguishMob()
-	if(on_fire)
+	return FALSE
+
+/mob/living/proc/ExtinguishMob(var/fire_stacks_to_remove = 0)
+
+	adjust_fire_stacks(-fire_stacks_to_remove)
+
+	if(fire_stacks <= 0 && on_fire)
 		on_fire = 0
-		fire_stacks = 0
 		set_light(max(0, light_range - MOB_FIRE_LIGHT_RANGE), max(0, light_power - MOB_FIRE_LIGHT_POWER))
 		update_fire()
+		return TRUE
+
+	return FALSE
+
+/mob/living/proc/ExtinguishMobCompletely()
+	return ExtinguishMob(fire_stacks)
 
 /mob/living/proc/update_fire()
 	return
 
-/mob/living/proc/adjust_fire_stacks(add_fire_stacks) //Adjusting the amount of fire_stacks we have on person
-    fire_stacks = Clamp(fire_stacks + add_fire_stacks, FIRE_MIN_STACKS, FIRE_MAX_STACKS)
+/mob/living/proc/adjust_fire_stacks(var/add_fire_stacks)
+	if(!fire_stacks)
+		fire_stacks = 0
+
+	fire_stacks = Clamp(fire_stacks + add_fire_stacks, FIRE_MIN_STACKS, FIRE_MAX_STACKS)
+
+	return fire_stacks
 
 /mob/living/proc/handle_fire()
 	if(fire_stacks < 0)
@@ -283,20 +303,19 @@
 	if(!on_fire)
 		return 1
 	else if(fire_stacks <= 0)
-		ExtinguishMob() //Fire's been put out.
+		ExtinguishMobCompletely() //Fire's been put out.
 		return 1
 
 	var/datum/gas_mixture/G = loc.return_air() // Check if we're standing in an oxygenless environment
 	if(G.gas["oxygen"] < 1)
-		ExtinguishMob() //If there's no oxygen in the tile we're on, put out the fire
+		ExtinguishMobCompletely() //If there's no oxygen in the tile we're on, put out the fire
 		return 1
 
 	var/turf/location = get_turf(src)
 	location.hotspot_expose(fire_burn_temperature(), 50, 1)
 
 /mob/living/fire_act()
-	adjust_fire_stacks(2)
-	IgniteMob()
+	IgniteMob(2)
 
 /mob/living/proc/get_cold_protection()
 	return 0

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -41,7 +41,7 @@
 	var/update_slimes = 1
 	var/silent = null 		// Can't talk. Value goes down every life proc.
 	var/on_fire = 0 //The "Are we on fire?" var
-	var/fire_stacks
+	var/fire_stacks = 0
 	var/footstep = 0
 
 	var/failed_last_breath = 0 //This is used to determine if the mob failed a breath. If they did fail a brath, they will attempt to breathe each tick, otherwise just once per 4 ticks.

--- a/code/modules/projectiles/guns/energy/magic.dm
+++ b/code/modules/projectiles/guns/energy/magic.dm
@@ -232,8 +232,7 @@ obj/item/weapon/gun/energy/staff/focus/attack_self(mob/living/user as mob)
 	if(!user.is_wizard())
 		if(istype(user, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = user
-			H.fire_stacks += 15
-			H.IgniteMob()
+			H.IgniteMob(15)
 			H.visible_message("<span class='danger'>\The [src] explodes in a shower of fire!</span>")
 			H.drop_item()
 			qdel(src)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -231,14 +231,10 @@
 	. = ..()
 	if(istype(M) && isliving(M))
 		var/mob/living/L = M
-		var/needed = L.fire_stacks * 10
-		if(amount > needed)
-			L.fire_stacks = 0
-			L.ExtinguishMob()
-			remove_self(needed)
+		if(M.on_fire)
+			M.ExtinguishMob(amount)
 		else
-			L.adjust_fire_stacks(-(amount / 10))
-			remove_self(amount)
+			M.adjust_fire_stacks(-amount*0.5)
 
 	if(istype(M) && !istype(M, /mob/abstract))
 		M.color = initial(M.color)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -316,14 +316,10 @@
 /datum/reagent/toxin/fertilizer/monoammoniumphosphate/touch_mob(var/mob/living/L, var/amount)
 	. = ..()
 	if(istype(L))
-		var/needed = L.fire_stacks * 10
-		if(amount > needed)
-			L.fire_stacks = 0
-			L.ExtinguishMob()
-			remove_self(needed)
+		if(M.on_fire)
+			M.ExtinguishMob(amount*2)
 		else
-			L.adjust_fire_stacks(-amount*0.5)
-			remove_self(amount)
+			M.adjust_fire_stacks(-amount*0.5)
 
 /datum/reagent/toxin/fertilizer/monoammoniumphosphate/affect_touch(var/mob/living/carbon/slime/S, var/alien, var/removed)
 	if(istype(S))

--- a/code/modules/spells/general/contract_spells.dm
+++ b/code/modules/spells/general/contract_spells.dm
@@ -30,10 +30,9 @@
 		target = target[1]
 	return target
 
-
 /spell/contract/reward
-	name = "Reward Contractee"
-	desc = "A spell that makes your contracted victim feel better."
+	name = "Extinguish Contractee"
+	desc = "A spell that extinguishes your contractee from flames."
 
 	charge_max = 300
 	cooldown_min = 100
@@ -45,8 +44,9 @@
 	if(!target)
 		return
 
-	target << "<span class='notice'>You feel great!</span>"
-	target.ExtinguishMob()
+	if(target.on_fire && target.fire_stacks > 0)
+		target << "<span class='notice'>Magical energies surround you, putting out all your flames.</span>"
+		target.ExtinguishMobCompletely()
 
 /spell/contract/punish
 	name = "Punish Contractee"
@@ -62,6 +62,5 @@
 	if(!target)
 		return
 
-	target << "<span class='danger'>You feel punished!</span>"
-	target.fire_stacks += 15
-	target.IgniteMob()
+	target << "<span class='danger'>Magical energies surround you, immolating you in a furious fashion!</span>"
+	target.IgniteMob(15)

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -52,10 +52,10 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 			var/active_hand = H.hand
 			user <<"<span class='warning'>You feel unimaginable agony as your eyes pour over millenia of forbidden knowledge!</span>"
 			user.show_message("<b>[user]</b> screams in horror!",2)
-			H.adjust_fire_stacks(2)
-			H.IgniteMob()
-			H.updatehealth()
 			H.ChangeToHusk()
+			H.fire_stacks = max(0,H.fire_stacks)
+			H.IgniteMob(2)
+			H.updatehealth()
 			user.drop_item()
 			playsound(user, 'sound/hallucinations/i_see_you2.ogg', 100, 1)
 			if(active_hand)
@@ -112,7 +112,7 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 		dat += "<center><A href='byond://?src=\ref[src];reset=1'>Re-memorize your spellbook.</a></center>"
 		dat += "<center><A href='byond://?src=\ref[src];lock=1'>[spellbook.book_flags & LOCKED ? "Unlock" : "Lock"] the spellbook.</a></center>"
 	user << browse(dat,"window=spellbook")
-	
+
 /obj/item/weapon/spellbook/Topic(href,href_list)
 	..()
 


### PR DESCRIPTION
# Overview
- Lighters can set people on fire when used if the person is covered in fuel. Towels can help extinguish flames slightly more effectively than patting people out.
- Patting out people's flames has a 10% chance to ignite you if you're also covered in fuel.
- Welder fuel is no longer as strong as napalm.
- Generally improved extinguishing/igniting code.

## WIP
Some things need to be retested.