### PR TITLE
Fixes ambitions to actually appear at roundend

### DIFF
--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -7,12 +7,12 @@
 	for(var/datum/mind/P in current_antagonists)
 		text += print_player_full(P)
 		text += get_special_objective_text(P)
+		if(P.ambitions)
+			text += "<br><font color='purple'><b>Their goals for today were:</b></font>"
+			text += "<br>  '[P.ambitions]'"
 		if(!global_objectives.len && P.objectives && P.objectives.len)
 			var/failed
 			var/num = 1
-			if(P.ambitions)
-				text += "<br>Their goals for today were..."
-				text += "<br><b>[P.ambitions]</b>"
 
 			for(var/datum/objective/O in P.objectives)
 				text += print_objective(O, num)

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -115,9 +115,9 @@ var/datum/antagonist/wizard/wizards
 				var/spell/spell = s
 				text += "<br><b>[spell.name]</b> - "
 				text += "Speed: [spell.spell_levels["speed"]] Power: [spell.spell_levels["power"]]"
-		if(p.ambitions)
+		if(P.ambitions)
 			text += "<br><font color='purple'><b>Their goals for today were:</b></font>"
-			text += "<br>  '[p.ambitions]'"
+			text += "<br>  '[P.ambitions]'"
 		text += "<br>"
 		to_world(text)
 

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -115,6 +115,9 @@ var/datum/antagonist/wizard/wizards
 				var/spell/spell = s
 				text += "<br><b>[spell.name]</b> - "
 				text += "Speed: [spell.spell_levels["speed"]] Power: [spell.spell_levels["power"]]"
+		if(P.ambitions)
+			text += "<br><font color='purple'><b>Their goals for today were:</b></font>"
+			text += "<br>  '[P.ambitions]'"
 		text += "<br>"
 		to_world(text)
 

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -115,9 +115,9 @@ var/datum/antagonist/wizard/wizards
 				var/spell/spell = s
 				text += "<br><b>[spell.name]</b> - "
 				text += "Speed: [spell.spell_levels["speed"]] Power: [spell.spell_levels["power"]]"
-		if(p.ambitions)
+		if(player.ambitions)
 			text += "<br><font color='purple'><b>Their goals for today were:</b></font>"
-			text += "<br>  '[p.ambitions]'"
+			text += "<br>  '[player.ambitions]'"
 		text += "<br>"
 		to_world(text)
 

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -115,9 +115,9 @@ var/datum/antagonist/wizard/wizards
 				var/spell/spell = s
 				text += "<br><b>[spell.name]</b> - "
 				text += "Speed: [spell.spell_levels["speed"]] Power: [spell.spell_levels["power"]]"
-		if(P.ambitions)
+		if(p.ambitions)
 			text += "<br><font color='purple'><b>Their goals for today were:</b></font>"
-			text += "<br>  '[P.ambitions]'"
+			text += "<br>  '[p.ambitions]'"
 		text += "<br>"
 		to_world(text)
 

--- a/html/changelogs/geeves-ambitionfix.yml
+++ b/html/changelogs/geeves-ambitionfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Geeves
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed antagonist ambitions to actually appear at round end. Remember to set them in the IC tab!"


### PR DESCRIPTION
The issue emerged that Aurora doesn't actually give antagonists objectives, so the if statement was never fulfilled. This places ambitions outside the if statement. If an ambition is set now, it will display like this (minus the objectives of course):

![image](https://user-images.githubusercontent.com/22774890/59966494-d87a6180-951d-11e9-8421-a3809ac7af0a.png)
