### PR TITLE
Reworking Bot API and optimizing for loops in admin code

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -1,5 +1,5 @@
 var/list/clients = list()							//list of all clients
-var/list/admins = list()							//list of all clients whom are admins
+var/list/staff = list()							//list of all clients whom are admins
 var/list/directory = list()							//list of all ckeys with associated client
 
 //Since it didn't really belong in any other category, I'm putting this here

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -1,5 +1,5 @@
 var/list/clients = list()							//list of all clients
-var/list/staff = list()							//list of all clients whom are admins
+var/list/staff = list()							//list of all clients who have any permissions
 var/list/directory = list()							//list of all ckeys with associated client
 
 //Since it didn't really belong in any other category, I'm putting this here

--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -57,7 +57,8 @@
 	if (level == SEVERITY_ERROR) // Errors are always logged
 		error(text)
 
-	for(var/client/C in admins)
+	for(var/s in staff)
+		var/client/C = s
 		if(!C.prefs) //This is to avoid null.toggles runtime error while still initialyzing players preferences
 			return
 		if(C.prefs.toggles & CHAT_DEBUGLOGS)

--- a/code/controllers/subsystems/statistics.dm
+++ b/code/controllers/subsystems/statistics.dm
@@ -54,7 +54,7 @@
 
 	// Handle population polling.
 	if (config.sql_enabled && config.sql_stats)
-		var/admincount = admins.len
+		var/admincount = staff.len
 		var/playercount = 0
 		for(var/mob/M in player_list)
 			if(M.client)

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -432,7 +432,8 @@ var/datum/controller/subsystem/vote/SSvote
 				var/admin_number_present = 0
 				var/admin_number_afk = 0
 
-				for (var/client/X in admins)
+				for (var/s in staff)
+					var/client/X = s
 					if (X.holder.rights & R_ADMIN)
 						admin_number_present++
 						if (X.is_afk())

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -69,7 +69,8 @@
 	var/num_cciaa_online = 0
 	var/num_devs_online = 0
 	if(holder)
-		for(var/client/C in admins)
+		for(var/s in staff)
+			var/client/C = s
 			if(R_ADMIN & C.holder.rights || (!R_MOD & C.holder.rights))	//Used to determine who shows up in admin rows
 
 				if(C.holder.fakekey && (!R_ADMIN & holder.rights && !R_MOD & holder.rights))		//Mentors can't see stealthmins
@@ -136,7 +137,8 @@
 				num_devs_online++
 
 	else
-		for(var/client/C in admins)
+		for(var/s in staff)
+			var/client/C = s
 			if(R_ADMIN & C.holder.rights || (!R_MOD & C.holder.rights))
 				if(!C.holder.fakekey)
 					msg += "\t[C] is a [C.holder.rank]\n"

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -81,14 +81,16 @@
 		a_ip = world.address
 
 	var/who
-	for(var/client/C in clients)
+	for(var/c in clients)
+		var/client/C = c
 		if(!who)
 			who = "[C]"
 		else
 			who += ", [C]"
 
 	var/adminwho
-	for(var/client/C in admins)
+	for(var/c in staff)
+		var/client/C = c
 		if(!adminwho)
 			adminwho = "[C]"
 		else

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -6,14 +6,16 @@ var/global/enabled_spooking = 0
 ////////////////////////////////
 /proc/message_admins(var/msg)
 	msg = "<span class=\"log_message\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message\">[msg]</span></span>"
-	for(var/client/C in admins)
+	for(var/s in staff)
+		var/client/C = s
 		if((R_ADMIN|R_MOD) & C.holder.rights)
 			to_chat(C, msg)
 
 /proc/msg_admin_attack(var/text,var/ckey="",var/ckey_target="") //Toggleable Attack Messages
 	log_attack(text,ckey=ckey,ckey_target=ckey_target)
 	var/rendered = "<span class=\"log_message\"><span class=\"prefix\">ATTACK:</span> <span class=\"message\">[text]</span></span>"
-	for(var/client/C in admins)
+	for(var/s in staff)
+		var/client/C = s
 		if((R_ADMIN|R_MOD) & C.holder.rights)
 			if(C.prefs.toggles & CHAT_ATTACKLOGS)
 				var/msg = rendered

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -61,10 +61,11 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 /proc/load_admins()
 	//clear the datums references
 	admin_datums.Cut()
-	for(var/client/C in admins)
+	for(var/s in staff)
+		var/client/C = s
 		C.remove_admin_verbs()
 		C.holder = null
-	admins.Cut()
+	staff.Cut()
 
 	// Clears admins from the world config.
 	for (var/A in world.GetConfig("admin"))

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -41,18 +41,18 @@ var/list/admin_datums = list()
 		owner = C
 		owner.holder = src
 		owner.add_admin_verbs()	//TODO
