### PR TITLE
Fixes syndicate force glove grabs having no reinforce timer

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -178,6 +178,8 @@
 			if(H.gloves && istype(H.gloves,/obj/item/clothing/gloves/force/syndicate)) //only antag gloves can do this for now
 				G.state = GRAB_AGGRESSIVE
 				G.icon_state = "grabbed1"
+				G.hud.icon_state = "reinforce1"
+				G.last_action = world.time
 				visible_message("<span class='warning'>[M] gets a strong grip on [src]!</span>")
 				return 1
 			visible_message("<span class='warning'>[M] has grabbed [src] passively!</span>")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -551,6 +551,8 @@ emp_act
 	if(user.gloves && istype(user.gloves,/obj/item/clothing/gloves/force/syndicate)) //only antag gloves can do this for now
 		G.state = GRAB_AGGRESSIVE
 		G.icon_state = "grabbed1"
+		G.hud.icon_state = "reinforce1"
+		G.last_action = world.time
 		visible_message("<span class='warning'>[user] gets a strong grip on [src]!</span>")
 		return 1
 	visible_message("<span class='warning'>[user] has grabbed [src] passively!</span>")

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -110,7 +110,6 @@
 		assailant.stop_pulling()
 
 	if(state <= GRAB_AGGRESSIVE)
-		allow_upgrade = 1
 		//disallow upgrading if we're grabbing more than one person
 		if((assailant.l_hand && assailant.l_hand != src && istype(assailant.l_hand, /obj/item/weapon/grab)))
 			var/obj/item/weapon/grab/G = assailant.l_hand
@@ -126,6 +125,8 @@
 			if(G == src) continue
 			if(G.state >= GRAB_AGGRESSIVE)
 				allow_upgrade = 0
+
+		allow_upgrade = 1
 
 		if(allow_upgrade)
 			if(state < GRAB_AGGRESSIVE)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -110,6 +110,7 @@
 		assailant.stop_pulling()
 
 	if(state <= GRAB_AGGRESSIVE)
+		allow_upgrade = 1
 		//disallow upgrading if we're grabbing more than one person
 		if((assailant.l_hand && assailant.l_hand != src && istype(assailant.l_hand, /obj/item/weapon/grab)))
 			var/obj/item/weapon/grab/G = assailant.l_hand
@@ -125,8 +126,6 @@
 			if(G == src) continue
 			if(G.state >= GRAB_AGGRESSIVE)
 				allow_upgrade = 0
-
-		allow_upgrade = 1
 
 		if(allow_upgrade)
 			if(state < GRAB_AGGRESSIVE)

--- a/html/changelogs/geeves-glovefix.yml
+++ b/html/changelogs/geeves-glovefix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Geeves
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes force gloves being able to upgrade instantly to red grab, locking the grabbee in place."


### PR DESCRIPTION
Force gloves allowed you do the first upgrade instantly, meaning you skip both passive and blue. According to the code, this is unintentional behavior and leads to further bugs, such as being stun-locked when this happens repeatedly.