### PR TITLE
Changes how pain checks works in game

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -164,7 +164,7 @@ var/list/sacrificed = list()
 					target.adjustBrainLoss(rand(1,5), 55)
 
 		initial_message = 1
-		if (target.species && (target.species.flags & NO_PAIN))
+		if (!target.can_feel_pain())
 			target.visible_message("<span class='warning'>The markings below [target] glow a bloody red.</span>")
 		else
 			target.visible_message("<span class='warning'>[target] writhes in pain as the markings below \him glow a bloody red.</span>", "<span class='danger'>AAAAAAHHHH!</span>", "<span class='warning'>You hear an anguished scream.</span>")

--- a/code/game/machinery/crusher_piston.dm
+++ b/code/game/machinery/crusher_piston.dm
@@ -501,7 +501,7 @@
 	return ..()
 
 /mob/living/carbon/piston_move()
-	if(!(species && (species.flags & NO_PAIN)))
+	if(can_feel_pain())
 		emote("scream")
 	return ..()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1197,7 +1197,7 @@ About the new airlock wires panel:
 
 /mob/living/carbon/airlock_crush(var/crush_damage)
 	. = ..()
-	if (!(species && (species.flags & NO_PAIN)))
+	if (can_feel_pain())
 		emote("scream")
 
 /mob/living/silicon/robot/airlock_crush(var/crush_damage)

--- a/code/game/machinery/kitchen/cooking_machines/fryer.dm
+++ b/code/game/machinery/kitchen/cooking_machines/fryer.dm
@@ -168,7 +168,7 @@
 	if(ishuman(victim) && user.zone_sel.selecting != "groin" && user.zone_sel.selecting != "chest")
 		var/mob/living/carbon/human/H = victim
 		E = H.get_organ(user.zone_sel.selecting)
-		if(!E || E.species.flags & NO_PAIN)
+		if(!E || !H.can_feel_pain())
 			nopain = 2
 		else if(E.robotic >= ORGAN_ROBOT)
 			nopain = 1

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -336,12 +336,12 @@
 				if(src.issuperUV)
 					var/burndamage = rand(28,35)
 					OCCUPANT.take_organ_damage(0,burndamage)
-					if (!(OCCUPANT.species && (OCCUPANT.species.flags & NO_PAIN)))
+					if (OCCUPANT.can_feel_pain())
 						OCCUPANT.emote("scream")
 				else
 					var/burndamage = rand(6,10)
 					OCCUPANT.take_organ_damage(0,burndamage)
-					if (!(OCCUPANT.species && (OCCUPANT.species.flags & NO_PAIN)))
+					if (OCCUPANT.can_feel_pain())
 						OCCUPANT.emote("scream")
 		if(i==3) //End of the cycle
 			if(!src.issuperUV)

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -84,7 +84,7 @@
 					if(affecting.take_damage(5, 0))
 						H.UpdateDamageIcon()
 					H.updatehealth()
-					if(!(H.species.flags & NO_PAIN))
+					if(H.can_feel_pain())
 						H.Weaken(3)
 					return
 				check -= picked

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -334,7 +334,7 @@
 					M.emote("scream")
 				else
 					var/mob/living/carbon/C = M
-					if (!(C.species && (C.species.flags & NO_PAIN)))
+					if (C.can_feel_pain())
 						C.emote("scream")
 
 			//Logging for this causes runtimes resulting in the cremator locking up. Commenting it out until that's figured out.

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -428,3 +428,13 @@
 
 /mob/living/carbon/proc/get_metabolism(metabolism)
 	return metabolism
+
+/mob/living/carbon/proc/can_feel_pain()
+	if (species && (species.flags & NO_PAIN))
+		return FALSE
+	if (is_berserk())
+		return FALSE
+	if (analgesic > 100)
+		return FALSE
+
+	return TRUE

--- a/code/modules/mob/living/carbon/carbon_powers.dm
+++ b/code/modules/mob/living/carbon/carbon_powers.dm
@@ -33,7 +33,7 @@
 	if(B.host_brain.ckey)
 		src << "<span class='warning'>You send a punishing spike of psychic agony lancing into your host's brain.</span>"
 
