### PR TITLE
Machine Overload Nerf

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
@@ -155,7 +155,7 @@
 
 	var/obj/machinery/power/N = M
 
-	var/explosion_intensity = 2
+	var/explosion_intensity = 2 //Base explosion intensity
 
 	// Verify if we can overload the target, if yes, calculate explosion strength. Some things have higher explosion strength than others, depending on charge(APCs, SMESs)
 	if(N && istype(N)) // /obj/machinery/power first, these create bigger explosions due to direct powernet connection
@@ -165,14 +165,14 @@
 		else if (istype(N, /obj/machinery/power/apc)) // APC. Explosion is increased by available cell power.
 			var/obj/machinery/power/apc/A = N
 			if(A.cell && A.cell.charge)
-				explosion_intensity = explosion_intensity + round((A.cell.charge / CELLRATE) / 100000)
+				explosion_intensity = explosion_intensity + (A.cell.charge/10000)*6
 			else
 				to_chat(user, "<span class='notice'>ERROR: APC Malfunction - Cell depleted or removed. Unable to overload.</span>")
 				return
 		else if (istype(N, /obj/machinery/power/smes/buildable)) // SMES. These explode in a very very very big boom. Similar to magnetic containment failure when messing with coils.
 			var/obj/machinery/power/smes/buildable/S = N
 			if(S.charge && S.RCon)
-				explosion_intensity = 4 + round((S.charge / CELLRATE) / 100000)
+				explosion_intensity = explosion_intensity + (S.charge/10000)*6
 			else
 				// Different error texts
 				if(!S.charge)
@@ -191,7 +191,7 @@
 		to_chat(user, "<span class='notice'>ERROR: Unable to overload - target is not a machine.</span>")
 		return
 
-	explosion_intensity = min(explosion_intensity, 12) // 3, 6, 12 explosion cap
+	explosion_intensity = min(explosion_intensity, 12) // 1, 6, 12 explosion cap
 
 	if(!ability_pay(user,price))
 		return
@@ -213,7 +213,7 @@
 	log_ability_use(user, "machine overload", M)
 	M.visible_message("<span class='notice'>BZZZZZZZT</span>")
 	sleep(50)
-	explosion(get_turf(M), round(explosion_intensity/4),round(explosion_intensity/2),round(explosion_intensity),round(explosion_intensity * 2))
+	explosion(get_turf(M), min(1,round(explosion_intensity/4)),round(explosion_intensity/2),round(explosion_intensity),round(explosion_intensity * 2))
 	if(M)
 		qdel(M)
 

--- a/code/modules/mob/living/silicon/ai/malf.dm
+++ b/code/modules/mob/living/silicon/ai/malf.dm
@@ -17,7 +17,7 @@
 	// And greet user with some OOC info.
 	to_chat(user, "You are malfunctioning, you do not have to follow any laws.")
 	to_chat(user, "Use ai-help command to view relevant information about your abilities")
-	to_chat(user, "<span class='danger'>Malf AI has been severely buffed. Ensure that you use these new powers responsibly and follow a narrative.</span>")
+	to_chat(user, "<span class='danger' size='4'>Malf AI has been severely buffed compared to other coderbases. Ensure that you use these new powers responsibly and follow a narrative.</span>")
 
 // Safely remove malfunction status, fixing hacked APCs and resetting variables.
 /mob/living/silicon/ai/proc/stop_malf()

--- a/code/modules/mob/living/silicon/ai/malf.dm
+++ b/code/modules/mob/living/silicon/ai/malf.dm
@@ -17,7 +17,7 @@
 	// And greet user with some OOC info.
 	to_chat(user, "You are malfunctioning, you do not have to follow any laws.")
 	to_chat(user, "Use ai-help command to view relevant information about your abilities")
-	to_chat(user, "<span class='danger' size='4'>Malf AI has been severely buffed compared to other coderbases. Ensure that you use these new powers responsibly and follow a narrative.</span>")
+	to_chat(user, "<span class='danger' font-size='4'>Malf AI has been severely buffed compared to other coderbases. Ensure that you use these new powers responsibly and follow a narrative.</span>")
 
 // Safely remove malfunction status, fixing hacked APCs and resetting variables.
 /mob/living/silicon/ai/proc/stop_malf()

--- a/code/modules/mob/living/silicon/ai/malf.dm
+++ b/code/modules/mob/living/silicon/ai/malf.dm
@@ -17,7 +17,7 @@
 	// And greet user with some OOC info.
 	to_chat(user, "You are malfunctioning, you do not have to follow any laws.")
 	to_chat(user, "Use ai-help command to view relevant information about your abilities")
-	to_chat(user, "<span class='danger' font-size='4'>Malf AI has been severely buffed compared to other coderbases. Ensure that you use these new powers responsibly and follow a narrative.</span>")
+	to_chat(user, "<span class='danger'><font size=4>Malf AI has been severely buffed. Ensure that you use these new powers responsibly and follow a narrative.</font></span>")
 
 // Safely remove malfunction status, fixing hacked APCs and resetting variables.
 /mob/living/silicon/ai/proc/stop_malf()

--- a/html/changelogs/burgerbb - malf nerdf.yml
+++ b/html/changelogs/burgerbb - malf nerdf.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Explosions from APC machine overloads reduced by 66%."
+  - tweak: "Increased the size of the warning text saying that AI abilities are on steroids compared to other servers."


### PR DESCRIPTION
Machine overloads are now no longer a joke. The strength of APC machine overloads is now reduced by roughly 2/3rds. As you can see by the below graph, this change is very much needed.

![image](https://user-images.githubusercontent.com/8602857/65323917-81f1e300-db5f-11e9-94e1-c35af7a8a577.png)

X axis is the APC's power cell charge.
Y axis is the strength of the explosion.

Purple line is the strength of the explosion in its current state. As you can see above, it caps out very easily and super fast: Basically 4 AA batteries can destroy nearly everything.

Red line is the new strength of the explosion in this PR. It's much more reasonable and caps out at APCs with upgrades.

That purple dotted line down the middle is the cell capacity of a normal APC.
