### PR TITLE
Examine tweaks: Hunger and Thirst

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -238,14 +238,6 @@
 	if(on_fire)
 		msg += "<span class='danger'>[T.He] [T.is] on fire!</span>\n"
 	msg += "<span class='warning'>"
-	/*if (!(src.species.flags & NO_CHUBBY) && max_nutrition > 0)
-		if(nutrition / max_nutrition <= CREW_NUTRITION_VERYHUNGRY)
-			msg += "[T.He] [T.is] severely malnourished.\n"
-		else if(nutrition / max_nutrition >= CREW_NUTRITION_OVEREATEN)
-			msg += "[T.He] [T.is] quite chubby.\n"
-	if(max_hydration > 0)
-		if(hydration / max_hydration <= CREW_HYDRATION_VERYTHIRSTY)
-			msg += "[T.He] [T.is] severely dehydrated.\n"*/
 
 	msg += "</span>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -245,7 +245,7 @@
 			msg += "[T.He] [T.is] quite chubby.\n"
 	if(max_hydration > 0)
 		if(hydration / max_hydration <= CREW_HYDRATION_VERYTHIRSTY)
-			msg += "[T.He] [T.is] severely dehydrated.\n"/*
+			msg += "[T.He] [T.is] severely dehydrated.\n"*/
 
 	msg += "</span>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -238,14 +238,14 @@
 	if(on_fire)
 		msg += "<span class='danger'>[T.He] [T.is] on fire!</span>\n"
 	msg += "<span class='warning'>"
-	if (!(src.species.flags & NO_CHUBBY) && max_nutrition > 0)
+	/*if (!(src.species.flags & NO_CHUBBY) && max_nutrition > 0)
 		if(nutrition / max_nutrition <= CREW_NUTRITION_VERYHUNGRY)
 			msg += "[T.He] [T.is] severely malnourished.\n"
 		else if(nutrition / max_nutrition >= CREW_NUTRITION_OVEREATEN)
 			msg += "[T.He] [T.is] quite chubby.\n"
 	if(max_hydration > 0)
 		if(hydration / max_hydration <= CREW_HYDRATION_VERYTHIRSTY)
-			msg += "[T.He] [T.is] severely dehydrated.\n"
+			msg += "[T.He] [T.is] severely dehydrated.\n"/*
 
 	msg += "</span>"
 

--- a/html/changelogs/geeves-examinestweak.yml
+++ b/html/changelogs/geeves-examinestweak.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Geeves
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removed ability to see whether someone is starved or thirsty via examination."


### PR DESCRIPTION
Removed the ability to examine people and see that they are "severely malnourished" or "severely thirsty". I figured it would be odd to, one, see that someone hasn't eaten in two hours, and two, have someone become visibly malnourished and visibly thirst-ridden in only two hours.