### PR TITLE
Secret Gamemodes Cannot Be Chosen Twice In A Row

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -7,6 +7,7 @@
 #define GAME_FAILURE_NO_ANTAGS             0x1
 #define GAME_FAILURE_NO_PLAYERS            0x2
 #define GAME_FAILURE_TOO_MANY_PLAYERS      0x4
+#define GAME_FAILURE_LAST_ROUND            0x8
 
 // Security levels.
 #define SEC_LEVEL_GREEN 0

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -993,7 +993,7 @@ var/list/gamemode_cache = list()
 			log_debug("GAMEMODE: ERROR: [M] does not exist!")
 			continue
 			
-		var/can_start = M.can_start()
+		var/can_start = M.can_start(secret_type == ROUNDTYPE_STR_SECRET)
 		if(can_start != GAME_FAILURE_NONE)
 			log_debug("GAMEMODE: [M.name] cannot start! Reason: [can_start]")
 			continue

--- a/code/controllers/subsystems/initialization/persistent_configuration.dm
+++ b/code/controllers/subsystems/initialization/persistent_configuration.dm
@@ -10,9 +10,9 @@
 // in this config! This config is viewable by VV.
 
 	// Keep this variable up to date for the parsers to work.
-	var/list/_variables_to_save = list("last_gamemode", "rounds_since_hard_restart")
-
+	var/list/_variables_to_save = list("last_gamemode", "last_secret_gamemode", "rounds_since_hard_restart")
 	var/last_gamemode = "extended"
+	var/last_secret_gamemode = "extended"
 	var/rounds_since_hard_restart = 0
 
 /datum/controller/subsystem/persistent_configuration/Initialize(timeofday)
@@ -54,6 +54,8 @@
 
 /datum/controller/subsystem/persistent_configuration/proc/populate_variables(list/decoded)
 	IF_FOUND_USE(decoded, last_gamemode)
+	IF_FOUND_USE(decoded, last_secret_gamemode)
+
 	master_mode = last_gamemode
 
 	IF_FOUND_CONV(decoded, rounds_since_hard_restart, text2num)

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -412,6 +412,9 @@ var/datum/controller/subsystem/ticker/SSticker
 	if(can_start & GAME_FAILURE_TOO_MANY_PLAYERS)
 		fail_reasons +=  "Too many players, less than [mode.max_players] antagonist(s) needed"
 
+	if(can_start & GAME_FAILURE_LAST_ROUND)
+		fail_reasons +=  "This secret selection was picked last round"		
+		
 	if(can_start != GAME_FAILURE_NONE)
 		world << "<B>Unable to start [mode.name].</B> [english_list(fail_reasons,"No reason specified",". ",". ")]"
 		current_state = GAME_STATE_PREGAME
@@ -429,6 +432,8 @@ var/datum/controller/subsystem/ticker/SSticker
 
 	if(hide_mode)
 		world << "<B>The current game mode is - [hide_mode == ROUNDTYPE_SECRET ? "Secret" : "Mixed Secret"]!</B>"
+		if(hide_mode == ROUNDTYPE_SECRET)
+			SSpersist_config.last_secret_gamemode = mode.config_tag
 		if(runnable_modes.len)
 			var/list/tmpmodes = new
 			for (var/datum/game_mode/M in runnable_modes)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -146,7 +146,7 @@ var/global/list/additional_antag_types = list()
 
 ///can_start()
 ///Checks to see if the game can be setup and ran with the current number of players or whatnot.
-/datum/game_mode/proc/can_start()
+/datum/game_mode/proc/can_start(var/secret_check = 0)
 
 	log_debug("GAMEMODE: Checking gamemode possibility selection for: [name]...")
 
@@ -166,6 +166,10 @@ var/global/list/additional_antag_types = list()
 	if(max_players && playerC > max_players)
 		log_debug("GAMEMODE: There are too many players ([playerC]/[max_players]) to start [name]!")
 		returning |= GAME_FAILURE_TOO_MANY_PLAYERS
+
+	if(secret_check && config_tag && SSpersist_config.last_secret_gamemode == config_tag)
+		log_debug("GAMEMODE: We already played [name] last round!")
+		returning |= GAME_FAILURE_LAST_ROUND
 
 	if(antag_templates && antag_templates.len)
 		log_debug("GAMEMODE: Checking antag templates...")

--- a/html/changelogs/burger - i am a god.yml
+++ b/html/changelogs/burger - i am a god.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Secret gamemodes can't be rolled twice in a row."


### PR DESCRIPTION
# Overview
Secret gamemodes cannot be chosen twice in a row, meaning that next time secret is voted, secret won't consider the same gamemode that was chosen to be chosen again.

Example:
Round 1: Secret Possibilities: A,B,C. Secret is voted. It chooses A. It removes A from the list of secret possibilities.
Round 2: Secret Possibilities: B,C. Secret is voted. It chooses B. It removes B from the list of secret possibilities and re-adds A.
Round 3: Secret Possibilities: A,C...

