### PR TITLE
Cent. Com. nerf

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -536,19 +536,23 @@ var/global/list/additional_antag_types = list()
 		for(var/mob/living/carbon/human/M in suspects)
 			if(player_is_antag(M.mind, only_offstation_roles = 1))
 				continue
-			intercepttext += "<br>     + [pick(business_jargon)] indicate that [M.mind.assigned_role] [M.name] [pick(mean_words)]."
+			intercepttext += "<br>     + [pick(business_jargon)] indicate that [M.mind.assigned_role] [M.name] [pick(mean_words)].<br>"
 		intercepttext += "Cent. Com recommends coordinating with human resources to resolve any issues with employment.<br>"
 
 	if(repeat_offenders)
 		intercepttext += "<br><B>The personnel listed below possess three or more offenses listed on record:</B>"
 		for(var/mob/living/carbon/human/M in repeat_offenders)
-			intercepttext += "<br>     + [M.mind.assigned_role] [M.name], [M.incidents.len] offenses."
+			if(player_is_antag(M.mind, only_offstation_roles = 1))
+				continue
+			intercepttext += "<br>     + [M.mind.assigned_role] [M.name], [M.incidents.len] offenses.<br>"
 		intercepttext += "Cent. Com recommends coordinating with internal security to monitor and rehabilitate these personnel.<br>"
 
 	if(loyalists)
 		intercepttext += "<br><B>The personnel listed below have been indicated as particularly loyal to NanoTrasen:</B>"
 		for(var/mob/living/carbon/human/M in loyalists)
-			intercepttext += "<br>     + [M.mind.assigned_role] [M.name]."
+			if(player_is_antag(M.mind, only_offstation_roles = 1))
+				continue
+			intercepttext += "<br>     + [M.mind.assigned_role] [M.name].<br>"
 		intercepttext += "Cent. Com recommends coordinating with human resources to reward and further motivate these personnel for their loyalty.<br>"
 
 	if(evil_department)

--- a/html/changelogs/johnwildkins-7209.yml
+++ b/html/changelogs/johnwildkins-7209.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Cent. Com. intercepts are no longer omniscient, and will no longer recommend rehabilitation for mercenaries and other off-station antagonists at round start."


### PR DESCRIPTION
Fixes #6456.

Added a check to repeat offenders (and also loyalists, just to be safe) on CentCom's roundstart report to command, so command won't be instructed to rehabilitate Mercenary Big Chungus.

ed: oh also fixed the formatting on the report slightly