### PR TITLE
Fixing Jump To Mob(And admin proc too)

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -827,12 +827,12 @@
 	else if(href_list["adminplayerobservejump"])
 		if(!check_rights(R_MOD|R_ADMIN))	return
 		var/client/C = usr.client
-		var/mob_in = (input("Jump-to-Mob") as null|anything in getmobs())
+		var/mob/M = locate(href_list["adminplayerobservejump"])
 		if(!mob_in)
 			return
 		if(!isobserver(usr))	C.admin_ghost()
 		sleep(2)
-		C.jumptomob(mob_in)
+		C.jumptomob(M)
 
 	else if(href_list["check_antagonist"])
 		check_antagonists()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -826,13 +826,10 @@
 
 	else if(href_list["adminplayerobservejump"])
 		if(!check_rights(R_MOD|R_ADMIN))	return
-
-		var/mob/M = locate(href_list["adminplayerobservejump"])
-
 		var/client/C = usr.client
 		if(!isobserver(usr))	C.admin_ghost()
 		sleep(2)
-		C.jumptomob(M)
+		C.jumptomob()
 
 	else if(href_list["check_antagonist"])
 		check_antagonists()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -827,9 +827,12 @@
 	else if(href_list["adminplayerobservejump"])
 		if(!check_rights(R_MOD|R_ADMIN))	return
 		var/client/C = usr.client
+		var/mob_in = (input("Jump-to-Mob") as null|anything in getmobs())
+		if(!mob_in)
+			return
 		if(!isobserver(usr))	C.admin_ghost()
 		sleep(2)
-		C.jumptomob()
+		C.jumptomob(mob_in)
 
 	else if(href_list["check_antagonist"])
 		check_antagonists()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -827,9 +827,9 @@
 	else if(href_list["adminplayerobservejump"])
 		if(!check_rights(R_MOD|R_ADMIN))	return
 		var/client/C = usr.client
+
 		var/mob/M = locate(href_list["adminplayerobservejump"])
-		if(!mob_in)
-			return
+
 		if(!isobserver(usr))	C.admin_ghost()
 		sleep(2)
 		C.jumptomob(M)

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -36,7 +36,7 @@
 		alert("Admin jumping disabled")
 	return
 
-/client/proc/jumptomob(input in getmobs())
+/client/proc/jumptomob(var/mob_in)
 	set category = "Admin"
 	set name = "Jump to Mob"
 
@@ -44,7 +44,7 @@
 		return
 
 	if(config.allow_admin_jump)
-		var/target = getmobs()[input]
+		var/target = getmobs()[mob_in]
 		if(!target) return
 		log_admin("[key_name(usr)] jumped to [key_name(target)]", admin_key=key_name(usr),ckey=key_name(target))
 		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(target)]", 1)

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -36,21 +36,19 @@
 		alert("Admin jumping disabled")
 	return
 
-/client/proc/jumptomob(var/mob_in)
+/client/proc/jumptomob(var/mob/M in mob_list)
 	set category = "Admin"
-	set name = "Jump to Mob"
+	set name = "Jump to Mob Admin"
 
 	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV))
 		return
 
 	if(config.allow_admin_jump)
-		var/target = getmobs()[mob_in]
-		if(!target) return
 		log_admin("[key_name(usr)] jumped to [key_name(target)]", admin_key=key_name(usr),ckey=key_name(target))
 		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(target)]", 1)
 		if(src.mob)
 			var/mob/A = src.mob
