### PR TITLE
Replaces the SM core present in one of the ruins with a shard.

### DIFF
--- a/html/changelogs/[Ferner]-[190519-bugfix_ruins_sm.yml
+++ b/html/changelogs/[Ferner]-[190519-bugfix_ruins_sm.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Ferner
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Replaced a supermatter core present in one of the ruins with a shard. To avoid confusing announcements from occuring."

--- a/maps/space_ruins/pra_blockade_runner.dmm
+++ b/maps/space_ruins/pra_blockade_runner.dmm
@@ -841,7 +841,10 @@
 /turf/simulated/floor/tiled/freezer,
 /area/derelict/ship)
 "cw" = (
-/obj/machinery/power/supermatter,
+/obj/machinery/power/supermatter/shard{
+	pixel_y = 6
+	},
+/obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor,
 /area/derelict/ship)
 "cx" = (


### PR DESCRIPTION
Reportedly, an SM core in one of the ruins starts to degrade on its own, sending announcements to station-side channels causing a lot of confusion. This replaces the core with a shard, which doesn't send out any announcements.
Fixes #6473 