### PR TITLE
Removed the Shield generator room being grille-shocked connected to the MAIN GRID

### DIFF
--- a/html/changelogs/burgerbb - what the hell.yml
+++ b/html/changelogs/burgerbb - what the hell.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "The station's meteor shield room is no longer connect to the main grid."

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -21,6 +21,20 @@
 /obj/structure/sign/electricshock,
 /turf/simulated/wall,
 /area/solar/port)
+"af" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/storage/shields)
 "ag" = (
 /turf/simulated/mineral/surface,
 /area/mine/unexplored)
@@ -28,6 +42,19 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/airless,
 /area/solar/fore)
+"ai" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/obj/structure/sign/securearea,
+/turf/simulated/floor/plating,
+/area/storage/shields)
 "aj" = (
 /obj/machinery/power/solar{
 	id = "auxsolarnorth";
@@ -807,6 +834,40 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/tcomsat)
+"bz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_command{
+	name = "Station Shield Control";
+	req_one_access = list(11,19,24)
+	},
+/turf/simulated/floor/tiled,
+/area/storage/shields)
+"bA" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/sign/securearea,
+/turf/simulated/floor/plating,
+/area/storage/shields)
 "bB" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -897,6 +958,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
+"bM" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/storage/shields)
 "bN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/floor_decal/corner/blue{
@@ -22132,25 +22205,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
-"Wm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/storage/shields)
 "Wo" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -22161,29 +22215,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
-/area/storage/shields)
-"Wp" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/structure/sign/securearea,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
 /area/storage/shields)
 "Wq" = (
 /obj/structure/cable/green{
@@ -22248,35 +22279,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/shields)
-"Wu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/door/airlock/glass_command{
-	name = "Station Shield Control";
-	req_one_access = list(11,19,24)
-	},
-/turf/simulated/floor/tiled,
-/area/storage/shields)
 "Wv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
@@ -22306,27 +22308,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/storage/shields)
-"Wz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/sign/securearea,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/turf/simulated/floor/plating,
 /area/storage/shields)
 "WA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -22368,19 +22349,6 @@
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled,
-/area/storage/shields)
-"WE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/simulated/floor/plating,
 /area/storage/shields)
 "WF" = (
 /obj/machinery/door/firedoor{
@@ -51933,11 +51901,11 @@ yq
 MN
 Ay
 Wi
-Wm
-Wp
-Wu
-Wz
-WE
+af
+ai
+bz
+bA
+bM
 Wi
 QU
 WO


### PR DESCRIPTION
# What this PR does

Before: Shield generator room having shocked grilles connected to the MAIN POWER GRID making it literally the most secure and dangerous room on the station, just before the vault and AI chamber.

After: None of that bullshit. The shield room is no longer grille shocked. This isn't fort knox.


## Why
The crew aren't animals. They're not greytiders. Attaching wires to electric grilles to protect the shield generator is dumb as hell. Like before, engineer had to setup the shield generator themselves but never made it a high secure mess. They just used a single layer of reinforced windows and some glass doors to make it look pretty.