### PR TITLE
Tesla tweaks and bugfixes

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -80,7 +80,7 @@
 	name = "ominous beacon"
 	desc = "This looks suspicious..."
 	icon = 'icons/obj/singularity.dmi'
-	icon_state = "beacon"
+	icon_state = "beacon0"
 
 	anchored = 0
 	density = 1
@@ -168,3 +168,7 @@
 /obj/machinery/power/singularity_beacon/syndicate
 	icontype = "beaconsynd"
 	icon_state = "beaconsynd0"
+
+/obj/machinery/power/singularity_beacon/emergency
+	name = "emergency singularity beacon"
+	desc = "A beacon that is designed to be used as last resort to contain Singularity or Tesla Engine. A one time use device."

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -30,9 +30,10 @@
 
 	var/chained = 0//Adminbus chain-grab
 
-/obj/singularity/New(loc, var/starting_energy = 50, var/temp = 0)
+/obj/singularity/New(loc, var/starting_energy = 50, var/temp = 0, var/alert = TRUE)
 	//CARN: admin-alert for chuckle-fuckery.
-	admin_investigate_setup()
+	if(alert)
+		admin_investigate_setup()
 	energy = starting_energy
 
 	if (temp)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -95,10 +95,12 @@
 	if(move_dir & (UP | DOWN) )
 		move_amount = 0
 
+	var/move_tesla = !move_amount ? 0.1 : move_amount
 	for(var/i in 0 to move_amount)
-		do_single_move(move_dir, move_amount)
+		do_single_move(move_dir)
+		sleep(1 SECOND / move_tesla)
 
-/obj/singularity/energy_ball/proc/do_single_move(var/move_dir, var/speed)
+/obj/singularity/energy_ball/proc/do_single_move(var/move_dir)
 	var/z_move = 0
 	var/turf/T
 	switch(move_dir)
@@ -118,7 +120,7 @@
 				zMove(UP)
 				visible_message(span("danger","\The [src] gravitates from below!"))
 			if(0)
-				walk_to(src, T, 0, speed)
+				Move(T)
 			if(-1)
 				visible_message(span("danger","\The [src] gravitates downwards!"))
 				zMove(DOWN)
@@ -159,6 +161,7 @@
 	else if(energy < energy_to_lower && orbiting_balls.len)
 		energy_to_raise = energy_to_raise / 1.25
 		energy_to_lower = (energy_to_raise / 1.25) - 20
+		energy = energy_to_raise - 5
 
 		var/Orchiectomy_target = pick(orbiting_balls)
 		qdel(Orchiectomy_target)
@@ -167,13 +170,13 @@
 
 		// Basically the more balls we have the faster Tesla looses energy.
 		if(orbiting_balls.len > 16)
-			dissipate_delay = 3
+			dissipate_delay = 1.5
 			dissipate_strength = 5
 		if(orbiting_balls.len > 12)
-			dissipate_delay = 5
+			dissipate_delay = 2.5
 			dissipate_strength = 2
 		if(orbiting_balls.len <= 12)
-			dissipate_delay = 10
+			dissipate_delay = 5
 			dissipate_strength = 1
 
 		dissipate() //sing code has a much better system.
@@ -184,7 +187,7 @@
 /obj/singularity/energy_ball/proc/new_mini_ball()
 	if(!loc)
 		return
-	var/obj/singularity/energy_ball/EB = new(loc, 0)
+	var/obj/singularity/energy_ball/EB = new(loc, 0, FALSE, FALSE)
 
 	EB.transform *= pick(0.3, 0.4, 0.5, 0.6, 0.7)
 	var/icon/I = icon(icon,icon_state,dir)
@@ -196,12 +199,30 @@
 
 
 /obj/singularity/energy_ball/Collide(atom/A)
-	. = ..()
-	dust_mobs(A)
+	if(isliving(A))
+		dust_mobs(A)
+	else if(isobj(A))
+		var/obj/O = A
+		O.tesla_act(0, TRUE)
 
 /obj/singularity/energy_ball/CollidedWith(atom/A)
+	if(isliving(A))
+		dust_mobs(A)
+	else if(isobj(A))
+		var/obj/O = A
+		O.tesla_act(0, TRUE)
+
+/obj/singularity/energy_ball/Move(NewLoc, Dir)
 	. = ..()
