### PR TITLE
Fixes Raiders Hazard Rig

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -253,6 +253,13 @@
 		/obj/item/rig_module/mounted/taser
 		)
 
+/obj/item/weapon/rig/hazard/equipped/pirate
+	req_access = list(access_syndicate)
+	helm_type = /obj/item/clothing/head/helmet/space/rig/hazard/pirate
+
+/obj/item/clothing/head/helmet/space/rig/hazard/pirate
+	camera_networks = list()
+
 /obj/item/weapon/rig/diving
 	name = "diving suit control module"
 	suit_type = "diving suit"

--- a/html/changelogs/Kaedwuff - Raider Rigs.yml
+++ b/html/changelogs/Kaedwuff - Raider Rigs.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Raiders can now access their own rigs. Additionally, they can no longer be spied on via station cameras."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -17967,9 +17967,7 @@
 /obj/item/weapon/tank/oxygen,
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/shoes/magboots,
-/obj/item/weapon/rig/hazard/equipped{
-	req_access = newlist()
-	},
+/obj/item/weapon/rig/hazard/equipped/pirate,
 /turf/simulated/shuttle/plating,
 /area/skipjack_station/start)
 "aOq" = (


### PR DESCRIPTION
Per #6429, someone mapped in a hazard suit into the pirate ship with a modified (and invalid) newlist access value that ATLAS could not understand.

To fix this, I have created a new pirate-only subtype of the hazard rig that can be accessed with the pirate's syndicate IDs.  I also removed its ability to be viewed through station cameras at the same time, as an added bonus.