### PR TITLE
Fix late-join not showing alt-title jobs with differing minimum ages from main job

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -102,7 +102,7 @@
 		if(jobban_isbanned(player, rank))
 			return FALSE
 
-		if(!(rank in player.client.prefs.GetValidTitles(job)))
+		if(!(player.client.prefs.GetPlayerAltTitle(job) in player.client.prefs.GetValidTitles(job)))
 			to_chat(player, "<span class='warning'>Your character is too young!</span>")
 			return FALSE
 

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -283,7 +283,9 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 	if (!(job.type in faction.allowed_role_types))
 		return FALSE
 
-	if(!(rank in client.prefs.GetValidTitles(job))) // does age/species check for us!
+	var/alt_rank = client.prefs.GetPlayerAltTitle(job)
+	var/titles = client.prefs.GetValidTitles(job)
+	if(!(rank in titles) && !(alt_rank in titles)) // does age/species check for us!
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -283,9 +283,7 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 	if (!(job.type in faction.allowed_role_types))
 		return FALSE
 
-	var/alt_rank = client.prefs.GetPlayerAltTitle(job)
-	var/titles = client.prefs.GetValidTitles(job)
-	if(!(rank in titles) && !(alt_rank in titles)) // does age/species check for us!
+	if(!(client.prefs.GetPlayerAltTitle(job) in client.prefs.GetValidTitles(job))) // does age/species check for us!
 		return FALSE
 
 	return TRUE

--- a/html/changelogs/johnwildkins-7156.yml
+++ b/html/changelogs/johnwildkins-7156.yml
@@ -38,4 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - bugfix: "Fixed IsJobAvailable() proc not accounting for differing age restrictions on alt-titles"
+  - bugfix: "Fixed being unable to late-join as alt-title jobs if character age below requirement for main title"
+  - bugfix: "Fixed 'Your character too young!' warning if late-joining as alt-title younger than main"

--- a/html/changelogs/johnwildkins-7156.yml
+++ b/html/changelogs/johnwildkins-7156.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed IsJobAvailable() proc not accounting for differing age restrictions on alt-titles"


### PR DESCRIPTION
Attends to #7122 - basically just makes IsJobAvailable() check for the player's selected alt-title rather than just the main title, so you can late-join as an 18-year-old medical intern again for example

Also first PR apologies in advance