-	dust_mobs(A)
+	for(var/v in loc)
+		if(istype(v, /obj/singularity))
+			continue
+
+		if(isliving(v))
+			dust_mobs(v)
+		else if(isobj(v))
+			var/obj/O = v
+			O.tesla_act(0, TRUE)
 
 /obj/singularity/energy_ball/orbit(obj/singularity/energy_ball/target)
 	if (istype(target))
@@ -271,7 +292,18 @@
 
 	for(var/A in typecache_filter_multi_list_exclusion(oview(source, zap_range+2), things_to_shock, blacklisted_types))
 
-		if(istype(A, /obj/machinery/power/tesla_coil))
+		if(istype(source, /obj/singularity/energy_ball) && istype(A, /obj/machinery/power/singularity_beacon/emergency))		
+			var/obj/machinery/power/singularity_beacon/emergency/E = A
+			var/obj/singularity/energy_ball/B = source
+			if(E.active)
+				return
+			B.visible_message("\The [src] discharges entirely at [A] until it dissapears and [A] melts down")
+			B.Beam(E, icon_state="lightning[rand(1,12)]", icon = 'icons/effects/effects.dmi', time=2)
+			E.tesla_act(0, TRUE)
+			qdel(B)
+			return
+
+		else if(istype(A, /obj/machinery/power/tesla_coil))
 			var/dist = get_dist(source, A)
 			var/obj/machinery/power/tesla_coil/C = A
 			if(dist <= zap_range && (dist < closest_dist || !closest_tesla_coil) && !C.being_shocked)
@@ -339,16 +371,18 @@
 	if(istype(source, /obj/singularity/energy_ball))
 		var/obj/singularity/energy_ball/E = source
 		if(E.energy && (E.orbiting_balls.len > rods_count * 4)) // so that miniballs don't fry stuff.
-			melt =  TRUE// 1 grounding rod can handle max 4 balls
+			melt =  TRUE // 1 grounding rod can handle max 4 balls
 			E.visible_message(span("danger", "All [E.orbiting_balls.len] energize for a second, sending their energy to the main ball, which redirects it at the nearest object! Sacrificing one of its miniballs!"))
 			for(var/obj/singularity/energy_ball/mini in E.orbiting_balls)
 				mini.Beam(source, icon_state="lightning[rand(1,12)]", icon = 'icons/effects/effects.dmi', time=2)
 			playsound(source.loc, 'sound/magic/lightning_chargeup.ogg', 100, 1, extrarange = 30)
 			E.energy_to_raise = E.energy_to_raise / 1.25
 			E.energy_to_lower = (E.energy_to_raise / 1.25) - 20
+			E.energy = E.energy_to_raise - 5
 
 			var/Orchiectomy_target = pick(E.orbiting_balls)
 			qdel(Orchiectomy_target)
+		E.dissipate()
 
 	//Alright, we've done our loop, now lets see if was anything interesting in range
 	if(closest_atom)
@@ -380,7 +414,7 @@
 			tesla_zap(closest_mob, 5, power / 1.5, explosive, stun_mobs)
 
 	else if(closest_machine)
-		closest_machine.tesla_act(power)
+		closest_machine.tesla_act(power, melt)
 
 	else if(closest_structure)
-		closest_structure.tesla_act(power)
+		closest_structure.tesla_act(power, melt)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -214,7 +214,7 @@
 
 /obj/singularity/energy_ball/Move(NewLoc, Dir)
 	. = ..()
-	for(var/v in loc)
+	for(var/v in view(0, loc))
 		if(istype(v, /obj/singularity))
 			continue
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -295,7 +295,7 @@
 		if(istype(source, /obj/singularity/energy_ball) && istype(A, /obj/machinery/power/singularity_beacon/emergency))		
 			var/obj/machinery/power/singularity_beacon/emergency/E = A
 			var/obj/singularity/energy_ball/B = source
-			if(E.active)
+			if(!E.active)
 				return
 			B.visible_message("\The [src] discharges entirely at [A] until it dissapears and [A] melts down")
 			B.Beam(E, icon_state="lightning[rand(1,12)]", icon = 'icons/effects/effects.dmi', time=2)

