### PR TITLE
Fixing tesla with no balls

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -174,7 +174,12 @@
 /obj/proc/see_emote(mob/M as mob, text, var/emote_type)
 	return
 
-/obj/proc/tesla_act(var/power)
+/obj/proc/tesla_act(var/power, var/melt = FALSE)
+	if(melt)
+		visible_message(span("danger", "\The [src] melts down until ashes are left!"))
+		new /obj/effect/decal/cleanable/ash(loc)
+		qdel(src)
+		return
 	being_shocked = 1
 	var/power_bounced = power / 2
 	tesla_zap(src, 3, power_bounced)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -30,7 +30,7 @@
 
 	if(W.iswrench())
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		user << "<span class='notice'>You [anchored ? "unfasten" : "fasten"] [src] to the flooring.</span>"
+		to_chat(user, "<span class='notice'>You [anchored ? "unfasten" : "fasten"] [src] to the flooring.</span>")
 		anchored = !anchored
 		if(!anchored)
 			disconnect_from_network()
@@ -38,7 +38,12 @@
 			connect_to_network()
 		return
 
-/obj/machinery/power/tesla_coil/tesla_act(var/power)
+/obj/machinery/power/tesla_coil/tesla_act(var/power, var/melt = FALSE)
+	if(melt)
+		visible_message(span("danger", "\The [src] melts down until ashes are left"))
+		new /obj/effect/decal/cleanable/ash(loc)
+		qdel(src)
+		return
 	if(anchored)
 		being_shocked = 1
 		//don't lose arc power when it's not connected to anything
@@ -76,12 +81,17 @@
 
 	if(W.iswrench())
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		user << "<span class='notice'>You [anchored ? "unfasten" : "fasten"] [src] to the flooring.</span>"
+		to_chat(user, "<span class='notice'>You [anchored ? "unfasten" : "fasten"] [src] to the flooring.</span>")
 		anchored = !anchored
 		return
 
 
-/obj/machinery/power/grounding_rod/tesla_act(var/power)
+/obj/machinery/power/grounding_rod/tesla_act(var/power, var/melt = FALSE)
+	if(melt)
+		visible_message(span("danger", "\The [src] melts down until ashes are left"))
+		new /obj/effect/decal/cleanable/ash(loc)
+		qdel(src)
+		return
 	flick("coil_shock_1", src)
 
 /obj/item/weapon/circuitboard/tesla_coil

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -39,12 +39,7 @@
 		return
 
 /obj/machinery/power/tesla_coil/tesla_act(var/power, var/melt = FALSE)
-	if(melt)
-		visible_message(span("danger", "\The [src] melts down until ashes are left"))
-		new /obj/effect/decal/cleanable/ash(loc)
-		qdel(src)
-		return
-	if(anchored)
+	if(anchored && !melt)
 		being_shocked = 1
 		//don't lose arc power when it's not connected to anything
 		//please place tesla coils all around the station to maximize effectiveness
@@ -87,12 +82,8 @@
 
 
 /obj/machinery/power/grounding_rod/tesla_act(var/power, var/melt = FALSE)
-	if(melt)
-		visible_message(span("danger", "\The [src] melts down until ashes are left"))
-		new /obj/effect/decal/cleanable/ash(loc)
-		qdel(src)
-		return
 	flick("coil_shock_1", src)
+	..()
 
 /obj/item/weapon/circuitboard/tesla_coil
 	name = "tesla coil circuitry"

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -163,7 +163,7 @@
 /obj/singularity/energy_ball/proc/new_mini_ball()
 	if(!loc)
 		return
-	var/obj/singularity/energy_ball/EB = new(loc)
+	var/obj/singularity/energy_ball/EB = new(loc, 0)
 
 	EB.transform *= pick(0.3, 0.4, 0.5, 0.6, 0.7)
 	var/icon/I = icon(icon,icon_state,dir)
@@ -188,15 +188,15 @@
 		target.dissipate_strength = target.orbiting_balls.len
 
 	. = ..()
+
 /obj/singularity/energy_ball/stop_orbit()
 	if (orbiting && istype(orbiting.orbiting, /obj/singularity/energy_ball))
 		var/obj/singularity/energy_ball/orbitingball = orbiting.orbiting
 		orbitingball.orbiting_balls -= src
 		orbitingball.dissipate_strength = orbitingball.orbiting_balls.len
