### PR TITLE
Changes how telescience works and teleportation damage nerf

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -180,7 +180,7 @@
 
 
 
-			if(istype(teleatom, /obj))
+			if(istype(teleatom, /obj) && !istype(teleatom, /obj/effect/portal))
 				valid = 1
 				var/obj/O = teleatom
 				if(newdest)

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -222,7 +222,7 @@
 							if(organs_to_gib.len)
 								var/obj/item/organ/external/E = pick(organs_to_gib)
 								to_chat(H, "<span class='danger'>You partially phase into \the [impediment], causing your [E.name] to violently dematerialize!</span>")
-								E.droplimb(0,DROPLIMB_BLUNT)
+								H.apply_damage(35, BRUTE, E, 0, sharp=0, edge=0)
 
 					else
 						if(newdest)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -6,7 +6,7 @@
 	density = 1
 	unacidable = 1//Can't destroy energy portals.
 	var/failchance = 5
-	var/obj/item/target = null
+	var/obj/target = null
 	var/creator = null
 	anchored = 1.0
 

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -1,7 +1,7 @@
 ///SCI TELEPAD///
 /obj/machinery/telepad
 	name = "telepad"
-	desc = "A bluespace telepad used for teleporting objects to and from a location."
+	desc = "A bluespace telepad used for creating bluespace portals."
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "pad-idle"
 	anchored = 1

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -215,11 +215,21 @@
 			flick("pad-beam", telepad)
 			playsound(telepad.loc, 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
 
-			var/obj/effect/portal/origin = new /obj/effect/portal(dest)
-			var/obj/effect/portal/destination = new /obj/effect/portal(source)
+			var/total_lifespawn = 250
+			var/total_failchance = 0
+
+			for(var/obj/item/I in crystals)
+				total_lifespawn += 25	//each crystal will increase the duration
+				total_failchance += 1
+
+			var/obj/effect/portal/origin = new /obj/effect/portal(dest, null, null, total_lifespawn)
+			var/obj/effect/portal/destination = new /obj/effect/portal(source,  null, null, total_lifespawn)
 
 			origin.target = destination
 			destination.target = origin
+
+			origin.failchance = total_failchance
+			destination.failchance = total_failchance
 
 			if (dd_hassuffix(log_msg, ", "))
 				log_msg = dd_limittext(log_msg, length(log_msg) - 2)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -117,8 +117,7 @@
 		t += " <A href='?src=\ref[src];scalar=1'>Recalibrate Warp-Funnel</A>"
 		t += "<div class='statusDisplay'>[potency]</div>"
 
-		t += "<BR><A href='?src=\ref[src];send=1'>Send</A>"
-		t += " <A href='?src=\ref[src];receive=1'>Receive</A>"
+		t += "<BR><A href='?src=\ref[src];send=1'>Open Portal</A>"
 		t += "<BR><A href='?src=\ref[src];recal=1'>Recalibrate Crystals</A> <A href='?src=\ref[src];eject=1'>Eject Crystals</A>"
 
 		// Information about the last teleport
@@ -215,44 +214,12 @@
 
 			flick("pad-beam", telepad)
 			playsound(telepad.loc, 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
-			for(var/atom/movable/ROI in range(potency,source))
-				// if is anchored, don't let through
-				if(ROI.anchored)
-					if(isliving(ROI))
-						var/mob/living/L = ROI
-						if(L.buckled)
-							// TP people on office chairs
-							if(L.buckled.anchored)
-								continue
 
-							log_msg += "[key_name(L)] (on a chair), "
-						else
-							continue
-					else if(!isobserver(ROI))
-						continue
-				if(ismob(ROI))
-					var/mob/T = ROI
-					log_msg += "[key_name(T)], "
-				else
-					log_msg += "[ROI.name]"
-					if (istype(ROI, /obj/structure/closet))
-						var/obj/structure/closet/C = ROI
-						log_msg += " ("
-						for(var/atom/movable/Q as mob|obj in C)
-							if(ismob(Q))
-								log_msg += "[key_name(Q)], "
-							else
-								log_msg += "[Q.name], "
-						if (dd_hassuffix(log_msg, "("))
-							log_msg += "empty)"
-						else
-							log_msg = dd_limittext(log_msg, length(log_msg) - 2)
-							log_msg += ")"
-					log_msg += ", "
-				var/x_offset = ROI.x - source.x
-				var/y_offset = ROI.y - source.y
+			var/obj/effect/portal/origin = new /obj/effect/portal(dest)
+			var/obj/effect/portal/destination = new /obj/effect/portal(source)
 
-				do_teleport(ROI, locate(dest.x + x_offset, dest.y + y_offset, dest.z))
+			origin.target = destination
+			destination.target = origin
 
 			if (dd_hassuffix(log_msg, ", "))
 				log_msg = dd_limittext(log_msg, length(log_msg) - 2)
@@ -270,6 +237,10 @@
 		telefail()
 		temp_msg = "ERROR!<BR>No power selected!"
 		return
+	if(telepad)
+		if(locate(/obj/effect/portal, telepad.loc))
+			temp_msg = "ERROR!<BR>Bluespace portal located at \the [telepad] location!"
+			return
 	if(angle < 1 || angle > 90)
 		telefail()
 		temp_msg = "ERROR!<BR>Elevation is less than 1 or greater than 90."
@@ -341,10 +312,6 @@
 
 	if(href_list["send"])
 		sending = 1
-		teleport(usr)
-
-	if(href_list["receive"])
-		sending = 0
 		teleport(usr)
 
 	if(href_list["scalar"])

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -211,12 +211,8 @@
 			flick("pad-beam", telepad)
 			playsound(telepad.loc, 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
 
-			var/total_lifespawn = 250
-			var/total_failchance = 0
-
-			for(var/obj/item/I in crystals)
-				total_lifespawn += 25	//each crystal will increase the duration
-				total_failchance += 1
+			var/total_lifespawn += 25 * crystals.len
+			var/total_failchance += crystals.len
 
 			var/obj/effect/portal/origin = new /obj/effect/portal(dest, null, null, total_lifespawn)
 			var/obj/effect/portal/destination = new /obj/effect/portal(source,  null, null, total_lifespawn)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -1,6 +1,6 @@
 /obj/machinery/computer/telescience
 	name = "\improper Telepad Control Console"
-	desc = "Used to teleport objects to and from the telescience telepad."
+	desc = "Used to create bluespace portals using the telescience telepad."
 	icon_screen = "teleport"
 	light_color = LIGHT_COLOR_BLUE
 	circuit = /obj/item/weapon/circuitboard/telesci_console
@@ -195,7 +195,7 @@
 
 			spark(telepad, 5, alldirs)
 
-			temp_msg = "Teleport successful.<BR>"
+			temp_msg = "Bluespace portal creation successful.<BR>"
 			if(teles_left < 10)
 				temp_msg += "<BR>Calibration required soon."
 			else

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -211,8 +211,8 @@
 			flick("pad-beam", telepad)
 			playsound(telepad.loc, 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
 
-			var/total_lifespawn += 25 * crystals.len
-			var/total_failchance += crystals.len
+			var/total_lifespawn = 25 * crystals.len
+			var/total_failchance = crystals.len
 
 			var/obj/effect/portal/origin = new /obj/effect/portal(dest, null, null, total_lifespawn)
 			var/obj/effect/portal/destination = new /obj/effect/portal(source,  null, null, total_lifespawn)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -20,7 +20,6 @@
 	var/rotation = 0
 	var/angle = 45
 	var/power = 5
-	var/potency = 0
 
 	// Based on the power used
 	var/teleport_cooldown = 0 // every index requires a bluespace crystal
@@ -102,7 +101,7 @@
 		t += "<div class='statusDisplay'>"
 
 		for(var/i = 1; i <= power_options.len; i++)
-			if(crystals.len + telepad.efficiency - potency  < i)
+			if(crystals.len + telepad.efficiency < i)
 				t += "<span class='linkOff'>[power_options[i]]</span>"
 				continue
 			if(power == power_options[i])
@@ -113,9 +112,6 @@
 
 		t += "<A href='?src=\ref[src];setz=1'>Set Sector</A>"
 		t += "<div class='statusDisplay'>[z_co ? z_co : "NULL"]</div>"
-
-		t += " <A href='?src=\ref[src];scalar=1'>Recalibrate Warp-Funnel</A>"
-		t += "<div class='statusDisplay'>[potency]</div>"
 
 		t += "<BR><A href='?src=\ref[src];send=1'>Open Portal</A>"
 		t += "<BR><A href='?src=\ref[src];recal=1'>Recalibrate Crystals</A> <A href='?src=\ref[src];eject=1'>Eject Crystals</A>"
@@ -174,7 +170,7 @@
 		var/area/A = get_area(target)
 		flick("pad-beam", telepad)
 
-		if(spawn_time > (15 * (potency + 1))) // 1.5 seconds
+		if(spawn_time > 15 ) // 1.5 seconds
 			playsound(telepad.loc, 'sound/weapons/flash.ogg', 25, 1)
 			// Wait depending on the time the projectile took to get there
 			teleporting = 1
@@ -187,11 +183,11 @@
 			if(telepad.stat & NOPOWER)
 				return
 			teleporting = 0
-			teleport_cooldown = world.time + (power * 2 * (potency + 1))
+			teleport_cooldown = world.time + (power * 2)
 			teles_left -= 1
 
 			// use a lot of power
-			use_power(power * 10 * (potency + 1))
+			use_power(power * 10)
 
 			spark(telepad, 5, alldirs)
 
@@ -299,7 +295,7 @@
 		var/index = href_list["setpower"]
 		index = text2num(index)
 		if(index != null && power_options[index])
-			if(crystals.len + telepad.efficiency - potency >= index)
+			if(crystals.len + telepad.efficiency >= index)
 				power = power_options[index]
 
 	if(href_list["setz"])
@@ -323,16 +319,6 @@
 	if(href_list["send"])
 		sending = 1
 		teleport(usr)
-
-	if(href_list["scalar"])
-		if(potency < max(0, crystals.len - 2))
-			potency++
-		else
-			potency = 0
-		if(crystals.len + telepad.efficiency - potency <= 0)
-			power = power_options[1]
-		else if(power_options[crystals.len + telepad.efficiency - potency] < power)
-			power = power_options[crystals.len + telepad.efficiency - potency]
 
 	if(href_list["recal"])
 		recalibrate()

--- a/html/changelogs/alberyk-telescience.yml
+++ b/html/changelogs/alberyk-telescience.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes: 
   - tweak: "Telescience has been changed; it will now create two bluespace portals, one at the telepad and other at the location of the coordinates."
+  - tweak: "Teleporting into solid objects is now less punishing, dealing brute damage instead of exploding limbs."

--- a/html/changelogs/alberyk-telescience.yml
+++ b/html/changelogs/alberyk-telescience.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Telescience has been changed; it will now create two bluespace portals, one at the telepad and other at the location of the coordinates."


### PR DESCRIPTION
This pr changes how telescience works; instead of just teleport things with zero risk or consequences, telescience will now create two portals, one in the telepad, and the other in the location.

Why?
Telescience has always been a really problematic part of the game, causing a lot of fuckery over the ages. It is pretty much riskless, besides some possible explosion, limb loss or whatever if you fuck up, but if you somewhat knew what you were doing, you could steal shit, and just teleport bombs or whatever upon your victims.

Now, telescience has some risk and difficulty attached to it. Since, for the scientist to steal/kidnapp/save someone, they must enter the portal, which puts them in the location of where they want to reach. It is also possible for the people that can reach the portal to end in the telescience lab, allowing for some counter play.