### PR TITLE
Misc cultist fixes

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -407,8 +407,7 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			scribewords += entry
 
 		var/chosen_rune = null
-		var/teleport_word = null
-
+		var/list/required = null
 		if(user)
 			chosen_rune = input ("Choose a rune to scribe.") in scribewords
 			if (!chosen_rune)
@@ -416,8 +415,9 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			if (chosen_rune == "none")
 				to_chat(user, "<span class='notice'>You decide against scribing a rune, perhaps you should take this time to study your notes.</span>")
 				return
+			required = dictionary[chosen_rune].Copy()
 			if(chosen_rune == "teleport" || chosen_rune == "teleport other")
-				teleport_word = input ("Choose a destination word") in english
+				required += input ("Choose a destination word") in english
 
 		if(user.get_active_hand() != src)
 			return
@@ -442,10 +442,9 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			var/mob/living/carbon/human/H = user
 			var/obj/effect/rune/R = new /obj/effect/rune(user.loc)
 			to_chat(user, "<span class='notice'>You finish drawing the arcane markings of the Geometer.</span>")
-			var/list/required = dictionary[chosen_rune]
 			R.word1 = english[required[1]]
 			R.word2 = english[required[2]]
-			R.word3 = teleport_word ? english[teleport_word] : english[required[3]] //if teleport word exists, use it. else use regular cultist word.
+			R.word3 = english[required[3]]
 			R.check_icon()
 			R.blood_DNA = list()
 			R.blood_DNA[H.dna.unique_enzymes] = H.dna.b_type

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -406,6 +406,7 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			scribewords += entry
 
 		var/chosen_rune = null
+		var/teleport_word = null
 
 		if(user)
 			chosen_rune = input ("Choose a rune to scribe.") in scribewords
@@ -414,10 +415,8 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			if (chosen_rune == "none")
 				to_chat(user, "<span class='notice'>You decide against scribing a rune, perhaps you should take this time to study your notes.</span>")
 				return
-			if (chosen_rune == "teleport")
-				dictionary[chosen_rune] += input ("Choose a destination word") in english
-			if (chosen_rune == "teleport other")
-				dictionary[chosen_rune] += input ("Choose a destination word") in english
+			if(chosen_rune == "teleport" || chosen_rune == "teleport other")
+				teleport_word = input ("Choose a destination word") in english
 
 		if(user.get_active_hand() != src)
 			return
@@ -437,7 +436,7 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			var/list/required = dictionary[chosen_rune]
 			R.word1 = english[required[1]]
 			R.word2 = english[required[2]]
-			R.word3 = english[required[3]]
+			R.word3 = teleport_word ? english[teleport_word] : english[required[3]] //if teleport word exists, use it. else use regular cultist word.
 			R.check_icon()
 			R.blood_DNA = list()
 			R.blood_DNA[H.dna.unique_enzymes] = H.dna.b_type

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -343,10 +343,6 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 			to_chat(user, "<span class='warning'>You are unable to write a rune here.</span>")
 			return
 
-		if(locate(/obj/effect/rune) in user.loc)
-			to_chat(user,  "<span class='warning'>There is already a rune in this location.</span>")
-			return
-
 		if (C>=26 + runedec + cult.current_antagonists.len) //including the useless rune at the secret room, shouldn't count against the limit of 25 runes - Urist
 			alert("The cloth of reality can't take that much of a strain. Remove some runes first!")
 			return
@@ -360,6 +356,11 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 						return
 					user << browse("[tomedat]", "window=Arcane Tome")
 					return
+		//only check if they want to scribe a rune, so they can still read if standing on a rune
+		if(locate(/obj/effect/rune) in user.loc)
+			to_chat(user,  "<span class='warning'>There is already a rune in this location.</span>")
+			return
+
 		if(isipc(user))
 			to_chat(user, "<span class='notice'>You cannot draw runes, as you have no blood.</span>")
 			return
@@ -427,9 +428,17 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 		user.take_overall_damage((rand(9)+1)/10) // 0.1 to 1.0 damage
 		if(do_after(user, 50))
 			var/area/A = get_area(user)
-			log_and_message_admins("created \an [chosen_rune] rune at \the [A.name] - [user.loc.x]-[user.loc.y]-[user.loc.z].")
+			
 			if(user.get_active_hand() != src)
 				return
+			
+			//prevents using multiple dialogs to layer runes. 
+			if(locate(/obj/effect/rune) in user.loc) //This is check is done twice. once when choosing to scribe a rune, once here
+				to_chat(user,  "<span class='warning'>There is already a rune in this location.</span>")
+				return
+
+			log_and_message_admins("created \an [chosen_rune] rune at \the [A.name] - [user.loc.x]-[user.loc.y]-[user.loc.z].") //only message if it's actually made
+
 			var/mob/living/carbon/human/H = user
 			var/obj/effect/rune/R = new /obj/effect/rune(user.loc)
 			to_chat(user, "<span class='notice'>You finish drawing the arcane markings of the Geometer.</span>")

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -523,7 +523,7 @@ var/list/sacrificed = list()
 			T.imbue = "emp"
 			imbued_from = R
 			break
-		if(R.word1==cultwords["blood"] && R.word2==cultwords["see"] && R.word3==cultwords["destroy"]) //conceal
+		if(R.word1==cultwords["hide"] && R.word2==cultwords["see"] && R.word3==cultwords["blood"]) //conceal
 			T = new(src.loc)
 			T.imbue = "conceal"
 			imbued_from = R

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -18,7 +18,7 @@
 			if("conceal")
 				call(/obj/effect/rune/proc/obscure)(user, 2)
 			if("revealrunes")
-				call(/obj/effect/rune/proc/revealrunes)(src)
+				call(/obj/effect/rune/proc/revealrunes)(user, src)
 			if("ire", "ego", "nahlizet", "certum", "veri", "jatkaa", "balaq", "mgar", "karazet", "geeri")
 				call(/obj/effect/rune/proc/teleport)(user, imbue)
 			if("communicate")

--- a/html/changelogs/synystersparx-pr-7260.yml
+++ b/html/changelogs/synystersparx-pr-7260.yml
@@ -1,0 +1,8 @@
+author: synystersparx
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed cultist teleport rune. Now uses proper user selected third word."
+  - bugfix: "Hide runes can now be imbued into talismans."
+  - bugfix: "Improved prevention of multiple runes on same location."

--- a/html/changelogs/synystersparx-pr-7260.yml
+++ b/html/changelogs/synystersparx-pr-7260.yml
@@ -4,5 +4,6 @@ delete-after: True
 
 changes: 
   - bugfix: "Fixed cultist teleport rune. Now uses proper user selected third word."
-  - bugfix: "Hide runes can now be imbued into talismans."
-  - bugfix: "Improved prevention of multiple runes on same location."
+  - bugfix: "Cultist hide rune can now be imbued into a talisman."
+  - bugfix: "Improved prevention of multiple cultist runes on same location."
+  - bugfix: "Cultist reveal talisman now works properly."


### PR DESCRIPTION
- Cultist teleport runes now use the proper third word.
- Can now imbue hide rune.
- Reveal talisman now functions properly.
- Improved prevention of multiple runes on same location.
