### PR TITLE
Tweaked Unbucklecuffing

### DIFF
--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -115,13 +115,16 @@
 			buckle_message_user = " and unbuckle yourself"
 			buckle_message_other = " and to unbuckle themself"
 			buckled.user_unbuckle_mob(src)
-
+		
 		if(violent_removal)
 			var/obj/item/organ/external/E = H.get_organ(pick("l_arm","r_arm"))
-			E.dislocate(1)
+			var/dislocate_message = ""
+			if(E && !E.is_dislocated())
+				E.dislocate(1)
+				dislocate_message = ", but dislocate your [E] in the process"
 			visible_message(
 				"<span class='danger'>\The [src] manages to remove \the [handcuffed][buckle_message_other]!</span>",
-				"<span class='notice'>You successfully remove \the [handcuffed][buckle_message_user], but dislocate your [E] in the process.</span>"
+				"<span class='notice'>You successfully remove \the [handcuffed][buckle_message_user][dislocate_message].</span>"
 				)
 		else
 			visible_message(

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -79,7 +79,11 @@
 	//If you are handcuffed with actual handcuffs... Well what do I know, maybe someone will want to handcuff you with toilet paper in the future...
 	if(istype(HC))
 		breakouttime = HC.breakouttime
-		displaytime = breakouttime / 600 //Minutes
+	
+	if(buckled)
+		breakouttime += 600 //If you are buckled, it takes a minute longer, but you are unbuckled and uncuffed instantly
+	
+	displaytime = breakouttime / 600 //Minutes
 
 	var/mob/living/carbon/human/H = src
 	if(istype(H) && H.gloves && istype(H.gloves,/obj/item/clothing/gloves/rig))
@@ -92,13 +96,20 @@
 		)
 
 	if(do_after(src, breakouttime))
-		if(!handcuffed || buckled)
+		if(!handcuffed)
 			return
 		visible_message(
 			"<span class='danger'>\The [src] manages to remove \the [handcuffed]!</span>",
 			"<span class='notice'>You successfully remove \the [handcuffed].</span>"
 			)
 		drop_from_inventory(handcuffed)
+		if(buckled) //If the person is buckled, also unbuckle the person
+			visible_message(
+				"<span class='danger'>[usr] manages to unbuckle themself!</span>",
+				"<span class='notice'>You successfully unbuckle yourself.</span>"
+				)
+			buckled.user_unbuckle_mob(src)
+
 
 /mob/living/carbon/proc/escape_legcuffs()
 	if(!canClick())
@@ -197,24 +208,3 @@
 	if(species.can_shred(src,1))
 		return 1
 	return ..()
-
-/mob/living/carbon/escape_buckle()
-
-	if(!buckled) return
-
-	if(!restrained())
-		..()
-	else
-		setClickCooldown(100)
-		visible_message(
-			"<span class='danger'>[usr] attempts to unbuckle themself!</span>",
-			"<span class='warning'>You attempt to unbuckle yourself. (This will take around 2 minutes and you need to stand still)</span>"
-			)
-
-		if(do_after(usr, 1200))
-			if(!buckled)
-				return
-			visible_message("<span class='danger'>[usr] manages to unbuckle themself!</span>",
-							"<span class='notice'>You successfully unbuckle yourself.</span>")
-			buckled.user_unbuckle_mob(src)
-

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -228,3 +228,7 @@
 	if(species.can_shred(src,1))
 		return 1
 	return ..()
+
+/mob/living/carbon/human/escape_buckle()
+	if(!restrained())
+		..()

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -90,25 +90,45 @@
 		breakouttime /= 2
 		displaytime /= 2
 
-	visible_message(
-		"<span class='danger'>\The [src] attempts to remove \the [HC]!</span>",
-		"<span class='warning'>You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)</span>"
-		)
+	//Check if the user is trying to violently remove the handcuffs
+	var/violent_removal = 0
+	if(a_intent == I_HURT)
+		violent_removal = 1
+		breakouttime = rand(450,600)
+		visible_message(
+			"<span class='danger'>\The [src] attempts to break out of \the [HC]!</span>",
+			"<span class='warning'>You attempt to break out of \the [HC]. (This will take around 1 minute and you need to stand still)</span>"
+			)
+	else
+		visible_message(
+			"<span class='danger'>\The [src] attempts to slip out of \the [HC]!</span>",
+			"<span class='warning'>You attempt to slip out of \the [HC]. (This will take around [displaytime] minutes and you need to stand still)</span>"
+			)
 
 	if(do_after(src, breakouttime))
 		if(!handcuffed)
 			return
-		visible_message(
-			"<span class='danger'>\The [src] manages to remove \the [handcuffed]!</span>",
-			"<span class='notice'>You successfully remove \the [handcuffed].</span>"
-			)
-		drop_from_inventory(handcuffed)
+
+		var/buckle_message_user = ""
+		var/buckle_message_other = ""
 		if(buckled) //If the person is buckled, also unbuckle the person
-			visible_message(
-				"<span class='danger'>[usr] manages to unbuckle themself!</span>",
-				"<span class='notice'>You successfully unbuckle yourself.</span>"
-				)
+			buckle_message_user = " and unbuckle yourself"
+			buckle_message_other = " and to unbuckle themself"
 			buckled.user_unbuckle_mob(src)
+
+		if(violent_removal)
+			var/obj/item/organ/external/E = H.get_organ(pick("l_arm","r_arm"))
+			E.dislocate(1)
+			visible_message(
+				"<span class='danger'>\The [src] manages to remove \the [handcuffed][buckle_message_other]!</span>",
+				"<span class='notice'>You successfully remove \the [handcuffed][buckle_message_user], but dislocate your [E] in the process.</span>"
+				)
+		else
+			visible_message(
+				"<span class='notice'>\The [src] manages to slip out of \the [handcuffed][buckle_message_other]!</span>",
+				"<span class='notice'>You successfully slip out of \the [handcuffed][buckle_message_user].</span>"
+				)
+		drop_from_inventory(handcuffed)
 
 
 /mob/living/carbon/proc/escape_legcuffs()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -692,7 +692,7 @@ default behaviour is:
 		H.forceMove(get_turf(H))
 
 /mob/living/proc/escape_buckle()
-	if(buckled)
+	if(buckled && !restrained())
 		buckled.user_unbuckle_mob(src)
 
 /mob/living/var/last_resist

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -692,7 +692,7 @@ default behaviour is:
 		H.forceMove(get_turf(H))
 
 /mob/living/proc/escape_buckle()
-	if(buckled && !restrained())
+	if(buckled)
 		buckled.user_unbuckle_mob(src)
 
 /mob/living/var/last_resist

--- a/html/changelogs/Arrow768-unbucklecuff.yml
+++ b/html/changelogs/Arrow768-unbucklecuff.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "If you resist while handcuffed and buckled to a chair you unbuckle and uncuff yourself at the same time."

--- a/html/changelogs/Arrow768-unbucklecuff.yml
+++ b/html/changelogs/Arrow768-unbucklecuff.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - tweak: "If you resist while handcuffed and buckled to a chair you unbuckle and uncuff yourself at the same time."
+  - tweak: "If you are on harm intent while removing your handcuffs, it only takes a minute to remove them but you dislocate your arm in the process."


### PR DESCRIPTION
If you are buckled and cuffed to a chair it now takes 60 seconds longer to unbuckle yourself, but you are uncuffed at the same time.

If you use harm intent, you can break out of your cuffs in around a minute, but you will dislocate one of our arms in the process.

Implements: https://forums.aurorastation.org/topic/11366-revert-bucklecuffing-taking-two-resists/