### PR TITLE
Killing off inconsistencies with impact wrenches / combi-tools

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -876,7 +876,7 @@ proc/is_hot(obj/item/W as obj)
 	return ( \
 		W.sharp													  || \
 		W.isscrewdriver()                   || \
-		istype(W, /obj/item/weapon/pen)                           || \
+		W.ispen()                           || \
 		W.iswelder()					  || \
 		istype(W, /obj/item/weapon/flame/lighter/zippo)			  || \
 		istype(W, /obj/item/weapon/flame/match)            		  || \

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -45,7 +45,7 @@ var/list/floor_light_cache = list()
 		update_brightness()
 	else if(W.force && user.a_intent == "hurt")
 		attack_hand(user)
-	else if(istype(W, /obj/item/weapon/crowbar))
+	else if(W.iscrowbar())
 		if(anchored)
 			to_chat(user, "<span class='warning'>\The [src] must be unfastened from the [loc] first!</span>")
 			return

--- a/code/game/machinery/kitchen/cooking_machines/_appliance.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_appliance.dm
@@ -207,7 +207,7 @@
 	else if(istype(check, /obj/item/weapon/disk/nuclear))
 		to_chat(user, "<span class='warning'>You can't cook that.</span>")
 		return 0
-	else if(istype(I, /obj/item/weapon/crowbar) || istype(I, /obj/item/weapon/screwdriver) || istype(I, /obj/item/weapon/storage/part_replacer))
+	else if(I.iscrowbar() || I.isscrewdriver() || istype(I, /obj/item/weapon/storage/part_replacer))
 		return 0
 	else if(!istype(check) && !istype(check, /obj/item/weapon/holder))
 		to_chat(user, "<span class='warning'>That's not edible.</span>")

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -324,15 +324,15 @@ Class Procs:
 			return 1
 	return 0
 
-/obj/machinery/proc/default_deconstruction_crowbar(var/mob/user, var/obj/item/weapon/crowbar/C)
-	if(!istype(C))
+/obj/machinery/proc/default_deconstruction_crowbar(var/mob/user, var/obj/item/C)
+	if(!istype(C) || !C.iscrowbar())
 		return 0
 	if(!panel_open)
 		return 0
 	. = dismantle()
 
-/obj/machinery/proc/default_deconstruction_screwdriver(var/mob/user, var/obj/item/weapon/screwdriver/S)
-	if(!istype(S))
+/obj/machinery/proc/default_deconstruction_screwdriver(var/mob/user, var/obj/item/S)
+	if(!istype(S) || !S.isscrewdriver())
 		return 0
 	playsound(src.loc,  S.usesound, 50, 1)
 	panel_open = !panel_open

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -916,7 +916,7 @@ obj/item/weapon/newspaper/Topic(href, href_list)
 
 
 obj/item/weapon/newspaper/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/weapon/pen))
+	if(W.ispen())
 		if(src.scribble_page == src.curr_page)
 			to_chat(user, "<FONT COLOR='blue'>There's already a scribble in this page... You wouldn't want to make things too cluttered, would you?</FONT>")
 		else

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -957,7 +957,7 @@
 				add_overlay("turret_frame_5c_[case_sprite_set]")
 				return
 
-	if(istype(I, /obj/item/weapon/pen))	//you can rename turrets like bots!
+	if(I.ispen())	//you can rename turrets like bots!
 		var/t = sanitizeSafe(input(user, "Enter new turret name", name, finish_name) as text, MAX_NAME_LEN)
 		if(!t)
 			return

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -107,16 +107,13 @@
 
 /obj/machinery/telecomms/attack_hand(var/mob/user as mob)
 
-	// You need a multitool to use this, or be silicon
-	if(!issilicon(user))
-		// istype returns false if the value is null
-		if(!istype(user.get_active_hand(), /obj/item/device/multitool))
-			return
-
 	if(stat & (BROKEN|NOPOWER))
 		return
 
-	var/obj/item/device/multitool/P = get_multitool(user)
+	var/obj/item/device/multitool/P = user.get_multitool()
+
+	if(!P)
+		return
 
 	user.set_machine(src)
 	var/dat
@@ -172,22 +169,6 @@
 	temp = ""
 	user << browse(dat, "window=tcommachine;size=520x500;can_resize=0")
 	onclose(user, "dormitory")
