### PR TITLE
Prevents ghosts from freely observing on the derelict.

### DIFF
--- a/code/controllers/subsystems/initialization/map_finalization.dm
+++ b/code/controllers/subsystems/initialization/map_finalization.dm
@@ -102,7 +102,8 @@
 	if (!maploader.load_map(file(mfile), 0, 0, no_changeturf = TRUE))
 		log_ss("finalize", "Failed to load '[mfile]'!")
 	else
-		log_ss("atlas", "Loaded space ruin in [(world.time - time)/10] seconds.")
+		log_ss("finalize", "Loaded space ruin on z [world.maxz] in [(world.time - time)/10] seconds.")
+		current_map.restricted_levels.Add(world.maxz)
 	QDEL_NULL(maploader)
 
 /datum/controller/subsystem/finalize/proc/place_dungeon_spawns()

--- a/code/controllers/subsystems/initialization/misc_late.dm
+++ b/code/controllers/subsystems/initialization/misc_late.dm
@@ -17,7 +17,7 @@
 				teleportlocs += AR.name
 				teleportlocs[AR.name] = AR
 
-		if(istype(AR, /area/turret_protected/aisat) || istype(AR, /area/derelict) || istype(AR, /area/tdome) || istype(AR, /area/shuttle/specops/centcom))
+		if(istype(AR, /area/turret_protected/aisat) || istype(AR, /area/tdome) || istype(AR, /area/shuttle/specops/centcom))
 			ghostteleportlocs += AR.name
 			ghostteleportlocs[AR.name] = AR
 

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -112,10 +112,6 @@
 			if(istype(target))
 				ManualFollow(target)
 
-/mob/abstract/observer/forceMove()
-	stop_following()
-	. = ..()
-
 /mob/abstract/observer/proc/initialise_postkey(set_timers = TRUE)
 	//This function should be run after a ghost has been created and had a ckey assigned
 	if (!set_timers)
@@ -195,10 +191,10 @@ Works together with spawning an observer, noted above.
 
 	if(following)
 		if(!iscarbon(following)) //If they are following something other than a carbon mob, teleport them
+			stop_following()
 			teleport_to_spawn("You can not follow \the [following] on this level.")
 		else
 			return
-
 	//If they are moving around freely, teleport them
 	teleport_to_spawn()
 	//And update their sight settings

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -165,7 +165,7 @@ Works together with spawning an observer, noted above.
 	if(!check)
 		check = z
 	//Check if they are a staff member
-	if(!check_rights(R_MOD|R_ADMIN|R_DEV, show_msg=FALSE, user=src))
+	if(check_rights(R_MOD|R_ADMIN|R_DEV, show_msg=FALSE, user=src))
 		return FALSE
 	
 	//Check if the z level is in the restricted list

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -163,7 +163,7 @@ Works together with spawning an observer, noted above.
 
 /mob/abstract/observer/proc/on_restricted_level()
 	//Check if they are a staff member
-	if(client && client.holder && (client.holder.rights & (R_MOD|R_ADMIN|R_DEV)))
+	if(!check_rights(R_MOD|R_ADMIN|R_DEV, show_msg=FALSE, user=src))
 		return FALSE
 	
 	//Check if the z level is in the restricted list

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -189,7 +189,7 @@ Works together with spawning an observer, noted above.
 
 	if(following)
 		if(!istype(following,/mob/living/carbon)) //If they are following something other than a carbon mob, teleport them
-			teleport_to_spawn("You can not follow \the [following] on this leavel.")
+			teleport_to_spawn("You can not follow \the [following] on this level.")
 		else
 			return
 

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -163,7 +163,7 @@ Works together with spawning an observer, noted above.
 
 /mob/abstract/observer/proc/on_restricted_level()
 	//Check if they are a staff member
-	if(client.holder && client.holder & (R_MOD|R_ADMIN|R_DEV))
+	if(client && client.holder && (client.holder.rights & (R_MOD|R_ADMIN|R_DEV)))
 		return FALSE
 	
 	//Check if the z level is in the restricted list

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -188,7 +188,7 @@ Works together with spawning an observer, noted above.
 		return
 
 	if(following)
-		if(!istype(following,/mob/living/carbon)) //If they are following something other than a carbon mob, teleport them
+		if(!iscarbon(following)) //If they are following something other than a carbon mob, teleport them
 			teleport_to_spawn("You can not follow \the [following] on this level.")
 		else
 			return

--- a/html/changelogs/arrow768.yml
+++ b/html/changelogs/arrow768.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Ghost are no longer able to freely move around on the derelict. They can follow human mobs on the drelict tough."

--- a/maps/_common/mapsystem/map.dm
+++ b/maps/_common/mapsystem/map.dm
@@ -8,6 +8,7 @@
 	var/list/contact_levels = list() // Z-levels that can be contacted from the station, for eg announcements
 	var/list/player_levels = list()  // Z-levels a character can typically reach
 	var/list/sealed_levels = list()  // Z-levels that don't allow random transit at edge
+	var/list/restricted_levels = list()  // Z-levels that dont allow ghosts to randomly move around
 
 	var/list/map_levels              // Z-levels available to various consoles, such as the crew monitor. Defaults to station_levels if unset.
 

--- a/maps/aurora/code/aurora.dm
+++ b/maps/aurora/code/aurora.dm
@@ -9,7 +9,7 @@
 	admin_levels = list(1)
 	contact_levels = list(3, 4, 5, 6)
 	player_levels = list(2, 3, 4, 5, 6, 7, 8)
-	restricted_levels = list(9) //TODO: Update that in the ruin loader
+	restricted_levels = list()
 	accessible_z_levels = list("8" = 10, "7" = 15, "2" = 60)
 	base_turf_by_z = list(
 		"1" = /turf/space,

--- a/maps/aurora/code/aurora.dm
+++ b/maps/aurora/code/aurora.dm
@@ -9,6 +9,7 @@
 	admin_levels = list(1)
 	contact_levels = list(3, 4, 5, 6)
 	player_levels = list(2, 3, 4, 5, 6, 7, 8)
+	restricted_levels = list(9) //TODO: Update that in the ruin loader
 	accessible_z_levels = list("8" = 10, "7" = 15, "2" = 60)
 	base_turf_by_z = list(
 		"1" = /turf/space,


### PR DESCRIPTION
Ghosts can now only observe on the derelict by following a member of a away mission.
If they stop following a member of they away mission, they are teleported back to the station.
They are also forced into the vision mode of a normal human mob as long as they are on the derelict.

https://forums.aurorastation.org/topic/12291-restricting-ghost-vision-on-derelicts/

ToDo:
- [x] Update the restricted_levels list automatically
- [x] Final testing