### PR TITLE
Balanced Explosions

### DIFF
--- a/code/game/turfs/simulated/floor_acts.dm
+++ b/code/game/turfs/simulated/floor_acts.dm
@@ -1,26 +1,17 @@
 /turf/simulated/floor/ex_act(severity)
-	//set src in oview(1)
-	switch(severity)
-		if(1.0)
-			src.ChangeTurf(baseturf)
-		if(2.0)
-			switch(pick(40;1,40;2,3))
-				if (1)
-					if(prob(33)) new /obj/item/stack/material/steel(src)
-					src.ReplaceWithLattice()
-				if(2)
-					src.ChangeTurf(baseturf)
-				if(3)
-					if(prob(33)) new /obj/item/stack/material/steel(src)
-					if(prob(80))
-						src.break_tile_to_plating()
-					else
-						src.break_tile()
-					src.hotspot_expose(1000,CELL_VOLUME)
-		if(3.0)
-			if (prob(50))
-				src.break_tile()
-				src.hotspot_expose(1000,CELL_VOLUME)
+
+	var/severity_mod = ((4-severity)/3)*100 + rand(-33,0)
+
+	if(severity_mod >= 80)
+		src.ChangeTurf(baseturf)
+		if(prob(33)) new /obj/item/stack/material/steel(src)
+	else if(severity_mod >= 33)
+		src.break_tile_to_plating()
+		src.hotspot_expose(1000,CELL_VOLUME)
+	else
+		src.break_tile()
+		src.hotspot_expose(1000,CELL_VOLUME)
+
 	return
 
 /turf/simulated/floor/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/html/changelogs/burgerbb - turf explosion nerf lerf merf kerf.yml
+++ b/html/changelogs/burgerbb - turf explosion nerf lerf merf kerf.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Floors are now typically more resistant to explosions."
+  - bugfix: "Fixed explosions causing vacuums in places where they shouldn't."

--- a/maps/aurora/code/aurora.dm
+++ b/maps/aurora/code/aurora.dm
@@ -15,9 +15,9 @@
 		"1" = /turf/space,
 		"2" = /turf/space,
 		"3" = /turf/space,
-		"4" = /turf/unsimulated/floor/asteroid/ash/rocky,
-		"5" = /turf/unsimulated/floor/asteroid/ash/rocky,
-		"6" = /turf/unsimulated/floor/asteroid/ash,
+		"4" = /turf/simulated/open/airless,
+		"5" = /turf/simulated/open/airless,
+		"6" = /turf/simulated/open/airless,
 		"7" = /turf/space,
 		"8" = /turf/space,
 		"9" = /turf/space


### PR DESCRIPTION
Strong enough explosions would cause the floor to break and expose asteroid turf. The problem with this is that that asteroid turf, in code, acts as an infinite air vacuum regardless of where the asteroid turf was created. This was apparently a result of a code improvement that changed asteroid sand from simulated to unsimulated.

This PR fixes that by making it so that it instead just spawns an open turf instead, and also makes it so that explosions are slightly more lenient when it comes to destroying floors and causing z-level breaches.

Here are some screenshots of various explosions strengths.

![image](https://user-images.githubusercontent.com/8602857/65330058-a5705a00-db6e-11e9-9cf8-06fbe5660f3c.png)
![image](https://user-images.githubusercontent.com/8602857/65330062-a86b4a80-db6e-11e9-826f-5463f6a74a84.png)
![image](https://user-images.githubusercontent.com/8602857/65330069-aacda480-db6e-11e9-8142-431fbf380036.png)
![image](https://user-images.githubusercontent.com/8602857/65330074-adc89500-db6e-11e9-8ef7-f6e5235f63b7.png)
![image](https://user-images.githubusercontent.com/8602857/65330080-b02aef00-db6e-11e9-829e-0dcecbd9b263.png)




