### PR TITLE
Integrated Circuit memory sprites fix

### DIFF
--- a/code/modules/integrated_electronics/subtypes/memory.dm
+++ b/code/modules/integrated_electronics/subtypes/memory.dm
@@ -5,7 +5,7 @@
 
 /obj/item/integrated_circuit/memory/storage
 	name = "memory chip"
-	icon_state = "memory"
+	icon_state = "memory1"
 	desc = "This tiny chip can store one piece of data."
 	inputs = list()
 	outputs = list()
@@ -72,7 +72,7 @@
 /obj/item/integrated_circuit/memory/constant
 	name = "constant chip"
 	desc = "This tiny chip can store one piece of data, which cannot be overwritten without disassembly."
-	icon_state = "memory"
+	icon_state = "memory1"
 	inputs = list()
 	outputs = list("output pin" = IC_PINTYPE_ANY)
 	activators = list(

--- a/html/changelogs/aleksix-ic_memory_sprite_fix.yml
+++ b/html/changelogs/aleksix-ic_memory_sprite_fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: aleksix
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Integrated Circuits memory and constant chips now have sprites"


### PR DESCRIPTION
Fixes sprite names for integrated circuit memory and sprite chips. Now they use the "memory1" sprite instead of non-existent "memory" sprites and thus show in-game.