--- a/html/changelogs/Sindorman-tesla.yml
+++ b/html/changelogs/Sindorman-tesla.yml
@@ -44,5 +44,5 @@ changes:
   - bugfix: "Telsa looses energy when dropping ball which should be slightly below how much is required for new ball."
   - tweak: "Tesla dissipation rate has been buffed, it now looses energy faster."
   - tweak: "Tesla dissipates every time it zaps something."
-  - tweak: "Tesla now melts anything it touches or zaps."
+  - tweak: "Tesla now melts any object or mob(but not turfs) it touches or zaps."
   - rscadd: "Added special emergency singularity beacon that is to be used when Singulo/Telsa are on the Loose. When Tesla zaps the beacon, it will discharge all energy into it, dying and destroying beacon."

--- a/html/changelogs/Sindorman-tesla.yml
+++ b/html/changelogs/Sindorman-tesla.yml
@@ -1,0 +1,47 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Tesla no longer gains energy from just colliding with objects."
+  - bugfix: "Fixes sprite for singularity beacon not showing up."
+  - bugfix: "Tesla no longer spams admin longs when a new ball is created outside of containment."
+  - bugfix: "Telsa looses energy when dropping ball which should be slightly below how much is required for new ball."
+  - tweak: "Tesla dissipation rate has been buffed, it now looses energy faster."
+  - tweak: "Tesla dissipates every time it zaps something."
+  - rscadd: "Added special emergency singularity beacon that is to be used when Singulo/Telsa are on the Loose. When Tesla zaps the beacon, it will discharge all energy into it, dying and destroying beacon."

--- a/html/changelogs/Sindorman-tesla.yml
+++ b/html/changelogs/Sindorman-tesla.yml
@@ -44,4 +44,5 @@ changes:
   - bugfix: "Telsa looses energy when dropping ball which should be slightly below how much is required for new ball."
   - tweak: "Tesla dissipation rate has been buffed, it now looses energy faster."
   - tweak: "Tesla dissipates every time it zaps something."
+  - tweak: "Tesla now melts anything it touches or zaps."
   - rscadd: "Added special emergency singularity beacon that is to be used when Singulo/Telsa are on the Loose. When Tesla zaps the beacon, it will discharge all energy into it, dying and destroying beacon."

--- a/html/changelogs/Sindorman-tesla.yml
+++ b/html/changelogs/Sindorman-tesla.yml
@@ -44,5 +44,5 @@ changes:
   - bugfix: "Telsa looses energy when dropping ball which should be slightly below how much is required for new ball."
   - tweak: "Tesla dissipation rate has been buffed, it now looses energy faster."
   - tweak: "Tesla dissipates every time it zaps something."
-  - tweak: "Tesla now melts any object or mob(but not turfs) it touches or zaps."
+  - tweak: "Tesla now melts any object or mob(but not turfs) it touches or when it zaps it while sacrificing a miniball."
   - rscadd: "Added special emergency singularity beacon that is to be used when Singulo/Telsa are on the Loose. When Tesla zaps the beacon, it will discharge all energy into it, dying and destroying beacon."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -67510,6 +67510,11 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled,
 /area/maintenance/engineering)
+"rbC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/singularity_beacon/emergency,
+/turf/simulated/floor/plating,
+/area/engineering/storage)
 "rcu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -86907,7 +86912,7 @@ akA
 akA
 amw
 anG
-anG
+rbC
 aqa
 arn
 ajL


### PR DESCRIPTION
- Bugfix: Tesla no longer gains energy from just colliding with objects

- Bugfix: Fixes sprite for singularity beacon not showing up

- Bugfix: Tesla no longer spams admin longs when a new ball is created outside of containment

- Bugfix: Telsa looses energy when dropping ball which should be slightly below how much is required for new ball. 

- tweak: Tesla dissipation rate has been buffed, it now looses energy faster

- tweak: Tesla dissipates every time it zaps something

- tweak: Tesla now melts any object or mob(but not turfs) it touches or when it zaps it while sacrificing a miniball.

- rscadd: Added special emergency singularity beacon that is to be used when Singulo/Telsa are on the Loose. When Tesla zaps the beacon, it will discharge all energy into it, dying and destroying beacon.