### PR TITLE
Disables ert from rev, with less metagaming now

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -234,8 +234,6 @@ var/global/list/additional_antag_types = list()
 
 	spawn (rand(waittime_l, waittime_h))
 		send_intercept()
-		spawn(rand(100,150))
-			announce_ert_disabled()
 
 	//Assign all antag types for this game mode. Any players spawned as antags earlier should have been removed from the pending list, so no need to worry about those.
 	for(var/datum/antagonist/antag in antag_templates)
@@ -689,7 +687,7 @@ proc/display_logout_report()
 
 	if(!check_rights(R_ADMIN|R_MOD))
 		return
-	to_chat(src,get_logout_report())	
+	to_chat(src,get_logout_report())
 
 proc/get_nt_opposed()
 	var/list/dudes = list()

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -10,3 +10,4 @@
 //	shuttle_delay = 3
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST)
 	require_all_templates = 1
+	ert_disabled = TRUE

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -150,6 +150,8 @@
 			revoke_maint_all_access()
 			feedback_inc("alert_keycard_auth_maintRevoke",1)
 		if("Emergency Response Team")
+			if(SSticker.mode.ert_disabled)
+				SSticker.mode.announce_ert_disabled()
 			if(is_ert_blocked())
 				to_chat(usr, "<span class='warning'>All emergency response teams are dispatched and can not be called at this time.</span>")
 				return

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -150,18 +150,20 @@
 			revoke_maint_all_access()
 			feedback_inc("alert_keycard_auth_maintRevoke",1)
 		if("Emergency Response Team")
-			if(SSticker.mode.ert_disabled)
-				SSticker.mode.announce_ert_disabled()
 			if(is_ert_blocked())
 				to_chat(usr, "<span class='warning'>All emergency response teams are dispatched and can not be called at this time.</span>")
 				return
-
 			SSresponseteam.trigger_armed_response_team()
 			feedback_inc("alert_keycard_auth_ert",1)
 
 /obj/machinery/keycard_auth/proc/is_ert_blocked()
-	if(config.ert_admin_call_only) return 1
-	return SSticker.mode && SSticker.mode.ert_disabled
+	if(config.ert_admin_call_only)
+		return 1
+	if(SSticker.mode.ert_disabled)
+		SSticker.mode.announce_ert_disabled()
+		return 1
+	else
+		return 0
 
 var/global/maint_all_access = 0
 

--- a/html/changelogs/alberyk-rev.yml
+++ b/html/changelogs/alberyk-rev.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Disabled ert during revolution rounds."


### PR DESCRIPTION
This pr disables ert from rev, this time the game won't tell you at round start, only when you swipe for it.