### PR TITLE
Station Engineers now have access to Telecommunications

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -62,8 +62,8 @@
 	supervisors = "the chief engineer"
 	selection_color = "#FFEA95"
 	economic_modifier = 5
-	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
-	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
+	access = list(access_tcomsat, access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
+	minimal_access = list(access_tcomsat, access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
 	alt_titles = list("Maintenance Technician","Engine Technician","Electrician")
 	outfit = /datum/outfit/job/engineer
 

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -68,6 +68,10 @@ var/global/list/engineering_networks = list(
 /obj/machinery/camera/network/telecom
 	network = list(NETWORK_TELECOM)
 
+/obj/machinery/camera/network/telecom/Initialize()
+	. = ..()
+	upgradeMotion()
+
 /obj/machinery/camera/network/thunder
 	network = list(NETWORK_THUNDER)
 

--- a/html/changelogs/burgerbb - telecomms.yml
+++ b/html/changelogs/burgerbb - telecomms.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - balance: "Station Engineers now have telecommunications access. All telecommunication cameras now have motion alarms."
-  - maptweak: "Telecommunications no longer have turrets."
+  - maptweak: "Telecommunications no longer have turrets. Added an alternative path connecting all the surface solars."

--- a/html/changelogs/burgerbb - telecomms.yml
+++ b/html/changelogs/burgerbb - telecomms.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Station Engineers now have telecommunications access."
+  - maptweak: "Telecommunications no longer have turrets."

--- a/html/changelogs/burgerbb - telecomms.yml
+++ b/html/changelogs/burgerbb - telecomms.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - balance: "Station Engineers now have telecommunications access."
+  - balance: "Station Engineers now have telecommunications access. All telecommunication cameras now have motion alarms."
   - maptweak: "Telecommunications no longer have turrets."

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -21,6 +21,23 @@
 /obj/structure/sign/electricshock,
 /turf/simulated/wall,
 /area/solar/port)
+"af" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/camera/network/telecom{
+	c_tag = "Telecomms - Foyer"
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/turret_protected/tcomfoyer)
 "ag" = (
 /turf/simulated/mineral/surface,
 /area/mine/unexplored)
@@ -1998,14 +2015,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/solar/port)
-"dT" = (
-/turf/simulated/floor/airless,
-/area/turret_protected/tcomsat)
-"dU" = (
-/obj/machinery/porta_turret/stationary,
-/obj/effect/decal/warning_stripes,
-/turf/simulated/floor/airless,
-/area/turret_protected/tcomsat)
 "dV" = (
 /turf/simulated/wall/r_wall,
 /area/tcommsat/chamber)
@@ -5730,18 +5739,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/turret_protected/tcomfoyer)
-"kC" = (
-/obj/machinery/porta_turret{
-	dir = 6
-	},
-/obj/effect/decal/warning_stripes,
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/turret_protected/tcomfoyer)
 "kD" = (
 /obj/structure/cable/blue{
 	d1 = 4;
@@ -5750,41 +5747,8 @@
 	},
 /turf/simulated/floor/tiled,
 /area/turret_protected/tcomfoyer)