-			var/turf/T = get_turf(target)
+			var/turf/T = get_turf(M)
 			if(isturf(T))
 				feedback_add_details("admin_verb","JM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 				A.on_mob_jump()

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -36,7 +36,7 @@
 		alert("Admin jumping disabled")
 	return
 
-/client/proc/jumptomob(var/mob/M in mob_list)
+/client/proc/jumptomob(input in getmobs())
 	set category = "Admin"
 	set name = "Jump to Mob"
 
@@ -44,11 +44,13 @@
 		return
 
 	if(config.allow_admin_jump)
-		log_admin("[key_name(usr)] jumped to [key_name(M)]",admin_key=key_name(usr),ckey=key_name(M))
-		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
+		var/target = getmobs()[input]
+		if(!target) return
+		log_admin("[key_name(usr)] jumped to [key_name(target)]", admin_key=key_name(usr),ckey=key_name(target))
+		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(target)]", 1)
 		if(src.mob)
 			var/mob/A = src.mob
-			var/turf/T = get_turf(M)
+			var/turf/T = get_turf(target)
 			if(isturf(T))
 				feedback_add_details("admin_verb","JM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 				A.on_mob_jump()

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -44,8 +44,8 @@
 		return
 
 	if(config.allow_admin_jump)
-		log_admin("[key_name(usr)] jumped to [key_name(target)]", admin_key=key_name(usr),ckey=key_name(target))
-		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(target)]", 1)
+		log_admin("[key_name(usr)] jumped to [key_name(M)]", admin_key=key_name(usr),ckey=key_name(M))
+		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
 		if(src.mob)
 			var/mob/A = src.mob
 			var/turf/T = get_turf(M)

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -379,24 +379,21 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	return (T && T.holy) && (invisibility <= SEE_INVISIBLE_LIVING || (mind in cult.current_antagonists))
 
-/mob/abstract/observer/verb/jumptomob(target in getmobs()) //Moves the ghost instead of just changing the ghosts's eye -Nodrak
+/mob/abstract/observer/verb/jumptomob(input in getmobs()) //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"
 	set name = "Jump to Mob"
 	set desc = "Teleport to a mob"
 
 	if(istype(usr, /mob/abstract/observer)) //Make sure they're an observer!
+		var/target = getmobs()[input]
+		if(!target) return
+		var/turf/T = get_turf(target) //Turf of the destination mob
 
-		if (!target)//Make sure we actually have a target
-			return
+		if(T && isturf(T))	//Make sure the turf exists, then move the source to that destination.
+			stop_following()
+			forceMove(T)
 		else
-			var/mob/M = getmobs()[target] //Destination mob
-			var/turf/T = get_turf(M) //Turf of the destination mob
-
-			if(T && isturf(T))	//Make sure the turf exists, then move the source to that destination.
-				stop_following()
-				forceMove(T)
-			else
-				to_chat(src, "This mob is not located in the game world.")
+			to_chat(src, "This mob is not located in the game world.")
 /*
 /mob/abstract/observer/verb/boo()
 	set category = "Ghost"

--- a/html/changelogs/Sindorman-jump.yml
+++ b/html/changelogs/Sindorman-jump.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Jump To Mob(and admin) now works properly and let's you jump to any mob in the world."
+  - tweak: "Jump to Mob(and admin) now display list format same way as Follow."

--- a/html/changelogs/Sindorman-jump.yml
+++ b/html/changelogs/Sindorman-jump.yml
@@ -38,5 +38,6 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - bugfix: "Jump To Mob(and admin) now works properly and let's you jump to any mob in the world."
-  - tweak: "Jump to Mob(and admin) now display list format same way as Follow."
+  - bugfix: "Jump To Mob now works properly and let's you jump to any mob in the world."
+  - tweak: "Jump to Mob now display list format same way as Follow."
+  - tweak: "Admin Jump to Mob was renamed, because byond confused with with player's Jump To Mob and was using it."


### PR DESCRIPTION
So I noticed that `Jump To Mob` proc of both observer and admin version is using wrong list, and it does not actually work on any mob because the mob it is looking for is of different format in the list.

- Fixes Jump To Mob for Ghost tab and Admin tab.

- Makes Jump To Mob use same list as Follow. Which makes it list things like `carp(2)` or if mob is dead or a ghost.

- Renames admin Jump To mob. Making admin panel use admin proc, instead of public.