### PR TITLE
Makes Telescience portals more accurate, fixing a number of issues

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -8,6 +8,7 @@
 	var/failchance = 5
 	var/obj/target = null
 	var/creator = null
+	var/precision = 1
 	anchored = 1.0
 
 /obj/effect/portal/CollidedWith(mob/M as mob|obj)
@@ -22,13 +23,15 @@
 	set waitfor = FALSE
 	src.teleport(user)
 
-/obj/effect/portal/New(loc, turf/target, creator=null, lifespan=300)
+/obj/effect/portal/New(loc, turf/target, creator=null, lifespan=300, precise = 1)
 	..()
 	src.target = target
 	src.creator = creator
 
 	if(lifespan > 0)
 		QDEL_IN(src, lifespan)
+	
+	precision = precise
 
 /obj/effect/portal/proc/teleport(atom/movable/M as mob|obj)
 	if(istype(M, /obj/effect)) //sparks don't teleport
@@ -45,4 +48,4 @@
 			src.icon_state = "portal1"
 			do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0)
 		else
-			do_teleport(M, target, 1) ///You will appear adjacent to the beacon
+			do_teleport(M, target, precision)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -214,8 +214,8 @@
 			var/total_lifespawn = 25 * crystals.len
 			var/total_failchance = crystals.len
 
-			var/obj/effect/portal/origin = new /obj/effect/portal(dest, null, null, total_lifespawn)
-			var/obj/effect/portal/destination = new /obj/effect/portal(source,  null, null, total_lifespawn)
+			var/obj/effect/portal/origin = new /obj/effect/portal(dest, null, null, total_lifespawn, 0)
+			var/obj/effect/portal/destination = new /obj/effect/portal(source,  null, null, total_lifespawn, 0)
 
 			origin.target = destination
 			destination.target = origin

--- a/html/changelogs/MDP-echoing-again.yml
+++ b/html/changelogs/MDP-echoing-again.yml
@@ -1,0 +1,4 @@
+author: MoondancerPony
+delete-after: True
+changes: 
+  - tweak: "Telescience portals now output things on their tile. This fixes a number of bugs."


### PR DESCRIPTION
* Telescience portals now have a precision of 0, meaning they output on the turf the portal is on.
* This means echoes can once again be reliably placed back into their bodies.
* This also means calibration should hopefully result in 1/4 the explosions.
If you don't like GPS units phasing into walls and blowing you up 90% of the time, this is the PR for you.