### PR TITLE
Highly-Anticipated Crayon Features

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -182,6 +182,14 @@
 			amount = list(1,2,3,4,5),
 			emag = 0
 		),
+		"crayon_box" = list(
+			name = "Crayon Box",
+			class = "Items",
+			object = /obj/item/weapon/storage/fancy/crayons,
+			cost = 600,
+			amount = list(1,2,3,4,5),
+			emag = 0
+		),
 		"animalhide" = list(
 			name = "Animal Hide",
 			class = "Construction",

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -3,36 +3,42 @@
 	colour = "#DA0000"
 	shadeColour = "#810C0C"
 	colourName = "red"
+	dust = "crayon_dust_red"
 
 /obj/item/weapon/pen/crayon/orange
 	icon_state = "crayonorange"
 	colour = "#FF9300"
 	shadeColour = "#A55403"
 	colourName = "orange"
+	dust = "crayon_dust_orange"
 
 /obj/item/weapon/pen/crayon/yellow
 	icon_state = "crayonyellow"
 	colour = "#FFF200"
 	shadeColour = "#886422"
 	colourName = "yellow"
+	dust = "crayon_dust_yellow"
 
 /obj/item/weapon/pen/crayon/green
 	icon_state = "crayongreen"
 	colour = "#A8E61D"
 	shadeColour = "#61840F"
 	colourName = "green"
+	dust = "crayon_dust_green"
 
 /obj/item/weapon/pen/crayon/blue
 	icon_state = "crayonblue"
 	colour = "#00B7EF"
 	shadeColour = "#0082A8"
 	colourName = "blue"
+	dust = "crayon_dust_blue"
 
 /obj/item/weapon/pen/crayon/purple
 	icon_state = "crayonpurple"
 	colour = "#DA00FF"
 	shadeColour = "#810CFF"
 	colourName = "purple"
+	dust = "crayon_dust_purple"
 
 /obj/item/weapon/pen/crayon/mime
 	icon_state = "crayonmime"
@@ -40,7 +46,8 @@
 	colour = "#FFFFFF"
 	shadeColour = "#000000"
 	colourName = "mime"
-	uses = 0
+	dust = "crayon_dust_grey"
+	chem_volume = 15
 
 /obj/item/weapon/pen/crayon/mime/attack_self(mob/living/user as mob) //inversion
 	if(colour != "#FFFFFF" && shadeColour != "#000000")
@@ -58,7 +65,8 @@
 	colour = "#FFF000"
 	shadeColour = "#000FFF"
 	colourName = "rainbow"
-	uses = 0
+	dust = "crayon_dust_brown"
+	chem_volume = 20
 
 /obj/item/weapon/pen/crayon/rainbow/attack_self(mob/living/user as mob)
 	colour = input(user, "Please select the main colour.", "Crayon colour") as color
@@ -89,9 +97,9 @@
 			new /obj/effect/decal/cleanable/crayon(target,colour,shadeColour,drawtype)
 			to_chat(user, "You finish drawing.")
 			target.add_fingerprint(user)		// Adds their fingerprints to the floor the crayon is drawn on.
-			if(uses)
-				uses--
-				if(!uses)
+			if(reagents)
+				reagents.remove_reagent(dust,0.5) //using crayons reduces crayon dust in it.
+				if(reagents.total_volume <= 0)
 					to_chat(user, "<span class='warning'>You used up your crayon!</span>")
 					qdel(src)
 	return
@@ -100,12 +108,10 @@
 	if(M == user)
 		to_chat(user, "You take a bite of the crayon and swallow it.")
 		user.adjustNutritionLoss(-1)
-		user.reagents.add_reagent("crayon_dust",min(5,uses)/3)
-		if(uses)
-			uses -= 5
-			if(uses <= 0)
-				to_chat(user, "<span class='warning'>You ate your crayon!</span>")
-				qdel(src)
+		reagents.trans_to_mob(user, 2, CHEM_INGEST)
+		if(reagents.total_volume <= 0)
+			to_chat(user, "<span class='warning'>You ate your crayon!</span>")
+			qdel(src)
 	else
 		..(M, user, target_zone)
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -189,10 +189,16 @@
 	attack_verb = list("attacked", "coloured")
 	colour = "#FF0000" //RGB
 	var/shadeColour = "#220000" //RGB
-	var/uses = 30 //0 for unlimited uses
 	var/instant = 0
 	var/colourName = "red" //for updateIcon purposes
+	var/chem_volume = 10 //crayon dust
+	var/dust = "crayon_dust"
 
 	New()
 		name = "[colourName] crayon"
 		..()
+
+/obj/item/weapon/pen/crayon/Initialize()
+	. = ..()
+	create_reagents(chem_volume)
+	reagents.add_reagent(dust,chem_volume)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -14,41 +14,49 @@
 	name = "Red crayon dust"
 	id = "crayon_dust_red"
 	color = "#FE191A"
+	taste_description = "chalky strawberry wax"
 
 /datum/reagent/crayon_dust/orange
 	name = "Orange crayon dust"
 	id = "crayon_dust_orange"
 	color = "#FFBE4F"
+	taste_description = "chalky orange peels"
 
 /datum/reagent/crayon_dust/yellow
 	name = "Yellow crayon dust"
 	id = "crayon_dust_yellow"
 	color = "#FDFE7D"
+	taste_description = "chalky lemon rinds"
 
 /datum/reagent/crayon_dust/green
 	name = "Green crayon dust"
 	id = "crayon_dust_green"
 	color = "#18A31A"
+	taste_description = "chalky lime rinds"
 
 /datum/reagent/crayon_dust/blue
 	name = "Blue crayon dust"
 	id = "crayon_dust_blue"
 	color = "#247CFF"
+	taste_description = "chalky blueberry skins"
 
 /datum/reagent/crayon_dust/purple
 	name = "Purple crayon dust"
 	id = "crayon_dust_purple"
 	color = "#CC0099"
+	taste_description = "chalky grape skins"
 
 /datum/reagent/crayon_dust/grey //Mime
 	name = "Grey crayon dust"
 	id = "crayon_dust_grey"
 	color = "#808080"
+	taste_description = "chalky crushed dreams"
 
 /datum/reagent/crayon_dust/brown //Rainbow
 	name = "Brown crayon dust"
 	id = "crayon_dust_brown"
 	color = "#846F35"
+	taste_description = "raw, powerful creativity"
 
 /datum/reagent/paint
 	name = "Paint"

--- a/html/changelogs/doxxmedearly - crayon fiesta.yml
+++ b/html/changelogs/doxxmedearly - crayon fiesta.yml
@@ -1,0 +1,18 @@
+
+
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added crayon dust to crayons! You can now place crayons in grinders to get dust. Using or eating a crayon will reduce the amount of dust it gives."
+  - rscadd: "Added unique flavor descriptions to each color of crayon dust. Sol Marines rejoice!"
+  - rscadd: "The biogenerator is now able to produce boxes of crayons."
+  - tweak: "Regular crayons now effectively have 20 uses, down from 30. Mime and Rainbow crayons are no longer infinite, but last longer than normal crayons (and give more crayon dust!)"


### PR DESCRIPTION
- Crayons finally have crayon dust in them. Use a grinder to get it (syringes won't work). 
- Removed the "uses" var for crayons and made the number of times a crayon can be used (or chewed on) based on the amount of crayon dust remaining.
- Normal crayons contain 10 units of crayon dust. One drawing consumes 0.5 dust (for 20 effective uses. Down from 30). Taking a bite transfer 2 units to you (For five bites). So where before you could bite a crayon 4 times and still use it 30 times, now if you bite a crayon 4 times (8 units) you can only use the nub to draw 4 times (2 units) before it's gone.
- Mime crayons have 15 units of dust, rainbow crayons have 20. 
- Biogenerator can produce crayon boxes now. It can already produce wax and cardboard, so this isn't a stretch. People will have to interact with hydro or cargo to get a good amount of a specific color of dust. 
- Gave crayon dust colors unique flavors because why not. It's fun. 
- Addresses #6284