### PR TITLE
Stuttering markup fix with a side of refactor

### DIFF
--- a/code/modules/flufftext/TextFilters.dm
+++ b/code/modules/flufftext/TextFilters.dm
@@ -24,8 +24,6 @@ proc/Intoxicated(phrase)
 	return newphrase
 
 proc/NewStutter(phrase,stunned)
-	phrase = html_decode(phrase)
-
 	var/list/split_phrase = text2list(phrase," ") //Split it up into words.
 
 	var/list/unstuttered_words = split_phrase.Copy()
@@ -39,25 +37,17 @@ proc/NewStutter(phrase,stunned)
 		unstuttered_words -= word //Remove from unstuttered words so we don't stutter it again.
 		var/index = split_phrase.Find(word) //Find the word in the split phrase so we can replace it.
 
-		//Search for dipthongs (two letters that make one sound.)
-		var/first_sound = copytext(word,1,3)
-		var/first_letter = copytext(word,1,2)
-		if(lowertext(first_sound) in list("ch","th","sh"))
-			first_letter = first_sound
-
-		//Repeat the first letter to create a stutter.
-		var/rnum = rand(1,3)
-		switch(rnum)
-			if(1)
-				word = "[first_letter]-[word]"
-			if(2)
-				word = "[first_letter]-[first_letter]-[word]"
-			if(3)
-				word = "[first_letter]-[word]"
+		var/regex/R = regex("^(\\W*)((?:\[Tt\]|\[Cc\]|\[Ss\])\[Hh\]|\\w)")
+		// regex replacement of prior logic; it strips everything that isn't a letter from the front so we don't stutter markup
+		// it also looks for dipthongs (th, ch, sh) before defaulting to stuttering the first letter
+		if(prob(66)) // two-thirds chance of normal stutter
+			word = R.Replace(word, "$1$2-$2")
+		else // double stutter
+			word = R.Replace(word, "$1$2-$2-$2")
 
 		split_phrase[index] = word
 
-	return sanitize(jointext(split_phrase," "))
+	return jointext(split_phrase," ")
 
 proc/Stagger(mob/M,d) //Technically not a filter, but it relates to drunkenness.
 	step(M, pick(d,turn(d,90),turn(d,-90)))

--- a/code/modules/flufftext/TextFilters.dm
+++ b/code/modules/flufftext/TextFilters.dm
@@ -23,7 +23,7 @@ proc/Intoxicated(phrase)
 		newphrase+="[newletter]";counter-=1
 	return newphrase
 
-proc/NewStutter(phrase, str = 1)
+proc/stutter(phrase, str = 1)
 	if(str < 1)
 		return phrase
 	else
@@ -32,8 +32,8 @@ proc/NewStutter(phrase, str = 1)
 	var/list/split_phrase = text2list(phrase," ") //Split it up into words.
 	var/list/unstuttered_words = split_phrase.Copy()
 
-	var/max_stutter = str <= split_phrase.len ? str : split_phrase.len
-	var/stutters = rand(1, max_stutter)
+	var/max_stutter = min(str, split_phrase.len)
+	var/stutters = rand(max(max_stutter - 3, 1), max_stutter)
 
 	for(var/i = 0, i < stutters, i++)
 		if (!unstuttered_words.len)
@@ -43,33 +43,40 @@ proc/NewStutter(phrase, str = 1)
 		unstuttered_words -= word //Remove from unstuttered words so we don't stutter it again.
 		var/index = split_phrase.Find(word) //Find the word in the split phrase so we can replace it.
 		var/regex/R = regex("^(\\W*)((?:\[Tt\]|\[Cc\]|\[Ss\])\[Hh\]|\\w)(\\w*)(\\W*)$")
+		var/regex/upper = regex("\[A-Z\]")
 
 		if(!R.Find(word))
 			continue
 
 		if (lentext(word) > 1)
-			if(prob(25) && str > 1) // stutter word instead
-				word = R.Replace(word, "$1$2$3-\\L$2$3")
-			else if(prob(50) && str > 1) // prolong word
+			if((prob(20) && str > 1) || (prob(30) && str > 4)) // stutter word instead
+				var/stuttered = R.group[2] + R.group[3]
+				if(upper.Find(stuttered) && !upper.Find(stuttered, 2)) // if they're screaming (all caps) or saying something like 'AI', keep the letter capitalized - else don't
+					stuttered = lowertext(stuttered)
+				word = R.Replace(word, "$1$2$3-[stuttered]$4")
+			else if(prob(25) && str > 1) // prolong word
 				var/prolonged = ""
-				for(var/j = 0, j < str, j++)
+				var/prolong_amt = min(lentext(word), 5)
+				prolong_amt = rand(1, prolong_amt)
+				for(var/j = 0, j < prolong_amt, j++)
 					prolonged += R.group[2]
