### PR TITLE
Fixes invalid clicking on chalk/crayons

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -108,3 +108,6 @@
 				qdel(src)
 	else
 		..(M, user, target_zone)
+
+/obj/item/weapon/pen/crayon/attack_self(var/mob/user)
+	return

--- a/code/game/objects/items/draftingchalk.dm
+++ b/code/game/objects/items/draftingchalk.dm
@@ -25,6 +25,9 @@
 	color = "#FFFFFF"
 	var/colorName = "whitec"
 
+/obj/item/weapon/pen/drafting/attack_self(var/mob/user)
+	return
+
 /obj/item/weapon/pen/drafting/afterattack(turf/target, mob/user, proximity)
 	if (!proximity || !istype(target, /turf/simulated) || target.density || target.is_hole)
 		return

--- a/html/changelogs/Kaedwuff - Clickfix.yml
+++ b/html/changelogs/Kaedwuff - Clickfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "You can no longer click chalk or crayons."


### PR DESCRIPTION
Per #6425 pointing out that you can click chalk, I discovered that the creator of #6393 neglected to bother coding in exceptions for all illogical children of the pen item in their rush to add in new memes.

Fortunately, I have cleaned up the mess.