### PR TITLE
Ling Hotfix

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -144,12 +144,17 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	if(!changeling)	return
 
 	if(changeling.isabsorbing)
-		to_chat(src, "<span class='warning'>We are already absorbing!</span>")
+		to_chat(src, "<span class='warning'>We are already engaged in an absorption!</span>")
 		return
 
 	var/mob/living/carbon/human/T = input(usr, "Who are we extracting from?", "Target selection") in typecache_filter_list(oview(1), typecacheof(/mob/living/carbon/human))|null
 	if (!T)
 		return
+	
+	if(changeling.isabsorbing)
+		to_chat(src, "<span class='warning'>We are already engaged in an absorption!</span>")
+		return
+
 	if(!istype(T))
 		to_chat(src, "<span class='warning'>[T] is not compatible with our biology.</span>")
 		return

--- a/html/changelogs/Kaedwuff - Absorb Stacking Hotfix.yml
+++ b/html/changelogs/Kaedwuff - Absorb Stacking Hotfix.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - balance: "The ability for changelings to stack Absorb DNA has been temporarily removed pending balance changes."
+  - bugfix: "The ability for changelings to stack Absorb DNA has been temporarily removed pending balance changes."

--- a/html/changelogs/Kaedwuff - Absorb Stacking Hotfix.yml
+++ b/html/changelogs/Kaedwuff - Absorb Stacking Hotfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "The ability for changelings to stack Absorb DNA has been temporarily removed pending balance changes."


### PR DESCRIPTION
I have plans to do another step towards reworking changelings, but right now, here is a hotfix to prevent abuse of the Absorb DNA feature.  It did not have a check after you select an target from the menu to stop you from queueing up multiple windows before you start absorbing someone's DNA, allowing for spamming abuse.