### PR TITLE
Diona fixes V2: attack of the nymphs

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
@@ -36,4 +36,13 @@
 		wear_hat(W)
 		user.visible_message("<span class='notice'>\The [user] puts \the [W] on \the [src].</span>")
 		return
+	else if(istype(W, /obj/item/weapon/reagent_containers) || istype(W, /obj/item/stack/medical) || istype(W,/obj/item/weapon/gripper/))
+		..(W, user)
+		return
+
+	else if(meat_type && (stat == DEAD))	//if the animal has a meat, and if it is dead.
+		if(istype(W, /obj/item/weapon/material/knife) || istype(W, /obj/item/weapon/material/kitchen/utensil/knife ))
+			harvest(user)
+			return
+
 	..(W, user)

--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -45,6 +45,7 @@
 	var/mob/living/carbon/alien/diona/master_nymph //nymph who owns this nymph if split. AI diona nymphs will follow this nymph, and these nymphs can be controlled by the master.
 	var/list/mob/living/carbon/alien/diona/birds_of_feather = list() //list of all related nymphs
 	var/echo = 0 //if it's an echo nymph, which has unique properties
+	var/detached = FALSE
 
 /mob/living/carbon/alien/diona/proc/cleanupTransfer()
 	if(!kept_clean)
@@ -246,7 +247,7 @@
 
 
 //This function makes sure the nymph has the correct split/merge verbs, depending on whether or not its part of a gestalt
-/mob/living/carbon/alien/diona/proc/update_verbs(var/detached = FALSE)
+/mob/living/carbon/alien/diona/proc/update_verbs()
 	if (gestalt && !detached)
 		if (!(/mob/living/carbon/alien/diona/proc/split in verbs))
 			verbs.Add(/mob/living/carbon/alien/diona/proc/split)
@@ -259,7 +260,7 @@
 		verbs.Remove(/mob/living/proc/devour)
 		verbs.Remove(/mob/living/carbon/alien/diona/proc/sample)
 	else
-		if (!(/mob/living/carbon/alien/diona/proc/merge in verbs))
+		if (!(/mob/living/carbon/alien/diona/proc/merge in verbs) && !detached)
 			verbs.Add(/mob/living/carbon/alien/diona/proc/merge)
 
 		if (!(/mob/living/carbon/proc/absorb_nymph in verbs))
@@ -375,14 +376,6 @@
 				DIO.master_nymph = D
 		return 1
 	. = ..()
-/mob/living/carbon/alien/diona/attackby(var/obj/item/O, var/mob/user)
-	if(istype(O, /obj/item/weapon/reagent_containers) || istype(O, /obj/item/stack/medical) || istype(O,/obj/item/weapon/gripper/))
-		..()
-
-	else if(meat_type && (stat == DEAD))	//if the animal has a meat, and if it is dead.
-		if(istype(O, /obj/item/weapon/material/knife) || istype(O, /obj/item/weapon/material/kitchen/utensil/knife ))
-			harvest(user)
-
 
 /mob/living/carbon/alien/diona/proc/harvest(var/mob/user)
 	var/actual_meat_amount = max(1,(meat_amount*0.75))

--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -246,8 +246,8 @@
 
 
 //This function makes sure the nymph has the correct split/merge verbs, depending on whether or not its part of a gestalt
-/mob/living/carbon/alien/diona/proc/update_verbs()
-	if (gestalt)
+/mob/living/carbon/alien/diona/proc/update_verbs(var/detached = FALSE)
+	if (gestalt && !detached)
 		if (!(/mob/living/carbon/alien/diona/proc/split in verbs))
 			verbs.Add(/mob/living/carbon/alien/diona/proc/split)
 

--- a/code/modules/mob/living/carbon/alien/diona/life.dm
+++ b/code/modules/mob/living/carbon/alien/diona/life.dm
@@ -30,11 +30,11 @@
 
 
 /mob/living/carbon/alien/diona/Life()
-	if (gestalt && (gestalt.life_tick % 5 == 0))//Minimal processing while in stasis
+	if (!detached && gestalt && (gestalt.life_tick % 5 == 0)) // Minimal processing while in stasis
 		updatehealth()
 		check_status_as_organ()
 
-	if (!gestalt)
+	else if (!gestalt || detached)
 		..()
 
 /mob/living/carbon/alien/diona/think()
@@ -42,6 +42,6 @@
 	if (!gestalt)
 		if(stat != DEAD)
 			if(master_nymph && !client && master_nymph != src)
