### PR TITLE
Moves "Adjust Mask" verb to the "Object" group

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -562,6 +562,8 @@
 	return
 
 /obj/item/clothing/mask/proc/adjust_mask(mob/user)
+	set name = "Adjust Mask"
+	set category = "Object"
 	if(!adjustable)
 		return
 	if(use_check_and_message(user))

--- a/html/changelogs/aleksix-mask_adjust_fix.yml
+++ b/html/changelogs/aleksix-mask_adjust_fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: aleksix
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Mask adjustment command now resides in the Object group and is properly capitalized, instead of having a separate category."


### PR DESCRIPTION
Breath masks, as well as other adjustable masks, didn't have a proper name and category set for them, resulting in "adjust mask" verb being in its own "commands" category. This PR capitalizes the verb name and moves it into "Object" category.