### PR TITLE
Tweaks the tau ceti foreign legion spawn chance

### DIFF
--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -139,8 +139,10 @@ proc/trigger_armed_response_team(var/force = 0, forced_choice = FALSE)
 	command_announcement.Announce("It would appear that an emergency response team was requested for [station_name()]. We will prepare and send one as soon as possible.", "[current_map.boss_name]")
 
 	if(!forced_choice)
-		var/random_team = pick("NanoTrasen Response Team", "Tau Ceti Foreign Legion")
-		ert_type = random_team
+		if(prob(75))
+			ert_type = "Tau Ceti Foreign Legion"
+		else
+			ert_type = "NanoTrasen Response Team"
 
 	can_call_ert = 0 // Only one call per round, gentleman.
 	send_emergency_team = 1

--- a/html/changelogs/alberyk-tcfl.yml
+++ b/html/changelogs/alberyk-tcfl.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "The Tau Ceti Foreign Legion has now a higher chance to be selected when an emergency team is called."


### PR DESCRIPTION
By request of the lore team, the tau ceti foreign legion has a higher chance to spawn.

Thread: https://forums.aurorastation.org/topic/11379-increase-the-chance-for-the-tau-ceti-legion-to-spawn/