### PR TITLE
Unapologetic Mounted Sleeper Nerfs

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -91,24 +91,10 @@
 		return "[output] [temp]"
 	return
 	
-/obj/item/mecha_parts/mecha_equipment/tool/sleeper/verb/move_eject()
-	set name = "Eject occupant"
-	set category = "Object"
-	set src in oview(0)
-	if(usr == occupant) //If the user is inside the sleeper...
-		if (usr.stat == 2) //and they're not dead....
-			return
-		to_chat(usr, "<span class='notice'>Release sequence activated. This will take a minute.</span>")
-		sleep(600)
-		if(!src || !usr || !occupant || (occupant != usr)) //Check if someone's released/replaced/bombed them already
-			return
-		go_out() //and release them from the eternal prison.
-	else
-		if (usr.stat != 0)
-			return
-		go_out()
-	add_fingerprint(usr)
-	return
+/obj/item/mecha_parts/mecha_equipment/tool/sleeper/relaymove(mob, direct)
+	to_chat(usr, "<span class='notice'>Remote release sequence activated. This will take ten seconds.</span>")
+	sleep(100)
+	go_out()
 
 /obj/item/mecha_parts/mecha_equipment/tool/sleeper/Topic(href,href_list)
 	..()

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -93,8 +93,7 @@
 	
 /obj/item/mecha_parts/mecha_equipment/tool/sleeper/relaymove(mob, direct)
 	to_chat(usr, "<span class='notice'>Remote release sequence activated. This will take ten seconds.</span>")
-	sleep(100)
-	go_out()
+	addtimer(CALLBACK(src, .proc/go_out), 10 SECONDS)
 
 /obj/item/mecha_parts/mecha_equipment/tool/sleeper/Topic(href,href_list)
 	..()

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -6,7 +6,7 @@
 	origin_tech = list(TECH_DATA = 2, TECH_BIO = 3)
 	energy_drain = 20
 	range = MELEE
-	equip_cooldown = 20
+	equip_cooldown = 60
 	var/mob/living/carbon/occupant = null
 	var/datum/global_iterator/pr_mech_sleeper
 	var/inject_amount = 10
@@ -41,6 +41,10 @@
 	chassis.visible_message("[chassis] starts putting [target] into [src].")
 	var/C = chassis.loc
 	var/T = target.loc
+	if(target.stat == UNCONSCIOUS)
+		equip_cooldown = 20
+	else
+		equip_cooldown = 60
 	if(do_after_cooldown(target))
 		if(chassis.loc!=C || target.loc!=T)
 			return
@@ -85,6 +89,25 @@
 		if(occupant)
 			temp = "<br />\[Occupant: [occupant] (Health: [occupant.health]%)\]<br /><a href='?src=\ref[src];view_stats=1'>View stats</a>|<a href='?src=\ref[src];eject=1'>Eject</a>"
 		return "[output] [temp]"
+	return
+	
+/obj/item/mecha_parts/mecha_equipment/tool/sleeper/verb/move_eject()
+	set name = "Eject occupant"
+	set category = "Object"
+	set src in oview(0)
+	if(usr == occupant) //If the user is inside the sleeper...
+		if (usr.stat == 2) //and they're not dead....
+			return
+		to_chat(usr, "<span class='notice'>Release sequence activated. This will take a minute.</span>")
+		sleep(600)
+		if(!src || !usr || !occupant || (occupant != usr)) //Check if someone's released/replaced/bombed them already
+			return
+		go_out() //and release them from the eternal prison.
+	else
+		if (usr.stat != 0)
+			return
+		go_out()
+	add_fingerprint(usr)
 	return
 
 /obj/item/mecha_parts/mecha_equipment/tool/sleeper/Topic(href,href_list)
@@ -202,9 +225,6 @@
 	M.AdjustStunned(-4)
 	M.AdjustWeakened(-4)
 	M.AdjustStunned(-4)
-	M.Paralyse(2)
-	M.Weaken(2)
-	M.Stun(2)
 	if(M.reagents.get_reagent_amount("inaprovaline") < 5)
 		M.reagents.add_reagent("inaprovaline", 5)
 	chassis.use_power(energy_drain)

--- a/html/changelogs/geeves-sleepernosleeping.yml
+++ b/html/changelogs/geeves-sleepernosleeping.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Geeves
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Increased the time it takes to put someone in an exosuit mounted sleeper to six seconds, if they're conscious."
+  - rscadd: "People put inside mounted sleepers no longer get knocked out."
+  - rscadd: "It is now possible to eject yourself from a mounted sleeper by moving."


### PR DESCRIPTION
A mounted sleeper is shockingly adept at shutting people down. It takes a whole two (2) (1+1) seconds to load someone into it, and knock them out. Taking the name "sleeper" to the next level here, guys.

This'll make it so it takes six (6) seconds to load someone in when they're awake, so a balance between people who willingly want help don't have to wait too long, and people who wishes to rip and tear the station, can finish their monologue and step out of the way. Also, people who are unconscious will still be loaded in two (2) seconds. Also, people who were loaded won't be knocked unconscious anymore. Also, it's now possible to eject yourself from the sleeper in one (1) minute by going to the object tab in the top right and clicking "Eject occupant".