-	..()
+	. = ..()
 	if (!loc && !QDELETED(src))
 		qdel(src)
-
 
 /obj/singularity/energy_ball/proc/dust_mobs(atom/A)
 	if(!iscarbon(A))

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -337,14 +337,6 @@
 	else if(closest_emitter)
 		closest_emitter.tesla_act(power, melt)
 
-		// Sacraficing three balls to escape the containment.
-
-		energy_to_raise = energy_to_raise / 1.25
-		energy_to_lower = (energy_to_raise / 1.25) - 20
-
-		var/Orchiectomy_target = pick(orbiting_balls)
-		qdel(Orchiectomy_target)
-
 	else if(closest_mob)
 		var/shock_damage = Clamp(round(power/400), 10, 90) + rand(-5, 5)
 		closest_mob.electrocute_act(shock_damage, source, 1, tesla_shock = 1)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -59,7 +59,7 @@
 			tesla_zap(ball, range, TESLA_MINI_POWER/7*range, TRUE)
 	else
 		energy = 0 // ensure we dont have miniballs of miniballs
-	if(energy == 0)
+	if(energy < 0)
 		qdel(src)
 
 /obj/singularity/energy_ball/examine(mob/user)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -159,6 +159,9 @@
 
 	else if(orbiting_balls.len)
 		dissipate() //sing code has a much better system.
+	else // that is when we have no balls but our energy is less
+		energy_to_raise = energy_to_raise / 1.25
+		energy_to_lower = (energy_to_raise / 1.25) - 20
 
 /obj/singularity/energy_ball/proc/new_mini_ball()
 	if(!loc)
@@ -245,8 +248,14 @@
 		/mob/living,
 		/obj/structure
 	))
+	var/melt = FALSE
+	if(istype(source, /obj/singularity/energy_ball))
+		var/obj/singularity/energy_ball/E = source
+		if(E.orbiting_balls.len >= 9)
+			melt = TRUE
 
 	for(var/A in typecache_filter_multi_list_exclusion(oview(source, zap_range+2), things_to_shock, blacklisted_types))
+		
 		if(istype(A, /obj/machinery/power/tesla_coil))
 			var/dist = get_dist(source, A)
 			var/obj/machinery/power/tesla_coil/C = A
@@ -311,10 +320,10 @@
 
 	//per type stuff:
 	if(closest_tesla_coil)
-		closest_tesla_coil.tesla_act(power)
+		closest_tesla_coil.tesla_act(power, melt)
 
 	else if(closest_grounding_rod)
-		closest_grounding_rod.tesla_act(power)
+		closest_grounding_rod.tesla_act(power, melt)
 
 	else if(closest_mob)
 		var/shock_damage = Clamp(round(power/400), 10, 90) + rand(-5, 5)

--- a/html/changelogs/Sindorman-tesla.yml
+++ b/html/changelogs/Sindorman-tesla.yml
@@ -39,5 +39,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - bugfix: "Tesla now can generate miniballs. And actually dies if it ha no energy"
-  - tweak: "There is no max limit of balls, but if Tesla has 9 or more balls it will start melting down tesla coils and grounding rods."
+  - tweak: "There is no max limit of balls, but if Tesla has 9 or more balls it will start melting down tesla coils and grounding rods. If Tesla has 10 or more balls it will start to target emitters and melt them as well."
 

--- a/html/changelogs/Sindorman-tesla.yml
+++ b/html/changelogs/Sindorman-tesla.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Tesla now can generate miniballs."

--- a/html/changelogs/Sindorman-tesla.yml
+++ b/html/changelogs/Sindorman-tesla.yml
@@ -38,4 +38,6 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - bugfix: "Tesla now can generate miniballs."
+  - bugfix: "Tesla now can generate miniballs. And actually dies if it ha no energy"
+  - tweak: "There is no max limit of balls, but if Tesla has 9 or more balls it will start melting down tesla coils and grounding rods."
+


### PR DESCRIPTION
This PR fixes Tesla not having miniballs. Problem was that it would delete its own generated balls. Fixes #5749 

- Tesla that has 9 or more balls will start to melt down any tesla coils or grounding rods.

- Tesla that has 10 or more balls will start to target and melt down emitters

- Tesla with no balls looses power as intended, thus dying with less than 0 power.

a bit of cool preview of Tesla with 400 energy
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/25555314/51785822-a6043e00-2110-11e9-8345-c8322b9b6bd0.gif)

