### PR TITLE
Buckets: Quiet Edition; Beakers: Small Handwriting Edition

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -56,8 +56,8 @@
 			return ..()
 	if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/device/flashlight/pen))
 		var/tmp_label = sanitizeSafe(input(user, "Enter a label for [name]", "Label", label_text), MAX_NAME_LEN)
-		if(length(tmp_label) > 10)
-			user << "<span class='notice'>The label can be at most 10 characters long.</span>"
+		if(length(tmp_label) > 15)
+			user << "<span class='notice'>The label can be at most 15 characters long.</span>"
 		else
 			user << "<span class='notice'>You set the label to \"[tmp_label]\".</span>"
 			label_text = tmp_label
@@ -80,6 +80,9 @@
 /obj/item/weapon/reagent_containers/glass/beaker/Initialize()
 	. = ..()
 	desc += " Can hold up to [volume] units."
+
+/obj/item/weapon/reagent_containers/glass/beaker/self_feed_message(var/mob/user)
+	to_chat(user, "<span class='notice'>You drink from \the [src].</span>")
 
 /obj/item/weapon/reagent_containers/glass/beaker/on_reagent_change()
 	update_icon()
@@ -223,6 +226,9 @@
 	cut_overlays()
 	if (!is_open_container())
 		add_overlay("lid_[initial(icon_state)]")
+
+/obj/item/weapon/reagent_containers/glass/bucket/self_feed_message(var/mob/user)
+	to_chat(user, "<span class='notice'>You drink heavily from \the [src].</span>")
 
 
 obj/item/weapon/reagent_containers/glass/bucket/wood

--- a/html/changelogs/stopalb2k19.yml
+++ b/html/changelogs/stopalb2k19.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Conspiir
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Drinking from beakers and buckets will no longer loudly inform nearby players."
+  - tweak: "Beakers can be labelled up to 15 characters instead of 10."


### PR DESCRIPTION
Prevents this: https://puu.sh/CwRrc/f4d0cbd55d.png

Also slightly expands how much writing you can put on a beaker. As someone that often works with beakers, flasks, and vials, you'd be amazed the amount of information you can shove on even an Eppendorf tube.