-		if (species && (species.flags & NO_PAIN))
+		if (can_feel_pain())
 			B.host_brain << "<span class='warning'>You feel a strange sensation as a foreign influence prods your mind.</span>"
 			src << "<span class='warning'>It doesn't seem to be as effective as you hoped.</span>"
 		else

--- a/code/modules/mob/living/carbon/carbon_powers.dm
+++ b/code/modules/mob/living/carbon/carbon_powers.dm
@@ -33,7 +33,7 @@
 	if(B.host_brain.ckey)
 		src << "<span class='warning'>You send a punishing spike of psychic agony lancing into your host's brain.</span>"
 
-		if (can_feel_pain())
+		if (!can_feel_pain())
 			B.host_brain << "<span class='warning'>You feel a strange sensation as a foreign influence prods your mind.</span>"
 			src << "<span class='warning'>It doesn't seem to be as effective as you hoped.</span>"
 		else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1158,7 +1158,7 @@
 		for(var/obj/item/O in organ.implants)
 			if(!istype(O,/obj/item/weapon/implant) && prob(5)) //Moving with things stuck in you could be bad.
 				// All kinds of embedded objects cause bleeding.
-				if(can_feel_pain())
+				if(!can_feel_pain())
 					src << "<span class='warning'>You feel [O] moving inside your [organ.name].</span>"
 				else
 					var/msg = pick( \

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1158,7 +1158,7 @@
 		for(var/obj/item/O in organ.implants)
 			if(!istype(O,/obj/item/weapon/implant) && prob(5)) //Moving with things stuck in you could be bad.
 				// All kinds of embedded objects cause bleeding.
-				if(species.flags & NO_PAIN)
+				if(can_feel_pain())
 					src << "<span class='warning'>You feel [O] moving inside your [organ.name].</span>"
 				else
 					var/msg = pick( \

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -248,7 +248,7 @@
 /mob/living/carbon/human/adjustHalLoss(var/amount, var/ignoreImmunity = 0)//An inherited version so this doesnt affect cyborgs
 	if(status_flags & GODMODE)	return 0	//godmode
 	if(!ignoreImmunity)//Adjusting how hallloss works. Species with the NO_PAIN flag will suffer most of the effects of halloss, but will be immune to most conventional sources of accumulating it
-		if (species && species.flags & NO_PAIN)//Species with this flag will only gather halloss through species-specific mechanics, which apply it with the ignoreImmunity flag
+		if (!can_feel_pain())//Species with the NO_PAIN flag will only gather halloss through species-specific mechanics, which apply it with the ignoreImmunity flag
 			return 0
 
 	if(wearing_rig) //I don't know if this is the best way, but I'm hard-pressed to think of a different way. Thanks Vaurca.
@@ -397,7 +397,7 @@ This function restores all organs.
 
 	//Handle other types of damage
 	if(damagetype != BRUTE && damagetype != BURN)
-		if(!stat && damagetype == HALLOSS && !(species && (species.flags & NO_PAIN)))
+		if(!stat && damagetype == HALLOSS && !(can_feel_pain()))
 			if ((damage > 25 && prob(20)) || (damage > 50 && prob(60)))
 				emote("scream")
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -397,7 +397,7 @@ This function restores all organs.
 
 	//Handle other types of damage
 	if(damagetype != BRUTE && damagetype != BURN)
-		if(!stat && damagetype == HALLOSS && !(can_feel_pain()))
+		if(!stat && damagetype == HALLOSS && (can_feel_pain()))
 			if ((damage > 25 && prob(20)) || (damage > 50 && prob(60)))
 				emote("scream")
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -77,7 +77,7 @@ emp_act
 					emote("me", 1, "drops what they were holding, their [affected.name] malfunctioning!")
 				else
 					var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")
-					emote("me", 1, "[(can_feel_pain()) ? "" : emote_scream ]drops what they were holding in their [affected.name]!")
+					emote("me", 1, "[(!can_feel_pain()) ? "" : emote_scream ]drops what they were holding in their [affected.name]!")
 
 	..(stun_amount, agony_amount, def_zone)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -77,7 +77,7 @@ emp_act
 					emote("me", 1, "drops what they were holding, their [affected.name] malfunctioning!")
 				else
 					var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")
-					emote("me", 1, "[(species && species.flags & NO_PAIN) ? "" : emote_scream ]drops what they were holding in their [affected.name]!")
+					emote("me", 1, "[(can_feel_pain()) ? "" : emote_scream ]drops what they were holding in their [affected.name]!")
 
 	..(stun_amount, agony_amount, def_zone)
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -16,7 +16,7 @@
 	var/health_deficiency = (100 - health)
 	if(health_deficiency >= 40) tally += (health_deficiency / 25)
 
-	if (!(species && (species.flags & NO_PAIN)))
+	if (!can_feel_pain())
 		if(halloss >= 10) tally += (halloss / 10) //halloss shouldn't slow you down if you can't even feel it
 
 	if(wear_suit)
@@ -44,7 +44,7 @@
 			else if(E.status & ORGAN_BROKEN)
 				tally += 1.5
 
-	if (!(species && (species.flags & NO_PAIN)))
+	if (can_feel_pain())
 		if(shock_stage >= 10) tally += 3
 
 	if(aiming && aiming.aiming_at) tally += 5 // Iron sights make you slower, it's a well-known fact.

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -16,7 +16,7 @@
 	var/health_deficiency = (100 - health)
 	if(health_deficiency >= 40) tally += (health_deficiency / 25)
 
-	if (!can_feel_pain())
+	if (can_feel_pain())
 		if(halloss >= 10) tally += (halloss / 10) //halloss shouldn't slow you down if you can't even feel it
 
 	if(wear_suit)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -99,7 +99,7 @@
 	// standing is poor
 	if(stance_damage >= 4 || (stance_damage >= 2 && prob(5)))
 		if(!(lying || resting))
-			if(species && !(species.flags & NO_PAIN))
+			if(can_feel_pain())
 				emote("scream")
 			custom_emote(1, "collapses!")
 		Weaken(5) //can't emote while weakened, apparently.

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -265,7 +265,7 @@
 			if(prob(10) && !(H.species.flags & NO_BLOOD))
 				to_chat(H,"<span class='warning'>Your nose begins to bleed...</span>")
 				H.drip(3)
-			else if(prob(25) && !(H.species.flags & NO_PAIN))
+			else if(prob(25) && (can_feel_pain()))
 				to_chat(H,"<span class='warning'>Your head hurts...</span>")
 			else if(prob(50))
 				to_chat(H,"<span class='warning'>Your mind buzzes...</span>")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1331,7 +1331,7 @@
 /mob/living/carbon/human/handle_shock()
 	..()
 	if(status_flags & GODMODE)	return 0	//godmode
-	if(species && species.flags & NO_PAIN) return
+	if(!can_feel_pain()) return
 
 	if(health < config.health_threshold_softcrit)// health 0 makes you immediately collapse
 		shock_stage = max(shock_stage, 61)
@@ -1592,7 +1592,7 @@
 	return slurring
 
 /mob/living/carbon/human/handle_stunned()
-	if(species.flags & NO_PAIN)
+	if(!can_feel_pain())
 		stunned = 0
 		return 0
 	if(..())

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -49,12 +49,17 @@ var/global/list/sparring_attack_cache = list()
 		return
 
 	var/stun_chance = rand(0, 100)
+	var/pain_message = TRUE
+
+	if(!target.can_feel_pain())
+		pain_message = FALSE
 
 	if(attack_damage >= 5 && armour < 100 && !(target == user) && stun_chance <= attack_damage * 5) // 25% standard chance
 		switch(zone) // strong punches can have effects depending on where they hit
 			if("head", "mouth", "eyes")
 				// Induce blurriness
-				target.visible_message("<span class='danger'>[target] looks momentarily disoriented.</span>", "<span class='danger'>You see stars.</span>")
+				if(pain_message)
+					target.visible_message("<span class='danger'>[target] looks momentarily disoriented.</span>", "<span class='danger'>You see stars.</span>")
 				target.apply_effect(attack_damage*2, EYE_BLUR, armour)
 			if("l_arm", "l_hand")
 				if (target.l_hand)
@@ -79,11 +84,13 @@ var/global/list/sparring_attack_cache = list()
 						target.set_dir(reverse_dir[target.dir])
 					target.apply_effect(attack_damage * 0.4, WEAKEN, armour)
 			if("groin")
-				target.visible_message("<span class='warning'>[target] looks like \he is in pain!</span>", "<span class='warning'>[(target.gender=="female") ? "Oh god that hurt!" : "Oh no, not your[pick("testicles", "crown jewels", "clockweights", "family jewels", "marbles", "bean bags", "teabags", "sweetmeats", "goolies")]!"]</span>")
+				if(pain_message)
+					target.visible_message("<span class='warning'>[target] looks like \he is in pain!</span>", "<span class='warning'>[(target.gender=="female") ? "Oh god that hurt!" : "Oh no, not your[pick("testicles", "crown jewels", "clockweights", "family jewels", "marbles", "bean bags", "teabags", "sweetmeats", "goolies")]!"]</span>")
 				target.apply_effects(stutter = attack_damage * 2, agony = attack_damage* 3, blocked = armour)
 			if("l_leg", "l_foot", "r_leg", "r_foot")
 				if(!target.lying)
-					target.visible_message("<span class='warning'>[target] gives way slightly.</span>")
+					if(pain_message)
+						target.visible_message("<span class='warning'>[target] gives way slightly.</span>")
 					target.apply_effect(attack_damage*3, AGONY, armour)
 	else if(attack_damage >= 5 && !(target == user) && (stun_chance + attack_damage * 5 >= 100) && armour < 100) // Chance to get the usual throwdown as well (25% standard chance)
 		if(!target.lying)
@@ -106,7 +113,7 @@ var/global/list/sparring_attack_cache = list()
 	eyes.take_damage(rand(3,4), 1)
 
 	user.visible_message("<span class='danger'>[user] presses \his [eye_attack_text] into [target]'s [eyes.name]!</span>")
-	target << "<span class='danger'>You experience[(target.can_feel_pain())? "" : " immense pain as you feel" ] [eye_attack_text_victim] being pressed into your [eyes.name][(target.can_feel_pain())? "." : "!"]</span>"
+	target << "<span class='danger'>You experience[(!target.can_feel_pain())? "" : " immense pain as you feel" ] [eye_attack_text_victim] being pressed into your [eyes.name][(!target.can_feel_pain())? "." : "!"]</span>"
 
 /datum/unarmed_attack/bite
 	attack_verb = list("bit")

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -106,7 +106,7 @@ var/global/list/sparring_attack_cache = list()
 	eyes.take_damage(rand(3,4), 1)
 
 	user.visible_message("<span class='danger'>[user] presses \his [eye_attack_text] into [target]'s [eyes.name]!</span>")
-	target << "<span class='danger'>You experience[(target.species.flags & NO_PAIN)? "" : " immense pain as you feel" ] [eye_attack_text_victim] being pressed into your [eyes.name][(target.species.flags & NO_PAIN)? "." : "!"]</span>"
+	target << "<span class='danger'>You experience[(target.can_feel_pain())? "" : " immense pain as you feel" ] [eye_attack_text_victim] being pressed into your [eyes.name][(target.can_feel_pain())? "." : "!"]</span>"
 
 /datum/unarmed_attack/bite
 	attack_verb = list("bit")

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -3,7 +3,7 @@
 
 // proc to find out in how much pain the mob is at the moment
 /mob/living/carbon/proc/updateshock()
-	if (species && (species.flags & NO_PAIN))
+	if (!can_feel_pain())
 		src.traumatic_shock = src.halloss //Nopain species only receive halloss from specific mechanics
 		return src.traumatic_shock
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -320,7 +320,7 @@ default behaviour is:
 /mob/living/carbon/adjustHalLoss(var/amount, var/ignoreImmunity = 0)//An inherited version so this doesnt affect cyborgs
 	if(status_flags & GODMODE)	return 0	//godmode
 	if(!ignoreImmunity)//Adjusting how hallloss works. Species with the NO_PAIN flag will suffer most of the effects of halloss, but will be immune to most conventional sources of accumulating it
-		if (species && species.flags & NO_PAIN)//Species with this flag will only gather halloss through species-specific mechanics, which apply it with the ignoreImmunity flag
+		if (!can_feel_pain())//Species with the NO_PAIN flag will only gather halloss through species-specific mechanics, which apply it with the ignoreImmunity flag
 			return 0
 
 	if(amount > 0)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -237,7 +237,7 @@
 			brute -= brute / 2
 
 	if(status & ORGAN_BROKEN && prob(40) && brute)
-		if (owner && !(owner.species && (owner.species.flags & NO_PAIN)))
+		if (owner && (owner.can_feel_pain()))
 			owner.emote("scream")	//getting hit on broken hand hurts
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)
@@ -916,7 +916,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			"<span class='warning'>You hear a loud cracking sound coming from \the [owner].</span>",\
 			"<span class='danger'>Something feels like it shattered in your [name]!</span>",\
 			"You hear a sickening crack.")
