### PR TITLE
Removes possibility of industrial rigs spawning in the vault.

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1119,7 +1119,7 @@
 		/obj/item/weapon/rig/eva= 1,
 		/obj/item/weapon/rig/hazard = 1,
 		/obj/item/weapon/rig/hazmat = 1,
-		/obj/item/weapon/rig/medical = 1,
+		/obj/item/weapon/rig/medical = 1
 	)
 
 /obj/random/telecrystals

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1120,7 +1120,6 @@
 		/obj/item/weapon/rig/hazard = 1,
 		/obj/item/weapon/rig/hazmat = 1,
 		/obj/item/weapon/rig/medical = 1,
-		/obj/item/weapon/rig/industrial = 1
 	)
 
 /obj/random/telecrystals

--- a/html/changelogs/[ferner]-PR-[6056].yml
+++ b/html/changelogs/[ferner]-PR-[6056].yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: ferner
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - Tweak: : "Removes the possibility of industrial rigs spawning in the vault."

--- a/html/changelogs/[ferner]-PR-[6056].yml
+++ b/html/changelogs/[ferner]-PR-[6056].yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - Tweak: "Removes the possibility of industrial rigs spawning in the vault."
+  - tweak: "Removes the possibility of industrial rigs spawning in the vault."

--- a/html/changelogs/[ferner]-PR-[6056].yml
+++ b/html/changelogs/[ferner]-PR-[6056].yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - Tweak: : "Removes the possibility of industrial rigs spawning in the vault."
+  - Tweak: "Removes the possibility of industrial rigs spawning in the vault."


### PR DESCRIPTION
This removes industrial rigs from the random rig spawn rotation in the vault.
I don't think their limited value makes them fit having a chance of being in there, and they have little use to either crew, or antags for that matter.
