### PR TITLE
Flower crown fix

### DIFF
--- a/code/game/objects/items/weapons/improvised_components.dm
+++ b/code/game/objects/items/weapons/improvised_components.dm
@@ -157,31 +157,21 @@
 	w_class = ITEMSIZE_SMALL
 
 /obj/item/woodcirclet/attackby(obj/item/W as obj, mob/user as mob)
-	var/obj/item/complete
-	if(istype(W,/obj/item/seeds/poppyseed))
-		to_chat(user, "<span class='notice'>You attach the poppy to the circlet and create a beautiful flower crown.</span>")
-		complete = new /obj/item/clothing/head/poppy_crown(get_turf(user))
-		user.drop_from_inventory(W)
-		user.drop_from_inventory(src)
-		qdel(W)
-		qdel(src)
-		user.put_in_hands(complete)
-		return
-	else if(istype(W,/obj/item/seeds/sunflowerseed))
-		to_chat(user, "<span class='notice'>You attach the sunflower to the circlet and create a beautiful flower crown.</span>")
-		complete = new /obj/item/clothing/head/sunflower_crown(get_turf(user))
-		user.drop_from_inventory(W)
-		user.drop_from_inventory(src)
-		qdel(W)
-		qdel(src)
-		user.put_in_hands(complete)
-		return
-	else if(istype(W,/obj/item/seeds/harebell))
-		to_chat(user, "<span class='notice'>You attach the harebell to the circlet and create a beautiful flower crown.</span>")
-		complete = new /obj/item/clothing/head/lavender_crown(get_turf(user))
-		user.drop_from_inventory(W)
-		user.drop_from_inventory(src)
-		qdel(W)
-		qdel(src)
-		user.put_in_hands(complete)
-		return
+	var/obj/item/complete = null
+	if(istype(W, /obj/item/seeds))	// Only allow seeds, since we rely on their structure
+		var/obj/item/seeds/S = W
+		if(istype(S.seed, /datum/seed/flower/poppy))
+			complete = new /obj/item/clothing/head/poppy_crown(get_turf(user))
+		else if(istype(S.seed, /datum/seed/flower/sunflower))
+			complete = new /obj/item/clothing/head/sunflower_crown(get_turf(user))
+		else if(istype(S.seed, /datum/seed/flower))  // Note: might be a problem if more flowers are added
+			complete = new /obj/item/clothing/head/lavender_crown(get_turf(user))
+
+		if(complete != null)
+			to_chat(user, "<span class='notice'>You attach the " + S.seed.seed_name + " to the circlet and create a beautiful flower crown.</span>")
+			user.drop_from_inventory(W)
+			user.drop_from_inventory(src)
+			qdel(W)
+			qdel(src)
+			user.put_in_hands(complete)
+			return

--- a/html/changelogs/aleksix-flower_crown_fix.yml
+++ b/html/changelogs/aleksix-flower_crown_fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: aleksix
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Flower crowns can now be made from non-vendor seeds"


### PR DESCRIPTION
The flower crowns couldn't be made with non-fresh seeds (i.e. from a seed maker) due to operating with seed items instead of seed datums. This PR fixes the problem and allows seeds from seed makers to be used for creating flower crowns.