### PR TITLE
'Toggle Helmet' action button for voidsuits

### DIFF
--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -56,6 +56,8 @@
 		"Machine" = 'icons/obj/clothing/species/machine/suits.dmi'
 		)
 
+	action_button_name = "Toggle Helmet"
+
 	//Breach thresholds, should ideally be inherited by most (if not all) voidsuits.
 	//With 0.2 resiliance, will reach 10 breach damage after 3 laser carbine blasts or 8 smg hits.
 	breach_threshold = 18
@@ -193,6 +195,9 @@
 	tank.canremove = 1
 	H.drop_from_inventory(tank)
 	src.tank = null
+
+/obj/item/clothing/suit/space/void/attack_self()
+	toggle_helmet()
 
 /obj/item/clothing/suit/space/void/attackby(obj/item/W as obj, mob/user as mob)
 

--- a/html/changelogs/johnwildkins-7184.yml
+++ b/html/changelogs/johnwildkins-7184.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Voidsuits now have an action button to deploy or retract their helmet."


### PR DESCRIPTION
Voidsuits now have a 'Toggle Helmet' button just like Toggle Helmet Light or Toggle Magboots.

Full credit to Kasuobes and Baystation12/Baystation12#15923, for coming up with a much more elegant solution than I could in ten minutes.

![t3IuKFipGt](https://user-images.githubusercontent.com/6022823/67016085-9b863c00-f0c5-11e9-9afd-5151367fbe9b.gif)
