### PR TITLE
Announcing live test PRs

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -992,22 +992,22 @@ var/list/gamemode_cache = list()
 		if(!M)
 			log_debug("GAMEMODE: ERROR: [M] does not exist!")
 			continue
-			
+
 		var/can_start = M.can_start()
 		if(can_start != GAME_FAILURE_NONE)
 			log_debug("GAMEMODE: [M.name] cannot start! Reason: [can_start]")
 			continue
-			
+
 		if(!probabilities[M.config_tag])
 			log_debug("GAMEMODE: ERROR: [M.name] does not have a config associated with it!")
 			continue
-		
+
 		if(probabilities[M.config_tag] <= 0)
 			log_debug("GAMEMODE: ERROR: [M.name] has a probability equal or less than 0!")
-			continue		
+			continue
 
 		runnable_modes |= M
-	
+
 	return runnable_modes
 
 /datum/configuration/proc/post_load()
@@ -1017,3 +1017,5 @@ var/list/gamemode_cache = list()
 			config.python_path = "/usr/bin/env python2"
 		else //probably windows, if not this should work anyway
 			config.python_path = "python"
+
+	revdata.generate_greeting_info()

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -40,8 +40,9 @@ var/datum/controller/subsystem/ticker/SSticker
 	var/delay_end = 0	//if set to nonzero, the round will not restart on it's own
 
 	var/triai = 0	//Global holder for Triumvirate
-	var/tipped = 0							//Did we broadcast the tip of the day yet?
+	var/tipped = FALSE						//Did we broadcast the tip of the day yet?
 	var/selected_tip						// What will be the tip of the day?
+	var/testmerges_printed = FALSE
 
 	var/round_end_announced = 0 // Spam Prevention. Announce round end only once.
 
@@ -133,6 +134,10 @@ var/datum/controller/subsystem/ticker/SSticker
 			SSvote.autogamemode()
 			pregame_timeleft--
 			return
+
+	if (pregame_timeleft <= 20 && !testmerges_printed)
+		print_testmerges()
+		testmerges_printed = TRUE
 
 	if (pregame_timeleft <= 10 && !tipped)
 		send_tip_of_the_round()
@@ -325,6 +330,12 @@ var/datum/controller/subsystem/ticker/SSticker
 	if(m)
 		world << "<font color='purple'><b>Tip of the round: \
 			</b>[html_encode(m)]</font>"
+
+/datum/controller/subsystem/ticker/proc/print_testmerges()
+	var/data = revdata.testmerge_overview()
+
+	if (data)
+		world << data
 
 /datum/controller/subsystem/ticker/proc/pregame()
 	set waitfor = FALSE

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -335,7 +335,7 @@ var/datum/controller/subsystem/ticker/SSticker
 	var/data = revdata.testmerge_overview()
 
 	if (data)
-		world << data
+		to_world(data)
 
 /datum/controller/subsystem/ticker/proc/pregame()
 	set waitfor = FALSE

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -30,6 +30,8 @@ var/global/datum/getrev/revdata = new()
 
 	if (api)
 		test_merges = api.TestMerges()
+	else
+		test_merges = list()
 
 	world.log << "Running revision:"
 	world.log << branch
@@ -67,9 +69,10 @@ client/verb/showrevinfo()
 
 /datum/getrev/proc/generate_greeting_info()
 	if (!test_merges.len)
