### PR TITLE
Gives the freelance mercs headsets and a couple other tweaks.

### DIFF
--- a/code/datums/outfits/ert/ert.dm
+++ b/code/datums/outfits/ert/ert.dm
@@ -102,7 +102,9 @@
 	suit = /obj/item/clothing/suit/space/void/merc
 	head = /obj/item/clothing/head/helmet/space/void/merc
 	suit_store = /obj/item/weapon/tank/oxygen
-	id = /obj/item/weapon/card/id/distress
+	id = /obj/item/weapon/card/id/syndicate
+
+	l_ear = /obj/item/device/radio/headset/distress
 
 	backpack_contents = list(
 		/obj/item/weapon/gun/projectile/automatic/c20r = 1,
@@ -139,7 +141,7 @@
 
 /datum/outfit/admin/ert/mercenary/leader
 	name = "Mercenary Freelancer Leader"
-	l_hand = /obj/item/weapon/gun/projectile/automatic/rifle
+	l_hand = /obj/item/weapon/gun/projectile/automatic/rifle/sts35
 	back = /obj/item/weapon/rig/merc/distress
 	suit_store = null
 	suit = null

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -233,8 +233,6 @@
 /obj/item/device/radio/headset/distress
 	name = "specialist radio headset"
 	desc = "A headset used by specialists."
-	icon_state = "com_headset"
-	item_state = "headset"
 	ks2type = /obj/item/device/encryptionkey/onlyert
 
 /obj/item/device/radio/headset/representative

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -230,6 +230,13 @@
 	item_state = "headset"
 	ks2type = /obj/item/device/encryptionkey/onlyert
 
+/obj/item/device/radio/headset/distress
+	name = "specialist radio headset"
+	desc = "A headset used by specialists."
+	icon_state = "com_headset"
+	item_state = "headset"
+	ks2type = /obj/item/device/encryptionkey/onlyert
+
 /obj/item/device/radio/headset/representative
 	name = "representative headset"
 	desc = "The headset of your worst enemy."

--- a/html/changelogs/191029-bugfix_freemerc_headset.yml
+++ b/html/changelogs/191029-bugfix_freemerc_headset.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Ferner
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Gave the freelance mercs a headset, switched their id to an agent one, and fixed the leader's rifle being the wrong type."


### PR DESCRIPTION
 - Gave the freelance mercs headsets. They have the common and response team channels.
 - Switched their id-type to agent ones, to allow them to be edited if needed.
 - Fixed the freelance merc leader's rifle being the wrong type.