### PR TITLE
Fixes the Jotun's wreckage sprites

### DIFF
--- a/code/game/mecha/combat/tank.dm
+++ b/code/game/mecha/combat/tank.dm
@@ -136,6 +136,7 @@
 	pixel_x = -41
 	health = 950
 	w_class = 45
+	wreckage = /obj/effect/decal/mecha_wreckage/tank/jotun
 
 /obj/mecha/combat/tank/jotun/Initialize()
 	.= ..()

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -210,3 +210,10 @@
 	anchored = TRUE
 	pixel_x = -16
 	layer = ABOVE_MOB_LAYER
+
+/obj/effect/decal/mecha_wreckage/tank/jotun
+	name = "adhomian light tank wreckage"
+	desc = "Remains of some unfortunate armored vehicle. Completely unrepairable."
+	icon = 'icons/mecha/mecha_114x59.dmi'
+	icon_state = "jotun-broken"
+	pixel_x = -41


### PR DESCRIPTION
This pr fixes the tau ceti foreign's legion tank wreckage having no proper sprite.