### PR TITLE
Department Account Number Leaked!

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -395,6 +395,16 @@
 
 		H.mind.store_memory(remembered_info)
 
+	//Allows any personnel to access their department account
+	if(H.mind && !(job.head_position) && !(job.account_exclude))
+		var/remembered_info = ""
+		var/datum/money_account/department_account = SSeconomy.get_department_account(job.department)
+
+		if(department_account)
+			remembered_info += "<b>Your department's account number is:</b> #[department_account.account_number]<br>"
+
+		H.mind.store_memory(remembered_info)
+
 	var/alt_title = null
 	if(H.mind)
 		H.mind.assigned_role = rank

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -1,6 +1,7 @@
 /datum/job/assistant
 	title = "Assistant"
 	flag = ASSISTANT
+	account_exclude = 1
 	department = "Civilian"
 	department_flag = CIVILIAN
 	faction = "Station"

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -153,6 +153,7 @@
 /datum/job/mining
 	title = "Shaft Miner"
 	flag = MINER
+	account_exclude = 1
 	department = "Cargo"
 	department_flag = CIVILIAN
 	faction = "Station"
@@ -212,6 +213,7 @@
 /datum/job/journalist
 	title = "Corporate Reporter"
 	flag = JOURNALIST
+	account_exclude = 1
 	department = "Civilian"
 	department_flag = CIVILIAN
 	faction = "Station"

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -2,6 +2,7 @@
 /datum/job/chaplain
 	title = "Chaplain"
 	flag = CHAPLAIN
+	account_exclude = 1
 	department = "Civilian"
 	department_flag = CIVILIAN
 	faction = "Station"

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -117,6 +117,7 @@
 /datum/job/intern_eng
 	title = "Engineering Apprentice"
 	flag = INTERN_ENG
+	account_exclude = 1
 	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 2

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -18,6 +18,7 @@
 	var/minimal_player_age = 0            // If you have use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
 	var/department = null                 // Does this position have a department tag?
 	var/head_position = 0                 // Is this position Command?
+	var/account_exclude = null			  // Excludes the job from recieving Dept. Account information
 	var/minimum_character_age = 17
 	var/ideal_character_age = 30
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -230,6 +230,7 @@
 /datum/job/intern_med
 	title = "Medical Resident"
 	flag = INTERN_MED
+	account_exclude = 1
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 2

--- a/code/game/jobs/job/outsider/merchant.dm
+++ b/code/game/jobs/job/outsider/merchant.dm
@@ -3,6 +3,7 @@
 	faction = "Station"
 	department = "Civilian"
 	flag = MERCHANT
+	account_exclude = 1
 	department_flag = CIVILIAN
 	total_positions = 0
 	spawn_positions = 0

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -1,6 +1,7 @@
 /datum/job/representative
 	title = "Corporate Liaison"
 	flag = LAWYER
+	account_exclude = 1
 	department = "Civilian"
 	department_flag = CIVILIAN
 	faction = "Station"

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -134,6 +134,7 @@
 /datum/job/intern_sci
 	title = "Lab Assistant"
 	flag = INTERN_SCI
+	account_exclude = 1
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 2

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -236,6 +236,7 @@
 /datum/job/intern_sec
 	title = "Security Cadet"
 	flag = INTERN_SEC
+	account_exclude = 1
 	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 2

--- a/html/changelogs/Ben10083-Accountz.yml
+++ b/html/changelogs/Ben10083-Accountz.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "To allow for more utilization of departmental funds, the NanoTrasen Board of Directors have authorized department account numbers to general crew."
+  - rscdel: "Assistants, intern positions, miners, chaplains, and some other jobs have been excluded from recieving the account number."


### PR DESCRIPTION
To make the Department Accounts more accessible, especially when no head is available, most jobs will be given their account number similar to how heads receive theirs. They will ONLY get the account number, which means the pin will be held only by the head, which will allow him to lock the department account to them if he/she/it wishes.