### PR TITLE
Fixes blood not setting species properly when being extracted

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -32,7 +32,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 			B.data = list(
 				"donor" = WEAKREF(src),
 				"viruses" = null,
-				"species" = species.name,
+				"species" = species.bodytype,
 				"blood_DNA" = dna.unique_enzymes,
 				"blood_colour" = species.blood_color,
 				"blood_type" = dna.b_type,
@@ -178,6 +178,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 		var/mob/living/carbon/human/H = src
 		B.data["blood_colour"] = H.species.blood_color
 		B.color = B.data["blood_colour"]
+		B.data["species"] = H.species.bodytype
 
 	var/list/temp_chem = list()
 	for(var/datum/reagent/R in src.reagents.reagent_list)

--- a/html/changelogs/alberyk-bloodfix.yml
+++ b/html/changelogs/alberyk-bloodfix.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - bugfix: "Blood should now properly respect species when used in transfusions."


### PR DESCRIPTION
This pr fixes an issue that when extracting blood with syringes or drip, it would not set the species of the owner properly, making so that you could inject a vaurca's blood into a human, but not a that blood into another vaurca