### PR TITLE
Adds a vote to evac shuttle calls.

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -256,7 +256,7 @@ var/datum/controller/subsystem/vote/SSvote
 					AddChoice(ROUNDTYPE_STR_MIXED_SECRET, "Mixed Secret")
 			if("crew_transfer")
 				if(!check_rights(R_ADMIN|R_MOD, 0))
-					if (get_security_level() == "red" || get_security_level() == "delta")
+					if (get_security-level() == "blue" || get_security_level() == "red" || get_security_level() == "delta")
 						to_chat(initiator_key, "The current alert status is too high to call for a crew transfer!")
 						return 0
 					if(SSticker.current_state <= 2)

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -167,7 +167,10 @@ var/datum/controller/subsystem/vote/SSvote
 				if(. == "Evacuate the Station")
 					emergency_shuttle.call_evac()
 				else
-					to_chat(initiator, "[current_map.boss_short] does not currently have a shuttle available in your sector. Please try again later. We apologise for any inconvenience caused by this.")
+					var/client/C = directory[ckey(initiator)]
+					if(!istype(C))
+						return 0
+					to_chat(C, "[current_map.boss_short] does not currently have a shuttle available in your sector. Please try again later. We apologise for any inconvenience caused by this. Please try again later.")
 			if("add_antagonist")
 				if(isnull(.) || . == "None")
 					antag_add_failed = 1

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -256,7 +256,7 @@ var/datum/controller/subsystem/vote/SSvote
 					AddChoice(ROUNDTYPE_STR_MIXED_SECRET, "Mixed Secret")
 			if("crew_transfer")
 				if(!check_rights(R_ADMIN|R_MOD, 0))
-					if (get_security-level() == "blue" || get_security_level() == "red" || get_security_level() == "delta")
+					if (get_security_level() == "blue" || get_security_level() == "red" || get_security_level() == "delta")
 						to_chat(initiator_key, "The current alert status is too high to call for a crew transfer!")
 						return 0
 					if(SSticker.current_state <= 2)

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -99,14 +99,14 @@ var/datum/controller/subsystem/vote/SSvote
 						factor = 1.4
 				choices["Initiate Crew Transfer"]["votes"] = round(choices["Initiate Crew Transfer"]["votes"] * factor)
 				to_world("<font color='purple'>Crew Transfer Factor: [factor]</font>")
-				greatest_votes = max(choices["Initiate Crew Transfer"]["votes"], choices["Continue The Round"]["votes"])
+				greatest_votes = max(choices["Initiate Crew Transfer"]["votes"], choices["Continue the Round"]["votes"])
 
 	if(mode == "crew_transfer")
 		if(round(get_round_duration() / 36000)+12 <= 14)
 			// Credit to Scopes @ oldcode.
 			to_world("<font color='purple'><b>Majority voting rule in effect. 2/3rds majority needed to initiate transfer.</b></font>")
 			choices["Initiate Crew Transfer"]["votes"] = round(choices["Initiate Crew Transfer"]["votes"] - round(total_votes / 3))
-			greatest_votes = max(choices["Initiate Crew Transfer"]["votes"], choices["Continue The Round"]["votes"])
+			greatest_votes = max(choices["Initiate Crew Transfer"]["votes"], choices["Continue the Round"]["votes"])
 
 	//get all options with that many votes and return them in a list
 	. = list()
@@ -163,6 +163,11 @@ var/datum/controller/subsystem/vote/SSvote
 				if(. == "Initiate Crew Transfer")
 					init_shift_change(null, 1)
 				last_transfer_vote = get_round_duration()
+			if("evacuate")
+				if(. == "Evacuate the Station")
+					emergency_shuttle.call_evac()
+				else
+					to_world("[current_map.boss_short] does not currently have a shuttle available in your sector. Please try again later. We apologise for any inconvenience caused by this.")
 			if("add_antagonist")
 				if(isnull(.) || . == "None")
 					antag_add_failed = 1
@@ -247,20 +252,20 @@ var/datum/controller/subsystem/vote/SSvote
 				if(ROUNDTYPE_STR_MIXED_SECRET in choices)
 					AddChoice(ROUNDTYPE_STR_MIXED_SECRET, "Mixed Secret")
 			if("crew_transfer")
