### PR TITLE
Cooking appliance boards, cooking and other machine fixes

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -110,7 +110,7 @@
 					if(P.iswirecutter())
 						playsound(src.loc, P.usesound, 50, 1, pitch_toggle)
 						to_chat(user, span("notice", "You remove the cables."))
-						state = 1
+						state = 2
 						icon_state = "blueprint_0"
 						var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( src.loc )
 						A.amount = 5

--- a/code/game/machinery/kitchen/cooking_machines/_appliance.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_appliance.dm
@@ -675,12 +675,3 @@
 	active_power_usage = initial(active_power_usage) - scan_rating * 25
 	heating_power = initial(heating_power) + cap_rating * 25
 	cooking_power = cooking_coeff * (1 + (scan_rating + cap_rating) / 20) // 100% eff. becomes 120%, 140%, 160% w/ better parts
-
-// /obj/item/weapon/circuitboard/cooking
-// 	name = "kitchen appliance circuitry"
-// 	desc = "The circuitboard for many kitchen appliances. Not of much use."
-// 	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
-// 	req_components = list(
-// 							"/obj/item/weapon/stock_parts/capacitor" = 3,
-// 							"/obj/item/weapon/stock_parts/scanning_module" = 1,
-// 							"/obj/item/weapon/stock_parts/matter_bin" = 2)

--- a/code/game/machinery/kitchen/cooking_machines/_appliance.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_appliance.dm
@@ -39,7 +39,7 @@
 
 	var/container_type = null
 
-	var/combine_first = 0//If 1, this appliance will do combinaiton cooking before checking recipes
+	var/combine_first = FALSE//If 1, this appliance will do combinaiton cooking before checking recipes
 
 /obj/machinery/appliance/Initialize()
 	. = ..()
@@ -58,7 +58,7 @@
 	..()
 	if(Adjacent(usr))
 		list_contents(user)
-		return 1
+		return TRUE
 
 /obj/machinery/appliance/proc/list_contents(var/mob/user)
 	if (cooking_objs.len)
@@ -219,9 +219,9 @@
 //This function is overridden by cookers that do stuff with containers
 /obj/machinery/appliance/proc/has_space(var/obj/item/I)
 	if (cooking_objs.len >= max_contents)
-		return 0
+		return FALSE
 
-	else return 1
+	else return TRUE
 
 /obj/machinery/appliance/attackby(var/obj/item/I, var/mob/user)
 	if(!cook_type || (stat & (BROKEN)))
@@ -255,7 +255,7 @@
 		return
 
 	var/datum/cooking_item/CI = has_space(I)
-	if (istype(I, /obj/item/weapon/reagent_containers/cooking_container) && CI == 1)
+	if (istype(I, /obj/item/weapon/reagent_containers/cooking_container) && CI)
 		var/obj/item/weapon/reagent_containers/cooking_container/CC = I
 		CI = new /datum/cooking_item/(CC)
 		I.forceMove(src)
@@ -277,7 +277,7 @@
 	user.visible_message("<span class='notice'>\The [user] puts \the [I] into \the [src].</span>")
 
 	get_cooking_work(CI)
-	cooking = 1
+	cooking = TRUE
 	return CI
 
 /obj/machinery/appliance/proc/get_cooking_work(var/datum/cooking_item/CI)
@@ -337,11 +337,11 @@
 //Called every tick while we're cooking something
 /obj/machinery/appliance/proc/do_cooking_tick(var/datum/cooking_item/CI)
 	if (!CI.max_cookwork)
-		return 0
+		return FALSE
 
-	var/was_done = 0
+	var/was_done = FALSE
 	if (CI.cookwork >= CI.max_cookwork)
-		was_done = 1
+		was_done = TRUE
 
 	CI.cookwork += cooking_power
 
@@ -358,7 +358,7 @@
 		if (M)
 			M.apply_damage(rand(1,3), mobdamagetype, "chest")
 
-	return 1
+	return TRUE
 
 /obj/machinery/appliance/machinery_process()
 	if (cooking_power > 0 && cooking)