-		admins |= C
+		staff |= C
 
 /datum/admins/proc/disassociate()
 	if(owner)
-		admins -= owner
+		staff -= owner
 		owner.remove_admin_verbs()
 		owner.deadmin_holder = owner.holder
 		owner.holder = null
 
 /datum/admins/proc/reassociate()
 	if(owner)
-		admins += owner
+		staff += owner
 		owner.holder = src
 		owner.deadmin_holder = null
 		owner.add_admin_verbs()

--- a/code/modules/admin/ticket.dm
+++ b/code/modules/admin/ticket.dm
@@ -128,7 +128,8 @@ var/global/list/ticket_panels = list()
 
 	if (!admin_found)
 		message_admins("<span class='danger'><b>[owner]'s ticket has yet to be closed!</b></span>")
-		for(var/client/C in admins)
+		for(var/s in staff)
+			var/client/C = s
 			if((C.holder.rights & (R_ADMIN|R_MOD)) && (C.prefs.toggles & SOUND_ADMINHELP))
 				sound_to(C, 'sound/effects/adminhelp.ogg')
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -116,15 +116,16 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	var/admin_number_present = 0
 	var/admin_number_afk = 0
 
-	for(var/client/X in admins)
-		if((R_ADMIN|R_MOD) & X.holder.rights)
+	for(var/s in staff)
+		var/client/C = s
+		if((R_ADMIN|R_MOD) & C.holder.rights)
 			admin_number_present++
-			if(X.is_afk())
+			if(C.is_afk())
 				admin_number_afk++
-			if(X.prefs.toggles & SOUND_ADMINHELP)
-				sound_to(X, 'sound/effects/adminhelp.ogg')
+			if(C.prefs.toggles & SOUND_ADMINHELP)
+				sound_to(C, 'sound/effects/adminhelp.ogg')
 
-			to_chat(X, msg)
+			to_chat(C, msg)
 
 	//show it to the person adminhelping too
 	to_chat(src, "<font color='blue'>PM to-<b>Staff </b>: [original_msg]</font>")

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -17,7 +17,8 @@
 		to_chat(src, "<font color='red'>Error: Admin-PM-Panel: Only administrators may use this command.</font>")
 		return
 	var/list/client/targets[0]
-	for(var/client/T)
+	for(var/p in player_list)
+		var/client/T = p
 		if(T.mob)
 			if(istype(T.mob, /mob/abstract/new_player))
 				targets["(New Player) - [T]"] = T
@@ -37,7 +38,7 @@
 //Fetching a message if needed. src is the sender and C is the target client
 
 /client/proc/cmd_admin_pm(var/client/C, var/msg = null, var/datum/ticket/ticket = null)
-	if(!istype(C,/client))
+	if(!istype(C, /client))
 		if(holder)	to_chat(src, "<font color='red'>Error: Private-Message: Client not found.</font>")
 		else		to_chat(src, "<font color='red'>Error: Private-Message: Client not found. They may have lost connection, so try using an adminhelp!</font>")
 		return
@@ -150,7 +151,8 @@
 	ticket.append_message(src.ckey, C.ckey, msg)
 
 	//we don't use message_admins here because the sender/receiver might get it too
-	for(var/client/X in admins)
+	for(var/s in staff)
+		var/client/X = s
 		//check client/X is an admin and isn't the sender or recipient
 		if(X == C || X == src)
 			continue
@@ -175,8 +177,9 @@
 	to_chat(src, "<span class='pm'><span class='out'>" + create_text_tag("pm_out_alt", "", src) + " to <span class='name'>Discord-[sender]</span>: <span class='message'>[msg]</span></span></span>")
 
 	log_admin("PM: [key_name(src)]->Discord-[sender]: [msg]")
-	for(var/client/X in admins)
-		if(X == src)
+	for(var/s in staff)
+		var/client/C = s
+		if(C == src)
 			continue
-		if(X.holder.rights & (R_ADMIN|R_MOD))
-			to_chat(X, "<span class='pm'><span class='other'>" + create_text_tag("pm_other", "PM:", X) + " <span class='name'>[key_name(src, X, 0)]</span> to <span class='name'>Discord-[sender]</span>: <span class='message'>[msg]</span></span></span>")
+		if(C.holder.rights & (R_ADMIN|R_MOD))
+			to_chat(C, "<span class='pm'><span class='other'>" + create_text_tag("pm_other", "PM:", C) + " <span class='name'>[key_name(src, C, 0)]</span> to <span class='name'>Discord-[sender]</span>: <span class='message'>[msg]</span></span></span>")

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -10,7 +10,8 @@
 	log_admin("ADMIN: [key_name(src)] : [msg]",admin_key=key_name(src))
 
 	if(check_rights(R_ADMIN,0))
