### PR TITLE
Changes the Station Engineer job title to Maintenance Technician

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -638,7 +638,7 @@ datum/objective/heist
 
 datum/objective/heist/kidnap
 	choose_target()
-		var/list/roles = list("Chief Engineer","Research Director","Roboticist","Pharmacist","Station Engineer")
+		var/list/roles = list("Chief Engineer","Research Director","Roboticist","Pharmacist","Maintenance Technician")
 		var/list/possible_targets = list()
 		var/list/priority_targets = list()
 

--- a/code/game/jobs/faction/hephaestus.dm
+++ b/code/game/jobs/faction/hephaestus.dm
@@ -50,7 +50,6 @@
 	)
 
 	titles_to_loadout = list(
-		"Station Engineer" = /datum/outfit/job/engineer/hephaestus,
 		"Maintenance Technician" = /datum/outfit/job/engineer/hephaestus,
 		"Engine Technician" = /datum/outfit/job/engineer/hephaestus,
 		"Electrician" = /datum/outfit/job/engineer/hephaestus,
@@ -67,7 +66,7 @@
 	)
 
 /datum/outfit/job/engineer/hephaestus
-	name = "Station Engineer - Hephaestus"
+	name = "Maintenance Technician - Hephaestus"
 	uniform = /obj/item/clothing/under/rank/hephaestus
 	id = /obj/item/weapon/card/id/hephaestus
 

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -54,7 +54,7 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
 
 /datum/job/engineer
-	title = "Station Engineer"
+	title = "Maintenance Technician"
 	flag = ENGINEER
 	department = "Engineering"
 	department_flag = ENGSEC
