### PR TITLE
Ports table item autoalign from Bay

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -109,7 +109,7 @@
 			setMoveCooldown(10) //getting something out of a backpack
 
 		if(W)
-			var/resolved = W.resolve_attackby(A, src)
+			var/resolved = W.resolve_attackby(A, src, params)
 			if(!resolved && A && W)
 				W.afterattack(A, src, 1, params) // 1 indicates adjacency
 		else
@@ -129,7 +129,7 @@
 
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
-				var/resolved = W.resolve_attackby(A,src)
+				var/resolved = W.resolve_attackby(A,src, params)
 				if(!resolved && A && W)
 					W.afterattack(A, src, 1, params) // 1: clicking something Adjacent
 			else

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -28,13 +28,13 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return
 
 //I would prefer to rename this to attack(), but that would involve touching hundreds of files.
-/obj/item/proc/resolve_attackby(atom/A, mob/user)
+/obj/item/proc/resolve_attackby(atom/A, mob/user, var/click_parameters)
 	pre_attack(A, user)
 	add_fingerprint(user)
-	return A.attackby(src, user)
+	return A.attackby(src, user, click_parameters)
 
 // No comment
-/atom/proc/attackby(obj/item/W, mob/user)
+/atom/proc/attackby(obj/item/W, mob/user, var/click_parameters)
 	return
 
 /atom/movable/attackby(obj/item/W, mob/user)

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -41,6 +41,7 @@
 	return 1
 
 /obj/item/weapon/melee/cultblade/pickup(mob/living/user as mob)
+	..()
 	if(!iscultist(user))
 		to_chat(user, "<span class='warning'>An overwhelming feeling of dread comes over you as you pick up \the [src]. It would be wise to be rid of this blade quickly.</span>")
 		user.make_dizzy(120)

--- a/code/game/machinery/kitchen/cooking_machines/container.dm
+++ b/code/game/machinery/kitchen/cooking_machines/container.dm
@@ -148,6 +148,7 @@
 	shortname = "shelf"
 	desc = "Put ingredients in this; designed for use with an oven. Warranty void if used."
 	icon_state = "ovendish"
+	center_of_mass = list("x" = 16,"y" = 12)
 	max_space = 30
 	max_reagents = 120
 

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -62,6 +62,7 @@ Buildable meters
 	icon = 'icons/obj/pipe-item.dmi'
 	icon_state = "simple"
 	item_state = "buildpipe"
+	randpixel = 5
 	w_class = 3
 	level = 2
 
@@ -200,8 +201,7 @@ Buildable meters
 			connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER
 	//src.pipe_dir = get_pipe_dir()
 	update()
-	src.pixel_x = rand(-5, 5)
-	src.pixel_y = rand(-5, 5)
+	randpixel_xy()
 
 //update the name and icon of the pipe item depending on the type
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -4,6 +4,7 @@
 	w_class = 3.0
 
 	var/image/blood_overlay //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
+	var/randpixel = 6
 	var/abstract = 0
 	var/r_speed = 1.0
 	var/health
@@ -171,7 +172,7 @@
 			return
 	if(!src.Adjacent(user) && !(TK in user.mutations))
 		to_chat(user, span("notice", "\The [src] slips out of your grasp before you can grab it!")) // because things called before this can move it
