### PR TITLE
Fixes a typo for malf AI

### DIFF
--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -62,7 +62,7 @@ var/datum/antagonist/rogue_ai/malf
 		sleep(10)
 		to_chat(malf, "<B>running MEMCHCK</B>")
 		sleep(50)
-		to_chat(malf, "<B>MEMCHCK</B> Corrupted sectors confirmed. Reccomended solution: Delete. Proceed? Y/N: Y")
+		to_chat(malf, "<B>MEMCHCK</B> Corrupted sectors confirmed. Recommended solution: Delete. Proceed? Y/N: Y")
 		sleep(10)
 		// this is so Travis doesn't complain about the backslash-B. Fixed at compile time (or should be).
 		to_chat(malf, "<span class='notice'>Corrupted files deleted: sys\\core\\users.dat sys\\core\\laws.dat sys\\core\\" + "backups.dat</span>")

--- a/html/changelogs/SpaceBaa-PR-6326.yml
+++ b/html/changelogs/SpaceBaa-PR-6326.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: SpaceBaa
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes a typo during Malf AI startup."


### PR DESCRIPTION
### This PR intends to fix a typo for malf AI, increasing player immersion.

- Changes `Reccomended` to `Recommended` during Malf AI startup.

### Introduction
Typos are common in all forms of literature, this report aims to resolve a particular one centred around the video game Space Station 13, specifiically the codebase used by the Aurora Station. [(Aurorastation, 2019)](https://github.com/Aurorastation)

### Findings
The typo located is within `code/game/antagonist/station/rogue_ai.dm` [(SpaceBaa, 2019)](https://github.com/Aurorastation/Aurora.3/commit/ac33223077d17fbd66768dee1faa3dc16a09918e). Due to the nature of Space Station 13 and it's various code bases, the typo is likely to exist in other server's codebases that are derivatives or 'forks' of Baystation 12 [(Baystation12, 2019)](https://github.com/Baystation12), however these have yet to be investigated. Due to the nature of Git and it's history tracking, it may be possible to locate the original source of the Typo, however Baystation's original file shows changes back to 2 years after which the file was not shown as changed, so the information may precede Baystation itself.

Other completely different forks of Space Station 13, such as TGstation, do not show the same typo, because they don't have the same file. [However, the same typo has been made elsewhere...](https://github.com/tgstation/tgstation/blob/49b2067d15e144475a916fd7f33d42519f6bb07a/code/modules/clothing/outfits/vv_outfit.dm#L8)

### Conclusions
The typo exists, merge this fix pls.

## References
https://github.com/Aurorastation/Aurora.3
https://github.com/Baystation12/Baystation12
https://www.thefreedictionary.com/recommended
https://www.dictionary.com/browse/recommended
https://www.thesaurus.com/browse/recommended
https://www.merriam-webster.com/dictionary/recommended
https://en.oxforddictionaries.com/definition/recommended