-"kE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/camera/network/telecom{
-	c_tag = "Telecomms - Foyer"
-	},
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/turretid/lethal{
-	ailock = 1;
-	check_synth = 1;
-	control_area = "\improper Telecoms Exterior";
-	desc = "A firewall prevents AIs from interacting with this device.";
-	name = "Telecoms lethal turret control";
-	pixel_y = 29;
-	req_access = list(61)
-	},
-/turf/simulated/floor/tiled,
-/area/turret_protected/tcomfoyer)
 "kF" = (
 /turf/simulated/floor/tiled,
-/area/turret_protected/tcomfoyer)
-"kG" = (
-/obj/machinery/porta_turret{
-	dir = 10
-	},
-/obj/effect/decal/warning_stripes,
-/turf/simulated/floor/plating,
 /area/turret_protected/tcomfoyer)
 "kH" = (
 /obj/structure/sign/drop{
@@ -6672,18 +6636,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/turret_protected/tcomfoyer)
-"mg" = (
-/obj/machinery/turretid/stun{
-	ailock = 1;
-	check_synth = 1;
-	control_area = "\improper Telecoms Foyer";
-	desc = "A firewall prevents AIs from interacting with this device.";
-	name = "Telecoms Foyer turret control";
-	pixel_y = 29;
-	req_access = list(61)
 	},
 /turf/simulated/floor/tiled,
 /area/turret_protected/tcomfoyer)
@@ -31319,7 +31271,6 @@ bv
 bv
 bv
 bv
-dT
 bv
 bv
 bv
@@ -31329,7 +31280,8 @@ bv
 bv
 bv
 bv
-dT
+bv
+bv
 bv
 bv
 lC
@@ -31576,7 +31528,6 @@ bv
 bv
 bv
 bv
-dU
 bv
 bv
 bv
@@ -31586,7 +31537,8 @@ bv
 bv
 bv
 bv
-dU
+bv
+bv
 bv
 bv
 bv
@@ -34157,7 +34109,7 @@ eO
 je
 eo
 dV
-kC
+kD
 le
 lE
 kA
@@ -34671,7 +34623,7 @@ iv
 eP
 jz
 jZ
-kE
+af
 lf
 lF
 lS
@@ -34932,7 +34884,7 @@ kF
 le
 lG
 kA
-mg
+kF
 kD
 mE
 mN
@@ -35185,7 +35137,7 @@ eO
 jf
 eo
 dV
-kG
+kF
 le
 lE
 kA
@@ -37744,7 +37696,7 @@ cC
 cX
 bH
 bh
-dU
+bv
 bv
 eR
 fw
@@ -37754,7 +37706,7 @@ hX
 iy
 eR
 bv
-dU
+bv
 bv
 bv
 bv
@@ -38011,7 +37963,7 @@ hY
 iz
 eS
 bv
-dT
+bv
 bv
 li
 bv

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -45,6 +45,20 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/airless,
 /area/solar/fore)