@@ -69,7 +69,7 @@
 
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
-	alt_titles = list("Maintenance Technician","Engine Technician","Electrician")
+	alt_titles = list("Engine Technician","Electrician")
 	outfit = /datum/outfit/job/engineer
 
 /datum/outfit/job/engineer

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -66,7 +66,7 @@ var/list/command_positions = list(
 
 var/list/engineering_positions = list(
 	"Chief Engineer",
-	"Station Engineer",
+	"Maintenance Technician",
 	"Atmospheric Technician",
 	"Engineering Apprentice"
 )

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -159,8 +159,8 @@
 	corpsegloves = /obj/item/clothing/gloves/yellow
 	corpsehelmet = /obj/item/clothing/head/hardhat
 	corpseid = 1
-	corpseidjob = "Station Engineer"
-	corpseidaccess = "Station Engineer"
+	corpseidjob = "Maintenance Technician"
+	corpseidaccess = "Maintenance Technician"
 
 /obj/effect/landmark/corpse/engineer/rig
 	corpsesuit = /obj/item/clothing/suit/space/void/engineering

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -85,7 +85,7 @@
 /datum/gear/accessory/brown_vest
 	display_name = "webbing, engineering"
 	path = /obj/item/clothing/accessory/storage/brown_vest
-	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice")
+	allowed_roles = list("Maintenance Technician", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice")
 
 /datum/gear/accessory/black_vest
 	display_name = "webbing, security"
@@ -105,7 +105,7 @@
 /datum/gear/accessory/brown_pouches
 	display_name = "drop pouches, engineering"
 	path = /obj/item/clothing/accessory/storage/pouches/brown
-	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice")
+	allowed_roles = list("Maintenance Technician", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice")
 
 /datum/gear/accessory/black_pouches
 	display_name = "drop pouches, security"
@@ -135,7 +135,7 @@
 /datum/gear/accessory/overalls_engineer
 	display_name = "overalls, engineering"
 	path = /obj/item/clothing/accessory/storage/overalls/engineer
-	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice")
+	allowed_roles = list("Maintenance Technician", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice")
 	cost = 2
 
 /datum/gear/accessory/sweater

--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -40,17 +40,17 @@
 /datum/gear/eyes/materialaviators
 	display_name = "aviators, material"
 	path = /obj/item/clothing/glasses/material/aviator
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Engineering Apprentice","Shaft Miner")
+	allowed_roles = list("Maintenance Technician","Atmospheric Technician","Chief Engineer","Engineering Apprentice","Shaft Miner")
 
 /datum/gear/eyes/mesonaviators
 	display_name = "aviators, meson"
 	path = /obj/item/clothing/glasses/meson/aviator
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Engineering Apprentice", "Research Director","Scientist", "Shaft Miner")
+	allowed_roles = list("Maintenance Technician","Atmospheric Technician","Chief Engineer","Engineering Apprentice", "Research Director","Scientist", "Shaft Miner")
 
 /datum/gear/eyes/mesonprescription
 	display_name = "meson goggles, prescription"
 	path = /obj/item/clothing/glasses/meson/prescription
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Engineering Apprentice", "Research Director","Scientist", "Shaft Miner")
+	allowed_roles = list("Maintenance Technician","Atmospheric Technician","Chief Engineer","Engineering Apprentice", "Research Director","Scientist", "Shaft Miner")
 
 /datum/gear/eyes/security
 	display_name = "security HUD"
@@ -114,13 +114,13 @@
 /datum/gear/eyes/mespatch
 	display_name = "HUDpatch, Mesons"
 	path = /obj/item/clothing/glasses/eyepatch/hud/meson
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Engineering Apprentice", "Research Director","Scientist", "Shaft Miner")
+	allowed_roles = list("Maintenance Technician","Atmospheric Technician","Chief Engineer","Engineering Apprentice", "Research Director","Scientist", "Shaft Miner")
 	cost = 2
 
 /datum/gear/eyes/matpatch
 	display_name = "HUDpatch, Material"
 	path = /obj/item/clothing/glasses/eyepatch/hud/material
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Engineering Apprentice", "Shaft Miner")
+	allowed_roles = list("Maintenance Technician","Atmospheric Technician","Chief Engineer","Engineering Apprentice", "Shaft Miner")
 	cost = 2
 
 /datum/gear/eyes/scipatch
@@ -131,7 +131,7 @@
 /datum/gear/eyes/weldpatch
 	display_name = "HUDpatch, Welding"
 	path = /obj/item/clothing/glasses/eyepatch/hud/welder
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Engineering Apprentice","Research Director","Roboticist")
+	allowed_roles = list("Maintenance Technician","Atmospheric Technician","Chief Engineer","Engineering Apprentice","Research Director","Roboticist")
 	cost = 2
 
 /datum/gear/eyes/spiffygogs

--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -48,7 +48,7 @@
 /datum/gear/head/beret/eng
 	display_name = "beret, engie-orange"
 	path = /obj/item/clothing/head/beret/engineering
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Engineering Apprentice")
+	allowed_roles = list("Maintenance Technician","Atmospheric Technician","Chief Engineer","Engineering Apprentice")
 
 /datum/gear/head/beret/purp
 	display_name = "beret, purple"
@@ -87,7 +87,7 @@
 /datum/gear/head/hardhat
 	display_name = "hardhat selection"
 	path = /obj/item/clothing/head/hardhat
-	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice")
+	allowed_roles = list("Maintenance Technician", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice")
 
 /datum/gear/head/hardhat/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -173,7 +173,7 @@
 /datum/gear/suit/winter/engineering
 	display_name = "winter coat, engineering"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering
-	allowed_roles = list("Station Engineer", "Chief Engineer", "Engineering Apprentice")
+	allowed_roles = list("Maintenance Technician", "Chief Engineer", "Engineering Apprentice")
 
 /datum/gear/suit/winter/atmos
 	display_name = "winter coat, atmospherics"

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -95,4 +95,4 @@
 	display_name = "tool-belt, alt"
 	cost = 2
 	path = /obj/item/weapon/storage/belt/utility/alt
-	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice", "Roboticist")
+	allowed_roles = list("Maintenance Technician", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice", "Roboticist")

--- a/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
@@ -56,7 +56,7 @@
 	whitelisted = list("Aut'akh Unathi")
 	sort_category = "Xenowear - Unathi"
 	cost = 3
-	allowed_roles = list("Station Engineer", "Chief Engineer", "Atmospheric Technician", "Engineering Apprentice", "Roboticist")
+	allowed_roles = list("Maintenance Technician", "Chief Engineer", "Atmospheric Technician", "Engineering Apprentice", "Roboticist")
 
 /datum/gear/autakh_mining
 	display_name = "mining grasper"

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -7,7 +7,7 @@ var/list/dreams = list(
 	"a blue light","an abandoned laboratory","NanoTrasen","mercenaries","blood","healing","power","respect",
 	"riches","space","a crash","happiness","pride","a fall","water","flames","ice","melons","flying","the eggs","money",
 	"the head of personnel","the head of security","a chief engineer","a research director","a chief medical officer",
-	"the detective","the warden","a member of the internal affairs","a station engineer","the janitor","atmospheric technician",
+	"the detective","the warden","a member of the internal affairs","a Maintenance Technician","the janitor","atmospheric technician",
 	"the quartermaster","a cargo technician","the botanist","a shaft miner","the psychologist","the chemist","the geneticist",
 	"the Biochemist","the roboticist","the chef","the bartender","the chaplain","the librarian","a mouse","an ert member",
 	"a beach","the holodeck","a smokey room","a voice","the cold","a mouse","an operating table","the bar","the rain","a skrell",

--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -17,7 +17,7 @@
 /mob/living/carbon/human/singularity_act()
 	var/gain = 20
 	if(mind)
-		if((mind.assigned_role == "Station Engineer") || (mind.assigned_role == "Chief Engineer"))
+		if((mind.assigned_role == "Maintenance Technician") || (mind.assigned_role == "Chief Engineer"))
 			gain = 100
 		if(mind.assigned_role == "Assistant")
 			gain = rand(0, 300)

--- a/config/example/jobs.txt
+++ b/config/example/jobs.txt
@@ -5,7 +5,7 @@ Chief Engineer=1
 Research Director=1
 Chief Medical Officer=1
 
-Station Engineer=5
+Maintenance Technician=5
 Roboticist=1
 
 Medical Doctor=5

--- a/html/changelogs/mattatlas-maintenance.yml
+++ b/html/changelogs/mattatlas-maintenance.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "The Station Engineer job has been changed to Maintenance Technician. Station Engineer is no longer an option."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -17696,7 +17696,7 @@
 	dir = 10
 	},
 /obj/effect/landmark/start{
-	name = "Station Engineer"
+	name = "Maintenance Technician"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -18923,7 +18923,7 @@
 	dir = 9
 	},
 /obj/effect/landmark/start{
-	name = "Station Engineer"
+	name = "Maintenance Technician"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -20951,7 +20951,7 @@
 	dir = 5
 	},
 /obj/effect/landmark/start{
-	name = "Station Engineer"
+	name = "Maintenance Technician"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)

--- a/maps/exodus/exodus-1_station.dmm
+++ b/maps/exodus/exodus-1_station.dmm
@@ -56017,7 +56017,7 @@
 /area/engineering/break_room)
 "bXT" = (
 /obj/effect/landmark/start{
-	name = "Station Engineer"
+	name = "Maintenance Technician"
 	},
 /obj/structure/bed/chair/comfy/brown,
 /turf/simulated/floor/carpet,
@@ -57013,7 +57013,7 @@
 /area/engineering/break_room)
 "bZz" = (
 /obj/effect/landmark/start{
-	name = "Station Engineer"
+	name = "Maintenance Technician"
 	},
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -58413,7 +58413,7 @@
 /area/engineering/break_room)
 "cch" = (
 /obj/effect/landmark/start{
-	name = "Station Engineer"
+	name = "Maintenance Technician"
 	},
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -66375,7 +66375,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start{
-	name = "Station Engineer"
+	name = "Maintenance Technician"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -66932,7 +66932,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start{
-	name = "Station Engineer"
+	name = "Maintenance Technician"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -70888,7 +70888,7 @@
 "cyS" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/start{
-	name = "Station Engineer"
+	name = "Maintenance Technician"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
@@ -75207,7 +75207,7 @@
 "cGD" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/landmark/start{
-	name = "Station Engineer"
+	name = "Maintenance Technician"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)


### PR DESCRIPTION
Yes this removes the Station Engineer title.

Most of the reason why is that it sounds cooler and gets rid of a very 'meh' alt title in terms of gameplay differences. Also, engineers are the people who do the theory, not the legwork.