### PR TITLE
Ensured that nearly all the vending machines have premium and contraband items + readds halloween candy

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -368,7 +368,7 @@
 		/obj/item/weapon/reagent_containers/food/drinks/medcup = 4
 	)
 	contraband = list(
-		/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate = 2,
+		/obj/item/weapon/reagent_containers/inhaler/space_drugs = 2,
 		/obj/item/weapon/reagent_containers/pill/tox = 3,
 		/obj/item/weapon/reagent_containers/pill/stox = 4
 	)

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -151,7 +151,7 @@
 	)
 	contraband = list(
 		/obj/item/weapon/reagent_containers/food/drinks/ice = 10,
-		/obj/item/weapon/reagent_containers/food/drinks/soymilk
+		/obj/item/weapon/reagent_containers/food/drinks/soymilk = 2
 	)
 	prices = list(
 		/obj/item/weapon/reagent_containers/food/drinks/coffee = 20,

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -101,6 +101,9 @@
 	contraband = list(
 		/obj/item/weapon/reagent_containers/food/drinks/tea = 10
 	)
+	premium = list(
+		/obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing = 2
+	)
 	vend_delay = 15
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 	product_slogans = "I hope nobody asks me for a bloody cup o' tea...;Alcohol is humanity's friend. Would you abandon a friend?;Quite delighted to serve you!;Is nobody thirsty on this station?"
@@ -120,7 +123,12 @@
 	)
 	contraband = list(
 		/obj/item/device/flashlight = 5,
-		/obj/item/device/assembly/timer = 2
+		/obj/item/device/assembly/timer = 2,
+		/obj/item/device/assembly/infra = 2,
+		/obj/item/device/assembly/voice = 2
+	)
+	premium = list(
+		/obj/item/device/multitool/ = 2
 	)
 	product_ads = "Only the finest!;Have some tools.;The most robust equipment.;The finest gear in space!"
 	restock_items = 1
@@ -142,7 +150,8 @@
 		/obj/item/weapon/reagent_containers/food/drinks/coffee/pslatte = 10
 	)
 	contraband = list(
-		/obj/item/weapon/reagent_containers/food/drinks/ice = 10
+		/obj/item/weapon/reagent_containers/food/drinks/ice = 10,
+		/obj/item/weapon/reagent_containers/food/drinks/soymilk
 	)
 	prices = list(
 		/obj/item/weapon/reagent_containers/food/drinks/coffee = 20,
@@ -150,6 +159,9 @@
 		/obj/item/weapon/reagent_containers/food/drinks/h_chocolate = 22,
 		/obj/item/weapon/reagent_containers/food/snacks/donut/normal = 6,
 		/obj/item/weapon/reagent_containers/food/drinks/coffee/pslatte = 25
+	)
+	premium = list(
+		/obj/item/weapon/reagent_containers/food/drinks/teapot/ = 5
 	)
 	vending_sound = "machines/vending/vending_coffee.ogg"
 	cooling_temperature = T0C + 57 //Optimal coffee temperature
@@ -177,11 +189,24 @@
 		/obj/item/weapon/reagent_containers/food/snacks/maps = 2,
 		/obj/item/weapon/reagent_containers/food/snacks/nathisnack = 2,
 		/obj/item/weapon/reagent_containers/food/snacks/koisbar_clean = 4,
-		/obj/item/weapon/reagent_containers/food/snacks/candy/koko = 5
+		/obj/item/weapon/reagent_containers/food/snacks/candy/koko = 5,
+		/obj/item/weapon/reagent_containers/food/snacks/cb01 = 6,
+		/obj/item/weapon/reagent_containers/food/snacks/cb02 = 6,
+		/obj/item/weapon/reagent_containers/food/snacks/cb03 = 6,
+		/obj/item/weapon/reagent_containers/food/snacks/cb04 = 6,
+		/obj/item/weapon/reagent_containers/food/snacks/cb05 = 6,
+		/obj/item/weapon/reagent_containers/food/snacks/cb06 = 6,
+		/obj/item/weapon/reagent_containers/food/snacks/cb07 = 6,
+		/obj/item/weapon/reagent_containers/food/snacks/cb08 = 6,
+		/obj/item/weapon/reagent_containers/food/snacks/cb09 = 6,
+		/obj/item/weapon/reagent_containers/food/snacks/cb10 = 6
 	)
 	contraband = list(
 		/obj/item/weapon/reagent_containers/food/snacks/syndicake = 6,
 		/obj/item/weapon/reagent_containers/food/snacks/koisbar = 4
+	)
+	premium = list(
+		/obj/item/weapon/reagent_containers/food/snacks/cookie = 6
 	)
 	prices = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy = 15,
