### PR TITLE
Copier and paper fixes

### DIFF
--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -2,8 +2,8 @@
 	name = "paper"
 	icon_state = "paper_stack"
 	item_state = "paper"
-	var/copied = 0
-	var/iscopy = 0
+	var/copied = FALSE
+	var/iscopy = FALSE
 
 
 /obj/item/weapon/paper/carbon/update_icon()
@@ -43,9 +43,9 @@
 		copy.fields = c.fields
 		copy.updateinfolinks()
 		to_chat(usr, "<span class='notice'>You tear off the carbon-copy!</span>")
-		c.copied = 1
-		copy.iscopy = 1
-		copy.copied = 1 // no more infinite copy chains
+		c.copied = TRUE
+		copy.iscopy = TRUE
+		copy.copied = TRUE // no more infinite copy chains
 		copy.verbs -= /obj/item/weapon/paper/carbon/verb/removecopy // TODO: anything but this, see above
 		copy.update_icon()
 		c.update_icon()

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -2,8 +2,8 @@
 	name = "paper"
 	icon_state = "paper_stack"
 	item_state = "paper"
-	var copied = 0
-	var iscopy = 0
+	var/copied = 0
+	var/iscopy = 0
 
 
 /obj/item/weapon/paper/carbon/update_icon()
@@ -33,7 +33,7 @@
 	if (copied == 0)
 		var/obj/item/weapon/paper/carbon/c = src
 		var/copycontents = html_decode(c.info)