-
-// Returns a multitool from a user depending on their mobtype.
-
-/obj/machinery/telecomms/proc/get_multitool(mob/user as mob)
-
-	var/obj/item/device/multitool/P = null
-	// Let's double check
-	if(!issilicon(user) && istype(user.get_active_hand(), /obj/item/device/multitool))
-		P = user.get_active_hand()
-	else if(isAI(user))
-		var/mob/living/silicon/ai/U = user
-		P = U.aiMulti
-	else if(isrobot(user) && in_range(user, src))
-		if(istype(user.get_active_hand(), /obj/item/device/multitool))
-			P = user.get_active_hand()
-	return P
 
 // Additional Options for certain machines. Use this when you want to add an option to a specific machine.
 // Example of how to use below.
@@ -255,14 +236,13 @@
 
 /obj/machinery/telecomms/Topic(href, href_list)
 
-	if(!issilicon(usr))
-		if(!istype(usr.get_active_hand(), /obj/item/device/multitool))
-			return
+	if(!isliving(usr))
+		return
 
 	if(stat & (BROKEN|NOPOWER))
 		return
 
-	var/obj/item/device/multitool/P = get_multitool(usr)
+	var/obj/item/device/multitool/P = usr.get_multitool()
 
 	if(href_list["input"])
 		switch(href_list["input"])

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -774,7 +774,7 @@
 	products = list(
 		/obj/item/clothing/glasses/meson = 2,
 		/obj/item/device/multitool = 4,
-		/obj/item/powerdrill = 2,
+		/obj/item/weapon/powerdrill = 2,
 		/obj/item/weapon/airlock_electronics = 10,
 		/obj/item/weapon/module/power_control = 10,
 		/obj/item/weapon/airalarm_electronics = 10,

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -373,7 +373,7 @@ var/list/global/slot_flags_enumeration = list(
 				if(!disable_warning)
 					to_chat(usr, "<span class='warning'>You somehow have a suit with no defined allowed items for suit storage, stop that.</span>")
 				return 0
-			if( !(istype(src, /obj/item/device/pda) || istype(src, /obj/item/weapon/pen) || is_type_in_list(src, H.wear_suit.allowed)) )
+			if( !(istype(src, /obj/item/device/pda) || src.ispen() || is_type_in_list(src, H.wear_suit.allowed)) )
 				return 0
 		if(slot_handcuffed)
 			if(!istype(src, /obj/item/weapon/handcuffs))

--- a/code/game/objects/items/airbubble.dm
+++ b/code/game/objects/items/airbubble.dm
@@ -392,7 +392,7 @@
 		to_chat(usr, "<span class='warning'>[src] has no power cell.</span>")
 
 // Handle most of things: restraining, cutting restrains, attaching tank.
-/obj/structure/closet/airbubble/attackby(W as obj, mob/user as mob)
+/obj/structure/closet/airbubble/attackby(obj/W, mob/user as mob)
 	if(istype(W, /obj/item/weapon/tank))
 		if(!isnull(use_internal_tank))
 			user.visible_message(
@@ -442,7 +442,7 @@
 
 		qdel(W)
 		update_icon()
-	else if(istype(W, /obj/item/weapon/wirecutters))
+	else if(W.iswirecutter())
 		if(!zipped)
 			to_chat(user, "<span class='warning'>[src] has no cables to cut.</span>")
 			attack_hand(user)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -43,7 +43,7 @@
 	var/contains_body = 0
 
 /obj/structure/closet/body_bag/attackby(var/obj/item/W, mob/user as mob)
-	if (istype(W, /obj/item/weapon/pen))
+	if (W.ispen())
 		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
 		if (user.get_active_hand() != W)
 			return

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1283,7 +1283,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		pai.update_location()//This notifies the pAI that they've been slotted into a PDA
 		to_chat(user, "<span class='notice'>You slot \the [C] into [src].</span>")
 		SSnanoui.update_uis(src) // update all UIs attached to src
-	else if(istype(C, /obj/item/weapon/pen))
+	else if(C.ispen())
 		if(pen)
 			to_chat(user, "<span class='notice'>There is already a pen in \the [src].</span>")
 		else

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -51,7 +51,7 @@
 		else
 			to_chat(user, "<span class='notice'>[src] already has a laser diode.</span>")
 
-	else if(istype(W, /obj/item/weapon/screwdriver))
+	else if(W.isscrewdriver())
 		if(diode)
 			to_chat(user, "<span class='notice'>You remove the [diode.name] from the [src].</span>")
 			diode.forceMove(get_turf(user))

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -255,7 +255,7 @@
 		else
 			to_chat(user, "<span class='warning'>The MMI must go in after everything else!</span>")
 
-	if (istype(W, /obj/item/weapon/pen))
+	if (W.ispen())
 		var/t = sanitizeSafe(input(user, "Enter new robot name", src.name, src.created_name), MAX_NAME_LEN)
 		if (!t)
 			return

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -132,7 +132,7 @@
 		else
 			to_chat(user, "<span class='warning'>You need one metal sheet to finish the light tile!</span>")
 
-	else if(istype(O, /obj/item/weapon/wirecutters))
+	else if(O.iswirecutter())
 		user.drop_from_inventory(O,get_turf(src))
 		to_chat(user, "<span class='notice'>You detach the wire from the [name].</span>")
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)

--- a/code/game/objects/items/stacks/tiles/light.dm
+++ b/code/game/objects/items/stacks/tiles/light.dm
@@ -18,7 +18,7 @@
 		state = 0 //fine
 
 /obj/item/stack/tile/light/attackby(var/obj/item/O, var/mob/user)
-	if(istype(O, /obj/item/weapon/crowbar))
+	if(O.iscrowbar())
 		amount--
 		to_chat(user, "<span class='notice'>You pry off the steel sheet from the [name].</span>")
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -20,7 +20,7 @@
 
 /obj/item/weapon/implantcase/attackby(obj/item/weapon/I as obj, mob/user as mob)
 	..()
-	if (istype(I, /obj/item/weapon/pen))
+	if (I.ispen())
 		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
 		if (user.get_active_hand() != I)
 			return

--- a/code/game/objects/items/weapons/implants/implantcircuits.dm
+++ b/code/game/objects/items/weapons/implants/implantcircuits.dm
@@ -39,7 +39,7 @@
 	IC.examine(user)
 
 /obj/item/weapon/implant/integrated_circuit/attackby(var/obj/item/O, var/mob/user)
-	if(istype(O, /obj/item/weapon/crowbar) || istype(O, /obj/item/device/integrated_electronics) || istype(O, /obj/item/integrated_circuit) || istype(O, /obj/item/weapon/screwdriver) || istype(O, /obj/item/weapon/cell/device) )
+	if(O.iscrowbar() || istype(O, /obj/item/device/integrated_electronics) || istype(O, /obj/item/integrated_circuit) || O.isscrewdriver() || istype(O, /obj/item/weapon/cell/device) )
 		IC.attackby(O, user)
 	else
 		..()

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -54,7 +54,7 @@
 		/obj/item/device/analyzer/plant_analyzer,
 		/obj/item/weapon/extinguisher/mini,
 		/obj/item/weapon/pipewrench,
-		/obj/item/powerdrill
+		/obj/item/weapon/powerdrill
 		)
 
 
@@ -66,7 +66,7 @@
 		/obj/item/weapon/crowbar = 1,
 		/obj/item/weapon/wirecutters = 1,
 		/obj/item/stack/cable_coil/random = 1,
-		/obj/item/powerdrill = 1
+		/obj/item/weapon/powerdrill = 1
 	)
 
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -578,7 +578,7 @@
 
 //combitool
 
