### PR TITLE
Improved NTNetRelay Interface

### DIFF
--- a/html/changelogs/geeves-relayjigger.yml
+++ b/html/changelogs/geeves-relayjigger.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Geeves
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Improved the NTNetRelay's UI a little, should be easier and less soul-crushing to use now."

--- a/nano/templates/ntnet_chat.tmpl
+++ b/nano/templates/ntnet_chat.tmpl
@@ -50,7 +50,7 @@
 		</div>
         </div>	
 	<div class="itemLabel">
-		Messenging: 
+		Messaging: 
 	</div>
 	<div class="itemContent">
 		<table>

--- a/nano/templates/ntnet_chat.tmpl
+++ b/nano/templates/ntnet_chat.tmpl
@@ -54,7 +54,7 @@
 	</div>
 	<div class="itemContent">
 		<table>
-			<tr><td>{{:helper.link("Send message", null, {'PRG_speak' : 1})}}
+			<tr><td>{{:helper.link("Send message", null, {'PRG_speak' : 1})}}</td></tr>
 		</table>
 	</div>
 {{else}}

--- a/nano/templates/ntnet_chat.tmpl
+++ b/nano/templates/ntnet_chat.tmpl
@@ -20,11 +20,10 @@
 		{{/if}}
 	</div>
 	<div class="itemLabel">
-		Controls: 
+		Chat Controls: 
 	</div>
 	<div class="itemContent">
 		<table>
-			<tr><td>{{:helper.link("Send message", null, {'PRG_speak' : 1})}}
 			<tr><td>{{:helper.link("Change nickname", null, {'PRG_changename' : 1})}}
 			<tr><td>{{:helper.link("Toggle administration mode", null, {'PRG_toggleadmin' : 1})}}
 			<tr><td>{{:helper.link("Leave channel", null, {'PRG_leavechannel' : 1})}}
@@ -35,7 +34,11 @@
 				<tr><td>{{:helper.link("Delete channel", null, {'PRG_deletechannel' : 1})}}
 			{{/if}}
 		</table>
-	</div>		
+	</div>
+	<b>Connected Users</b><br>
+	{{for data.clients}}
+		{{:value.name}}<br>
+	{{/for}}
 	<b>Chat Window</b>
         <div class="statusDisplay" style="overflow: auto;">
 		<div class="item">
@@ -46,10 +49,13 @@
 			</div>
 		</div>
         </div>	
- 	<b>Connected Users</b><br>
-	{{for data.clients}}
-		{{:value.name}}<br>
-	{{/for}}
+	<div class="itemLabel">
+		Messenging: 
+	</div>
+	<div class="itemContent">
+		<table>
+			<tr><td>{{:helper.link("Send message", null, {'PRG_speak' : 1})}}
+		</table>
 {{else}}
 	<b>Controls:</b>
 	<table>

--- a/nano/templates/ntnet_chat.tmpl
+++ b/nano/templates/ntnet_chat.tmpl
@@ -56,6 +56,7 @@
 		<table>
 			<tr><td>{{:helper.link("Send message", null, {'PRG_speak' : 1})}}
 		</table>
+	</div>
 {{else}}
 	<b>Controls:</b>
 	<table>


### PR DESCRIPTION
I encountered an issue when I was using the in-game IRC, where I had the "send message" button was above the box where the chat takes place, so when the chat eventually grew to a rather large size, you had to scroll up above the last message to hit "send message", which feels awkward and not very fun, having to scroll up and down the whole time.

So, I separated the chat controls into stuff that doesn't have to do with messages, and stuff that has to do with messages, and placed the one above the box, and the other beneath the box, resulting in this:
![image](https://user-images.githubusercontent.com/22774890/59553654-08fb5200-8f98-11e9-8e43-28e878d9d66d.png)