### PR TITLE
Finding Newton's G theory

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
@@ -26,9 +26,14 @@
 /datum/malf_research_ability/manipulation/emergency_forcefield
 	ability = new/datum/game_mode/malfunction/verb/emergency_forcefield()
 	price = 1750
-	next = new/datum/malf_research_ability/manipulation/machine_overload()
+	next = new/datum/malf_research_ability/manipulation/gravity_malfunction()
 	name = "Emergency Forcefield"
 
+/datum/malf_research_ability/manipulation/gravity_malfunction
+	ability = new/datum/game_mode/malfunction/verb/gravity_malfunction()
+	price = 2500
+	next = new/datum/malf_research_ability/manipulation/machine_overload()
+	name = "Gravity Malfunction"
 
 /datum/malf_research_ability/manipulation/machine_overload
 	ability = new/datum/game_mode/malfunction/verb/machine_overload()
@@ -211,5 +216,18 @@
 	explosion(get_turf(M), round(explosion_intensity/4),round(explosion_intensity/2),round(explosion_intensity),round(explosion_intensity * 2))
 	if(M)
 		qdel(M)
+
+/datum/game_mode/malfunction/verb/gravity_malfunction()
+	set name = "Gravity Malfunction"
+	set desc = "300 CPU - Hacks the gravity generator. Making gravity reverse for short moment and making victims fall down really hard on the floor."
+	set category = "Software"
+	var/price = 300
+	var/mob/living/silicon/ai/user = usr
+	if(!ability_prechecks(user, price) || !ability_pay(user,price))
+		return
+	for(var/A in SSmachinery.gravity_generators)
+		var/obj/machinery/gravity_generator/main/B = A
+		B.throw_up_and_down()
+	log_ability_use(user, "gravity malfunction")
 
 // END ABILITY VERBS

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -410,8 +410,6 @@
 	var/z_velocity = 5*(levels_fallen**2)
 	var/damage = ((60 + z_velocity) + rand(-20,20)) * damage_mod
 
-	if(istype(loc, /turf/unsimulated/floor/asteroid))
-		damage *= 0.75
 	apply_damage(damage, BRUTE)
 
 	// The only piece of duplicate code. I was so close. Soooo close. :ree:
@@ -455,9 +453,6 @@
 	var/z_velocity = 5*(levels_fallen**2)
 	var/damage = (((60 * species.fall_mod) + z_velocity) + rand(-20,20)) * combat_roll * damage_mod
 
-	// Gravity is weaker outdoors, than indoors.
-	if(istype(loc, /turf/unsimulated/floor/asteroid))
-		damage *= 0.75
 	var/limb_damage = rand(0,damage/2)
 
 	if(prob(30) && combat_roll >= 1) //landed on their legs
@@ -513,7 +508,8 @@
 			visible_message("\The [src] falls and lands on \the [loc]!",
 				"With a loud thud, you land on \the [loc]!", "You hear a thud!")
 
-	apply_damage(damage - limb_damage, BRUTE, "chest")
+	if(!limb_damage)
+		apply_damage(damage, BRUTE, "chest")
 
 	Weaken(rand(damage/4, damage/2))
 
@@ -553,8 +549,6 @@
 
 	var/z_velocity = 5*(levels_fallen**2)
 	var/damage = ((60 + z_velocity) + rand(-20,20)) * damage_mod
-	if(istype(loc, /turf/unsimulated/floor/asteroid))
-		damage *= 0.75
 
 	take_damage(damage)
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -460,7 +460,7 @@
 		damage *= 0.75
 	var/limb_damage = rand(0,damage/2)
 
-	if(prob(30) && combat_roll >= 1) //landed on their head
+	if(prob(30) && combat_roll >= 1) //landed on their legs
 		var/left_damage = rand(0,damage/2)
 		var/right_damage = rand(0,damage/2)
 		var/leftf_damage = rand(0,damage/4)
@@ -502,7 +502,7 @@
 		visible_message("<span class='warning'>\The [src] falls and lands arms first!</span>",
 			"<span class='danger'>You brace your fall with your arms, hitting \the [loc] with a loud thud.</span>", "You hear a thud!")
 