@@ -515,7 +515,7 @@
 
 /obj/machinery/appliance/proc/burn_food(var/datum/cooking_item/CI)
 	// You dun goofed.
-	CI.burned = 1
+	CI.burned = TRUE
 	CI.container.clear()
 	new /obj/item/weapon/reagent_containers/food/snacks/badrecipe(CI.container)
 
@@ -546,25 +546,25 @@
 			var/datum/cooking_item/CI = menuoptions[selection]
 			eject(CI, user)
 			update_icon()
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/machinery/appliance/proc/can_remove_items(var/mob/user)
 	if (!Adjacent(user))
-		return 0
+		return FALSE
 
 	if (isanimal(user))
-		return 0
+		return FALSE
 
-	return 1
+	return TRUE
 
 /obj/machinery/appliance/proc/eject(var/datum/cooking_item/CI, var/mob/user = null)
 	var/obj/item/thing
-	var/delete = 1
+	var/delete = TRUE
 	var/status = CI.container.check_contents()
 	if (status == 1)//If theres only one object in a container then we extract that
 		thing = locate(/obj/item) in CI.container
-		delete = 0
+		delete = FALSE
 	else//If the container is empty OR contains more than one thing, then we must extract the container
 		thing = CI.container
 	if (!user || !user.put_in_hands(thing))
@@ -642,7 +642,7 @@
 		//3 Combination cooking, EG Donut Bread, Donk pocket pizza, etc
 		//4:Specific recipe cooking. EG: Turning raw potato sticks into fries
 
-	var/burned = 0
+	var/burned = FALSE
 
 	var/oil = 0
 	var/max_oil = 0//Used for fryers.
@@ -655,7 +655,7 @@
 	max_cookwork = 0
 	cookwork = 0
 	result_type = 0
-	burned = 0
+	burned = FALSE
 	max_oil = 0
 	oil = 0
 	combine_target = null

--- a/code/game/machinery/kitchen/cooking_machines/_appliance.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_appliance.dm
@@ -41,13 +41,6 @@
 
 	var/combine_first = 0//If 1, this appliance will do combinaiton cooking before checking recipes
 
-	component_types = list(
-			/obj/item/weapon/circuitboard/cooking,
-			/obj/item/weapon/stock_parts/capacitor = 3,
-			/obj/item/weapon/stock_parts/scanning_module,
-			/obj/item/weapon/stock_parts/matter_bin = 2
-		)
-
 /obj/machinery/appliance/Initialize()
 	. = ..()
 	if(output_options.len)
@@ -214,6 +207,8 @@
 	else if(istype(check, /obj/item/weapon/disk/nuclear))
 		to_chat(user, "<span class='warning'>You can't cook that.</span>")
 		return 0
+	else if(istype(I, /obj/item/weapon/crowbar) || istype(I, /obj/item/weapon/screwdriver) || istype(I, /obj/item/weapon/storage/part_replacer))
+		return 0
 	else if(!istype(check) && !istype(check, /obj/item/weapon/holder))
 		to_chat(user, "<span class='warning'>That's not edible.</span>")
 		return 0
@@ -238,6 +233,8 @@
 		if(default_deconstruction_screwdriver(user, I))
 			return
 		else if(default_part_replacement(user, I))
+			return
+		else if(default_deconstruction_crowbar(user, I))
 			return
 		else
 			return
@@ -679,11 +676,11 @@
 	heating_power = initial(heating_power) + cap_rating * 25
 	cooking_power = cooking_coeff * (1 + (scan_rating + cap_rating) / 20) // 100% eff. becomes 120%, 140%, 160% w/ better parts
 