-				if(check_rights(R_ADMIN|R_MOD, 0))
-					question = "End the shift?"
-					AddChoice("Initiate Crew Transfer")
-					AddChoice("Continue The Round")
-				else
+				if(!check_rights(R_ADMIN|R_MOD, 0))
 					if (get_security_level() == "red" || get_security_level() == "delta")
 						to_chat(initiator_key, "The current alert status is too high to call for a crew transfer!")
 						return 0
 					if(SSticker.current_state <= 2)
-						return 0
 						to_chat(initiator_key, "The crew transfer button has been disabled!")
-					question = "End the shift?"
-					AddChoice("Initiate Crew Transfer")
-					AddChoice("Continue The Round")
+						return 0
+				question = "End the shift?"
+				AddChoice("Initiate Crew Transfer")
+				AddChoice("Continue the Round")
+			if("evacuate")
+				question = "Evacuate the station?"
+				AddChoice("Evacuate the Station")
+				AddChoice("Continue the Round")
 			if("add_antagonist")
 				if(!config.allow_extra_antags || SSticker.current_state >= 2)
 					return 0

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -167,7 +167,7 @@ var/datum/controller/subsystem/vote/SSvote
 				if(. == "Evacuate the Station")
 					emergency_shuttle.call_evac()
 				else
-					to_world("[current_map.boss_short] does not currently have a shuttle available in your sector. Please try again later. We apologise for any inconvenience caused by this.")
+					to_chat(initiator, "[current_map.boss_short] does not currently have a shuttle available in your sector. Please try again later. We apologise for any inconvenience caused by this.")
 			if("add_antagonist")
 				if(isnull(.) || . == "None")
 					antag_add_failed = 1

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -239,7 +239,7 @@
 							if(SEC_LEVEL_YELLOW)
 								feedback_inc("alert_comms_yellow",1)
 			else
-				to_chat(usr, "You press button, but red light flashes and nothing happens.") //This should never happen)
+				to_chat(usr, "You press the button, but a red light flashes and nothing happens.") //This should never happen)
 			current_status = STATE_DEFAULT
 		if("viewmessage")
 			if(is_authenticated(user) && ntn_comm)
@@ -392,11 +392,20 @@ Command action procs
 		to_chat(user, "Under directive 7-10, [station_name()] is quarantined until further notice.")
 		return 0
 
-	to_chat(user, "[current_map.boss_short] has received your request for an evacuation shuttle and will respond in approximately one minute.")
-	SSvote.initiate_vote("evacuate",user.key)
-	log_game("[key_name(user)] has initiated an evacuation vote.",ckey=key_name(user))
-	message_admins("[key_name_admin(user)] has initiated an evacuation vote.", 1)
-
+	switch(get_security_level())
+		if("green")
+			to_chat(user, "[current_map.boss_short] does not have any shuttles available for a low-priority crew evacuation at this time. Please try again if the priority changes.")
+			return 0
+		if("blue", "yellow")
+			to_chat(user, "[current_map.boss_short] has received your request for an evacuation shuttle and will respond in approximately one minute.")
+			SSvote.initiate_vote("evacuate",user.key)
+			log_game("[key_name(user)] has initiated an evacuation vote.",ckey=key_name(user))
+			message_admins("[key_name_admin(user)] has initiated an evacuation vote.", 1)
+		if("red", "delta")
+			to_chat(user, "[current_map.boss_short] has received your priority evacuation request.")
+			emergency_shuttle.call_evac()
+			log_game("[key_name(user)] has called an evacuation shuttle.",ckey=key_name(user))
+			message_admins("[key_name(user)] has called an evacuation shuttle.", 1)
 	return 1
 
 /proc/init_shift_change(var/mob/user, var/force = 0)

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -134,17 +134,17 @@
 		if("sw_menu")
 			current_status = text2num(href_list["target"])
 		if("announce")
-			if(is_authenticated(user) && !issilicon(usr) && ntn_comm)
+			if(is_authenticated(user) && !issilicon(user) && ntn_comm)
 				if(user)
 					var/obj/item/weapon/card/id/id_card = user.GetIdCard()
 					crew_announcement.announcer = GetNameAndAssignmentFromId(id_card)
 				else
 					crew_announcement.announcer = "Unknown"
 				if(announcment_cooldown)
