### PR TITLE
Buffs Fireaxe

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -205,7 +205,7 @@
 			P.die_off()
 
 /obj/item/weapon/material/twohanded/fireaxe/pre_attack(var/mob/living/target, var/mob/living/user)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 2.5)
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 1.5)
 	if(istype(target) && wielded)
 		cleave(user, target)
 	..()

--- a/html/changelogs/geeves - fireAxeBuff.yml
+++ b/html/changelogs/geeves - fireAxeBuff.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Lowers fireaxe after-click cooldown to 1.2 seconds down from 2.0."


### PR DESCRIPTION
* Lowers the post-attack cooldown click from 2.0 to 1.2.

I made this a separate PR cuz the fire-axe IS pretty powerful, and was nerfed this way for a reason, but the 2 second cooldown for clicking felt AWFUL.