-/obj/item/weapon/circuitboard/cooking
-	name = "kitchen appliance circuitry"
-	desc = "The circuitboard for many kitchen appliances. Not of much use."
-	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
-	req_components = list(
-							"/obj/item/weapon/stock_parts/capacitor" = 3,
-							"/obj/item/weapon/stock_parts/scanning_module" = 1,
-							"/obj/item/weapon/stock_parts/matter_bin" = 2)
+// /obj/item/weapon/circuitboard/cooking
+// 	name = "kitchen appliance circuitry"
+// 	desc = "The circuitboard for many kitchen appliances. Not of much use."
+// 	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
+// 	req_components = list(
+// 							"/obj/item/weapon/stock_parts/capacitor" = 3,
+// 							"/obj/item/weapon/stock_parts/scanning_module" = 1,
+// 							"/obj/item/weapon/stock_parts/matter_bin" = 2)

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -77,16 +77,11 @@
 /obj/machinery/appliance/cooker/proc/update_cooking_power()
 	var/temp_scale = 0
 	if(temperature > min_temp)
-
-		temp_scale = (temperature - 273.15) / (optimal_temp - 273.15)
-		//If we're between min and optimal this will yield a value in the range 0.4-1
-
-		if (temp_scale > 1)
-			//We're above optimal, efficiency goes down as we pass too much over it
-			if (temp_scale >= 2)
-				temp_scale = 0
-			else
-				temp_scale = 1 - (temp_scale - 1)
+		if(temperature >= optimal_temp)
+			temp_scale = 1
+		else
+			temp_scale = (temperature - 73.15) / (optimal_temp - 73.15)
+		//If we're between min and optimal this will yield a value in the range 0.7 to 1
 
 	cooking_coeff = optimal_power * temp_scale
 	RefreshParts()

--- a/code/game/machinery/kitchen/cooking_machines/_mixer.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_mixer.dm
@@ -12,7 +12,7 @@ fundamental differences
 /obj/machinery/appliance/mixer
 	max_contents = 1
 	stat = POWEROFF
-	cooking_power = 0.4
+	cooking_coeff = 0.75
 	active_power_usage = 3000
 	idle_power_usage = 50
 

--- a/code/game/machinery/kitchen/cooking_machines/candy.dm
+++ b/code/game/machinery/kitchen/cooking_machines/candy.dm
@@ -6,7 +6,7 @@
 	on_icon = "mixer_on"
 	cook_type = "candied"
 	appliancetype = CANDYMAKER
-	cooking_power = 0.6
+	cooking_coeff = 1.0
 
 	output_options = list(
 		"Jawbreaker" = /obj/item/weapon/reagent_containers/food/snacks/variable/jawbreaker,

--- a/code/game/machinery/kitchen/cooking_machines/candy.dm
+++ b/code/game/machinery/kitchen/cooking_machines/candy.dm
@@ -15,6 +15,13 @@
 		"Jelly" = /obj/item/weapon/reagent_containers/food/snacks/variable/jelly
 	)
 
+	component_types = list(
+			/obj/item/weapon/circuitboard/candymachine,
+			/obj/item/weapon/stock_parts/capacitor = 3,
+			/obj/item/weapon/stock_parts/scanning_module,
+			/obj/item/weapon/stock_parts/matter_bin = 2
+		)
+
 /obj/machinery/appliance/mixer/candy/change_product_appearance(var/obj/item/weapon/reagent_containers/food/snacks/cooked/product)
 	food_color = get_random_colour(1)
 	. = ..()

--- a/code/game/machinery/kitchen/cooking_machines/cereal.dm
+++ b/code/game/machinery/kitchen/cooking_machines/cereal.dm
@@ -12,6 +12,13 @@
 		"Cereal" = /obj/item/weapon/reagent_containers/food/snacks/variable/cereal
 	)
 