-		if(owner.species && !(owner.species.flags & NO_PAIN))
+		if(owner.species && (owner.can_feel_pain()))
 			owner.emote("scream")
 
 	playsound(src.loc, "fracture", 100, 1, -2)

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -10,7 +10,7 @@ mob/var/next_pain_time = 0
 mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0)
 	if(stat >= 1)
 		return
-	if(species && (species.flags & NO_PAIN))
+	if(!can_feel_pain())
 		return
 	if(analgesic > 40)
 		return
@@ -53,7 +53,7 @@ mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0
 mob/living/carbon/human/proc/custom_pain(var/message, var/flash_strength)
 	if(stat >= 1)
 		return
-	if(species.flags & NO_PAIN)
+	if(!can_feel_pain())
 		return
 	if(reagents.has_reagent("tramadol"))
 		return
@@ -74,7 +74,7 @@ mob/living/carbon/human/proc/custom_pain(var/message, var/flash_strength)
 mob/living/carbon/human/proc/handle_pain()
 	// not when sleeping
 
-	if(species.flags & NO_PAIN) return
+	if(!can_feel_pain()) return
 
 	if(stat >= 2) return
 	if(analgesic > 70)

--- a/code/modules/organs/subtypes/parasite.dm
+++ b/code/modules/organs/subtypes/parasite.dm
@@ -56,7 +56,7 @@
 	if (!owner)
 		return
 