@@ -197,7 +222,17 @@
 		/obj/item/weapon/reagent_containers/food/snacks/maps = 23,
 		/obj/item/weapon/reagent_containers/food/snacks/nathisnack = 24,
 		/obj/item/weapon/reagent_containers/food/snacks/koisbar_clean = 60,
-		/obj/item/weapon/reagent_containers/food/snacks/candy/koko = 40
+		/obj/item/weapon/reagent_containers/food/snacks/candy/koko = 40,
+		/obj/item/weapon/reagent_containers/food/snacks/cb01 = 15,
+		/obj/item/weapon/reagent_containers/food/snacks/cb02 = 14,
+		/obj/item/weapon/reagent_containers/food/snacks/cb03 = 15,
+		/obj/item/weapon/reagent_containers/food/snacks/cb04 = 16,
+		/obj/item/weapon/reagent_containers/food/snacks/cb05 = 18,
+		/obj/item/weapon/reagent_containers/food/snacks/cb06 = 10,
+		/obj/item/weapon/reagent_containers/food/snacks/cb07 = 12,
+		/obj/item/weapon/reagent_containers/food/snacks/cb08 = 13,
+		/obj/item/weapon/reagent_containers/food/snacks/cb09 = 12,
+		/obj/item/weapon/reagent_containers/food/snacks/cb10 = 15
 	)
 
 /obj/machinery/vending/cola
@@ -224,6 +259,11 @@
 	contraband = list(
 		/obj/item/weapon/reagent_containers/food/drinks/cans/thirteenloko = 5,
 		/obj/item/weapon/reagent_containers/food/snacks/liquidfood = 6
+	)
+	premium = list(
+		/obj/item/weapon/reagent_containers/food/drinks/bottle/cola = 2,
+		/obj/item/weapon/reagent_containers/food/drinks/bottle/space_mountain_wind = 2,
+		/obj/item/weapon/reagent_containers/food/drinks/bottle/space_up = 2
 	)
 	prices = list(
 		/obj/item/weapon/reagent_containers/food/drinks/cans/cola = 15,
@@ -262,6 +302,12 @@
 		/obj/item/weapon/cartridge/captain = 3,
 		/obj/item/weapon/cartridge/quartermaster = 10
 	)
+	contraband = list(
+		/obj/item/weapon/cartridge/clown = 2
+	)
+	premium = list(
+		/obj/item/weapon/cartridge/captain = 1
+	)
 	restock_items = 1
 
 
@@ -280,11 +326,12 @@
 		/obj/item/weapon/spacecash/ewallet/lotto = 30
 	)
 	contraband = list(
-		/obj/item/weapon/flame/lighter/zippo = 4
+		/obj/item/weapon/storage/fancy/cigarettes/blank = 5,
+		/obj/item/weapon/storage/fancy/cigarettes/acmeco = 5
 	)
 	premium = list(
-		/obj/item/weapon/storage/fancy/cigar = 5,
-		/obj/item/weapon/storage/fancy/cigarettes/acmeco = 5
+		/obj/item/weapon/flame/lighter/zippo = 4,
+		/obj/item/weapon/storage/fancy/cigar = 5
 	)
 	prices = list(
 		/obj/item/weapon/storage/fancy/cigarettes = 200,
@@ -321,8 +368,12 @@
 		/obj/item/weapon/reagent_containers/food/drinks/medcup = 4
 	)
 	contraband = list(
+		/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate = 2,
 		/obj/item/weapon/reagent_containers/pill/tox = 3,
 		/obj/item/weapon/reagent_containers/pill/stox = 4
+	)
+	premium = list(
+		/obj/item/weapon/reagent_containers/glass/bottle/epinephrine = 2
 	)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 	random_itemcount = 0
