### PR TITLE
Fix autopunctuation issues.

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -161,6 +161,11 @@ proc/get_radio_key_from_channel(var/channel)
 
 	var/message_mode = parse_message_mode(message, "headset")
 
+	var/ending = copytext(message, length(message), (length(message) + 1))
+
+	if(ending && ending != "!" && ending != "." && ending != "?" && ending != "-" && ending != "~" && ending != "*" && ending != "/") //Check * and / for markup.
+		message += "."
+
 	message = process_chat_markup(message, list("~", "_"))
 
 	switch(copytext(message,1,2))
@@ -175,10 +180,6 @@ proc/get_radio_key_from_channel(var/channel)
 			message = copytext(message,3)
 
 	message = trim_left(message)
-
-	var/ending = copytext(message, length(message), (length(message) + 1))
-	if(ending != "!" && ending != "." && ending != "?" && ending != "-")
-		message += "."
 
 	//parse the language code and consume it
 	if(!speaking)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -161,9 +161,9 @@ proc/get_radio_key_from_channel(var/channel)
 
 	var/message_mode = parse_message_mode(message, "headset")
 
+	var/static/list/correct_punctuation = list("!" = TRUE, "." = TRUE, "?" = TRUE, "-" = TRUE, "~" = TRUE, "*" = TRUE, "/" = TRUE)
 	var/ending = copytext(message, length(message), (length(message) + 1))
-
-	if(ending && ending != "!" && ending != "." && ending != "?" && ending != "-" && ending != "~" && ending != "*" && ending != "/") //Check * and / for markup.
+	if(ending && !correct_punctuation[ending])
 		message += "."
 
 	message = process_chat_markup(message, list("~", "_"))

--- a/html/changelogs/mattatlas-6578.yml
+++ b/html/changelogs/mattatlas-6578.yml
@@ -1,0 +1,7 @@
+author: MattAtlas
+
+delete-after: True
+
+changes: 
+  - bugfix: "Autopunctuation will no longer autopunctuate if markup (* or /) is present at the end of the sentence."
+  - bugfix: "Autopunctuation will no longer send a period if you input an empty chat box."


### PR DESCRIPTION
Autopunctuation will no longer autopunctuate if markup (* or /) is present at the end of the sentence.

It will also no longer input an empty period if you put nothing in the chat box.

Fixes #6536