### PR TITLE
Fixes memory abuse

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -115,7 +115,12 @@
 		new_character.key = key		//now transfer the key to link the client to our new body
 
 /datum/mind/proc/store_memory(new_text)
-	memory += "[new_text]<BR>"
+	. = length(memory + new_text)
+
+	if (. > MAX_PAPER_MESSAGE_LEN)
+		memory = copytext(memory, . - MAX_PAPER_MESSAGE_LEN, .)
+	else
+		memory += "[new_text]<BR>"
 
 /datum/mind/proc/show_memory(mob/recipient)
 	var/output = "<B>[current.real_name]'s Memory</B><HR>"

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -87,7 +87,8 @@
 		set_death_time(MINISYNTH, world.time)
 	else if (isliving(src))
 		set_death_time(CREW, world.time)//Crew is the fallback
-	if(mind) mind.store_memory("Time of death: [worldtime2text()]", 0)
+	if(mind)
+		mind.store_memory("Time of death: [worldtime2text()]", 0)
 	living_mob_list -= src
 	dead_mob_list |= src
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -393,26 +393,16 @@
 	set name = "Add Note"
 	set category = "IC"
 
-	msg = sanitize(msg)
-
-	if(mind)
-		mind.store_memory(msg)
-	else
+	if (!mind)
 		to_chat(src, "The game appears to have misplaced your mind datum, so we can't show you your notes.")
+		return
 
-/mob/proc/store_memory(msg as message, popup, sane = 1)
-	msg = copytext(msg, 1, MAX_MESSAGE_LEN)
+	if (length(mind.memory) > MAX_PAPER_MESSAGE_LEN)
+		to_chat(src, "<span class='danger'>You are exceeding the alotted text size for memories.</span>")
+		return
 
-	if (sane)
-		msg = sanitize(msg)
-
-	if (length(memory) == 0)
-		memory += msg
-	else
-		memory += "<BR>[msg]"
-
-	if (popup)
-		memory()
+	msg = sanitize(msg)
+	mind.store_memory(msg)
 
 /mob/proc/update_flavor_text()
 	set src in usr

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -397,11 +397,16 @@
 		to_chat(src, "The game appears to have misplaced your mind datum, so we can't show you your notes.")
 		return
 
-	if (length(mind.memory) > MAX_PAPER_MESSAGE_LEN)
-		to_chat(src, "<span class='danger'>You are exceeding the alotted text size for memories.</span>")
+	if (length(mind.memory) >= MAX_PAPER_MESSAGE_LEN)
+		to_chat(src, "<span class='danger'>You have exceeded the alotted text size for memories.</span>")
 		return
 
 	msg = sanitize(msg)
+
+	if (length(mind.memory + msg) >= MAX_PAPER_MESSAGE_LEN)
+		to_chat(src, "<span class='danger'>Your input would exceed the alotted text size for memories. Try again with a shorter message.</span>")
+		return
+
 	mind.store_memory(msg)
 
 /mob/proc/update_flavor_text()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -51,7 +51,6 @@
 	var/character_id = 0
 	var/obj/machinery/machine = null
 	var/other_mobs = null
-	var/memory = ""
 	var/sdisabilities = 0	//Carbon
 	var/disabilities = 0	//Carbon
 	var/atom/movable/pulling = null

--- a/html/changelogs/skull132_exploit.yml
+++ b/html/changelogs/skull132_exploit.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  security: "Capped the maximum size of player controlled IC notes to be the same length as paper. You will get an error if you exceed that while adding to them. Credit to CMSS13 team for spotting and alerting about this."

--- a/html/changelogs/skull132_exploit.yml
+++ b/html/changelogs/skull132_exploit.yml
@@ -1,5 +1,0 @@
-author: Skull132
-delete-after: True
-
-changes:
-  security: "Capped the maximum size of player controlled IC notes to be the same length as paper. You will get an error if you exceed that while adding to them. Credit to CMSS13 team for spotting and alerting about this."


### PR DESCRIPTION
What:
The `mind/memory` variable is a variable that is used to store IC notes. Players can add to it at will, using the `Add Note` verb. The problem, is that they can add to this infinitely. This can be weaponized with macros to generate an infinitely long string. Well, infinite in theory, in reality, this will cause DD to OOM and crash.

Solution:
Capped the length of `mind/memory` to `MAX_PAPER_MESSAGE_LEN` (3072) characters. This length is checked when the user attempts to input, and also when the notes are actually edited. The former produces an error for the user, the latter will simply shift the memory contents forward, potentially causing HTML break. But this limit is not likely to be reached via other means.

Other:
Removes the variable `/mob/memory`, which is not used.