### PR TITLE
Restrict telescience teleportation to station levels

### DIFF
--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -274,7 +274,7 @@
 		telefail()
 		temp_msg = "ERROR!<BR>Elevation is less than 1 or greater than 90."
 		return
-	if(z_co in !current_map.station_levels)
+	if(!(z_co in current_map.station_levels))
 		telefail()
 		temp_msg = "ERROR! Sector is invalid! Valid sectors are [english_list(current_map.station_levels)]."
 		return

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -274,9 +274,9 @@
 		telefail()
 		temp_msg = "ERROR!<BR>Elevation is less than 1 or greater than 90."
 		return
-	if(z_co in current_map.admin_levels)
+	if(z_co in !current_map.station_levels)
 		telefail()
-		temp_msg = "ERROR! Sector is invalid! Valid sectors are [english_list(current_map.player_levels)]."
+		temp_msg = "ERROR! Sector is invalid! Valid sectors are [english_list(current_map.station_levels)]."
 		return
 	if(teles_left > 0)
 		doteleport(user)

--- a/html/changelogs/albery-telescienceoof.yml
+++ b/html/changelogs/albery-telescienceoof.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Telescience teleportation can now only reach the station levels."


### PR DESCRIPTION
This pr restricts telescience teleportation to station levels, stopping people from easily raiding loot from other levels, like the derelict.