-	else if(prob(30) && combat_roll >= 1)//landed on their legs
+	else if(prob(30) && combat_roll >= 1)//landed on their head
 		apply_damage(limb_damage, BRUTE, "head")
 		visible_message("<span class='warning'>\The [src] falls and lands on their face!</span>",
 			"<span class='danger'>With a loud thud, you land on your head. Hard.</span>", "You hear a thud!")

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -451,7 +451,7 @@
 				"<span class='notice'>You tuck into a roll as you hit \the [loc], minimizing damage!</span>")
 
 	var/z_velocity = 5*(levels_fallen**2)
-	var/damage = (((60 * species.fall_mod) + z_velocity) + rand(-20,20)) * combat_roll * damage_mod
+	var/damage = (((40 * species.fall_mod) + z_velocity) + rand(-20,20)) * combat_roll * damage_mod
 
 	var/limb_damage = rand(0,damage/2)
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -409,6 +409,9 @@
 
 	var/z_velocity = 5*(levels_fallen**2)
 	var/damage = ((60 + z_velocity) + rand(-20,20)) * damage_mod
+
+	if(istype(loc, /turf/unsimulated/floor/asteroid))
+		damage *= 0.75
 	apply_damage(damage, BRUTE)
 
 	// The only piece of duplicate code. I was so close. Soooo close. :ree:
@@ -451,33 +454,13 @@
 
 	var/z_velocity = 5*(levels_fallen**2)
 	var/damage = (((60 * species.fall_mod) + z_velocity) + rand(-20,20)) * combat_roll * damage_mod
+
+	// Gravity is weaker outdoors, than indoors.
+	if(istype(loc, /turf/unsimulated/floor/asteroid))
+		damage *= 0.75
 	var/limb_damage = rand(0,damage/2)
 
 	if(prob(30) && combat_roll >= 1) //landed on their head
-		apply_damage(limb_damage, BRUTE, "head")
-		visible_message("<span class='warning'>\The [src] falls and lands on their face!</span>",
-			"<span class='danger'>With a loud thud, you land on your head. Hard.</span>", "You hear a thud!")
-
-	else if(prob(30) && combat_roll >= 1) //landed on their arms
-		var/left_damage = rand(0,damage/4)
-		var/right_damage = rand(0,damage/4)
-		var/lefth_damage = rand(0,damage/4)
-		var/righth_damage = rand(0,damage/4)
-
-		apply_damage(left_damage, BRUTE, "l_arm")
-		apply_damage(right_damage, BRUTE, "r_arm")
-
-		if(prob(50))
-			apply_damage(lefth_damage, BRUTE, "r_hand")
-		if(prob(50))
-			apply_damage(righth_damage, BRUTE, "l_hand")
-
-		limb_damage = left_damage + right_damage + lefth_damage + righth_damage
-
-		visible_message("<span class='warning'>\The [src] falls and lands arms first!</span>",
-			"<span class='danger'>You brace your fall with your arms, hitting \the [loc] with a loud thud.</span>", "You hear a thud!")
-
-	else if(prob(30) && combat_roll >= 1)//landed on their legs
 		var/left_damage = rand(0,damage/2)
 		var/right_damage = rand(0,damage/2)
 		var/leftf_damage = rand(0,damage/4)
@@ -499,6 +482,30 @@
 			"<span class='danger'>You land on your feet, and the impact brings you to your knees.</span>")
 
 		limb_damage = left_damage + right_damage + leftf_damage + rightf_damage + groin_damage
+
+	else if(prob(30) && combat_roll >= 1) //landed on their arms
+		var/left_damage = rand(0,damage/4)
+		var/right_damage = rand(0,damage/4)
+		var/lefth_damage = rand(0,damage/4)
+		var/righth_damage = rand(0,damage/4)
+
+		apply_damage(left_damage, BRUTE, "l_arm")
+		apply_damage(right_damage, BRUTE, "r_arm")
+
+		if(prob(50))
+			apply_damage(lefth_damage, BRUTE, "r_hand")
+		if(prob(50))
+			apply_damage(righth_damage, BRUTE, "l_hand")
+
+		limb_damage = left_damage + right_damage + lefth_damage + righth_damage
+
+		visible_message("<span class='warning'>\The [src] falls and lands arms first!</span>",
+			"<span class='danger'>You brace your fall with your arms, hitting \the [loc] with a loud thud.</span>", "You hear a thud!")
+
+	else if(prob(30) && combat_roll >= 1)//landed on their legs
+		apply_damage(limb_damage, BRUTE, "head")
+		visible_message("<span class='warning'>\The [src] falls and lands on their face!</span>",
+			"<span class='danger'>With a loud thud, you land on your head. Hard.</span>", "You hear a thud!")
 
 	else
 		limb_damage = 0
