### PR TITLE
Tea no longer harms dionae

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -977,6 +977,7 @@
 
 
 /datum/reagent/drink/dynjuice/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
 	M.adjustToxLoss(-0.3 * removed)
 
 /datum/reagent/drink/dynjuice/hot
@@ -1089,22 +1090,14 @@
 	glass_name = "cup of tea"
 	glass_desc = "Tasty black tea, it has antioxidants, it's good for you!"
 
-	var/last_taste_time = -100
-
 /datum/reagent/drink/tea/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	M.adjustToxLoss(-0.1 * removed)
 
 
 /datum/reagent/drink/tea/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
-		if(last_taste_time + 800 < world.time) // Not to spam message
-			to_chat(M, "<span class='danger'>Your body withers as you feel slight pain throughout.</span>")
-			last_taste_time = world.time
-		metabolism = REM * 0.33
-		M.adjustToxLoss(1.5 * removed)
-	else
-		M.adjustToxLoss(-0.1 * removed)
+	..()
+	M.adjustToxLoss(-0.1 * removed)
 
 /datum/reagent/drink/tea/icetea
 	name = "Iced Tea"
@@ -2147,23 +2140,14 @@
 	glass_name = "cup of teathpaste"
 	glass_desc = "Recommended by 1 out of 5 dentists."
 
-
-	var/last_taste_time = -100
-
 /datum/reagent/drink/toothpaste/teathpaste/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed) //contains tea. Gotta get those tea effects.
 	..()
 	M.adjustToxLoss(-0.1 * removed)
 
 
 /datum/reagent/drink/toothpaste/teathpaste/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
-		if(last_taste_time + 800 < world.time) // Not to spam message
-			to_chat(M, "<span class='danger'>Your body withers as you feel slight pain throughout.</span>")
-			last_taste_time = world.time
-		metabolism = REM * 0.33
-		M.adjustToxLoss(1.5 * removed)
-	else
-		M.adjustToxLoss(-0.1 * removed)
+	..()
+	M.adjustToxLoss(-0.1 * removed)
 
 /* Alcohol */
 
@@ -4453,23 +4437,14 @@
 	glass_name = "cup of Trizkizki tea"
 	glass_desc = "A popular drink from Ouerea that smells of crisp sea air."
 
-
-	var/last_taste_time = -100
-
 /datum/reagent/alcohol/butanol/trizkizki_tea/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed) //contains tea. Gotta get those tea effects.
 	..()
 	M.adjustToxLoss(-0.1 * removed)
 
 
 /datum/reagent/alcohol/butanol/trizkizki_tea/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
-		if(last_taste_time + 800 < world.time) // Not to spam message
-			to_chat(M, "<span class='danger'>Your body withers as you feel slight pain throughout.</span>")
-			last_taste_time = world.time
-		metabolism = REM * 0.33
-		M.adjustToxLoss(1.5 * removed)
-	else
-		M.adjustToxLoss(-0.1 * removed)
+	..()
+	M.adjustToxLoss(-0.1 * removed)
 
 //ZZZZOOOODDDDAAAAA
 

--- a/html/changelogs/doxxmedearly - dionaetea.yml
+++ b/html/changelogs/doxxmedearly - dionaetea.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Tea no longer causes toxins damage to dionae in any way. Tea never healed radiation, so it shouldn't have had this effect. Trees, rejoice!"


### PR DESCRIPTION
Confirmed with Yonnimer before doing this PR. All hail tree maintainer. 
Tea had harmful affect_blood effects on dionae, but tea was never an anti-rad, so this really shouldn't have been a thing. PR removes this effect for all drinks in the tea parent path (as well as the two tea-based drinks in xeno booze paths). 