### PR TITLE
Research is now properly enclosed during biohazards

### DIFF
--- a/html/changelogs/VTCobaltblood - stupid_forts.yml
+++ b/html/changelogs/VTCobaltblood - stupid_forts.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: VTCobaltblood
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Research's biohazard shutter now properly shields Research from the world, and the world from Research. Robotics not included."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -40839,6 +40839,15 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	closed_layer = 3.5;
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "bru" = (
@@ -40849,6 +40858,15 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/sign/flag/nanotrasen/left,
+/obj/machinery/door/blast/regular{
+	closed_layer = 3.5;
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "brv" = (
@@ -40859,6 +40877,15 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/sign/flag/nanotrasen/right,
+/obj/machinery/door/blast/regular{
+	closed_layer = 3.5;
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "brw" = (
@@ -40870,6 +40897,15 @@
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	closed_layer = 3.5;
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
@@ -40886,6 +40922,15 @@
 /obj/machinery/door/airlock/glass_research{
 	name = "Robotics Lab";
 	req_access = list(29)
+	},
+/obj/machinery/door/blast/regular{
+	closed_layer = 3.5;
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -40840,9 +40840,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
-	closed_layer = 3.5;
 	density = 0;
-	dir = 1;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "Biohazard";
 	name = "Biohazard Shutter";
@@ -40859,9 +40858,8 @@
 /obj/machinery/door/firedoor,
 /obj/structure/sign/flag/nanotrasen/left,
 /obj/machinery/door/blast/regular{
-	closed_layer = 3.5;
 	density = 0;
-	dir = 1;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "Biohazard";
 	name = "Biohazard Shutter";
@@ -40878,9 +40876,8 @@
 /obj/machinery/door/firedoor,
 /obj/structure/sign/flag/nanotrasen/right,
 /obj/machinery/door/blast/regular{
-	closed_layer = 3.5;
 	density = 0;
-	dir = 1;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "Biohazard";
 	name = "Biohazard Shutter";
@@ -40899,9 +40896,8 @@
 	dir = 4
 	},
 /obj/machinery/door/blast/regular{
-	closed_layer = 3.5;
 	density = 0;
-	dir = 1;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "Biohazard";
 	name = "Biohazard Shutter";
@@ -40924,9 +40920,8 @@
 	req_access = list(29)
 	},
 /obj/machinery/door/blast/regular{
-	closed_layer = 3.5;
 	density = 0;
-	dir = 1;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "Biohazard";
 	name = "Biohazard Shutter";


### PR DESCRIPTION
The biohazard shutter now covers Robotics's hallway door and window, isolating it from the rest of Research during a biohazard situation. 
![image](https://user-images.githubusercontent.com/17379794/63022221-16a35a00-beab-11e9-8b25-7684f6016fc6.png)

Inspired by Smog's comment in the robotics layout project: https://forums.aurorastation.org/topic/12559-robotics-layout-suggestion-additional-tool-request/?do=findComment&comment=119564