### PR TITLE
Allows Maintenance Drones to pull disposal pipes.

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -42,7 +42,10 @@
 	can_pull_size = 3
 	can_pull_mobs = MOB_PULL_SMALLER
 	//Allow drones to pull disposal pipes
-	var/list/pull_list = list(/obj/structure/disposalconstruct)
+	var/list/pull_list = list(
+					/obj/structure/disposalconstruct,
+					/obj/item/pipe
+					)
 
 	mob_bump_flag = SIMPLE_ANIMAL
 	//mob_swap_flags = SIMPLE_ANIMAL

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -41,6 +41,8 @@
 
 	can_pull_size = 3
 	can_pull_mobs = MOB_PULL_SMALLER
+	//Allow drones to pull disposal pipes
+	var/list/pull_list = list(/obj/structure/disposalconstruct)
 
 	mob_bump_flag = SIMPLE_ANIMAL
 	//mob_swap_flags = SIMPLE_ANIMAL
@@ -328,17 +330,34 @@
 	to_chat(src, "Use <b>say ;Hello</b> to talk to other drones and <b>say Hello</b> to speak silently to your nearby fellows.")
 
 /mob/living/silicon/robot/drone/start_pulling(var/atom/movable/AM)
+	if(!AM)
+		return
 
-	if(!(istype(AM,/obj/item/pipe) || istype(AM,/obj/structure/disposalconstruct)))
-		if(istype(AM,/obj/item))
-			var/obj/item/O = AM
-			if(O.w_class > can_pull_size)
-				to_chat(src, "<span class='warning'>You are too small to pull that.</span>")
+	for(var/A in pull_list)
+		if(istype(AM, A))
+			if(pulling)
+				var/pulling_old = pulling
+				stop_pulling()
+				// Are we pulling the same thing twice? Just stop pulling.
+				if(pulling_old == AM)
+					return
+
+			src.pulling = AM
+			AM.pulledby = src
+
+			if(pullin)
+				pullin.icon_state = "pull1"
 				return
-		else
-			if(!can_pull_mobs)
-				to_chat(src, "<span class='warning'>You are too small to pull that.</span>")
-				return
+			return
+	if(istype(AM, /obj/item))
+		var/obj/item/O = AM
+		if(O.w_class > can_pull_size)
+			to_chat(src, "<span class='warning'>You are too small to pull that.</span>")
+			return
+	else
+		if(!can_pull_mobs)
+			to_chat(src, "<span class='warning'>You are too small to pull that.</span>")
+			return
 	..()
 
 

--- a/html/changelogs/SpaceBaa-MaintenanceDronesCanPullDisposalPipe.yml
+++ b/html/changelogs/SpaceBaa-MaintenanceDronesCanPullDisposalPipe.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: SpaceBaa
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Maintenance Drones can now pull disposal pipes."


### PR DESCRIPTION
### This change intends to make Maintenance Drones more practical, despite breaking the laws of physics
Maintenance Drones are unable to pull disposal pipe.
This is because the pipes are size 10, and drones cannot pull anything larger than themselves, (they're size 3).

Law-wise it makes no sense to change this, however it is impractical and makes it impossible for maintenance drones to repair Disposal Pipe, which is one of the most annoying breakages on station, spreading litter in the crew's departments, engineers have to drag over the whole dispensary etc.

So, why not just ignore the laws of physics and let Maintenance Drones pull the pipe that's almost four times as large as they are?

If you look at the current code, it looks like someone's already tried to https://github.com/Aurorastation/Aurora.3/blob/master/code/modules/mob/living/silicon/robot/drone/drone.dm#L330
This doesn't work though because when it calls the parent proc a further check for size is done.

In that sense this is technically a bugfix >.>

Credit to @Sindorman for basically writing the new Proc for me.

See PR #6303 for related tales.

If this doesn't make it through I'll make another pull request to remove this proc altogether, because it's not doing anything.