+	component_types = list(
+			/obj/item/weapon/circuitboard/cerealmaker,
+			/obj/item/weapon/stock_parts/capacitor = 3,
+			/obj/item/weapon/stock_parts/scanning_module,
+			/obj/item/weapon/stock_parts/matter_bin = 2
+		)
+
 /*
 /obj/machinery/appliance/cereal/change_product_strings(var/obj/item/weapon/reagent_containers/food/snacks/product, var/datum/cooking_item/CI)
 	. = ..()

--- a/code/game/machinery/kitchen/cooking_machines/fryer.dm
+++ b/code/game/machinery/kitchen/cooking_machines/fryer.dm
@@ -28,6 +28,13 @@
 	var/optimal_oil = 9000//90 litres of cooking oil
 	var/datum/looping_sound/deep_fryer/fry_loop
 
+	component_types = list(
+			/obj/item/weapon/circuitboard/fryer,
+			/obj/item/weapon/stock_parts/capacitor = 3,
+			/obj/item/weapon/stock_parts/scanning_module,
+			/obj/item/weapon/stock_parts/matter_bin = 2
+		)
+
 /obj/machinery/appliance/cooker/fryer/examine(var/mob/user)
 	if (..())//no need to duplicate adjacency check
 		to_chat(user, "Oil Level: [oil.total_volume]/[optimal_oil]")

--- a/code/game/machinery/kitchen/cooking_machines/oven.dm
+++ b/code/game/machinery/kitchen/cooking_machines/oven.dm
@@ -36,6 +36,13 @@
 		"Donut" = /obj/item/weapon/reagent_containers/food/snacks/variable/donut
 	)
 
+	component_types = list(
+			/obj/item/weapon/circuitboard/oven,
+			/obj/item/weapon/stock_parts/capacitor = 3,
+			/obj/item/weapon/stock_parts/scanning_module,
+			/obj/item/weapon/stock_parts/matter_bin = 2
+		)
+
 
 /obj/machinery/appliance/cooker/oven/update_icon()
 	if (!open)
@@ -72,17 +79,25 @@
 
 	if (open)
 		open = 0
-		loss = (active_power_usage / resistance)*0.5
+		loss = (heating_power / resistance) * 0.5
 	else
 		open = 1
-		loss = (active_power_usage / resistance)*4
-		//When the oven door is opened, heat is lost MUCH faster
+		loss = (heating_power / resistance) * 1.5
+		//When the oven door is opened, oven slowly loses heat
 
 	playsound(src, 'sound/machines/hatch_open.ogg', 20, 1)
 	update_icon()
 
+/obj/machinery/appliance/cooker/oven/proc/manip(var/obj/item/I)
+	// check if someone's trying to manipulate the machine
+
+	if(I.iscrowbar() || I.isscrewdriver() || istype(I, /obj/item/weapon/storage/part_replacer))
+		return TRUE
+	else
+		return FALSE
+
 /obj/machinery/appliance/cooker/oven/can_insert(var/obj/item/I, var/mob/user)
-	if (!open)
+	if (!open && !manip(I))
 		to_chat(user, "<span class='warning'>You can't put anything in while the door is closed!</span>")
 		return 0
 

--- a/code/game/machinery/kitchen/cooking_machines/oven.dm
+++ b/code/game/machinery/kitchen/cooking_machines/oven.dm
@@ -22,7 +22,7 @@
 
 	stat = POWEROFF	//Starts turned off
 
-	var/open = 0 // Start closed so people don't heat up ovens with the door open
+	var/open = FALSE // Start closed so people don't heat up ovens with the door open
 
 	output_options = list(
 		"Pizza" = /obj/item/weapon/reagent_containers/food/snacks/variable/pizza,
@@ -78,10 +78,10 @@
 		return
 
 	if (open)
-		open = 0
+		open = FALSE
 		loss = (heating_power / resistance) * 0.5
 	else
-		open = 1
+		open = TRUE
 		loss = (heating_power / resistance) * 1.5
 		//When the oven door is opened, oven slowly loses heat
 
@@ -117,7 +117,7 @@
 /obj/machinery/appliance/cooker/oven/can_remove_items(var/mob/user)
 	if (!open)
 		to_chat(user, "<span class='warning'>You can't take anything out while the door is closed!</span>")
-		return 0
+		return FALSE
 
 	else
 		return ..()

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -19,6 +19,13 @@
 	var/appliancetype = MICROWAVE
 	var/datum/looping_sound/microwave/soundloop
 
+	component_types = list(
+			/obj/item/weapon/circuitboard/microwave,
+			/obj/item/weapon/stock_parts/capacitor = 3,
+			/obj/item/weapon/stock_parts/scanning_module,
+			/obj/item/weapon/stock_parts/matter_bin = 2
+		)
+
 // see code/modules/food/recipes_microwave.dm for recipes
 
 /*******************
@@ -138,19 +145,27 @@
 		var/obj/item/weapon/grab/G = O
 		to_chat(user, "<span class='warning'>This is ridiculous. You can not fit \the [G.affecting] in this [src].</span>")
 		return 1
+	else if(O.isscrewdriver())
+		default_deconstruction_screwdriver(user, O)
+		return
 	else if(O.iscrowbar())
-		user.visible_message( \
-			"<span class='notice'>\The [user] begins [src.anchored ? "unsecuring" : "securing"] the microwave.</span>", \
-			"<span class='notice'>You attempt to [src.anchored ? "unsecure" : "secure"] the microwave.</span>"
-			)
-		if (do_after(user,20/O.toolspeed))
-			user.visible_message( \
-			"<span class='notice'>\The [user] [src.anchored ? "unsecures" : "secures"] the microwave.</span>", \
-			"<span class='notice'>You [src.anchored ? "unsecure" : "secure"] the microwave.</span>"
-			)
-			src.anchored = !src.anchored
+		if(default_deconstruction_crowbar(user, O))
+			return
 		else
-			to_chat(user, "<span class='notice'>You decide not to do that.</span>")
+			user.visible_message( \
+				"<span class='notice'>\The [user] begins [src.anchored ? "unsecuring" : "securing"] the microwave.</span>", \
+				"<span class='notice'>You attempt to [src.anchored ? "unsecure" : "secure"] the microwave.</span>"
+				)
+			if (do_after(user,20/O.toolspeed))
+				user.visible_message( \
+				"<span class='notice'>\The [user] [src.anchored ? "unsecures" : "secures"] the microwave.</span>", \
+				"<span class='notice'>You [src.anchored ? "unsecure" : "secure"] the microwave.</span>"
+				)
+				src.anchored = !src.anchored
+			else
+				to_chat(user, "<span class='notice'>You decide not to do that.</span>")
+	else if(default_part_replacement(user, O))
+		return
 	else
 
 		to_chat(user, "<span class='warning'>You have no idea what you can cook with this [O].</span>")

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -33,7 +33,7 @@
 ********************/
 
 /obj/machinery/microwave/Initialize(mapload)
