### PR TITLE
Changes the icon states of some mapped in machine frames.

### DIFF
--- a/html/changelogs/Ferner-190910-bugfix_machineframes.yml
+++ b/html/changelogs/Ferner-190910-bugfix_machineframes.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Ferner
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Changed the icon states of some mapped in machine blueprints."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -2124,8 +2124,12 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/security_starboard)
 "aei" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
 "aej" = (
@@ -7755,8 +7759,12 @@
 /area/security/brig)
 "apy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/cobweb2,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/wood,
 /area/maintenance/vault)
 "apB" = (
@@ -52538,19 +52546,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hydroponics)
-"bNA" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/camera/network/civilian_main{
-	c_tag = "Hydroponics - West";
-	dir = 1
-	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
-"bNB" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light,
-/turf/simulated/floor/grass,
-/area/hydroponics)
 "bND" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/alarm{
@@ -63062,7 +63057,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "cBK" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
 	dir = 8
@@ -69470,6 +69469,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
+"wEb" = (
+/obj/structure/flora/pottedplant/random,
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Hydroponics - West";
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "wEn" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -99031,7 +99038,7 @@ bJT
 bJT
 bJT
 bJT
-bJS
+wEb
 bGr
 bOQ
 bPA
@@ -99288,7 +99295,7 @@ bKO
 bLx
 bLx
 bML
-bNA
+bJT
 bOp
 uuz
 bPB
@@ -99545,7 +99552,7 @@ bKP
 bLy
 bMg
 bMM
-bNB
+bJT
 bJb
 bOS
 bPA

--- a/maps/space_ruins/derelict.dmm
+++ b/maps/space_ruins/derelict.dmm
@@ -96,7 +96,11 @@
 /turf/simulated/floor/wood,
 /area/derelict/hallway/northwest)
 "aq" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/wood,
 /area/derelict/hallway/northwest)
 "ar" = (
@@ -298,8 +302,12 @@
 /turf/simulated/floor/wood,
 /area/derelict/hallway/northwest)
 "aX" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/wood,
 /area/derelict/hallway/northwest)
 "aY" = (
@@ -356,7 +364,11 @@
 /turf/simulated/floor/airless,
 /area/derelict/hallway/northeast)
 "bj" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/airless,
 /area/derelict/hallway/northeast)
 "bk" = (
@@ -395,8 +407,12 @@
 /turf/simulated/floor/airless,
 /area/derelict/hallway/northeast)
 "br" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/structure/window/reinforced,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/airless,
 /area/derelict/hallway/northeast)
 "bs" = (
@@ -502,15 +518,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/derelict/hallway/northwest)
 "bN" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 1
 	},
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/derelict/hallway/northwest)
 "bO" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/derelict/hallway/northwest)
 "bP" = (
@@ -1194,7 +1218,11 @@
 /turf/simulated/floor/airless,
 /area/derelict/hallway/northeast)
 "dY" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/template_noop,
 /area/template_noop)
 "dZ" = (
@@ -1987,9 +2015,13 @@
 /turf/simulated/floor/tiled/airless,
 /area/derelict/hallway/northeast)
 "gn" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/airless,
 /area/derelict/hallway/northeast)
 "go" = (
@@ -2876,7 +2908,11 @@
 /turf/simulated/floor/airless,
 /area/derelict/hallway/southeast)
 "ji" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/white,
 /area/derelict/hallway/southeast)
 "jj" = (
@@ -3826,7 +3862,11 @@
 /area/derelict/hallway/southeast)
 "lY" = (
 /obj/item/weapon/gun/energy/mindflayer,
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/airless,
 /area/derelict/hallway/southeast)
 "lZ" = (
@@ -3896,7 +3936,11 @@
 /turf/template_noop,
 /area/derelict/hallway/southwest)
 "mh" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/airless,
 /area/derelict/hallway/southwest)
 "mi" = (
@@ -3904,8 +3948,12 @@
 /turf/simulated/floor/tiled/airless,
 /area/derelict/hallway/southwest)
 "mj" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/wood,
 /area/derelict/hallway/southwest)
 "mk" = (
@@ -4023,7 +4071,11 @@
 /turf/simulated/floor/tiled/airless,
 /area/derelict/hallway/southwest)
 "mz" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/airless,
 /area/derelict/hallway/southwest)
 "mA" = (
@@ -4781,8 +4833,12 @@
 /turf/simulated/floor/tiled/white,
 /area/derelict/hallway/southeast)
 "oD" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/machinery/light,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/white,
 /area/derelict/hallway/southeast)
 "oE" = (
@@ -4962,8 +5018,12 @@
 /turf/simulated/floor/airless,
 /area/derelict/hallway/southeast)
 "pc" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/white,
 /area/derelict/hallway/southeast)
 "pd" = (
@@ -5372,8 +5432,12 @@
 /turf/simulated/floor/tiled/airless,
 /area/derelict/hallway/southeast)
 "qk" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/airless,
 /area/derelict/hallway/southeast)
 "ql" = (
@@ -6599,8 +6663,12 @@
 /turf/simulated/floor/airless,
 /area/derelict/hallway/southwest)
 "tD" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/airless,
 /area/derelict/hallway/southwest)
 "tE" = (
@@ -7519,9 +7587,13 @@
 /turf/simulated/floor/tiled/white,
 /area/derelict/hallway/southeast)
 "vJ" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/white,
 /area/derelict/hallway/southeast)
 "vK" = (
@@ -7697,8 +7769,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/derelict/hallway/southwest)
 "wm" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/airless,
 /area/derelict/hallway/southwest)
 "wn" = (
@@ -7725,9 +7801,13 @@
 /turf/simulated/floor/airless,
 /area/derelict/hallway/southwest)
 "wr" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/airless,
 /area/derelict/hallway/southwest)
 "ws" = (

--- a/maps/space_ruins/scrapheap.dmm
+++ b/maps/space_ruins/scrapheap.dmm
@@ -2028,7 +2028,11 @@
 /turf/unsimulated/floor/asteroid/ash,
 /area/derelict)
 "fQ" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/derelict/ship)
 "fR" = (
@@ -6407,8 +6411,12 @@
 	},
 /area/derelict)
 "tl" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
@@ -7820,9 +7828,13 @@
 	},
 /area/derelict)
 "wF" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
 	},
 /turf/unsimulated/floor{
 	icon_state = "white"
@@ -8033,7 +8045,11 @@
 	},
 /area/derelict)
 "xj" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/unsimulated/floor{
 	icon_state = "white"
 	},
@@ -8848,7 +8864,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/derelict/bridge)
 "zG" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/derelict/bridge)
 "zH" = (
@@ -9664,7 +9684,11 @@
 /turf/simulated/floor/tiled,
 /area/derelict/bridge)
 "BH" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled,
 /area/derelict/bridge)
 "BI" = (
@@ -9783,9 +9807,13 @@
 /turf/simulated/floor/wood,
 /area/derelict/bridge)
 "Cb" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
 	},
 /turf/simulated/floor/tiled,
 /area/derelict/bridge)
@@ -14088,8 +14116,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/derelict/ship)
 "OD" = (
-/obj/machinery/constructable_frame/machine_frame,
 /obj/machinery/light,
+/obj/machinery/constructable_frame/machine_frame{
+	icon_state = "box_0";
+	name = "machine frame";
+	state = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/derelict/ship)
 "OE" = (


### PR DESCRIPTION
Machine frames are used in a bunch of locations for decoration purposes, with the epic construction update their base icon state was changed to something not appropriate for most of these locations. 
As such I've changed the affected frames' icon states and build states to be fit for purpose and look the original intended part.