### PR TITLE
Secures plushie diversity

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -317,6 +317,15 @@
 		/obj/item/toy/plushie/kitten,
 		/obj/item/toy/plushie/lizard,
 		/obj/item/toy/plushie/farwa,
+		/obj/random/squid_plushie
+	)
+
+/obj/random/squid_plushie
+	name = "random squid plushie"
+	desc = "This is a random squid plushie."
+	icon = 'icons/obj/toy.dmi'
+	icon_state = "greensquid"
+	spawnlist = list(
 		/obj/item/toy/plushie/squid/green,
 		/obj/item/toy/plushie/squid/mint,
 		/obj/item/toy/plushie/squid/blue,


### PR DESCRIPTION
Due to the sheer variety of squid plushies, they are far too common in the plushie toy selection. This pr fixes this, by having the squid plushie having the same chance as spawning as any other plushie.