### PR TITLE
Albert Einstein's special-relativity equation

### DIFF
--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -50,10 +50,12 @@ var/list/diona_banned_languages = list(
 	DS.last_location = loc
 	if(light_amount)
 		adjustNutritionLoss(-light_amount) // regenerate our nutrition from light.
-	move_delay_mod = max(initial(move_delay_mod) - light_amount * 1.5, 0)
-	species.sprint_cost_factor = max(min(initial(species.sprint_cost_factor), initial(species.sprint_cost_factor) - light_amount * DIONA_LIGHT_COEFICIENT), 0)
+	move_delay_mod = min(initial(move_delay_mod) - light_amount * 1.5, 0)
+	sprint_speed_factor = initial(sprint_speed_factor)
+	sprint_cost_factor = Clamp(initial(sprint_cost_factor) - light_amount * DIONA_LIGHT_COEFICIENT, 0, initial(sprint_cost_factor))
 	if (total_radiation)
 		move_delay_mod = max(move_delay_mod * total_radiation * 3, -7)
+		sprint_speed_factor = 0.75
 		sprint_cost_factor = 0
 
 /mob/living/carbon/proc/diona_handle_radiation(var/datum/dionastats/DS)

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -20,7 +20,7 @@ var/list/diona_banned_languages = list(
 	/datum/language/binary,
 	/datum/language/binary/drone)
 
-
+#define DIONA_LIGHT_COEFICIENT 0.25
 /mob/living/carbon/proc/diona_handle_light(var/datum/dionastats/DS) //Carbon is the highest common denominator between gestalts and nymphs. They will share light code
 	//if light_organ is non null, then we're working with a gestalt. otherwise nymph
 
@@ -50,6 +50,13 @@ var/list/diona_banned_languages = list(
 	DS.last_location = loc
 	if(light_amount)
 		adjustNutritionLoss(-light_amount) // regenerate our nutrition from light.
+	move_delay_mod = max(initial(move_delay_mod) - light_amount * 1.5, 0)
+	species.sprint_cost_factor = min(initial(species.sprint_cost_factor), initial(species.sprint_cost_factor) - light_amount * DIONA_LIGHT_COEFICIENT)
+	if(species.sprint_cost_factor < 0)
+		species.sprint_cost_factor = 0
+	if (total_radiation)
+		move_delay_mod = max(move_delay_mod * total_radiation * 3, -7)
+		sprint_cost_factor = 0
 
 /mob/living/carbon/proc/diona_handle_radiation(var/datum/dionastats/DS)
 	//Converts radiation to stored energy if its needed, and gives messages related to radiation
@@ -553,3 +560,4 @@ var/list/diona_banned_languages = list(
 #undef REGROW_ENERGY_REQ
 #undef diona_max_pressure
 #undef diona_nutrition_factor
+#undef DIONA_LIGHT_COEFICIENT

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -51,9 +51,7 @@ var/list/diona_banned_languages = list(
 	if(light_amount)
 		adjustNutritionLoss(-light_amount) // regenerate our nutrition from light.
 	move_delay_mod = max(initial(move_delay_mod) - light_amount * 1.5, 0)
-	species.sprint_cost_factor = min(initial(species.sprint_cost_factor), initial(species.sprint_cost_factor) - light_amount * DIONA_LIGHT_COEFICIENT)
-	if(species.sprint_cost_factor < 0)
-		species.sprint_cost_factor = 0
+	species.sprint_cost_factor = max(min(initial(species.sprint_cost_factor), initial(species.sprint_cost_factor) - light_amount * DIONA_LIGHT_COEFICIENT), 0)
 	if (total_radiation)
 		move_delay_mod = max(move_delay_mod * total_radiation * 3, -7)
 		sprint_cost_factor = 0

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -360,7 +360,7 @@
 	if (!DS)
 		return 0 //Something is very wrong
 
-	var/remainder = cost * sprint_cost_factor
+	var/remainder = cost * H.sprint_cost_factor
 
 	if (H.total_radiation)
 		if (H.total_radiation > (cost*0.5))//Radiation counts as double energy

--- a/html/changelogs/Sindorman-diona.yml
+++ b/html/changelogs/Sindorman-diona.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Diona speed and sprint energy cost is now based off light and radiation. Walking/spriting inside of light will give a buff to base walk/sprint to Diona and decreases sprint cost. There is no penalty to areas with no light."
+  - tweak: "Albert Einstein's special-relativity equation. Diona speed and sprint energy cost is now based off light and radiation. Walking/spriting inside of light will give a buff to base walk/sprint to Diona and decreases sprint cost. There is no penalty to areas with no light."
   - tweak: "Radiation now increases Diona's speed a lot, and makes spriting cost to be 0 while affected with radiation."

--- a/html/changelogs/Sindorman-diona.yml
+++ b/html/changelogs/Sindorman-diona.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Diona speed and sprint energy cost is now based off light and radiation. Walking/spriting inside of light will give a buff to base walk/sprint to Diona and decreases sprint cost. There is no penalty to areas with no light."
+  - tweak: "Radiation now increases Diona's speed a lot, and makes spriting cost to be 0 while affected with radiation."


### PR DESCRIPTION
As Requested by Neinbox - light and radiation now affect Diona's speed and sprint cost. It affects both walking and spiriting. Also radiation increases it even more.

-  Diona speed and sprint energy cost is now based off light and radiation. Walking/spriting inside of light will give a buff to base walk/sprint to Diona and decreases sprint cost. There is no penalty to areas with no light.
-  Radiation now increases Diona's speed a lot, and makes spriting cost to be 0 while affected with radiation.

TODO:

- [x] Test nymph speed.