### PR TITLE
Disables ERT on Revolution

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -5,6 +5,7 @@
 	extended_round_description = "Revolutionaries - Remove the heads of staff from power. Convert other crewmembers to your cause using the 'Convert Bourgeoise' verb. Protect your leaders."
 	required_players = 10
 	required_enemies = 4
+	ert_disabled = 1
 	auto_recall_shuttle = 0
 	end_on_antag_death = 0
 //	shuttle_delay = 3

--- a/html/changelogs/paradoxspace-babyimananarchist.yml
+++ b/html/changelogs/paradoxspace-babyimananarchist.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: ParadoxSpace
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "ERT is now disabled on the revolution gamemode. Admins can still send it if it's really needed."


### PR DESCRIPTION
probably a lazy PR but it's pretty hot out today.
i don't really think it's at all fair that ERT is a thing on revolution. it's basically a guaranteed safety net for loyalists unless they're stubborn, or the revs somehow blitz the (well-fortified) bridge first. neither of which are particularly common. if ERT should exist on rev, the ability for revs to call in syndicate backup should as well. until then, ERT isn't necessary. it's just a loyalist 'ok good fun but i win' button. no.