### PR TITLE
Adding verb to empty Bags quickly

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -25,7 +25,7 @@
 	var/species_restricted = list("exclude","Vaurca Breeder","Vaurca Warform")
 	drop_sound = 'sound/items/drop/backpack.ogg'
 	allow_quick_empty = TRUE
-	empty_delay = 1 SECOND
+	empty_delay = 0.5 SECOND
 
 /obj/item/weapon/storage/backpack/mob_can_equip(M as mob, slot)
 
@@ -82,7 +82,7 @@
 		slot_l_hand_str = "holdingpack",
 		slot_r_hand_str = "holdingpack"
 		)
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 	attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(istype(W, /obj/item/weapon/storage/backpack/holding))
@@ -103,10 +103,9 @@
 	icon_state = "giftbag0"
 	item_state = "giftbag"
 	w_class = 4.0
-	max_w_class = 3
 	max_storage_space = 400 // can store a ton of shit!
 	item_state_slots = null
-	empty_delay = 3 SECOND
+	empty_delay = 1 SECOND
 
 /obj/item/weapon/storage/backpack/cultpack
 	name = "trophy rack"
@@ -136,14 +135,14 @@
 	desc = "It's a special backpack made exclusively for officers."
 	icon_state = "captainpack"
 	item_state_slots = null
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/industrial
 	name = "industrial backpack"
 	desc = "It's a tough backpack for the daily grind of station life."
 	icon_state = "engiepack"
 	item_state_slots = null
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/toxins
 	name = "laboratory backpack"
