### PR TITLE
Replaces the tranquilizer rifle magazine with a box

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1109,3 +1109,13 @@
 	new /obj/item/weapon/reagent_containers/food/snacks/crabmeat(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/crabmeat(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/crabmeat(src)
+
+/obj/item/weapon/storage/box/tranquilizer
+	name = "box of tranquilizer darts"
+	desc = "It has a picture of a tranquilizer dart and several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
+	icon_state = "incendiaryshot_box"
+
+/obj/item/weapon/storage/box/tranquilizer/fill()
+	..()
+	for(var/i in 1 to 8)
+		new /obj/item/ammo_casing/tranq(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -139,7 +139,7 @@
 		//Tools
 		new /obj/item/weapon/cartridge/hos(src)
 		new /obj/item/device/radio/headset/heads/hos(src)
-		new /obj/item/ammo_magazine/tranq(src)
+		new /obj/item/weapon/storage/box/tranquilizer(src)
 		new /obj/item/clothing/glasses/sunglasses/sechud(src)
 		new /obj/item/clothing/glasses/sunglasses/sechud/head(src)
 		new /obj/item/weapon/shield/riot/tact(src)

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -245,19 +245,6 @@
 /obj/item/ammo_magazine/trodpack/empty
 	initial_ammo = 0
 
-/obj/item/ammo_magazine/tranq
-	name = "tranquilizer darts (.50 cal PPS)"
-	icon_state = "incendiaryshot_box"
-	origin_tech = list(TECH_COMBAT = 2)
-	mag_type = SINGLE_CASING
-	caliber = "PPS"
-	matter = list(DEFAULT_WALL_MATERIAL = 4500)
-	ammo_type = /obj/item/ammo_casing/tranq
-	max_ammo = 4
-
-/obj/item/ammo_magazine/tranq/empty
-	initial_ammo = 0
-
 /obj/item/ammo_magazine/a762
 	name = "magazine box (7.62mm)"
 	icon_state = "a762"

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -111,10 +111,6 @@
 	recoil = 1
 	silenced = 1
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'
-	handle_casings = HOLD_CASINGS
-	load_method = SINGLE_CASING
-	magazine_type = null
-	allowed_magazines = list(/obj/item/ammo_magazine/tranq)
 	max_shells = 4
 	ammo_type = null
 	accuracy = -3

--- a/html/changelogs/albery-box.yml
+++ b/html/changelogs/albery-box.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Replaced the tranquilizer gun magazine in the head of security locker with a box full of darts."


### PR DESCRIPTION
The head of security officer came with a magazine for the tranquilizer rifle, however the rifle did not accept magazines, and worked like the regular am rifle, where you have to load one shell at the time. This pr replaces the magazine, that forced you to empty it on the ground to load the rifle, with a regular box full of darts.