### PR TITLE
Airlock and Access Tweaks

### DIFF
--- a/html/changelogs/furrycactus - tweaks.yml
+++ b/html/changelogs/furrycactus - tweaks.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Gave the Forensic Tech office a solid airlock instead of glass, so that the chromatic windows aren't redundant."
+  - bugfix: "Medical staff actually have access to Medbay maintenance now."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -34434,7 +34434,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
@@ -47709,7 +47710,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/freezer_maint{
 	name = "Transfusion Supplies";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/maintenance/medbay)
@@ -47720,7 +47722,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -49800,7 +49803,8 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
@@ -51038,7 +51042,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/medical{
 	name = "Room 3";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/medbay)
@@ -51632,7 +51637,8 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintance";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -51707,7 +51713,8 @@
 "bLQ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Starboard Ward";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -52007,11 +52014,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bMs" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintance";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bMu" = (
@@ -63475,7 +63483,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
@@ -65101,7 +65110,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/medical{
 	name = "Room 1";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/medbay)
@@ -65873,7 +65883,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintance";
-	req_access = list(12)
+	req_access = list(12);
+	req_one_access = null
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
@@ -66195,6 +66206,18 @@
 /obj/structure/curtain/medical,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/medbay)
+"mRu" = (
+/obj/effect/floor_decal/corner/brown{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
 "mUs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -66522,7 +66545,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/medical{
 	name = "Room 2";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/medbay)
@@ -66646,7 +66670,8 @@
 "ovg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Starboard Ward";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -66744,6 +66769,14 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/bar)
+"oST" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
 "oVj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_research{
@@ -66980,7 +67013,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
 	name = "Patient Bathroom";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/maintenance/medbay)
@@ -67456,18 +67490,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"qZA" = (
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/eva)
 "qZF" = (
 /obj/item/weapon/material/shard/shrapnel,
 /obj/effect/decal/cleanable/dirt,
@@ -68690,7 +68712,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	name = "Physical Therapy";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/medbay)
@@ -68807,14 +68830,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/medbay)
-"uPw" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/eva)
 "uRt" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/disposalpipe/segment{
@@ -69668,7 +69683,8 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
-	req_access = list(12)
+	req_access = null;
+	req_one_access = list(12,66)
 	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -94180,7 +94196,7 @@ cfZ
 cgq
 cgG
 cgW
-qZA
+mRu
 cho
 chC
 chM
@@ -94437,7 +94453,7 @@ cfk
 cgr
 cgH
 cgX
-uPw
+oST
 chp
 cfk
 cfk

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -3080,12 +3080,6 @@
 	},
 /obj/item/device/camera_film,
 /obj/item/device/camera,
-/obj/machinery/requests_console{
-	department = "Forensic Technician";
-	departmentType = 5;
-	pixel_x = -32;
-	pixel_y = 0
-	},
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 9
@@ -3468,7 +3462,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_security{
+/obj/machinery/door/airlock/security{
 	name = "Forensic Technician";
 	req_access = list(4)
 	},
@@ -3479,11 +3473,6 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3492,6 +3481,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/security/forensics_office)
@@ -3504,6 +3498,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/security/forensics_office)
@@ -3758,6 +3757,12 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/csi,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/security/forensics_office)
 "gT" = (
@@ -10966,6 +10971,12 @@
 	dir = 9
 	},
 /obj/machinery/computer/records/security,
+/obj/machinery/requests_console{
+	department = "Forensic Technician";
+	departmentType = 5;
+	pixel_x = -32;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/security/forensics_office)
 "Pm" = (
@@ -11661,17 +11672,8 @@
 /area/maintenance/interstitial_main)
 "TH" = (
 /obj/structure/table/standard,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/item/stack/packageWrap,
 /obj/item/weapon/hand_labeler,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 9
@@ -49379,8 +49381,8 @@ fw
 fN
 gj
 fw
-fw
-fw
+fN
+gj
 gx
 fw
 fw


### PR DESCRIPTION
- Gives the Forensic Tech office a solid airlock instead of a glass one, so that the chromatic windows aren't rendered redundant.
- Actually gives Medical access to their maintenance area.