### PR TITLE
Bigger explosive implants

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -200,7 +200,7 @@ Implant Specifics:<BR>"}
 				explosion(get_turf(T), -1, 0, 1, 6)
 				T.gib()
 			if (elevel == "Full Explosion")
-				explosion(get_turf(T), 0, 1, 3, 6)
+				explosion_spread(get_turf(T), rand(8,13))
 				T.gib()
 
 		else
@@ -213,6 +213,15 @@ Implant Specifics:<BR>"}
 
 	if(t)
 		t.hotspot_expose(3500,125)
+
+/proc/explosion_spread(turf/epicenter, power, adminlog = 1, z_transfer = UP|DOWN)
+	var/datum/explosiondata/data = new
+	data.epicenter = epicenter
+	data.rec_pow = power
+	data.spreading = TRUE
+	data.adminlog = adminlog
+	data.z_transfer = z_transfer
+	SSexplosives.queue(data)
 
 /obj/item/weapon/implant/explosive/implanted(mob/source as mob)
 	elevel = alert("What sort of explosion would you prefer?", "Implant Intent", "Localized Limb", "Destroy Body", "Full Explosion")

--- a/html/changelogs/Arrow768-bigger-explosive-implants.yml
+++ b/html/changelogs/Arrow768-bigger-explosive-implants.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "The explosive implants have a increased yield potential."


### PR DESCRIPTION
Revives #5631 

> Due to how pathetic the explosive implants are when you actually set them to 'full explosion' I have tweaked them to actually pack a punch instead of just killing the person exploded and making people nearby get some blood on them.

> What this means:
> I have created a new proc for use in this. The full explosion now uses a variant of iterative explosions that has slightly more precision.

> Also, it has a variable strength, discouraging people from using it as anything more than a last ditch attack, because it's not reliably dangerous, just potentially. It's also very unlikely to kill, but it can hurt a lot. After 10 tests of experiencing a point-blank explosion, only once did it deal enough damage to floor me to the point of not being able to stand, but it does cause a lot of scary station damage.

> Since it uses iterative explosion method, too, the STRENGTH of the explosion doesn't actually directly relate to how much damage people nearby take. More power means they're more likely to take more damage, but there's a strong element of RNG.

https://forums.aurorastation.org/viewtopic.php?f=21&t=12269