### PR TITLE
Fixing water and foam wasted on mobs that do not need to be extinguished

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -236,8 +236,9 @@
 	. = ..()
 	if(istype(M) && isliving(M))
 		var/mob/living/L = M
-		L.ExtinguishMob(L.on_fire ? amount : amount*0.5)
-		remove_self(amount)
+		var/needed = L.fire_stacks >= amount ? amount : L.fire_stacks
+		L.ExtinguishMob(needed)
+		remove_self(needed)
 
 	if(istype(M) && !istype(M, /mob/abstract))
 		M.color = initial(M.color)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -236,7 +236,7 @@
 	. = ..()
 	if(istype(M) && isliving(M))
 		var/mob/living/L = M
-		var/needed = L.fire_stacks >= amount ? amount : L.fire_stacks
+		var/needed = min(L.fire_stacks, amount)
 		L.ExtinguishMob(needed)
 		remove_self(needed)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -316,7 +316,7 @@
 /datum/reagent/toxin/fertilizer/monoammoniumphosphate/touch_mob(var/mob/living/L, var/amount)
 	. = ..()
 	if(istype(L))
-		var/needed = L.fire_stacks >= 3 * amount ? 3 * amount : L.fire_stacks
+		var/needed = min(L.fire_stacks, 3 * amount)
 		L.ExtinguishMob(needed)
 		remove_self(needed)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -316,8 +316,8 @@
 /datum/reagent/toxin/fertilizer/monoammoniumphosphate/touch_mob(var/mob/living/L, var/amount)
 	. = ..()
 	if(istype(L))
-		var/needed = min(L.fire_stacks, 3 * amount)
-		L.ExtinguishMob(needed)
+		var/needed = min(L.fire_stacks, amount)
+		L.ExtinguishMob(3* needed) // Foam is 3 times more efficient at extinguishing
 		remove_self(needed)
 
 /datum/reagent/toxin/fertilizer/monoammoniumphosphate/affect_touch(var/mob/living/carbon/slime/S, var/alien, var/removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -316,8 +316,9 @@
 /datum/reagent/toxin/fertilizer/monoammoniumphosphate/touch_mob(var/mob/living/L, var/amount)
 	. = ..()
 	if(istype(L))
-		L.ExtinguishMob(L.on_fire ? amount*3 : amount*1.5)
-		remove_self(amount)
+		var/needed = L.fire_stacks >= 3 * amount ? 3 * amount : L.fire_stacks
+		L.ExtinguishMob(needed)
+		remove_self(needed)
 
 /datum/reagent/toxin/fertilizer/monoammoniumphosphate/affect_touch(var/mob/living/carbon/slime/S, var/alien, var/removed)
 	if(istype(S))

--- a/html/changelogs/example - Copy.yml
+++ b/html/changelogs/example - Copy.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Water and Fire extinguisher foam now properly reacts with Mobs and does not dissapear entirely. Splashing people/slimes with water/foam will now work properly."


### PR DESCRIPTION
This PR fixes #6459 

- Water no longer is entirely used when extinguishing mobs when we only need a bit of it.

- Fire Extinguisher foam no longer is entirely used when extinguishing mobs when we only need a bit of it.