### PR TITLE
Fixes some energy melee weapons being unable to be picked up after being dropped

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -37,6 +37,11 @@
 	edge = initial(edge)
 	w_class = initial(w_class)
 
+/obj/item/weapon/melee/energy/dropped(var/mob/user)
+	..()
+	if(!istype(loc,/mob))
+		deactivate(user)
+
 /obj/item/weapon/melee/energy/attack_self(mob/living/user as mob)
 	if (active)
 		if ((user.is_clumsy()) && prob(50))
@@ -219,11 +224,6 @@
 	edge = 1
 	var/blade_color
 	shield_power = 75
-
-/obj/item/weapon/melee/energy/sword/dropped(var/mob/user)
-	..()
-	if(!istype(loc,/mob))
-		deactivate(user)
 
 /obj/item/weapon/melee/energy/sword/New()
 	blade_color = pick("red","blue","green","purple")

--- a/html/changelogs/190921-bugfix_energy.yml
+++ b/html/changelogs/190921-bugfix_energy.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Ferner
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed some energy melee weapons being unable to be picked up after they've been dropped, e.g. e-axe, e-glaive and power swords."


### PR DESCRIPTION
Title.
This is done by moving the dropped proc that deactivates them so it works with all energy melee weapons and not just the basic energy swords.