### PR TITLE
Various oven/fryer fixes, part 1 of many

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -2,13 +2,14 @@
 	var/temperature = T20C
 	var/min_temp = 80 + T0C	//Minimum temperature to do any cooking
 	var/optimal_temp = 200 + T0C	//Temperature at which we have 100% efficiency. efficiency is lowered on either side of this
-	var/optimal_power = 0.1//cooking power at 100%
+	var/optimal_power = 1.1//cooking power at 100%
 
 	var/loss = 1	//Temp lost per proc when equalising
-	var/resistance = 320000	//Resistance to heating. combines with active power usage to determine how long heating takes
+	var/resistance = 320000	//Resistance to heating. combines with heating power to determine how long heating takes
 
 	var/light_x = 0
 	var/light_y = 0
+	cooking_coeff = 0
 	cooking_power = 0
 
 /obj/machinery/appliance/cooker/examine(var/mob/user)
@@ -16,7 +17,7 @@
 	if (.)	//no need to duplicate adjacency check
 		if (!stat)
 			if (temperature < min_temp)
-				to_chat(user, span("warning", "The [src] is still heating up and is too cold to cook anything yet."))
+				to_chat(user, span("warning", "\The [src] is still heating up and is too cold to cook anything yet."))
 			else
 				to_chat(user, span("notice", "It is running at [round(get_efficiency(), 0.1)]% efficiency!"))
 			to_chat(user, "Temperature: [round(temperature - T0C, 0.1)]C / [round(optimal_temp - T0C, 0.1)]C")
@@ -34,10 +35,9 @@
 				string += "- [CI.container.label(num)], [report_progress(CI)]</br>"
 		to_chat(usr, string)
 	else
-		to_chat(usr, span("notice","It is empty."))
+		to_chat(usr, span("notice","It's empty."))
 
 /obj/machinery/appliance/cooker/proc/get_efficiency()
-	RefreshParts()
 	. = (cooking_power / optimal_power) * 100
 
 /obj/machinery/appliance/cooker/Initialize()
@@ -78,8 +78,8 @@
 	var/temp_scale = 0
 	if(temperature > min_temp)
 
-		temp_scale = (temperature - min_temp) / (optimal_temp - min_temp)
-		//If we're between min and optimal this will yield a value in the range 0-1
+		temp_scale = (temperature - 273.15) / (optimal_temp - 273.15)
+		//If we're between min and optimal this will yield a value in the range 0.4-1
 
 		if (temp_scale > 1)
 			//We're above optimal, efficiency goes down as we pass too much over it
@@ -88,8 +88,7 @@
 			else
 				temp_scale = 1 - (temp_scale - 1)
 
-
-	cooking_power = optimal_power * temp_scale
+	cooking_coeff = optimal_power * temp_scale
 	RefreshParts()
 
 /obj/machinery/appliance/cooker/proc/heat_up()
@@ -98,7 +97,7 @@
 			playsound(src, 'sound/machines/click.ogg', 20, 1)
 			use_power = 2.//If we're heating we use the active power
 			update_icon()
-		temperature += active_power_usage / resistance
+		temperature += heating_power / resistance
 		update_cooking_power()
 		return 1
 	else

--- a/code/game/machinery/kitchen/cooking_machines/fryer.dm
+++ b/code/game/machinery/kitchen/cooking_machines/fryer.dm
@@ -9,14 +9,15 @@
 	food_color = "#FFAD33"
 	appliancetype = FRYER
 	active_power_usage = 12 KILOWATTS
+	heating_power = 12000
 
-	optimal_power = 0.35
+	optimal_power = 1.35
 
 	idle_power_usage = 3.6 KILOWATTS
 	//Power used to maintain temperature once it's heated.
 	//Going with 25% of the active power. This is a somewhat arbitrary value
 
-	resistance = 20000	// Approx. 8-9 minutes to heat up.
+	resistance = 60000	// Approx. 10 minutes.
 
 	max_contents = 2
 	container_type = /obj/item/weapon/reagent_containers/cooking_container/fryer

--- a/code/game/machinery/kitchen/cooking_machines/oven.dm
+++ b/code/game/machinery/kitchen/cooking_machines/oven.dm
@@ -8,12 +8,13 @@
 	food_color = "#A34719"
 	can_burn_food = 1
 	active_power_usage = 6 KILOWATTS
+	heating_power = 6000
 	//Based on a double deck electric convection oven
 
-	resistance = 16000
+	resistance = 30000 // Approx. 12 minutes.
 	idle_power_usage = 2 KILOWATTS
 	//uses ~30% power to stay warm
-	optimal_power = 0.2
+	optimal_power = 1.2
 
 	light_x = 2
 	max_contents = 5
@@ -21,7 +22,7 @@
 
 	stat = POWEROFF	//Starts turned off
 
-	var/open = 1
+	var/open = 0 // Start closed so people don't heat up ovens with the door open
 
 	output_options = list(
 		"Pizza" = /obj/item/weapon/reagent_containers/food/snacks/variable/pizza,

--- a/html/changelogs/johnwildkins-7164.yml
+++ b/html/changelogs/johnwildkins-7164.yml
@@ -1,0 +1,48 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Cooking appliances requiring pre-heat (ovens, fryers, etc.) now must actually be pre-heated before use."
+  - bugfix: "Oven trays will no longer duplicate messages when inserted."
+  - bugfix: "Oven/fryer temperature efficiency now correctly plays a role in time-to-cook."
+  - bugfix: "Ovens and fryers now draw the correct amount of power, 6 KW and 12 KW respectively."
+  - bugfix: "Upgrading an oven or fryer's scanner module will no longer increase time-to-heat."
+  - tweak: "Ovens should now reach minimum operating temperature in approx. 12 minutes, and fryers in around 10. Additionally, they will start at 40% effiency, rather than 0%."
+  - tweak: "Upgrading oven/fryer components is now much more effective."
+  - backend: "Various minor changes and fixes to appliance behavior, removal of superfluous procs and vars"


### PR DESCRIPTION
First, the bugfixes:
- Ovens, fryers, and similar devices that "require preheat" now actually require preheat before cooking.
- Oven trays no longer duplicate messages when inserted.
- Oven/fryer temperature efficiency now correctly plays a role in time-to-cook.
- Ovens and fryers now draw the correct amount of power.
- Upgrading an oven or fryer's scanner module no longer reduces its heat output.
- While not exactly a bug, removed an unneeded proc here and there as well as replaced most initial vars with initial() counterparts

Now, the tweaks - I tried to keep these light, since I was really just here to fix bugs and get the existing functionality working. However, compared to the status quo of cooking, actually getting the intended system working would have basically been a massive nerf; before now, `cooking_power` was locked at 1.4 throughout the "heating process"; now, after tweaks, you start at around 0.48 and end at 1.2. 

- Heating power increased and resistance reduced so that both machines should preheat in about ten minutes, as opposed to 30-60.
- In addition, once they are usable, ovens and fryers will start at 40% efficiency, rather than climbing from 0% after the initial time-lock.
- Efficiency is now based on a linear scale of temperature to optimal temperature. This is mostly because it was the simplest way to implement the starting efficiency once preheating is finished.
- Upgrading oven/fryer components is now much more rewarding. I may have overdone the numbers a bit, but on the other hand - there should probably be some reward for bothering to upgrade the stove of all things.

The other conclusion I came to (but didn't implement) was the thought that one time-lock should go; either efficiency starts at 0% but you can cook from the beginning, or you have to wait for the preheat cycle and then there's no efficiency to worry about. Obviously, I prefer the former.
