### PR TITLE
Fixes IE circuit printers not being able to print things

### DIFF
--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -116,6 +116,10 @@
 		if(!build_type || !ispath(build_type))
 			return 1
 
+		if (!can_print(build_type))
+			to_chat(usr, "<span class='danger'>[src] buzzes angrily at you!</span>")
+			return 1
+
 		var/cost = 1
 		var/is_asm = FALSE
 		if(ispath(build_type, /obj/item/device/electronic_assembly))
@@ -125,8 +129,6 @@
 		else if(ispath(build_type, /obj/item/integrated_circuit))
 			var/obj/item/integrated_circuit/IC = build_type
 			cost = initial(IC.w_class)
-		else
-			return
 
 		if(metal - cost < 0)
 			to_chat(usr, "<span class='warning'>You need [cost] metal to build that!.</span>")
@@ -138,6 +140,15 @@
 			new build_type(get_turf(loc))
 
 	interact(usr)
+
+/obj/item/device/integrated_circuit_printer/proc/can_print(build_type)
+	var/list/current_list = SSelectronics.printer_recipe_list[current_category]
+
+	for (var/obj/O in current_list)
+		if (O.type == build_type)
+			return TRUE
+
+	return FALSE
 
 // FUKKEN UPGRADE DISKS
 /obj/item/weapon/disk/integrated_circuit/upgrade

--- a/html/changelogs/skull132-fixes_printer.yml
+++ b/html/changelogs/skull132-fixes_printer.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  bugfix: "Fixes the integrted circuits printer not being able to print specific components. Sorry it took so long, gents."

--- a/html/changelogs/skull132-fixes_printer.yml
+++ b/html/changelogs/skull132-fixes_printer.yml
@@ -2,4 +2,4 @@ author: Skull132
 delete-after: True
 
 changes:
-  bugfix: "Fixes the integrted circuits printer not being able to print specific components. Sorry it took so long, gents."
+  - bugfix: "Fixes the integrted circuits printer not being able to print specific components. Sorry it took so long, gents."


### PR DESCRIPTION
Issue:
A previous exploit by me was haphazardly implemented. I had assumed that the IE printer could only print items of the two types. Turns out, not the case. Result: printer can't print half the shit is should.

Solution:
Implement proper sanitazation. I found out that all printable items are in the SSelectronics list. So I implemented `/obj/item/device/integrated_circuit_printer/proc/can_print(build_type)` to check if the `build_type` is represented in the list of items of the current category.