-				var/regex/upper = regex("\[A-Z\]")
 				if(!upper.Find(R.group[3]))
 					prolonged = lowertext(prolonged)
 				word = R.Replace(word, "$1$2[prolonged]$3$4")
 			else
-				if(prob(10 * str)) // harder stutter if stronger
+				if(prob(5 * str)) // harder stutter if stronger
+					word = R.Replace(word, "$1$2-$2-$2-$2$3$4")
+				else if(prob(10 * str))
 					word = R.Replace(word, "$1$2-$2-$2$3$4")
 				else // normal stutter
 					word = R.Replace(word, "$1$2-$2$3$4")
 
-		if(prob(3 * str)) // stammer / pause
-			word = R.Replace(word, "$0 ... ")
+		if(prob(3 * str) && index != unstuttered_words.len - 1) // stammer / pause - don't pause at the end of sentences!
+			word = R.Replace(word, "$0 ...")
 
 		split_phrase[index] = word
 
-	return jointext(split_phrase," ")
+	return jointext(split_phrase, " ")
 
 proc/Stagger(mob/M,d) //Technically not a filter, but it relates to drunkenness.
 	step(M, pick(d,turn(d,90),turn(d,-90)))

--- a/code/modules/mob/abstract/observer/say.dm
+++ b/code/modules/mob/abstract/observer/say.dm
@@ -15,8 +15,6 @@
 
 
 /mob/abstract/observer/emote(var/act, var/type, var/message)
-	//message = sanitize(message) - already sanitized in verb/me_verb()
-
 	if(!message)
 		return
 
@@ -31,29 +29,3 @@
 			return
 
 	. = src.emote_dead(message)
-
-/*
-	for (var/mob/M in hearers(null, null))
-		if (!M.stat)
-			if(M.job == "Chaplain")
-				if (prob (49))
-					M.show_message("<span class='game'><i>You hear muffled speech... but nothing is there...</i></span>", 2)
-					if(prob(20))
-						playsound(src.loc, pick('sound/effects/ghost.ogg','sound/effects/ghost2.ogg'), 10, 1)
-				else
-					M.show_message("<span class='game'><i>You hear muffled speech... you can almost make out some words...</i></span>", 2)
-//				M.show_message("<span class='game'><i>[stutter(message)]</i></span>", 2)
-					if(prob(30))
-						playsound(src.loc, pick('sound/effects/ghost.ogg','sound/effects/ghost2.ogg'), 10, 1)
-			else
-				if (prob(50))
-					return
-				else if (prob (95))
-					M.show_message("<span class='game'><i>You hear muffled speech... but nothing is there...</i></span>", 2)
-					if(prob(20))
-						playsound(src.loc, pick('sound/effects/ghost.ogg','sound/effects/ghost2.ogg'), 10, 1)
-				else
-					M.show_message("<span class='game'><i>You hear muffled speech... you can almost make out some words...</i></span>", 2)
-//				M.show_message("<span class='game'><i>[stutter(message)]</i></span>", 2)
-					playsound(src.loc, pick('sound/effects/ghost.ogg','sound/effects/ghost2.ogg'), 10, 1)
-*/

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -151,7 +151,7 @@
 		if(braindam >= 60)
 			speech_problem_flag = 1
 			if(prob(braindam/4))
