### PR TITLE
Security is less likely to become certain types of antags

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -1,9 +1,10 @@
 /datum/antagonist
 
 	// Text shown when becoming this antagonist.
-	var/list/restricted_jobs =     list()   // Jobs that cannot be this antagonist (depending on config)
-	var/list/protected_jobs =      list()   // As above.
-	var/list/restricted_species =   list()   // species that cannot be this antag - Ryan784
+	var/list/restricted_jobs = list()        // Jobs that cannot be this antagonist (depending on config)
+	var/list/protected_jobs = list()         // As above.
+	var/list/restricted_species = list()     // species that cannot be this antag - Ryan784
+	var/list/chance_restricted_jobs = list() // chance based restrictions. see the autotratitor gamemode for an example
 
 	// Strings.
 	var/welcome_text = "Cry havoc and let slip the dogs of war!"
@@ -110,6 +111,8 @@
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are blacklisted for this role!")
 		else if(player_is_antag(player))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist!")
+		if(!can_become_antag_chance(player))
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are unlucky (based on job)!")
 		else
 			candidates += player
 

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -11,7 +11,12 @@
 		if(player.current.client.prefs && player.current.client.prefs.species in restricted_species)
 			return 0
 	return 1
-
+	
+/datum/antagonist/proc/can_become_antag_chance(var/datum/mind/player)
+	if(player.assigned_role in chance_restricted_jobs)
+		return prob(chance_restricted_jobs[player.assigned_role])
+	else
+		return 1
 /datum/antagonist/proc/antags_are_dead()
 	for(var/datum/mind/antag in current_antagonists)
 		if(mob_path && !istype(antag.current,mob_path))

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -5,8 +5,9 @@
 	bantype = "changeling"
 	feedback_tag = "changeling_objective"
 	restricted_jobs = list("AI", "Cyborg", "Head of Security", "Captain", "Internal Affairs Agent")
-
 	protected_jobs = list("Security Officer", "Security Cadet", "Warden", "Detective", "Forensic Technician")
+	chance_restricted_jobs = list("Security Officer" = 50, "Security Cadet" = 75, "Warden" = 25, "Detective" = 25, "Forensic Technician" = 50) //Second value is chance to be considered for antag. Unlisted roles here are 100 by default.
+
 	restricted_species = list(
 		"Baseline Frame",
 		"Shell Frame",

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -19,6 +19,8 @@ var/datum/antagonist/cultist/cult
 	bantype = "cultist"
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Internal Affairs Agent", "Head of Security", "Captain")
 	protected_jobs = list("Security Officer", "Security Cadet", "Warden", "Detective", "Forensic Technician")
+	chance_restricted_jobs = list("Security Officer" = 50, "Security Cadet" = 75, "Warden" = 25, "Detective" = 25, "Forensic Technician" = 50) //Second value is chance to be considered for antag. Unlisted roles here are 100 by default.
+
 	feedback_tag = "cult_objective"
 	antag_indicator = "cult"
 	welcome_text = "You have a talisman in your possession; one that will help you start the cult on this station. Use it well and remember - there are others."

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -5,6 +5,7 @@ var/datum/antagonist/traitor/traitors
 	id = MODE_TRAITOR
 	restricted_jobs = list("Internal Affairs Agent", "Head of Security", "Captain", "AI")
 	protected_jobs = list("Security Officer", "Security Cadet", "Warden", "Detective", "Forensic Technician")
+	chance_restricted_jobs = list("Security Officer" = 50, "Security Cadet" = 75, "Warden" = 25, "Detective" = 25, "Forensic Technician" = 50) //Second value is chance to be considered for antag. Unlisted roles here are 100 by default.
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 
 	faction = "syndicate"

--- a/code/game/antagonist/station/vampire.dm
+++ b/code/game/antagonist/station/vampire.dm
@@ -7,8 +7,9 @@ var/datum/antagonist/vampire/vamp = null
 	bantype = "vampires"
 	feedback_tag = "vampire_objective"
 	restricted_jobs = list("AI", "Cyborg", "Chaplain", "Head of Security", "Captain", "Internal Affairs Agent")
-
 	protected_jobs = list("Security Officer", "Security Cadet", "Warden", "Detective", "Forensic Technician")
+	chance_restricted_jobs = list("Security Officer" = 50, "Security Cadet" = 75, "Warden" = 25, "Detective" = 25, "Forensic Technician" = 50) //Second value is chance to be considered for antag. Unlisted roles here are 100 by default.
+
 	restricted_species = list(
 		"Baseline Frame",
 		"Shell Frame",

--- a/html/changelogs/burgerbb - security powernerf.yml
+++ b/html/changelogs/burgerbb - security powernerf.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Certain roles of security are less likely to gain antag status (25%-75%)."


### PR DESCRIPTION
# Overview
The security department is less likely to be considered for certain antags for when a query is called. Queries are called on round start, or when autotratior wishes for a traitor. If a player is not considered for antag at the round start, they could still be considered for antag later on.

The current chances are the following:
- Security Officer: 50% chance to get antag.
- Security Cadet: 75% chance to get antag.
- Warden: 25% chance to get antag.
- Detective: 25% chance to get antag.
- Forensic Technician 50% chance to get antag.

This affects the following gamemodes:
- Changeling
- Traitor
- Vampire
- Cultist
	


