### PR TITLE
Making Tesla Engine SMES input/output by default

### DIFF
--- a/html/changelogs/Sindorman-fix.yml
+++ b/html/changelogs/Sindorman-fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Tesla Engine SMES is now set to input/output by default, so that newly remapped APC doesn't run out of charge."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -1003,8 +1003,10 @@
 "acm" = (
 /obj/machinery/power/smes/buildable{
 	charge = 2e+006;
+	input_attempt = 1;
 	input_level_max = 350000;
 	is_critical = 1;
+	output_attempt = 1;
 	output_level_max = 350000;
 	RCon_tag = "Tesla - Containment"
 	},


### PR DESCRIPTION
This is an oversight I didn't see when I remapped Tesla Engine APC to the Engine SMES, the SMES is not outputting/inputting by default - causing to have power alert later. 
Having it input/output by default will fix it and the energy would be enough for `SMES will run out of charge in 5 hours, 26 minutes` Fixes #6000 