### PR TITLE
Fixed Vaurca Consular Officers not getting their mission fax.

### DIFF
--- a/code/modules/background/citizenship/vaurca.dm
+++ b/code/modules/background/citizenship/vaurca.dm
@@ -39,7 +39,7 @@
 
 
 /datum/outfit/job/representative/consular/zora/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	if(!visualsOnly)
+	if(H && !visualsOnly)
 		if(isvaurca(H))
 			var/r = H.r_skin
 			var/g = H.g_skin
@@ -58,3 +58,5 @@
 
 			H.change_skin_color(r, g, b)
 			H.update_dna()
+		addtimer(CALLBACK(src, .proc/send_representative_mission, H), 5 MINUTES)
+	return TRUE

--- a/html/changelogs/CodePanter-missing-mission-fix.yml
+++ b/html/changelogs/CodePanter-missing-mission-fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: CodePanter
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed Vaurca Consular Officers not getting their mission fax."


### PR DESCRIPTION
As reported here https://github.com/Aurorastation/Aurora.3/issues/6895 the Vaurca Consular Officer didn't get a mission fax, as (from what I understand) their custom post_equip function overwrites the one that sends the fax. The custom function now also sends this fax message.