### PR TITLE
Rework spam protection

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -102,16 +102,6 @@
 	if (!message)
 		return
 
-	if (src.client)
-		if(client.prefs.muted & MUTE_IC)
-			to_chat(src, "You cannot send IC messages (muted).")
-			return
-		if (src.client.handle_spam_prevention(message,MUTE_IC))
-			return
-
-	friend_talk(message)
-
-/mob/abstract/mental/friend/proc/friend_talk(message)
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 
 	if(!message)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -26,9 +26,6 @@
 		if(!config.dooc_allowed && (mob.stat == DEAD))
 			to_chat(usr, "<span class='danger'>OOC for dead mobs has been turned off.</span>")
 			return
-		if(prefs.muted & MUTE_OOC)
-			to_chat(src, "<span class='danger'>You cannot use OOC (muted).</span>")
-			return
 		if(handle_spam_prevention(msg,MUTE_OOC))
 			return
 		if(findtext(msg, "byond://"))
@@ -96,9 +93,6 @@
 			return
 		if(!config.dooc_allowed && (mob.stat == DEAD))
 			to_chat(usr, "<span class='danger'>OOC for dead mobs has been turned off.</span>")
-			return
-		if(prefs.muted & MUTE_OOC)
-			to_chat(src, "<span class='danger'>You cannot use OOC (muted).</span>")
 			return
 		if(handle_spam_prevention(msg, MUTE_OOC))
 			return

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -70,11 +70,6 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 		to_chat(usr, "<span class='warning'>Speech is currently admin-disabled.</span>")
 		return
 
-	//handle muting and automuting
-	if(prefs.muted & MUTE_ADMINHELP)
-		to_chat(src, "<font color='red'>Error: Admin-PM: You cannot send adminhelps (Muted).</font>")
-		return
-
 	adminhelped = ADMINHELPED
 
 	if(src.handle_spam_prevention(msg,MUTE_ADMINHELP))

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -37,10 +37,6 @@
 //Fetching a message if needed. src is the sender and C is the target client
 
 /client/proc/cmd_admin_pm(var/client/C, var/msg = null, var/datum/ticket/ticket = null)
-	if(prefs.muted & MUTE_ADMINHELP)
-		to_chat(src, "<font color='red'>Error: Private-Message: You are unable to use PM-s (muted).</font>")
-		return
-
 	if(!istype(C,/client))
 		if(holder)	to_chat(src, "<font color='red'>Error: Private-Message: Client not found.</font>")
 		else		to_chat(src, "<font color='red'>Error: Private-Message: Client not found. They may have lost connection, so try using an adminhelp!</font>")

--- a/code/modules/admin/verbs/antag-ooc.dm
+++ b/code/modules/admin/verbs/antag-ooc.dm
@@ -7,8 +7,7 @@
 		to_chat(src, "<span class='warning'>You cannot use AOOC while ghosting/observing!</span>")
 		return
 
