### PR TITLE
Cyborg grabber QOL and fixes

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -262,7 +262,6 @@
 				var/mob/living/silicon/robot/R = usr
 				if(R.module)
 					R.uneq_active()
-					R.hud_used.update_robot_modules_display()
 				else
 					to_chat(R, "You haven't selected a module yet.")
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -85,6 +85,9 @@ Contains:
 	if(..())
 		return 1
 
+	if (!can_use(1, user))
+		return 0
+
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
@@ -152,6 +155,9 @@ Contains:
 	if(..())
 		return 1
 
+	if (!can_use(1, user))
+		return 0
+
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
@@ -192,6 +198,9 @@ Contains:
 /obj/item/stack/medical/advanced/bruise_pack/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(..())
 		return 1
+
+	if (!can_use(1, user))
+		return 0
 
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -351,6 +360,9 @@ Contains:
 /obj/item/stack/medical/splint/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(..())
 		return 1
+
+	if (!can_use(1, user))
+		return 0
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -21,6 +21,8 @@
 /obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob, var/target_zone)
 	if (!istype(M) || !istype(user))
 		return 0
+	if (!can_use(1, user))
+		return 0
 	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs
 		var/mob/living/silicon/robot/R = M
 		if (R.getBruteLoss() || R.getFireLoss() )

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -190,8 +190,10 @@
 
 //Return 1 if an immediate subsequent call to use() would succeed.
 //Ensures that code dealing with stacks uses the same logic
-/obj/item/stack/proc/can_use(var/used)
+/obj/item/stack/proc/can_use(var/used, var/mob/user=null)
 	if (get_amount() < used)
+		if(user && isrobot(user))
+			to_chat(user, span("warning", "You don't have enough charge left in your synthesizer!"))
 		return 0
 	return 1
 
@@ -211,7 +213,8 @@
 			return 0
 		for(var/i = 1 to charge_costs.len)
 			var/datum/matter_synth/S = synths[i]
-			S.use_charge(charge_costs[i] * used) // Doesn't need to be deleted
+			if(!S.use_charge(charge_costs[i] * used)) // Doesn't need to be deleted
+				return 0
 		return 1
 	return 0
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -320,7 +320,7 @@
 	if(!usr.canmove || usr.stat || usr.restrained()) // Don't use it if you're not able to! Checks for stuns, ghost and restrain
 		return
 
-	if(ishuman(usr))
+	if(ishuman(usr) || isrobot(usr))
 		add_fingerprint(usr)
 		togglelock(usr)
 	else

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -282,6 +282,7 @@
 					continue
 				NG.attackby(G, user)
 			to_chat(user, "You add the newly-formed grass to the stack. It now contains [G.amount] tiles.")
+		user.drop_from_inventory(src)
 		qdel(src)
 		return
 

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -207,7 +207,8 @@
 		/obj/item/weapon/card/id,
 		/obj/item/weapon/book,
 		/obj/item/weapon/newspaper,
-		/obj/item/weapon/stamp
+		/obj/item/weapon/stamp,
+		/obj/item/weapon/ducttape
 		)
 
 /obj/item/weapon/gripper/research //A general usage gripper, used for toxins/robotics/xenobio/etc
@@ -233,7 +234,9 @@
 		/obj/item/weapon/disk,
 		/obj/item/device/analyzer/plant_analyzer,//For farmbot construction
 		/obj/item/weapon/material/minihoe,//Farmbots and xenoflora
-		/obj/item/weapon/computer_hardware
+		/obj/item/weapon/computer_hardware,
+		/obj/item/weapon/slimesteroid,
+		/obj/item/weapon/slimesteroid2
 		)
 
 /obj/item/weapon/gripper/chemistry //A gripper designed for chemistry, to allow borgs to work efficiently in the lab

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -252,6 +252,7 @@
 		/obj/item/weapon/reagent_containers/spray,
 		/obj/item/weapon/storage/pill_bottle,
 		/obj/item/weapon/hand_labeler,
+		/obj/item/weapon/paper,
 		/obj/item/stack/material/phoron
 		)
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -3,6 +3,7 @@
 
 //Returns the thing in our active hand (whatever is in our active module-slot, in this case)
 /mob/living/silicon/robot/get_active_hand()
+	// TODO: see if refactoring this to return the gripped object (should one exist) works - would make a lot of edge cases a lot simpler
 	return module_active
 
 /*-------TODOOOOOOOOOO--------*/
@@ -11,7 +12,7 @@
 /mob/living/silicon/robot/verb/cmd_unequip_module()
 	set name = "unequip-module"
 	set hidden = 1
