### PR TITLE
Removes a ripley paint kit that wasn't supposed to appear under normal circumstances

### DIFF
--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -160,7 +160,7 @@
 
 /obj/item/device/kit/paint/ripley/random/New()
 	..()
-	var/list/ripleys = (typesof(/obj/item/device/kit/paint/ripley) - typesof(/obj/item/device/kit/paint/ripley/fluff))
+	var/list/ripleys = (typesof(/obj/item/device/kit/paint/ripley) - typesof(/obj/item/device/kit/paint/ripley/fluff) - /obj/item/device/kit/paint/ripley/shire)
 	var/build_path = pick(ripleys)
 	new build_path(src.loc)
 	qdel(src)

--- a/html/changelogs/191104-bugfix_shirevendor.yml
+++ b/html/changelogs/191104-bugfix_shirevendor.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Ferner
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Stopped the supposedly over a century old shire paint kit from appearing in the mining vendor."


### PR DESCRIPTION
 - Removes the lorewise centuries old shire kit as a possibility you can get from mining vendors. It's supposed to be a thing you can solely get from certain derelict sites.