-	if(prob(10) && !(owner.species.flags & NO_PAIN))
+	if(prob(10) && (owner.can_feel_pain()))
 		owner << "<span class='warning'>You feel a stinging pain in your abdomen!</span>"
 		owner.emote("me",1,"winces slightly.")
 		owner.adjustHalLoss(5)
@@ -96,7 +96,7 @@
 			S.set_up(R, 20, 0, T, 40)
 			S.start()
 
-			if(!(owner.species.flags & NO_PAIN))
+			if(owner.can_feel_pain())
 				owner.emote("scream")
 				owner.adjustHalLoss(15)
 				owner.drip(15)
@@ -122,7 +122,7 @@
 /obj/item/organ/parasite/blackkois/process()
 	..()
 
-	if(prob(10) && !(owner.species.flags & NO_PAIN))
+	if(prob(10) && (owner.can_feel_pain()))
 		if(stage < 3)
 			owner << "<span class='warning'>You feel a stinging pain in your abdomen!</span>"
 		else
@@ -175,7 +175,7 @@
 			removed_langs = 1
 
 		if(prob(10))
-			if(!(owner.species.flags & NO_PAIN))
+			if(owner.can_feel_pain())
 				owner << "<span class='warning'>You feel an unbearable pain in your mind!</span>"
 				owner.emote("scream")
 			owner.adjustBrainLoss(1)
