### PR TITLE
Buffs ore summoners

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1135,7 +1135,7 @@ var/list/total_extraction_beacons = list()
 	var/oresummon_delay = 25
 
 /obj/item/weapon/oreportal/attack_self(mob/user)
-	last_scan_time = world.time
+	last_oresummon_time = world.time
 	if(world.time - last_oresummon_time >= oresummon_delay)
 		to_chat(user, "<span class='info'>You pulse the ore summoner.</span>")
 		for(var/obj/item/weapon/ore/O in orange(7,user))

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1139,7 +1139,7 @@ var/list/total_extraction_beacons = list()
 		var/limit = 50
 		for(var/obj/item/weapon/ore/O in orange(7,user))
 		if(limit <= 0)
-                	break
+			break
 		single_spark(O.loc)
 		do_teleport(O, user, 0)
 		limit -= 1

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1143,7 +1143,7 @@ var/list/total_extraction_beacons = list()
 			single_spark(O.loc)
 			do_teleport(O, user, 0)
 			limit -= 1
-		CHECK_TICK
+			CHECK_TICK
 	else
 		user << "The ore summoner is in the middle of some calibrations."
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1135,9 +1135,9 @@ var/list/total_extraction_beacons = list()
 	var/oresummon_delay = 25
 
 /obj/item/weapon/oreportal/attack_self(mob/user)
-	last_oresummon_time = world.time
 	if(world.time - last_oresummon_time >= oresummon_delay)
 		to_chat(user, "<span class='info'>You pulse the ore summoner.</span>")
+		last_oresummon_time = world.time
 		for(var/obj/item/weapon/ore/O in orange(7,user))
 			if(limit <= 0)
 				break

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1133,7 +1133,7 @@ var/list/total_extraction_beacons = list()
 
 /obj/item/weapon/oreportal/attack_self(mob/user)
 	user << "<span class='info'>You pulse the ore summoner.</span>"
-	var/limit = 10
+	var/limit = 50
 	for(var/obj/item/weapon/ore/O in orange(7,user))
 		if(limit <= 0)
 			break

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1135,6 +1135,7 @@ var/list/total_extraction_beacons = list()
 	var/oresummon_delay = 25
 
 /obj/item/weapon/oreportal/attack_self(mob/user)
+	last_scan_time = world.time
 	if(world.time - last_oresummon_time >= oresummon_delay)
 		to_chat(user, "<span class='info'>You pulse the ore summoner.</span>")
 		for(var/obj/item/weapon/ore/O in orange(7,user))
@@ -1146,6 +1147,7 @@ var/list/total_extraction_beacons = list()
 			CHECK_TICK
 	else
 		user << "The ore summoner is in the middle of some calibrations."
+		return 0
 
 /******************************Sculpting*******************************/
 /obj/item/weapon/autochisel

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1146,7 +1146,7 @@ var/list/total_extraction_beacons = list()
 			limit -= 1
 			CHECK_TICK
 	else
-		user << "The ore summoner is in the middle of some calibrations."
+		to_chat(user, "The ore summoner is in the middle of some calibrations.")
 		return 0
 
 /******************************Sculpting*******************************/

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1120,34 +1120,33 @@ var/list/total_extraction_beacons = list()
 /******************************Ore Summoner*******************************/
 
 /obj/item/weapon/oreportal
