### PR TITLE
Adds ability to print Yield Declarations to the Ore Redemption Console

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -176,6 +176,10 @@
 	if(!input_mats.len && !output_mats.len && !alloy_mats)
 		to_chat(user, span("warning", "There is no data to print."))
 		return
+	if(printing)
+		return
+
+	printing = TRUE
 
 	var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(user.loc)
 	var/date_string = worlddate2text()
@@ -194,18 +198,22 @@
 	dat += "Ore Yields: <br>"
 
 	dat += "<table>"
-	for(var/material/OM in output_mats) {
+
+	for(var/material/OM in output_mats)
 		if(output_mats[OM] > 1)
 			dat += "<tr><td><b><small>[output_mats[OM]]</b></small></td><td><small>[OM.display_name] [OM.sheet_plural_name]</small></td></tr>"
 		else
 			dat += "<tr><td><b><small>[output_mats[OM]]</b></small></td><td><small>[OM.display_name] [OM.sheet_singular_name]</small></td></tr>"
-	}
-	for(var/datum/alloy/AM in alloy_mats) {
+
+	CHECK_TICK
+
+	for(var/datum/alloy/AM in alloy_mats)
 		if(alloy_mats[AM] > 1)
 			dat += "<tr><td><b><small>[alloy_mats[AM]]</b></td><td><small>[AM.metaltag] sheets</small></td></tr>"
 		else
 			dat += "<tr><td><b><small>[alloy_mats[AM]]</b></td><td><small>[AM.metaltag] sheet</small></td></tr>"
-	}
+
+	CHECK_TICK
 
 	dat += "</table><br>"
 
@@ -213,12 +221,14 @@
 		dat += "Waste detected: "
 		dat += "[waste] unit(s) of material were wasted due to operator error. This includes: <br>"
 		dat += "<table>"
-		for(var/ore/IM in input_mats) {
+		for(var/ore/IM in input_mats)
 			if(input_mats[IM] > 1)
 				dat += "<tr><td><b><small>[input_mats[IM]]</small></b></td><td><small>[IM.display_name]</small></td></tr>"
 			else
 				dat += "<tr><td><b><small>[input_mats[IM]]</small></b></td><td><small>[IM.display_name]</small></td></tr>"
-		}
+
+		CHECK_TICK
+
 		dat += "</table><br>"
 
 	dat += "Additional Notes: <span class=\"paper_field\"></span><br><br>"
@@ -250,6 +260,7 @@
 	if(ishuman(user) && !(user.l_hand && user.r_hand))
 		user.put_in_hands(P)
 
+	printing = FALSE
 	return
 
 /**********************Mineral processing unit**************************/

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -205,7 +205,7 @@
 		else
 			dat += "<tr><td><b><small>[output_mats[OM]]</b></small></td><td><small>[OM.display_name] [OM.sheet_singular_name]</small></td></tr>"
 
-	CHECK_TICK
+		CHECK_TICK
 
 	for(var/datum/alloy/AM in alloy_mats)
 		if(alloy_mats[AM] > 1)
@@ -213,7 +213,7 @@
 		else
 			dat += "<tr><td><b><small>[alloy_mats[AM]]</b></td><td><small>[AM.metaltag] sheet</small></td></tr>"
 
-	CHECK_TICK
+		CHECK_TICK
 
 	dat += "</table><br>"
 
@@ -227,7 +227,7 @@
 			else
 				dat += "<tr><td><b><small>[input_mats[IM]]</small></b></td><td><small>[IM.display_name]</small></td></tr>"
 
-		CHECK_TICK
+			CHECK_TICK
 
 		dat += "</table><br>"
 

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -17,7 +17,7 @@
 
 	var/ore/list/input_mats = list()
 	var/material/list/output_mats = list()
-	var/datum/alloy/alloy_mats = list()
+	var/datum/alloy/list/alloy_mats = list()
 	var/waste = 0
 	var/idx = 0
 
@@ -173,7 +173,7 @@
 	if(!inserted_id)
 		to_chat(user, span("warning", "No ID inserted. Cannot digitally sign."))
 		return