-					to_chat(usr, "Please allow at least one minute to pass between announcements")
+					to_chat(user, "Please allow at least one minute to pass between announcements.")
 					SSnanoui.update_uis(src)
 					return
-				var/input = input(usr, "Please write a message to announce to the station crew.", "Priority Announcement") as null|message
+				var/input = input(user, "Please write a message to announce to the station crew.", "Priority Announcement") as null|message
 				if(!input || !can_still_topic())
 					SSnanoui.update_uis(src)
 					return
@@ -155,29 +155,29 @@
 		if("message")
 			if(href_list["target"] == "emagged")
 				if(program)
-					if(is_authenticated(user) && program.computer_emagged && !issilicon(usr) && ntn_comm)
+					if(is_authenticated(user) && program.computer_emagged && !issilicon(user) && ntn_comm)
 						if(centcomm_message_cooldown)
-							to_chat(usr, "<span class='warning'>Arrays recycling. Please stand by.</span>")
+							to_chat(user, "<span class='warning'>Arrays recycling. Please stand by.</span>")
 							SSnanoui.update_uis(src)
 							return
-						var/input = sanitize(input(usr, "Please choose a message to transmit to \[ABNORMAL ROUTING CORDINATES\] via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination. Transmission does not guarantee a response. There is a 30 second delay before you may send another message, be clear, full and concise.", "To abort, send an empty message.", "") as null|text)
+						var/input = sanitize(input(user, "Please choose a message to transmit to \[ABNORMAL ROUTING CORDINATES\] via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination. Transmission does not guarantee a response. There is a 30 second delay before you may send another message, be clear, full and concise.", "To abort, send an empty message.", "") as null|text)
 						if(!input || !can_still_topic())
 							SSnanoui.update_uis(src)
 							return
-						Syndicate_announce(input, usr)
-						to_chat(usr, "<span class='notice'>Message transmitted.</span>")
-						log_say("[key_name(usr)] has made an illegal announcement: [input]",ckey=key_name(usr))
+						Syndicate_announce(input, user)
+						to_chat(user, "<span class='notice'>Message transmitted.</span>")
+						log_say("[key_name(usr)] has made an illegal announcement: [input]",ckey=key_name(user))
 						centcomm_message_cooldown = 1
 						spawn(300)//30 second cooldown
 							centcomm_message_cooldown = 0
 			else if(href_list["target"] == "regular")
-				if(is_authenticated(user) && !issilicon(usr) && ntn_comm)
+				if(is_authenticated(user) && !issilicon(user) && ntn_comm)
 					if(centcomm_message_cooldown)
-						to_chat(usr, "<span class='warning'>Arrays recycling. Please stand by.</span>")
+						to_chat(user, "<span class='warning'>Arrays recycling. Please stand by.</span>")
 						SSnanoui.update_uis(src)
 						return
 					if(!is_relay_online())//Contact Centcom has a check, Syndie doesn't to allow for Traitor funs.
-						to_chat(usr, "<span class='warning'>No Emergency Bluespace Relay detected. Unable to transmit message.</span>")
+						to_chat(user, "<span class='warning'>No Emergency Bluespace Relay detected. Unable to transmit message.</span>")
 						SSnanoui.update_uis(src)
 						return
 					var/input = sanitize(input("Please choose a message to transmit to [current_map.boss_short] via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination.  Transmission does not guarantee a response. There is a 30 second delay before you may send another message, be clear, full and concise.", "To abort, send an empty message.", "") as null|text)
@@ -185,7 +185,7 @@
 						SSnanoui.update_uis(src)
 						return
 					Centcomm_announce(input, usr)
-					to_chat(usr, "<span class='notice'>Message transmitted.</span>")
+					to_chat(user, "<span class='notice'>Message transmitted.</span>")
 					log_say("[key_name(usr)] has made an IA [current_map.boss_short] announcement: [input]",ckey=key_name(usr))
 					centcomm_message_cooldown = 1
 					spawn(300) //30 second cooldown
@@ -376,9 +376,9 @@ Command action procs
 		to_chat(user, "The emergency shuttle may not be sent at this time. Please try again later.")
 		return 0
 
