### PR TITLE
Bunch of animal trap fixes

### DIFF
--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -639,7 +639,7 @@
 		)
 		if (!do_after(usr, 2 SECONDS, act_target = src))
 			return
-		if(usr.a_intent == I_HELP || (usr.a_intent != I_HURT && prob(50))) // 50% chance to pass by without getting caught on disarm, drag, 100% on help. Harm will get you caught.
+		if(usr.a_intent == I_HELP || captured?.resolve() || (usr.a_intent != I_HURT && prob(50))) // 50% chance to pass by without getting caught on disarm, drag, 100% on help. Harm will get you caught.
 			usr.forceMove(src.loc)
 			usr.visible_message("<span class='notice'>[usr] pass through \the [src] without triggering it.</span>",
 								"<span class='notice'>You pass through \the [src] without triggering it.</span>"

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -145,7 +145,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 1750)
 	deployed = 0
 	time_to_escape = 3 // Minutes
-	can_buckle = TRUE
+	can_buckle = FALSE
 	var/breakout = FALSE
 	var/last_shake = 0
 	var/list/allowed_mobs = list(/mob/living/simple_animal/rat, /mob/living/simple_animal/chick, /mob/living/simple_animal/lizard)
@@ -175,7 +175,7 @@
 	if(world.time - release_time < 50) // If we just released the animal, not to let it get caught again right away
 		return
 
-	if(contents.len) // It is full
+	if(captured?.resolve()) // It is full
 		return
 	capture(AM)
 
@@ -189,6 +189,7 @@
 					"<span class='danger'>You enter \the [src], and it snaps shut with a clatter!</span>",
 					"<b>You hear a loud metallic snap!</b>"
 					)
+				can_buckle = TRUE
 				captured = WEAKREF(L)
 				playsound(src, 'sound/weapons/beartrap_shut.ogg', 100, 1)
 				deployed = 1
@@ -359,6 +360,7 @@
 	deployed = FALSE
 	update_icon()
 	release_time = world.time
+	can_buckle = FALSE
 
 /obj/item/weapon/trap/animal/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/reagent_containers) && contents.len)
@@ -366,6 +368,9 @@
 		W.afterattack(L, user, TRUE)
 	else if(W.iswelder())
 		var/obj/item/weapon/weldingtool/WT = W
+		if (!WT.welding)
+			to_chat(user, "Your \the [W] is off!")
+			return
 		user.visible_message("<span class='notice'>[user] is trying to slice \the [src]!</span>",
 							 "You are trying to slice \the [src]!")
 
@@ -377,7 +382,7 @@
 			new /obj/item/stack/rods(src.loc, resources["rods"])
 			if(resources.len == 2)
 				new /obj/item/stack/material/steel(src.loc, resources["metal"])
-			release()
+			release(user)
 			qdel(src)
 
 	else if(W.isscrewdriver())

--- a/html/changelogs/Sindorman-traps.yml
+++ b/html/changelogs/Sindorman-traps.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Animal traps no longer can have more than one prey at a time."
+  - bugfix: "Traps now properly trap prey when it is thrown at them."
+  - bugfix: "Deconstructing trap with prey inside no longer makes prey anchored to the turf."
+  - bugfix: "You cannot buckle a person into a trap."
+  - bugfix: "You can no longer deconstruct trap with welder off."

--- a/html/changelogs/Sindorman-traps.yml
+++ b/html/changelogs/Sindorman-traps.yml
@@ -43,3 +43,4 @@ changes:
   - bugfix: "Deconstructing trap with prey inside no longer makes prey anchored to the turf."
   - bugfix: "You cannot buckle a person into a trap."
   - bugfix: "You can no longer deconstruct trap with welder off."
+  - bugfix: "Passing throuh trap no longer traps you if it is full."


### PR DESCRIPTION
  - bugfix: "Animal traps no longer can have more than one prey at a time.". Fixes #7219
  - bugfix: "Traps now properly trap prey when it is thrown at them."
  - bugfix: "Deconstructing trap with prey inside no longer makes prey anchored to the turf."
  - bugfix: "You cannot buckle a person into a trap."
  - bugfix: "You can no longer deconstruct trap with welder off."
  - bugfix: "Passing throuh trap no longer traps you if it is full."