### PR TITLE
Properly inherits Zeng-Hu xenobio outfit

### DIFF
--- a/code/game/jobs/faction/zeng_hu.dm
+++ b/code/game/jobs/faction/zeng_hu.dm
@@ -64,8 +64,8 @@
 		"Roboticist" = /datum/outfit/job/roboticist/zeng_hu,
 		"Biomechanical Engineer" = /datum/outfit/job/roboticist/zeng_hu,
 		"Mechatronic Engineer" = /datum/outfit/job/roboticist/zeng_hu,
-		"Xenobiologist" = /datum/outfit/job/xenobiologist/zeng_hu,
-		"Xenobotanist" = /datum/outfit/job/xenobiologist/zeng_hu,
+		"Xenobiologist" = /datum/outfit/job/scientist/xenobiologist/zeng_hu,
+		"Xenobotanist" = /datum/outfit/job/scientist/xenobiologist/zeng_hu,
 		"Corporate Liaison" = /datum/outfit/job/representative/zeng_hu
 	)
 
@@ -99,7 +99,7 @@
 	uniform = /obj/item/clothing/under/rank/zeng
 	id = /obj/item/weapon/card/id/zeng_hu
 
-/datum/outfit/job/xenobiologist/zeng_hu
+/datum/outfit/job/scientist/xenobiologist/zeng_hu
 	name = "Xenobiologist - Zeng-Hu"
 	uniform = /obj/item/clothing/under/rank/zeng
 	id = /obj/item/weapon/card/id/zeng_hu

--- a/html/changelogs/aleksix-xenobio_suit_fix.yml
+++ b/html/changelogs/aleksix-xenobio_suit_fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: aleksix
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Zeng-Hu xenobiologists now spawn with complete equipment."


### PR DESCRIPTION
Zeng-Hu xenobiology outfits didn't inherit properly from normal station xenobiologists, meaning they spawned with standard, non-science headsets and no labcoats. This PR fixes that.
Closes #7111 