### PR TITLE
Misc. kitchen / reagent fixes

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/_cooker_output.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker_output.dm
@@ -34,7 +34,7 @@
 	M.Scale(scale)
 	src.transform = M
 
-	w_class *= scale
+	w_class = round(w_class * scale)
 	if (!prefix)
 		if (scale == min_scale)
 			prefix = "tiny"

--- a/code/game/machinery/kitchen/cooking_machines/oven.dm
+++ b/code/game/machinery/kitchen/cooking_machines/oven.dm
@@ -113,6 +113,7 @@
 /obj/machinery/appliance/cooker/oven/finish_cooking(var/datum/cooking_item/CI)
 	if(CI.combine_target)
 		CI.result_type = 3//Combination type. We're making something out of our ingredients
+		src.visible_message("<span class='notice'>\The [src] pings!</span>")
 		combination_cook(CI)
 		return
 	else

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -16,6 +16,9 @@
 			return 0
 	return 1
 
+/mob/living/bot/isSynthetic()
+	return 1
+
 /mob/living/silicon/isSynthetic()
 	return 1
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3169,7 +3169,7 @@
 	id = "ice_to_water"
 	result = "water"
 	required_reagents = list("ice" = 1)
-	required_temperatures_min = list("ice" = T0C + 1)
+	required_temperatures_min = list("ice" = T0C + 25) // stop-gap fix to allow recipes requiring ice to be made without breaking the server with HALF_LIFE
 	result_amount = 1
 	mix_message = "The ice melts."
 	reaction_sound = ""

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -169,6 +169,14 @@
 		to_chat(user, "<span class='notice'>\The [src] is empty.</span>")
 		return 1
 
+	var/mob/living/list/eaters = list(
+		/mob/living/carbon,
+		/mob/living/simple_animal
+	)
+
+	if(!is_type_in_list(target, eaters))
+		return 0
+
 	//var/types = target.find_type()
 
 	var/mob/living/carbon/human/H

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -157,7 +157,7 @@
 /obj/item/weapon/reagent_containers/proc/feed_sound(var/mob/user)
 	playsound(user.loc, 'sound/items/drink.ogg', rand(10, 50), 1)
 
-/obj/item/weapon/reagent_containers/proc/standard_feed_mob(var/mob/user, var/mob/target) // This goes into attack
+/obj/item/weapon/reagent_containers/proc/standard_feed_mob(var/mob/user, var/mob/living/target) // This goes into attack
 
 	if(!istype(target))
 		return 0
@@ -169,13 +169,8 @@
 		to_chat(user, "<span class='notice'>\The [src] is empty.</span>")
 		return 1
 
-	var/mob/living/list/eaters = list(
-		/mob/living/carbon,
-		/mob/living/simple_animal
-	)
-
-	if(!is_type_in_list(target, eaters))
-		return 0
+	if(target.isSynthetic() && !isipc(target))
+		return FALSE
 
 	//var/types = target.find_type()
 

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -41,7 +41,7 @@
 /obj/item/weapon/reagent_containers/food/drinks/proc/boom(mob/user as mob)
 	user.visible_message("<span class='danger'>\The [src] explodes all over [user] as they open it!</span>","<span class='danger'>\The [src] explodes all over you as you open it!</span>","You can hear a soda can explode.")
 	playsound(loc,'sound/items/soda_burst.ogg', rand(20,50), 1)
-	QDEL_NULL(reagents)
+	reagents.clear_reagents()
 	flags |= OPENCONTAINER
 	shaken = 0
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -271,7 +271,7 @@
 
 //Code for dipping food in batter
 /obj/item/weapon/reagent_containers/food/snacks/afterattack(obj/O as obj, mob/user as mob, proximity)
-	if(O.is_open_container() && O.reagents && !(istype(O, /obj/item/weapon/reagent_containers/food)))
+	if(O.is_open_container() && O.reagents && !(istype(O, /obj/item/weapon/reagent_containers/food)) && proximity)
 		for (var/r in O.reagents.reagent_list)
 
 			var/datum/reagent/R = r
@@ -4442,13 +4442,13 @@
 	icon_state = "lasagna"
 	trash = /obj/item/trash/grease
 	center_of_mass = list("x"=16, "y"=17)
-	nutriment_amt = 5
+	nutriment_amt = 12
 	nutriment_desc = list("pasta" = 4, "tomato" = 2)
 	bitesize = 6
 
-/obj/item/weapon/reagent_containers/food/snacks/classichotdog/Initialize()
+/obj/item/weapon/reagent_containers/food/snacks/lasagna/Initialize()
 	. = ..()
-	reagents.add_reagent("protein", 4)
+	reagents.add_reagent("protein", 12)
 
 /obj/item/weapon/reagent_containers/food/snacks/donerkebab
 	name = "doner kebab"
@@ -4460,7 +4460,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/donerkebab/Initialize()
 	. = ..()
-	reagents.add_reagent("protein", 2)
+	reagents.add_reagent("protein", 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/sashimi
 	name = "carp sashimi"

--- a/html/changelogs/johnwildkins-7182.yml
+++ b/html/changelogs/johnwildkins-7182.yml
@@ -1,0 +1,46 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Reagent ice now melts at 25 C, allowing drinks requiring it to be made once again."
+  - bugfix: "Soda cans (incl. water bottles) can now be filled, and no longer freeze chemistry interfaces when inserted."
+  - bugfix: "Custom outputs from cooking appliances (personal pizzas, etc.) should now fit inside storage containers."
+  - bugfix: "The oven now pings when a custom output is completed."
+  - bugfix: "You can no longer force-feed robots or silicons."
+  - bugfix: "Batter can no longer be applied from infinite distance. Lasagna and doner kebab have had their reagents boosted to match their ingredients."


### PR DESCRIPTION
A shotgun-blast of various minor fixes as well as a somewhat-large tweak.

- **Ice now melts at 25C.** Other methods to fix the ice-instantly-melting issue didn't end so well ( #6617 et al.) and this seems to be how most baycode implementations handle the problem. If someone has a better solution, please, suggest, and I'll nuke this into the floor. Fixes #6119.

- Soda cans (incl. water bottles) can now be re-filled after bursting open from shaking. This also fixes a crash related to putting these cans into chem machines and the like. Fixes #6499.
- Robots and silicons can no longer be force-fed. Fixes #5016.
- Custom output food from cooking appliances now fits inside storage containers. Fixes #4106.
- Custom output food from the oven now causes a 'ding' as with normal cooking. Fixes #3904.
- Batter now requires proximity to be applied. Fixes #5724.
- Lasagne and doner kebab contents buffed to match the ingredients used in their creation. Fixes #6195.