### PR TITLE
Death to earmuff duping (and other fixes/tweaks)

### DIFF
--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -51,15 +51,39 @@
 		if (( usr.restrained() ) || ( usr.stat ))
 			return
 
-		if (!usr.unEquip(src))
+		if (!usr.canUnEquip(src))
 			return
+
+		var/obj/item/clothing/C = src
 
 		switch(over_object.name)
 			if("r_hand")
-				usr.put_in_r_hand(src)
+				if(istype(src, /obj/item/clothing/ears))
+					C = check_two_ears(usr)
+				usr.put_in_r_hand(C)
 			if("l_hand")
-				usr.put_in_l_hand(src)
+				if(istype(src, /obj/item/clothing/ears))
+					C = check_two_ears(usr)
+				usr.put_in_l_hand(C)
 		src.add_fingerprint(usr)
+
+/obj/item/clothing/proc/check_two_ears(var/mob/user)
+	// if you have to ask, it's earcode
+	// var/obj/item/clothing/ears/E
+	var/obj/item/clothing/ears/main_ear
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+
+	for(var/obj/item/clothing/ears/E in H.contents)
+		H.u_equip(E)
+		if(istype(E, /obj/item/clothing/ears/offear))
+			qdel(E)
+		else
+			main_ear = E
+
+	return main_ear
+
 
 /obj/item/clothing/examine(var/mob/user)
 	..(user)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1262,6 +1262,7 @@ var/list/total_extraction_beacons = list()
 		target = get_atom_on_turf(src)
 	if(!target)
 		target = src
+	target.cut_overlay(image_overlay, TRUE)
 	if(location)
 		new /obj/effect/overlay/temp/explosion(location)
 		playsound(location, 'sound/effects/Explosion1.ogg', 100, 1)
@@ -1285,11 +1286,11 @@ var/list/total_extraction_beacons = list()
 					if(!isipc(L))
 						addtimer(CALLBACK(L, /mob/living/carbon/.proc/vomit), 20)
 
-		spawn(2)
-			for(var/turf/simulated/mineral/M in range(7,location))
-				if(prob(75))
-					M.GetDrilled(1)
+		addtimer(CALLBACK(src, .proc/drill, location), 2)
 
-	if(target)
-		target.overlays -= image_overlay
 	qdel(src)
+
+/obj/item/weapon/plastique/seismic/proc/drill(var/turf/drill_loc)
+	for(var/turf/simulated/mineral/M in range(7,drill_loc))
+		if(prob(75))
+			M.GetDrilled(1)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -438,6 +438,9 @@
 //Used to attack a joint through grabbing
 /mob/living/carbon/human/proc/grab_joint(var/mob/living/user, var/def_zone)
 	var/has_grab = 0
+
+	if(user.limb_breaking)
+		return 0
 	for(var/obj/item/weapon/grab/G in list(user.l_hand, user.r_hand))
 		if(G.affecting == src && G.state == GRAB_NECK)
 			has_grab = 1
@@ -455,10 +458,12 @@
 		return 0
 
 	user.visible_message("<span class='warning'>[user] begins to dislocate [src]'s [organ.joint]!</span>")
+	user.limb_breaking = TRUE
 	if(do_after(user, 100))
 		organ.dislocate(1)
 		admin_attack_log(user, src, "dislocated [organ.joint].", "had his [organ.joint] dislocated.", "dislocated [organ.joint] of")
 		src.visible_message("<span class='danger'>[src]'s [organ.joint] [pick("gives way","caves in","crumbles","collapses")]!</span>")
+		user.limb_breaking = FALSE
 		return 1
 	user.visible_message("<span class='warning'>[user] fails to dislocate [src]'s [organ.joint]!</span>")
 	return 0

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -466,6 +466,7 @@
 		user.limb_breaking = FALSE
 		return 1
 	user.visible_message("<span class='warning'>[user] fails to dislocate [src]'s [organ.joint]!</span>")
+	user.limb_breaking = FALSE
 	return 0
 
 //Breaks all grips and pulls that the mob currently has.

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -332,6 +332,9 @@ This saves us from having to call add_fingerprint() any time something is put in
 			check_flags = EYES
 		if(slot_gloves, slot_w_uniform)
 			covering = src.wear_suit
+		if(slot_l_ear, slot_r_ear)
+			covering = src.head
+			check_flags = HEAD
 
 	if(covering && (covering.body_parts_covered & (I.body_parts_covered|check_flags)))
 		to_chat(user, "<span class='warning'>\The [covering] is in the way.</span>")

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -78,3 +78,5 @@
 
 	var/burn_mod = 1
 	var/brute_mod = 1
+
+	var/limb_breaking = FALSE // used to limit people from queuing up limb-breaks

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -332,6 +332,8 @@ obj/machinery/lapvend/attackby(obj/item/weapon/W as obj, mob/user as mob)
 			S.worth -= total_price
 			if(S.worth <= 0)
 				qdel(S)
+			else
+				S.update_icon()
 			return 1
 
 	else // just incase

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -642,11 +642,12 @@
 	update_icon()
 	update_held_icon()
 
-/obj/item/weapon/gun/mob_can_equip(M as mob, slot)
+/obj/item/weapon/gun/mob_can_equip(M as mob, slot, disable_warning, ignore_blocked)
 	//Cannot equip wielded items.
 	if(is_wieldable)
 		if(wielded)
-			to_chat(M, "<span class='warning'>Lower the [initial(name)] first!</span>")
+			if(!disable_warning) // unfortunately not sure there's a way to get this to only fire once when it's looped
+				to_chat(M, "<span class='warning'>Lower the [initial(name)] first!</span>")
 			return 0
 
 	return ..()

--- a/html/changelogs/johnwildkins-7216.yml
+++ b/html/changelogs/johnwildkins-7216.yml
@@ -1,0 +1,46 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Earmuffs and other equipment that covers both ears no longer duplicate infinite instances of themselves when click+dragged out of their slot."
+  - bugfix: "Helmets and other equipment that cover the head now prevent ear equipment from being equipped or unequipped."
+  - bugfix: "Seismic charges now correctly have their overlay removed from the object they're placed on when detonated."
+  - bugfix: "You can no longer queue up simultaneous limb-breaks while aggressively grabbing someone."
+  - bugfix: "Using credit chips at the laptop vendor now correctly updates the credit chips' sprite and examined value."
+  - bugfix: "Attempting to equip a wielded gun with the equip hotkey (def: E) no longer spams the chat log with error messages."


### PR DESCRIPTION
may earcode die a slow and painful death

- Earmuffs and other equipment that covers both ears are no longer duplicated when click+dragged out of their slot. Fixes #6892
- Helmets and other equipment that covers the head now blocks ear equipment from being equipped or unequipped. Resolves #5496
- Seismic charges now remove their overlay properly once detonated. Fixes  #3121
- You can no longer queue up simultaneous limb-breaks while aggressively grabbing someone. Fixes  #6136
- Using credit chips at the laptop vendor now correctly updates the credit chips' sprite and examined value. Fixes #5343
- Attempting to equip a wielded gun with the equip hotkey (def: E) no longer spams the chat log with error messages. Fixes #1511