-/obj/item/combitool
+/obj/item/weapon/combitool
 	name = "combi-tool"
 	desc = "It even has one of those nubbins for doing the thingy."
 	icon = 'icons/obj/tools.dmi'
@@ -595,36 +595,36 @@
 		)
 	var/current_tool = 1
 
-/obj/item/combitool/Initialize()
+/obj/item/weapon/combitool/Initialize()
 	desc = "[initial(desc)] ([tools.len]. [tools.len] possibilit[tools.len == 1 ? "y" : "ies"])"
 	. = ..()
 
-/obj/item/combitool/examine(var/mob/user)
+/obj/item/weapon/combitool/examine(var/mob/user)
 	. = ..()
 	if(. && tools.len)
 		to_chat(user, "It has the following fittings:")
 		for(var/tool in tools)
 			to_chat(user, "- [tool][tools[current_tool] == tool ? " (selected)" : ""]")
 
-/obj/item/combitool/iswrench()
+/obj/item/weapon/combitool/iswrench()
 	return tools[current_tool] == "wrench"
 
-/obj/item/combitool/isscrewdriver()
+/obj/item/weapon/combitool/isscrewdriver()
 	return tools[current_tool] == "screwdriver"
 
-/obj/item/combitool/iswirecutter()
+/obj/item/weapon/combitool/iswirecutter()
 	return tools[current_tool] == "wirecutters"
 