-	name = "ore summoner"
-	contained_sprite = 1
-	icon = 'icons/obj/mining_contained.dmi'
-	icon_state = "supermagneto"
-	item_state = "jaunter"
-	desc = "A handheld device that creates a well of warp energy that teleports minerals of a very specific type, size, and state to its user."
-	w_class = 3
-	force = 15
-	throwforce = 5
-	origin_tech = list(TECH_BLUESPACE = 4, TECH_ENGINEERING = 3)
-	var/limit = 50
-	var/last_oresummon_time = 0
-	var/oresummon_delay = 25
+    name = "ore summoner"
+    contained_sprite = 1
+    icon = 'icons/obj/mining_contained.dmi'
+    icon_state = "supermagneto"
+    item_state = "jaunter"
+    desc = "A handheld device that creates a well of warp energy that teleports minerals of a very specific type, size, and state to its user."
+    w_class = 3
+    force = 15
+    throwforce = 5
+    origin_tech = list(TECH_BLUESPACE = 4, TECH_ENGINEERING = 3)
+    var/last_oresummon_time = 0
 
 /obj/item/weapon/oreportal/attack_self(mob/user)
-	if(world.time - last_oresummon_time >= oresummon_delay)
-		to_chat(user, "<span class='info'>You pulse the ore summoner.</span>")
-		last_oresummon_time = world.time
-		for(var/obj/item/weapon/ore/O in orange(7,user))
-			if(limit <= 0)
-				break
-			single_spark(O.loc)
-			do_teleport(O, user, 0)
-			limit -= 1
-			CHECK_TICK
-	else
-		to_chat(user, "The ore summoner is in the middle of some calibrations.")
-		return 0
+    if(world.time - last_oresummon_time >= 25)
+        to_chat(user, "<span class='notice'>You pulse the ore summoner.</span>")
+        last_oresummon_time = world.time
+        var/limit = 50
+        for(var/obj/item/weapon/ore/O in orange(7,user))
+            if(limit <= 0)
+                break
+            single_spark(O.loc)
+            do_teleport(O, user, 0)
+            limit -= 1
+            CHECK_TICK
+    else
+        to_chat(user, "The ore summoner is in the middle of some calibrations.")
+        return 0
 
 /******************************Sculpting*******************************/
 /obj/item/weapon/autochisel

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1120,33 +1120,33 @@ var/list/total_extraction_beacons = list()
 /******************************Ore Summoner*******************************/
 
 /obj/item/weapon/oreportal
-    name = "ore summoner"
-    contained_sprite = 1
-    icon = 'icons/obj/mining_contained.dmi'
-    icon_state = "supermagneto"
-    item_state = "jaunter"
-    desc = "A handheld device that creates a well of warp energy that teleports minerals of a very specific type, size, and state to its user."
-    w_class = 3
-    force = 15
-    throwforce = 5
-    origin_tech = list(TECH_BLUESPACE = 4, TECH_ENGINEERING = 3)
-    var/last_oresummon_time = 0
+	name = "ore summoner"
+	contained_sprite = 1
+	icon = 'icons/obj/mining_contained.dmi'
+	icon_state = "supermagneto"
+	item_state = "jaunter"
+	desc = "A handheld device that creates a well of warp energy that teleports minerals of a very specific type, size, and state to its user."
+	w_class = 3
+	force = 15
+	throwforce = 5
+	origin_tech = list(TECH_BLUESPACE = 4, TECH_ENGINEERING = 3)
+	var/last_oresummon_time = 0
 
 /obj/item/weapon/oreportal/attack_self(mob/user)
-    if(world.time - last_oresummon_time >= 25)
-        to_chat(user, "<span class='notice'>You pulse the ore summoner.</span>")
-        last_oresummon_time = world.time
-        var/limit = 50
-        for(var/obj/item/weapon/ore/O in orange(7,user))
-            if(limit <= 0)
-                break
-            single_spark(O.loc)
-            do_teleport(O, user, 0)
-            limit -= 1
-            CHECK_TICK
-    else
-        to_chat(user, "The ore summoner is in the middle of some calibrations.")
-        return 0
+	if(world.time - last_oresummon_time >= 25)
+		to_chat(user, "<span class='notice'>You pulse the ore summoner.</span>")
+		last_oresummon_time = world.time
+		var/limit = 50
+		for(var/obj/item/weapon/ore/O in orange(7,user))
+		if(limit <= 0)
+                	break
+		single_spark(O.loc)
+		do_teleport(O, user, 0)
+		limit -= 1
+		CHECK_TICK
+	else
+		to_chat(user, "The ore summoner is in the middle of some calibrations.")
+		return 0
 
 /******************************Sculpting*******************************/
 /obj/item/weapon/autochisel

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1136,7 +1136,7 @@ var/list/total_extraction_beacons = list()
 
 /obj/item/weapon/oreportal/attack_self(mob/user)
 	if(world.time - last_oresummon_time >= oresummon_delay)
