### PR TITLE
Liver Tweaks

### DIFF
--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -120,6 +120,7 @@
 	parent_organ = "groin"
 	robotic_name = "toxin filter"
 	robotic_sprite = "liver-prosthetic"
+	var/tolerance = 3
 
 /obj/item/organ/liver/process()
 
@@ -138,9 +139,9 @@
 	if(owner.life_tick % PROCESS_ACCURACY == 0)
 
 		//A liver's duty is to get rid of toxins
-		if(owner.getToxLoss() > 0 && owner.getToxLoss() <= 3)
+		if(owner.getToxLoss() > 0 && owner.getToxLoss() <= tolerance)
 			owner.adjustToxLoss(-0.2) //there isn't a lot of toxin damage, so we're going to be chill and slowly filter it out
-		else if(owner.getToxLoss() > 3)
+		else if(owner.getToxLoss() > tolerance)
 			if(is_bruised())
 				//damaged liver works less efficiently
 				owner.adjustToxLoss(-0.5)

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -120,7 +120,7 @@
 	parent_organ = "groin"
 	robotic_name = "toxin filter"
 	robotic_sprite = "liver-prosthetic"
-	var/tolerance = 3
+	var/tolerance = 5
 
 /obj/item/organ/liver/process()
 

--- a/code/modules/organs/subtypes/vaurca.dm
+++ b/code/modules/organs/subtypes/vaurca.dm
@@ -54,9 +54,11 @@
 	robotic = 2
 	robotic_name = null
 	robotic_sprite = null
+	tolerance = 25
 
 /obj/item/organ/liver/vaurca
 	icon_state = "liver_vaurca"
+	tolerance = 25
 
 /obj/item/organ/brain/vaurca
 	icon_state = "brain_vaurca"

--- a/code/modules/organs/subtypes/vaurca.dm
+++ b/code/modules/organs/subtypes/vaurca.dm
@@ -54,11 +54,11 @@
 	robotic = 2
 	robotic_name = null
 	robotic_sprite = null
-	tolerance = 25
+	tolerance = 20
 
 /obj/item/organ/liver/vaurca
 	icon_state = "liver_vaurca"
-	tolerance = 25
+	tolerance = 20
 
 /obj/item/organ/brain/vaurca
 	icon_state = "brain_vaurca"

--- a/code/modules/organs/subtypes/xenos.dm
+++ b/code/modules/organs/subtypes/xenos.dm
@@ -55,4 +55,4 @@
 	name = "waste tract"
 	parent_organ = "chest"
 	color = "#0033cc"
-	tolerance = 25
+	tolerance = 20

--- a/code/modules/organs/subtypes/xenos.dm
+++ b/code/modules/organs/subtypes/xenos.dm
@@ -55,3 +55,4 @@
 	name = "waste tract"
 	parent_organ = "chest"
 	color = "#0033cc"
+	tolerance = 25

--- a/html/changelogs/geeves-vacliverlives.yml
+++ b/html/changelogs/geeves-vacliverlives.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Geeves
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Livers can withstand slightly more toxin before getting damaged. Vaurca and Vox livers are much more robust, and will not perish when switching masks."


### PR DESCRIPTION
The liver's ability to deal with toxins was super ultra giga-bad. This lead to damage that was pretty annoying to deal with, and definite round-enders for Vaurca.
This PR adds a tolerance level to livers, and gives Vaurca and Vox livers a higher tolerance to toxins, that being up to 20 toxins. It also minorly boosts all the other species' tolerance to 5 toxins, rather than 3.
Vaurca get the toxin chemical added to their bloodstream when they breathe in oxygen, so damage will persist if you start breathing phoron after having no oxygen for a bit. Get to medical ASAP if this happens, anti-toxin will nullify the liver damaging process completely.
With this update, you have slightly more leeway with lag and mask switches.