### PR TITLE
Makes Ninja need slight higher Playercount

### DIFF
--- a/code/game/gamemodes/ninja/ninja.dm
+++ b/code/game/gamemodes/ninja/ninja.dm
@@ -9,7 +9,7 @@
 		the omniscience of the AI and rival the most hardened weapons your station is capable of. Tread lightly and \
 		only hope these unknown assassins aren't here for you."
 	config_tag = "ninja"
-	required_players = 10
+	required_players = 15
 	max_players = 30
 	required_enemies = 2
 	end_on_antag_death = 0

--- a/html/changelogs/geeves - ninjaNoNinja.yml
+++ b/html/changelogs/geeves - ninjaNoNinja.yml
@@ -1,0 +1,7 @@
+
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Ninja now needs 15 players playing before it gets chosen as a gamemode."


### PR DESCRIPTION
* Ninja now needs 15 players playing to start, instead of just 10. It won't solve the problem, but it'll make it slightly less punishing on low-pop.