### PR TITLE
Allowing AI to play music in an area via intercomms

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -1,5 +1,3 @@
-var/list/intercomm_list = list()
-
 /obj/item/device/radio/intercom
 	name = "station intercom (General)"
 	desc = "Talk through this."
@@ -49,7 +47,6 @@ var/list/intercomm_list = list()
 /obj/item/device/radio/intercom/Initialize()
 	. = ..()
 	power_interface = new(loc, src)
-	intercomm_list += src
 
 /obj/item/device/radio/intercom/department/medbay/Initialize()
 	. = ..()
@@ -93,7 +90,6 @@ var/list/intercomm_list = list()
 
 /obj/item/device/radio/intercom/Destroy()
 	QDEL_NULL(power_interface)
-	intercomm_list -= src
 	return ..()
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -1,3 +1,5 @@
+var/list/intercomm_list = list()
+
 /obj/item/device/radio/intercom
 	name = "station intercom (General)"
 	desc = "Talk through this."
@@ -47,6 +49,7 @@
 /obj/item/device/radio/intercom/Initialize()
 	. = ..()
 	power_interface = new(loc, src)
+	intercomm_list += src
 
 /obj/item/device/radio/intercom/department/medbay/Initialize()
 	. = ..()
@@ -90,6 +93,7 @@
 
 /obj/item/device/radio/intercom/Destroy()
 	QDEL_NULL(power_interface)
+	intercomm_list -= src
 	return ..()
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -177,6 +177,8 @@ var/global/list/default_medbay_channels = list(
 
 /obj/item/device/radio/proc/ToggleReception()
 	listening = !listening && !(wires.IsIndexCut(WIRE_RECEIVE) || wires.IsIndexCut(WIRE_SIGNAL))
+	if(!listening)
+		playsound(src, null)
 
 /obj/item/device/radio/CanUseTopic()
 	if(!on)
@@ -214,7 +216,6 @@ var/global/list/default_medbay_channels = list(
 		else
 			if (channels[chan_name] & FREQ_LISTENING)
 				channels[chan_name] &= ~FREQ_LISTENING
-				playsound(src.loc, null)
 			else
 				channels[chan_name] |= FREQ_LISTENING
 		. = 1

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -178,7 +178,7 @@ var/global/list/default_medbay_channels = list(
 /obj/item/device/radio/proc/ToggleReception()
 	listening = !listening && !(wires.IsIndexCut(WIRE_RECEIVE) || wires.IsIndexCut(WIRE_SIGNAL))
 	if(!listening)
-		playsound(src, null)
+		playsound(src, null, ai_music_channel)
 
 /obj/item/device/radio/CanUseTopic()
 	if(!on)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -178,7 +178,7 @@ var/global/list/default_medbay_channels = list(
 /obj/item/device/radio/proc/ToggleReception()
 	listening = !listening && !(wires.IsIndexCut(WIRE_RECEIVE) || wires.IsIndexCut(WIRE_SIGNAL))
 	if(!listening)
-		playsound(src, null, channel = ai_music_channel)
+		playsound(src, null, 100, channel = ai_music_channel, status = SOUND_MUTE)
 
 /obj/item/device/radio/CanUseTopic()
 	if(!on)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -178,7 +178,7 @@ var/global/list/default_medbay_channels = list(
 /obj/item/device/radio/proc/ToggleReception()
 	listening = !listening && !(wires.IsIndexCut(WIRE_RECEIVE) || wires.IsIndexCut(WIRE_SIGNAL))
 	if(!listening)
-		playsound(src, null, ai_music_channel)
+		playsound(src, null, channel = ai_music_channel)
 
 /obj/item/device/radio/CanUseTopic()
 	if(!on)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -214,6 +214,7 @@ var/global/list/default_medbay_channels = list(
 		else
 			if (channels[chan_name] & FREQ_LISTENING)
 				channels[chan_name] &= ~FREQ_LISTENING
+				playsound(src.loc, null)
 			else
 				channels[chan_name] |= FREQ_LISTENING
 		. = 1

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -168,7 +168,7 @@ var/list/footstepfx = list("defaultstep","concretestep","grassstep","dirtstep","
 
 //var/list/gun_sound = list('sound/weapons/gunshot/gunshot1.ogg', 'sound/weapons/gunshot/gunshot2.ogg','sound/weapons/gunshot/gunshot3.ogg','sound/weapons/gunshot/gunshot4.ogg')
 
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, is_global, usepressure = 1, environment = -1, required_preferences = 0, required_asfx_toggles = 0)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, is_global, usepressure = 1, environment = -1, required_preferences = 0, required_asfx_toggles = 0, var/channel = 0)
 	if (istext(soundin))
 		soundin = get_sfx(soundin) // same sound for everyone
 	else if (isarea(source))
@@ -200,9 +200,9 @@ var/list/footstepfx = list("defaultstep","concretestep","grassstep","dirtstep","
 			if (required_asfx_toggles && (M.client.prefs.asfx_togs & required_asfx_toggles) != required_asfx_toggles)
 				continue
 
-			M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global, usepressure, environment, S)
+			M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global, usepressure, environment, S, channel)
 
-/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global, usepressure = 1, environment = -1, sound/S)
+/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global, usepressure = 1, environment = -1, sound/S, var/channel = 0)
 	if(!client || ear_deaf > 0)
 		return 0
 
@@ -210,7 +210,7 @@ var/list/footstepfx = list("defaultstep","concretestep","grassstep","dirtstep","
 		S = sound(get_sfx(soundin))
 
 	S.wait = 0 //No queue
-	S.channel = 0 //Any channel
+	S.channel = channel
 	S.environment = environment
 
 	if (vary)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -166,9 +166,8 @@ var/list/pickaxesounds = list(
 
 var/list/footstepfx = list("defaultstep","concretestep","grassstep","dirtstep","waterstep","sandstep", "gravelstep")
 
-//var/list/gun_sound = list('sound/weapons/gunshot/gunshot1.ogg', 'sound/weapons/gunshot/gunshot2.ogg','sound/weapons/gunshot/gunshot3.ogg','sound/weapons/gunshot/gunshot4.ogg')
 
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, is_global, usepressure = 1, environment = -1, required_preferences = 0, required_asfx_toggles = 0, var/channel = 0)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, is_global, usepressure = 1, environment = -1, required_preferences = 0, required_asfx_toggles = 0, var/channel = 0, var/status)
 	if (istext(soundin))
 		soundin = get_sfx(soundin) // same sound for everyone
 	else if (isarea(source))
@@ -199,10 +198,9 @@ var/list/footstepfx = list("defaultstep","concretestep","grassstep","dirtstep","
 
 			if (required_asfx_toggles && (M.client.prefs.asfx_togs & required_asfx_toggles) != required_asfx_toggles)
 				continue
+			M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global, usepressure, environment, S, channel, status)
 
-			M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global, usepressure, environment, S, channel)
-
-/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global, usepressure = 1, environment = -1, sound/S, var/channel = 0)
+/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global, usepressure = 1, environment = -1, sound/S, var/channel = 0, var/status)
 	if(!client || ear_deaf > 0)
 		return 0
 