@@ -194,7 +194,7 @@
 			S.set_up(R, 20, 0, T, 40)
 			S.start()
 
-			if(!(owner.species.flags & NO_PAIN))
+			if(owner.can_feel_pain())
 				owner.emote("scream")
 				owner.adjustHalLoss(15)
 				owner.drip(15)
@@ -224,7 +224,7 @@
 	if (!owner)
 		return
 
-	if(prob(10) && !(owner.species.flags & NO_PAIN))
+	if(prob(10) && (owner.can_feel_pain()))
 		owner << "<span class='warning'>You feel a burning sensation on your skin!</span>"
 		owner.make_jittery(10)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -459,7 +459,7 @@
 				if(affecting.take_damage(0, removed * power * 0.1))
 					H.UpdateDamageIcon()
 				if(prob(100 * removed / meltdose)) // Applies disfigurement
-					if (!(H.species && (H.species.flags & NO_PAIN)))
+					if (H.can_feel_pain())
 						H.emote("scream")
 					H.status_flags |= DISFIGURED
 		else

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -582,7 +582,7 @@
 /datum/reagent/capsaicin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.species && (H.species.flags & (NO_PAIN)))
+		if(!H.can_feel_pain())
 			return
 	if(dose < agony_dose)
 		if(prob(5) || dose == metabolism) //dose == metabolism is a very hacky way of forcing the message the first time this procs
