### PR TITLE
Fixes the lack of a LAZYACCESS causing AI clicks to fail

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -56,7 +56,7 @@
 
 	if(multitool_mode && isobj(A))
 		var/obj/O = A
-		var/datum/expansion/multitool/MT = O.expansions[/datum/expansion/multitool]
+		var/datum/expansion/multitool/MT = LAZYACCESS(O.expansions[/datum/expansion/multitool])
 		if(MT)
 			MT.interact(aiMulti, src)
 			return

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -56,7 +56,7 @@
 
 	if(multitool_mode && isobj(A))
 		var/obj/O = A
-		var/datum/expansion/multitool/MT = LAZYACCESS(O.expansions[/datum/expansion/multitool])
+		var/datum/expansion/multitool/MT = LAZYACCESS(O.expansions, /datum/expansion/multitool)
 		if(MT)
 			MT.interact(aiMulti, src)
 			return

--- a/html/changelogs/skull132_ai-clicks.yml
+++ b/html/changelogs/skull132_ai-clicks.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - bugfix: "Fixed a case where leaving the multitool mode enabled as the AI would cause your clicks to fail in 90% of the cases."


### PR DESCRIPTION
Fixes #6605 

```
runtime error:
[08:26:38]bad index
[08:26:38]proc name: ClickOn (/mob/living/silicon/ai/ClickOn)
[08:26:38]  source file: ai.dm,59
[08:26:38]  usr: (src)
[08:26:38]  src: Dragon (/mob/living/silicon/ai)
[08:26:38]  src.loc: the processing strata (206,146,3) (/turf/simulated/floor/bluegrid)
[08:26:38]  call stack:
[08:26:38]Dragon (/mob/living/silicon/ai): ClickOn(the AI holopad (/obj/machinery/hologram/holopad), "icon-x=19;icon-y=14;left=1;scr...")
[08:26:38]the AI holopad (/obj/machinery/hologram/holopad): Click(the floor (119,99,4) (/turf/simulated/floor/tiled), "mapwindow.map", "icon-x=19;icon-y=14;left=1;scr...")
```

Caused by a bad access of a lazy list. Would fail 90% of clicks if the AI left multitool mode enabled.