### PR TITLE
Silicon ladder QOL

### DIFF
--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -79,6 +79,14 @@
 		climbLadder(M, target_ladder)
 
 /obj/structure/ladder/attack_ghost(var/mob/M)
+	instant_climb(M)
+
+/obj/structure/ladder/attack_ai(var/mob/M)
+	var/mob/living/silicon/ai/ai = M
+	if(istype(ai) && istype(ai.eyeobj))
+		instant_climb(ai.eyeobj)
+
+/obj/structure/ladder/proc/instant_climb(var/mob/M)
 	var/target_ladder = getTargetLadder(M)
 	if(target_ladder)
 		M.forceMove(get_turf(target_ladder))
@@ -117,7 +125,7 @@
 	to_chat(src, "<span class='warning'>You're too heavy to climb [ladder]!</span>")
 	return FALSE
 
-/mob/living/silicon/robot/drone/may_climb_ladders(ladder)
+/mob/living/silicon/robot/may_climb_ladders(ladder)
 	if(!Adjacent(ladder))
 		to_chat(src, "<span class='warning'>You need to be next to \the [ladder] to start climbing.</span>")
 		return FALSE

--- a/html/changelogs/2019_01_17_robotclimbing.yml
+++ b/html/changelogs/2019_01_17_robotclimbing.yml
@@ -1,0 +1,7 @@
+author: Atlantiscze
+
+delete-after: True
+
+changes: 
+  - rscadd: "Cyborgs can now climb ladders."
+  - rscadd: "AI can click ladders to quickly move its view up/down."


### PR DESCRIPTION
- All robots may climb ladders now, not just drones. There are places in which you can get stuck (trash compactor is a wonderful example) and there is no real way out as there is only a ladder in some of such areas. I suppose it is not a serious balance change - i've made the same thing for Baystation about two years ago and it worked.
- AI can now move its eye up/down through the ladder by clicking on it. This is kind of a QOL shortcut.

If someone wants to use arguments like "how can a heavy robot climb ladder" or similar, here is a slightly more IC perspective - about a third of robot icons are hover models. For those it would be no problem to fly up/down through the ladder. A half is more or less humanoid shape with arms that would also allow climbing motion. The remaining fraction would probably have some special ladder-climbing attachments as well. Its a common obstacle, and it would make sense for an advanced robot to be able to get past it.