### PR TITLE
Changes the away site research shuttle base turf to be reinforced floor

### DIFF
--- a/maps/_common/areas/shuttles.dm
+++ b/maps/_common/areas/shuttles.dm
@@ -216,7 +216,7 @@
 /area/shuttle/research/away
 	icon_state = "shuttle"
 	station_area = 0
-	base_turf = /turf/space
+	base_turf = /turf/simulated/floor/reinforced
 
 /area/shuttle/legion/centcom
 	name = "\improper Foreign Legion Shuttle"


### PR DESCRIPTION
What it says in the title, so this stops away sites from getting vented out of nowhere.