### PR TITLE
Fixes vaurca missing jargon citizenship and a bit more

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -115,7 +115,7 @@
 
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/claw
 
-	allowed_citizenships = list(CITIZENSHIP_ZORA, CITIZENSHIP_IZWESKI, CITIZENSHIP_BIESEL, CITIZENSHIP_ERIDANI)
+	allowed_citizenships = list(CITIZENSHIP_ZORA, CITIZENSHIP_IZWESKI, CITIZENSHIP_BIESEL, CITIZENSHIP_ERIDANI, CITIZENSHIP_JARGON)
 	allowed_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_PILOTDREAM, RELIGION_NONE, RELIGION_OTHER)
 
 /datum/species/bug/before_equip(var/mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -50,8 +50,6 @@
 	slowdown = 2
 	eyes = "breeder_eyes" //makes it so that eye colour is not changed when skin colour is.
 	eyes_icons = 'icons/mob/human_face/eyes48x48.dmi'
-	brute_mod = 0.1 //note to self: remove is_synthetic checks for brmod and burnmod
-	burn_mod = 0.8 //2x was a bit too much. we'll see how this goes.
 	grab_mod = 4
 	toxins_mod = 1 //they're not used to all our weird human bacteria.
 	breakcuffs = list(MALE,FEMALE,NEUTER)
@@ -76,7 +74,6 @@
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/bugbite,
-		/mob/living/carbon/human/proc/devour_head,
 		/mob/living/carbon/human/proc/hivenet
 		)
 

--- a/html/changelogs/alberyk-literalbugfix.yml
+++ b/html/changelogs/alberyk-literalbugfix.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - bugfix: "Vaurca can now select Jargon Federation citizenship."
+


### PR DESCRIPTION
-fixes #6873
-removes the vaurca breeder head eating powers
-brings the vaurca breeder resists to be closer to the baseline species