### PR TITLE
The Lore PR

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -179,16 +179,6 @@ other types of metals and chemistry for reagents).
 	build_path =/obj/item/weapon/weldingtool/experimental
 	sort_string = "VABAJ"
 
-/datum/design/item/posibrain
-	name = "Positronic brain"
-	id = "posibrain"
-	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 6, TECH_BLUESPACE = 2, TECH_DATA = 4)
-	build_type = PROTOLATHE | MECHFAB
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 500, "phoron" = 500, "diamond" = 100)
-	build_path = /obj/item/device/mmi/digital/posibrain
-	category = "Misc"
-	sort_string = "VACAB"
-
 /datum/design/item/mmi
 	name = "Man-machine interface"
 	id = "mmi"

--- a/html/changelogs/VTCobaltblood - the_pr.yml
+++ b/html/changelogs/VTCobaltblood - the_pr.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscdel: "Removed positronic brains from the protolathe designs list."
-  - tweak: "Gave Robotics some more posibrains."
+  - maptweak: "Gave Robotics some more posibrains."

--- a/html/changelogs/VTCobaltblood - the_pr.yml
+++ b/html/changelogs/VTCobaltblood - the_pr.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscdel: "Removed positronic brains from the protolathe designs list."
+  - tweak: "Gave Robotics some more posibrains."

--- a/html/changelogs/VTCobaltblood - the_pr.yml
+++ b/html/changelogs/VTCobaltblood - the_pr.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: VTCobaltblood
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removed positronic brains from the protolathe designs list."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -40182,10 +40182,11 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/weapon/crowbar,
 /obj/item/device/mmi/digital/posibrain,
-/obj/item/device/robotanalyzer,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/item/device/mmi/digital/posibrain,
+/obj/item/device/robotanalyzer,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
 "bqs" = (


### PR DESCRIPTION
Removes positronic brains from the list of protolathe designs.

Their presence there never made any sense lore-wise, since posibrains are extremely expensive and pretty difficult to program and manufacture. Being able to print a posibrain in 30 minutes since the start of the shift goes directly contrary to literally every single piece of lore related to them.

To compensate, Robotics now starts with 2 posibrains instead of 1. Ideally, they should also be orderable from cargo for an exorbitant price, but I can't make that change lmao please give cargo config to us why is it on the server side