### PR TITLE
Various Cooking Recipe Fixes

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/container.dm
+++ b/code/game/machinery/kitchen/cooking_machines/container.dm
@@ -11,8 +11,9 @@
 	var/list/insertable = list(
 		/obj/item/weapon/reagent_containers/food/snacks,
 		/obj/item/weapon/holder,
-		/obj/item/weapon/paper
-	)
+		/obj/item/weapon/paper,
+		/obj/item/weapon/flame/candle
+		)
 
 /obj/item/weapon/reagent_containers/cooking_container/Initialize()
 	. = ..()

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -1099,7 +1099,7 @@ I said no!
 
 /datum/recipe/cheese_cracker
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/spreads/butter,
+		/obj/item/weapon/reagent_containers/food/snacks/spreads,
 		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 	)

--- a/code/modules/food/recipes_oven.dm
+++ b/code/modules/food/recipes_oven.dm
@@ -473,7 +473,7 @@
 
 /datum/recipe/cake/birthday
 	appliance = OVEN
-	items = list(/obj/item/clothing/head/cakehat)
+	items = list(/obj/item/weapon/flame/candle)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/cake/birthday
 
 /datum/recipe/cake/apple
@@ -488,13 +488,13 @@
 
 /datum/recipe/pancakes
 	appliance = OVEN
-	fruit = list("blueberries" = 2)
+	fruit = list("berries" = 2)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough,
 		/obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough
-	)
+		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/pancakes
-	result = /obj/item/weapon/reagent_containers/food/snacks/pancakes
+	result_quantity = 2
 
 /datum/recipe/lasagna
 	appliance = OVEN
@@ -565,7 +565,7 @@
 
 /datum/recipe/truffle
 	appliance = OVEN
-	reagents = list("sugar" = 5, "cream" = 5)
+	reagents = list("coco" = 2, "cream" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar
 	)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4420,7 +4420,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/pancakes
 	name = "pancakes"
-	desc = "Pancakes with blueberries, delicious."
+	desc = "Pancakes with berries, delicious."
 	icon_state = "pancakes"
 	trash = /obj/item/trash/plate
 	center_of_mass = "x=15;y=11"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2346,7 +2346,7 @@
 	reagents.add_reagent("tomatojuice", 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatballspagetti
-	name = "spaghetti & meatballs"
+	name = "spaghetti and meatballs"
 	desc = "Now thats a nic'e meatball!"
 	icon_state = "meatballspagetti"
 	trash = /obj/item/trash/plate

--- a/html/changelogs/cookingfixes.yml
+++ b/html/changelogs/cookingfixes.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Conspiir
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Updates the recipes for birthday cake (now uses 1 candle instead of the hat), truffles (now uses 2 coco powder instead of 5 sugar), and pancakes (now accepts normal berries)."
+  - tweak: "Cheese toast can now be made with nutri-spread from the biogenerator as well as butter."
+  - spellcheck: "The name of spaghetti and meatballs has been updated to not show spaghetti_meatballs."


### PR DESCRIPTION
This PR fixes exactly:

The Birthday Cake recipe - Could not be made (hat couldn't go in the oven). Altered the oven to allow candles instead. Recipe is now a base cake with 1 candle.  Fixes: #2328  

Spaghetti and Meatballs - When right-clicked, it would show spaghetti_meatballs. Removed the ampersand and replaced with words. 

Pancakes - Could not be made. Would always result in 2 flatbread. Altered the recipe (and description!) so it is made from "berries" (this includes blueberries, but does not exclude berries).

Truffles - Could not be made. Bluespace caused making truffles to produce fortune cookies (?!?!). Altered the recipe to be made with 2 coco powder instead of 5 sugar. Fixes the issue _and_ aligns with how truffles can really be made!  Fixes: #4837

Supreme cheese toast - Can now be made with nutri-spread, not just butter.

Huuuge thanks to UncleJo for letting me know what the heck was busted.