### PR TITLE
Slime Mutation Toxin Tweaks

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -509,7 +509,7 @@
 	glass_name = "glass of beer"
 	glass_desc = "A freezing pint of beer"
 	glass_center_of_mass = list("x"=16, "y"=8)
-	
+
 	fallback_specific_heat = 1.2
 
 /* Drugs */
@@ -654,7 +654,7 @@
 	taste_description = "sludge"
 
 /datum/reagent/slimetoxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(ishuman(M))
+	if(prob(10) && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.species.name != "Slime")
 			M << "<span class='danger'>Your flesh rapidly mutates!</span>"
@@ -668,30 +668,13 @@
 	color = "#13BC5E"
 	taste_description = "sludge"
 
-/datum/reagent/aslimetoxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed) // TODO: check if there's similar code anywhere else
-	if(M.transforming)
-		return
-	M << "<span class='danger'>Your flesh rapidly mutates!</span>"
-	M.transforming = 1
-	M.canmove = 0
-	M.icon = null
-	M.cut_overlays()
-	M.invisibility = 101
-	for(var/obj/item/W in M)
-		if(istype(W, /obj/item/weapon/implant)) //TODO: Carn. give implants a dropped() or something
-			qdel(W)
-			continue
-		W.layer = initial(W.layer)
-		W.forceMove(M.loc)
-		W.dropped(M)
-	var/mob/living/carbon/slime/new_mob = new /mob/living/carbon/slime(M.loc)
-	new_mob.a_intent = "hurt"
-	new_mob.universal_speak = 1
-	if(M.mind)
-		M.mind.transfer_to(new_mob)
-	else
-		new_mob.key = M.key
-	qdel(M)
+/datum/reagent/aslimetoxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(prob(10) && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(!H.dna.GetSEState(MONKEYBLOCK))
+			H.dna.check_integrity()
+			H.dna.SetSEState(MONKEYBLOCK,1)
+			domutcheck(H, null)
 
 /datum/reagent/nanites
 	name = "Nanomachines"

--- a/html/changelogs/burgerbb - mutation memes.yml
+++ b/html/changelogs/burgerbb - mutation memes.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Advanced Mutation Toxin now turns victims into their lesser form (See: Monkey) instead of a slime."
+  - balance: "Mutation Toxin and Advanced Mutation Toxin now has a 10% chance to trigger its effects per tick, similar to nanites."


### PR DESCRIPTION
# Overview
Advanced Slime Toxin will no longer turn you into a slime mob, but into your species' lesser form if you have one (See: Monkey.)

Both variants of slime toxin now have a 10% chance to trigger per metabolism tick, so it isn't instant.

Specifically, it modifies your monkey DNA block so theoretically you can be cured with genetic treatment.

Feedback Thread:
https://forums.aurorastation.org/topic/11213-slime-mutation-reagent-nerfs-rework/