-	uneq_active()
+	drop_item()
 
 /mob/living/silicon/robot/verb/cmd_toggle_module(module as num)
 	set name = "toggle-module"
@@ -52,7 +53,9 @@
 		module_state_3:loc = module
 		module_state_3 = null
 		inv3.icon_state = "inv3"
+
 	updateicon()
+	hud_used.update_robot_modules_display()
 
 /mob/living/silicon/robot/proc/uneq_all()
 	module_active = null
@@ -268,12 +271,14 @@
 	return 0
 
 
-//If our active module is a gripper, drop the thing in it.
-//Otherwise do nothing. We don't drop our modules
-/mob/living/silicon/robot/drop_item(var/atom/target)
+/mob/living/silicon/robot/drop_item()
 	if (istype(module_active, /obj/item/weapon/gripper))
 		var/obj/item/weapon/gripper/G = module_active
-		G.drop(target)
+		if (G.wrapped)
+			G.drop_item()
+			return
+
+	uneq_active()
 
 
 

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -136,40 +136,49 @@
 
 /obj/item/weapon/paper_bundle/Topic(href, href_list)
 	..()
+	var/obj/item/weapon/in_hand = null
 	if((src in usr.contents) || (istype(src.loc, /obj/item/weapon/folder) && (src.loc in usr.contents)))
-		usr.set_machine(src)
-		var/obj/item/weapon/in_hand = usr.get_active_hand()
-		if(href_list["next_page"])
-			if(in_hand && (istype(in_hand, /obj/item/weapon/paper) || istype(in_hand, /obj/item/weapon/photo)))
-				insert_sheet_at(usr, page+1, in_hand)
-			else if(page != pages.len)
-				page++
-				playsound(src.loc, "pageturn", 50, 1)
-		if(href_list["prev_page"])
-			if(in_hand && (istype(in_hand, /obj/item/weapon/paper) || istype(in_hand, /obj/item/weapon/photo)))
-				insert_sheet_at(usr, page, in_hand)
-			else if(page > 1)
-				page--
-				playsound(src.loc, "pageturn", 50, 1)
-		if(href_list["remove"])
-			var/obj/item/weapon/W = pages[page]
-			usr.put_in_hands(W)
-			pages.Remove(pages[page])
-
-			to_chat(usr, "<span class='notice'>You remove the [W.name] from the bundle.</span>")
-
-			if(pages.len <= 1)
-				var/obj/item/weapon/paper/P = src[1]
-				usr.put_in_hands(P)
-				qdel(src)
-				return
-
-			if(page > pages.len)
-				page = pages.len
-
-			update_icon()
+		in_hand = usr.get_active_hand()
+	else if(isrobot(usr) && istype(usr.get_active_hand(), /obj/item/weapon/gripper/paperwork))
+		var/obj/item/weapon/gripper/paperwork/PW = usr.get_active_hand()
+		if(!(src in PW.contents) && !(istype(src.loc, /obj/item/weapon/folder) || !(src.loc in PW.contents)))
+			return // paper bundle isn't in the gripper
 	else
 		to_chat(usr, "<span class='notice'>You need to hold it in hands!</span>")
+		return
+
+	usr.set_machine(src)
+
+	if(href_list["next_page"])
+		if(in_hand && (istype(in_hand, /obj/item/weapon/paper) || istype(in_hand, /obj/item/weapon/photo)))
+			insert_sheet_at(usr, page+1, in_hand)
+		else if(page != pages.len)
+			page++
+			playsound(src.loc, "pageturn", 50, 1)
+	if(href_list["prev_page"])
+		if(in_hand && (istype(in_hand, /obj/item/weapon/paper) || istype(in_hand, /obj/item/weapon/photo)))
+			insert_sheet_at(usr, page, in_hand)
+		else if(page > 1)
+			page--
+			playsound(src.loc, "pageturn", 50, 1)
+	if(href_list["remove"])
+		var/obj/item/weapon/W = pages[page]
+		usr.put_in_hands(W)
+		pages.Remove(pages[page])
+
+		to_chat(usr, "<span class='notice'>You remove the [W.name] from the bundle.</span>")
+
+		if(pages.len <= 1)
+			var/obj/item/weapon/paper/P = src[1]
+			usr.put_in_hands(P)
+			qdel(src)
+			return
+
+		if(page > pages.len)
+			page = pages.len
+
+		update_icon()
+
 	if (istype(src.loc, /mob) ||istype(src.loc.loc, /mob))
 		src.attack_self(usr)
 		updateUsrDialog()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1965,6 +1965,9 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Expand()
 	src.visible_message("<span class='notice'>\The [src] expands!</span>")
