### PR TITLE
Ninja Tweak: Stealth and Power Sink

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -472,7 +472,7 @@
 		drain_complete(H)
 		return
 
-	holder.cell.give(target_drained * CELLRATE)
+	holder.cell.give(target_drained * CELLRATE * 2)
 	total_power_drained += target_drained
 
 	return 1

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -480,9 +480,9 @@
 /obj/item/rig_module/power_sink/proc/drain_complete(var/mob/living/M)
 
 	if(!interfaced_with)
-		if(M) to_chat(M, "<font color='blue'><b>Total power drained:</b> [round(total_power_drained/1000)]kJ.</font>")
+		if(M) to_chat(M, "<font color='blue'><b>Total power drained:</b> [round(total_power_drained/500)]kJ.</font>")
 	else
-		if(M) to_chat(M, "<font color='blue'><b>Total power drained from [interfaced_with]:</b> [round(total_power_drained/1000)]kJ.</font>")
+		if(M) to_chat(M, "<font color='blue'><b>Total power drained from [interfaced_with]:</b> [round(total_power_drained/500)]kJ.</font>")
 		interfaced_with.drain_power(0,1,0) // Damage the victim.
 
 	drain_loc = null

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -353,9 +353,9 @@
 	. = ..()
 	if (. && ismob(A) && istype(back, /obj/item/weapon/rig))
 		var/obj/item/weapon/rig/R = back
-		R.attackdisrupts(src)
+		R.attack_disrupt_check(src)
 
-/obj/item/weapon/rig/proc/attackdisrupts(var/cost, var/obj/item/rig_module)
+/obj/item/weapon/rig/proc/attack_disrupt_check()
 	for (var/obj/item/rig_module/module in installed_modules)
 		if (module.active && module.attackdisrupts)
 			module.deactivate()

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -207,7 +207,7 @@
 		return 0
 
 	active = 0
-	log_debug("dragons")
+
 	spawn(1)
 		if(suit_overlay_inactive)
 			suit_overlay = suit_overlay_inactive
@@ -351,7 +351,7 @@
 
 /mob/living/carbon/human/ClickOn(atom/A, params)
 	. = ..()
-	if (. && ismob(A) && istype(back, /obj/item/weapon/rig))
+	if (ismob(A) && istype(back, /obj/item/weapon/rig))
 		var/obj/item/weapon/rig/R = back
 		R.attack_disrupt_check(src)
 

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -35,6 +35,7 @@
 
 	var/active                          // Basic module status
 	var/disruptable                     // Will deactivate if some other powers are used.
+	var/attackdisrupts = 0             // Will deactivate if user attacks
 
 	var/use_power_cost = 0              // Power used when single-use ability called.
 	var/active_power_cost = 0           // Power used when turned on.
@@ -206,7 +207,7 @@
 		return 0
 
 	active = 0
-
+	log_debug("dragons")
 	spawn(1)
 		if(suit_overlay_inactive)
 			suit_overlay = suit_overlay_inactive
@@ -347,3 +348,14 @@
 		name = "[charge.display_name] ([charge.charges]C) - Change"
 		return 1
 	return 0
+
+/mob/living/carbon/human/ClickOn(atom/A, params)
+	. = ..()
+	if (. && ismob(A) && istype(back, /obj/item/weapon/rig))
+		var/obj/item/weapon/rig/R = back
+		R.attackdisrupts(src)
+
+/obj/item/weapon/rig/proc/attackdisrupts(var/cost, var/obj/item/rig_module)
+	for (var/obj/item/rig_module/module in installed_modules)
+		if (module.active && module.attackdisrupts)
+			module.deactivate()

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -18,9 +18,10 @@
 	toggleable = 1
 	disruptable = 1
 	disruptive = 0
+	attackdisrupts = 1
 	confined_use = 1
 
-	use_power_cost = 150
+	use_power_cost = 75
 	active_power_cost = 5
 	passive_power_cost = 0
 	module_cooldown = 30

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -21,7 +21,7 @@
 	confined_use = 1
 
 	use_power_cost = 50
-	active_power_cost = 10
+	active_power_cost = 5
 	passive_power_cost = 0
 	module_cooldown = 30
 
@@ -65,7 +65,7 @@
 
 	for(var/mob/O in oviewers(H))
 		O.show_message("[H.name] appears from thin air!",1)
-	playsound(get_turf(H), 'sound/effects/stealthoff.ogg', 75, 1)
+	playsound(get_turf(H), 'sound/effects/stealthoff.ogg', 10, 1)
 
 
 /obj/item/rig_module/teleporter

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -20,7 +20,7 @@
 	disruptive = 0
 	confined_use = 1
 
-	use_power_cost = 50
+	use_power_cost = 150
 	active_power_cost = 5
 	passive_power_cost = 0
 	module_cooldown = 30

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -581,7 +581,7 @@
 	construction_cost = list(DEFAULT_WALL_MATERIAL=15000, "glass"= 1250, "silver"=5250)
 	construction_time = 300
 
-	disruptive = 1
+	disruptive = 0
 
 	use_power_cost = 5
 	module_cooldown = 25

--- a/html/changelogs/Kaedwuff - Ninjatweak.yml
+++ b/html/changelogs/Kaedwuff - Ninjatweak.yml
@@ -38,7 +38,8 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "The stealth module now is half as expensive to use."
+  - tweak: "The stealth field ninjas get now costs 750 to activate, but only drains half as much as before."
   - tweak: "Deactivating the stealth suit is much quieter now."
   - tweak: "The power sink module now drains power twice as fast, and is possible to use while stealthed for reduced charge speed."
-  - balance: "The stealth suit deactivates if you attack anything."
+  - balance: "The stealth suit deactivates if you interact with (click on) any mob. This includes attacks as well as grabs, disarms, and taps."
+  - tweak: "Leg actuators will no longer disable your stealth field."

--- a/html/changelogs/Kaedwuff - Ninjatweak.yml
+++ b/html/changelogs/Kaedwuff - Ninjatweak.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "The stealth module now is half as expensive to use."
+  - tweak: "Deactivating the stealth suit is much quieter now."
+  - tweak: "The power sink module now drains power twice as fast, and is possible to use while stealthed for reduced charge speed."
+  - balance: "The stealth suit deactivates if you attack anything."


### PR DESCRIPTION
Response to this thread: 

https://forums.aurorastation.org/topic/11873-minor-ninja-cloak-rework/?tab=comments#comment-113601

Update details
-Stealth suit is half as expensive to maintain, but costs 750 power to activate, to encourage it being used for actual stealth instead of cheesing by attacking and repeatedly re-cloaking.
-Power sink draws power twice as fast now.  It is possible to use this while stealthed and have positive energy gain (about 100 every couple seconds, kind of like the reverse of the speed stealth used to drain power).  This makes it better for use with the stealth module than the emergency power module, because using it doesn't decloak you. However, it still does make a lot of noise and sparks.  There is a tradeoff for everything.
-Deactivating stealth is now a lot quieter, and should not be nearly as audible over long distances, reducing meta.
-Interacting with mobs deactivates the stealth field.
-Leg actuators no longer are disruptive and do not deactivate stealth.