-	if (src.prefs.muted & MUTE_AOOC)
-		to_chat(src, "<span class='warning'>You are muted from speaking on AOOC!</span>")
+	if (handle_spam_prevention(msg, MUTE_AOOC))
 		return
 
 	msg = sanitize(msg)

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -5,11 +5,10 @@
 	if(!src.holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
+
 	if(!src.mob)
 		return
-	if(prefs.muted & MUTE_DEADCHAT)
-		to_chat(src, "<span class='danger'>You cannot send DSAY messages (muted).</span>")
-		return
+
 
 	if(!(prefs.toggles & CHAT_DEAD))
 		to_chat(src, "<span class='warning'>You have deadchat muted.</span>")

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -9,12 +9,8 @@
 	msg = sanitize(msg)
 	if(!msg)	return
 
-	if(usr.client)
-		if(usr.client.prefs.muted & MUTE_PRAY)
-			to_chat(usr, "<span class='warning'>You cannot pray (muted).</span>")
-			return
-		if(src.client.handle_spam_prevention(msg,MUTE_PRAY))
-			return
+	if(client && client.handle_spam_prevention(msg,MUTE_PRAY))
+		return
 
 	var/image/cross = image('icons/obj/storage.dmi',"bible")
 	msg = "<span class='notice'>\icon[cross] <b><font color=purple>PRAY: </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[src]'>SM</A>) ([admin_jump_link(src, src)]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>):</b> [msg]</span>"

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -249,14 +249,14 @@
 		return FALSE
 
 	if (config.macro_trigger && (REALTIMEOFDAY - last_message_time) < config.macro_trigger)
-		spam_alert = max(spam_alert + 1, 4)
+		spam_alert = min(spam_alert + 1, 4)
 		log_debug("SPAM_PROTECT: [src] tripped macro-trigger. Now at alert [spam_alert].")
 
-	if (spam_alert > 3 && !(prefs.muted & mute_type))
-		cmd_admin_mute(src.mob, mute_type, 1)
-		to_chat(src, "<span class='danger'>You have tripped the macro-trigger. An auto-mute was applied.</span>")
-		log_debug("SPAM_PROTECT: [src] tripped macro-trigger, now muted.")
-		return TRUE
+		if (spam_alert > 3 && !(prefs.muted & mute_type))
+			cmd_admin_mute(src.mob, mute_type, 1)
+			to_chat(src, "<span class='danger'>You have tripped the macro-trigger. An auto-mute was applied.</span>")
+			log_debug("SPAM_PROTECT: [src] tripped macro-trigger, now muted.")
+			return TRUE
 
 	spam_alert = max(0, spam_alert - 1)
 	return FALSE

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -273,13 +273,15 @@
 			to_chat(src, "<span class='danger'>You have exceeded the spam filter limit for identical messages. An auto-mute was applied.</span>")
 			cmd_admin_mute(mob, mute_type, 1)
 			log_debug("SPAM_PROTECT: [src] tripped duplicate message filter, now muted.")
+			last_message_count = 0
 			return TRUE
 		else if(last_message_count >= SPAM_TRIGGER_WARNING)
 			to_chat(src, "<span class='danger'>You are nearing the spam filter limit for identical messages.</span>")
 			log_debug("SPAM_PROTECT: [src] tripped duplicate message filter, now warned.")
 			return FALSE
+	else
+		last_message_count = 0
 
-	last_message_count = 0
 	return FALSE
 
 /client/proc/handle_spam_prevention(message, mute_type)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -287,7 +287,10 @@
 /client/proc/handle_spam_prevention(message, mute_type)
 	. = FALSE
 
-	if (config.automute_on && !holder && length(message))
+	if (prefs.muted & mute_type)
+		to_chat(src, "<span class='warning'>You are muted and cannot send messages.</span>")
+		. = TRUE
+	else if (config.automute_on && !holder && length(message))
 		. = . || automute_by_time(mute_type)
 
 		. = . || automute_by_duplicate(message, mute_type)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -244,37 +244,54 @@
 /proc/client_by_ckey(ckey)
 	return directory[ckey]
 
-/client/proc/handle_spam_prevention(var/message, var/mute_type)
-	if (config.automute_on && !holder && length(message))
-		if (last_message_time)
-			if (world.time - last_message_time < config.macro_trigger)
-				spam_alert++
-				if (spam_alert > 3)
-					if (!(prefs.muted & mute_type))
-						cmd_admin_mute(src.mob, mute_type, 1)
+/client/proc/automute_by_time(mute_type)
+	if (!last_message_time)
+		return FALSE
 
-					to_chat(src, "<span class='danger'>You have tripped the macro filter. An auto-mute was applied.</span>")
-					last_message_time = world.time
-					spam_alert = 4
-					return 1
-			else
-				spam_alert = max(0, spam_alert--)
+	if (config.macro_trigger && (REALTIMEOFDAY - last_message_time) < config.macro_trigger)
+		spam_alert = max(spam_alert + 1, 4)
+		log_debug("SPAM_PROTECT: [src] tripped macro-trigger. Now at alert [spam_alert].")
 
-		last_message_time = world.time
+	if (spam_alert > 3 && !(prefs.muted & mute_type))
+		cmd_admin_mute(src.mob, mute_type, 1)
+		to_chat(src, "<span class='danger'>You have tripped the macro-trigger. An auto-mute was applied.</span>")
+		log_debug("SPAM_PROTECT: [src] tripped macro-trigger, now muted.")
+		return TRUE
 
-		if(last_message == message)
-			last_message_count++
-			if(last_message_count >= SPAM_TRIGGER_AUTOMUTE)
-				to_chat(src, "<span class='danger'>You have exceeded the spam filter limit for identical messages. An auto-mute was applied.</span>")
-				cmd_admin_mute(src.mob, mute_type, 1)
-				return 1
-			if(last_message_count >= SPAM_TRIGGER_WARNING)
-				to_chat(src, "<span class='danger'>You are nearing the spam filter limit for identical messages.</span>")
-				return 0
+	spam_alert = max(0, spam_alert - 1)
+	return FALSE
 
-	last_message = message
+/client/proc/automute_by_duplicate(message, mute_type)
+	if (!last_message)
+		return FALSE
+
+	if (last_message == message)
+		last_message_count++
+		log_debug("SPAM_PROTECT: [src] tripped duplicate message filter. Last message count: [last_message_count]. Message: [message]")
+
+		if(last_message_count >= SPAM_TRIGGER_AUTOMUTE)
+			to_chat(src, "<span class='danger'>You have exceeded the spam filter limit for identical messages. An auto-mute was applied.</span>")
+			cmd_admin_mute(mob, mute_type, 1)
+			log_debug("SPAM_PROTECT: [src] tripped duplicate message filter, now muted.")
+			return TRUE
+		else if(last_message_count >= SPAM_TRIGGER_WARNING)
+			to_chat(src, "<span class='danger'>You are nearing the spam filter limit for identical messages.</span>")
+			log_debug("SPAM_PROTECT: [src] tripped duplicate message filter, now warned.")
+			return FALSE
+
 	last_message_count = 0
-	return 0
+	return FALSE
+
+/client/proc/handle_spam_prevention(message, mute_type)
+	. = FALSE
+
+	if (config.automute_on && !holder && length(message))
+		. = . || automute_by_time(mute_type)
+
+		. = . || automute_by_duplicate(message, mute_type)
+
+	last_message_time = REALTIMEOFDAY
+	last_message = message
 
 //This stops files larger than UPLOAD_LIMIT being sent from client to server via input(), client.Import() etc.
 /client/AllowUpload(filename, filelength)

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -8,13 +8,8 @@
 
 	message = sanitize(message)
 
-	if (src.client)
-		if (src.client.prefs.muted & MUTE_IC)
-			to_chat(src, "<span class='warning'>You cannot whisper (muted).</span>")
-			return
-
-		if (src.client.handle_spam_prevention(message,MUTE_IC))
-			return
+	if (client && client.handle_spam_prevention(message,MUTE_IC))
+		return
 
 	if (src.stat == 2)
 		return src.say_dead(message)

--- a/code/modules/mob/living/parasite/meme_captive.dm
+++ b/code/modules/mob/living/parasite/meme_captive.dm
@@ -4,12 +4,6 @@
 	universal_understand = 1
 
 /mob/living/parasite/captive_brain/say(var/message)
-
-	if (src.client)
-		if(client.prefs.muted & MUTE_IC)
-			to_chat(src, "<span class='warning'>You cannot speak in IC (muted).</span>")
-			return
-
 	if(istype(src.loc,/mob/living/parasite/meme))
 
 		message = sanitize(message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -154,12 +154,6 @@ proc/get_radio_key_from_channel(var/channel)
 	return verb
 
 /mob/living/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="")
-
-	if(client)
-		if(client.prefs.muted & MUTE_IC)
-			to_chat(src, "<span class='warning'>You cannot speak in IC (Muted).</span>")
-			return
-
 	if(stat)
 		if(stat == DEAD)
 			return say_dead(message)

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -1,10 +1,5 @@
 /mob/living/silicon/robot/drone/say(var/message)
 	if(local_transmit)
-		if (src.client)
-			if(client.prefs.muted & MUTE_IC)
-				to_chat(src, "You cannot send IC messages (muted).")
-				return 0
-
 		message = sanitize(message)
 
 		if (stat == 2)

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -4,12 +4,6 @@
 	universal_understand = 1
 
 /mob/living/captive_brain/say(var/message)
-
-	if (src.client)
-		if(client.prefs.muted & MUTE_IC)
-			to_chat(src, "<span class='danger'>You cannot speak in IC (muted).</span>")
-			return
-
 	if(istype(src.loc,/mob/living/simple_animal/borer))
 
 		message = sanitize(message)

--- a/code/modules/mob/living/simple_animal/borer/say.dm
+++ b/code/modules/mob/living/simple_animal/borer/say.dm
@@ -12,11 +12,6 @@
 	if (stat)
 		return
 
-	if (src.client)
-		if(client.prefs.muted & MUTE_IC)
-			to_chat(src, "<span class='danger'>You cannot speak in IC (muted).</span>")
-			return
-
 	if (copytext(message, 1, 2) == "*")
 		return emote(copytext(message, 2))
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -156,8 +156,10 @@
 //This is triggered when a mob steps on an NPC mouse, or manually by a playermouse
 /mob/living/simple_animal/mouse/proc/squeak(var/manual = 1)
 	if (stat == CONSCIOUS)
-		if (squeakcooldown > world.time) return
+		if (squeakcooldown > world.time)
+			return
 		squeakcooldown = world.time + 2 SECONDS
+
 		playsound(src, 'sound/effects/mousesqueek.ogg', 70, 1)
 		if (manual)
 			log_say("[key_name(src)] squeaks! ",ckey=key_name(src))
@@ -171,7 +173,9 @@
 		var/sound = pick(new_squeaks)
 
 		last_softsqueak = sound
-		if (squeakcooldown > world.time) return
+
+		if (squeakcooldown > world.time)
+			return
 
 		squeakcooldown = world.time + 2 SECONDS
 		playsound(src, sound, 5, 1, -4.6)
@@ -184,7 +188,9 @@
 //Triggered manually, when a mouse dies, or rarely when its stepped on
 /mob/living/simple_animal/mouse/proc/squeak_loud(var/manual = 0)
 	if (stat == CONSCIOUS)
-		if (squeakcooldown > world.time) return
+		if (squeakcooldown > world.time)
+			return
+
 		squeakcooldown = world.time + 4 SECONDS
 
 		if (squeals > 0 || !manual)
@@ -200,9 +206,7 @@
 	set name = "Squeal!"
 	set category = "Abilities"
 
-	if (usr.client.handle_spam_prevention(null, MUTE_IC))
-		return
-	else if (usr.client.prefs.muted & MUTE_IC)
+	if (usr.client.prefs.muted & MUTE_IC)
 		to_chat(usr, "<span class='danger'>You are muted from IC emotes.</span>")
 		return
 
@@ -212,9 +216,7 @@
 	set name = "Soft Squeaking"
 	set category = "Abilities"
 
-	if (usr.client.handle_spam_prevention(null, MUTE_IC))
-		return
-	else if (usr.client.prefs.muted & MUTE_IC)
+	if (usr.client.prefs.muted & MUTE_IC)
 		to_chat(usr, "<span class='danger'>You are muted from IC emotes.</span>")
 		return
 
@@ -224,9 +226,7 @@
 	set name = "Squeak"
 	set category = "Abilities"
 
-	if (usr.client.handle_spam_prevention(null, MUTE_IC))
-		return
-	else if (usr.client.prefs.muted & MUTE_IC)
+	if (usr.client.prefs.muted & MUTE_IC)
 		to_chat(usr, "<span class='danger'>You are muted from IC emotes.</span>")
 		return
 

--- a/html/changelogs/skull132-automutes.yml
+++ b/html/changelogs/skull132-automutes.yml
@@ -1,0 +1,6 @@
+author: Skull132
+
+delete-after: True
+
+changes:
+  - bugfix: "Imaginary friends are no longer auto-muted after saying shit."


### PR DESCRIPTION
* Makes the trail a little more obvious to follow.
* Adds (temporary) debug logging.
* fixes the issue of spam protection kicking in due to dependence on ingame time, which gets dilated due to cases of lag
* Fixes #4454
* Closes #5103 (invalidated)
* **High risk:** Removes unnecessary checks against client prefs.muted. Rationale: lower level procs (`mob/proc/say` and its overrides specifically) should not worry about the user being muted. Their access points (`mob/verb/say_verb`) should do that instead. This makes overriding code easier, since you don't have to worry about checking for mutes everywhere.