### PR TITLE
Cultist teleport fix

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -3,7 +3,7 @@
 	round_description = "Some crewmembers are attempting to start a cult!"
 	extended_round_description = "The station has been infiltrated by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
 	config_tag = "cult"
-	required_players = 9
-	required_enemies = 4
+	required_players = 1
+	required_enemies = 1
 	end_on_antag_death = 1
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -3,7 +3,7 @@
 	round_description = "Some crewmembers are attempting to start a cult!"
 	extended_round_description = "The station has been infiltrated by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
 	config_tag = "cult"
-	required_players = 1
-	required_enemies = 1
+	required_players = 9
+	required_enemies = 4
 	end_on_antag_death = 1
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -398,9 +398,14 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 
 		var/list/scribewords = list("none")
 
+
+		//this only seems to be for teleportation words, which makes sense since it's the what's in the input for teleport below
 		for (var/entry in words)
 			if (words[entry] != entry)
 				english += list(words[entry] = entry)
+				user << "entry: [entry]"
+				user <<"words: [words]" //list
+				user<<"words\[entry]: [words[entry]]"
 
 		for (var/entry in dictionary)
 			scribewords += entry
@@ -414,8 +419,13 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			if (chosen_rune == "none")
 				to_chat(user, "<span class='notice'>You decide against scribing a rune, perhaps you should take this time to study your notes.</span>")
 				return
+			//choose last word of teleportation here
 			if (chosen_rune == "teleport")
 				dictionary[chosen_rune] += input ("Choose a destination word") in english
+				user<<"Final word selected:"
+				for(var/word in dictionary[chosen_rune])
+					//this records the right words (travel, self, [input]) but needs to be cleared, as it will become (travel, self, [input1], [input2])
+					user<< "[word]"
 			if (chosen_rune == "teleport other")
 				dictionary[chosen_rune] += input ("Choose a destination word") in english
 
@@ -435,9 +445,15 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			var/obj/effect/rune/R = new /obj/effect/rune(user.loc)
 			to_chat(user, "<span class='notice'>You finish drawing the arcane markings of the Geometer.</span>")
 			var/list/required = dictionary[chosen_rune]
+			//this seems confusing to me, as what it outputs is actually cult speak?
+			//removing the english[] reference actually makes it output english
 			R.word1 = english[required[1]]
 			R.word2 = english[required[2]]
 			R.word3 = english[required[3]]
+			user << "Required:"
+			user << "[R.word1]"
+			user << R.word2
+			user << "[R.word3]" //for teleport, word 3 is always ire(or the same within a game, at least) so teleports always lead to each other and become mingled
 			R.check_icon()
 			R.blood_DNA = list()
 			R.blood_DNA[H.dna.unique_enzymes] = H.dna.b_type

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -415,13 +415,9 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 				to_chat(user, "<span class='notice'>You decide against scribing a rune, perhaps you should take this time to study your notes.</span>")
 				return
 			//choose last word of teleportation here
-			if (chosen_rune == "teleport")
+			if(chosen_rune == "teleport" || chosen_rune == "teleport other")
 				if(dictionary[chosen_rune].len > 2)
 					dictionary[chosen_rune].Cut(3, 4) //removes the third teleport word, if it exists (which it always will after the first teleport rune is drawn)
-				dictionary[chosen_rune] += input ("Choose a destination word") in english
-			if (chosen_rune == "teleport other")
-				if(dictionary[chosen_rune].len > 2)
-					dictionary[chosen_rune].Cut(3, 4)
 				dictionary[chosen_rune] += input ("Choose a destination word") in english
 
 		if(user.get_active_hand() != src)

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -443,6 +443,7 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			R.word1 = english[required[1]]
 			R.word2 = english[required[2]]
 			R.word3 = english[required[3]]
+			R.check_icon()
 			R.blood_DNA = list()
 			R.blood_DNA[H.dna.unique_enzymes] = H.dna.b_type
 		return

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -398,14 +398,9 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 
 		var/list/scribewords = list("none")
 
-
-		//this only seems to be for teleportation words, which makes sense since it's the what's in the input for teleport below
 		for (var/entry in words)
 			if (words[entry] != entry)
 				english += list(words[entry] = entry)
-				user << "entry: [entry]"
-				user <<"words: [words]" //list
-				user<<"words\[entry]: [words[entry]]"
 
 		for (var/entry in dictionary)
 			scribewords += entry
@@ -421,12 +416,12 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 				return
 			//choose last word of teleportation here
 			if (chosen_rune == "teleport")
+				if(dictionary[chosen_rune].len > 2)
+					dictionary[chosen_rune].Cut(3, 4) //removes the third teleport word, if it exists (which it always will after the first teleport rune is drawn)
 				dictionary[chosen_rune] += input ("Choose a destination word") in english
-				user<<"Final word selected:"
-				for(var/word in dictionary[chosen_rune])
-					//this records the right words (travel, self, [input]) but needs to be cleared, as it will become (travel, self, [input1], [input2])
-					user<< "[word]"
 			if (chosen_rune == "teleport other")
+				if(dictionary[chosen_rune].len > 2)
+					dictionary[chosen_rune].Cut(3, 4)
 				dictionary[chosen_rune] += input ("Choose a destination word") in english
 
 		if(user.get_active_hand() != src)
@@ -445,16 +440,9 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			var/obj/effect/rune/R = new /obj/effect/rune(user.loc)
 			to_chat(user, "<span class='notice'>You finish drawing the arcane markings of the Geometer.</span>")
 			var/list/required = dictionary[chosen_rune]
-			//this seems confusing to me, as what it outputs is actually cult speak?
-			//removing the english[] reference actually makes it output english
 			R.word1 = english[required[1]]
 			R.word2 = english[required[2]]
 			R.word3 = english[required[3]]
-			user << "Required:"
-			user << "[R.word1]"
-			user << R.word2
-			user << "[R.word3]" //for teleport, word 3 is always ire(or the same within a game, at least) so teleports always lead to each other and become mingled
-			R.check_icon()
 			R.blood_DNA = list()
 			R.blood_DNA[H.dna.unique_enzymes] = H.dna.b_type
 		return

--- a/html/changelogs/synystersparx-PR-7250.yml
+++ b/html/changelogs/synystersparx-PR-7250.yml
@@ -1,0 +1,6 @@
+author: SynysterSparx
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed cultist teleport runes all being on the same network."


### PR DESCRIPTION
Fixed cultist teleport runes all being on the same network.

There is probably a better way to solve this, but at least they work now. 

The core problem was that each time a cultist created a teleport rune, it added the chosen word to the teleport word list, which is originally just "travel, see." After the second teleport, the word list would be 4 long ("travel, see, technology,  join," where the last two depend on the cultist's choice over the creation of two teleport runes), then 5, etc. Since only the third word was read, this caused only the one network to be used. 

This fixes the use of talismans to teleport as well, which is where I thought the problem was before.

Let me know if there is a better way to solve this, thanks!

P.S. I didn't actually test this with teleport other.