-	. = ..()
+	. = ..(mapload, 0, FALSE) // shadow-realm the parts for now, jimbo
 	reagents = new/datum/reagents(100)
 	reagents.my_atom = src
 	soundloop = new(list(src), FALSE)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -394,8 +394,8 @@ Class Procs:
 	playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
 	var/obj/machinery/constructable_frame/machine_frame/M = new /obj/machinery/constructable_frame/machine_frame(loc)
 	M.set_dir(src.dir)
-	M.state = 2
-	M.icon_state = "box_1"
+	M.state = 3
+	M.icon_state = "blueprint_1"
 	for(var/obj/I in component_parts)
 		I.forceMove(loc)
 	qdel(src)

--- a/code/game/objects/items/weapons/circuitboards/machinery/miscboards.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/miscboards.dm
@@ -108,15 +108,61 @@
 							/obj/item/weapon/stock_parts/matter_bin = 1,
 							/obj/item/weapon/stock_parts/micro_laser = 2)
 
-/obj/item/weapon/circuitboard/cooking
-	name = T_BOARD("kitchen appliance")
-	desc = "The circuitboard for many kitchen appliances. Not of much use."
+/obj/item/weapon/circuitboard/microwave
+	name = T_BOARD("microwave")
+	desc = "The circuitboard for a microwave."
+	build_path = "/obj/machinery/microwave"
+	contain_parts = 0
 	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
