### PR TITLE
Fixes the ability to join mid-round as any job, despite faction restrictions

### DIFF
--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -272,10 +272,18 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 
 /mob/abstract/new_player/proc/IsJobAvailable(rank)
 	var/datum/job/job = SSjobs.GetJob(rank)
-	if(!job)	return 0
-	if(!job.is_position_available()) return 0
-	if(jobban_isbanned(src,rank))	return 0
-	return 1
+	if (!job)
+		return FALSE
+	if (!job.is_position_available())
+		return FALSE
+	if (jobban_isbanned(src,rank))
+		return FALSE
+
+	var/datum/faction/faction = SSjobs.name_factions[client.prefs.faction] || SSjobs.default_faction
+	if (!(job.type in faction.allowed_role_types))
+		return FALSE
+
+	return TRUE
 
 
 /mob/abstract/new_player/proc/AttemptLateSpawn(rank,var/spawning_at)
@@ -486,7 +494,8 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 	return "Human"
 
 /mob/abstract/new_player/get_gender()
-	if(!client || !client.prefs) ..()
+	if(!client || !client.prefs)
+		..()
 	return client.prefs.gender
 
 /mob/abstract/new_player/is_ready()

--- a/html/changelogs/skull132_factions-bug.yml
+++ b/html/changelogs/skull132_factions-bug.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - bugfix: "Removed the ability to join as any job despite faction restrictions when using the mid-round join menu."


### PR DESCRIPTION
Bug:
Select a faction that's not NT. Wait for round to start. Proceed to join as any job (even locked ones) through the mid round join menu.

Fix:
Add a relevant check to `/mob/abstract/new_player/proc/IsJobAvailable()`. This is checked both when generating the menu and when actually joining, so href exploiting isn't an issue either.