### PR TITLE
Balance: Absorb DNA cooldown

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -144,7 +144,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	var/datum/changeling/changeling = changeling_power(0,0,100)
 	if(!changeling)	return
 
-	if (justate + 60 SECONDS > world.time)
+	if (changeling.justate + 60 SECONDS > world.time)
 		to_chat(src, "<span class='warning'>We still processing our last DNA sample!</span>")
 		return
 
@@ -206,7 +206,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	else
 		addtimer(CALLBACK(T, /mob/living/.proc/adjustCloneLoss, rand(10, 15)), rand(10, 15) SECONDS)
 
-	justate = world.time
+	changeling.justate = world.time
 
 	changeling.chem_charges += 5
 	changeling.geneticpoints += 1

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -14,6 +14,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	var/geneticpoints = 5
 	var/purchasedpowers = list()
 	var/mimicing = ""
+	var/justate
 
 /datum/changeling/New(var/gender=FEMALE)
 	..()
@@ -143,6 +144,10 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	var/datum/changeling/changeling = changeling_power(0,0,100)
 	if(!changeling)	return
 
+	if (last_succ + 60 SECONDS > world.time)
+		to_chat(src, "<span class='warning'>We still processing our last DNA sample!</span>")
+		return
+
 	if(changeling.isabsorbing)
 		to_chat(src, "<span class='warning'>We are already engaged in an absorption!</span>")
 		return
@@ -200,7 +205,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 		to_chat(T, "<span class='danger'>You are wracked with agony collapse as your body twists and changes, turning you into a hideous monstrosity!</span>")
 	else
 		addtimer(CALLBACK(T, /mob/living/.proc/adjustCloneLoss, rand(10, 15)), rand(10, 15) SECONDS)
-
+	justate = world.time
 
 	changeling.chem_charges += 5
 	changeling.geneticpoints += 1

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -144,7 +144,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	var/datum/changeling/changeling = changeling_power(0,0,100)
 	if(!changeling)	return
 
-	if (last_succ + 60 SECONDS > world.time)
+	if (justate + 60 SECONDS > world.time)
 		to_chat(src, "<span class='warning'>We still processing our last DNA sample!</span>")
 		return
 
@@ -205,6 +205,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 		to_chat(T, "<span class='danger'>You are wracked with agony collapse as your body twists and changes, turning you into a hideous monstrosity!</span>")
 	else
 		addtimer(CALLBACK(T, /mob/living/.proc/adjustCloneLoss, rand(10, 15)), rand(10, 15) SECONDS)
+
 	justate = world.time
 
 	changeling.chem_charges += 5

--- a/html/changelogs/Kaedwuff - DNA Digestion.yml
+++ b/html/changelogs/Kaedwuff - DNA Digestion.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Changelings now require a full minute to finish digesting a sample of DNA taken from the Absorb DNA ability."


### PR DESCRIPTION
On request from a staff member, I have implemented a delay on using Absorb DNA.  Changelings will be unable to use the ability for a full minute after successfully completing it.