### PR TITLE
Fixing ranged hostile mob's targetting

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -668,6 +668,10 @@
 	return
 
 /obj/mecha/bullet_act(var/obj/item/projectile/Proj)
+	// We do not care about test projectile
+	if(!Proj.damage)
+		return
+
 	if(Proj.damage_type == HALLOSS && !(src.r_deflect_coeff > 1))
 		use_power(Proj.agony * 5)
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -669,7 +669,7 @@
 
 /obj/mecha/bullet_act(var/obj/item/projectile/Proj)
 	// We do not care about test projectile
-	if(!Proj.damage)
+	if(istype(Proj, /obj/item/projectile/test))
 		return
 
 	if(Proj.damage_type == HALLOSS && !(src.r_deflect_coeff > 1))

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -259,11 +259,13 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 
 	var/target_hit = FALSE
 	var/flags = ispath(projectiletype, /obj/item/projectile/beam) ? PASSTABLE|PASSGLASS|PASSGRILLE : PASSTABLE
-	for(var/mob/M in check_trajectory(target_mob, src, pass_flags=flags))
-		if(M == target_mob)
+	for(var/V in check_trajectory(target_mob, src, pass_flags=flags))
+		if(V == target_mob)
 			target_hit = TRUE
-		if((M.faction == faction) || (M in friends))
-			return FALSE
+		if(ismob(V))
+			var/mob/M = V
+			if((M.faction == faction) || (M in friends))
+				return FALSE
 
 	return target_hit
 

--- a/html/changelogs/Sindorman-fixes.yml
+++ b/html/changelogs/Sindorman-fixes.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed hostile mobs trajectory check. Allowing them to shoot mechs, shields, mobs, etc."
+  - tweak: "Mechs no longer display message about armour delfecting projectiles which have no damage, like test projectiles."

--- a/html/changelogs/Sindorman-fixes.yml
+++ b/html/changelogs/Sindorman-fixes.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - bugfix: "Fixed hostile mobs trajectory check. Allowing them to shoot mechs, shields, mobs, etc."
-  - tweak: "Mechs no longer display message about armour delfecting projectiles which have no damage, like test projectiles."
+  - tweak: "Mechs no longer display message about armour delfecting trajectory test projectiles which have no damage."


### PR DESCRIPTION
- This PR fixes trajectory check for ranged hostile mobs, before it would only check it for targeting mob types only, but we have other types to target like mechs, shields, etc. 

- Mech's no longer display message of deflecting trajectory test projectiles which have no damage