-	if(!input_mats.len && !output_mats.len && !alloy_mats.len)
+	if(!input_mats.len && !output_mats.len && !alloy_mats)
 		to_chat(user, span("warning", "There is no data to print."))
 		return
 

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -15,6 +15,12 @@
 	var/points = 0
 	var/obj/item/weapon/card/id/inserted_id
 
+	var/ore/list/input_mats = list()
+	var/material/list/output_mats = list()
+	var/datum/alloy/alloy_mats = list()
+	var/waste = 0
+	var/idx = 0
+
 /obj/machinery/mineral/processing_unit_console/proc/setup_machine(mob/user)
 	if(!machine)
 		var/area/A = get_area(src)
@@ -65,6 +71,7 @@
 	if(istype(inserted_id))
 		dat += "You have [inserted_id.mining_points] mining points collected. <A href='?src=\ref[src];choice=eject'>Eject ID.</A><br>"
 		dat += "<A href='?src=\ref[src];choice=claim'>Claim points.</A><br>"
+		dat += "<A href='?src=\ref[src];choice=print_report'>Print yield declaration.</A><br>"
 	else
 		dat += "No ID inserted.  <A href='?src=\ref[src];choice=insert'>Insert ID.</A><br>"
 
@@ -121,6 +128,12 @@
 						to_chat(usr, "<span class='warning'>[station_name()]'s mining division is currently indebted to NanoTrasen. Transaction incomplete until debt is cleared.</span>")
 				else
 					to_chat(usr, "<span class='warning'>Required access not found.</span>")
+			if(href_list["choice"] == "print_report")
+				if(access_mining_station in inserted_id.access)
+					print_report(usr)
+				else
+					to_chat(usr, "<span class='warning'>Required access not found.</span>")
+
 		else if(href_list["choice"] == "insert")
 			var/obj/item/weapon/card/id/I = usr.get_active_hand()
 			if(istype(I))
@@ -154,6 +167,89 @@
 		show_all_ores = !show_all_ores
 
 	src.updateUsrDialog()
+	return
+
+/obj/machinery/mineral/processing_unit_console/proc/print_report(var/mob/living/user)
+	if(!inserted_id)
+		to_chat(user, span("warning", "No ID inserted. Cannot digitally sign."))
+		return
+	if(!input_mats.len && !output_mats.len)
+		to_chat(user, span("warning", "There is no data to print."))
+		return
+
+	var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(loc)
+	var/date_string = worlddate2text()
+	idx++
+
+	var/form_title = "Form 0600 - Mining Yield Declaration"
+	var/dat = "<small><center><b>NanoTrasen Inc.<br>"
+	dat += "Civilian Branch of Operation</b><br><br>"
+
+	dat += "Form 0600<br> Mining Yield Declaration</center><hr>"
+	dat += "Facility: NSS Aurora<br>"
+	dat += "Date: [date_string]<br>"
+	dat += "Index: [idx]<br><br>"
+
+	dat += "Miner(s): <span class=\"paper_field\"></span><br>"
+	dat += "Ore Yields: <br>"
+
+	dat += "<table>"
+	for(var/material/OM in output_mats) {
+		if(output_mats[OM] > 1)
+			dat += "<tr><td><b><small>[output_mats[OM]]</b></small></td><td><small>[OM.display_name] [OM.sheet_plural_name]</small></td></tr>"
+		else
+			dat += "<tr><td><b><small>[output_mats[OM]]</b></small></td><td><small>[OM.display_name] [OM.sheet_singular_name]</small></td></tr>"
+	}
+	for(var/datum/alloy/AM in alloy_mats) {
+		if(alloy_mats[AM] > 1)
+			dat += "<tr><td><b><small>[alloy_mats[AM]]</b></td><td><small>[AM.metaltag] sheets</small></td></tr>"
+		else
+			dat += "<tr><td><b><small>[alloy_mats[AM]]</b></td><td><small>[AM.metaltag] sheet</small></td></tr>"
+	}
+
+	dat += "</table><br>"
+
+	if(waste > 0)
+		dat += "Waste detected: "
+		dat += "[waste] unit(s) of material were wasted due to operator error. This includes: <br>"
+		dat += "<table>"
+		for(var/ore/IM in input_mats) {
+			if(input_mats[IM] > 1)
+				dat += "<tr><td><b><small>[input_mats[IM]]</small></b></td><td><small>[IM.display_name]</small></td></tr>"
+			else
+				dat += "<tr><td><b><small>[input_mats[IM]]</small></b></td><td><small>[IM.display_name]</small></td></tr>"
+		}
+		dat += "</table><br>"
+
+	dat += "Additional Notes: <span class=\"paper_field\"></span><br><br>"
+
+	dat += "Quartermaster's / Head of Personnel's / Captain's Stamp: </small>"
+
+	P.set_content(form_title, dat)
+
+	//stamp the paper
+	var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+	stampoverlay.icon_state = "paper_stamp-cent"
+	if(!P.stamped)
+		P.stamped = new
+	P.offset_x += 0
+	P.offset_y += 0
+	P.ico += "paper_stamp-cent"
+	P.stamped += /obj/item/weapon/stamp
+	P.add_overlay(stampoverlay)
+	P.stamps += "<HR><i>This paper has been stamped by the NT Ore Processing System.</i>"
+
+	playsound(loc, "sound/bureaucracy/print.ogg", 75, 1)
+	user.visible_message("\The [src] spits out a piece of paper.")
+
+	// reset
+	output_mats = list()
+	input_mats = list()
+	waste = 0
+
+	if(istype(user,/mob/living/carbon/human) && !(user.l_hand && user.r_hand))
+		user.put_in_hands(P)
+
 	return
 
 /**********************Mineral processing unit**************************/
