### PR TITLE
Revert "Apostrophe Bugfix: Plastic Variables"

### DIFF
--- a/code/modules/acting/acting_items.dm
+++ b/code/modules/acting/acting_items.dm
@@ -30,7 +30,6 @@
 		H.change_appearance(APPEARANCE_ALL, H.loc, H, H.generate_valid_species(), state = z_state)
 		var/getName = sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)
 		if(getName)
-			getName = html_decode(getName)
 			H.real_name = getName
 			H.name = getName
 			H.dna.real_name = getName

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -16,7 +16,6 @@
 			return
 
 		var/new_name = sanitize(input(usr,"What would you like to name this mob?","Input a name",M.real_name) as text|null, MAX_NAME_LEN)
-		new_name = html_decode(new_name)
 		if( !new_name || !M )	return
 
 		message_admins("Admin [key_name_admin(usr)] renamed [key_name_admin(M)] to [new_name].")


### PR DESCRIPTION
Reverts Aurorastation/Aurora.3#6547

This introduces an HTML-injection attack. You can inject arbitrary HTML code into character names and have it be executed upon examining someone.