### PR TITLE
Removes roundstart AI core, adds additional stationbound slot.

### DIFF
--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -4,7 +4,7 @@
 	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 0 // Not used for AI, see is_position_available below and modules/mob/living/silicon/ai/latejoin.dm
-	spawn_positions = 1
+	spawn_positions = 0
 	selection_color = "#00ff00"
 	supervisors = "your laws"
 	minimal_player_age = 7
@@ -27,8 +27,8 @@
 	flag = CYBORG
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#4dff4d"
 	minimal_player_age = 1

--- a/html/changelogs/geeves - deletAI.yml
+++ b/html/changelogs/geeves - deletAI.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Geeves
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "The AI core has been removed, meaning no AI spawns at roundstart, or can latejoin into it. Robotics will need to manufacture a new one if the going gets tough."
+  - rscadd: "An additional stationbound can spawn to compensate for this loss."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -6532,9 +6532,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/landmark{
-	name = "tripai"
-	},
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";
 	temperature = 278
@@ -6627,6 +6624,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/effect/landmark/start{
+	name = "Cyborg"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_cyborg_station)
@@ -7330,7 +7330,8 @@
 	pixel_y = 36
 	},
 /obj/machinery/turretid/stun{
-	check_synth = 1;
+	check_synth = 0;
+	enabled = 0;
 	name = "AI Chamber turret control";
 	pixel_x = 36;
 	pixel_y = 36
@@ -7390,9 +7391,6 @@
 /obj/structure/cable/cyan{
 	d2 = 4;
 	icon_state = "0-4"
-	},
-/obj/effect/landmark/start{
-	name = "AI"
 	},
 /turf/simulated/floor/bluegrid{
 	name = "cooled mainframe floor";


### PR DESCRIPTION
* The AI core has been removed, meaning no AI spawns at roundstart, or can latejoin into it. Robotics will need to manufacture a new one if the going gets tough.
* An additional stationbound slot has been opened to compensate for this loss.