### PR TITLE
Fixing mobs and turrets

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -251,9 +251,7 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 		return FALSE
 
 	var/target_hit = FALSE
-	var/flags = PASSTABLE
-	if(istype(projectiletype, /obj/item/projectile/beam))
-		flags |= (PASSGLASS|PASSGRILLE)
+	var/flags = ispath(projectiletype, /obj/item/projectile/beam) ? PASSTABLE|PASSGLASS|PASSGRILLE : PASSTABLE
 	for(var/mob/M in check_trajectory(target_mob, src, pass_flags=flags))
 		if(M == target_mob)
 			target_hit = TRUE

--- a/html/changelogs/Sindorman-fixes.yml
+++ b/html/changelogs/Sindorman-fixes.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Hostile mobs that use beam weapons now properly check if they can shoot throught windows or grille."
+  - tweak: "Turrets will now consider piloted mechs as valid targets to shoot."
+  - tweak: "Turrets now check if their weapon can shoot throught windows or grille at people."


### PR DESCRIPTION
Round of bugfixes for hostile mobs and turrets

- Fixes #6442 

- Fixes #6438 

- Adds proper flag checks for turrets trajectory check. Makes them check if they can hit people through windows or grille or tables.