+"ai" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "aj" = (
 /obj/machinery/power/solar{
 	id = "auxsolarnorth";
@@ -824,6 +838,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/tcomsat)
+"bz" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
+"bA" = (
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "bB" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -914,6 +936,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
+"bM" = (
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "bN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/floor_decal/corner/blue{
@@ -996,6 +1021,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/tcomsat)
+"bY" = (
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply,
+/obj/structure/cable{
+	d1 = 32;
+	d2 = 2;
+	icon_state = "11-2"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/zpipe/down,
+/turf/simulated/open,
+/area/maintenance/solarmaint)
 "bZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1305,6 +1342,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
+"cF" = (
+/obj/effect/decal/warning_stripes,
+/obj/structure/ladder{
+	icon_state = "ladder01";
+	pixel_y = 16
+	},
+/turf/simulated/open,
+/area/maintenance/solarmaint)
 "cG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/effect/floor_decal/industrial/warning/cee,
@@ -1712,6 +1757,21 @@
 /obj/effect/floor_decal/corner/blue/full,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
+"ds" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
+"dt" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "du" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -1976,6 +2036,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
+"dP" = (
+/obj/machinery/meter{
+	name = "Scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "dQ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2015,6 +2085,30 @@
 	},
 /turf/simulated/floor/airless,
 /area/solar/port)
+"dT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
+"dU" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "dV" = (
 /turf/simulated/wall/r_wall,
 /area/tcommsat/chamber)
@@ -2726,6 +2820,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
+"fi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "fj" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -2950,6 +3059,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
+"fH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list(12,61)
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "fI" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -3934,6 +4062,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
+"hq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "hr" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -4304,6 +4448,18 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
+"ib" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "ic" = (
 /obj/machinery/door/airlock/glass{
 	name = "Yellow Dock"
@@ -4540,6 +4696,33 @@
 /obj/item/weapon/stock_parts/subspace/crystal,
 /turf/simulated/floor/tiled,
 /area/turret_protected/tcomsat)
+"iB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/meter{
+	name = "Air supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
+"iC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "iD" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5739,6 +5922,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/turret_protected/tcomfoyer)
+"kC" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "engineering_surface_airlock";
+	name = "interior access button";
+	pixel_x = 30;
+	pixel_y = 26;
+	req_one_access = list(13)
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "kD" = (
 /obj/structure/cable/blue{
 	d1 = 4;
@@ -5747,9 +5945,49 @@
 	},
 /turf/simulated/floor/tiled,
 /area/turret_protected/tcomfoyer)
+"kE" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "engineering_surface_inner";
+	locked = 1;
+	name = "Telecoms Surface Access";
+	req_access = list(13)
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "kF" = (
 /turf/simulated/floor/tiled,
 /area/turret_protected/tcomfoyer)
+"kG" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "engineering_surface_airlock";
+	pixel_x = 0;
+	pixel_y = 30;
+	req_one_access = list(13);
+	tag_airpump = "engineering_surface_pump";
+	tag_chamber_sensor = "engineering_surface_sensor";
+	tag_exterior_door = "engineering_surface_outer";
+	tag_interior_door = "engineering_surface_inner"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "engineering_surface_sensor";
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = "engineering_surface_pump"
+	},
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "kH" = (
 /obj/structure/sign/drop{
 	pixel_x = 32
@@ -6639,6 +6877,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/turret_protected/tcomfoyer)
+"mg" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "engineering_surface_outer";
+	locked = 1;
+	name = "Telecoms Surface Access";
+	req_access = list(13)
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "mh" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
@@ -7085,36 +7337,32 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mX" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
+/area/maintenance/solarmaint)
 "mY" = (
-/obj/random/junk,
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
+/area/maintenance/solarmaint)
 "mZ" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/unsimulated/floor/asteroid/ash,
+/area/maintenance/solarmaint)
 "na" = (
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
-/obj/machinery/atmospherics/pipe/zpipe/down/supply,
-/obj/structure/cable{
-	d1 = 32;
-	d2 = 2;
-	icon_state = "11-2"
+/obj/machinery/atmospherics/binary/pump/on{
+	name = "Distro to Canisters";
+	target_pressure = 150
 	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/zpipe/down,
-/turf/simulated/open,
-/area/maintenance/telecoms_ladder)
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "nb" = (
-/obj/effect/decal/warning_stripes,
-/obj/structure/ladder{
-	icon_state = "ladder01";
-	pixel_y = 16
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
 	},
-/turf/simulated/open,
-/area/maintenance/telecoms_ladder)
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "nc" = (
 /obj/effect/floor_decal/corner/lime/full,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7180,6 +7428,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
+"nh" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "ni" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7225,47 +7480,17 @@
 /turf/simulated/floor/tiled,
 /area/tcommsat/entrance)
 "nm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"nn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"no" = (
-/obj/machinery/meter{
-	name = "Scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"np" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 5
 	},
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
+/area/maintenance/solarmaint)
+"nn" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/turf/simulated/floor/plating,
+/area/maintenance/solarmaint)
 "nq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -7408,145 +7633,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/tcommsat/entrance)
-"nD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/tcommsat/entrance)
-"nE" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"nF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"nG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/meter{
-	name = "Air supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"nH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"nI" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "engineering_surface_airlock";
-	name = "interior access button";
-	pixel_x = 30;
-	pixel_y = 26;
-	req_one_access = list(13)
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"nJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "door_locked";
-	id_tag = "engineering_surface_inner";
-	locked = 1;
-	name = "Telecoms Surface Access";
-	req_access = list(13)
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"nK" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
-	id_tag = "engineering_surface_airlock";
-	pixel_x = 0;
-	pixel_y = 30;
-	req_one_access = list(13);
-	tag_airpump = "engineering_surface_pump";
-	tag_chamber_sensor = "engineering_surface_sensor";
-	tag_exterior_door = "engineering_surface_outer";
-	tag_interior_door = "engineering_surface_inner"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "engineering_surface_sensor";
-	pixel_x = 0;
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1380;
-	id_tag = "engineering_surface_pump"
-	},
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"nL" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "door_locked";
-	id_tag = "engineering_surface_outer";
-	locked = 1;
-	name = "Telecoms Surface Access";
-	req_access = list(13)
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
 "nM" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -7722,16 +7808,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tcommsat/entrance)
-"ob" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"oc" = (
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
-/turf/unsimulated/floor/asteroid/ash,
-/area/maintenance/telecoms_ladder)
 "od" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -7821,9 +7897,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/tcommsat/entrance)
-"on" = (
-/turf/simulated/mineral/surface,
 /area/tcommsat/entrance)
 "oo" = (
 /obj/structure/extinguisher_cabinet{
@@ -8115,22 +8188,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/solarmaint)
-"pd" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/solarmaint)
@@ -17808,10 +17865,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo/surface)
-"IY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
 "IZ" = (
 /obj/structure/disposalpipe/down{
 	icon_state = "pipe-d";
@@ -19092,9 +19145,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/bridge/levela)
-"Mg" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/telecoms_ladder)
 "Mh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	icon_state = "map_scrubber_on";
@@ -19651,14 +19701,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
-"Ob" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 5
-	},
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
 "Oe" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_l"
@@ -19705,16 +19747,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
-"On" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
-"Oo" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
 "Op" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
@@ -19886,13 +19918,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/arrivals)
-"OR" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
 "OU" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plating,
@@ -22567,13 +22592,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo/surface)
-"Xl" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
 "Xm" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -22954,13 +22972,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
