### PR TITLE
Traumas tweaks

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -118,7 +118,7 @@
 
 /datum/brain_trauma/mild/concussion/on_life()
 	if(prob(25))
-		switch(rand(1,11))
+		switch(rand(1,9))
 			if(1)
 				to_chat(owner, "<span class='notice'>Your stomach writhes with pain.</span>")
 				owner.vomit()
@@ -132,12 +132,6 @@
 			if(6 to 9)
 				to_chat(owner, "<span class='notice'>Your tongue feels thick in your mouth.</span>")
 				owner.slurring += 30
-			if(10)
-				to_chat(owner, "<span class='notice'>You forget for a moment what you were doing.</span>")
-				owner.Stun(20)
-			if(11)
-				to_chat(owner, "<span class='warning'>You faint.</span>")
-				owner.Sleeping(80)
 
 	..()
 

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -107,7 +107,7 @@
 	switch(reaction)
 		if(1)
 			to_chat(owner, "<span class='warning'>You are paralyzed with fear!</span>")
-			owner.Stun(15)
+			owner.Stun(3)
 			owner.Jitter(15)
 		if(2)
 			owner.Jitter(5)

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -56,6 +56,7 @@
 	gain_text = "<span class='warning'>You can't feel your body anymore!</span>"
 	lose_text = "<span class='notice'>You can feel your limbs again!</span>"
 	cure_type = CURE_SURGERY
+	can_gain = FALSE
 
 /datum/brain_trauma/severe/paralysis/on_life()
 	owner.Weaken(200)
@@ -72,6 +73,7 @@
 	gain_text = "<span class='warning'>You have a constant feeling of drowsiness...</span>"
 	lose_text = "<span class='notice'>You feel awake and aware again.</span>"
 	cure_type = CURE_HYPNOSIS
+	can_gain = FALSE
 
 /datum/brain_trauma/severe/narcolepsy/on_life()
 	..()

--- a/html/changelogs/alberyk-traumas.yml
+++ b/html/changelogs/alberyk-traumas.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Reduced the sleeping and stun aspects of some traumas, such as the phobias and the concussion."
+  - rscdel: "Removed paralysis and narcoleps from the possible traumas selection."


### PR DESCRIPTION
This pr changes and removes some traumas, based on player feedback:

-removes the stunning/sleeping from the concussion
-removes paralysis and narcoleps from the possible traumas random pool, because they were the same thing and pretty much just stunned people forever
-stuns from phobia has been reduced to avoid someone being stunlocked in fear