### PR TITLE
Fixes Portable Destructive Analyzer being able to destroy everything

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -92,6 +92,12 @@
 		if (I.anchored)
 			to_chat(user, span("notice", "\The [I] is anchored in place."))
 			return
+		if(!I.origin_tech)
+			to_chat(user, "<span class='notice'>This doesn't seem to have a tech origin.</span>")
+			return
+		if(I.origin_tech.len == 0)
+			to_chat(user, "<span class='notice'>You cannot deconstruct this item.</span>")
+			return
 		I.forceMove(src)
 		loaded_item = I
 		for(var/mob/M in viewers())

--- a/html/changelogs/alberyk-portablefix.yml
+++ b/html/changelogs/alberyk-portablefix.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Research cyborg's portable destructive analyzer can now only load items with research tech."


### PR DESCRIPTION
As the pra says, this adds origin_tech checks to the portable destructiver analyzer, so, you can't destroy everything with it.