@@ -187,7 +186,7 @@
 	name = "wizard federation sack"
 	desc = "Perfect for keeping your shining crystal balls inside of."
 	icon_state = "wizardpack"
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /*
  * Satchel Types
@@ -220,7 +219,7 @@
 		slot_l_hand_str = "engiepack",
 		slot_r_hand_str = "engiepack"
 		)
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/satchel_med
 	name = "medical satchel"
@@ -273,19 +272,19 @@
 		slot_l_hand_str = "satchel-cap",
 		slot_r_hand_str = "satchel-cap"
 		)
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/satchel_syndie
 	name = "syndicate satchel"
 	desc = "A satchel in the new age style of a multi-corperate terrorist organisation."
 	icon_state = "satchel-syndie"
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/satchel_wizard
 	name = "wizard federation satchel"
 	desc = "This stylish satchel will put a spell on anyone with some fashion sense to spare."
 	icon_state = "satchel-wizard"
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 //ERT backpacks.
 /obj/item/weapon/storage/backpack/ert
@@ -296,7 +295,7 @@
 		slot_l_hand_str = "securitypack",
 		slot_r_hand_str = "securitypack"
 		)
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 //Commander
 /obj/item/weapon/storage/backpack/ert/commander
@@ -342,7 +341,7 @@
 		slot_l_hand_str = "duffle_captain",
 		slot_r_hand_str = "duffle_captain"
 	)
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/duffel/hyd
 	name = "botanist's duffel bag"
@@ -375,7 +374,7 @@
 		slot_l_hand_str = "duffle_eng",
 		slot_r_hand_str = "duffle_eng"
 	)
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/duffel/tox
 	name = "scientist's duffel bag"
@@ -410,14 +409,14 @@
 		slot_r_hand_str = "duffle_syndie"
 	)
 	slowdown = 0
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/duffel/wizard
 	name = "wizardly duffel bag"
 	desc = "A fancy blue wizard bag, duffel edition."
 	icon_state = "duffel-wizard"
 	slowdown = 0
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /*
  * Messenger Bags
@@ -457,13 +456,13 @@
 	name = "captain's messenger bag"
 	desc = "A special backpack worn over one shoulder.  This one is made specifically for command officers."
 	icon_state = "courierbagcom"
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/messenger/engi
 	name = "engineering messenger bag"
 	desc = "A strong backpack worn over one shoulder. This one is designed for industrial work."
 	icon_state = "courierbagengi"
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/messenger/hyd
 	name = "hydroponics messenger bag"
@@ -489,7 +488,7 @@
 	name = "military rucksack"
 	desc = "A sturdy backpack with the emblems and markings of the Tau Ceti Foreign Legion."
 	icon_state = "legion_bag"
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/typec
 	icon = 'icons/mob/species/breeder/inventory.dmi'
@@ -499,7 +498,6 @@
 	item_state = "wings"
 	w_class = 5.0
 	slot_flags = SLOT_BACK
-	max_w_class = 3
 	max_storage_space = 12
 	canremove = 0
 	species_restricted = list("Vaurca Breeder")

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -180,7 +180,7 @@
 	name = "syndicate rucksack"
 	desc = "The latest in carbon fiber and red satin combat rucksack technology. Comfortable and tough!"
 	icon_state = "syndiepack"
-	empty_delay = 2 SECOND
+	empty_delay = 0.8 SECOND
 
 /obj/item/weapon/storage/backpack/wizard
 	name = "wizard federation sack"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -24,6 +24,8 @@
 	max_storage_space = 28
 	var/species_restricted = list("exclude","Vaurca Breeder","Vaurca Warform")
 	drop_sound = 'sound/items/drop/backpack.ogg'
+	allow_quick_empty = TRUE
+	empty_delay = 1 SECOND
 
 /obj/item/weapon/storage/backpack/mob_can_equip(M as mob, slot)
 
@@ -80,6 +82,7 @@
 		slot_l_hand_str = "holdingpack",
 		slot_r_hand_str = "holdingpack"
 		)
+	empty_delay = 2 SECOND
 
 	attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(istype(W, /obj/item/weapon/storage/backpack/holding))
@@ -103,6 +106,7 @@
 	max_w_class = 3
 	max_storage_space = 400 // can store a ton of shit!
 	item_state_slots = null
+	empty_delay = 3 SECOND
 
 /obj/item/weapon/storage/backpack/cultpack
 	name = "trophy rack"
@@ -132,12 +136,14 @@
 	desc = "It's a special backpack made exclusively for officers."
 	icon_state = "captainpack"
 	item_state_slots = null
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/industrial
 	name = "industrial backpack"
 	desc = "It's a tough backpack for the daily grind of station life."
 	icon_state = "engiepack"
 	item_state_slots = null
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/toxins
 	name = "laboratory backpack"
@@ -175,11 +181,13 @@
 	name = "syndicate rucksack"
 	desc = "The latest in carbon fiber and red satin combat rucksack technology. Comfortable and tough!"
 	icon_state = "syndiepack"
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/wizard
 	name = "wizard federation sack"
 	desc = "Perfect for keeping your shining crystal balls inside of."
 	icon_state = "wizardpack"
+	empty_delay = 2 SECOND
 
 /*
  * Satchel Types
@@ -212,6 +220,7 @@
 		slot_l_hand_str = "engiepack",
 		slot_r_hand_str = "engiepack"
 		)
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/satchel_med
 	name = "medical satchel"
@@ -264,16 +273,19 @@
 		slot_l_hand_str = "satchel-cap",
 		slot_r_hand_str = "satchel-cap"
 		)
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/satchel_syndie
 	name = "syndicate satchel"
 	desc = "A satchel in the new age style of a multi-corperate terrorist organisation."
 	icon_state = "satchel-syndie"
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/satchel_wizard
 	name = "wizard federation satchel"
 	desc = "This stylish satchel will put a spell on anyone with some fashion sense to spare."
 	icon_state = "satchel-wizard"
+	empty_delay = 2 SECOND
 
 //ERT backpacks.
 /obj/item/weapon/storage/backpack/ert
@@ -284,6 +296,7 @@
 		slot_l_hand_str = "securitypack",
 		slot_r_hand_str = "securitypack"
 		)
+	empty_delay = 2 SECOND
 
 //Commander
 /obj/item/weapon/storage/backpack/ert/commander
@@ -329,6 +342,7 @@
 		slot_l_hand_str = "duffle_captain",
 		slot_r_hand_str = "duffle_captain"
 	)
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/duffel/hyd
 	name = "botanist's duffel bag"
@@ -361,6 +375,7 @@
 		slot_l_hand_str = "duffle_eng",
 		slot_r_hand_str = "duffle_eng"
 	)
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/duffel/tox
 	name = "scientist's duffel bag"
@@ -395,12 +410,14 @@
 		slot_r_hand_str = "duffle_syndie"
 	)
 	slowdown = 0
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/duffel/wizard
 	name = "wizardly duffel bag"
 	desc = "A fancy blue wizard bag, duffel edition."
 	icon_state = "duffel-wizard"
 	slowdown = 0
+	empty_delay = 2 SECOND
 
 /*
  * Messenger Bags
@@ -440,11 +457,13 @@
 	name = "captain's messenger bag"
 	desc = "A special backpack worn over one shoulder.  This one is made specifically for command officers."
 	icon_state = "courierbagcom"
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/messenger/engi
 	name = "engineering messenger bag"
 	desc = "A strong backpack worn over one shoulder. This one is designed for industrial work."
 	icon_state = "courierbagengi"
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/messenger/hyd
 	name = "hydroponics messenger bag"
@@ -470,6 +489,7 @@
 	name = "military rucksack"
 	desc = "A sturdy backpack with the emblems and markings of the Tau Ceti Foreign Legion."
 	icon_state = "legion_bag"
+	empty_delay = 2 SECOND
 
 /obj/item/weapon/storage/backpack/typec
 	icon = 'icons/mob/species/breeder/inventory.dmi'

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -37,7 +37,7 @@
 	var/collection_mode = 1  //0 = pick one at a time, 1 = pick all on tile
 	var/use_sound = "rustle"	//sound played when used. null for no sound.
 	var/list/starts_with // for pre-filled items
-	var/empty_delay = 0 SECOND
+	var/empty_delay = 0 SECOND // time it takes to empty bag. this is multiplies by number of objects stored
 
 /obj/item/weapon/storage/Destroy()
 	close_all()
@@ -568,7 +568,7 @@
 	if(empty_delay)
 		visible_message("\The [usr] starts to empty the contents of \the [src].")
 
-	if(!do_after(usr, empty_delay, act_target=usr))
+	if(!do_after(usr, contents.len * empty_delay, act_target=usr))
 		return
 
 	var/turf/T = get_turf(src)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -565,7 +565,9 @@
 	if((!ishuman(usr) && (src.loc != usr)) || usr.stat || usr.restrained())
 		return
 
-	visible_message("\The [usr] starts to empty the contents of \the [src].")
+	if(empty_delay)
+		visible_message("\The [usr] starts to empty the contents of \the [src].")
+
 	if(!do_after(usr, empty_delay, act_target=usr))
 		return
 
@@ -577,7 +579,9 @@
 		CHECK_TICK
 
 	post_remove_from_storage_deferred(loc, usr)
-	visible_message("\The [usr] empties the contents of \the [src].")
+
+	if(empty_delay)
+		visible_message("\The [usr] empties the contents of \the [src].")
 
 // Override this to fill the storage object with stuff.
 /obj/item/weapon/storage/proc/fill()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -37,6 +37,7 @@
 	var/collection_mode = 1  //0 = pick one at a time, 1 = pick all on tile
 	var/use_sound = "rustle"	//sound played when used. null for no sound.
 	var/list/starts_with // for pre-filled items
+	var/empty_delay = 0 SECOND
 
 /obj/item/weapon/storage/Destroy()
 	close_all()
@@ -564,6 +565,10 @@
 	if((!ishuman(usr) && (src.loc != usr)) || usr.stat || usr.restrained())
 		return
 
+	visible_message("\The [usr] starts to empty the contents of \the [src].")
+	if(!do_after(usr, empty_delay, act_target=usr))
+		return
+
 	var/turf/T = get_turf(src)
 	hide_from(usr)
 	for(var/obj/item/I in contents)
@@ -572,6 +577,7 @@
 		CHECK_TICK
 
 	post_remove_from_storage_deferred(loc, usr)
+	visible_message("\The [usr] empties the contents of \the [src].")
 
 // Override this to fill the storage object with stuff.
 /obj/item/weapon/storage/proc/fill()

--- a/html/changelogs/Sindorman-backpack.yml
+++ b/html/changelogs/Sindorman-backpack.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Enabled Empty Contents verb in Object tab for Bags. Bags have base delay of 1 second to empty and special bags like Captain, Wizard, Synie, Engineering have 2 second delay."
+  - tweak: "Enabled Empty Contents verb in Object tab for Bags. Bags have base delay of 0.5 second per item to empty and special bags like Captain, Wizard, Synie, Engineering have 0.8 second delay per item."

--- a/html/changelogs/Sindorman-backpack.yml
+++ b/html/changelogs/Sindorman-backpack.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Enabled Empty Contents verb in Object tab for Bags. Bags have base delay of 1 second to empty and special bags like Captain, Wizard, Synie, Engineering have 2 second delay."


### PR DESCRIPTION
- Enabled verb for quick emptying of backpacks.

- Bags have a delay to empty. Which is base 0.5 second per item.

- Captain, Syndicate, Engineering, Wizard Bags have 0.8 second delay per item.

as per suggeestion thread: https://forums.aurorastation.org/topic/12927-allow-people-to-dump-out-bags/