### PR TITLE
Skull balances all of engineering

### DIFF
--- a/code/modules/shieldgen/energy_field.dm
+++ b/code/modules/shieldgen/energy_field.dm
@@ -13,7 +13,7 @@
 	var/strength = 0
 	var/ticks_recovering = 10
 
-	atmos_canpass = CANPASS_NEVER
+	atmos_canpass = CANPASS_ALWAYS
 
 /obj/effect/energy_field/New()
 	..()
@@ -56,7 +56,7 @@
 	else if(strength < 1)
 		invisibility = 101
 		density = 0
-	
+
 	if (density != old_density)
 		update_nearby_tiles()
 
@@ -67,4 +67,4 @@
 	//Outputs: Boolean if can pass.
 
 	//return (!density || !height || air_group)
-	return !density
+	return (!density || air_group)

--- a/html/changelogs/skull132-shields.yml
+++ b/html/changelogs/skull132-shields.yml
@@ -1,0 +1,5 @@
+author: skull132
+delete-after: true
+
+changes:
+  - tweak: "'energy field' type shields (regular hull shields) no longer block air."


### PR DESCRIPTION
It was brought to my attention that regular hull shields block air. This is an unfortunate meme, and must be quelled.

Hull shields are too easy to set up and maintain, thus making them block air is a relatively over powered way of dealing with breaches.