-				message = stutter(message)
+				message = get_stuttered_message(message)
 				verb = pick("stammers", "stutters")
 			if(prob(braindam))
 				message = uppertext(message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -87,10 +87,7 @@ proc/get_radio_key_from_channel(var/channel)
 	return stutter(message)
 
 /mob/living/carbon/get_stuttered_message(message)
-	if (shock_stage >= 30)
-		return stutter(message)
-	else
-		return NewStutter(message)
+	return NewStutter(message)
 
 /mob/living/proc/get_default_language()
 	return default_language
@@ -161,11 +158,11 @@ proc/get_radio_key_from_channel(var/channel)
 
 	var/message_mode = parse_message_mode(message, "headset")
 
-	message = process_chat_markup(message, list("~", "_"))
+	var/regex/emote = regex("^(\[\\*^\])\[^*\]+$")
 
-	switch(copytext(message,1,2))
-		if("*") return emote(copytext(message,2))
-		if("^") return custom_emote(1, copytext(message,2))
+	if(emote.Find(message))
+		if(emote.group[1] == "*") return emote(copytext(message, 2))
+		if(emote.group[1] == "^") return custom_emote(1, copytext(message,2))
 
 	//parse the radio code and consume it
 	if (message_mode)
@@ -213,6 +210,8 @@ proc/get_radio_key_from_channel(var/channel)
 
 	if(!message || message == "")
 		return 0
+
+	message = process_chat_markup(message, list("~", "_"))
 
 	//handle nonverbal and sign languages here
 	if (speaking)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -84,7 +84,7 @@ proc/get_radio_key_from_channel(var/channel)
 		if(dongle.translate_binary) return 1
 
 /mob/living/proc/get_stuttered_message(message)
-	return NewStutter(message, stuttering)
+	return stutter(message, stuttering)
 
 /mob/living/proc/get_default_language()
 	return default_language

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -84,10 +84,7 @@ proc/get_radio_key_from_channel(var/channel)
 		if(dongle.translate_binary) return 1
 
 /mob/living/proc/get_stuttered_message(message)
-	return stutter(message)
-
-/mob/living/carbon/get_stuttered_message(message)
-	return NewStutter(message)
+	return NewStutter(message, stuttering)
 
 /mob/living/proc/get_default_language()
 	return default_language

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -352,30 +352,6 @@ proc/slur(phrase, strength = 100)
 		newphrase+="[newletter]";counter-=1
 	return newphrase
 
-/proc/stutter(n)
-	var/te = html_decode(n)
-	var/t = ""//placed before the message. Not really sure what it's for.
-	n = length(n)//length of the entire word
-	var/p = null
-	p = 1//1 is the start of any word
-	while(p <= n)//while P, which starts at 1 is less or equal to N which is the length.
-		var/n_letter = copytext(te, p, p + 1)//copies text from a certain distance. In this case, only one letter at a time.
-		if (prob(80) && (ckey(n_letter) in list("b","c","d","f","g","h","j","k","l","m","n","p","q","r","s","t","v","w","x","y","z")))
-			if (prob(10))
-				n_letter = text("[n_letter]-[n_letter]-[n_letter]-[n_letter]")//replaces the current letter with this instead.
-			else
-				if (prob(20))
-					n_letter = text("[n_letter]-[n_letter]-[n_letter]")
-				else
-					if (prob(5))
-						n_letter = null
-					else
-						n_letter = text("[n_letter]-[n_letter]")
-		t = text("[t][n_letter]")//since the above is ran through for each letter, the text just adds up back to the original word.
-		p++//for each letter p is increased to find where the next letter will be.
-	return sanitize(t)
-
-
 proc/Gibberish(t, p)//t is the inputted message, and any value higher than 70 for p will cause letters to be replaced instead of added
 	/* Turn text into complete gibberish! */
 	var/returntext = ""

--- a/html/changelogs/johnwildkins-stutter.yml
+++ b/html/changelogs/johnwildkins-stutter.yml
@@ -4,4 +4,5 @@ delete-after: True
 
 changes: 
   - bugfix: "Stuttering no longer breaks markup tags (bold, italics, etc.)."
-  - backend: "All carbon life now uses the NewStutter proc, which now uses regex to handle stutter replacement."
+  - backend: "Stutter procs merged and refactored; stuttering now properly draws off of the strength of the applied stuttering effect to the affected mob."
+  - rscadd: "Stuttering now takes the form of first-phoneme repetition, stammering, word repetition, and sound elongation, as opposed to simple letter duplication."

--- a/html/changelogs/johnwildkins-stutter.yml
+++ b/html/changelogs/johnwildkins-stutter.yml
@@ -1,0 +1,7 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes: 
+  - bugfix: "Stuttering no longer breaks markup tags (bold, italics, etc.)."
+  - backend: "All carbon life now uses the NewStutter proc, which now uses regex to handle stutter replacement."


### PR DESCRIPTION
Fixes #997.

- Stuttering no longer breaks markup tags or produces broken HTML. Scream in bold while fading out of pain-crit to your hearts content.
- Stuttering is now (vaguely) more realistic, and there are more variations in stuttering. As stuttering condition gets more severe, those affected will start to pause, hold on syllables, or repeat entire words, rather than just stuttering the start of a word.
- oh and also stutter() now actually takes into account the stuttering variable that, up until now, was functionally irrelevant beyond being a binary "are they stuttering" flag

back-end:
- All stuttering is now handled by stutter() (fmr. NewStutter()) - the old stutter proc was wiped off of the earth. All stutter handling is piped through get_stuttered_message().
- stutter() has been refactored to use regex replacement instead of copytext and if chaining, mainly because it makes not deleting markup tags much, much easier. Also it no longer sanitizes input because it's only called from already sanitized functions and all that did was break markup
- In that same vein, because it makes things easier and makes more logical sense, say-processing has been changed slightly:
  - markup tags aren't processed until after stuttering is processed; this is mostly to make ignoring markup easier in the stutter code
  - emotes are now found using restrictive regex now so bold markup won't be confused for emotes and vice versa, regardless of their order in the say processing