### PR TITLE
Fixes the blast doors

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -191,6 +191,8 @@
 		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_open)
 		securitylock = 0
 
+/obj/machinery/door/blast/attack_hand(mob/user as mob)
+	return
 
 // SUBTYPE: Regular
 // Your classical blast door, found almost everywhere.

--- a/html/changelogs/alberyk-blastdoor.yml
+++ b/html/changelogs/alberyk-blastdoor.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed being able to open blastdoors by clicking them with an empty hand."


### PR DESCRIPTION
You can't open or close blast doors by clicking them with an empty hand anymore.