@@ -340,8 +391,16 @@
 		/obj/item/device/transfer_valve = 6,
 		/obj/item/device/assembly/timer = 6,
 		/obj/item/device/assembly/signaler = 6,
-		/obj/item/device/assembly/prox_sensor = 6,
 		/obj/item/device/assembly/igniter = 6
+	)
+	contraband = list(
+		/obj/item/device/assembly/prox_sensor = 4,
+		/obj/item/device/assembly/infra = 4,
+		/obj/item/device/assembly/mousetrap = 4,
+		/obj/item/device/assembly/voice = 4
+	)
+	premium = list(
+		/obj/item/clothing/head/collectable/petehat = 1
 	)
 	restock_items = 1
 	random_itemcount = 0
@@ -367,6 +426,9 @@
 		/obj/item/weapon/reagent_containers/syringe/antiviral = 4,
 		/obj/item/weapon/reagent_containers/pill/tox = 1
 	)
+	premium = list(
+		/obj/item/weapon/reagent_containers/pill/tramadol = 4
+	)
 	random_itemcount = 0
 	temperature_setting = -1
 
@@ -387,6 +449,9 @@
 	)
 	contraband = list(
 		/obj/item/weapon/reagent_containers/pill/tox = 3
+	)
+	premium = list(
+		/obj/item/weapon/reagent_containers/pill/tramadol = 4
 	)
 	random_itemcount = 0
 	temperature_setting = -1
@@ -506,11 +571,13 @@
 	contraband = list(
 		/obj/item/seeds/ambrosiavulgarisseed = 3,
 		/obj/item/seeds/amanitamycelium = 3,
-		/obj/item/seeds/ambrosiadeusseed = 3,
 		/obj/item/seeds/glowshroom = 3,
 		/obj/item/seeds/libertymycelium = 3,
 		/obj/item/seeds/nettleseed = 3,
 		/obj/item/seeds/reishimycelium = 3
+	)
+	premium = list(
+		/obj/item/seeds/ambrosiadeusseed = 3
 	)
 	prices = list(
 		/obj/item/seeds/appleseed = 50,
@@ -595,16 +662,22 @@
 	product_slogans = "Sling spells the proper way with MagiVend!;Be your own Houdini! Use MagiVend!"
 	vend_delay = 15
 	vend_reply = "Have an enchanted evening!"
-	product_ads = "FJKLFJSD;AJKFLBJAKL;1234 LOONIES LOL!;>MFW;Kill them fuckers!;GET DAT FUKKEN DISK;HONK!;EI NATH;Destroy the station!;Admin conspiracies since forever!;Space-time bending hardware!"
+	product_ads = "FJKLFJSD;AJKFLBJAKL;1234 LOONIES LOL!;>MFW;Kill them fuckers!;GET DAT FUKKEN DISK;HONK!;EI NATH;Destroy the station!;Admin conspiracies since forever!;Space-time bending hardware!" //What the fuck is this
 	vend_id = "magic"
 	products = list(
 		/obj/item/clothing/head/wizard = 1,
 		/obj/item/clothing/suit/wizrobe = 1,
+		/obj/item/clothing/shoes/sandal = 1,
+		/obj/item/weapon/staff = 1
+	)
+	contraband = list(
 		/obj/item/clothing/head/wizard/red = 1,
 		/obj/item/clothing/suit/wizrobe/red = 1,
-		/obj/item/clothing/shoes/sandal = 1,
-		/obj/item/weapon/staff = 2
 	)
+	premium = list(
+		/obj/item/clothing/head/wizard/fake = 1
+	)
+
 	restock_items = 1
 	random_itemcount = 0
 
@@ -632,6 +705,9 @@
 	)
 	contraband = list(
 		/obj/item/weapon/storage/toolbox/lunchbox/syndicate = 2
+	)
+	premium = list(
+		/obj/item/weapon/storage/toolbox/lunchbox/nt/filled = 2
 	)
 	restock_items = 1
 	random_itemcount = 0