+	if(istype(loc, /obj/item/weapon/gripper/research)) // fixes ghost cube when using syringe
+		var/obj/item/weapon/gripper/research/G = loc
+		G.drop_item()
 	var/mob/living/carbon/human/H = new(src.loc)
 	H.set_species(monkey_type)
 	H.real_name = H.species.get_random_name()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1965,8 +1965,8 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Expand()
 	src.visible_message("<span class='notice'>\The [src] expands!</span>")
-	if(istype(loc, /obj/item/weapon/gripper/research)) // fixes ghost cube when using syringe
-		var/obj/item/weapon/gripper/research/G = loc
+	if(istype(loc, /obj/item/weapon/gripper)) // fixes ghost cube when using syringe
+		var/obj/item/weapon/gripper/G = loc
 		G.drop_item()
 	var/mob/living/carbon/human/H = new(src.loc)
 	H.set_species(monkey_type)

--- a/html/changelogs/johnwildkins-7201.yml
+++ b/html/changelogs/johnwildkins-7201.yml
@@ -38,11 +38,12 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "With the grabber, hitting the drop hotkey (Q) now drops the held item. If there is no held item, the grabber is put away as normal."
-  - tweak: "The scientific grabber can now hold slime steroids."
+  - tweak: "With the gripper, hitting the drop hotkey (Q) now drops the held item. If there is no held item, the gripper is put away as normal."
+  - tweak: "The scientific gripper can now hold slime steroids."
+  - tweak: "The chemistry gripper can now hold paper. This is mostly to assist medical borgs handling scans and the like."
   - bugfix: "Modules relying on cyborg synthesizers (nanopaste, ATKs, etc.) now cannot be used once the synthesizer is depleted."
-  - bugfix: "Injecting a monkey cube in a cyborg grabber no longer places the monkey inside the grabber's pocket dimension."
-  - bugfix: "Service cyborgs can no longer open a plane to infinite grass tiles via their service grabber."
+  - bugfix: "Injecting a monkey cube in a cyborg gripper no longer places the monkey inside the gripper's pocket dimension."
+  - bugfix: "Service cyborgs can no longer open a plane to infinite grass tiles via their service gripper."
   - bugfix: "Cyborgs can now re-lock secure crates."
-  - bugfix: "Clerical cyborgs can now browse paper bundles and pick up duct-taped paper with their grabber."
+  - bugfix: "Clerical cyborgs can now browse paper bundles and pick up duct-taped paper with their gripper."
   - bugfix: "The cyborg module inventory now correctly updates when using the drop hotkey (Q, default) to put away a module."

--- a/html/changelogs/johnwildkins-7201.yml
+++ b/html/changelogs/johnwildkins-7201.yml
@@ -1,0 +1,48 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "With the grabber, hitting the drop hotkey (Q) now drops the held item. If there is no held item, the grabber is put away as normal."
+  - tweak: "The scientific grabber can now hold slime steroids."
+  - bugfix: "Modules relying on cyborg synthesizers (nanopaste, ATKs, etc.) now cannot be used once the synthesizer is depleted."
+  - bugfix: "Injecting a monkey cube in a cyborg grabber no longer places the monkey inside the grabber's pocket dimension."
+  - bugfix: "Service cyborgs can no longer open a plane to infinite grass tiles via their service grabber."
+  - bugfix: "Cyborgs can now re-lock secure crates."
+  - bugfix: "Clerical cyborgs can now browse paper bundles and pick up duct-taped paper with their grabber."
+  - bugfix: "The cyborg module inventory now correctly updates when using the drop hotkey (Q, default) to put away a module."


### PR DESCRIPTION
Tweaks:
- With the gripper, hitting the drop hotkey (Q) now drops the held item. If no item is held, the grabber is put away as normal.
- The scientific gripper can now hold slime steroids.
- The chemistry gripper can now hold paper.

Bugfixes:
- Using the drop hotkey (Q) to put away a module now correctly updates the module list interface. Fixes #4343.
- Modules relying on cyborg synthesizers (nanopaste, et al.) now cannot be used when their synthesizer charge is depleted. Fixes #1288.
- Injecting a monkey cube held in a gripper no longer places the monkey inside the gripper's internal contents. Fixes #1097.
- Cyborgs can now re-lock secured crates. Fixes #4833.
- Service borgs can no longer open a portal to infinite grass tiles. Fixes #3814.
- Clerical borgs can now browse through paper bundles held in their gripper, and can pick up taped paper. Fixes #4479. Fixes #6501.