### PR TITLE
Fixes ooc issues with remote authed clients

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -352,6 +352,7 @@
 		src.authed = FALSE
 		var/mob/abstract/unauthed/m = new()
 		m.client = src
+		src.InitPrefs() //Init some default prefs
 		return m
 		//Do auth shit
 	else

--- a/code/modules/mob/abstract/unauthed/login.dm
+++ b/code/modules/mob/abstract/unauthed/login.dm
@@ -29,6 +29,7 @@
 	show_browser(src, null, "window=auth;")
 	client.verbs += typesof(/client/verb) // Let's return regular client verbs
 	client.authed = TRUE // We declare client as authed now
+	client.prefs = null //Null them so we can load them from the db again for the correct ckey
 	// Check for bans
 	var/list/ban_data = world.IsBanned(ckey(newkey), c.address, c.computer_id, 1, TRUE)
 	if(ban_data)


### PR DESCRIPTION
Fixes ooc issues caused by external auth clients without preference datums.

Initializes preference datums for external auth clients and resets them before the actual ckey is assigned (so they are looked up properly for the new ckey)