@@ -212,6 +210,7 @@ var/list/footstepfx = list("defaultstep","concretestep","grassstep","dirtstep","
 	S.wait = 0 //No queue
 	S.channel = channel
 	S.environment = environment
+	S.status = status
 
 	if (vary)
 		if(frequency)
@@ -296,7 +295,7 @@ var/list/footstepfx = list("defaultstep","concretestep","grassstep","dirtstep","
 /client/proc/playtitlemusic()
 	if(!SSticker.login_music)	return
 	if(prefs.toggles & SOUND_LOBBY)
-		src << sound(SSticker.login_music, repeat = 0, wait = 0, volume = 85, channel = 1) // MAD JAMS)
+		sound_to(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = 85, channel = 1)) // MAD JAMS)
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.

--- a/code/modules/mob/abstract/freelook/ai/eye.dm
+++ b/code/modules/mob/abstract/freelook/ai/eye.dm
@@ -97,3 +97,29 @@
 
 	eyeobj.acceleration = !eyeobj.acceleration
 	to_chat(usr, "Camera acceleration has been toggled [eyeobj.acceleration ? "on" : "off"].")
+
+/mob/living/silicon/ai/proc/play_sound()
+	set category = "AI Commands"
+	set name = "Play Music In The Area"
+
+	var/delay = world.time - time_music
+	if(delay < 3000)
+		delay \= 10
+		to_chat(src, "<span class='warning'>You have played music recently, you have to wait [(round(delay/60) > 0) ? ("[round(delay/60)] minutes") : ("[delay] seconds") ]</span>")
+		return
+	var/list/sounds = file2list("sound/serversound_list.txt");
+	sounds += "--CANCEL--"
+	sounds += sounds_cache
+
+	var/melody = input("Select a sound from the server to play", "Server sound list", "--CANCEL--") in sounds
+
+	if(melody == "--CANCEL--")	return
+
+	log_admin("[key_name(src)] played sound [melody]",admin_key=key_name(src))
+	message_admins("[key_name_admin(src)] played sound [melody]", 1)
+	var/area/A = get_area(eyeobj.loc)
+	for(var/obj/item/device/radio/intercom/i in A)
+		playsound(i.loc, melody, 40, 0)
+	time_music = world.time
+
+	feedback_add_details("admin_verb","PGS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/abstract/freelook/ai/eye.dm
+++ b/code/modules/mob/abstract/freelook/ai/eye.dm
@@ -115,9 +115,12 @@
 
 	if(melody == "--CANCEL--")	return
 
-	log_admin("[key_name(src)] played sound [melody]",admin_key=key_name(src))
-	message_admins("[key_name_admin(src)] played sound [melody]", 1)
 	var/area/A = get_area(eyeobj.loc)
+	if(!A) return
+
+	log_admin("[key_name(src)] played sound [melody] in [A]", admin_key=key_name(src))
+	message_admins("[key_name_admin(src)] played sound [melody] in [A]", 1)
+
 	for(var/obj/item/device/radio/intercom/i in A)
 		playsound(i.loc, melody, 40, 0)
 	time_music = world.time

--- a/code/modules/mob/abstract/freelook/ai/eye.dm
+++ b/code/modules/mob/abstract/freelook/ai/eye.dm
@@ -104,10 +104,10 @@ var/ai_music_channel = 0 // Storing on which channel does AI plays music
 	set category = "AI Commands"
 	set name = "Play Music In The Area"
 
-	var/delay = world.time - time_music
-	if(delay < 3000)
-		delay \= 10
-		to_chat(src, "<span class='warning'>You have played music recently, you have to wait [(round(delay/60) > 0) ? ("[round(delay/60)] minutes") : ("[delay] seconds") ]</span>")
+	var/music_delay = world.time - time_music
+	if(music_delay < 3000)
+		music_delay \= 10
+		to_chat(src, "<span class='warning'>You have played music recently, you have to wait [(round(music_delay/60) > 0) ? ("[5 - round(music_delay/60)] minutes") : ("[300 - music_delay] seconds") ]</span>")
 		return
 	var/list/sounds = file2list("sound/serversound_list.txt");
 	sounds += sounds_cache
@@ -127,7 +127,7 @@ var/ai_music_channel = 0 // Storing on which channel does AI plays music
 	ai_music_channel = pick(1, 8) // Hope we won't stop some other sound
 	for(var/obj/item/device/radio/intercom/i in played_area)
 		i.listening = TRUE
-		playsound(i, melody, channel = ai_music_channel, 60, 0)
+		playsound(i, melody, 60, 0, channel = ai_music_channel)
 		CHECK_TICK
 	time_music = world.time
 

--- a/code/modules/mob/abstract/freelook/ai/eye.dm
+++ b/code/modules/mob/abstract/freelook/ai/eye.dm
@@ -3,6 +3,8 @@
 // A mob that the AI controls to look around the station with.
 // It streams chunks as it moves around, which will show it what the AI can and cannot see.
 
+var/ai_music_channel = 0 // Storing on which channel does AI plays music
+
 /mob/abstract/eye/aiEye
 	name = "Inactive AI Eye"
 	icon_state = "AI-eye"
@@ -122,9 +124,10 @@
 	log_game("[key_name(src)] played sound [melody] in [played_area]", admin_key=key_name(src))
 	message_admins("[key_name_admin(src)] played sound [melody] in [played_area]", 1)
 
+	ai_music_channel = pick(1, 8) // Hope we won't stop some other sound
 	for(var/obj/item/device/radio/intercom/i in played_area)
 		i.listening = TRUE
-		playsound(i, melody, 60, 0)
+		playsound(i, melody, channel = ai_music_channel, 60, 0)
 		CHECK_TICK
 	time_music = world.time
 
@@ -134,6 +137,6 @@
 	if(!played_area) return
 
 	for(var/obj/item/device/radio/intercom/i in played_area)
-		playsound(i, null)
+		playsound(i, null, channel = ai_music_channel)
 		CHECK_TICK
 	

--- a/code/modules/mob/abstract/freelook/ai/eye.dm
+++ b/code/modules/mob/abstract/freelook/ai/eye.dm
@@ -137,6 +137,6 @@ var/ai_music_channel = 0 // Storing on which channel does AI plays music
 	if(!played_area) return
 
 	for(var/obj/item/device/radio/intercom/i in played_area)
-		playsound(i, null, channel = ai_music_channel)
+		playsound(i, null, 100, channel = ai_music_channel, status = SOUND_MUTE)
 		CHECK_TICK
 	

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -3,6 +3,7 @@
 
 /mob/living/silicon/ai
 	var/time_music = -3000
+	var/area/played_area = null
 
 var/list/ai_list = list()
 var/list/ai_verbs_default = list(
@@ -30,7 +31,8 @@ var/list/ai_verbs_default = list(
 	/mob/living/silicon/ai/proc/ai_examine,
 	/mob/living/silicon/ai/proc/multitool_mode,
 	/mob/living/silicon/ai/proc/toggle_hologram_movement,
-	/mob/living/silicon/ai/proc/play_sound
+	/mob/living/silicon/ai/proc/play_sound,
+	/mob/living/silicon/ai/proc/cancel_sound
 )
 
 //Not sure why this is necessary...

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1,6 +1,9 @@
 #define AI_CHECK_WIRELESS 1
 #define AI_CHECK_RADIO 2
 
+/mob/living/silicon/ai
+	var/time_music = -3000
+
 var/list/ai_list = list()
 var/list/ai_verbs_default = list(
 	/mob/living/silicon/ai/proc/ai_announcement,
@@ -26,7 +29,8 @@ var/list/ai_verbs_default = list(
 	/mob/living/silicon/ai/proc/toggle_camera_light,
 	/mob/living/silicon/ai/proc/ai_examine,
 	/mob/living/silicon/ai/proc/multitool_mode,
-	/mob/living/silicon/ai/proc/toggle_hologram_movement
+	/mob/living/silicon/ai/proc/toggle_hologram_movement,
+	/mob/living/silicon/ai/proc/play_sound
 )
 
 //Not sure why this is necessary...

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -63,6 +63,7 @@
 
 
 /obj/machinery/power/rtg/advanced
+	name = "advanced radioisotope thermoelectric generator"
 	desc = "An advanced RTG capable of moderating isotope decay, increasing power output but reducing lifetime. It uses phoron-fueled radiation collectors to increase output even further."
 	power_gen = 1250 // 2500 on T1, 10000 on T4.
 
@@ -75,6 +76,19 @@
 		/obj/item/weapon/circuitboard/rtg/advanced
 	)
 
+/obj/machinery/power/rtg/advanced/experimental
+	name = "experimental radioisotope thermoelectric generator"
+	desc = "An experimental RTG capable of moderating isotope decay, increasing power output but reducing lifetime. It uses special phoron infused radiation collectors to increase output drastically."
+	power_gen = 4200
+
+	component_types = list(
+		/obj/item/stack/cable_coil{amount = 5},
+		/obj/item/weapon/stock_parts/capacitor/super,
+		/obj/item/weapon/stock_parts/micro_laser/ultra,
+		/obj/item/stack/material/uranium{amount = 10},
+		/obj/item/stack/material/phoron{amount = 5},
+		/obj/item/weapon/circuitboard/rtg/advanced
+	)
 
 /obj/item/weapon/circuitboard/rtg
 	name = T_BOARD("radioisotope thermoelectric generator")

--- a/maps/runtime/runtime-1.dmm
+++ b/maps/runtime/runtime-1.dmm
@@ -21,7 +21,6 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/atmos)
 "ag" = (
-/obj/machinery/power/rtg/advanced,
 /obj/structure/cable{
 	icon_state = "0-2";
 	d2 = 2
@@ -35,6 +34,10 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/power/rtg/advanced{
+	name = "Experimental radioisotope thermoelectric generator";
+	power_gen = 25000
 	},
 /turf/simulated/floor/airless,
 /area/template_noop)
@@ -122,9 +125,11 @@
 /obj/machinery/power/smes/buildable{
 	charge = 1e+006;
 	input_attempt = 1;
-	input_level = 150000;
+	input_level = 250000;
+	input_level_max = 250000;
 	output_attempt = 1;
-	output_level = 150000
+	output_level = 150000;
+	output_level_max = 250000
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
@@ -181,7 +186,10 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "ay" = (
-/obj/machinery/power/rtg/advanced,
+/obj/machinery/power/rtg/advanced{
+	name = "Experimental radioisotope thermoelectric generator";
+	power_gen = 25000
+	},
 /obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4
@@ -411,7 +419,6 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "aZ" = (
-/obj/machinery/power/rtg/advanced,
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -420,6 +427,10 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/power/rtg/advanced{
+	name = "Experimental radioisotope thermoelectric generator";
+	power_gen = 25000
 	},
 /turf/simulated/floor/airless,
 /area/template_noop)
@@ -1436,6 +1447,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"pt" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/rtg/advanced{
+	name = "Experimental radioisotope thermoelectric generator";
+	power_gen = 25000
+	},
+/turf/simulated/floor/airless,
+/area/template_noop)
 "pX" = (
 /obj/structure/cable{
 	d1 = 16;
@@ -1447,10 +1469,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
 "ss" = (
-/obj/machinery/power/rtg/advanced,
 /obj/structure/cable{
 	icon_state = "0-8";
 	d2 = 8
+	},
+/obj/machinery/power/rtg/advanced{
+	name = "Experimental radioisotope thermoelectric generator";
+	power_gen = 25000
 	},
 /turf/simulated/floor/airless,
 /area/template_noop)
@@ -2623,10 +2648,10 @@ aa
 ad
 ab
 ay
-ay
-ay
-ay
-ay
+pt
+pt
+pt
+pt
 ab
 bs
 bE

--- a/maps/runtime/runtime-1.dmm
+++ b/maps/runtime/runtime-1.dmm
@@ -26,6 +26,16 @@
 	icon_state = "0-2";
 	d2 = 2
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/airless,
 /area/template_noop)
 "ah" = (
@@ -47,15 +57,6 @@
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"al" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/template_noop,
-/area/template_noop)
 "am" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -67,6 +68,11 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -116,7 +122,9 @@
 /obj/machinery/power/smes/buildable{
 	charge = 1e+006;
 	input_attempt = 1;
-	output_attempt = 1
+	input_level = 150000;
+	output_attempt = 1;
+	output_level = 150000
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
@@ -297,15 +305,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"aM" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/template_noop,
-/area/template_noop)
 "aN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -315,6 +314,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -409,6 +413,14 @@
 "aZ" = (
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/airless,
 /area/template_noop)
 "ba" = (
@@ -471,6 +483,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
+/obj/machinery/camera/network/command{
+	c_tag = "Level 1 - Atmospherics";
+	dir = 1;
+	network = list("Engineering")
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "bj" = (
@@ -491,6 +508,11 @@
 /obj/item/weapon/screwdriver,
 /obj/item/weapon/wirecutters,
 /obj/structure/table/standard,
+/obj/machinery/camera/network/command{
+	c_tag = "Level 1 - TEGS Control Room";
+	dir = 1;
+	network = list("Engineering")
+	},
 /turf/simulated/floor/plating,
 /area/engineering)
 "bm" = (
@@ -503,6 +525,11 @@
 "bn" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Level 1 - Gravity Gen";
+	dir = 1;
+	network = list("Engineering")
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
@@ -1073,6 +1100,11 @@
 	dir = 8
 	},
 /obj/structure/table/standard,
+/obj/machinery/camera/network/command{
+	c_tag = "Level 1 - Auxillary Room";
+	dir = 1;
+	network = list("Civillian")
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry)
 "cI" = (
@@ -1350,6 +1382,11 @@
 /obj/item/weapon/material/twohanded/fireaxe,
 /obj/item/weapon/extinguisher,
 /obj/structure/table/standard,
+/obj/machinery/camera/network/command{
+	c_tag = "Level 1 - Main Room";
+	dir = 1;
+	network = list("Civillian")
+	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "dB" = (
@@ -1371,35 +1408,15 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
-"ie" = (
-/obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"ga" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/camera/network/command{
+	c_tag = "Level 1 - Stairs";
+	network = list("Civillian")
 	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/central_one)
-"jf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/r_wall,
-/area/engineering/gravity_gen)
-"ob" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
-"pX" = (
+/turf/simulated/floor/tiled,
+/area/construction)
+"iN" = (
 /obj/structure/cable{
 	d1 = 16;
 	d2 = 0;
@@ -1409,35 +1426,29 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
-"Bd" = (
+"jf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/engineering/gravity_gen)
+"kO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/construction)
-"Go" = (
+"tf" = (
+/obj/machinery/power/rtg/advanced,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-8";
+	d2 = 8
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
-"HB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
-"HJ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
-"HK" = (
+/turf/simulated/floor/airless,
+/area/template_noop)
+"uE" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -1449,7 +1460,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction)
-"TP" = (
+"vh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"vN" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -1458,6 +1477,57 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction)
+"xu" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"AL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"BZ" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/central_one)
+"EW" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Level 1 - Main hallway";
+	dir = 1;
+	network = list("Civillian")
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"Kt" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"Xj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera/network/command{
+	c_tag = "Level 1 - Main hallway 2";
+	dir = 1;
+	network = list("Civillian")
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 
 (1,1,1) = {"
 aa
@@ -2074,15 +2144,15 @@ ae
 ae
 ae
 bw
-HJ
-Go
-Go
-Go
-Go
-ob
-Go
-pX
-HB
+Kt
+vh
+vh
+vh
+vh
+xu
+vh
+iN
+AL
 ae
 ae
 ae
@@ -2128,7 +2198,7 @@ af
 af
 af
 bx
-ie
+BZ
 bV
 bV
 bV
@@ -2136,7 +2206,7 @@ bV
 bx
 cK
 cK
-Bd
+kO
 cK
 cK
 cK
@@ -2190,8 +2260,8 @@ bK
 bK
 cL
 cT
-HK
-TP
+uE
+vN
 di
 di
 di
@@ -2241,7 +2311,7 @@ bJ
 bJ
 bz
 bJ
-bJ
+Xj
 cM
 cU
 de
@@ -2552,11 +2622,11 @@ ab
 aa
 ad
 ab
-ag
-al
 ay
-aM
-aZ
+ay
+ay
+ay
+ay
 ab
 bs
 bE
@@ -2621,7 +2691,7 @@ cA
 bB
 bB
 cK
-cV
+ga
 de
 de
 de
@@ -2660,11 +2730,11 @@ ab
 aa
 ad
 ab
-ab
-ab
+tf
+tf
 aA
-ab
-ab
+tf
+tf
 ab
 bs
 bF
@@ -2997,7 +3067,7 @@ bB
 bB
 cx
 bB
-bB
+EW
 cP
 cZ
 cZ

--- a/maps/runtime/runtime-1.dmm
+++ b/maps/runtime/runtime-1.dmm
@@ -35,10 +35,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/power/rtg/advanced{
-	name = "Experimental radioisotope thermoelectric generator";
-	power_gen = 25000
-	},
+/obj/machinery/power/rtg/advanced/experimental,
 /turf/simulated/floor/airless,
 /area/template_noop)
 "ah" = (
@@ -186,14 +183,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "ay" = (
-/obj/machinery/power/rtg/advanced{
-	name = "Experimental radioisotope thermoelectric generator";
-	power_gen = 25000
-	},
 /obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4
 	},
+/obj/machinery/power/rtg/advanced/experimental,
 /turf/simulated/floor/airless,
 /area/template_noop)
 "az" = (
@@ -428,10 +422,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/power/rtg/advanced{
-	name = "Experimental radioisotope thermoelectric generator";
-	power_gen = 25000
-	},
+/obj/machinery/power/rtg/advanced/experimental,
 /turf/simulated/floor/airless,
 /area/template_noop)
 "ba" = (
@@ -1447,17 +1438,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
-"pt" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/rtg/advanced{
-	name = "Experimental radioisotope thermoelectric generator";
-	power_gen = 25000
-	},
-/turf/simulated/floor/airless,
-/area/template_noop)
 "pX" = (
 /obj/structure/cable{
 	d1 = 16;
@@ -1485,6 +1465,14 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/construction)
+"Bn" = (
+/obj/structure/cable{
+	icon_state = "0-8";
+	d2 = 8
+	},
+/obj/machinery/power/rtg/advanced/experimental,
+/turf/simulated/floor/airless,
+/area/template_noop)
 "Go" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2648,10 +2636,10 @@ aa
 ad
 ab
 ay
-pt
-pt
-pt
-pt
+ay
+ay
+ay
+ay
 ab
 bs
 bE
@@ -2755,11 +2743,11 @@ ab
 aa
 ad
 ab
-ss
+Bn
 ss
 aA
-ss
-ss
+Bn
+Bn
 ab
 bs
 bF

--- a/maps/runtime/runtime-1.dmm
+++ b/maps/runtime/runtime-1.dmm
@@ -1408,15 +1408,35 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
-"ga" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/camera/network/command{
-	c_tag = "Level 1 - Stairs";
-	network = list("Civillian")
+"ie" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/construction)
-"iN" = (
+/turf/simulated/floor/plating,
+/area/hallway/primary/central_one)
+"jf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/engineering/gravity_gen)
+"ob" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"pX" = (
 /obj/structure/cable{
 	d1 = 16;
 	d2 = 0;
@@ -1426,21 +1446,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
-"jf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/r_wall,
-/area/engineering/gravity_gen)
-"kO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/construction)
-"tf" = (
+"ss" = (
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable{
 	icon_state = "0-8";
@@ -1448,7 +1454,35 @@
 	},
 /turf/simulated/floor/airless,
 /area/template_noop)
-"uE" = (
+"Bd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/construction)
+"Go" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"HB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"HJ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
+"HK" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -1460,50 +1494,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction)
-"vh" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
-"vN" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
+"Jp" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/camera/network/command{
+	c_tag = "Level 1 - Stairs";
+	network = list("Civillian")
 	},
 /turf/simulated/floor/tiled,
 /area/construction)
-"xu" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
-"AL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
-"BZ" = (
-/obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/central_one)
-"EW" = (
+"NX" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Level 1 - Main hallway";
 	dir = 1;
@@ -1511,15 +1510,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"Kt" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
-"Xj" = (
+"Pm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera/network/command{
 	c_tag = "Level 1 - Main hallway 2";
@@ -1528,6 +1519,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
+"TP" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/construction)
 
 (1,1,1) = {"
 aa
@@ -2144,15 +2144,15 @@ ae
 ae
 ae
 bw
-Kt
-vh
-vh
-vh
-vh
-xu
-vh
-iN
-AL
+HJ
+Go
+Go
+Go
+Go
+ob
+Go
+pX
+HB
 ae
 ae
 ae
@@ -2198,7 +2198,7 @@ af
 af
 af
 bx
-BZ
+ie
 bV
 bV
 bV
@@ -2206,7 +2206,7 @@ bV
 bx
 cK
 cK
-kO
+Bd
 cK
 cK
 cK
@@ -2260,8 +2260,8 @@ bK
 bK
 cL
 cT
-uE
-vN
+HK
+TP
 di
 di
 di
@@ -2311,7 +2311,7 @@ bJ
 bJ
 bz
 bJ
-Xj
+Pm
 cM
 cU
 de
@@ -2691,7 +2691,7 @@ cA
 bB
 bB
 cK
-ga
+Jp
 de
 de
 de
@@ -2730,11 +2730,11 @@ ab
 aa
 ad
 ab
-tf
-tf
+ss
+ss
 aA
-tf
-tf
+ss
+ss
 ab
 bs
 bF
@@ -3067,7 +3067,7 @@ bB
 bB
 cx
 bB
-EW
+NX
 cP
 cZ
 cZ

--- a/maps/runtime/runtime-2.dmm
+++ b/maps/runtime/runtime-2.dmm
@@ -703,13 +703,6 @@
 	},
 /area/turret_protected/ai)
 "bi" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 2;
-	icon_state = "left";
-	name = "Core Modules";
-	req_access = list(20)
-	},
 /obj/structure/table/standard,
 /obj/item/weapon/aiModule/robocop,
 /obj/item/weapon/aiModule/paladin,
@@ -720,13 +713,6 @@
 	},
 /area/turret_protected/ai)
 "bj" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 2;
-	icon_state = "right";
-	name = "Core Modules";
-	req_access = list(20)
-	},
 /obj/structure/table/standard,
 /obj/item/weapon/aiModule/freeformcore,
 /obj/item/weapon/aiModule/asimov,

--- a/maps/runtime/runtime-2.dmm
+++ b/maps/runtime/runtime-2.dmm
@@ -1,15 +1,25 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"aa" = (
 /turf/template_noop,
 /area/template_noop)
-"c" = (
+"ab" = (
+/obj/effect/decal/warning_stripes,
+/obj/machinery/porta_turret{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"ac" = (
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
-"d" = (
+"ad" = (
 /turf/simulated/floor/airless,
 /area/template_noop)
-"e" = (
+"ae" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -20,7 +30,7 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/construction/Storage)
-"f" = (
+"af" = (
 /obj/machinery/alarm{
 	frequency = 1439;
 	locked = 0;
@@ -35,19 +45,37 @@
 	icon_state = "0-2";
 	d2 = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"g" = (
+"ag" = (
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"h" = (
+"ah" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"i" = (
+"ai" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -57,19 +85,19 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"j" = (
+"aj" = (
 /turf/simulated/open,
 /area/construction/Storage)
-"k" = (
+"ak" = (
 /obj/structure/lattice/catwalk,
 /turf/simulated/open,
 /area/construction/Storage)
-"l" = (
+"al" = (
 /obj/machinery/light{
 	dir = 4
 	},
@@ -78,38 +106,38 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"m" = (
+"am" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"n" = (
+"an" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"o" = (
+"ao" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
 /turf/simulated/open,
 /area/construction/Storage)
-"p" = (
+"ap" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"q" = (
+"aq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"r" = (
+"ar" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
@@ -118,25 +146,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"s" = (
+"as" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"t" = (
+"at" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"u" = (
+"au" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"v" = (
+"av" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -145,17 +173,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"w" = (
+"aw" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"x" = (
+"ax" = (
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"y" = (
+"ay" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -164,17 +192,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"z" = (
+"az" = (
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"A" = (
+"aA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"B" = (
+"aB" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
@@ -183,7 +211,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"C" = (
+"aC" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
@@ -192,14 +220,28 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"E" = (
+"aD" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"aE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 9
 	},
 /turf/simulated/wall/r_wall,
 /area/construction/Storage)
-"F" = (
+"aF" = (
 /obj/structure/cable{
 	d1 = 16;
 	d2 = 0;
@@ -209,13 +251,40 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /turf/simulated/floor/airless,
 /area/construction/Storage)
-"J" = (
+"aG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"aH" = (
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai)
+"aI" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai)
+"aJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /turf/simulated/wall/r_wall,
 /area/construction/Storage)
-"K" = (
+"aK" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -224,17 +293,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"L" = (
+"aL" = (
 /turf/simulated/wall/r_wall,
 /area/construction/Storage)
-"N" = (
+"aM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"aN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
 	dir = 6
 	},
 /turf/simulated/wall/r_wall,
 /area/construction/Storage)
-"O" = (
+"aO" = (
 /obj/structure/cable{
 	d1 = 32;
 	d2 = 2;
@@ -244,7 +326,99 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/supply,
 /turf/simulated/open,
 /area/construction/Storage)
-"T" = (
+"aP" = (
+/obj/item/device/radio/intercom{
+	listening = 0;
+	name = "Custom Channel";
+	pixel_x = 0;
+	pixel_y = 19
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	frequency = 1343;
+	name = "Private Channel";
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	listening = 1;
+	name = "Common Channel";
+	pixel_x = 27;
+	pixel_y = -3
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/machinery/requests_console{
+	department = "AI";
+	departmentType = 5;
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the AI core maintenance door.";
+	id = "AICore";
+	name = "AI Maintenance Hatch";
+	pixel_x = 17;
+	pixel_y = 25;
+	req_access = list(20)
+	},
+/obj/effect/decal/warning_stripes,
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/landmark/start{
+	name = "AI"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"aQ" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai)
+"aR" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"aS" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai)
+"aT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -253,7 +427,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
-"U" = (
+"aU" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -267,2816 +441,3333 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/airless,
 /area/construction/Storage)
-"Y" = (
+"aV" = (
+/obj/machinery/anti_bluespace,
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"aW" = (
+/obj/machinery/door/firedoor{
+	dir = 2
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/turret_protected/ai)
+"aX" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/cyan{
+	d2 = 4;
+	dir = 2;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/turret_protected/ai)
+"aY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
 /area/construction/Storage)
+"aZ" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "AICore";
+	name = "AI core maintenance hatch";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/cyan{
+	d2 = 4;
+	dir = 2;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/turret_protected/ai)
+"ba" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "ai_core_outer";
+	locked = 1;
+	name = "Outer Core Airlock";
+	req_access = list(13)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating{
+	temperature = 273.15
+	},
+/area/turret_protected/ai)
+"bb" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "ai_core_airlock";
+	name = "AI Core airlock controller";
+	pixel_x = 0;
+	pixel_y = 30;
+	req_one_access = list(13);
+	tag_airpump = "ai_core_pump";
+	tag_chamber_sensor = "ai_core_sensor";
+	tag_exterior_door = "ai_core_outer";
+	tag_exterior_sensor = "ai_core_sensor_exterior";
+	tag_interior_door = "ai_core_inner";
+	tag_interior_sensor = "ai_core_sensor_interior"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "ai_core_sensor";
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/machinery/light/small,
+/obj/effect/decal/warning_stripes,
+/obj/effect/decal/remains/mouse,
+/obj/machinery/camera/network/command{
+	c_tag = "AI Core - Core Airlock"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1380;
+	id_tag = "ai_core_pump"
+	},
+/turf/simulated/floor/plating{
+	temperature = 273.15
+	},
+/area/turret_protected/ai)
+"bc" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "ai_core_inner";
+	locked = 1;
+	name = "Inner Core Airlock";
+	req_access = list(13)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "AICore";
+	name = "AI core maintenance hatch";
+	opacity = 0
+	},
+/turf/simulated/floor/plating{
+	temperature = 273.15
+	},
+/area/turret_protected/ai)
+"bd" = (
+/obj/machinery/door/firedoor{
+	dir = 2
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	dir = 2;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/turret_protected/ai)
+"be" = (
+/obj/machinery/door/firedoor{
+	dir = 2
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	dir = 2;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/turret_protected/ai)
+"bf" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "AICore";
+	name = "AI core maintenance hatch";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/cyan{
+	d2 = 4;
+	dir = 2;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/turret_protected/ai)
+"bg" = (
+/obj/machinery/computer/aiupload,
+/obj/item/device/radio/intercom/locked{
+	frequency = 1343;
+	locked_frequency = 1343;
+	name = "Private AI Channel";
+	pixel_x = -5;
+	pixel_y = 22
+	},
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "cobweb1"
+	},
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bh" = (
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bi" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 2;
+	icon_state = "left";
+	name = "Core Modules";
+	req_access = list(20)
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/aiModule/robocop,
+/obj/item/weapon/aiModule/paladin,
+/obj/item/weapon/aiModule/corp,
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bj" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 2;
+	icon_state = "right";
+	name = "Core Modules";
+	req_access = list(20)
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/aiModule/freeformcore,
+/obj/item/weapon/aiModule/asimov,
+/obj/item/weapon/aiModule/nanotrasen,
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bk" = (
+/obj/structure/table/standard,
+/obj/item/weapon/aiModule/teleporterOffline,
+/obj/item/weapon/aiModule/antimov,
+/obj/item/weapon/aiModule/purge,
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bl" = (
+/obj/machinery/hologram/holopad,
+/obj/item/weapon/cigbutt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bm" = (
+/obj/machinery/computer/borgupload,
+/obj/item/device/radio/intercom/locked{
+	frequency = 1343;
+	locked_frequency = 1343;
+	name = "Private AI Channel";
+	pixel_x = -5;
+	pixel_y = -27
+	},
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bn" = (
+/obj/machinery/computer/robotics,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/command{
+	c_tag = "AI Core - Main Core";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bo" = (
+/obj/structure/table/standard,
+/obj/item/weapon/aiModule/oneHuman,
+/obj/item/weapon/aiModule/oxygen,
+/obj/item/weapon/aiModule/freeformcore,
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bq" = (
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"br" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bs" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bt" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bu" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/dark{
+	name = "cooled dark floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 9
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bx" = (
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 22;
+	pixel_y = 36
+	},
+/obj/machinery/turretid/stun{
+	check_synth = 1;
+	name = "AI Chamber turret control";
+	pixel_x = 36;
+	pixel_y = 36
+	},
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "AI Core Door";
+	req_access = list(16)
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"by" = (
+/obj/machinery/power/apc/super/critical{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "AI Core - Alpha Core";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"bz" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Level 2";
+	network = list("Civillian")
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (2,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (3,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (4,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (5,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (6,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (7,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (8,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (9,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (10,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (11,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-L
-N
-Y
-J
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+aL
+aN
+aY
+aJ
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (12,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-O
-U
-F
-E
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+aO
+aU
+aF
+aE
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (13,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-L
-e
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+aL
+ae
+aL
+aL
+aL
+aL
+aL
+aL
+aL
+aL
+aL
+aL
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (14,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-f
-i
-T
-m
-m
-m
-m
-m
-p
-m
-K
-A
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+af
+ai
+aT
+am
+am
+am
+am
+am
+ap
+am
+aK
+aA
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (15,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-q
-j
-j
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+ag
+aj
+aj
+ak
+aj
+aj
+aj
+aj
+aq
+aj
+aj
+at
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (16,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-r
-v
-v
-B
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+ag
+aj
+aj
+ak
+aj
+aj
+aj
+aj
+ar
+av
+av
+aB
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (17,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-k
-k
-o
-k
-k
-k
-k
-o
-k
-k
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+ag
+ak
+ak
+ao
+ak
+ak
+ak
+ak
+ao
+ak
+ak
+at
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (18,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-k
-j
-j
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+ag
+aj
+aj
+ak
+aj
+aj
+aj
+aj
+ak
+aj
+aj
+at
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (19,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-k
-j
-j
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+bz
+aj
+aj
+ak
+aj
+aj
+aj
+aj
+ak
+aj
+aj
+at
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (20,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-k
-j
-j
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+ag
+aj
+aj
+ak
+aj
+aj
+aj
+aj
+ak
+aj
+aj
+at
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (21,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-k
-j
-j
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+ag
+aj
+aj
+ak
+aj
+aj
+aj
+aj
+ak
+aj
+aj
+at
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (22,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-k
-k
-o
-k
-k
-k
-k
-o
-k
-k
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+ag
+ak
+ak
+ao
+ak
+ak
+ak
+ak
+ao
+ak
+ak
+at
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (23,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-s
-w
-y
-C
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+ag
+aj
+aj
+ak
+aj
+aj
+aj
+aj
+as
+aw
+ay
+aC
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (24,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-t
-x
-z
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+ag
+aj
+aj
+ak
+aj
+aj
+aj
+aj
+at
+ax
+az
+at
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (25,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-h
-l
-n
-n
-n
-n
-n
-n
-u
-h
-l
-u
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+aD
+aG
+aM
+aM
+aR
+an
+an
+an
+au
+ah
+al
+au
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (26,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+aL
+aL
+aL
+aL
+aW
+ba
+bd
+aL
+aL
+aL
+aL
+aL
+aL
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (27,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aX
+bb
+be
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (28,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aH
+aH
+aH
+aZ
+bc
+bf
+aH
+aH
+aH
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (29,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aH
+bg
+bh
+bp
+bv
+bh
+bh
+bm
+aH
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (30,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aH
+bh
+bh
+br
+bl
+bh
+bh
+bn
+aH
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (31,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aH
+bi
+ab
+bs
+bw
+bq
+ab
+bk
+aH
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (32,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aH
+bj
+bq
+bt
+bq
+bq
+bq
+bo
+aH
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (33,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aH
+aV
+bq
+bu
+bx
+by
+bq
+aV
+aH
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (34,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aH
+aH
+aH
+aH
+aP
+aI
+aH
+aH
+aH
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (35,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aI
+aQ
+aS
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (36,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (37,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (38,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (39,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (40,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (41,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (42,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (43,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (44,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (45,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (46,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (47,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (48,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (49,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (50,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (51,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (52,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}

--- a/maps/runtime/runtime-3.dmm
+++ b/maps/runtime/runtime-3.dmm
@@ -163,21 +163,6 @@
 /turf/simulated/floor/tiled,
 /area/construction/hallway)
 "B" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/construction/hallway)
-"C" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/construction/hallway)
-"D" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -188,7 +173,51 @@
 	},
 /turf/simulated/floor/airless,
 /area/construction/hallway)
-"F" = (
+"E" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/camera/network/command{
+	c_tag = "Level 3";
+	network = list("Civillian")
+	},
+/turf/simulated/floor/tiled,
+/area/construction/hallway)
+"H" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/construction/hallway)
+"J" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/hallway)
+"N" = (
+/obj/structure/cable{
+	d1 = 32;
+	d2 = 2;
+	icon_state = "11-2"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply,
+/turf/simulated/open,
+/area/construction/hallway)
+"P" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/hallway)
+"T" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -202,41 +231,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/hallway)
-"G" = (
-/obj/structure/cable{
-	d1 = 32;
-	d2 = 2;
-	icon_state = "11-2"
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/zpipe/down/supply,
-/turf/simulated/open,
-/area/construction/hallway)
-"L" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/construction/hallway)
-"T" = (
+"X" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/construction/hallway)
-"V" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/camera/network/command{
-	c_tag = "Level 3";
-	network = list("Civillian")
 	},
 /turf/simulated/floor/tiled,
 /area/construction/hallway)
@@ -865,8 +865,8 @@ d
 d
 d
 e
-G
-D
+N
+B
 e
 d
 d
@@ -920,7 +920,7 @@ e
 e
 e
 e
-L
+H
 e
 e
 e
@@ -974,14 +974,14 @@ e
 f
 i
 m
-F
 T
-B
-B
-B
-B
-B
-C
+X
+P
+P
+P
+P
+P
+J
 u
 e
 d
@@ -1241,7 +1241,7 @@ d
 d
 d
 e
-V
+E
 j
 j
 j

--- a/maps/runtime/runtime-3.dmm
+++ b/maps/runtime/runtime-3.dmm
@@ -163,6 +163,21 @@
 /turf/simulated/floor/tiled,
 /area/construction/hallway)
 "B" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/hallway)
+"C" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/hallway)
+"D" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -173,43 +188,7 @@
 	},
 /turf/simulated/floor/airless,
 /area/construction/hallway)
-"H" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/construction/hallway)
-"J" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/construction/hallway)
-"N" = (
-/obj/structure/cable{
-	d1 = 32;
-	d2 = 2;
-	icon_state = "11-2"
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/zpipe/down/supply,
-/turf/simulated/open,
-/area/construction/hallway)
-"P" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/construction/hallway)
-"T" = (
+"F" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -223,12 +202,41 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/hallway)
-"X" = (
+"G" = (
+/obj/structure/cable{
+	d1 = 32;
+	d2 = 2;
+	icon_state = "11-2"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply,
+/turf/simulated/open,
+/area/construction/hallway)
+"L" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/construction/hallway)
+"T" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/construction/hallway)
+"V" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/camera/network/command{
+	c_tag = "Level 3";
+	network = list("Civillian")
 	},
 /turf/simulated/floor/tiled,
 /area/construction/hallway)
@@ -857,8 +865,8 @@ d
 d
 d
 e
-N
-B
+G
+D
 e
 d
 d
@@ -912,7 +920,7 @@ e
 e
 e
 e
-H
+L
 e
 e
 e
@@ -966,14 +974,14 @@ e
 f
 i
 m
+F
 T
-X
-P
-P
-P
-P
-P
-J
+B
+B
+B
+B
+B
+C
 u
 e
 d
@@ -1233,7 +1241,7 @@ d
 d
 d
 e
-g
+V
 j
 j
 j


### PR DESCRIPTION
This PR allows AI to play music via intercomms in an area. The music choice is given from using saved on the server(so admins can moderate it). Ability has a cooldown of 3 minutes, and uses intercoms to broadcast it.

- If players want to disable music ICly they can just turn off speakers on intercoms in the area.

- Admins will be able to stop playing of music too

- Players also can choose to mute it OOCly with preferences

- Music has to be uploaded and approved by admins to the server `sound/serversound_list.txt`. So basically it is like custom items, but music.

TODO:

- [x] Finish testing if turning off intercom speaker stops music.

- [ ] Changelog