### PR TITLE
Binoculars now zoom out if the user moves

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -218,7 +218,7 @@
 		if(L.incorporeal_move)//Move though walls
 			Process_Incorpmove(direct)
 			return
-		if(mob.client && (mob.client.view != world.view) || (mob.client.pixel_x != 0) || (mob.client.pixel_y != 0))		// If mob moves while zoomed in with device, unzoom them.
+		if(mob.client && ((mob.client.view != world.view) || (mob.client.pixel_x != 0) || (mob.client.pixel_y != 0)))		// If mob moves while zoomed in with device, unzoom them.
 			for(var/obj/item/item in mob)
 				if(item.zoom)
 					item.zoom(mob)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -218,8 +218,7 @@
 		if(L.incorporeal_move)//Move though walls
 			Process_Incorpmove(direct)
 			return
-
-		if(mob.client && mob.client.view != world.view)		// If mob moves while zoomed in with device, unzoom them.
+		if(mob.client && (mob.client.view != world.view) || (mob.client.pixel_x != 0) || (mob.client.pixel_y != 0))		// If mob moves while zoomed in with device, unzoom them.
 			for(var/obj/item/item in mob)
 				if(item.zoom)
 					item.zoom(mob)

--- a/html/changelogs/johnwildkins-7187.yml
+++ b/html/changelogs/johnwildkins-7187.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Binoculars now correctly zoom out when the user moves."


### PR DESCRIPTION
Fixes the /client/Move check for zoomed entities to check for pixel displacement, and not just view displacement itself (since the binoculars don't change view size)

Fixes #5689