### PR TITLE
Separate Dead OOC Allowed From Dead LOOC Allowed

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -205,6 +205,7 @@ var/list/gamemode_cache = list()
 	var/ooc_allowed = 1
 	var/looc_allowed = 1
 	var/dooc_allowed = 1
+	var/dead_looc_allowed = TRUE
 	var/dsay_allowed = 1
 
 	var/starlight = 0	// Whether space turfs have ambient light or not
@@ -286,7 +287,7 @@ var/list/gamemode_cache = list()
 
 	var/docs_load_docs_from
 	var/docs_image_host
- 
+
 	var/ert_base_chance = 10
 	var/ert_green_inc = 1
 	var/ert_yellow_inc = 1
@@ -532,6 +533,9 @@ var/list/gamemode_cache = list()
 
 				if ("disable_dead_ooc")
 					config.dooc_allowed = 0
+
+				if ("disable_dead_looc")
+					config.dead_looc_allowed = FALSE
 
 				if ("disable_dsay")
 					config.dsay_allowed = 0
@@ -787,7 +791,7 @@ var/list/gamemode_cache = list()
 
 				if("sql_saves")
 					config.sql_saves = 1
-				
+
 				if("sql_ccia_logs")
 					config.sql_ccia_logs = 1
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -91,8 +91,8 @@
 		if(!config.looc_allowed)
 			to_chat(src, "<span class='danger'>LOOC is globally muted.</span>")
 			return
-		if(!config.dooc_allowed && (mob.stat == DEAD))
-			to_chat(usr, "<span class='danger'>OOC for dead mobs has been turned off.</span>")
+		if(!config.dead_looc_allowed && (mob.stat == DEAD))
+			to_chat(usr, "<span class='danger'>LOOC for dead mobs has been turned off.</span>")
 			return
 		if(handle_spam_prevention(msg, MUTE_OOC))
 			return

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -736,9 +736,19 @@ proc/admin_notice(var/message, var/rights)
 		return
 
 	config.dooc_allowed = !( config.dooc_allowed )
-	log_admin("[key_name(usr)] toggled Dead OOC.")
-	message_admins("[key_name_admin(usr)] toggled Dead OOC.", 1)
+	log_and_message_admins("toggled dead (global) OOC. (New state: [config.dooc_allowed])")
 	feedback_add_details("admin_verb","TDOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/datum/admins/proc/toggle_dead_looc()
+	set category = "Server"
+	set desc = "Toggle Dead LOOC."
+	set name = "Toggle Dead LOOC"
+
+	if (!check_rights(R_ADMIN))
+		return
+
+	config.dead_looc_allowed = !config.dead_looc_allowed
+	log_and_message_admins("toggled dead LOOC. (New state: [config.dead_looc_allowed])")
 
 /datum/admins/proc/togglehubvisibility()
 	set category = "Server"

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -376,8 +376,11 @@ EVENT_CUSTOM_START_MAJOR 80;100
 ## Uncomment to disable the OOC channel by default.
 #DISABLE_OOC
 
-## Uncomment to disable the dead OOC channel by default.
+## Uncomment to disable the dead (global) OOC channel by default.
 #DISABLE_DEAD_OOC
+
+## Uncomment to disable the dead LOOC channel by default.
+#DISABLE_DEAD_LOOC
 
 ## Uncomment to disable ghost chat by default.
 #DISABLE_DSAY

--- a/html/changelogs/skull132-dead_looc.yml
+++ b/html/changelogs/skull132-dead_looc.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - backend: "Enabled the reistriction of the ghosts's ability to speak in LOOC via config."

--- a/html/changelogs/skull132-dead_looc.yml
+++ b/html/changelogs/skull132-dead_looc.yml
@@ -2,4 +2,4 @@ author: Skull132
 delete-after: True
 
 changes:
-  - backend: "Enabled the reistriction of the ghosts's ability to speak in LOOC via config."
+  - backend: "Enabled the restriction of ghosts' ability to speak in LOOC via config."


### PR DESCRIPTION
Currently, `DISABLE_DEAD_OOC` is used as a singular toggle for determining whether or not ghosts can talk on both OOC and LOOC. This is undesireable, should we wish to only disable their access to LOOC via config.

This PR implements a `DISABLE_DEAD_LOOC` config flag, which explicitly restricts the access of dead people to LOOC. While leaving `DISABLE_DEAD_OOC` as its own flag for when we want to exclusively restrict global OOC.