-/obj/item/combitool/iscrowbar()
+/obj/item/weapon/combitool/iscrowbar()
 	return tools[current_tool] == "crowbar"
 
-/obj/item/combitool/ismultitool()
+/obj/item/weapon/combitool/ismultitool()
 	return tools[current_tool] == "multitool"
 
-/obj/item/combitool/proc/update_tool()
+/obj/item/weapon/combitool/proc/update_tool()
 	icon_state = "[initial(icon_state)]-[tools[current_tool]]"
 
-/obj/item/combitool/attack_self(var/mob/user)
+/obj/item/weapon/combitool/attack_self(var/mob/user)
 	if(++current_tool > tools.len)
 		current_tool = 1
 	var/tool = tools[current_tool]
@@ -636,7 +636,7 @@
 	return 1
 
 
-/obj/item/powerdrill
+/obj/item/weapon/powerdrill
 	name = "impact wrench"
 	desc = " The screwdriver's big brother."
 	icon = 'icons/obj/tools.dmi'
@@ -653,7 +653,7 @@
 		)
 	var/current_tool = 1
 
-/obj/item/powerdrill/Initialize()
+/obj/item/weapon/powerdrill/Initialize()
 	. = ..()
 
 	switch(pick("red","blue","yellow","green"))
@@ -667,23 +667,23 @@
 			drillcolor = "yellow"
 	icon_state = "powerdrill[drillcolor]"
 
-/obj/item/powerdrill/examine(var/mob/user)
+/obj/item/weapon/powerdrill/examine(var/mob/user)
 	. = ..()
 	if(. && tools.len)
 		to_chat(user, "It has the following fittings:")
 		for(var/tool in tools)
 			to_chat(user, "- [tool][tools[current_tool] == tool ? " (selected)" : ""]")
 
-/obj/item/powerdrill/iswrench()
+/obj/item/weapon/powerdrill/iswrench()
 	usesound = 'sound/items/air_wrench.ogg'
 	return tools[current_tool] == "wrenchbit"
 
-/obj/item/powerdrill/isscrewdriver()
+/obj/item/weapon/powerdrill/isscrewdriver()
 	usesound = 'sound/items/drill_use.ogg'
 
 	return tools[current_tool] == "screwdriverbit"
 
-/obj/item/powerdrill/proc/update_tool()
+/obj/item/weapon/powerdrill/proc/update_tool()
 	if(isscrewdriver())
 		cut_overlays()
 		add_overlay("screwdriverbit")
@@ -691,7 +691,7 @@
 		cut_overlays()
 		add_overlay("wrenchbit")
 
-/obj/item/powerdrill/attack_self(var/mob/user)
+/obj/item/weapon/powerdrill/attack_self(var/mob/user)
 	if(++current_tool > tools.len)
 		current_tool = 1
 	var/tool = tools[current_tool]

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -153,7 +153,7 @@
 
 
 /obj/structure/door_assembly/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/weapon/pen))
+	if(W.ispen())
 		var/t = sanitizeSafe(input(user, "Enter the name for the door.", src.name, src.created_name), MAX_NAME_LEN)
 		if(!t)	return
 		if(!in_range(src, usr) && src.loc != usr)	return

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -90,8 +90,8 @@
 	update()
 	return
 
-/obj/structure/morgue/attackby(P as obj, mob/user as mob)
-	if (istype(P, /obj/item/weapon/pen))
+/obj/structure/morgue/attackby(obj/P, mob/user as mob)
+	if (P.ispen())
 		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
 		if (user.get_active_hand() != P)
 			return
@@ -274,8 +274,8 @@
 	src.add_fingerprint(user)
 	update()
 
