### PR TITLE
Power Insulated

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -132,7 +132,15 @@ var/list/possible_cable_coil_colours = list(
 	if(!T.can_have_cabling())
 		return
 
-	if(W.iswirecutter())
+	if(W.iswirecutter() || (W.sharp || W.edge))
+
+		if(!W.iswirecutter())
+			if(user.a_intent != I_HELP)
+				return
+
+			if(W.flags & CONDUCT)
+				shock(user, 50, 0.7)
+
 		if(d1 == 12 || d2 == 12)
 			user << "<span class='warning'>You must cut this cable from above.</span>"
 			return
@@ -181,10 +189,6 @@ var/list/possible_cable_coil_colours = list(
 			user << "<span class='warning'>The cable is not powered.</span>"
 
 		shock(user, 5, 0.2)
-
-	else
-		if (W.flags & CONDUCT)
-			shock(user, 50, 0.7)
 
 	src.add_fingerprint(user)
 

--- a/html/changelogs/menown.yml
+++ b/html/changelogs/menown.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: LordFowl
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "It is now no longer to be electrocuted by merely clicking an exposed power cable with something conductive."
+  - rscadd: "It is now possibly to sever a power cable by clicking on it with anything sharp or edgy. Doing so may electrocute you if that object is also conductive."


### PR DESCRIPTION
It is now no longer to electrocute yourself by merely clicking on an exposed power cable with an object that happens to be conductive. Power cables are now insulated.

It is now possible to sever cables with an object that is sharp or edgy by clicking on an exposed power cable with said object while on help intent (to alleviate potential misclicks while fighting in maint, which one assumes is normally done in harm intent.) If the sharp object is conductive you will electrocute yourself.

### IC changelog
In response to recent controversy regarding the untimely death of a NanoTrasen employee due to an electrical accident and as a result of long-standing allegations of purposefully employing shoddy construction materials in order to alleviate costs, NanoTrasen has conducted a general inspection of all infrastructural materials and found that the insulation used for cable arrays experiences severe degradation in zero-g environments, resulting in increasingly dangerous work environments over a rapid period of time due to periodic maintenance on the gravity generators aboard NanoTrasen vessels. In response to this research staff aboard the NSS Upsilon quickly derived a new cost-effective spray-based insulation coating that can be easily applied to existing infrastructure to reinforce and prevent further degradation. Thanks to this rapid development NanoTrasen has successfully reinforced over 80% of its infrastructure in a matter of days with very little credit loss. They assure that this will mitigate any future potential electrical incidents.