-		user << "<span class='info'>You pulse the ore summoner.</span>"
+		to_chat(user, "<span class='info'>You pulse the ore summoner.</span>")
 		for(var/obj/item/weapon/ore/O in orange(7,user))
 			if(limit <= 0)
 				break

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1130,17 +1130,22 @@ var/list/total_extraction_beacons = list()
 	force = 15
 	throwforce = 5
 	origin_tech = list(TECH_BLUESPACE = 4, TECH_ENGINEERING = 3)
+	var/limit = 50
+	var/last_oresummon_time = 0
+	var/oresummon_delay = 25
 
 /obj/item/weapon/oreportal/attack_self(mob/user)
-	user << "<span class='info'>You pulse the ore summoner.</span>"
-	var/limit = 50
-	for(var/obj/item/weapon/ore/O in orange(7,user))
-		if(limit <= 0)
-			break
-		single_spark(O.loc)
-		do_teleport(O, user, 0)
-		limit -= 1
+	if(world.time - last_oresummon_time >= oresummon_delay)
+		user << "<span class='info'>You pulse the ore summoner.</span>"
+		for(var/obj/item/weapon/ore/O in orange(7,user))
+			if(limit <= 0)
+				break
+			single_spark(O.loc)
+			do_teleport(O, user, 0)
+			limit -= 1
 		CHECK_TICK
+	else
+		user << "The ore summoner is in the middle of some calibrations."
 
 /******************************Sculpting*******************************/
 /obj/item/weapon/autochisel

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1138,12 +1138,12 @@ var/list/total_extraction_beacons = list()
 		last_oresummon_time = world.time
 		var/limit = 50
 		for(var/obj/item/weapon/ore/O in orange(7,user))
-		if(limit <= 0)
-			break
-		single_spark(O.loc)
-		do_teleport(O, user, 0)
-		limit -= 1
-		CHECK_TICK
+			if(limit <= 0)
+				break
+			single_spark(O.loc)
+			do_teleport(O, user, 0)
+			limit -= 1
+			CHECK_TICK
 	else
 		to_chat(user, "The ore summoner is in the middle of some calibrations.")
 		return 0

--- a/html/changelogs/SchevOreSummoner-27-12-2019.yml
+++ b/html/changelogs/SchevOreSummoner-27-12-2019.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Scheveningen
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Buffs ore summoners."


### PR DESCRIPTION
Allow me to explain in the event someone potentially complains about this.

Each vein of ore in a single tile drops roughly 5 bits of that ore type. It doesn't matter if it's diamonds, coal or whatever else.

The problem with this, however, is that the ore summoner is only adjusted to grab 10 bits of ore and nothing else, making it inefficient and useless to buy in the mining vendor.

This was changed because of 'performance problems' (whether this is true I have no idea) but only 10 bits of ore is just ridiculous in my opinion, because it means it'll only draw from 2 veins mined out, which is not effective in the slightest. You'd be better off using the ore magnet right now.

Of course, this change hopes to change that so that this isn't a useless item to buy from the ore vendor and to (somewhat) restore it to its former glory. Albeit with a sanity check.

Edit: **Be aware, do not use the ore summoner while inside an anchored object or mounted on a bike with 50 ore-bits nearby unless you want to die.**

https://youtu.be/qnd9GS-kkMo

srsly. dont. its hilarious but dont.