-"Yq" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	name = "Distro to Canisters";
-	target_pressure = 150
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/telecoms_ladder)
 "Yr" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
@@ -34895,7 +34906,7 @@ oa
 LB
 ow
 mK
-pd
+ai
 pu
 pG
 pU
@@ -35152,7 +35163,7 @@ mL
 mL
 ox
 mK
-aP
+bM
 pu
 pu
 pu
@@ -35409,8 +35420,8 @@ mK
 mK
 mK
 mK
-ag
-ag
+bM
+aP
 ag
 ag
 ag
@@ -35660,14 +35671,14 @@ mz
 kA
 kA
 bc
-mK
-nD
-mK
-on
-ag
-ag
-ag
-ag
+aP
+fi
+bM
+bM
+bM
+bM
+bM
+aP
 ag
 ag
 ag
@@ -35917,14 +35928,14 @@ kA
 kA
 kA
 bc
-mK
-nD
-mK
-on
-ag
-ag
-ag
-ag
+aP
+fi
+aP
+aP
+aP
+aP
+aP
+aP
 ag
 ag
 ag
@@ -36173,10 +36184,10 @@ bv
 bg
 bg
 bg
-mK
-mK
-nC
-mK
+aP
+aP
+fH
+aP
 ag
 ag
 ag
@@ -36430,10 +36441,10 @@ bv
 bv
 bg
 bg
-mZ
-nm
-nE
-Mg
+bz
+ds
+hq
+aP
 ag
 ag
 ag
@@ -36687,10 +36698,10 @@ bv
 bv
 bg
 bg
-mZ
-nn
-nF
-Mg
+bz
+dt
+ib
+aP
 ag
 ag
 ag
@@ -36944,10 +36955,10 @@ bv
 bv
 bg
 bg
-mY
-no
-nG
-Mg
+bA
+dP
+iB
+aP
 ag
 ag
 ag
@@ -37201,13 +37212,13 @@ bv
 bv
 bg
 bg
-mX
-nn
-nF
-Mg
-Mg
-Mg
-Mg
+bM
+dt
+ib
+aP
+aP
+aP
+aP
 ag
 ag
 ag
@@ -37458,13 +37469,13 @@ bv
 bv
 bg
 bg
+bY
+dT
+iC
+mX
 na
-np
-nH
-IY
-Yq
-Ob
-Mg
+nm
+aP
 ag
 ag
 ag
@@ -37715,13 +37726,13 @@ bv
 bv
 bg
 bg
+cF
+dU
+kC
+mY
 nb
-Xl
-nI
-ob
-On
-Oo
-Mg
+nn
+aP
 ag
 ag
 ag
@@ -37972,13 +37983,13 @@ bv
 bg
 bg
 bg
-Mg
-Mg
-nJ
-Mg
-OR
-OR
-Mg
+aP
+aP
+kE
+aP
+nh
+nh
+aP
 ag
 ag
 ag
@@ -38230,12 +38241,12 @@ bg
 bg
 ag
 ag
-Mg
-nK
-Mg
-Mg
-Mg
-Mg
+aP
+kG
+aP
+aP
+aP
+aP
 ag
 ag
 ag
@@ -38487,9 +38498,9 @@ bg
 ag
 ag
 ag
-Mg
-nL
-Mg
+aP
+mg
+aP
 ag
 ag
 ag
@@ -38746,7 +38757,7 @@ ag
 ag
 aw
 nM
-oc
+mZ
 ag
 ag
 ag


### PR DESCRIPTION
For **some reason** (see: NTSL abuse, bad antaggonists) telecomms was more secure than the vault and the AI core. It had several turrets that only the CE or the Captain (not even the AI) could access. The last set of turrets were even set to **lethal by default**.

This PR does the following things:
- Removes the turrets in telecommunications.
- Gives Station Engineers (not atmos techs, not atmosphere techs) telecomms access.
- Makes it so that every telecoms camera has motion alarms.
- Makes it so that you don't need to go into telecomms to wire the solars.

I think this is a good PR because it allows engineering to fix any telecoms related issue that come up. Currently traitors have a huge advantage when it comes to telecoms shutdown as they easily bypass any security. present by breaking into the surface satellite lounge while non-antags are usually fucked when it comes to repairs. because of the turrets. This PR would also allow players to learn how telecomms work without having to become a Chief Engineer.

![image](https://user-images.githubusercontent.com/8602857/65487885-b0700680-de5c-11e9-89aa-95d5575d6d93.png)