-/obj/structure/crematorium/attackby(P as obj, mob/user as mob)
-	if (istype(P, /obj/item/weapon/pen))
+/obj/structure/crematorium/attackby(obj/P, mob/user as mob)
+	if (P.ispen())
 		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
 		if (user.get_active_hand() != P)
 			return

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -64,15 +64,16 @@
 			return
 		var/obj/item/P = locate(href_list["write"])
 		if((P && P.loc == src)) //ifthe paper's on the board
-			if(istype(usr.r_hand, /obj/item/weapon/pen)) //and you're holding a pen
-				add_fingerprint(usr)
-				P.attackby(usr.r_hand, usr) //then do ittttt
+			var/obj/item/R = usr.r_hand
+			var/obj/item/L = usr.l_hand
+			if(R.ispen())
+				P.attackby(R, usr)
+			else if(L.ispen())
+				P.attackby(L, usr)
 			else
-				if(istype(usr.l_hand, /obj/item/weapon/pen)) //check other hand for pen
-					add_fingerprint(usr)
-					P.attackby(usr.l_hand, usr)
-				else
-					to_chat(usr, "<span class='notice'>You'll need something to write with!</span>")
+				to_chat(usr, "<span class='notice'>You'll need something to write with!</span>")
+				return
+			add_fingerprint(usr)
 	if(href_list["read"])
 		var/obj/item/weapon/paper/P = locate(href_list["read"])
 		if((P && P.loc == src))

--- a/code/modules/custom_ka/core.dm
+++ b/code/modules/custom_ka/core.dm
@@ -398,7 +398,7 @@
 		custom_name = sanitize(input("Enter a custom name for your [name]", "Set Name") as text|null)
 		to_chat(user,"You label \the [name] as \"[custom_name]\"")
 		update_icon()
-	else if(istype(I,/obj/item/weapon/wrench))
+	else if(I.iswrench())
 		if(installed_upgrade_chip)
 			playsound(src,I.usesound, 50, 0)
 			to_chat(user,"You remove \the [installed_upgrade_chip].")

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -263,7 +263,7 @@
 		update_icon()
 		return TRUE
 
-	else if(istype(I, /obj/item/device/integrated_electronics/wirer) || istype(I, /obj/item/device/integrated_electronics/debugger) || istype(I, /obj/item/weapon/screwdriver))
+	else if(istype(I, /obj/item/device/integrated_electronics/wirer) || istype(I, /obj/item/device/integrated_electronics/debugger) || I.isscrewdriver())
 		if(opened)
 			interact(user)
 		else

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -211,14 +211,14 @@ a creative player the means to solve many problems.  Circuits are held inside an
 				ea.interact(usr)
 
 	if(href_list["pin_name"])
-		if (!istype(held_item, /obj/item/device/multitool) || !allow_multitool)
+		if (!held_item.ismultitool() || !allow_multitool)
 			href_list["wire"] = 1
 		else
 			var/obj/item/device/multitool/M = held_item
 			M.wire(pin,usr)
 
 	if(href_list["pin_data"])
-		if (!istype(held_item, /obj/item/device/multitool) || !allow_multitool)
+		if (!held_item.ismultitool() || !allow_multitool)
 			href_list["wire"] = 1
 
 		else
@@ -226,7 +226,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 			io.ask_for_pin_data(usr) // The pins themselves will determine how to ask for data, and will validate the data.
 
 	if(href_list["pin_unwire"])
-		if (!istype(held_item, /obj/item/device/multitool) || !allow_multitool)
+		if (!held_item.ismultitool() || !allow_multitool)
 			href_list["wire"] = 1
 		else
 			var/obj/item/device/multitool/M = held_item

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -30,7 +30,7 @@
 	if(istype(O, /obj/item/weapon/book))
 		user.drop_from_inventory(O,src)
 		update_icon()
-	else if(istype(O, /obj/item/weapon/pen))
+	else if(O.ispen())
 		var/newname = sanitizeSafe(input("What would you like to title this bookshelf?"), MAX_NAME_LEN)
 		if(!newname)
 			return
@@ -235,7 +235,7 @@
 		else
 			to_chat(user, "<span class='notice'>There's already something in [title]!</span>")
 			return
-	if(istype(W, /obj/item/weapon/pen))
+	if(W.ispen())
 		if(unique)
 			to_chat(user, "These pages don't seem to take the ink well. Looks like you can't modify it.")
 			return

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -387,7 +387,7 @@ var/list/cleanbot_types // Going to use this to generate a list of types once th
 		to_chat(user, "<span class='notice'>You add the robot arm to the bucket and sensor assembly. Beep boop!</span>")
 		qdel(src)
 
