### PR TITLE
Fire CO2 production fix. Upgrading SM's waste handling system.

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -156,7 +156,7 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 		icon_state = "1"
 		set_light(3, FIRE_LIGHT_1, no_update = TRUE)
 	
-	air_contents.adjust_gas("carbon_dioxide", air_contents.gas["carbon_dioxide"] + firelevel * 0.07)
+	air_contents.adjust_gas("carbon_dioxide", firelevel * 0.07)
 
 	for(var/mob/living/L in loc)
 		L.FireBurn(firelevel, air_contents.temperature, air_contents.return_pressure())  //Burn the mobs!

--- a/html/changelogs/Sindorman-sm.yml
+++ b/html/changelogs/Sindorman-sm.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - maptweak: "Due to recent change that makes fire produce CO2 SM waste handling system has been upgraded. It now has high volume pump to support high flow of waste. It also is connected to tha scrubbers network to dump waste directly into atmo's main filtering system. You can still use canisters if you want. Engineers are recommended to make waste system dump waste directly into scrubbers network for best result."
+  - maptweak: "Fire no longer produces CO2 exponetially. Now linearly."

--- a/html/changelogs/Sindorman-sm.yml
+++ b/html/changelogs/Sindorman-sm.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Due to recent change that makes fire produce CO2 SM waste handling system has been upgraded. It now has high volume pump to support high flow of waste. It also is connected to tha scrubbers network to dump waste directly into atmo's main filtering system. You can still use canisters if you want. Engineers are recommended to make waste system dump waste directly into scrubbers network for best result."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -5279,9 +5279,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "akm" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/black{
-	dir = 4
-	},
+/obj/machinery/atmospherics/binary/pump/high_power,
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "akn" = (
@@ -5299,8 +5297,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
@@ -5832,10 +5830,6 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/engine_room)
 "all" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	name = "Waste Pump"
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -5846,13 +5840,16 @@
 	req_access = null;
 	req_one_access = list(11,24)
 	},
+/obj/machinery/atmospherics/binary/pump/high_power{
+	icon_state = "map_off";
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "alm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 5
 	},
-/obj/machinery/meter,
 /obj/machinery/door/window/brigdoor/westleft{
 	dir = 1;
 	icon_state = "leftsecure";
@@ -5863,9 +5860,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "aln" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -5877,6 +5871,9 @@
 	req_access = null;
 	req_one_access = list(11,24)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "alo" = (
@@ -5886,6 +5883,10 @@
 	pixel_x = 24
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "alp" = (
@@ -65213,6 +65214,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/chemistry)
+"fUO" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/turf/simulated/floor/plating,
+/area/engineering/engine_waste)
 "fXR" = (
 /obj/structure/table/standard,
 /obj/item/clothing/head/beret/sec{
@@ -66148,6 +66153,12 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/research_port)
+"ljA" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_waste)
 "lnw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -80654,8 +80665,8 @@ aab
 ahi
 ahV
 aiQ
-ajC
 akl
+ajD
 all
 amn
 anw
@@ -80911,7 +80922,7 @@ aab
 ahi
 ahW
 aiR
-ajD
+fUO
 akm
 alm
 amo
@@ -81168,7 +81179,7 @@ aab
 ahi
 ahV
 aiS
-ajC
+ljA
 akn
 aln
 amo


### PR DESCRIPTION
This PR upgrade SM's waste handling system to be directly connected to the scrubber's network to dump waste into main atmo's filtering system. Due to recent change that makes fire produce CO2, so SM doesn't get overrun with CO2 using standard canister setup. Pump is also upgraded to high volume pump to support filter's max flow of 200. Fixes #6191

- Fire no longer produces CO2 exponentially (fire level * 0.07 * N^2), instead it produces it linearly (fire level * 0.07)