### PR TITLE
Removes bluespace echo creation from teleportation.

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -229,30 +229,6 @@
 							to_chat(L, "<span class='danger'>You partially phase into \the [impediment], causing a chunk of you to violently dematerialize!</span>")
 							L.adjustBruteLoss(40)
 
-					if(!newdest && L.mind)
-						var/mob/living/simple_animal/shade/bluespace/BS = new /mob/living/simple_animal/shade/bluespace(destturf)
-						to_chat(L, "<span class='danger'>You feel your spirit violently rip from your body in a flurry of violent extradimensional disarray!</span>")
-						L.mind.transfer_to(BS)
-						to_chat(BS, "<b>You are now a bluespace echo - consciousness imprinted upon wavelengths of bluespace energy. You currently retain no memories of your previous life, but do express a strong desire to return to corporeality. You will die soon, fading away forever. Good luck!</b>")
-						BS.original_body = L
-
-						var/list/turfs_to_teleport = list()
-						for(var/turf/T in orange(20, get_turf(BS)))
-							turfs_to_teleport += T
-						do_teleport(BS, pick(turfs_to_teleport))
-
-						for(var/mob/living/M in L)
-							if(M.mind)
-								var/mob/living/simple_animal/shade/bluespace/more_BS = new /mob/living/simple_animal/shade/bluespace(get_turf(M))
-								to_chat(M, "<span class='danger'>You feel your spirit violently rip from your body in a flurry of violent extradimensional disarray!</span>")
-								M.mind.transfer_to(more_BS)
-								to_chat(more_BS, "<b>You are now a bluespace echo - consciousness imprinted upon wavelengths of bluespace energy. You currently retain no memories of your previous life, but do express a strong desire to return to corporeality. You will die soon, fading away forever. Good luck!</b>")
-								more_BS.original_body = M
-
-								for(var/turf/T in orange(20, get_turf(BS)))
-									turfs_to_teleport += T
-								do_teleport(more_BS, pick(turfs_to_teleport))
-
 				else
 					newdest = destturf
 					valid = 0

--- a/html/changelogs/alberyk_echo.yml
+++ b/html/changelogs/alberyk_echo.yml
@@ -1,0 +1,5 @@
+author: Alberyk
+
+delete-after: True
+changes: 
+  - rscdel: "Telescience accidents can not create bluespace echos anymore."


### PR DESCRIPTION
What it says in the title. Due to the latest telescience changes, this is not needed anymore. Also, there is no way to echoes inside bodies anymore.