### PR TITLE
Fix borg inflatable dispenser

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -285,12 +285,12 @@
 	to_chat(user, "It has [stored_walls] wall segment\s and [stored_doors] door segment\s stored.")
 	to_chat(user, "It is set to deploy [mode ? "doors" : "walls"]")
 
-/obj/item/weapon/inflatable_dispenser/attack_self()
+/obj/item/weapon/inflatable_dispenser/attack_self(mob/user)
 	if(!deploying)
 		mode = !mode
-		to_chat(usr, "You set \the [src] to deploy [mode ? "doors" : "walls"].")
+		to_chat(user, "You set \the [src] to deploy [mode ? "doors" : "walls"].")
 	else
-		to_chat(usr, span("warning", "You can't do that while deploying a [mode ? "door" : "wall"]!"))
+		to_chat(user, span("warning", "You can't do that while deploying a [mode ? "door" : "wall"]!"))
 
 /obj/item/weapon/inflatable_dispenser/afterattack(var/atom/A, var/mob/user)
 	..(A, user)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -286,8 +286,11 @@
 	to_chat(user, "It is set to deploy [mode ? "doors" : "walls"]")
 
 /obj/item/weapon/inflatable_dispenser/attack_self()
-	mode = !mode
-	to_chat(usr, "You set \the [src] to deploy [mode ? "doors" : "walls"].")
+	if(!deploying)
+		mode = !mode
+		to_chat(usr, "You set \the [src] to deploy [mode ? "doors" : "walls"].")
+	else
+		to_chat(usr, span("warning", "You can't do that while deploying a [mode ? "door" : "wall"]!"))
 
 /obj/item/weapon/inflatable_dispenser/afterattack(var/atom/A, var/mob/user)
 	..(A, user)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -290,7 +290,7 @@
 		mode = !mode
 		to_chat(user, "You set \the [src] to deploy [mode ? "doors" : "walls"].")
 	else
-		to_chat(user, span("warning", "You can't do that while deploying a [mode ? "door" : "wall"]!"))
+		to_chat(user, span("warning", "You can't switch modes while deploying a [mode ? "door" : "wall"]!"))
 
 /obj/item/weapon/inflatable_dispenser/afterattack(var/atom/A, var/mob/user)
 	..(A, user)

--- a/html/changelogs/johnwildkins-7193.yml
+++ b/html/changelogs/johnwildkins-7193.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed an issue where borgs could swap the mode of their inflatable dispenser while deploying one, thereby creating an unrecoverable door or wall."


### PR DESCRIPTION
Fixes #7191.

Simply put, borg inflatable dispenser didn't have a check to see if it was actively deploying, so you could swap modes and place down an unrecoverable barricade as per issue linked above. This resolves that issue.