-	board_type = "other"
+	board_type = "machine"
 	req_components = list(
-							/obj/item/weapon/stock_parts/capacitor = 3,
-							/obj/item/weapon/stock_parts/scanning_module = 1,
-							/obj/item/weapon/stock_parts/matter_bin = 2)
+							"/obj/item/weapon/stock_parts/capacitor" = 3,
+							"/obj/item/weapon/stock_parts/scanning_module" = 1,
+							"/obj/item/weapon/stock_parts/matter_bin" = 2)
+
+/obj/item/weapon/circuitboard/oven
+	name = T_BOARD("oven")
+	desc = "The circuitboard for an oven."
+	build_path = "/obj/machinery/appliance/cooker/oven"
+	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
+	board_type = "machine"
+	req_components = list(
+							"/obj/item/weapon/stock_parts/capacitor" = 3,
+							"/obj/item/weapon/stock_parts/scanning_module" = 1,
+							"/obj/item/weapon/stock_parts/matter_bin" = 2)
+
+/obj/item/weapon/circuitboard/fryer
+	name = T_BOARD("deep fryer")
+	desc = "The circuitboard for a deep fryer."
+	build_path = "/obj/machinery/appliance/cooker/fryer"
+	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
+	board_type = "machine"
+	req_components = list(
+							"/obj/item/weapon/stock_parts/capacitor" = 3,
+							"/obj/item/weapon/stock_parts/scanning_module" = 1,
+							"/obj/item/weapon/stock_parts/matter_bin" = 2)
+
+/obj/item/weapon/circuitboard/cerealmaker
+	name = T_BOARD("cereal maker")
+	desc = "The circuitboard for a cereal maker."
+	build_path = "/obj/machinery/appliance/mixer/cereal"
+	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
+	board_type = "machine"
+	req_components = list(
+							"/obj/item/weapon/stock_parts/capacitor" = 3,
+							"/obj/item/weapon/stock_parts/scanning_module" = 1,
+							"/obj/item/weapon/stock_parts/matter_bin" = 2)
+
+/obj/item/weapon/circuitboard/candymachine
+	name = T_BOARD("candy machine")
+	desc = "The circuitboard for a candy machine."
+	build_path = "/obj/machinery/appliance/mixer/candy"
+	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
+	board_type = "machine"
+	req_components = list(
+							"/obj/item/weapon/stock_parts/capacitor" = 3,
+							"/obj/item/weapon/stock_parts/scanning_module" = 1,
+							"/obj/item/weapon/stock_parts/matter_bin" = 2)
 
 /obj/item/weapon/circuitboard/holopad
 	name = T_BOARD("Holopad")

--- a/code/modules/research/designs/circuit_designs.dm
+++ b/code/modules/research/designs/circuit_designs.dm
@@ -294,7 +294,7 @@
 	name = "smart fridge board"
 	id = "fridge_board"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
-	build_path = /obj/item/weapon/circuitboard/optable
+	build_path = /obj/item/weapon/circuitboard/smartfridge
 	sort_string = "HACAJ"
 
 /datum/design/circuit/requestconsole
@@ -325,6 +325,41 @@
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/weapon/circuitboard/crystelpodconsole
 	sort_string = "HACAL"
+
+/datum/design/circuit/microwave
+	name = "microwave board"
+	id = "microwave_board"
+	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
+	build_path = /obj/item/weapon/circuitboard/microwave
+	sort_string = "HACAM"
+
+/datum/design/circuit/oven
+	name = "oven board"
+	id = "oven_board"
+	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
+	build_path = /obj/item/weapon/circuitboard/oven
+	sort_string = "HACAN"
+
+/datum/design/circuit/fryer
+	name = "deep fryer board"
+	id = "fryer_board"
+	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
+	build_path = /obj/item/weapon/circuitboard/fryer
+	sort_string = "HACAO"
+
+/datum/design/circuit/cerealmaker
+	name = "cereal maker board"
+	id = "cerealmaker_board"
+	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
+	build_path = /obj/item/weapon/circuitboard/cerealmaker
+	sort_string = "HACAP"
+
+/datum/design/circuit/candymaker
+	name = "candy machine board"
+	id = "candymachine_board"
+	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
+	build_path = /obj/item/weapon/circuitboard/candymachine
+	sort_string = "HACAQ"
 
 
 

