### PR TITLE
Heads of staff buff (clipboard QOL + fixes)

### DIFF
--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -9,6 +9,8 @@
 	throw_range = 10
 	var/obj/item/weapon/pen/haspen		//The stored pen.
 	var/obj/item/weapon/toppaper	//The topmost piece of paper.
+	var/list/r_contents = list()
+	var/ui_open = FALSE
 	slot_flags = SLOT_BELT
 
 /obj/item/weapon/clipboard/Initialize()
@@ -52,12 +54,19 @@
 		user.drop_from_inventory(W,src)
 		if(istype(W, /obj/item/weapon/paper))
 			toppaper = W
+		r_contents = reverselist(contents)
 		to_chat(user, "<span class='notice'>You clip the [W] onto \the [src].</span>")
-		update_icon()
 
 	else if(istype(toppaper) && istype(W, /obj/item/weapon/pen))
-		toppaper.attackby(W, usr)
-		update_icon()
+		toppaper.attackby(W, user)
+
+	else if(istype(W, /obj/item/weapon/pen))
+		add_pen(user)
+
+	if(ui_open)
+		attack_self(user)
+
+	update_icon()
 
 	return
 
@@ -69,21 +78,35 @@
 		dat += "<A href='?src=\ref[src];addpen=1'>Add Pen</A><BR><HR>"
 
 	//The topmost paper. I don't think there's any way to organise contents in byond, so this is what we're stuck with.	-Pete
+	//i'm leaving this here because it's funny - wildkins
+
 	if(toppaper)
 		var/obj/item/weapon/paper/P = toppaper
 		dat += "<A href='?src=\ref[src];write=\ref[P]'>Write</A> <A href='?src=\ref[src];remove=\ref[P]'>Remove</A> <A href='?src=\ref[src];rename=\ref[P]'>Rename</A> - <A href='?src=\ref[src];read=\ref[P]'>[P.name]</A><BR><HR>"
 
-	for(var/obj/item/weapon/paper/P in src)
+	for(var/obj/item/weapon/paper/P in r_contents) // now this is podracing
 		if(P==toppaper)
 			continue
-		dat += "<A href='?src=\ref[src];remove=\ref[P]'>Remove</A> <A href='?src=\ref[src];rename=\ref[P]'>Rename</A> - <A href='?src=\ref[src];read=\ref[P]'>[P.name]</A><BR>"
-	for(var/obj/item/weapon/photo/Ph in src)
+		dat += "<A href='?src=\ref[src];write=\ref[P]'>Write</A> <A href='?src=\ref[src];remove=\ref[P]'>Remove</A> <A href='?src=\ref[src];rename=\ref[P]'>Rename</A> - <A href='?src=\ref[src];read=\ref[P]'>[P.name]</A><BR>"
+	for(var/obj/item/weapon/photo/Ph in r_contents)
 		dat += "<A href='?src=\ref[src];remove=\ref[Ph]'>Remove</A> <A href='?src=\ref[src];rename=\ref[Ph]'>Rename</A> - <A href='?src=\ref[src];look=\ref[Ph]'>[Ph.name]</A><BR>"
 
 	user << browse(dat, "window=clipboard")
+	if(!ui_open)
+		ui_open = TRUE
 	onclose(user, "clipboard")
-	add_fingerprint(usr)
+	add_fingerprint(user)
 	return
+
+/obj/item/weapon/clipboard/proc/add_pen(mob/user)
+	if(!haspen)
+		var/obj/item/weapon/pen/W = user.get_active_hand()
+		if(istype(W, /obj/item/weapon/pen))
+			user.drop_from_inventory(W,src)
+			haspen = W
+			to_chat(user, "<span class='notice'>You slot the pen into \the [src].</span>")
+	else
+		to_chat(user, span("notice", "This clipboard already has a pen!"))
 
 /obj/item/weapon/clipboard/Topic(href, href_list)
 	..()
@@ -99,29 +122,26 @@
 				haspen = null
 
 		else if(href_list["addpen"])
-			if(!haspen)
-				var/obj/item/weapon/pen/W = usr.get_active_hand()
-				if(istype(W, /obj/item/weapon/pen))
-					usr.drop_from_inventory(W,src)
-					haspen = W
-					to_chat(usr, "<span class='notice'>You slot the pen into \the [src].</span>")
+			add_pen(usr)
 
 		else if(href_list["write"])
 			var/obj/item/weapon/P = locate(href_list["write"])
 
-			if(P && (P.loc == src) && istype(P, /obj/item/weapon/paper) && (P == toppaper) )
+			if(P && (P.loc == src) && istype(P, /obj/item/weapon/paper))
 
 				var/obj/item/I = usr.get_active_hand()
 
 				if(istype(I, /obj/item/weapon/pen))
-
 					P.attackby(I, usr)
+				else if (haspen)
+					P.attackby(haspen, usr)
 
 		else if(href_list["remove"])
 			var/obj/item/P = locate(href_list["remove"])
 
 			if(P && (P.loc == src) && (istype(P, /obj/item/weapon/paper) || istype(P, /obj/item/weapon/photo)) )
 
+				r_contents -= P
 				P.forceMove(usr.loc)
 				usr.put_in_hands(P)
 				if(P == toppaper)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -361,6 +361,7 @@
 			return
 
 		var/obj/item/i = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
+		/var/obj/item/weapon/clipboard/c
 		var/iscrayon = 0
 		if(!istype(i, /obj/item/weapon/pen))
 			if(usr.back && istype(usr.back,/obj/item/weapon/rig))
@@ -368,6 +369,12 @@
 				var/obj/item/rig_module/device/pen/m = locate(/obj/item/rig_module/device/pen) in r.installed_modules
 				if(!r.offline && m)
 					i = m.device
+				else
+					return
+			else if(istype(src.loc, /obj/item/weapon/clipboard))
+				c = src.loc
+				if(c.haspen)
+					i = c.haspen
 				else
 					return
 			else
@@ -403,6 +410,8 @@
 
 		playsound(src, pick('sound/bureaucracy/pen1.ogg','sound/bureaucracy/pen2.ogg'), 20)
 		update_icon()
+		if(c)
+			c.update_icon()
 
 
 /obj/item/weapon/paper/attackby(obj/item/weapon/P as obj, mob/user as mob)
@@ -519,6 +528,7 @@
 	else if(P.iswelder())
 		burnpaper(P, user)
 
+	update_icon()
 	add_fingerprint(user)
 	return
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -361,7 +361,7 @@
 			return
 
 		var/obj/item/i = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
-		/var/obj/item/weapon/clipboard/c
+		var/obj/item/weapon/clipboard/c
 		var/iscrayon = 0
 		if(!istype(i, /obj/item/weapon/pen))
 			if(usr.back && istype(usr.back,/obj/item/weapon/rig))

--- a/html/changelogs/johnwildkins-7204.yml
+++ b/html/changelogs/johnwildkins-7204.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "All pages of the clipboard are now writable."
+  - tweak: "You can now write to a clipboard with an attached pen, without needing to remove it. If a clipboard is empty, you can also attach a pen by clicking on the clipboard with a pen in your active hand."
+  - bugfix: "Clipboard UI now updates when papers or a pen is added to the clipboard."
+  - bugfix: "Clipboard icon now updates when the front page is written on. "


### PR DESCRIPTION
- You can now write to any paper on the clipboard using the UI.
- You can now write to papers on the clipboard with the attached pen, without needing to remove it.
- The UI now updates when a pen or papers are added to the clipboard.
- You can add a pen to an empty clipboard by clicking on the clipboard with a pen in your active hand.
- Clipboard icon state now updates when the front page is written on.