### PR TITLE
Fixes autohiss breaking for humans

### DIFF
--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -108,6 +108,8 @@
 		)
 
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
+	if (!autohiss_basic_map || !autohiss_basic_map.len)
+		return message
 
 	if(autohiss_exempt && (lang.name in autohiss_exempt))
 		return message

--- a/html/changelogs/skull132_autohiss.yml
+++ b/html/changelogs/skull132_autohiss.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - bugfix: "Fixed a bug where, as a human, if you enabled autohiss, you would be unable to speak until you disabled it again."


### PR DESCRIPTION
Humans could enable autohiss. This resulted in the `handle_autohiss` proc runtiming, due to missing expected maps. The runtiming rendered the person unable to speak until they turned autohiss off again.

Fixes this by checking for the presence and length of `autohiss_basic_map`. The map is expected as a predicate towards autohiss working in the first place.