### PR TITLE
Hotfix to stop ERTs stopping shuttles

### DIFF
--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -368,10 +368,6 @@ Command action procs
 		to_chat(user, "<span class='notice'>Cannot establish a bluespace connection.</span>")
 		return 0
 
-	if(deathsquad.deployed)
-		to_chat(user, "[current_map.boss_short] will not allow the shuttle to be called. Consider all contracts terminated.")
-		return 0
-
 	if(emergency_shuttle.deny_shuttle)
 		to_chat(user, "The emergency shuttle may not be sent at this time. Please try again later.")
 		return 0
@@ -414,10 +410,6 @@ Command action procs
 	if(!force)
 		if(emergency_shuttle.deny_shuttle)
 			to_chat(user, "[current_map.boss_short] does not currently have a shuttle available in your sector. Please try again later.")
-			return
-
-		if(deathsquad.deployed == 1)
-			to_chat(user, "[current_map.boss_short] will not allow the shuttle to be called. Consider all contracts terminated.")
 			return
 
 		if(world.time < 54000) // 30 minute grace period to let the game get going

--- a/html/changelogs/johnwildkins-ertfix.yml
+++ b/html/changelogs/johnwildkins-ertfix.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes: 
+  - bugfix: "ERTs should no longer stop the emergency shuttle from being called."


### PR DESCRIPTION
oh sweet christ what have I done

- removes deathsquad deployment halting shuttle calls

this functionality will be put back once I or anyone gets down to the bottom of why all ERTs are being considered deathsquads (it's probably my shitcode)