### PR TITLE
MASSIVE Nerf to Everyone, Especially Unathi and Vaurca

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -102,28 +102,28 @@
 
 
 /mob/living/carbon/human/adjustBruteLoss(var/amount)
-	amount *= brute_mod
 	if(amount > 0)
 		take_overall_damage(amount, 0)
+		amount *= brute_mod
 	else
 		heal_overall_damage(-amount, 0)
 	BITSET(hud_updateflag, HEALTH_HUD)
 
 /mob/living/carbon/human/adjustFireLoss(var/amount)
-	amount *= burn_mod
 	if(amount > 0)
 		take_overall_damage(0, amount)
+		amount *= burn_mod
 	else
 		heal_overall_damage(0, -amount)
 	BITSET(hud_updateflag, HEALTH_HUD)
 
 /mob/living/carbon/human/proc/adjustBruteLossByPart(var/amount, var/organ_name, var/obj/damage_source = null)
-	amount *= brute_mod
 	if (organ_name in organs_by_name)
 		var/obj/item/organ/external/O = get_organ(organ_name)
 
 		if(amount > 0)
 			O.take_damage(amount, 0, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
+			amount *= brute_mod
 		else
 			//if you don't want to heal robot organs, they you will have to check that yourself before using this proc.
 			O.heal_damage(-amount, 0, internal=0, robo_repair=(O.status & ORGAN_ROBOT))
@@ -131,12 +131,12 @@
 	BITSET(hud_updateflag, HEALTH_HUD)
 
 /mob/living/carbon/human/proc/adjustFireLossByPart(var/amount, var/organ_name, var/obj/damage_source = null)
-	amount *= burn_mod
 	if (organ_name in organs_by_name)
 		var/obj/item/organ/external/O = get_organ(organ_name)
 
 		if(amount > 0)
 			O.take_damage(0, amount, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
+			amount *= burn_mod
 		else
 			//if you don't want to heal robot organs, they you will have to check that yourself before using this proc.
 			O.heal_damage(0, -amount, internal=0, robo_repair=(O.status & ORGAN_ROBOT))
@@ -214,7 +214,9 @@
 	if(species.flags & NO_BREATHE)
 		oxyloss = 0
 	else
-		amount = amount*species.oxy_mod
+		if(amount > 0)
+			amount *= species.oxy_mod
+
 		if(getOxyLoss() + amount >=  abs(config.health_threshold_crit)) //start taking brain damage if they go into crit from oxyloss
 			adjustBrainLoss(amount,55) //this brain damage won't be lethal)
 		..(amount)
@@ -231,12 +233,11 @@
 	return ..()
 
 /mob/living/carbon/human/adjustToxLoss(var/amount)
-	if(species && species.toxins_mod)
-		amount = amount*species.toxins_mod
+	if(species && species.toxins_mod && amount > 0)
+		amount *= species.toxins_mod
 	if(species.flags & NO_POISON)
 		toxloss = 0
 	else
-		amount = amount*species.toxins_mod
 		..(amount)
 
 /mob/living/carbon/human/setToxLoss(var/amount)
@@ -423,12 +424,14 @@ This function restores all organs.
 	switch(damagetype)
 		if(BRUTE)
 			damageoverlaytemp = 20
-			damage = damage*species.brute_mod
+			if(damage > 0)
+				damage *= species.brute_mod
 			if(organ.take_damage(damage, 0, sharp, edge, used_weapon))
 				UpdateDamageIcon()
 		if(BURN)
 			damageoverlaytemp = 20
-			damage = damage*species.burn_mod
+			if(damage > 0)
+				damage *= species.burn_mod
 			if(organ.take_damage(0, damage, sharp, edge, used_weapon))
 				UpdateDamageIcon()
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -103,16 +103,16 @@
 
 /mob/living/carbon/human/adjustBruteLoss(var/amount)
 	if(amount > 0)
-		take_overall_damage(amount, 0)
 		amount *= brute_mod
+		take_overall_damage(amount, 0)
 	else
 		heal_overall_damage(-amount, 0)
 	BITSET(hud_updateflag, HEALTH_HUD)
 
 /mob/living/carbon/human/adjustFireLoss(var/amount)
 	if(amount > 0)
-		take_overall_damage(0, amount)
 		amount *= burn_mod
+		take_overall_damage(0, amount)
 	else
 		heal_overall_damage(0, -amount)
 	BITSET(hud_updateflag, HEALTH_HUD)
@@ -122,8 +122,8 @@
 		var/obj/item/organ/external/O = get_organ(organ_name)
 
 		if(amount > 0)
-			O.take_damage(amount, 0, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 			amount *= brute_mod
+			O.take_damage(amount, 0, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 		else
 			//if you don't want to heal robot organs, they you will have to check that yourself before using this proc.
 			O.heal_damage(-amount, 0, internal=0, robo_repair=(O.status & ORGAN_ROBOT))
@@ -135,8 +135,8 @@
 		var/obj/item/organ/external/O = get_organ(organ_name)
 
 		if(amount > 0)
-			O.take_damage(0, amount, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 			amount *= burn_mod
+			O.take_damage(0, amount, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 		else
 			//if you don't want to heal robot organs, they you will have to check that yourself before using this proc.
 			O.heal_damage(0, -amount, internal=0, robo_repair=(O.status & ORGAN_ROBOT))

--- a/html/changelogs/weakbones.yml
+++ b/html/changelogs/weakbones.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: LordFowl
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Damage mods now only apply to positive damage. Ie a species that takes 2x damage is no longer healed twice as much also."


### PR DESCRIPTION
- [x] Quantify the problem.
- [x] Analyze the solution.
- [x] Put the solution to code.
- [x] Think of ways to screw over Unathi and Vaurca.
- [x] Analyze if this effect applies to medicine.
- [x] Changelog.
- [x] Get Reviewed.

This PR represents a massive nerf to Unathi and Vaurca, along with some smaller nerfs to a variety of our other xenos. This is in an attempt to curb some pretty gross powercreep that has been occurring lately, and to bring them more in line with the humans so as to make the choice more mechanically meaningful and less obvious, allowing people to be motivated more by roleplay than powergaming. Don't believe me? Just watch.

How does this work? Well, this is in reality a bugfix, because powercreep is a bug, especially for the bugs. Essentially, there is a pretty big oversight in every damage proc except the radiation proc which means that a species' damage coefficient was applied to both positive AND negative values. In effect, if a species took 2x brute damage they also healed brute damage twice as much. This definitely impacted most magical, supernatural, and adminbus forms of healing, however I am also fairly certain that it applied to chemical and medical healing as well.

Where did this problem originate? I think I am actually to blame, back when I modified these procs so that brute mod was carried by the human mob and not just the species.