### PR TITLE
Fixes the paper taping

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -69,6 +69,7 @@
 #include "code\_helpers\maths.dm"
 #include "code\_helpers\matrices.dm"
 #include "code\_helpers\mobs.dm"
+#include "code\_helpers\mouse.dm"
 #include "code\_helpers\names.dm"
 #include "code\_helpers\overlay.dm"
 #include "code\_helpers\sanitize_values.dm"

--- a/code/_helpers/mouse.dm
+++ b/code/_helpers/mouse.dm
@@ -1,0 +1,14 @@
+
+/**
+ * @brief Returns a list of "icon-x" and "icon-y" from mouse parameters, which
+ * are safely clamped to 0-32 for icon operations.
+ */
+/proc/mouse_safe_xy(params, lim_x = 32, lim_y = 32)
+	if (!params)
+		return list("icon-x" = 0, "icon-y" = 0)
+
+	. = params2list(params)
+
+	testing("X: [.["icon-x"]], Y: [.["icon-y"]]")
+	return list("icon-x" = Clamp(text2num(.["icon-x"]), 0, lim_x),
+                "icon-y" = Clamp(text2num(.["icon-y"]), 0, lim_y))

--- a/code/game/objects/items/devices/floor_painter.dm
+++ b/code/game/objects/items/devices/floor_painter.dm
@@ -76,9 +76,9 @@
 		if(!decal_data["precise"])
 			painting_dir = user.dir
 		else
-			var/list/mouse_control = params2list(params)
-			var/mouse_x = text2num(mouse_control["icon-x"])
-			var/mouse_y = text2num(mouse_control["icon-y"])
+			var/list/mouse_control = mouse_safe_xy(params)
+			var/mouse_x = mouse_control["icon-x"]
+			var/mouse_y = mouse_control["icon-y"]
 			if(isnum(mouse_x) && isnum(mouse_y))
 				if(mouse_x <= 16)
 					if(mouse_y <= 16)

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -141,15 +141,15 @@
 	playsound(src, 'sound/items/tape.ogg',25)
 
 	if(params)
-		var/list/mouse_control = params2list(params)
+		var/list/mouse_control = mouse_safe_xy(params)
 		if(mouse_control["icon-x"])
-			pixel_x = text2num(mouse_control["icon-x"]) - 16
+			pixel_x = mouse_control["icon-x"] - 16
 			if(dir_offset & EAST)
 				pixel_x += 32
 			else if(dir_offset & WEST)
 				pixel_x -= 32
 		if(mouse_control["icon-y"])
-			pixel_y = text2num(mouse_control["icon-y"]) - 16
+			pixel_y = mouse_control["icon-y"] - 16
 			if(dir_offset & NORTH)
 				pixel_y += 32
 			else if(dir_offset & SOUTH)

--- a/code/modules/battlemonsters/items/core.dm
+++ b/code/modules/battlemonsters/items/core.dm
@@ -83,10 +83,10 @@
 		)
 
 		//Places the item on a grid
-		var/list/mouse_control = params2list(params)
+		var/list/mouse_control = mouse_safe_xy(params)
 
-		var/mouse_x = text2num(mouse_control["icon-x"])
-		var/mouse_y = text2num(mouse_control["icon-y"])
+		var/mouse_x = mouse_control["icon-x"]
+		var/mouse_y = mouse_control["icon-y"]
 
 		if(!isnum(mouse_x) || !isnum(mouse_y))
 			return

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -67,12 +67,12 @@
 
 	if(proximity && params && istype(target, /obj/structure/table) && center_of_mass && center_of_mass.len)
 		//Places the item on a grid
-		var/list/mouse_control = params2list(params)
+		var/list/mouse_control = mouse_safe_xy(params)
 
-		var/mouse_x = text2num(mouse_control["icon-x"])
-		var/mouse_y = text2num(mouse_control["icon-y"])
+		var/mouse_x = mouse_control["icon-x"]
+		var/mouse_y = mouse_control["icon-y"]
 
-		if(isnum(mouse_x) || isnum(mouse_y))
+		if(isnum(mouse_x) && isnum(mouse_y))
 			var/cell_x = max(0, min(CELLS-1, round(mouse_x/CELLSIZE)))
 			var/cell_y = max(0, min(CELLS-1, round(mouse_y/CELLSIZE)))
 

--- a/html/changelogs/skull132_paper_exploit.yml
+++ b/html/changelogs/skull132_paper_exploit.yml
@@ -1,0 +1,6 @@
+author: Skull132
+
+delete-after: true
+
+changes:
+  - bugfix: "Fixed an exploit which allowed players to teleport taped paper icons to any point on the screen."


### PR DESCRIPTION
Any and all code which uses mouse `icon-x` and `icon-y` is susceptible to the following: if you alt click, and then initiate a click on the newly opened alt menu, then coordinates returned from there will easily exceed the expected range of [0, 32]. A similar thing can happen when clicking on multi-tile objects, for example. As long as the icon itself is larger than 32, this is an issue.

The solution, as proposed, is a sanity checker proc. This discards all other data, however. I looked over all references to `icon-x` and `icon-y`, and replaced the appropriate ones with this.