@@ -733,6 +809,9 @@
 	contraband = list(
 		/obj/item/weapon/grenade/flashbang/clusterbang = 1 //this can only go well.
 	)
+	premium = list(
+		/obj/item/weapon/grenade/chem_grenade/gas = 2
+	)
 	random_itemcount = 0
 
 /obj/machinery/vending/tacticool/ert //Slightly more !FUN!
@@ -757,6 +836,12 @@
 		/obj/item/ammo_magazine/a556/ap = 4,
 		/obj/item/weapon/material/knife/tacknife = 4,
 		/obj/item/device/firing_pin = 12
+	)
+	contraband = list(
+		/obj/item/weapon/gun/bang/deagle = 1
+	)
+	premium = list(
+		/obj/item/weapon/shield/riot/tact = 2
 	)
 	random_itemcount = 0
 
@@ -828,6 +913,12 @@
 		/obj/item/weapon/screwdriver = 5,
 		/obj/item/weapon/crowbar = 5
 	)
+	contraband = list(
+		/obj/item/device/flash = 2
+	)
+	premium = list(
+		/obj/item/device/paicard = 2
+	)
 	//everything after the power cell had no amounts, I improvised.  -Sayu
 	restock_blocked_items = list(
 		/obj/item/stack/cable_coil,
@@ -851,11 +942,12 @@
 		/obj/item/weapon/reagent_containers/food/drinks/cans/zoraklax = 4,
 		/obj/item/weapon/reagent_containers/food/drinks/cans/zoraphoron = 5,
 		/obj/item/weapon/reagent_containers/food/drinks/cans/zoravenom = 5,
-		/obj/item/weapon/reagent_containers/food/drinks/cans/zorahozm = 2,
 		/obj/item/weapon/reagent_containers/food/drinks/cans/zoradrone = 5,
 	)
 	contraband = list(
 		/obj/item/weapon/reagent_containers/food/drinks/cans/zoracthur = 2,
+	)
+	premium = list(
 		/obj/item/weapon/reagent_containers/food/drinks/cans/zorajelly = 2,
 	)
 	prices = list(

--- a/html/changelogs/burgerbb - vending machine tweaks.yml
+++ b/html/changelogs/burgerbb - vending machine tweaks.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Tweaked nearly all vending machines to have their own contraband and premium items."


### PR DESCRIPTION
Most of the vending machines didn't have premium or contraband items, which is depressing because other servers don't have this problem. This PR specifically does the following:

- Moves a bunch of assembly items into the contraband ToolAssist vendor.
- Adds a multitool to the ToolAssit vendor.
- Adds soymilk to the contraband Coffee vendor.
- Adds a teapot to the premium Coffee vendor.
- Adds all the halloween candy to the snacks vendor.
- Adds a cookie to the premium snacks vendor.
- Adds 2L bottles of cola, space mountain wind, and space up to the premium drinks vendor.
- Adds a clown cartridge to the HoP's Contraband PDA vendor.
- Adds a captain's cartridge to the HoP's premium PDA vendor.
- Adds Blank Cigarettes and AcmeCo Cigarettes to the contraband smokes vendor.
- Adds Zippo to the premium smokes vendor.
- Adds a bottle of chloral hydrate to the contraband nanomed.
- Adds epinephrine to the premium nanomed.
- Adds a bunch of sensors to the ToxMate contraband vendor.
- Adds an ultra rare hat to the premium ToxMate vendor.
- Adds Tramadol to the premium nanomed wallmed vendor.
- Adds ambrosia deus to the premium garden vendor.
- Moved the red wizard outfit and wizard hat to the contraband section of the wizard vendor.
- Added a fake wizard hat to the premium section of the wizard vendor.
- Added a filled NT lunchbox to the premium section of the Kitchen vendor.
- Added chloral hydrate gas grenades to the premium section of the tacticool vendor.
- Added a fake desert eagle to the contraband section of the ERT vendor.
- Added tactical shields to the premium section of the ERT vendor.
- Added real flashes to the contraband section of the robotics vendor.
- Added pAI cards to the premium section of the robotics vendor.
- Moved Zora Jelly to the premium section of the Zora Soda vendor.