-	else if(istype(O, /obj/item/weapon/pen))
+	else if(O.ispen())
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)
 		if(!t)
 			return

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -296,7 +296,7 @@
 /obj/item/weapon/secbot_assembly/ed209_assembly/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	..()
 
-	if(istype(W, /obj/item/weapon/pen))
+	if(W.ispen())
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)
 		if(!t)
 			return

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -380,7 +380,7 @@
 		qdel(src)
 		return 1
 
-	else if(istype(W, /obj/item/weapon/pen))
+	else if(W.ispen())
 		var/t = input(user, "Enter new robot name", name, created_name) as text
 		t = sanitize(t, MAX_NAME_LEN)
 		if(!t)

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -341,7 +341,7 @@
 		to_chat(user, "<span class='notice'>You add the sensor to the toolbox and tiles!</span>")
 		qdel(src)
 		return 1
-	else if (istype(W, /obj/item/weapon/pen))
+	else if (W.ispen())
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)
 		if(!t)
 			return
@@ -371,7 +371,7 @@
 		to_chat(user, "<span class='notice'>You add the robot arm to the odd looking toolbox assembly! Boop beep!</span>")
 		qdel(src)
 		return 1
-	else if(istype(W, /obj/item/weapon/pen))
+	else if(W.ispen())
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)
 		if(!t)
 			return

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -347,7 +347,7 @@
 
 /obj/item/weapon/firstaid_arm_assembly/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
-	if(istype(W, /obj/item/weapon/pen))
+	if(W.ispen())
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)
 		if(!t)
 			return

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -597,7 +597,7 @@
 
 /mob/living/bot/secbot/attackby(var/obj/item/O, var/mob/user)
 	..()
-	if(istype(O, /obj/item/weapon/card/id) || istype(O, /obj/item/weapon/pen) || istype(O, /obj/item/device/pda))
+	if(istype(O, /obj/item/weapon/card/id) || O.ispen() || istype(O, /obj/item/device/pda))
 		return
 
 	target = user
@@ -708,7 +708,7 @@
 		qdel(src)
 		return 1
 
