### PR TITLE
Changes fireaxe to only cleave when wielded

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -205,7 +205,7 @@
 
 /obj/item/weapon/material/twohanded/fireaxe/pre_attack(var/mob/living/target, var/mob/living/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 2.5)
-	if(istype(target))
+	if(istype(target) && wielded)
 		cleave(user, target)
 	..()
 

--- a/html/changelogs/geeves-cleavetweaks.yml
+++ b/html/changelogs/geeves-cleavetweaks.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Geeves
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changed fireaxe to only cleave when wielded with two hands."


### PR DESCRIPTION
As an engineering main that had to make use of the fireaxe to deal with biohazards, it got old fast when someone entered your range while you were swinging and you decapitate them with the might of Zeus. That can still happen, but, if you know you're gonna be swinging when people are around, you can do it with only one hand to prevent multi-decapitation.

Besides, how well can you drive a fireaxe through multiple bodies if you're only using one arm?

Sidenote: I wanted to do this with other weapons as well, but my brain is simply too small to comprehend what the hell's going on with half of them, so, I'm just sticking with the fireaxe for now.