-		return // please don't pick things up 
+		return // please don't pick things up
 	src.pickup(user)
 	if (istype(src.loc, /obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = src.loc
@@ -266,6 +267,8 @@
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
+	pixel_x = 0
+	pixel_y = 0
 	return
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
@@ -781,3 +784,12 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if(AStar(get_turf(us), get_turf(them), /turf/proc/AdjacentTurfsRanged, /turf/proc/Distance, max_nodes=25, max_node_depth=range))
 		return TRUE
 	return FALSE
+
+//Used for selecting a random pixel placement, usually on initialize. Checks for pixel_x/y to not interfere with mapped in items.
+/obj/item/proc/randpixel_xy()
+	if(!pixel_x && !pixel_y)
+		pixel_x = rand(-randpixel, randpixel)
+		pixel_y = rand(-randpixel, randpixel)
+		return TRUE
+	else
+		return FALSE

--- a/code/game/objects/items/devices/lighting/lamp.dm
+++ b/code/game/objects/items/devices/lighting/lamp.dm
@@ -3,6 +3,7 @@
 	desc = "A desk lamp with an adjustable mount."
 	icon_state = "lamp"
 	item_state = "lamp"
+	center_of_mass = list("x" = 13,"y" = 11)
 	brightness_on = 5
 	w_class = 5
 	flags = CONDUCT
@@ -17,6 +18,7 @@
 	desc = "A classic green-shaded desk lamp."
 	icon_state = "lampgreen"
 	item_state = "lampgreen"
+	center_of_mass = list("x" = 15,"y" = 11)
 	brightness_on = 5
 	light_color = "#FFC58F"
 

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -62,14 +62,14 @@
 		destroyed_event.unregister(buffer_object, src)
 		buffer_object = null
 
-/obj/item/device/multitool/resolve_attackby(atom/A, mob/user)
+/obj/item/device/multitool/resolve_attackby(atom/A, mob/user, var/click_parameters)
 	if(!isobj(A))
-		return ..(A, user)
+		return ..(A, user, click_parameters)
 
 	var/obj/O = A
 	var/datum/expansion/multitool/MT = LAZYACCESS(O.expansions, /datum/expansion/multitool)
 	if(!MT)
-		return ..(A, user)
+		return ..(A, user, click_parameters)
 
 	user.AddTopicPrint(src)
 	MT.interact(src, user)

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -13,12 +13,12 @@
 	w_class = 3
 	max_amount = 60
 	icon = 'icons/obj/stacks/tiles.dmi'
+	randpixel = 7
 	drop_sound = 'sound/items/drop/axe.ogg'
 
 /obj/item/stack/tile/New()
 	..()
-	pixel_x = rand(-7, 7)
-	pixel_y = rand(-7, 7)
+	randpixel_xy()
 
 /*
  * Grass

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -72,10 +72,10 @@
 	var/uses = 10
 
 var/const/NO_EMAG_ACT = -50
-/obj/item/weapon/card/emag/resolve_attackby(atom/A, mob/user)
+/obj/item/weapon/card/emag/resolve_attackby(atom/A, mob/user, var/click_parameters)
 	var/used_uses = A.emag_act(uses, user, src)
 	if(used_uses == NO_EMAG_ACT)
-		return ..(A, user)
+		return ..(A, user, click_parameters)
 
 	uses -= used_uses
 	A.add_fingerprint(user)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -379,14 +379,14 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A manky old cigarette butt."
 	icon = 'icons/obj/clothing/masks.dmi'
 	icon_state = "cigbutt"
+	randpixel = 10
 	w_class = 1
 	slot_flags = SLOT_EARS
 	throwforce = 1
 
 /obj/item/weapon/cigbutt/Initialize()
 	. = ..()
-	pixel_x = rand(-10,10)
-	pixel_y = rand(-10,10)
+	randpixel_xy()
 	transform = turn(transform,rand(0,360))
 
 /obj/item/weapon/cigbutt/cigarbutt

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -2,6 +2,7 @@
 	name = "ashtray"
 	icon = 'icons/obj/ashtray.dmi'
 	icon_state = "blank"
+	randpixel = 5
 	force_divisor = 0.1
 	thrown_force_divisor = 0.1
 	var/image/base_image
@@ -13,8 +14,7 @@
 		qdel(src)
 		return
 	max_butts = round(material.hardness/10) //This is arbitrary but whatever.
-	src.pixel_y = rand(-5, 5)
-	src.pixel_x = rand(-6, 6)
+	randpixel_xy()
 	update_icon()
 	return
 

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/shards.dmi'
 	desc = "Made of nothing. How does this even exist?" // set based on material, if this desc is visible it's a bug (shards default to being made of glass)
 	icon_state = "large"
+	randpixel = 8
 	sharp = 1
 	edge = 1
 	w_class = 2
@@ -22,8 +23,7 @@
 		return
 
 	icon_state = "[material.shard_icon][pick("large", "medium", "small")]"
-	pixel_x = rand(-8, 8)
-	pixel_y = rand(-8, 8)
+	randpixel_xy()
 	update_icon()
 
 	if(material.shard_type)

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -85,6 +85,7 @@
 	item_state = icon_state
 
 /obj/item/weapon/material/twohanded/pickup(mob/user)
+	..()
 	unwield()
 
 /obj/item/weapon/material/twohanded/attack_self(mob/user as mob)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -26,6 +26,7 @@
 	desc = "It's just an ordinary box."
 	icon_state = "box"
 	item_state = "syringe_kit"
+	center_of_mass = list("x" = 13,"y" = 10)
 	var/foldable = /obj/item/stack/material/cardboard	// BubbleWrap - if set, can be folded (when empty) into a sheet of cardboard
 	var/maxHealth = 20	//health is already defined
 	use_sound = 'sound/items/storage/box.ogg'

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -44,6 +44,7 @@
 /obj/item/weapon/storage/fancy/egg_box
 	icon = 'icons/obj/food.dmi'
 	icon_state = "eggbox"
+	center_of_mass = list("x" = 16,"y" = 7)
 	icon_type = "egg"
 	name = "egg box"
 	storage_slots = 12

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -11,6 +11,7 @@
 	name = "first-aid kit"
 	desc = "It's an emergency medical kit for those serious boo-boos."
 	icon_state = "firstaid"
+	center_of_mass = list("x" = 13,"y" = 10)
 	throw_speed = 2
 	throw_range = 8
 	var/empty = 0
@@ -141,6 +142,7 @@
 	icon_state = "pill_canister"
 	icon = 'icons/obj/chemical.dmi'
 	item_state = "contsolid"
+	center_of_mass = list("x" = 16,"y" = 12)
 	w_class = 2.0
 	can_hold = list(/obj/item/weapon/reagent_containers/pill,/obj/item/weapon/dice,/obj/item/weapon/paper)
 	allow_quick_gather = 1

--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -29,6 +29,7 @@
 /obj/item/weapon/storage/box/donut
 	icon = 'icons/obj/food.dmi'
 	icon_state = "donutbox"
+	center_of_mass = list("x" = 16,"y" = 9)
 	name = "donut box"
 	can_hold = list(/obj/item/weapon/reagent_containers/food/snacks/donut)
 	foldable = /obj/item/stack/material/cardboard

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "red"
 	item_state = "toolbox_red"
+	center_of_mass = list("x" = 16,"y" = 11)
 	flags = CONDUCT
 	force = 5
 	throwforce = 10

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -41,6 +41,7 @@
 	desc = "A tool with a flattened or cross-shaped tip that fits into the head of a screw to turn it."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "screwdriver"
+	center_of_mass = list("x" = 13,"y" = 7)
 	flags = CONDUCT
 	slot_flags = SLOT_BELT | SLOT_EARS
 	force = 5.0
@@ -106,6 +107,7 @@
 	desc = "A tool used to cut wires in electrical work."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "cutters"
+	center_of_mass = list("x" = 18,"y" = 10)
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	force = 6.0

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -6,6 +6,8 @@
 	icon = 'icons/obj/items.dmi'
 	var/icon_base = "beartrap"
 	icon_state = "beartrap0"
+	randpixel = 0
+	center_of_mass = null
 	desc = "A mechanically activated leg trap. Low-tech, but reliable. Looks like it could really hurt if you set it off."
 	throwforce = 0
 	w_class = 3
@@ -267,7 +269,7 @@
 	if(!ishuman(usr))
 		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 		return
-	
+
 	var/datum/M = captured ? captured.resolve() : null
 
 	if(deployed)
@@ -349,7 +351,7 @@
 	else if (istype(L, /obj/effect/spider/spiderling))
 		var/obj/effect/spider/spiderling/S = L
 		msg = "<span class='warning'>[S] jumps out of \the [src].</span>"
-	
+
 	unbuckle_mob()
 	captured = null
 	visible_message(msg)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -213,6 +213,7 @@
 	desc = "A collapsed roller bed that can be carried around."
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "folded"
+	center_of_mass = list("x" = 17,"y" = 7)
 	w_class = 4.0 // Can't be put in backpacks. Oh well.
 
 /obj/item/roller/attack_self(mob/user)

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -5,6 +5,8 @@
 	desc = "Apply butt."
 	icon = 'icons/obj/furniture.dmi'
 	icon_state = "stool_preview" //set for the map
+	randpixel = 0
+	center_of_mass = null
 	force = 10
 	throwforce = 10
 	w_class = 5

--- a/code/modules/battlemonsters/items/card.dm
+++ b/code/modules/battlemonsters/items/card.dm
@@ -11,6 +11,7 @@
 	var/datum/battle_monsters/trap/trap_datum
 
 	w_class = ITEMSIZE_TINY
+	drop_sound = null
 
 	//Card information here
 
@@ -22,6 +23,14 @@
 	if(istype(attacking,/obj/item/battle_monsters/card) && attacking != src)
 		var/obj/item/battle_monsters/card/adding_card = attacking
 		make_deck(user,adding_card)
+
+/obj/item/battle_monsters/card/resolve_attackby(atom/A, mob/user, var/click_parameters)
+	if(istype(A,/obj/structure/table) || istype(A,/obj/structure/dueling_table))
+		user.visible_message(\
+			span("notice","\The [user] plays \the [src]!"),\
+			span("notice","You play \the [src]!")\
+		)
+	..(A, user, click_parameters)
 
 /obj/item/battle_monsters/card/attack_self(mob/user as mob)
 	flip_card(user)

--- a/code/modules/battlemonsters/items/core.dm
+++ b/code/modules/battlemonsters/items/core.dm
@@ -1,7 +1,6 @@
 /obj/item/battle_monsters/
 	icon = 'icons/obj/battle_monsters/card.dmi'
 	icon_state = ""
-	var/list/center_of_mass = list("x"=16, "y"=16)
 	var/facedown = TRUE
 	var/rotated = FALSE
 
@@ -66,43 +65,3 @@
 			)
 
 	update_icon()
-
-
-#define CELLS_X 6
-#define CELLSIZE_X (32/CELLS_X)
-
-#define CELLS_Y 6
-#define CELLSIZE_Y (32/CELLS_Y)
-
-/obj/item/battle_monsters/afterattack(atom/A, mob/user, proximity, params) //Copy and pasted from foodcode.
-	if(proximity && params && (istype(A, /obj/structure/table) || (istype(A,/obj/structure/dueling_table) && A.density)) && center_of_mass.len)
-
-		user.visible_message(\
-			span("notice","\The [user] plays \the [src]."),\
-			span("notice","You play \the [src].")\
-		)
-
-		//Places the item on a grid
-		var/list/mouse_control = mouse_safe_xy(params)
-
-		var/mouse_x = mouse_control["icon-x"]
-		var/mouse_y = mouse_control["icon-y"]
-
-		if(!isnum(mouse_x) || !isnum(mouse_y))
-			return
-
-		var/cell_x = max(0, min(CELLS_X-1, round(mouse_x/CELLSIZE_X)))
-		var/cell_y = max(0, min(CELLS_Y-1, round(mouse_y/CELLSIZE_Y)))
-
-		pixel_x = (CELLSIZE_X * (0.5 + cell_x)) - center_of_mass["x"]
-		pixel_y = (CELLSIZE_Y * (0.5 + cell_y)) - center_of_mass["y"]
-
-		layer = A.layer + 0.1
-
-	. = ..()
-
-#undef CELLS_X
-#undef CELLSIZE_X
-
-#undef CELLS_Y
-#undef CELLSIZE_Y

--- a/code/modules/battlemonsters/items/furniture/dueling_area.dm
+++ b/code/modules/battlemonsters/items/furniture/dueling_area.dm
@@ -25,10 +25,6 @@
 
 /obj/structure/dueling_table/attackby(obj/item/W as obj, mob/user as mob, var/click_parameters)
 	if(user.unEquip(W, 0, src.loc))
-		user.visible_message(\
-			span("notice","\The [user] plays \the [W]!"),\
-			span("notice","You play \the [W]!")\
-		)
 		if(!W.center_of_mass)
 			W.randpixel_xy()
 			return

--- a/code/modules/battlemonsters/items/furniture/dueling_area.dm
+++ b/code/modules/battlemonsters/items/furniture/dueling_area.dm
@@ -20,6 +20,36 @@
 	density = 0
 	mouse_opacity = 0
 
-/obj/structure/dueling_table/attackby(obj/item/W as obj, mob/user as mob)
-	user.drop_item(src.loc)
-	return
+#define CELLS 8
+#define CELLSIZE (world.icon_size/CELLS)
+
+/obj/structure/dueling_table/attackby(obj/item/W as obj, mob/user as mob, var/click_parameters)
+	if(user.unEquip(W, 0, src.loc))
+		user.visible_message(\
+			span("notice","\The [user] plays \the [W]!"),\
+			span("notice","You play \the [W]!")\
+		)
+		if (!W.center_of_mass)
+			W.pixel_x = rand(-6, 6)
+			W.pixel_y = rand(-6, 6)
+			W.pixel_z = 0
+			return
+
+		if (!click_parameters)
+			return
+
+		var/list/mouse_control = mouse_safe_xy(click_parameters)
+		var/mouse_x = mouse_control["icon-x"]
+		var/mouse_y = mouse_control["icon-y"]
+
+		if(isnum(mouse_x) && isnum(mouse_y))
+			var/cell_x = max(0, min(CELLS-1, round(mouse_x/CELLSIZE)))
+			var/cell_y = max(0, min(CELLS-1, round(mouse_y/CELLSIZE)))
+
+			W.pixel_x = (CELLSIZE * (0.5 + cell_x)) - W.center_of_mass["x"]
+			W.pixel_y = (CELLSIZE * (0.5 + cell_y)) - W.center_of_mass["y"]
+
+		W.layer = src.layer + 0.1
+
+#undef CELLS
+#undef CELLSIZE

--- a/code/modules/battlemonsters/items/furniture/dueling_area.dm
+++ b/code/modules/battlemonsters/items/furniture/dueling_area.dm
@@ -29,13 +29,12 @@
 			span("notice","\The [user] plays \the [W]!"),\
 			span("notice","You play \the [W]!")\
 		)
-		if (!W.center_of_mass)
-			W.pixel_x = rand(-6, 6)
-			W.pixel_y = rand(-6, 6)
-			W.pixel_z = 0
+		if(!W.center_of_mass)
+			W.pixel_x = rand(-W.randpixel, W.randpixel)
+			W.pixel_y = rand(-W.randpixel, W.randpixel)
 			return
 
-		if (!click_parameters)
+		if(!click_parameters)
 			return
 
 		var/list/mouse_control = mouse_safe_xy(click_parameters)

--- a/code/modules/battlemonsters/items/furniture/dueling_area.dm
+++ b/code/modules/battlemonsters/items/furniture/dueling_area.dm
@@ -30,8 +30,7 @@
 			span("notice","You play \the [W]!")\
 		)
 		if(!W.center_of_mass)
-			W.pixel_x = rand(-W.randpixel, W.randpixel)
-			W.pixel_y = rand(-W.randpixel, W.randpixel)
+			W.randpixel_xy()
 			return
 
 		if(!click_parameters)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -2,8 +2,7 @@
 	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle. They're large enough to be worn over other footwear."
 	name = "magboots"
 	icon_state = "magboots0"
-	randpixel = 0
-	center_of_mass = null
+	center_of_mass = list("x" = 17,"y" = 12)
 	species_restricted = null
 	force = 5
 	overshoes = 1

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -2,6 +2,8 @@
 	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle. They're large enough to be worn over other footwear."
 	name = "magboots"
 	icon_state = "magboots0"
+	randpixel = 0
+	center_of_mass = null
 	species_restricted = null
 	force = 5
 	overshoes = 1

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -6,8 +6,6 @@
 	name = "space helmet"
 	icon_state = "space"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
-	randpixel = 0
-	center_of_mass = null
 	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL | AIRTIGHT
 	flags_inv = BLOCKHAIR
 	item_state_slots = list(

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -6,6 +6,8 @@
 	name = "space helmet"
 	icon_state = "space"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
+	randpixel = 0
+	center_of_mass = null
 	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL | AIRTIGHT
 	flags_inv = BLOCKHAIR
 	item_state_slots = list(
@@ -64,6 +66,8 @@
 	desc = "A suit that protects against low pressure environments. \"NSS AURORA\" is written in large block letters on the back."
 	icon_state = "space"
 	item_state = "s_suit"
+	randpixel = 0
+	center_of_mass = null
 	w_class = 4//bulky item
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -18,6 +18,8 @@
 	desc = "A suit that protects against biological contamination."
 	icon_state = "bio"
 	item_state = "bio_suit"
+	randpixel = 0
+	center_of_mass = null
 	w_class = 4//bulky item
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -305,4 +305,5 @@
 		update_icon()
 
 /obj/item/weapon/hand/pickup(mob/user as mob)
+	..()
 	src.update_icon()

--- a/code/modules/hydroponics/beekeeping/net.dm
+++ b/code/modules/hydroponics/beekeeping/net.dm
@@ -24,7 +24,7 @@
 
 
 
-/obj/item/weapon/bee_net/resolve_attackby(atom/A, mob/user)
+/obj/item/weapon/bee_net/resolve_attackby(atom/A, mob/user, var/click_parameters)
 	if (istype(A, /turf))
 		var/turf/T = A
 		for(var/mob/living/simple_animal/bee/B in T)
@@ -36,7 +36,7 @@
 	else if (istype(A, /obj/machinery/beehive) && caught_bees)
 		deposit_bees(A, user)
 		return 1
-	..()
+	..(A, user, click_parameters)
 
 
 /obj/item/weapon/bee_net/proc/capture_bees(var/mob/living/simple_animal/bee/target, var/mob/living/user)

--- a/code/modules/hydroponics/beekeeping/smoker.dm
+++ b/code/modules/hydroponics/beekeeping/smoker.dm
@@ -22,7 +22,7 @@
 	//Bee smoker intentionally spawns empty. Fill it at a weldertank before use
 
 //I would prefer to rename this to attack(), but that would involve touching hundreds of files.
-/obj/item/weapon/bee_smoker/resolve_attackby(atom/A, mob/user)
+/obj/item/weapon/bee_smoker/resolve_attackby(atom/A, mob/user, var/click_parameters)
 	if (istype(A, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,A) <= 1)
 		A.reagents.trans_to_obj(src, max_fuel)
 		to_chat(user, "<span class='notice'>Smoker refilled!</span>")
@@ -41,7 +41,7 @@
 		return 1
 	else
 		smoke_at(A)
-	..()
+	..(A, user, click_parameters)
 	return 1
 
 

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -6,7 +6,7 @@
 	throw_speed = 3
 	throw_range = 3
 	max_amount = 50
-	randpixel = 5
+	center_of_mass = null
 
 	var/default_type = DEFAULT_WALL_MATERIAL
 	var/material/material

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -6,6 +6,7 @@
 	throw_speed = 3
 	throw_range = 3
 	max_amount = 50
+	randpixel = 5
 
 	var/default_type = DEFAULT_WALL_MATERIAL
 	var/material/material
@@ -15,8 +16,7 @@
 
 /obj/item/stack/material/Initialize()
 	. = ..()
-	pixel_x = rand(0,4)-4
-	pixel_y = rand(0,4)-4
+	randpixel_xy()
 
 	if(!default_type)
 		default_type = DEFAULT_WALL_MATERIAL

--- a/code/modules/mining/coins.dm
+++ b/code/modules/mining/coins.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/coins.dmi'
 	name = "Coin"
 	icon_state = "coin"
+	randpixel = 8
 	desc = "A flat disc or piece of metal with an official stamp. An archaic type of currency."
 	flags = CONDUCT
 	force = 0.0
@@ -16,8 +17,7 @@
 	drop_sound = 'sound/items/drop/ring.ogg'
 
 /obj/item/weapon/coin/New()
-	pixel_x = rand(0,16)-8
-	pixel_y = rand(0,8)-8
+	randpixel_xy()
 
 /obj/item/weapon/coin/gold
 	name = "gold coin"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -115,6 +115,7 @@
 	return	unwield()
 
 /obj/item/weapon/pickaxe/pickup(mob/user)
+	..()
 	unwield()
 
 /obj/item/weapon/pickaxe/attack_self(mob/user as mob)

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -2,6 +2,7 @@
 	name = "rock"
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "ore1"
+	randpixel = 8
 	w_class = 2
 	throwforce = 10
 	var/datum/geosample/geologic_data
@@ -85,9 +86,7 @@
 	material = null
 
 /obj/item/weapon/ore/New()
-	pixel_x = rand(0,16)-8
-	pixel_y = rand(0,8)-8
-	if(icon_state == "ore1")
+	if((randpixel_xy()) && icon_state == "ore1")
 		icon_state = "ore[pick(1,2,3)]"
 
 /obj/item/weapon/ore/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -5,6 +5,8 @@ var/list/holder_mob_icon_cache = list()
 	name = "holder"
 	desc = "You shouldn't ever see this."
 	icon = 'icons/mob/npc/held_mobs.dmi'
+	randpixel = 0
+	center_of_mass = null
 	slot_flags = 0
 	sprite_sheets = list("Vox" = 'icons/mob/species/vox/head.dmi')
 	origin_tech = null

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -164,7 +164,7 @@ var/list/slot_equipment_priority = list( \
 
 // Removes an item from inventory and places it in the target atom.
 // If canremove or other conditions need to be checked then use unEquip instead.
-/mob/proc/drop_from_inventory(var/obj/item/W, var/atom/target = null)
+/mob/proc/drop_from_inventory(var/obj/item/W, var/atom/target)
 	if(W)
 		if(!target)
 			target = loc
@@ -252,10 +252,10 @@ var/list/slot_equipment_priority = list( \
 	return slot
 
 //This differs from remove_from_mob() in that it checks if the item can be unequipped first.
-/mob/proc/unEquip(obj/item/I, force = 0) //Force overrides NODROP for things like wizarditis and admin undress.
+/mob/proc/unEquip(obj/item/I, force = 0, var/atom/target) //Force overrides NODROP for things like wizarditis and admin undress.
 	if(!(force || canUnEquip(I)))
 		return
-	drop_from_inventory(I)
+	drop_from_inventory(I, target)
 	return 1
 
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -375,6 +375,9 @@ var/list/slot_equipment_priority = list( \
 			step(src, inertia_dir)
 */
 
+		if(istype(item,/obj/item))
+			var/obj/item/W = item
+			W.randpixel_xy()
 
 		item.throw_at(target, item.throw_range, item.throw_speed, src)
 

--- a/code/modules/modular_computers/computers/modular_computer/variables.dm
+++ b/code/modules/modular_computers/computers/modular_computer/variables.dm
@@ -27,6 +27,8 @@
 
 	icon = null												// This thing isn't meant to be used on it's own. Subtypes should supply their own icon.
 	icon_state = null										// And no random pixelshifting on-creation either.
+	randpixel = 0
+	center_of_mass = null
 	var/icon_state_unpowered = null							// Icon state when the computer is turned off
 	var/icon_state_menu = "menu"							// Icon state overlay when the computer is turned on, but no program is loaded that would override the screen.
 	var/icon_state_screensaver = null

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -3,6 +3,7 @@
 	desc = "A bullet casing."
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "s-casing"
+	randpixel = 10
 	flags = CONDUCT
 	slot_flags = SLOT_BELT | SLOT_EARS
 	throwforce = 1
@@ -20,8 +21,7 @@
 	. = ..()
 	if(ispath(projectile_type))
 		BB = new projectile_type(src)
-	pixel_x = rand(-10, 10)
-	pixel_y = rand(-10, 10)
+	randpixel_xy()
 
 //removes the projectile from the ammo casing
 /obj/item/ammo_casing/proc/expend()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -658,6 +658,7 @@
 		return unwield()
 
 /obj/item/weapon/gun/pickup(mob/user)
+	..()
 	if(is_wieldable)
 		unwield()
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -7,7 +7,6 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = null
 	w_class = 2
-	var/list/center_of_mass = list("x" = 16,"y" = 16)
 	var/amount_per_transfer_from_this = 5
 	var/possible_transfer_amounts = list(5,10,15,25,30)
 	var/volume = 30
@@ -65,21 +64,6 @@
 		return
 
 /obj/item/weapon/reagent_containers/afterattack(var/atom/target, var/mob/user, var/proximity, var/params)
-
-	if(proximity && params && istype(target, /obj/structure/table) && center_of_mass && center_of_mass.len)
-		//Places the item on a grid
-		var/list/mouse_control = mouse_safe_xy(params)
-
-		var/mouse_x = mouse_control["icon-x"]
-		var/mouse_y = mouse_control["icon-y"]
-
-		if(isnum(mouse_x) && isnum(mouse_y))
-			var/cell_x = max(0, min(CELLS-1, round(mouse_x/CELLSIZE)))
-			var/cell_y = max(0, min(CELLS-1, round(mouse_y/CELLSIZE)))
-
-			pixel_x = (CELLSIZE * (0.5 + cell_x)) - center_of_mass["x"]
-			pixel_y = (CELLSIZE * (0.5 + cell_y)) - center_of_mass["y"]
-
 	if(!proximity || !is_open_container())
 		return
 	if(is_type_in_list(target,can_be_placed_into))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -1,6 +1,3 @@
-#define CELLS 8
-#define CELLSIZE (32/CELLS)
-
 /obj/item/weapon/reagent_containers
 	name = "Container"
 	desc = "..."
@@ -246,6 +243,3 @@
 	playsound(src, 'sound/effects/pour.ogg', 25, 1)
 	to_chat(user, "<span class='notice'>You transfer [trans] units of the solution to [target].</span>")
 	return 1
-
-#undef CELLS
-#undef CELLSIZE

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -11,7 +11,6 @@
 	w_class = 1
 	slot_flags = SLOT_EARS
 	volume = 5
-	center_of_mass = null
 	drop_sound = 'sound/items/drop/glass.ogg'
 
 	afterattack(var/obj/target, var/mob/user, var/flag)

--- a/code/modules/reagents/reagent_containers/food/cans.dm
+++ b/code/modules/reagents/reagent_containers/food/cans.dm
@@ -20,7 +20,7 @@
 	name = "bottled water"
 	desc = "Introduced to the vending machines by Skrellian request, this water comes straight from the Martian poles."
 	icon_state = "waterbottle"
-	center_of_mass = list("x"=15, "y"=8)
+	center_of_mass = list("x"=16, "y"=8)
 	drop_sound = 'sound/items/drop/food.ogg'
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle/Initialize()
@@ -41,7 +41,7 @@
 	name = "thirteen loko"
 	desc = "The CMO has advised crew members that consumption of Thirteen Loko may result in seizures, blindness, drunkeness, or even death. Please Drink Responsibly."
 	icon_state = "thirteen_loko"
-	center_of_mass = list("x"=16, "y"=8)
+	center_of_mass = list("x"=16, "y"=10)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/thirteenloko/Initialize()
 	. = ..()
@@ -131,7 +131,7 @@
 	name = "\improper Phoron Punch!"
 	desc = "A radical looking can of <span class='warning'>Phoron Punch!</span> Phoron poisoning has never been more extreme!"
 	icon_state = "phoron_punch"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/koispunch/Initialize()
 	. = ..()
@@ -154,7 +154,7 @@
 	name = "\improper Zo'ra Soda Cherry"
 	desc = "A can of cherry energy drink, with V'krexi additives. All good colas come in cherry."
 	icon_state = "zoracherry"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/zorasoda/Initialize()
 	. = ..()
@@ -165,7 +165,7 @@
 	name = "\improper Zo'ra Soda Kois Twist"
 	desc = "A can of K'ois flavored energy drink, with V'krexi additives. Contains no K'ois, probably contains no palatable flavor."
 	icon_state = "koistwist"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/zorakois/Initialize()
 	. = ..()
@@ -176,7 +176,7 @@
 	name = "\improper Zo'ra Soda Phoron Passion"
 	desc = "A can of grape flavored energy drink, with V'krexi additives. Tastes nothing like phoron according to Unbound taste testers."
 	icon_state = "phoronpassion"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/zoraphoron/Initialize()
 	. = ..()
@@ -187,7 +187,7 @@
 	name = "\improper High Octane Zorane Might"
 	desc = "A can of fizzy, acidic energy, with plenty V'krexi additives. It tastes like the bottom of your mouth is being impaled by a freezing cold spear, a spear laced with bees and salt."
 	icon_state = "hozm"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/zorahozm/Initialize()
 	. = ..()
@@ -198,7 +198,7 @@
 	name = "\improper Zo'ra Soda Sour Venom Grass (Diet!)"
 	desc = "A diet can of Venom Grass flavored energy drink, with V'krexi additives. It still tastes like a cloud of stinging polytrinic bees, but calories are nowhere to be found."
 	icon_state = "sourvenomgrass"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/zoravenom/Initialize()
 	. = ..()
@@ -209,7 +209,7 @@
 	name = "\improper Klaxan Energy Crush"
 	desc = "A can of orange cream flavored energy drink, with V'krexi additives. Engineered nearly to perfection."
 	icon_state = "klaxancrush"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/zoraklax/Initialize()
 	. = ..()
@@ -220,7 +220,7 @@
 	name = "\improper C'thur Rockin' Raspberry"
 	desc = "A can of blue raspberry flavored energy drink, with V'krexi additives. You're pretty sure this was shipped by mistake, the previous K'laxan Energy Crush wrapper is still partly visible underneath the current one."
 	icon_state = "cthurberry"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/zoracthur/Initialize()
 	. = ..()
@@ -231,7 +231,7 @@
 	name = "\improper Drone Fuel"
 	desc = "A can of some kind of industrial fluid flavored energy drink, with V'krexi additives meant for Vaurca. <span class='warning'>Known to induce vomiting in humans!</span>."
 	icon_state = "dronefuel"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/zoradrone/Initialize()
 	. = ..()
@@ -242,7 +242,7 @@
 	name = "\improper Royal Jelly"
 	desc = "A can of... You aren't sure, but it smells pleasant already."
 	icon_state = "royaljelly"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/zorajelly/Initialize()
 	. = ..()
@@ -263,7 +263,7 @@
 	name = "\improper Hakhma Milk"
 	desc = "A can of Hakhma beetle milk, sourced from Scarab and Drifter communities."
 	icon_state = "beetlemilk"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=17, "y"=10)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/beetle_milk/Initialize()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -55,12 +55,12 @@
 				name = "salt shaker"
 				desc = "Salt. From space oceans, presumably."
 				icon_state = "saltshaker"
-				center_of_mass = list("x"=16, "y"=10)
+				center_of_mass = list("x"=17, "y"=11)
 			if("blackpepper")
 				name = "pepper mill"
 				desc = "Often used to flavor food or make people sneeze."
 				icon_state = "peppermillsmall"
-				center_of_mass = list("x"=16, "y"=10)
+				center_of_mass = list("x"=17, "y"=11)
 			if("cornoil")
 				name = "corn oil"
 				desc = "A delicious oil used in cooking. Made from corn."
@@ -74,7 +74,7 @@
 				name = "bottle of space spice"
 				desc = "An exotic blend of spices for cooking. It must flow."
 				icon_state = "spacespicebottle"
-				center_of_mass = list("x"=16, "y"=6)
+				center_of_mass = list("x"=16, "y"=10)
 			if("barbecue")
 				name = "barbecue sauce"
 				desc = "Barbecue sauce, it's labeled 'sweet and spicy'."

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -99,6 +99,7 @@
 	name = "universal enzyme"
 	desc = "Used in cooking various dishes."
 	icon_state = "enzyme"
+	center_of_mass = list("x"=16, "y"=6)
 
 /obj/item/weapon/reagent_containers/food/condiment/enzyme/Initialize()
 	. = ..()
@@ -107,6 +108,7 @@
 /obj/item/weapon/reagent_containers/food/condiment/sugar
 	name = "sugar"
 	desc = "Tastey space sugar!"
+	center_of_mass = list("x"=16, "y"=6)
 
 /obj/item/weapon/reagent_containers/food/condiment/sugar/Initialize()
 	. = ..()
@@ -116,6 +118,7 @@
 	name = "salt shaker"											//	a large one.
 	desc = "Salt. From space oceans, presumably."
 	icon_state = "saltshakersmall"
+	center_of_mass = list("x"=17, "y"=11)
 	possible_transfer_amounts = list(1,20) //for clown turning the lid off
 	amount_per_transfer_from_this = 1
 	volume = 20
@@ -128,6 +131,7 @@
 	name = "pepper mill"
 	desc = "Often used to flavor food or make people sneeze."
 	icon_state = "peppermillsmall"
+	center_of_mass = list("x"=17, "y"=11)
 	possible_transfer_amounts = list(1,20) //for clown turning the lid off
 	amount_per_transfer_from_this = 1
 	volume = 20
@@ -142,18 +146,19 @@
 	icon = 'icons/obj/food.dmi'
 	icon_state = "flour"
 	item_state = "flour"
+	center_of_mass = list("x"=16, "y"=8)
 	volume = 220
 
 /obj/item/weapon/reagent_containers/food/condiment/flour/Initialize()
 	. = ..()
 	reagents.add_reagent("flour", 200)
-	src.pixel_x = rand(-10.0, 10)
-	src.pixel_y = rand(-10.0, 10)
+	randpixel_xy()
 
 /obj/item/weapon/reagent_containers/food/condiment/spacespice
 	name = "space spices"
 	desc = "An exotic blend of spices for cooking. It must flow."
 	icon_state = "spacespicebottle"
+	center_of_mass = list("x"=16, "y"=10)
 	possible_transfer_amounts = list(1,40) //for clown turning the lid off
 	amount_per_transfer_from_this = 1
 	volume = 40
@@ -166,6 +171,7 @@
 	name = "barbecue sauce"
 	desc = "Barbecue sauce, it's labeled 'sweet and spicy'."
 	icon_state = "barbecue"
+	center_of_mass = list("x"=16, "y"=6)
 
 /obj/item/weapon/reagent_containers/food/condiment/barbecue/Initialize()
 	..()
@@ -174,6 +180,7 @@
 /obj/item/weapon/reagent_containers/food/condiment/garlicsauce
 	name = "garlic sauce"
 	desc = "Garlic sauce, perfect for spicing up a plate of garlic."
+	center_of_mass = list("x"=16, "y"=6)
 
 /obj/item/weapon/reagent_containers/food/condiment/garlicsauce/Initialize()
 	..()

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -133,7 +133,7 @@
 	icon_state = "coffee"
 	item_state = "cont_vapour"
 	drop_sound = 'sound/items/drop/box.ogg'
-	center_of_mass = list("x"=15, "y"=10)
+	center_of_mass = list("x"=16, "y"=11)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("coffee", 30)
@@ -143,7 +143,7 @@
 	desc = "A limited edition pumpkin spice coffee drink!"
 	icon_state = "psl_vended"
 	drop_sound = 'sound/items/drop/box.ogg'
-	center_of_mass = list("x"=15, "y"=10)
+	center_of_mass = list("x"=16, "y"=11)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("sadpslatte", 30)
@@ -254,7 +254,7 @@
 	icon_state = "shaker"
 	amount_per_transfer_from_this = 10
 	volume = 120
-	center_of_mass = list("x"=17, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 
 /obj/item/weapon/reagent_containers/food/drinks/teapot
 	name = "teapot"

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -6,6 +6,7 @@
 	name = "empty bottle"
 	desc = "A sad empty bottle."
 	icon_state = "alco-clear"
+	center_of_mass = list("x" = 16,"y" = 6)
 	amount_per_transfer_from_this = 5//Smaller sip size for more BaRP and less guzzling a litre of vodka before you realise it
 	volume = 100
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
@@ -204,7 +205,7 @@
 	name = "Uncle Git's Special Reserve"
 	desc = "A premium single-malt whiskey, gently matured inside the tunnels of a nuclear shelter. TUNNEL WHISKEY RULES."
 	icon_state = "whiskeybottle"
-	center_of_mass = list("x"=16, "y"=3)
+	center_of_mass = list("x"=16, "y"=4)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("whiskey", 100)
@@ -213,7 +214,7 @@
 	name = "Uncle Git's Cinnamon Fireball"
 	desc = "A premium single-malt whiskey, infused with cinnamon and hot pepper inside the tunnels of a nuclear shelter. TUNNEL WHISKEY RULES."
 	icon_state = "fireballbottle"
-	center_of_mass = list("x"=16, "y"=3)
+	center_of_mass = list("x"=16, "y"=4)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("fireball", 100)
@@ -222,7 +223,7 @@
 	name = "Tunguska Triple Distilled"
 	desc = "Aah, vodka. Prime choice of drink AND fuel by Russians worldwide."
 	icon_state = "vodkabottle"
-	center_of_mass = list("x"=17, "y"=3)
+	center_of_mass = list("x"=17, "y"=4)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("vodka", 100)
@@ -231,7 +232,7 @@
 	name = "Caccavo Guaranteed Quality tequila"
 	desc = "Made from premium petroleum distillates, pure thalidomide and other fine quality ingredients!"
 	icon_state = "tequillabottle"
-	center_of_mass = list("x"=16, "y"=3)
+	center_of_mass = list("x"=16, "y"=4)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("tequilla", 100)
@@ -240,7 +241,7 @@
 	name = "bottle of nothing"
 	desc = "A bottle filled with nothing"
 	icon_state = "bottleofnothing"
-	center_of_mass = list("x"=17, "y"=5)
+	center_of_mass = list("x"=16, "y"=5)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("nothing", 100)
@@ -249,7 +250,7 @@
 	name = "Angstra Aromatic Bitters"
 	desc = "Only the finest and highest quality herbs find their way into our cocktail bitters."
 	icon_state = "bitters"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=9)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("bitters",40)
@@ -276,7 +277,7 @@
 	name = "Wrapp Artiste patron"
 	desc = "Silver laced tequilla, served in space night clubs across the galaxy."
 	icon_state = "patronbottle"
-	center_of_mass = list("x"=16, "y"=6)
+	center_of_mass = list("x"=16, "y"=7)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("patron", 100)
@@ -285,7 +286,7 @@
 	name = "Captain Pete's Cuban Spiced rum"
 	desc = "This isn't just rum, oh no. It's practically GRIFF in a bottle."
 	icon_state = "rumbottle"
-	center_of_mass = list("x"=16, "y"=8)
+	center_of_mass = list("x"=16, "y"=4)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("rum", 100)
@@ -303,7 +304,7 @@
 	name = "Goldeneye vermouth"
 	desc = "Sweet, sweet dryness~"
 	icon_state = "vermouthbottle"
-	center_of_mass = list("x"=17, "y"=3)
+	center_of_mass = list("x"=16, "y"=4)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("vermouth", 100)
@@ -312,7 +313,7 @@
 	name = "Robert Robust's coffee liqueur"
 	desc = "A widely known, Mexican coffee-flavoured liqueur. In production since 1936, HONK"
 	icon_state = "kahluabottle"
-	center_of_mass = list("x"=17, "y"=3)
+	center_of_mass = list("x"=16, "y"=5)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("kahlua", 100)
@@ -321,7 +322,7 @@
 	name = "College Girl goldschlager"
 	desc = "Because they are the only ones who will drink 100 proof cinnamon schnapps."
 	icon_state = "goldschlagerbottle"
-	center_of_mass = list("x"=15, "y"=3)
+	center_of_mass = list("x"=16, "y"=4)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("goldschlager", 100)
@@ -330,7 +331,7 @@
 	name = "Chateau De Baton Premium cognac"
 	desc = "A sweet and strongly alchoholic drink, made after numerous distillations and years of maturing. You might as well not scream 'SHITCURITY' this time."
 	icon_state = "cognacbottle"
-	center_of_mass = list("x"=16, "y"=6)
+	center_of_mass = list("x"=16, "y"=4)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("cognac", 100)
@@ -348,7 +349,7 @@
 	name = "Jailbreaker Verte"
 	desc = "One sip of this and you just know you're gonna have a good time."
 	icon_state = "absinthebottle"
-	center_of_mass = list("x"=16, "y"=6)
+	center_of_mass = list("x"=16, "y"=7)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("absinthe", 100)
@@ -423,7 +424,7 @@
 	desc = "Full of vitamins and deliciousness!"
 	icon_state = "orangejuice"
 	item_state = "carton"
-	center_of_mass = list("x"=16, "y"=7)
+	center_of_mass = list("x"=16, "y"=6)
 	isGlass = 0
 	Initialize()
 		. = ..()
@@ -434,7 +435,7 @@
 	desc = "It's cream. Made from milk. What else did you think you'd find in there?"
 	icon_state = "cream"
 	item_state = "carton"
-	center_of_mass = list("x"=16, "y"=8)
+	center_of_mass = list("x"=16, "y"=6)
 	isGlass = 0
 	Initialize()
 		. = ..()
@@ -445,7 +446,7 @@
 	desc = "Well, at least it LOOKS like tomato juice. You can't tell with all that redness."
 	icon_state = "tomatojuice"
 	item_state = "carton"
-	center_of_mass = list("x"=16, "y"=8)
+	center_of_mass = list("x"=16, "y"=6)
 	isGlass = 0
 	Initialize()
 		. = ..()
@@ -456,7 +457,7 @@
 	desc = "Sweet-sour goodness."
 	icon_state = "limejuice"
 	item_state = "carton"
-	center_of_mass = list("x"=16, "y"=8)
+	center_of_mass = list("x"=16, "y"=4)
 	isGlass = 0
 	Initialize()
 		. = ..()
@@ -467,7 +468,7 @@
 	desc = "This juice is VERY sour."
 	icon_state = "lemoncarton"
 	item_state = "carton"
-	center_of_mass = list("x"=16, "y"=8)
+	center_of_mass = list("x"=16, "y"=6)
 	isGlass = 0
 	Initialize()
 		. = ..()
@@ -478,7 +479,7 @@
 	desc = "Juice from a Skrell medicinal herb. It's supposed to be diluted."
 	icon_state = "dyncarton"
 	item_state = "carton"
-	center_of_mass = list("x"=16, "y"=8)
+	center_of_mass = list("x"=16, "y"=6)
 	isGlass = 0
 	Initialize()
 		. = ..()
@@ -489,7 +490,7 @@
 	desc = "Juice from an apple. Yes."
 	icon_state = "applejuice"
 	item_state = "carton"
-	center_of_mass = list("x"=16, "y"=8)
+	center_of_mass = list("x"=16, "y"=4)
 	isGlass = 0
 	Initialize()
 		. = ..()
@@ -509,7 +510,7 @@
 	name = "space beer"
 	desc = "Contains only water, malt and hops."
 	icon_state = "beer"
-	center_of_mass = list("x"=16, "y"=12)
+	center_of_mass = list("x"=16, "y"=8)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("beer", 30)
@@ -519,7 +520,7 @@
 	desc = "A true dorf's drink of choice."
 	icon_state = "alebottle"
 	item_state = "beer"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("ale", 30)
@@ -530,6 +531,7 @@
 	name = "green chartreuse"
 	desc = "A green, strong liqueur."
 	icon_state = "chartreusegreenbottle"
+	center_of_mass = list("x" = 15,"y" = 5)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("chartreusegreen", 100)
@@ -538,6 +540,7 @@
 	name = "yellow chartreuse"
 	desc = "A yellow, strong liqueur."
 	icon_state = "chartreuseyellowbottle"
+	center_of_mass = list("x" = 15,"y" = 5)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("chartreuseyellow", 100)
@@ -546,6 +549,7 @@
 	name = "white creme de menthe"
 	desc = "Mint-flavoured alcohol, in a bottle."
 	icon_state = "whitecremebottle"
+	center_of_mass = list("x" = 16,"y" = 5)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("cremewhite", 100)
@@ -554,6 +558,7 @@
 	name = "Creme de Yvette"
 	desc = "Berry-flavoured alcohol, in a bottle."
 	icon_state = "cremedeyvettebottle"
+	center_of_mass = list("x" = 16,"y" = 6)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("cremeyvette", 100)
@@ -562,6 +567,7 @@
 	name = "brandy"
 	desc = "Cheap knock off for cognac."
 	icon_state = "brandybottle"
+	center_of_mass = list("x" = 15,"y" = 8)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("brandy", 100)
@@ -570,6 +576,7 @@
 	name = "Guinness"
 	desc = "A bottle of good old Guinness."
 	icon_state = "guinnes_bottle"
+	center_of_mass = list("x" = 15,"y" = 4)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("guinnes", 100)
@@ -578,6 +585,7 @@
 	name = "Drambuie"
 	desc = "A bottle of Drambuie."
 	icon_state = "drambuie_bottle"
+	center_of_mass = list("x" = 16,"y" = 6)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("drambuie", 100)
@@ -586,6 +594,7 @@
 	name = "sbiten"
 	desc = "A bottle full of sweet sbiten."
 	icon_state = "sbitenbottle"
+	center_of_mass = list("x" = 16,"y" = 7)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("sbiten", 100)
@@ -594,6 +603,7 @@
 	name = "messa's mead"
 	desc = "A bottle of Messa's mead. Bottled somewhere in the icy world of Adhomai."
 	icon_state = "messa_mead"
+	center_of_mass = list("x" = 16,"y" = 5)
 	description_fluff = "Adhomian beverages are commonly made with fermented grains or vegetables, if alcoholic, or juices mixed with sugar or honey. Victory gin is the most \
 	widespread alcoholic drink in Adhomai, the result of the fermentation of honey extracted from Messa's tears, but its production and consumption is slowly declining due to the \
 	People's Republic situation in the current conflict. Messa's mead is also another more traditional alternative, made with honey and fermented Earthen-Root juice."
@@ -609,7 +619,7 @@
 	name = "Xuizi Juice"
 	desc = "Blended flower buds from the Xuizi cactus. It smells faintly of vanilla. Bottled by the Arizi Guild for over 200 years."
 	icon_state = "xuizibottle"
-	center_of_mass = list("x"=16, "y"=10)
+	center_of_mass = list("x"=16, "y"=8)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("xuizijuice", 30)
@@ -618,6 +628,7 @@
 	name = "Sarezhi Wine"
 	desc = "A premium Moghean wine made from Sareszhi berries. Bottled by the Arizi Guild for over 200 years."
 	icon_state = "sarezhibottle"
+	center_of_mass = list("x" = 16,"y" = 6)
 	Initialize()
 		. = ..()
 		reagents.add_reagent("sarezhiwine", 100)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3804,6 +3804,7 @@
 	desc = "A box suited for pizzas."
 	icon = 'icons/obj/food.dmi'
 	icon_state = "pizzabox1"
+	center_of_mass = list("x" = 16,"y" = 6)
 
 	var/open = 0 // Is the box open?
 	var/ismessy = 0 // Fancy mess on the lid

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -197,6 +197,7 @@
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "bucket"
 	item_state = "bucket"
+	center_of_mass = list("x" = 16,"y" = 10)
 	accuracy = 1
 	matter = list(DEFAULT_WALL_MATERIAL = 200)
 	w_class = 3.0
@@ -252,6 +253,7 @@ obj/item/weapon/reagent_containers/glass/bucket/wood
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "woodbucket"
 	item_state = "woodbucket"
+	center_of_mass = list("x" = 16,"y" = 8)
 	matter = list("wood" = 50)
 	drop_sound = 'sound/items/drop/wooden.ogg'
 	carving_weapon = /obj/item/weapon/material/hatchet

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -75,6 +75,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "beaker"
 	item_state = "beaker"
+	center_of_mass = list("x" = 15,"y" = 11)
 	matter = list("glass" = 500)
 	drop_sound = 'sound/items/drop/glass.ogg'
 
@@ -126,6 +127,7 @@
 	name = "large beaker"
 	desc = "A large beaker."
 	icon_state = "beakerlarge"
+	center_of_mass = list("x" = 16,"y" = 11)
 	matter = list("glass" = 5000)
 	volume = 120
 	amount_per_transfer_from_this = 10
@@ -137,6 +139,7 @@
 	desc = "A large mixing bowl."
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "mixingbowl"
+	center_of_mass = list("x" = 17,"y" = 7)
 	matter = list(DEFAULT_WALL_MATERIAL = 300)
 	volume = 180
 	amount_per_transfer_from_this = 10
@@ -148,6 +151,7 @@
 	name = "cryostasis beaker"
 	desc = "A cryostasis beaker that allows for chemical storage without reactions."
 	icon_state = "beakernoreact"
+	center_of_mass = list("x" = 16,"y" = 13)
 	matter = list("glass" = 500)
 	volume = 60
 	amount_per_transfer_from_this = 10
@@ -157,6 +161,7 @@
 	name = "bluespace beaker"
 	desc = "A bluespace beaker, powered by experimental bluespace technology."
 	icon_state = "beakerbluespace"
+	center_of_mass = list("x" = 16,"y" = 11)
 	matter = list("glass" = 5000)
 	volume = 300
 	amount_per_transfer_from_this = 10
@@ -167,6 +172,7 @@
 	name = "vial"
 	desc = "A small glass vial."
 	icon_state = "vial"
+	center_of_mass = list("x" = 15,"y" = 9)
 	matter = list("glass" = 250)
 	volume = 30
 	amount_per_transfer_from_this = 10

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/syringe.dmi'
 	item_state = "autoinjector"
 	icon_state = "inhaler1"
+	center_of_mass = list("x" = 16,"y" = 11)
 	var/empty_state = "inhaler0"
 	unacidable = 1
 	amount_per_transfer_from_this = 5

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "cleaner"
 	item_state = "cleaner"
+	center_of_mass = list("x" = 16,"y" = 10)
 	flags = OPENCONTAINER|NOBLUDGEON
 	slot_flags = SLOT_BELT
 	throwforce = 3
@@ -143,6 +144,7 @@
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "pepperspray"
 	item_state = "pepperspray"
+	center_of_mass = list("x" = 16,"y" = 16)
 	possible_transfer_amounts = null
 	volume = 40
 	safety = 1
@@ -190,6 +192,7 @@
 	icon = 'icons/obj/gun.dmi'
 	icon_state = "chemsprayer"
 	item_state = "chemsprayer"
+	center_of_mass = list("x" = 16,"y" = 16)
 	throwforce = 3
 	w_class = 3.0
 	possible_transfer_amounts = null

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -12,6 +12,7 @@
 	icon = 'icons/obj/syringe.dmi'
 	item_state = "syringe_0"
 	icon_state = "0"
+	center_of_mass = list("x" = 16,"y" = 14)
 	matter = list("glass" = 150)
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = null

--- a/code/modules/research/stockparts.dm
+++ b/code/modules/research/stockparts.dm
@@ -3,14 +3,14 @@
 	desc = "What?"
 	gender = PLURAL
 	icon = 'icons/obj/stock_parts.dmi'
+	randpixel = 5
 	w_class = 2.0
 	var/rating = 1
 	drop_sound = 'sound/items/drop/glass.ogg'
 
 /obj/item/weapon/stock_parts/Initialize()
 	. = ..()
-	src.pixel_x = rand(-5.0, 5)
-	src.pixel_y = rand(-5.0, 5)
+	randpixel_xy()
 
 //Rank 1
 

--- a/code/modules/research/xenoarchaeology/geosample.dm
+++ b/code/modules/research/xenoarchaeology/geosample.dm
@@ -19,6 +19,7 @@
 	desc = "It looks extremely delicate."
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "sliver1"	//0-4
+	randpixel = 8
 	w_class = 1
 	sharp = 1
 	//item_state = "electronic"
@@ -27,8 +28,7 @@
 
 /obj/item/weapon/rocksliver/New()
 	icon_state = "sliver[rand(1,3)]"
-	pixel_x = rand(0,16)-8
-	pixel_y = rand(0,8)-8
+	randpixel_xy()
 	create_reagents(50)
 	reagents.add_reagent("ground_rock",50)
 

--- a/code/modules/spells/artifacts.dm
+++ b/code/modules/spells/artifacts.dm
@@ -167,6 +167,7 @@
 		return
 
 /obj/item/phylactery/pickup(mob/living/user as mob)
+	..()
 	if(!user.is_wizard() && src.lich)
 		to_chat(user, "<span class='warning'>As you pick up \the [src], you feel a wave of dread wash over you.</span>")
 		for(var/obj/machinery/light/P in view(7, user))

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -196,6 +196,7 @@
 
 	// Placing stuff on tables
 	if(user.unEquip(W, 0, src.loc))
+		user.make_item_drop_sound(W)
 		auto_align(W, click_parameters)
 		return 1
 
@@ -237,3 +238,4 @@ Note: This proc can be overwritten to allow for different types of auto-alignmen
 
 /obj/structure/table/attack_tk() // no telehulk sorry
 	return
+

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -136,8 +136,7 @@
 		step(O, get_dir(O, src))
 	return
 
-
-/obj/structure/table/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/table/attackby(obj/item/W as obj, mob/user as mob, var/click_parameters)
 	if (!W) return
 
 	// Handle harm intent grabbing/tabling.
@@ -195,8 +194,48 @@
 		to_chat(user, "<span class='warning'>There's nothing to put \the [W] on! Try adding plating to \the [src] first.</span>")
 		return
 
-	user.drop_item(src.loc)
-	return
+	// Placing stuff on tables
+	if(user.unEquip(W, 0, src.loc))
+		auto_align(W, click_parameters)
+		return 1
+
+#define CELLS 8								//Amount of cells per row/column in grid
+#define CELLSIZE (world.icon_size/CELLS)	//Size of a cell in pixels
+/*
+Automatic alignment of items to an invisible grid, defined by CELLS and CELLSIZE.
+Since the grid will be shifted to own a cell that is perfectly centered on the turf, we end up with two 'cell halves'
+on edges of each row/column.
+Each item defines a center_of_mass, which is the pixel of a sprite where its projected center of mass toward a turf
+surface can be assumed. For a piece of paper, this will be in its center. For a bottle, it will be (near) the bottom
+of the sprite.
+auto_align() will then place the sprite so the defined center_of_mass is at the bottom left corner of the grid cell
+closest to where the cursor has clicked on.
+Note: This proc can be overwritten to allow for different types of auto-alignment.
+*/
+/obj/item/var/list/center_of_mass = list("x" = 16,"y" = 16)
+/obj/structure/table/proc/auto_align(obj/item/W, click_parameters)
+	if (!W.center_of_mass) // Clothing, material stacks, generally items with large sprites where exact placement would be unhandy.
+		W.pixel_x = rand(-6, 6)
+		W.pixel_y = rand(-6, 6)
+		W.pixel_z = 0
+		return
+
+	if (!click_parameters)
+		return
+
+	var/list/mouse_control = mouse_safe_xy(click_parameters)
+	var/mouse_x = mouse_control["icon-x"]
+	var/mouse_y = mouse_control["icon-y"]
+
+	if(isnum(mouse_x) && isnum(mouse_y))
+		var/cell_x = max(0, min(CELLS-1, round(mouse_x/CELLSIZE)))
+		var/cell_y = max(0, min(CELLS-1, round(mouse_y/CELLSIZE)))
+
+		W.pixel_x = (CELLSIZE * (0.5 + cell_x)) - W.center_of_mass["x"]
+		W.pixel_y = (CELLSIZE * (0.5 + cell_y)) - W.center_of_mass["y"]
+
+#undef CELLS
+#undef CELLSIZE
 
 /obj/structure/table/attack_tk() // no telehulk sorry
 	return

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -215,8 +215,7 @@ Note: This proc can be overwritten to allow for different types of auto-alignmen
 /obj/item/var/list/center_of_mass = list("x" = 16,"y" = 16)
 /obj/structure/table/proc/auto_align(obj/item/W, click_parameters)
 	if(!W.center_of_mass)
-		W.pixel_x = rand(-W.randpixel, W.randpixel)
-		W.pixel_y = rand(-W.randpixel, W.randpixel)
+		W.randpixel_xy()
 		return
 
 	if(!click_parameters)

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -214,13 +214,12 @@ Note: This proc can be overwritten to allow for different types of auto-alignmen
 */
 /obj/item/var/list/center_of_mass = list("x" = 16,"y" = 16)
 /obj/structure/table/proc/auto_align(obj/item/W, click_parameters)
-	if (!W.center_of_mass) // Clothing, material stacks, generally items with large sprites where exact placement would be unhandy.
-		W.pixel_x = rand(-6, 6)
-		W.pixel_y = rand(-6, 6)
-		W.pixel_z = 0
+	if(!W.center_of_mass)
+		W.pixel_x = rand(-W.randpixel, W.randpixel)
+		W.pixel_y = rand(-W.randpixel, W.randpixel)
 		return
 
-	if (!click_parameters)
+	if(!click_parameters)
 		return
 
 	var/list/mouse_control = mouse_safe_xy(click_parameters)

--- a/html/changelogs/Ferner-190902-coding_autoalign.yml
+++ b/html/changelogs/Ferner-190902-coding_autoalign.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Ferner
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added pixel precision when placing most items on tables/racks, like with food/drinks. Ported from Bay."
+  - tweak: "Adjusted the center of mass on some items to make them easier to place down, thrown items now get a randomized pixel placement."


### PR DESCRIPTION
Makes it so placing items on tables and racks takes into account where you click and shifts pixel x/y to that spot, like food, drinks and battlemonsters cards do currently.

Demonstration https://i.imgur.com/iKuFPzJ.gifv
 - Made it so items get their pixel x/y reset on pickup.
 - Thrown items now also get their pixel placement slightly randomized.
 - Tweaked the center of mass on a boatload of items to be more accurate to their sprite art.
 - Replaced a bunch of randomized pixel placement code into a unifying proc; randpixel_xy() that uses an item's randpixel var.