### PR TITLE
Ion rifle nerf

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -14,6 +14,8 @@
 	slot_flags = SLOT_BACK
 	charge_cost = 300
 	max_shots = 10
+	fire_delay = 12
+	fire_delay_wielded = 5
 	secondary_projectile_type =  /obj/item/projectile/ion
 	secondary_fire_sound = 'sound/weapons/Laser.ogg'
 	can_turret = 1

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -173,7 +173,7 @@
 		to_chat(H, span("warning", "Warning: small electric discharge detected in the system. Battery has lost 35% of charge!"))
 		H.nutrition -= H.max_nutrition * 0.35
 		if(H.nutrition / H.max_nutrition < 0.5)
-			H.Weaken(15)
+			H.Weaken(5)
 
 /obj/item/projectile/beam/gatlinglaser
 	name = "diffused laser"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -166,15 +166,6 @@
 	tracer_type = /obj/effect/projectile/tracer/stun
 	impact_type = /obj/effect/projectile/impact/stun
 
-/obj/item/projectile/beam/stun/on_impact(var/atom/A)
-	. = ..()
-	if(isipc(A))
-		var/mob/living/carbon/human/H = A
-		to_chat(H, span("warning", "Warning: small electric discharge detected in the system. Battery has lost 35% of charge!"))
-		H.nutrition -= H.max_nutrition * 0.35
-		if(H.nutrition / H.max_nutrition < 0.5)
-			H.Weaken(5)
-
 /obj/item/projectile/beam/gatlinglaser
 	name = "diffused laser"
 	icon_state = "heavylaser"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -166,6 +166,15 @@
 	tracer_type = /obj/effect/projectile/tracer/stun
 	impact_type = /obj/effect/projectile/impact/stun
 
+/obj/item/projectile/beam/stun/on_impact(var/atom/A)
+	. = ..()
+	if(isipc(A))
+		var/mob/living/carbon/human/H = A
+		to_chat(H, span("warning", "Warning: small electric discharge detected in the system. Battery has lost 35% of charge!"))
+		H.nutrition -= H.max_nutrition * 0.35
+		if(H.nutrition / H.max_nutrition < 0.5)
+			H.Weaken(15)
+
 /obj/item/projectile/beam/gatlinglaser
 	name = "diffused laser"
 	icon_state = "heavylaser"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -49,6 +49,15 @@
 	damage_type = HALLOSS
 	//Damage will be handled on the MOB side, to prevent window shattering.
 
+/obj/item/projectile/energy/electrode/on_impact(var/atom/A)
+	. = ..()
+	if(isipc(A))
+		var/mob/living/carbon/human/H = A
+		to_chat(H, span("warning", "Warning: small electric discharge detected in the system. Battery has lost 35% of charge!"))
+		H.nutrition -= H.max_nutrition * 0.35
+		if(H.nutrition / H.max_nutrition < 0.5)
+			H.Weaken(15)
+
 /obj/item/projectile/energy/electrode/stunshot
 	name = "stunshot"
 	damage = 5

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -56,7 +56,7 @@
 		to_chat(H, span("warning", "Warning: small electric discharge detected in the system. Battery has lost 35% of charge!"))
 		H.nutrition -= H.max_nutrition * 0.35
 		if(H.nutrition / H.max_nutrition < 0.5)
-			H.Weaken(15)
+			H.Weaken(5)
 
 /obj/item/projectile/energy/electrode/stunshot
 	name = "stunshot"

--- a/html/changelogs/Sindorman-ion.yml
+++ b/html/changelogs/Sindorman-ion.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Ion rifle fire delay has been increased twice for unweidled and 5 times to weilded.(Since it was practicaly 1 and making it 2 was not noticable at all)."
+  - tweal: "Taser shots and energy gun stun beams will now drain 35% of IPC battery per shot. If IPC battery is less than 5%, the shot will also stun them for 5 seconds."

--- a/html/changelogs/Sindorman-ion.yml
+++ b/html/changelogs/Sindorman-ion.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - tweak: "Ion rifle fire delay has been increased twice for unweidled and 5 times to weilded.(Since it was practicaly 1 and making it 2 was not noticable at all)."
-  - tweal: "Taser shots and energy gun stun beams will now drain 35% of IPC battery per shot. If IPC battery is less than 5%, the shot will also stun them for 5 seconds."
+  - tweak: "Taser shots and energy gun stun beams will now drain 35% of IPC battery per shot. If IPC battery is less than 5%, the shot will also stun them for 5 seconds."


### PR DESCRIPTION
 - tweak: "Ion rifle fire delay has been increased twice for unweidled and 5 times to weilded.(Since it was practicaly 1 and making it 2 was not noticable at all)."

  - tweak: "Taser shots and energy gun stun beams will now drain 35% of IPC battery per shot. If IPC battery is less than 5%, the shot will also stun them for 5 seconds."