-		for(var/client/C in admins)
+		for(var/s in staff)
+			var/client/C = s
 			if(R_ADMIN & C.holder.rights)
 				to_chat(C, "<span class='admin_channel'>" + create_text_tag("admin", "ADMIN:", C) + " <span class='name'>[key_name(usr, 1)]</span>([admin_jump_link(mob, src)]): <span class='message'>[msg]</span></span>")
 
@@ -32,7 +33,8 @@
 	var/sender_name = key_name(usr, 1)
 	if(check_rights(R_ADMIN, 0))
 		sender_name = "<span class='admin'>[sender_name]</span>"
-	for(var/client/C in admins)
+	for(var/s in staff)
+		var/client/C = s
 		if ((R_ADMIN|R_MOD) & C.holder.rights)
 			to_chat(C, "<span class='mod_channel'>" + create_text_tag("mod", "MOD:", C) + " <span class='name'>[sender_name]</span>(<A HREF='?src=\ref[C.holder];adminplayerobservejump=\ref[mob]'>JMP</A>): <span class='message'>[msg]</span></span>")
 
@@ -52,7 +54,8 @@
 
 	if(check_rights(R_DEV,0))
 		msg = "<span class='devsay'><span class='prefix'>DEV:</span> <EM>[key_name(usr, 0, 1, 0)]</EM>: <span class='message'>[msg]</span></span>"
-		for(var/client/C in admins)
+		for(var/s in staff)
+			var/client/C = s
 			if(C.holder.rights & (R_ADMIN|R_DEV))
 				to_chat(C, msg)
 
@@ -70,6 +73,7 @@
 
 	if(check_rights((R_CCIAA|R_ADMIN),0))
 		msg = "<span class='cciaasay'><span class='prefix'>CCIAAgent:</span> <EM>[key_name(usr, 0, 1, 0)]</EM>: <span class='message'>[msg]</span></span>"
-		for(var/client/C in admins)
+		for(var/s in staff)
+			var/client/C = s
 			if(C.holder.rights & (R_ADMIN|R_CCIAA))
 				to_chat(C, msg)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -502,19 +502,19 @@
 	set name = "Debug Mob Lists"
 	set desc = "For when you just gotta know"
 
-	switch(input("Which list?") in list("Players","Admins","Mobs","Living Mobs","Dead Mobs", "Clients"))
+	switch(input("Which list?") in list("Players","Staff","Mobs","Living Mobs","Dead Mobs", "Clients"))
 		if("Players")
-			to_chat(usr, jointext(player_list,","))
-		if("Admins")
-			to_chat(usr, jointext(admins,","))
+			to_chat(usr, jointext(player_list,", "))
+		if("Staff")
+			to_chat(usr, jointext(staff,", "))
 		if("Mobs")
-			to_chat(usr, jointext(mob_list,","))
+			to_chat(usr, jointext(mob_list,", "))
 		if("Living Mobs")
-			to_chat(usr, jointext(living_mob_list,","))
+			to_chat(usr, jointext(living_mob_list,", "))
 		if("Dead Mobs")
-			to_chat(usr, jointext(dead_mob_list,","))
+			to_chat(usr, jointext(dead_mob_list,", "))
 		if("Clients")
-			to_chat(usr, jointext(clients,","))
+			to_chat(usr, jointext(clients,", "))
 
 // DNA2 - Admin Hax
 /client/proc/cmd_admin_toggle_block(var/mob/M,var/block)

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -15,7 +15,8 @@
 	var/image/cross = image('icons/obj/storage.dmi',"bible")
 	msg = "<span class='notice'>\icon[cross] <b><font color=purple>PRAY: </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[src]'>SM</A>) ([admin_jump_link(src, src)]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>):</b> [msg]</span>"
 
-	for(var/client/C in admins)
+	for(var/s in staff)
+		var/client/C = s
 		if(C.holder.rights & (R_ADMIN|R_MOD|R_FUN))
 			if(C.prefs.toggles & CHAT_PRAYER)
 				to_chat(C, msg)
@@ -31,7 +32,8 @@
 	var/cciaa_present = 0
 	var/cciaa_afk = 0
 
-	for(var/client/C in admins)
+	for(var/s in staff)
+		var/client/C = s
 		if(R_ADMIN & C.holder.rights)
 			to_chat(C, msg_admin)
 		else if (R_CCIAA & C.holder.rights)