-	if(world.time < 6000) // Ten minute grace period to let the game get going without lolmetagaming. -- TLE
-		to_chat(user, "The emergency shuttle is refueling. Please wait another [round((6000-world.time)/600)] minute\s before trying again.")
-		return 0
+	//if(world.time < 6000) // Ten minute grace period to let the game get going without lolmetagaming. -- TLE
+	//	to_chat(user, "The emergency shuttle is refueling. Please wait another [round((6000-world.time)/600)] minute\s before trying again.")
+	//	return 0
 
 	if(emergency_shuttle.going_to_centcom())
 		to_chat(user, "The emergency shuttle may not be called while returning to [current_map.boss_short].")
@@ -392,6 +392,7 @@ Command action procs
 		to_chat(user, "Under directive 7-10, [station_name()] is quarantined until further notice.")
 		return 0
 
+	to_chat(user, "[current_map.boss_short] has received your request for an evacuation shuttle and will respond in approximately one minute.")
 	SSvote.initiate_vote("evacuate",user.key)
 	log_game("[key_name(user)] has initiated an evacuation vote.",ckey=key_name(user))
 	message_admins("[key_name_admin(user)] has initiated an evacuation vote.", 1)

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -72,7 +72,7 @@
 	data["message_line2"] = msg_line2
 	data["state"] = current_status
 	data["isAI"] = issilicon(usr)
-	data["authenticated"] = is_autenthicated(user)
+	data["authenticated"] = is_authenticated(user)
 	data["boss_short"] = current_map.boss_short
 	data["current_security_level"] = security_level
 	data["current_security_level_title"] = num2seclevel(security_level)
@@ -105,7 +105,7 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/datum/nano_module/program/comm/proc/is_autenthicated(var/mob/user)
+/datum/nano_module/program/comm/proc/is_authenticated(var/mob/user)
 	if(program)
 		return program.can_run(user)
 	return 1
@@ -134,7 +134,7 @@
 		if("sw_menu")
 			current_status = text2num(href_list["target"])
 		if("announce")
-			if(is_autenthicated(user) && !issilicon(usr) && ntn_comm)
+			if(is_authenticated(user) && !issilicon(usr) && ntn_comm)
 				if(user)
 					var/obj/item/weapon/card/id/id_card = user.GetIdCard()
 					crew_announcement.announcer = GetNameAndAssignmentFromId(id_card)
@@ -155,7 +155,7 @@
 		if("message")
 			if(href_list["target"] == "emagged")
 				if(program)
-					if(is_autenthicated(user) && program.computer_emagged && !issilicon(usr) && ntn_comm)
+					if(is_authenticated(user) && program.computer_emagged && !issilicon(usr) && ntn_comm)
 						if(centcomm_message_cooldown)
 							to_chat(usr, "<span class='warning'>Arrays recycling. Please stand by.</span>")
 							SSnanoui.update_uis(src)
@@ -171,7 +171,7 @@
 						spawn(300)//30 second cooldown
 							centcomm_message_cooldown = 0
 			else if(href_list["target"] == "regular")
-				if(is_autenthicated(user) && !issilicon(usr) && ntn_comm)
+				if(is_authenticated(user) && !issilicon(usr) && ntn_comm)
 					if(centcomm_message_cooldown)
 						to_chat(usr, "<span class='warning'>Arrays recycling. Please stand by.</span>")
 						SSnanoui.update_uis(src)
@@ -191,7 +191,7 @@
 					spawn(300) //30 second cooldown
 						centcomm_message_cooldown = 0
 		if("shuttle")
-			if(is_autenthicated(user) && ntn_cont && can_call_shuttle())
+			if(is_authenticated(user) && ntn_cont && can_call_shuttle())
 				if(href_list["target"] == "call")
 					var/confirm = alert("Are you sure you want to call the shuttle?", name, "No", "Yes")
 					if(confirm == "Yes" && can_still_topic())
@@ -201,7 +201,7 @@
 					if(confirm == "Yes" && can_still_topic())
 						cancel_call_proc(usr)
 		if("setstatus")
-			if(is_autenthicated(user) && ntn_cont)
+			if(is_authenticated(user) && ntn_cont)
 				switch(href_list["target"])
 					if("line1")
 						var/linput = reject_bad_text(sanitize(input("Line 1", "Enter Message Text", msg_line1) as text|null, 40), 40)
@@ -219,7 +219,7 @@
 						post_display_status(href_list["target"])
 
 		if("setalert")