-	else if(istype(O, /obj/item/weapon/pen))
+	else if(O.ispen())
 		var/t = sanitizeSafe(input(user, "Enter new robot name", name, created_name), MAX_NAME_LEN)
 		if(!t)
 			return

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -356,7 +356,7 @@ var/global/list/robot_modules = list(
 /obj/item/weapon/robot_module/engineering/construction/New()
 	..()
 	src.modules += new /obj/item/device/flash(src)
-	src.modules += new /obj/item/powerdrill(src)
+	src.modules += new /obj/item/weapon/powerdrill(src)
 	src.modules += new /obj/item/borg/sight/meson(src)
 	src.modules += new /obj/item/weapon/extinguisher(src)
 	src.modules += new /obj/item/weapon/rfd/construction/borg(src)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1207,8 +1207,8 @@ proc/is_blind(A)
 
 #undef SAFE_PERP
 
-/mob/proc/get_multitool(var/obj/item/device/multitool/P)
-	if(istype(P))
+/mob/proc/get_multitool(var/obj/P)
+	if(P.ismultitool())
 		return P
 
 /mob/abstract/observer/get_multitool()

--- a/code/modules/organs/subtypes/autakh.dm
+++ b/code/modules/organs/subtypes/autakh.dm
@@ -291,7 +291,7 @@
 /obj/item/organ/external/hand/right/autakh/tool
 	name = "engineering grasper"
 	action_button_name = "Deploy Mechanical Combitool"
-	var/augment_type = /obj/item/combitool/robotic
+	var/augment_type = /obj/item/weapon/combitool/robotic
 
 /obj/item/organ/external/hand/right/autakh/tool/refresh_action_button()
 	. = ..()
@@ -329,15 +329,15 @@
 		owner.put_in_active_hand(M)
 		owner.visible_message("<span class='notice'>\The [M] slides out of \the [owner]'s [src].</span>","<span class='notice'>You deploy \the [M]!</span>")
 
-/obj/item/combitool/robotic
+/obj/item/weapon/combitool/robotic
 	name = "robotic combitool"
 	desc = "An integrated combitool module."
 	icon_state = "digitool"
 
-/obj/item/combitool/robotic/throw_at()
+/obj/item/weapon/combitool/robotic/throw_at()
 	usr.drop_from_inventory(src)
 
-/obj/item/combitool/robotic/dropped()
+/obj/item/weapon/combitool/robotic/dropped()
 	loc = null
 	qdel(src)
 

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -57,10 +57,10 @@
 		r_contents = reverselist(contents)
 		to_chat(user, "<span class='notice'>You clip the [W] onto \the [src].</span>")
 
-	else if(istype(toppaper) && istype(W, /obj/item/weapon/pen))
+	else if(istype(toppaper) && W.ispen())
 		toppaper.attackby(W, user)
 
-	else if(istype(W, /obj/item/weapon/pen))
+	else if(W.ispen())
 		add_pen(user)
 
 	if(ui_open)
@@ -101,7 +101,7 @@
 /obj/item/weapon/clipboard/proc/add_pen(mob/user)
 	if(!haspen)
 		var/obj/item/weapon/pen/W = user.get_active_hand()
-		if(istype(W, /obj/item/weapon/pen))
+		if(W.ispen())
 			user.drop_from_inventory(W,src)
 			haspen = W
 			to_chat(user, "<span class='notice'>You slot the pen into \the [src].</span>")
@@ -131,7 +131,7 @@
 
 				var/obj/item/I = usr.get_active_hand()
 
-				if(istype(I, /obj/item/weapon/pen))
+				if(I.ispen())
 					P.attackby(I, usr)
 				else if (haspen)
 					P.attackby(haspen, usr)

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -41,7 +41,7 @@
 		user.drop_from_inventory(W,src)
 		to_chat(user, "<span class='notice'>You put the [W] into \the [src].</span>")
 		update_icon()
-	else if(istype(W, /obj/item/weapon/pen))
+	else if(W.ispen())
 		var/n_name = sanitizeSafe(input(usr, "What would you like to label the folder?", "Folder Labelling", null)  as text, MAX_NAME_LEN)
 		if((loc == usr && usr.stat == 0))
 			name = "folder[(n_name ? text("- '[n_name]'") : null)]"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -245,7 +245,7 @@
 	update_icon()
 
 /obj/item/weapon/paper/proc/get_signature(var/obj/item/weapon/pen/P, mob/user as mob)
-	if(P && istype(P, /obj/item/weapon/pen))
+	if(P && P.ispen())
 		return P.get_signature(user)
 
 	if (user)
@@ -363,7 +363,7 @@
 		var/obj/item/i = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
 		var/obj/item/weapon/clipboard/c
 		var/iscrayon = 0
-		if(!istype(i, /obj/item/weapon/pen))
+		if(!i.ispen())
 			if(usr.back && istype(usr.back,/obj/item/weapon/rig))
 				var/obj/item/weapon/rig/r = usr.back
 				var/obj/item/rig_module/device/pen/m = locate(/obj/item/rig_module/device/pen) in r.installed_modules
@@ -474,7 +474,7 @@
 		B.amount = 2
 		B.update_icon()
 
-	else if(istype(P, /obj/item/weapon/pen))
+	else if(P.ispen())
 		if(icon_state == "scrap")
 			to_chat(user, span("warning", "The [src] is too crumpled to write on."))
 			return

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -42,7 +42,7 @@ var/global/photo_count = 0
 	user.examinate(src)
 
 /obj/item/weapon/photo/attackby(obj/item/weapon/P as obj, mob/user as mob)
-	if(istype(P, /obj/item/weapon/pen))
+	if(P.ispen())
 		var/txt = sanitize(input(user, "What would you like to write on the back?", "Photo Writing", null)  as text, 128)
 		if(loc == user && user.stat == 0)
 			scribble = txt

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -79,14 +79,14 @@
 
 /obj/item/weapon/reagent_containers/blood/attackby(obj/item/weapon/P as obj, mob/user as mob)
 	..()
-	if (istype(P, /obj/item/weapon/pen))
+	if (P.ispen())
 		if (reagents.get_reagent_amount("blood") && name != "empty blood pack") //Stops people mucking with bloodpacks that are filled
 			to_chat(usr, "<span class='notice'>You can't relabel [name] until it is empty!</span>")
 			return
 		var/blood_name = input(usr, "What blood type would you like to label it as?", "Blood Types") in list("A+", "A-", "B+", "B-", "O+", "O-", "AB+", "AB-", "Cancel")
 		if (blood_name == "Cancel") return
 		var/obj/item/i = usr.get_active_hand()
-		if (!istype(i, /obj/item/weapon/pen) || !in_range(user, src)) return //Checks to see if pen is still held or bloodback is in range
+		if (!i.ispen() || !in_range(user, src)) return //Checks to see if pen is still held or bloodback is in range
 		name = "blood pack [blood_name]"
 		desc = "Contains blood used for transfusion."
 		to_chat(usr, "<span class='notice'>You label the blood pack as [blood_name].</span>")

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3955,7 +3955,7 @@
 			to_chat(user, "<span class='warning'>You try to push \the [I] through the lid but it doesn't work!</span>")
 		return
 
-	if( istype(I, /obj/item/weapon/pen/) )
+	if( I.ispen() )
 
 		if( src.open )
 			return

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -54,7 +54,7 @@
 	if(istype(W,/obj/item/weapon/storage/part_replacer))
 		if(!reagents || !reagents.total_volume)
 			return ..()
-	if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/device/flashlight/pen))
+	if(W.ispen() || istype(W, /obj/item/device/flashlight/pen))
 		var/tmp_label = sanitizeSafe(input(user, "Enter a label for [name]", "Label", label_text), MAX_NAME_LEN)
 		if(length(tmp_label) > 15)
 			to_chat(user, "<span class='notice'>The label can be at most 15 characters long.</span>")

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -43,7 +43,7 @@
 		else
 			to_chat(user, "<span class='warning'>You need to set a destination first!</span>")
 