@@ -546,6 +553,9 @@
 
 	var/z_velocity = 5*(levels_fallen**2)
 	var/damage = ((60 + z_velocity) + rand(-20,20)) * damage_mod
+	if(istype(loc, /turf/unsimulated/floor/asteroid))
+		damage *= 0.75
+
 	take_damage(damage)
 
 	playsound(loc, "sound/effects/bang.ogg", 100, 1)
@@ -558,6 +568,9 @@
 
 	var/z_velocity = 5*(levels_fallen**2)
 	var/damage = ((60 + z_velocity) + rand(-20,20)) * damage_mod
+	if(istype(loc, /turf/unsimulated/floor/asteroid))
+		damage /= 2
+
 	health -= (damage * brute_dam_coeff)
 
 	playsound(loc, "sound/effects/clang.ogg", 75, 1)

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -460,3 +460,16 @@
 		return AREA_SPECIAL
 	else
 		return AREA_STATION
+
+/obj/machinery/gravity_generator/main/proc/throw_up_and_down()
+	to_world("<h2 class='alert'>Station Announcement:</h2>")
+	to_world(span("danger", "Warning! Station Gravity Generator malfunction detected. Brace for dangerous gravity change!"))
+	sleep(50)
+	set_state(FALSE)
+	sleep(30)
+	set_state(TRUE)
+	for(var/mob/living/M in mob_list)
+		var/turf/their_turf = get_turf(M)
+		if(their_turf.loc in localareas)
+			to_chat(M, span("danger", "Suddenly the gravity pushed you up to the ceiling and dropped you back on the floor with great force!"))
+			M.fall_impact(1)

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -470,6 +470,6 @@
 	set_state(TRUE)
 	for(var/mob/living/M in mob_list)
 		var/turf/their_turf = get_turf(M)
-		if(their_turf.loc in localareas)
+		if(their_turf && (their_turf.loc in localareas))
 			to_chat(M, span("danger", "Suddenly the gravity pushed you up to the ceiling and dropped you back on the floor with great force!"))
 			M.fall_impact(1)

--- a/html/changelogs/Sindorman-gravity.yml
+++ b/html/changelogs/Sindorman-gravity.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "fallin on asteroid deals 25% less damage than indoors. Priority of limbs damage was also changed, now it is Legs > arms > head."
+  - tweak: "Fall damaged was nerfed: you no longer take remaining damage to the chest if you took limb damage. Priority of limbs damage was also changed, now it is Legs > arms > head."
   - rscadd: "Added new Malf ability to malfunction gravity generator. Ability makes station loose gravity for 3 seconds and push everyone to the groun as if they fell on Z level."

--- a/html/changelogs/Sindorman-gravity.yml
+++ b/html/changelogs/Sindorman-gravity.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Fall damaged was nerfed: you no longer take remaining damage to the chest if you took limb damage. Priority of limbs damage was also changed, now it is Legs > arms > head."
+  - tweak: "Fall damaged was nerfed: from base 60 to base 40. You no longer take remaining damage to the chest if you took limb damage. Priority of limbs damage was also changed, now it is Legs > arms > head."
   - rscadd: "Added new Malf ability to malfunction gravity generator. Ability makes station loose gravity for 3 seconds and push everyone to the groun as if they fell on Z level."

--- a/html/changelogs/Sindorman-gravity.yml
+++ b/html/changelogs/Sindorman-gravity.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "fallin on asteroid deals 25% less damage than indoors. Priority of limbs damage was also changed, now it is Legs > arms > head."
+  - rscadd: "Added new Malf ability to malfunction gravity generator. Ability makes station loose gravity for 3 seconds and push everyone to the groun as if they fell on Z level."


### PR DESCRIPTION
Gravity change PR.

- Falling base damage was reduced from 60 to 40. Also you no longer take remaining damage from limbs to the chest.
- Changed falling limb priority damage from `head > arms > leg` to `legs > arms> head`

- Added new Malf ability to Malfunction gravity. it costs 2500 to research and 300 CPU to use. The ability will disable station gravity for 3 seconds and push them back on the ground with force as if they fell from 1 Z level.