### PR TITLE
Stage 1 Ling Rework

### DIFF
--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -14,6 +14,12 @@ var/list/datum/power/changeling/powerinstances = list()
 	var/allowduringlesserform = 0
 	var/genomecost = 500000 // Cost for the changling to evolve this power.
 
+/datum/power/changeling/extract_dna
+	name = "Extract DNA"
+	desc = "Permits us to syphon the DNA from a human. They become one with us, and we become stronger."
+	genomecost = 0
+	verbpath = /mob/proc/changeling_extract_dna
+
 /datum/power/changeling/absorb_dna
 	name = "Absorb DNA"
 	desc = "Permits us to syphon the DNA from a human. They become one with us, and we become stronger."
@@ -85,13 +91,15 @@ var/list/datum/power/changeling/powerinstances = list()
 	genomecost = 1
 	verbpath = /mob/proc/changeling_mimicvoice
 
-/datum/power/changeling/extractdna
-	name = "Extract DNA"
-	desc = "We stealthily sting a target and extract the DNA from them."
-	helptext = "Will give you the DNA of your target, allowing you to transform into them. Does not count towards absorb objectives."
-	genomecost = 2
-	allowduringlesserform = 1
-	verbpath = /mob/proc/changeling_extract_dna_sting
+//   Commenting this out for now because it is redundant, but may be used later//
+
+// /datum/power/changeling/extractdna
+// 	name = "Extract DNA"
+// 	desc = "We stealthily sting a target and extract the DNA from them."
+// 	helptext = "Will give you the DNA of your target, allowing you to transform into them. Does not count towards absorb objectives."
+// 	genomecost = 2
+// 	allowduringlesserform = 1
+// 	verbpath = /mob/proc/changeling_extract_dna_sting
 
 /datum/power/changeling/transformation_sting
 	name = "Transformation Sting"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -317,7 +317,7 @@
 			if(!istype(O,/obj/item/weapon/implant) && !istype(O,/obj/item/weapon/material/shard/shrapnel))
 				msg += "<span class='danger'>[src] [T.has] \a [O] sticking out of [T.his] [organ.name]!</span>\n"
 	if(digitalcamo)
-		msg += "[T.He] [T.is] repulsively uncanny!\n"
+		msg += "[T.He] [T.is] a little difficult to identify.\n"
 
 	if(hasHUD(user,"security"))
 		var/perpname = "wot"

--- a/html/changelogs/Kaedwuff- Ling Rework 1.0.yml
+++ b/html/changelogs/Kaedwuff- Ling Rework 1.0.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Changelings no longer have to murder for precious DNA, but can instead extract from someone adjacent to them. This is the first phase of a ling rework."
+  - tweak: "People who have been succed by a ling now show up as dying to something less overtly metagameable."
+  - tweak: "Digital Camo's examine text has been changed to something less awkward and weird."


### PR DESCRIPTION
I'm finally doing it.  _Praise._

This is Stage 1 of my ling rework.  It is intended to be a standalone fix that corrects many of the particularly frustrating aspects of changeling, along with a few minor QoL tweaks. There WILL be more stuff later as I continue the rework, but this is sorely needed now.

Here is what it has done:
-There is now an ability called Extract DNA available to all changelings.  
--It can target anyone adjacent to you, and they can't move or it fails.   
--It takes the same time as a normal succ, but you don't have to grab them, you just have to chat with them or whatever to encourage them to remain put.  You know, roleplay and stuff.  
--It does not kill the target, or work on other changelings.
--After it is completed, you receive 1 DNA point
--Approximately 10-15 seconds after you complete the process, the target will receive a small but noticeable amount of genetic damage.  This is do prevent people from immediately flipping the fuck out because they took damage and pointing at the person next to them as the cause.  

The original flavor succ is still there, but it has been renamed to Full DNA Extraction.  Using it gives you 10 DNA points, though if you think that is too many, I can reduce it.  Maybe to 5? I want it to be rewarding as killing someone is supposed to a rare thing for antags.