### PR TITLE
Removes negative values and burst delay from protogun bounties

### DIFF
--- a/code/modules/cargo/bounties/weapon_prototype.dm
+++ b/code/modules/cargo/bounties/weapon_prototype.dm
@@ -6,8 +6,6 @@
 	var/stat_comparison = "greater than"
 
 /datum/bounty/weapon_prototype/New()
-	if(rand(3) == 1)
-		stat_value *= -1
 	name = "Weapon ([stat_name] of [stat_value])"
 	description = "[current_map.company_name] is interested in a laser prototype with a [stat_name] stat [stat_comparison] [stat_value]. [current_map.boss_name] will pay handsomely for such a weapon."
 	reward += rand(0, 4) * 500
@@ -51,13 +49,13 @@
 /datum/bounty/weapon_prototype/burst/accepts_weapon(var/obj/item/weapon/gun/energy/laser/prototype/P)
 	return P.burst > stat_value
 
-/datum/bounty/weapon_prototype/burst_delay
-	stat_name = "burst delay"
-	stat_value = 0.9
+/datum/bounty/weapon_prototype/fire_delay
+	stat_name = "fire delay"
+	stat_value = 1
 	stat_comparison = "smaller than"
 
-/datum/bounty/weapon_prototype/burst_delay/accepts_weapon(var/obj/item/weapon/gun/energy/laser/prototype/P)
-	return P.burst_delay < stat_value
+/datum/bounty/weapon_prototype/fire_delay/accepts_weapon(var/obj/item/weapon/gun/energy/laser/prototype/P)
+	return P.fire_delay < stat_value
 
 /datum/bounty/weapon_prototype/reliability
 	stat_name = "reliability"

--- a/code/modules/cargo/bounties/weapon_prototype.dm
+++ b/code/modules/cargo/bounties/weapon_prototype.dm
@@ -6,7 +6,7 @@
 	var/stat_comparison = "greater than"
 
 /datum/bounty/weapon_prototype/New()
-	name = "Weapon ([stat_name] of [stat_value])"
+	name = "Weapon ([stat_name] [stat_comparison] [stat_value])"
 	description = "[current_map.company_name] is interested in a laser prototype with a [stat_name] stat [stat_comparison] [stat_value]. [current_map.boss_name] will pay handsomely for such a weapon."
 	reward += rand(0, 4) * 500
 	..()

--- a/html/changelogs/VTCobaltblood - give_me_my_money.yml
+++ b/html/changelogs/VTCobaltblood - give_me_my_money.yml
@@ -38,4 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
+  - bugfix: "Central Commands actually tells you what values it wants, not what it compares against."
   - bugfix: "Central Command no longer wants impossible guns."

--- a/html/changelogs/VTCobaltblood - give_me_my_money.yml
+++ b/html/changelogs/VTCobaltblood - give_me_my_money.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - bugfix: "Weapon bounties should now be always possible to complete."
+  - bugfix: "Central Command no longer wants impossible guns."

--- a/html/changelogs/VTCobaltblood - give_me_my_money.yml
+++ b/html/changelogs/VTCobaltblood - give_me_my_money.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: VTCobaltblood
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Weapon bounties should now be always possible to complete."

--- a/html/changelogs/VTCobaltblood - give_me_my_money.yml
+++ b/html/changelogs/VTCobaltblood - give_me_my_money.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - bugfix: "Central Commands actually tells you what values it wants, not what it compares against."
+  - bugfix: "Central Commands actually tells you what gun values it wants, not what it compares against."
   - bugfix: "Central Command no longer wants impossible guns."


### PR DESCRIPTION
Burst delay is replaced with fire delay. Fixes #6816
Bounties also now properly tell you they're _comparing_ against a value, not actually wanting a weapon with that exact stat.