-		return {"<div class="alert alert-info">
-		         There are currently no test merges loaded onto the server.
-		         </div>"}
+		greeting_info = {"<div class="alert alert-info">
+		                  There are currently no test merges loaded onto the server.
+		                  </div>"}
+		return
 
 	var/list/out = list("<p>There are currently [test_merges.len] PRs being tested live.</p>",
 		{"<table class="table table-hover">"}

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -5,6 +5,7 @@ var/global/datum/getrev/revdata = new()
 	var/revision
 	var/date
 	var/showinfo
+	var/list/datum/tgs_revision_information/test_merge/test_merges
 
 /datum/getrev/New()
 	var/list/head_branch = file2list(".git/HEAD", "\n")
@@ -23,6 +24,11 @@ var/global/datum/getrev/revdata = new()
 				if(unix_time)
 					date = unix2date(unix_time)
 			break
+
+	var/datum/tgs_api/api = TGS_READ_GLOBAL(tgs)
+
+	if (api)
+		test_merges = api.TestMerges()
 
 	world.log << "Running revision:"
 	world.log << branch
@@ -44,3 +50,27 @@ client/verb/showrevinfo()
 		src << "Revision unknown"
 
 	src << "<b>Current Map:</b> [current_map.full_name]"
+
+/datum/getrev/proc/testmerge_overview()
+	if (!test_merges.len)
+		return
+
+	var/list/out = list("<br><center><font color='purple'><b>PRs test-merged for this round:</b><br>")
+
+	for (var/TM in test_merges)
+		out += testmerge_short_overview(TM)
+
+	out += "</font></center><br>"
+
+	return out.Join()
+
+/datum/getrev/proc/testmerge_short_overview(datum/tgs_revision_information/test_merge/tm)
+	. = list()
+
+	. += "<hr><p>PR #[tm.number]: \"[html_encode(tm.title)]\""
+	. += "<br>\tAuthor: [html_encode(tm.author)]"
+
+	if (config.githuburl)
+		. += "<br>\t<a href='[config.githuburl]pull/[tm.number]'>\[Details...\]</a>"
+
+	. += "</p>"

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -30,6 +30,14 @@ var/global/datum/getrev/revdata = new()
 	if (api)
 		test_merges = api.TestMerges()
 
+	var/datum/tgs_revision_information/test_merge/tm = new()
+	tm.number = 5330
+	tm.author = "BurgerBBB"
+	tm.title = "free MEMES"
+
+	test_merges = list()
+	test_merges += tm
+
 	world.log << "Running revision:"
 	world.log << branch
 	world.log << date

--- a/code/datums/server_greeting.dm
+++ b/code/datums/server_greeting.dm
@@ -247,6 +247,16 @@
 	data["content"] = motd
 	user << output(JS_SANITIZE(data), "greeting.browser:AddContent")
 
+	data["div"] = "#testmerges"
+	data["content"] = revdata.greeting_info
+
+	if (revdata.test_merges.len)
+		data["update"] = 1
+	else
+		data["update"] = 0
+	data["changeHash"] = null
+	user << output(JS_SANITIZE(data), "greeting.browser:AddContent")
+
 /*
  * Basically the Topic proc for the greeting datum.
  */
@@ -338,3 +348,5 @@
 #undef OUTDATED_MOTD
 
 #undef MEMOFILE
+
+#undef JS_SANITIZE

--- a/code/datums/server_greeting.dm
+++ b/code/datums/server_greeting.dm
@@ -179,7 +179,7 @@
 	var/datum/asset/welcome = get_asset_datum(/datum/asset/simple/misc)
 	welcome.send(user)
 
-	user << browse('html/templates/welcome_screen.html', "window=greeting;size=640x500")
+	user << browse('html/templates/welcome_screen.html', "window=greeting;size=740x500")
 
 /*
  * A proc used to close the server greeting window for a user.

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -186,8 +186,12 @@
 			if ("github")
 				if (!config.githuburl)
 					src << "<span class='danger'>Github URL not set in the config. Unable to open the site.</span>"
-				else if (alert("This will open the issue tracker in your browser. Are you sure?",, "Yes", "No") == "Yes")
-					src << link(config.githuburl)
+				else if (alert("This will open the Github page in your browser. Are you sure?",, "Yes", "No") == "Yes")
+					if (href_list["pr"])
+						var/pr_link = "[config.githuburl]pull/[href_list["pr"]]"
+						src << link(pr_link)
+					else
+						src << link(config.githuburl)
 
 			// Forum link from various panels.
 			if ("forums")

--- a/html/changelogs/skull132_revdata.yml
+++ b/html/changelogs/skull132_revdata.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: true
+
+changes:
+  - rscadd: "The active test merges are now displayed at the start of each round. They can also be inspected from the greetings window."

--- a/html/templates/welcome_screen.html
+++ b/html/templates/welcome_screen.html
@@ -47,6 +47,7 @@
 						</p>
 					</div>
 					<div role="tabpanel" class="tab-pane" id="motd"><div class="row"></div></div>
+					<div role="tabpanel" class="tab-pane" id="testmerges"></div>
 					<div role="tabpanel" class="tab-pane" id="memo"></div>
 					<div role="tabpanel" class="tab-pane" id="note"><div class="alert alert-info" id="note-placeholder">You do not have any notifications to show.</div></div>
 				</div>

--- a/html/templates/welcome_screen.html
+++ b/html/templates/welcome_screen.html
@@ -6,11 +6,15 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<!-- Bootstrap -->
 		<link href="bootstrap.min.css" rel="stylesheet" media="screen">
-        <style media="screen">
-            .nav-tabs>li.updated>a, .nav-tabs>li.updated>a:hover, .nav-tabs>li.updated>a:focus {
-                background-color: #fcf8e3;
-            }
-        </style>
+		<style media="screen">
+			.nav-tabs>li.updated>a, .nav-tabs>li.updated>a:hover, .nav-tabs>li.updated>a:focus {
+				background-color: #fcf8e3;
+			}
+
+			.hiddenRow {
+				padding: 0 !important;
+			}
+		</style>
 	</head>
 	<body>
 		<div class="container-fluid">
@@ -18,6 +22,7 @@
 				<ul class="nav nav-tabs" id="myTab" role="tablist">
 					<li role="presentation" class="active" id="home-tab"><a href="#home" aria-controls="home" role="tab" data-toggle="tab">Home</a></li>
 					<li role="presentation" id="motd-tab"><a href="#motd" aria-controls="motd" role="tab" data-toggle="tab">Announcements</a></li>
+					<li role="presentation" id="testmerges-tab"><a href="#testmerges" aria-controls="testmerges" role="tab" data-toggle="tab">Test Merges</a></li>
 					<li role="presentation" id="memo-tab"><a href="#memo" aria-controls="memo" role="tab" data-toggle="tab">Staff Memos</a></li>
 					<li role="presentation" id="note-tab"><a href="#note" aria-controls="note" role="tab" data-toggle="tab">Notifications</a></li>
 					<li role="presentation"><a href="#webint">My Profile</a></li>


### PR DESCRIPTION
PRs currently used in the round are now announced at round start, and are available for better review in the server greeting window.

Example of the greeting window: https://kama.skullnet.me/index.php/s/2QWDKMD2n6qCpje
Example of the before-round-announcement (Don't mind the formatting error, it's been cleared): https://cdn.discordapp.com/attachments/131489773268238336/527469663605620756/unknown.png
