### PR TITLE
Ninja Tweaks + Bugfix

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -236,7 +236,7 @@
 	l_ear = /obj/item/device/radio/headset/ninja
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud/tactical
 	id = /obj/item/weapon/card/id/syndicate
-	l_pocket = /obj/item/device/ninja_uplink
+	l_pocket = null
 	r_pocket = null
 	accessory = /obj/item/clothing/accessory/storage/black_pouches
 
@@ -250,6 +250,14 @@
 	)
 
 	id_access = "Syndicate Agent"
+
+/datum/outfit/admin/syndicate/ninja/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(visualsOnly)
+		return
+
+	H.equip_to_slot_or_del(new /obj/item/device/ninja_uplink(H, H.mind), slot_l_store)
+
 
 /datum/outfit/admin/nt
 	name = "NanoTrasen Representative"

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -464,8 +464,8 @@
 		drain_complete(H)
 		return
 
-	// Attempts to drain up to 40kW, determines this value from remaining cell capacity to ensure we don't drain too much..
-	var/to_drain = min(40000, ((holder.cell.maxcharge - holder.cell.charge) / CELLRATE))
+	// Attempts to drain up to 80kW, determines this value from remaining cell capacity to ensure we don't drain too much..
+	var/to_drain = min(80000, ((holder.cell.maxcharge - holder.cell.charge) / CELLRATE))
 	var/target_drained = interfaced_with.drain_power(0,0,to_drain)
 	if(target_drained <= 0)
 		to_chat(H, "<span class = 'danger'>Your power sink flashes a red light; there is no power left in [interfaced_with].</span>")

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -270,7 +270,7 @@
 
 	interface_name = "emergency power generator"
 	interface_desc = "A high yield power generating device that takes a long time to recharge."
-	var/generation_ammount = 2500
+	var/generation_ammount = 3500
 
 	category = MODULE_SPECIAL
 
@@ -286,7 +286,7 @@
 		playsound(H.loc, 'sound/effects/sparks2.ogg', 50, 1)
 		holder.cell.give(generation_ammount)
 		cooldown = 1
-		addtimer(CALLBACK(src, /obj/item/rig_module/emergency_powergenerator/proc/reset_cooldown), 5 MINUTES)
+		addtimer(CALLBACK(src, /obj/item/rig_module/emergency_powergenerator/proc/reset_cooldown), 2 MINUTES)
 
 /obj/item/rig_module/emergency_powergenerator/proc/reset_cooldown()
 	cooldown = 0

--- a/html/changelogs/geeves-ninjaOHFUCK.yml
+++ b/html/changelogs/geeves-ninjaOHFUCK.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Geeves
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "The ninja uplink now gives proper access to the infiltrator store."
+  - tweak: "The powersink now drains more power."
+  - tweak: "The cooldown for the emergency power generator has been reduced to 2 minutes from 5."
+  - tweak: "The power generator now generates 3500 units of power."


### PR DESCRIPTION
* "The ninja uplink now gives proper access to the infiltrator store."
* "The powersink now drains more power."
* "The cooldown for the emergency power generator has been reduced to 2 minutes from 5."
* "The power generator now generates 3500 units of power."