-	else if(istype(W, /obj/item/weapon/pen))
+	else if(W.ispen())
 		switch(alert("What would you like to alter?",,"Title","Description", "Cancel"))
 			if("Title")
 				var/str = sanitizeSafe(input(usr,"Label text?","Set label",""), MAX_NAME_LEN)
@@ -153,7 +153,7 @@
 		else
 			to_chat(user, "<span class='warning'>You need to set a destination first!</span>")
 
-	else if(istype(W, /obj/item/weapon/pen))
+	else if(W.ispen())
 		switch(alert("What would you like to alter?",,"Title","Description", "Cancel"))
 			if("Title")
 				var/str = sanitizeSafe(input(usr,"Label text?","Set label",""), MAX_NAME_LEN)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -132,7 +132,7 @@ other types of metals and chemistry for reagents).
 	id = "powerdrill"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 60, "glass" = 50)
-	build_path = /obj/item/powerdrill
+	build_path = /obj/item/weapon/powerdrill
 	sort_string = "GAAAD"
 
 ///////////////////////////////////

--- a/code/modules/research/xenoarchaeology/chemistry.dm
+++ b/code/modules/research/xenoarchaeology/chemistry.dm
@@ -14,7 +14,7 @@
 	flags = OPENCONTAINER
 
 obj/item/weapon/reagent_containers/glass/solution_tray/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
-	if(istype(W, /obj/item/weapon/pen))
+	if(W.ispen())
 		var/new_label = sanitizeSafe(input("What should the new label be?","Label solution tray"), MAX_NAME_LEN)
 		if(new_label)
 			name = "solution tray ([new_label])"

--- a/html/changelogs/johnwildkins-combitool.yml
+++ b/html/changelogs/johnwildkins-combitool.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - refactor: "(Essentially) all instances of istype checks for tools removed. As such, combitools and impact wrenches should now work for all normal tool uses except mech and RIG crafting."


### PR DESCRIPTION
Part 1 in the "why my impact wrench no wrench bolt" saga

tl;dr for end users: combitools / impact wrenches now work on everything their non-powered versions do (except mechs and RIGs, tune in next time on dragon ball Z for that)

essentially all this PR does is murder every istype() check possible that could use a helper function instead, most notably many pen checks with ispen(). it also repaths combitools and powerdrills to /obj/item/weapon so they aren't instantly taken out of contention by half of the known attackby() prompts

I already squashed a couple runtimes here and there from the pen changes and it's possible I missed another because pencode is another scourge upon our lives