### PR TITLE
Money Duplication Bugfix

### DIFF
--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -75,6 +75,13 @@
 
 /obj/item/weapon/spacecash/bundle/attack_self()
 	var/amount = input(usr, "How many credits do you want to take? (0 to [src.worth])", "Take Money", 20) as num
+
+	if(QDELETED(src))
+		return 0
+
+	if(get_turf(src) != get_turf(usr))
+		return 0
+
 	amount = round(Clamp(amount, 0, src.worth))
 	if(amount==0) return 0
 
@@ -82,7 +89,7 @@
 	src.update_icon()
 	if(!worth)
 		usr.drop_from_inventory(src)
-		
+
 	if(amount in list(1000,500,200,100,50,20,1))
 		var/cashtype = text2path("/obj/item/weapon/spacecash/c[amount]")
 		var/obj/cash = new cashtype (usr.loc)
@@ -92,7 +99,7 @@
 		bundle.worth = amount
 		bundle.update_icon()
 		usr.put_in_hands(bundle)
-		
+
 	if(!worth)
 		qdel(src)
 
@@ -185,7 +192,7 @@ proc/spawn_money(var/sum, spawnloc, mob/living/carbon/human/human_user as mob)
 	if(next_scratch > world.time)
 		user << "<span class='warning'>The card flashes: \"Please wait!\"</span>"
 		return
-		
+
 	next_scratch = world.time + 6 SECONDS
 
 	user << "<span class='notice'>You initiate the simulated scratch action process on the [src]...</span>"

--- a/html/changelogs/burgerbb - duplication fix.yml
+++ b/html/changelogs/burgerbb - duplication fix.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - experiment: "Fixed a money duplication bug that allowed you to double your money every 3-5 seconds. This bug existed for more than 2 years, by the way."


### PR DESCRIPTION
Fixed a bug that allowed people to double their money every 4-5 seconds without reading from a "Get Rich Quick" book.