@@ -55,6 +57,7 @@
 
 /proc/Syndicate_announce(var/msg, var/mob/Sender)
 	msg = "<span class='notice'><b><font color=crimson>ILLEGAL:</font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) ([admin_jump_link(Sender, src)]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;SyndicateReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
-	for(var/client/C in admins)
+	for(var/s in staff)
+		var/client/C = s
 		if(R_ADMIN & C.holder.rights)
 			to_chat(C, msg)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -338,7 +338,7 @@
 	//Admin Authorisation
 	holder = admin_datums[ckey]
 	if(holder)
-		admins += src
+		staff += src
 		holder.owner = src
 
 	log_client_to_db()
@@ -425,7 +425,7 @@
 	ticket_panels -= src
 	if(holder)
 		holder.owner = null
-		admins -= src
+		staff -= src
 	directory -= ckey
 	clients -= src
 	SSassets.handle_disconnect(src)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -283,7 +283,8 @@ var/list/admin_departments
 
 	var/cciaa_present = 0
 	var/cciaa_afk = 0
-	for(var/client/C in admins)
+	for(var/s in staff)
+		var/client/C = s
 		var/flags = C.holder.rights & (R_ADMIN|R_CCIAA)
 		if(flags)
 			to_chat(C, msg)

--- a/code/modules/world_api/commands/admin.dm
+++ b/code/modules/world_api/commands/admin.dm
@@ -105,7 +105,7 @@
 	sound_to(C, 'sound/effects/adminhelp.ogg')
 	to_chat(C, message)
 
-	for(var/client/A in admins)
+	for(var/client/A in staff)
 		if(A != C)
 			to_chat(A, amessage)
 

--- a/code/modules/world_api/commands/api_helpers.dm
+++ b/code/modules/world_api/commands/api_helpers.dm
@@ -12,7 +12,7 @@
 	var/versionstring = null
 	//The Version Number follows SemVer http://semver.org/
 	version["major"] = 2 //Major Version Number --> Increment when implementing breaking changes
-	version["minor"] = 5 //Minor Version Number --> Increment when adding features
+	version["minor"] = 6 //Minor Version Number --> Increment when adding features
 	version["patch"] = 0 //Patchlevel --> Increment when fixing bugs
 
 	versionstring = "[version["major"]].[version["minor"]].[version["patch"]]"

--- a/code/modules/world_api/commands/server_query.dm
+++ b/code/modules/world_api/commands/server_query.dm
@@ -25,6 +25,8 @@
 
 	for(var/S in staff)
 		var/client/C = S
+		if(C.holder.fakekey)
+			continue
 		if(C.holder.rights & (R_MOD|R_ADMIN))
 			s["admins"]++
 

--- a/code/modules/world_api/commands/server_query.dm
+++ b/code/modules/world_api/commands/server_query.dm
@@ -21,12 +21,11 @@
 
 	s["players"] = clients.len
 	s["admins"] = 0
+	s["staff"] = staff.len
 
-	for(var/client/C in clients)
-		if(C.holder)
-			if(C.holder.fakekey)
-				continue
-
+	for(var/S in staff)
+		var/client/C = S
+		if(C.holder.rights & (R_MOD|R_ADMIN))
 			s["admins"]++
 
 	statuscode = 200
@@ -42,7 +41,7 @@
 
 /datum/topic_command/get_stafflist/run_command(queryparams)
 	var/list/staff = list()
-	for (var/client/C in admins)
+	for (var/client/C in staff)
 		staff[C] = C.holder.rank
 
 	statuscode = 200

--- a/code/modules/world_api/commands/server_query.dm
+++ b/code/modules/world_api/commands/server_query.dm
@@ -27,7 +27,7 @@
 		var/client/C = S
 		if(C.holder.fakekey)
 			continue
-		if(C.holder.rights & (R_MOD|R_ADMIN))
+		if(C.holder.rights & R_BAN) // we are doing R_BAN to not count retired admins, since they get R_MOD and R_ADMIN but not R_BAN.
 			s["admins"]++
 
 	statuscode = 200

--- a/html/changelogs/Sindorman-bot.yml
+++ b/html/changelogs/Sindorman-bot.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Borealisbot now counts admins properly and now has another field for all staff count. Server API updated."
+  - backend: "Renamed globabl admin list to staff, since it includes all staff."
+  - backend: "Optimized for loops that iterate over client lists, saving istype check in admin code."


### PR DESCRIPTION
This PR goes along with https://github.com/Aurorastation/BOREALISbot2/pull/28

It:

- Reworks API to count staff and admins. Makes them as separate fields for bot to display

- Renames global list `admin` to `staff` since it includes anyone with perms.

- Optimizes all for loops that iterate over client lists, reducing byond in-built `istype()` check. 