-				walk_to(src,master_nymph,1,movement_delay())
+				walk_to(src,master_nymph, 1, movement_delay())
 			else
 				walk_to(src,0)

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -389,9 +389,19 @@ var/list/diona_banned_languages = list(
 	if (!organ_path || !DS)
 		return
 
-	var/obj/item/organ/O = new organ_path(src)
-	visible_message("<span class='danger'>With a shower of sticky sap, a new mass of tendrils bursts forth from [src]'s trunk, forming a new [O]</span>",
-		"<span class='danger'>With a shower of sticky sap, a new mass of tendrils bursts forth from your trunk, forming a new [O]</span>")
+	var/obj/item/organ/external/E = new organ_path(src)
+	var/obj/item/organ/external/E_old
+	for(var/obj/item/organ/external/stump/S in organs)
+		if(S.limb_name == E.limb_name)
+			E_old = S
+			break
+
+	// Remove the stump, if it exists
+	if(E_old)
+		qdel(E_old)
+
+	visible_message("<span class='danger'>With a shower of sticky sap, a new mass of tendrils bursts forth from [src]'s trunk, forming a new [E]</span>",
+		"<span class='danger'>With a shower of sticky sap, a new mass of tendrils bursts forth from your trunk, forming a new [E]</span>")
 	var/datum/reagents/vessel = get_vessel(0)
 	var/datum/reagent/B = vessel.get_master_reagent()
 	B.touch_turf(get_turf(src))
@@ -566,7 +576,7 @@ var/list/diona_banned_languages = list(
 			verbs -= /mob/living/carbon/alien/diona/proc/switch_to_gestalt
 			C.verbs -= /mob/living/carbon/human/proc/switch_to_nymph
 			C.DS.nym = null
-			qdel(src)
+			src.forceMove(C)
 			break
 
 //DIONASTATS DEFINES

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -375,7 +375,7 @@ var/list/diona_banned_languages = list(
 				//Only one per proc
 
 		//If we have less than six nymphs, we add one each proc
-		if (topup_nymphs(1))
+		if (topup_nymphs())
 			if (DS.stored_energy < REGROW_ENERGY_REQ)
 				return
 
@@ -576,6 +576,7 @@ var/list/diona_banned_languages = list(
 			verbs -= /mob/living/carbon/alien/diona/proc/switch_to_gestalt
 			C.verbs -= /mob/living/carbon/human/proc/switch_to_nymph
 			C.DS.nym = null
+			detached = FALSE
 			src.forceMove(C)
 			break
 

--- a/code/modules/mob/living/carbon/human/diona_gestalt.dm
+++ b/code/modules/mob/living/carbon/human/diona_gestalt.dm
@@ -264,6 +264,7 @@
 	M.verbs += /mob/living/carbon/alien/diona/proc/switch_to_gestalt
 	verbs += /mob/living/carbon/human/proc/switch_to_nymph
 	M.update_verbs(TRUE)
+	M.detached = TRUE
 
 	update_dionastats() //Re-find the organs in case they were lost or regained
 	nutrition -= REGROW_FOOD_REQ

--- a/code/modules/mob/living/carbon/human/diona_gestalt.dm
+++ b/code/modules/mob/living/carbon/human/diona_gestalt.dm
@@ -199,7 +199,7 @@
 
 	textbox	= "What shall we name our new collective? Type in a name, or leave blank to cancel. We recall that we were once part of a collective named [mind.name] but it is not necessary to return to that"
 
-	newname = input(src,textbox,"Choosing a name.",suggestion)
+	newname = input(src, textbox, "Choosing a name.", suggestion)
 	if (newname)
 		real_name = newname
 		name = newname
@@ -263,6 +263,7 @@
 	M.verbs += /mob/living/carbon/alien/diona/proc/merge_back_to_gestalt
 	M.verbs += /mob/living/carbon/alien/diona/proc/switch_to_gestalt
 	verbs += /mob/living/carbon/human/proc/switch_to_nymph
+	M.update_verbs(TRUE)
 
 	update_dionastats() //Re-find the organs in case they were lost or regained
 	nutrition -= REGROW_FOOD_REQ

--- a/html/changelogs/Sindorman-dionafix.yml
+++ b/html/changelogs/Sindorman-dionafix.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Diona Gestalt no longer has stump left after it has regenerated lost limb."
+  - bugfix: "Diona nymph can now be attacked by any weapons."
+  - bugfix: "Detached limb nymph now gets all verbs of regular nymph, and no longer ignores damage."
+  - tweak: "Detached nymph that merges back together now moves inside of Gestalt, thus preventing Gestalt from regenerating another nymph and wasting energy."


### PR DESCRIPTION
Second round of fixes for Diona. Tackles old bugs and new:

-  Diona Gestalt no longer has stump left after it has regenerated lost limb.

- Diona nymph can now be attacked by any weapons. By deleting duplicated override of `attackby()`

- Detached limb nymph now gets all verbs of regular nymph, and no longer ignores damage.

- Detached nymph that merges back together now moves inside of Gestalt, thus preventing Gestalt from regenerating another nymph and wasting energy.
