### PR TITLE
Implement "send_link" macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ jobs:
         - (! find nano/templates/ -type f -exec md5sum {} + | sort | uniq -D -w 32 | grep nano)
         - (! grep -E "<\s*span\s+class\s*=\s*('[^'>]+|[^'>]+')\s*>" **/*.dm)
         - (! grep -r --include=\*.dm '#define UIDEBUG' ./)
+        - (! grep -r --include=\*.dm 'to_chat(.*,\s*link(' ./)
         - (cd vueui && (npm run lint | tee lint.log))
         - grep "No lint errors found!" vueui/lint.log
         - (cd vueui && npm run build)

--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -63,6 +63,7 @@
 #define show_browser(target, browser_content, browser_name) target << browse(browser_content, browser_name)
 #define send_rsc(target, rsc_content, rsc_name)             target << browse_rsc(rsc_content, rsc_name)
 #define send_output(target, msg, control)                   target << output(msg, control)
+#define send_link(target, url)                              target << link(url)
 
 #define CanInteract(user, state) (CanUseTopic(user, state) == STATUS_INTERACTIVE)
 

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -200,7 +200,7 @@ What a mess.*/
 		switch(href_list["choice"])
 // Open Action URL
 			if("openActionUrl")
-				to_chat(usr, link(href_list["url"]))
+				send_link(usr, href_list["url"])
 // SORTING!
 			if("Sorting")
 				// Reverse the order if clicked twice

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -194,9 +194,9 @@
 				else if (alert("This will open the Github page in your browser. Are you sure?",, "Yes", "No") == "Yes")
 					if (href_list["pr"])
 						var/pr_link = "[config.githuburl]pull/[href_list["pr"]]"
-						to_chat(src, link(pr_link))
+						send_link(src, pr_link)
 					else
-						to_chat(src, link(config.githuburl))
+						send_link(src, config.githuburl)
 
 			// Forum link from various panels.
 			if ("forums")
@@ -671,7 +671,7 @@
 			log_debug("Unrecognized process_webint_link() call used. Route sent: '[route]'.")
 			return
 
-	to_chat(src, link(linkURL))
+	send_link(src, linkURL)
 	return
 
 /client/verb/show_greeting()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -251,7 +251,7 @@ datum/preferences
 
 	if(href_list["preference"] == "open_whitelist_forum")
 		if(config.forumurl)
-			to_chat(user, link(config.forumurl))
+			send_link(user, config.forumurl)
 		else
 			to_chat(user, "<span class='danger'>The forum URL is not set in the server configuration.</span>")
 			return

--- a/code/modules/mob/abstract/new_player/poll.dm
+++ b/code/modules/mob/abstract/new_player/poll.dm
@@ -46,7 +46,7 @@
 			link = select_query.item[1]
 
 		if(link && link != "")
-			to_chat(usr, link(link))
+			send_link(usr, link)
 		else
 			log_debug("Polling: [usr.ckey] tried to open poll [pollid] with a invalid link: [link]")
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -6,7 +6,7 @@
 	if( config.wikiurl )
 		if(alert("This will open the wiki in your browser. Are you sure?",,"Yes","No")=="No")
 			return
-		to_chat(src, link(config.wikiurl))
+		send_link(src, config.wikiurl)
 	else
 		to_chat(src, "<span class='warning'>The wiki URL is not set in the server configuration.</span>")
 	return
@@ -18,7 +18,7 @@
 	if( config.forumurl )
 		if(alert("This will open the forum in your browser. Are you sure?",,"Yes","No")=="No")
 			return
-		to_chat(src, link(config.forumurl))
+		send_link(src, config.forumurl)
 	else
 		to_chat(src, "<span class='warning'>The forum URL is not set in the server configuration.</span>")
 	return
@@ -30,7 +30,7 @@
 	if( config.githuburl )
 		if(alert("This will open the issue tracker in your browser. Are you sure?",,"Yes","No")=="No")
 			return
-		to_chat(src, link(config.githuburl + "/issues"))
+		send_link(src, config.githuburl + "/issues")
 	else
 		to_chat(src, span("warning", "The issue tracker URL is not set in the server configuration."))
 	return
@@ -175,7 +175,7 @@ Any-Mode: (hotkey doesn't need to be on)
 	if (config.webint_url)
 		if(alert("This will open the web interface in your browser. Are you sure?", ,"Yes","No") == "No")
 			return
-		to_chat(src, link(config.webint_url))
+		send_link(src, config.webint_url)
 	else
 		to_chat(src, span("warning", "The web interface URL is not set in the server configuration."))
 	return
@@ -189,7 +189,7 @@ Any-Mode: (hotkey doesn't need to be on)
 		if(alert("This will open Discord in your browser or directly. Are you sure?",, "Yes", "No") == "Yes")
 			var/url_link = discord_bot.retreive_invite()
 			if (url_link)
-				to_chat(src, link(url_link))
+				send_link(src, url_link)
 			else
 				to_chat(src, span("danger", "An error occured retreiving the invite."))
 	else

--- a/tools/Redirector/Redirector.dm
+++ b/tools/Redirector/Redirector.dm
@@ -58,7 +58,7 @@ mob/Login()
 		if(S.weight == lowest)
 			serverlink = S.link
 
-	to_chat(src, link(serverlink))
+	send_link(src, serverlink)
 
 proc/extract(var/data, var/type = PLAYERS)
 


### PR DESCRIPTION
When `to_chat` gets converted to a proc, then the construct of `to_chat(some, link(url))` will no longer work. Or will produce odd results.

As a result, the `send_link` macro is now created. Replaced existent instances of the previous construct and added a simple grep check for this as well. It won't catch all, probably, but it'll catch the most common instances.