### PR TITLE
Borg Upgrades

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -249,6 +249,8 @@
 	return 1
 
 //DRONE LIFE/DEATH
+/mob/living/silicon/robot/drone/process_level_restrictions()
+	return
 
 //For some goddamn reason robots have this hardcoded. Redefining it for our fragile friends here.
 /mob/living/silicon/robot/drone/updatehealth()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -334,10 +334,16 @@
 	return canmove
 
 /mob/living/silicon/robot/proc/process_level_restrictions()
-	if (src.z in current_map.player_levels || src.z in current_map.admin_levels) //Make sure they are not in a authorized z-level
+	//If they are on a player level -> abort
+	if (src.z in current_map.player_levels)
 		return
-	if(!lockcharge && !scrambledcodes && !emagged) //Make sure they are not self destructing already or have scrambled codes (syndie borgs) or are emagged
-		self_destruct(TRUE)
+	//If they are on centcom -> abort
+	if (istype(get_area(src), /area/centcom))
+		return
+	//Make sure they should not get blown
+	if (lockcharge || scrambledcodes || emagged)
+		return
+	self_destruct(TRUE)
 
 /mob/living/silicon/robot/update_fire()
 	cut_overlay(image("icon"='icons/mob/OnFire.dmi', "icon_state"="Standing"))

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -19,6 +19,7 @@
 		process_killswitch()
 		process_locks()
 		process_queued_alarms()
+		process_level_restrictions()
 	update_canmove()
 
 /mob/living/silicon/robot/proc/clamp_values()
@@ -331,6 +332,12 @@
 	if(paralysis || stunned || weakened || buckled || lockcharge || !is_component_functioning("actuator")) canmove = 0
 	else canmove = 1
 	return canmove
+
+/mob/living/silicon/robot/proc/process_level_restrictions()
+	if (src.z in current_map.player_levels || src.z in current_map.admin_levels) //Make sure they are not in a authorized z-level
+		return
+	if(!lockcharge && !scrambledcodes) //Make sure they are not self destructing already or have scrambled codes (syndie borgs)
+		self_destruct(TRUE)
 
 /mob/living/silicon/robot/update_fire()
 	cut_overlay(image("icon"='icons/mob/OnFire.dmi', "icon_state"="Standing"))

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -336,7 +336,7 @@
 /mob/living/silicon/robot/proc/process_level_restrictions()
 	if (src.z in current_map.player_levels || src.z in current_map.admin_levels) //Make sure they are not in a authorized z-level
 		return
-	if(!lockcharge && !scrambledcodes) //Make sure they are not self destructing already or have scrambled codes (syndie borgs)
+	if(!lockcharge && !scrambledcodes && !emagged) //Make sure they are not self destructing already or have scrambled codes (syndie borgs) or are emagged
 		self_destruct(TRUE)
 
 /mob/living/silicon/robot/update_fire()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -338,7 +338,7 @@
 	if (src.z in current_map.player_levels)
 		return
 	//If they are on centcom -> abort
-	if (istype(get_area(src), /area/centcom))
+	if (istype(get_area(src), /area/centcom) || istype(get_area(src), /area/shuttle/escape) || istype(get_area(src), /area/shuttle/arrival))
 		return
 	//Make sure they should not get blown
 	if (lockcharge || scrambledcodes || emagged)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1016,8 +1016,11 @@
 							to_chat(cleaned_human, "<span class='warning'>[src] cleans your face!</span>")
 		return
 
-/mob/living/silicon/robot/proc/self_destruct()
-	say("WARNING: Self-destruct initiated. Unit [src] will self destruct in five seconds.")
+/mob/living/silicon/robot/proc/self_destruct(var/anti_theft=FALSE)
+	if(anti_theft)
+		say("WARNING: Removal from NanoTrasen property detected. Anti-Theft mode activated. Unit [src] will self destruct in five seconds.")
+	else
+		say("WARNING: Self-destruct initiated. Unit [src] will self destruct in five seconds.")
 	lockcharge = 1
 	update_canmove()
 	sleep(20)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1019,6 +1019,7 @@
 /mob/living/silicon/robot/proc/self_destruct(var/anti_theft=FALSE)
 	if(anti_theft)
 		say("WARNING: Removal from NanoTrasen property detected. Anti-Theft mode activated. Unit [src] will self destruct in five seconds.")
+		to_chat(src,"<span class='warning'>All databases containing information related to NanoTrasen have been wiped!</span>")
 	else
 		say("WARNING: Self-destruct initiated. Unit [src] will self destruct in five seconds.")
 	lockcharge = 1

--- a/html/changelogs/arrow768-anti-borg-theft.yml
+++ b/html/changelogs/arrow768-anti-borg-theft.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Borgs now have a anti-theft mode."


### PR DESCRIPTION
Adds a anti-theft mode to the borgs to prevent them from leaving NT property

### IC changelog
`NanoTrasen Borgs have been fitted with a state of the art anti-theft module`