-			if(is_autenthicated(user) && !issilicon(usr) && ntn_cont && ntn_comm)
+			if(is_authenticated(user) && !issilicon(usr) && ntn_cont && ntn_comm)
 				var/current_level = text2num(href_list["target"])
 				var/confirm = alert("Are you sure you want to change alert level to [num2seclevel(current_level)]?", name, "No", "Yes")
 				if(confirm == "Yes" && can_still_topic())
@@ -242,25 +242,25 @@
 				to_chat(usr, "You press button, but red light flashes and nothing happens.") //This should never happen)
 			current_status = STATE_DEFAULT
 		if("viewmessage")
-			if(is_autenthicated(user) && ntn_comm)
+			if(is_authenticated(user) && ntn_comm)
 				current_viewing_message_id = text2num(href_list["target"])
 				for(var/list/m in l.messages)
 					if(m["id"] == current_viewing_message_id)
 						current_viewing_message = m
 				current_status = STATE_VIEWMESSAGE
 		if("delmessage")
-			if(is_autenthicated(user) && ntn_comm && l != global_message_listener)
+			if(is_authenticated(user) && ntn_comm && l != global_message_listener)
 				l.Remove(current_viewing_message)
 			current_status = STATE_MESSAGELIST
 		if("printmessage")
-			if(is_autenthicated(user) && ntn_comm)
+			if(is_authenticated(user) && ntn_comm)
 				if(program && program.computer && program.computer.nano_printer)
 					if(!program.computer.nano_printer.print_text(current_viewing_message["contents"],current_viewing_message["title"]))
 						to_chat(usr, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")
 					else
 						program.computer.visible_message("<span class='notice'>\The [program.computer] prints out paper.</span>")
 		if("toggleintercept")
-			if(is_autenthicated(user) && ntn_comm)
+			if(is_authenticated(user) && ntn_comm)
 				if(program && program.computer && program.computer.nano_printer)
 					var/datum/computer_file/program/comm/P = program
 					P.intercept = !P.intercept
@@ -392,9 +392,9 @@ Command action procs
 		to_chat(user, "Under directive 7-10, [station_name()] is quarantined until further notice.")
 		return 0
 
-	emergency_shuttle.call_evac()
-	log_game("[key_name(user)] has called the shuttle.",ckey=key_name(user))
-	message_admins("[key_name_admin(user)] has called the shuttle.", 1)
+	initiate_vote("evacuate",user.key)
+	log_game("[key_name(user)] has initiated an evacuation vote.",ckey=key_name(user))
+	message_admins("[key_name_admin(user)] has initiated an evacuation vote.", 1)
 
 	return 1
 

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -392,7 +392,7 @@ Command action procs
 		to_chat(user, "Under directive 7-10, [station_name()] is quarantined until further notice.")
 		return 0
 
-	initiate_vote("evacuate",user.key)
+	SSvote.initiate_vote("evacuate",user.key)
 	log_game("[key_name(user)] has initiated an evacuation vote.",ckey=key_name(user))
 	message_admins("[key_name_admin(user)] has initiated an evacuation vote.", 1)
 

--- a/html/changelogs/evacvote-mdp.yml
+++ b/html/changelogs/evacvote-mdp.yml
@@ -1,0 +1,4 @@
+author: MoondancerPony
+delete-after: True
+changes: 
+  - rscadd: "Added a vote to evac shuttle requests. This vote is OOC."

--- a/html/changelogs/evacvote-mdp.yml
+++ b/html/changelogs/evacvote-mdp.yml
@@ -1,4 +1,5 @@
 author: MoondancerPony
 delete-after: True
 changes: 
-  - rscadd: "Added a vote to evac shuttle requests. This vote is OOC."
+  - rscadd: "Added a vote to evac shuttle requests on code blue/yellow. This vote is OOC."
+  - tweak: "A crew transfer cannot be called on code blue. It can still be called on yellow and green."


### PR DESCRIPTION
* Players can now vote to accept/reject an evac shuttle call.
* This is intended to allow interesting rounds to go on for longer; if the majority of the crew is interested in continuing a conflict, it won't be ended because of Command.
* If a vote fails, Command is also not to blame; it is played off as a shuttle from CentCom not being available in the region.
* Also fixes a typo in which `is_authenticated` was spelled `is_autenthicated`.