-		var/obj/item/weapon/paper/carbon/copy = new /obj/item/weapon/paper/carbon (usr.loc)
+		var/obj/item/weapon/paper/carbon/copy = new /obj/item/weapon/paper/carbon (usr.loc) // TODO: a better way of making copies that maintains icon state without bloating paper.dm and also doesn't give copies the remove copy verb
 		// <font>
 		copycontents = replacetext(copycontents, "<font face=\"[c.deffont]\" color=", "<font face=\"[c.deffont]\" nocolor=")	//state of the art techniques in action
 		copycontents = replacetext(copycontents, "<font face=\"[c.crayonfont]\" color=", "<font face=\"[c.crayonfont]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
@@ -45,6 +45,8 @@
 		to_chat(usr, "<span class='notice'>You tear off the carbon-copy!</span>")
 		c.copied = 1
 		copy.iscopy = 1
+		copy.copied = 1 // no more infinite copy chains
+		copy.verbs -= /obj/item/weapon/paper/carbon/verb/removecopy // TODO: anything but this, see above
 		copy.update_icon()
 		c.update_icon()
 	else

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -424,9 +424,9 @@
 				add_fingerprint(user)
 				return
 		var/obj/item/weapon/paper_bundle/B = new(src.loc)
-		if (name != "paper")
+		if (name != initial(name))
 			B.name = name
-		else if (P.name != "paper" && P.name != "photo")
+		else if (P.name != initial(P.name))
 			B.name = P.name
 		user.drop_from_inventory(P,B)
 		//TODO: Look into this stuff

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -46,8 +46,8 @@
 	else
 		if(istype(W, /obj/item/weapon/tape_roll))
 			return 0
-		if(istype(W, /obj/item/weapon/pen))
-			usr << browse("", "window=[name]") //Closes the dialog)
+		// if(istype(W, /obj/item/weapon/pen))
+			// usr << browse("", "window=[name]") // TODO: actually does nothing, either fix it so you can write directly to the bundle screen or actually prevent the window from opening until you're done
 		var/obj/P = pages[page]
 		P.attackby(W, user)
 
@@ -102,14 +102,14 @@
 
 	// first
 	if(page == 1)
-		dat+= "<DIV STYLE='float:left; text-align:left; width:33.33333%'><A href='?src=\ref[src];prev_page=1'>Front</A></DIV>"
+		dat+= "<DIV STYLE='float:left; text-align:left; width:33.33333%'>Front</DIV>"
 		dat+= "<DIV STYLE='float:left; text-align:center; width:33.33333%'><A href='?src=\ref[src];remove=1'>Remove [(istype(W, /obj/item/weapon/paper)) ? "paper" : "photo"]</A></DIV>"
 		dat+= "<DIV STYLE='float:left; text-align:right; width:33.33333%'><A href='?src=\ref[src];next_page=1'>Next Page</A></DIV><BR><HR>"
 	// last
 	else if(page == pages.len)
 		dat+= "<DIV STYLE='float:left; text-align:left; width:33.33333%'><A href='?src=\ref[src];prev_page=1'>Previous Page</A></DIV>"
 		dat+= "<DIV STYLE='float:left; text-align:center; width:33.33333%'><A href='?src=\ref[src];remove=1'>Remove [(istype(W, /obj/item/weapon/paper)) ? "paper" : "photo"]</A></DIV>"
-		dat+= "<DIV STYLE='float;left; text-align:right; with:33.33333%'><A href='?src=\ref[src];next_page=1'>Back</A></DIV><BR><HR>"
+		dat+= "<DIV STYLE='float:left; text-align:right; width:33.33333%'>Back</DIV><BR><HR>"
 	// middle pages
 	else
 		dat+= "<DIV STYLE='float:left; text-align:left; width:33.33333%'><A href='?src=\ref[src];prev_page=1'>Previous Page</A></DIV>"

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -137,7 +137,7 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 		return B
 	else
 		to_chat(usr, "<span class='warning'>\The [c_item] can't be copied by \the [src].</span>")
-		return 0
+		return FALSE
 
 /obj/machinery/photocopier/ex_act(severity)
 	switch(severity)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -54,17 +54,9 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 			if(toner <= 0)
 				break
 
-			if (istype(copyitem, /obj/item/weapon/paper))
-				copy(copyitem)
-				sleep(20)
-			else if (istype(copyitem, /obj/item/weapon/photo))
-				photocopy(copyitem)
-				sleep(15)
-			else if (istype(copyitem, /obj/item/weapon/paper_bundle))
-				var/obj/item/weapon/paper_bundle/B = bundlecopy(copyitem)
-				sleep(15*B.pages.len)
-			else
-				to_chat(usr, "<span class='warning'>\The [copyitem] can't be copied by \the [src].</span>")
+			var/c_type = copy_type()
+
+			if(!c_type) // if there's something that can't be copied
 				break
 
 			use_power(active_power_usage)
@@ -130,6 +122,23 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 		to_chat(user, "<span class='notice'>You [anchored ? "wrench" : "unwrench"] \the [src].</span>")
 	return
 
+/obj/machinery/photocopier/proc/copy_type(var/c_item = copyitem) // helper proc to reduce ctrl+c ctrl+v
+	if (istype(c_item, /obj/item/weapon/paper))
+		var/obj/item/weapon/paper/C = copy(c_item)
+		sleep(20)
+		return C
+	else if (istype(c_item, /obj/item/weapon/photo))
+		var/obj/item/weapon/photo/P = photocopy(c_item)
+		sleep(20)
+		return P
+	else if (istype(c_item, /obj/item/weapon/paper_bundle))
+		var/obj/item/weapon/paper_bundle/B = bundlecopy(c_item)
+		sleep(15*B.pages.len)
+		return B
+	else
+		to_chat(usr, "<span class='warning'>\The [c_item] can't be copied by \the [src].</span>")
+		return 0
+
 /obj/machinery/photocopier/ex_act(severity)
 	switch(severity)
 		if(1.0)
@@ -148,7 +157,7 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 					toner = 0
 	return
 
-/obj/machinery/photocopier/proc/copy(var/obj/item/weapon/paper/copy, var/print = 1, var/use_sound = 1, var/delay = 20)
+/obj/machinery/photocopier/proc/copy(var/obj/item/weapon/paper/copy, var/print = 1, var/use_sound = 1, var/delay = 10) // note: var/delay is the delay from copy to print, it should be less than the sleep in copy_type()
 	var/obj/item/weapon/paper/c = new /obj/item/weapon/paper()
 	var/info
 	var/pname
@@ -229,10 +238,7 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 			break
 
 
-		if(istype(W, /obj/item/weapon/paper))
-			W = copy(W)
-		else if(istype(W, /obj/item/weapon/photo))
-			W = photocopy(W)
+		W = copy_type(W)
 		W.forceMove(p)
 		p.pages += W
 

--- a/html/changelogs/johnwildkins-7168.yml
+++ b/html/changelogs/johnwildkins-7168.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Photocopier no longer prints half the correct number of copies."
+  - bugfix: "You can no longer infinitely tear-off copies of carbon copies. Carbon copies no longer have the remove-copy verb, either."
+  - tweak: "Copying paper bundles in the photocopier now prints them sequentially and adds them to the bundle."
+  - bugfix: "Copying a paper bundle no longer creates a 'ghost' paper linked to the first page of the copied bundle."
+  - bugfix: "You can once again write to normal sheets of paper in paper bundles."


### PR DESCRIPTION
Resolves #2836, resolves #4226, resolves #4266, and resolves #4366.

- Race condition between copying and printing solved, no longer does the photocopier print half the requested copies.
- You can no longer infinitely tear off copies of carbon copies. Additionally, copies have their remove-copy verb removed.
- Copying paper bundles in the photocopier now works at the correct speed. Additionally, the bug mentioned in #4266 has been removed.
- You can now write to papers inside paper bundles once again. 

Most of this section could honestly do with a revamp, but I'm not exactly the person to do that,  and we are talking about paperwork of all things. This just gets the functionality working again, more or less.