@@ -626,8 +626,8 @@
 			return
 		var/mob/living/carbon/human/H = M
 		protection = list(H.head, H.glasses, H.wear_mask)
-		if(H.species && (H.species.flags & NO_PAIN))
-			no_pain = 1 //TODO: living-level can_feel_pain() proc
+		if(!H.can_feel_pain())
+			no_pain = 1
 
 		// Robo-eyes are immune to pepperspray now. Wee.
 		var/obj/item/organ/eyes/E = H.get_eyes()
@@ -672,7 +672,7 @@
 /datum/reagent/capsaicin/condensed/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.species && (H.species.flags & NO_PAIN))
+		if(!H.can_feel_pain())
 			return
 	if(dose == metabolism)
 		M << "<span class='danger'>You feel like your insides are burning!</span>"
@@ -3227,7 +3227,7 @@
 	if(alien != IS_DIONA)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
-			if(H.species && (H.species.flags & (NO_PAIN)))
+			if(!H.can_feel_pain())
 				return
 		if(dose < agony_dose)
 			if(prob(5) || dose == metabolism)

--- a/code/modules/spells/artifacts.dm
+++ b/code/modules/spells/artifacts.dm
@@ -281,7 +281,7 @@
 			to_chat(H, "<span class='warning'>You stab \the [src] with \the [W]!</span>")
 			H.apply_damage(2, BRUTE, target_zone, edge = TRUE)
 			playsound(get_turf(H), 'sound/weapons/bladeslice.ogg', 50, 1, -1)
-			if(!(H.species.flags & NO_PAIN))
+			if(H.can_feel_pain())
 				var/obj/item/organ/external/organ = H.get_organ(target_zone)
 				to_chat(H, "<span class='danger'>You feel a stabbing pain in your [organ.name]!</span>")
 

--- a/html/changelogs/alberyk-painfix.yml
+++ b/html/changelogs/alberyk-painfix.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Pain related effects, such as stun batons and pepperspray, will now properly take in consideration other factors, like painkillers."


### PR DESCRIPTION
This pr creates a new check, can_feel_pain, it checks for the NO_PAIN flag, if the target is under influence of mind altering drugs or strong painkillers. This check replaces all the species procs and fixes somethings, like people under the influence of pain killers still getting knocked out from pain and etc.