### PR TITLE
Adjusts shrapnel to cause HALLOSS

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1136,10 +1136,7 @@
 						"<span class='warning'>Your movement jostles [O] in your [organ.name] painfully.</span>")
 					to_chat(src, msg)
 
-				organ.take_damage(rand(1,3), 0, 0)
-				if(!(organ.status & ORGAN_ROBOT) && !(species.flags & NO_BLOOD)) //There is no blood in protheses.
-					organ.status |= ORGAN_BLEEDING
-					src.adjustToxLoss(rand(1,3))
+				src.adjustHalLoss(rand(1, 3))
 
 /mob/living/carbon/human/verb/check_pulse()
 	set category = "Object"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1136,7 +1136,7 @@
 						"<span class='warning'>Your movement jostles [O] in your [organ.name] painfully.</span>")
 					to_chat(src, msg)
 
-				src.adjustHalLoss(rand(1, 3))
+				adjustHalLoss(rand(1, 3))
 
 /mob/living/carbon/human/verb/check_pulse()
 	set category = "Object"

--- a/html/changelogs/skull132_shrapnel.yml
+++ b/html/changelogs/skull132_shrapnel.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - tweak: "Shrapnel no longer causes direct damage. Instead, it causes HALLOSS."


### PR DESCRIPTION
Shrapnel no longer causes damage. This is to make this shit less lethal, and to increase the survivability of combat when ballistics are in play. They do cause HALLOSS now, though. Which should still result in the person getting filled with shrapnel being immobilized and effectively useless in combat.