### PR TITLE
Fixes an oversight with pen attack to_chat

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -65,7 +65,7 @@
 /obj/item/weapon/pen/attack(mob/M as mob, mob/user as mob, var/target_zone)
 	if(!ismob(M))
 		return
-	to_chat(user, "<span class='warning'>You stab [M] with the [src].</span>")
+	to_chat(user, "<span class='warning'>You stab [M] with \the [src].</span>")
 //	to_chat(M, "\red You feel a tiny prick!" //That's a whole lot of meta!)
 	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been stabbed with [name]  by [user.name] ([user.ckey])</font>")
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to stab [M.name] ([M.ckey])</font>")

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -65,7 +65,7 @@
 /obj/item/weapon/pen/attack(mob/M as mob, mob/user as mob, var/target_zone)
 	if(!ismob(M))
 		return
-	to_chat(user, "<span class='warning'>You stab [M] with the pen.</span>")
+	to_chat(user, "<span class='warning'>You stab [M] with the [src].</span>")
 //	to_chat(M, "\red You feel a tiny prick!" //That's a whole lot of meta!)
 	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been stabbed with [name]  by [user.name] ([user.ckey])</font>")
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to stab [M.name] ([M.ckey])</font>")

--- a/html/changelogs/otatoh_penfix.yml
+++ b/html/changelogs/otatoh_penfix.yml
@@ -1,0 +1,9 @@
+# Your name.  
+author: otatoh
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+changes: 
+  - bugfix: "Fixes an oversight with pen attack to_chat."


### PR DESCRIPTION
[bugfix] Attacking a mob with a pen used "pen" instead of "[src]", so children & renamed pens would display incorrect attack text.