@@ -275,6 +371,7 @@
 							sheets += total-1
 
 						for(var/i=0,i<total,i++)
+							console.alloy_mats[A]++
 							new A.product(output.loc)
 
 			else if(ores_processing[metal] == 2 && O.compresses_to) //Compressing.
@@ -293,6 +390,7 @@
 					use_power(100)
 					ores_stored[metal]-=2
 					sheets+=2
+					console.output_mats[M]++
 					new M.stack_type(output.loc)
 
 			else if(ores_processing[metal] == 1 && O.smelts_to) //Smelting.
@@ -309,6 +407,7 @@
 					use_power(100)
 					ores_stored[metal]--
 					sheets++
+					console.output_mats[M]++
 					new M.stack_type(output.loc)
 			else
 				if(console)
@@ -316,6 +415,8 @@
 				use_power(500)
 				ores_stored[metal]--
 				sheets++
+				console.input_mats[O]++
+				console.waste++
 				new /obj/item/weapon/ore/slag(output.loc)
 		else
 			continue

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -173,7 +173,7 @@
 	if(!inserted_id)
 		to_chat(user, span("warning", "No ID inserted. Cannot digitally sign."))
 		return
-	if(!input_mats.len && !output_mats.len)
+	if(!input_mats.len && !output_mats.len && !alloy_mats.len)
 		to_chat(user, span("warning", "There is no data to print."))
 		return
 

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -177,7 +177,7 @@
 		to_chat(user, span("warning", "There is no data to print."))
 		return
 
-	var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(loc)
+	var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(user.loc)
 	var/date_string = worlddate2text()
 	idx++
 
@@ -247,7 +247,7 @@
 	input_mats = list()
 	waste = 0
 
-	if(istype(user,/mob/living/carbon/human) && !(user.l_hand && user.r_hand))
+	if(ishuman(user) && !(user.l_hand && user.r_hand))
 		user.put_in_hands(P)
 
 	return

--- a/html/changelogs/johnwildkins-7192.yml
+++ b/html/changelogs/johnwildkins-7192.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Add the ability for ore redemption consoles to print yield declaration reports, with a valid inserted ID and prior processed ores."


### PR DESCRIPTION
Title. Yield Declarations follow standard format, with the addition of an optional 'waste detected' field that displays any materials that the miners wasted. This also offers a vague IC trade-off if the miners are lazy but also suck at their jobs. The papers are also auto-stamped by the machine, although they should still be stamped by a QM or head as well, this is just a certificate of authenticity so to speak.

Yield Declarations can only be printed with an inserted ID and any amount of output materials (or wasted input). The miner and note fields are left blank to be filled in by the user, see below.

![](https://i.imgur.com/3gmpnMO.png)

![](https://i.imgur.com/PTxNqXF.png)