--- a/html/changelogs/johnwildkins-7174.yml
+++ b/html/changelogs/johnwildkins-7174.yml
@@ -1,0 +1,47 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Microwave, oven, deep fryer, cereal maker, and candy maker circuit boards added."
+  - rscadd: "You can now upgrade and deconstruct/reconstruct microwaves and other cooking appliances. Note: upgrading microwaves has no effect (TBC)."
+  - tweak: "Oven efficiency now starts at 70% and grows slower to 100%."
+  - tweak: "Oven heat loss due to door open cut down massively, to 1.5x heating from 4x."
+  - tweak: "Deconstructing a machine now returns cable coil. Wirecutting a blueprint on the cable-coil stage lowers it to the 'secured blueprint' stage, and as such now requires a wrench to remove."
+  - bugfix: "Printing a smart-fridge board no longer gives you an operating table circuit board."
+  - bugfix: "Deconstructing a machine no longer displays the incorrect icon state."

--- a/html/changelogs/johnwildkins-7174.yml
+++ b/html/changelogs/johnwildkins-7174.yml
@@ -45,3 +45,4 @@ changes:
   - tweak: "Deconstructing a machine now returns cable coil. Wirecutting a blueprint on the cable-coil stage lowers it to the 'secured blueprint' stage, and as such now requires a wrench to remove."
   - bugfix: "Printing a smart-fridge board no longer gives you an operating table circuit board."
   - bugfix: "Deconstructing a machine no longer displays the incorrect icon state."
+  - bugfix: "Candy and cereal makers no longer fail to cook."

--- a/html/changelogs/johnwildkins-7174.yml
+++ b/html/changelogs/johnwildkins-7174.yml
@@ -39,7 +39,7 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Microwave, oven, deep fryer, cereal maker, and candy maker circuit boards added."
-  - rscadd: "You can now upgrade and deconstruct/reconstruct microwaves and other cooking appliances. Note: upgrading microwaves has no effect (TBC)."
+  - rscadd: "You can now upgrade and deconstruct/reconstruct microwaves and other cooking appliances. Note: advanced parts currently do not affect microwaves, and deconstructing a microwave yields no parts. This will be fixed in the overhaul."
   - tweak: "Oven efficiency now starts at 70% and grows slower to 100%."
   - tweak: "Oven heat loss due to door open cut down massively, to 1.5x heating from 4x."
   - tweak: "Deconstructing a machine now returns cable coil. Wirecutting a blueprint on the cable-coil stage lowers it to the 'secured blueprint' stage, and as such now requires a wrench to remove."


### PR DESCRIPTION
Resolves #7172. Resolves #7190.

Cooking appliances are no longer esoteric technology beyond the control of NT's finest researchers.

- Adds microwave, oven, deep fryer, cereal maker, and candy maker circuit boards for research and construction.
- Constructing, upgrading, and deconstructing microwaves and other cooking appliances is now possible. (Note, as of yet upgrading microwaves has no purpose. Will be fixed ASAP along w/ microwave overhaul)
- Oven efficiency now starts at 70% once pre-heated, to alleviate the incredibly slow cooking times at round-start.
- Oven heat loss from the door being open cut down to 1.5x from 4x.
- Deconstructing a machine now returns cable coil.
- Wirecutting a blueprint on the cable-coil stage lowers it to the 'secured blueprint' stage, requiring a wrench to disassemble instead of wirecutters again.
- Printing a smart-fridge board no longer gives you an operating table circuit board.
- Deconstructing a machine no longer displays the incorrect icon state (box instead of blueprint).
- Candy and cereal makers work again. (woops)