### PR TITLE
Decompiler Tweaks

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -58,9 +58,10 @@
 				plastic.add_charge(1000)
 
 
-		else if(istype(M,/mob/living/simple_animal/lizard) || (istype(M,/mob/living/simple_animal/rat) && M.mob_size <= 2))
+		else if(istype(M,/mob/living/simple_animal) && M.mob_size <= 3 && !istype(M, /mob/living/simple_animal/cat)) //includes things like rats, lizards, tindalos while excluding bigger things and station pets.
 			src.loc.visible_message("<span class='danger'>[src.loc] sucks [M] into its decompiler. There's a horrible crunching noise.</span>","<span class='danger'>It's a bit of a struggle, but you manage to suck [M] into your decompiler. It makes a series of visceral crunching noises.</span>")
 			new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
+			playsound(src.loc, 'sound/effects/squelch1.ogg')
 			qdel(M)
 			if(wood)
 				wood.add_charge(2000)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -124,6 +124,9 @@
 				wood.add_charge(4000)
 		else if(istype(W,/obj/item/pipe))
 			// This allows drones and engiborgs to clear pipe assemblies from floors.
+		else if(istype(W,/obj/item/weapon/broken_bottle))
+			if(glass)
+				glass.add_charge(2000)
 		else
 			continue
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -58,10 +58,9 @@
 				plastic.add_charge(1000)
 
 
-		else if(istype(M,/mob/living/simple_animal) && M.mob_size <= 3 && !istype(M, /mob/living/simple_animal/cat)) //includes things like rats, lizards, tindalos while excluding bigger things and station pets.
+		else if(istype(M,/mob/living/simple_animal/lizard) || (istype(M,/mob/living/simple_animal/rat) && M.mob_size <= 2))
 			src.loc.visible_message("<span class='danger'>[src.loc] sucks [M] into its decompiler. There's a horrible crunching noise.</span>","<span class='danger'>It's a bit of a struggle, but you manage to suck [M] into your decompiler. It makes a series of visceral crunching noises.</span>")
 			new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
-			playsound(src.loc, 'sound/effects/squelch1.ogg')
 			qdel(M)
 			if(wood)
 				wood.add_charge(2000)
@@ -124,6 +123,9 @@
 				wood.add_charge(4000)
 		else if(istype(W,/obj/item/pipe))
 			// This allows drones and engiborgs to clear pipe assemblies from floors.
+		else if(istype(W,/obj/item/weapon/broken_bottle))
+			if(glass)
+				glass.add_charge(2000)
 		else
 			continue
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -58,9 +58,10 @@
 				plastic.add_charge(1000)
 
 
-		else if(istype(M,/mob/living/simple_animal/lizard) || (istype(M,/mob/living/simple_animal/rat) && M.mob_size <= 2))
+		else if(istype(M,/mob/living/simple_animal) && M.mob_size <= 3 && !istype(M, /mob/living/simple_animal/cat)) //includes things like rats, lizards, tindalos while excluding bigger things and station pets.
 			src.loc.visible_message("<span class='danger'>[src.loc] sucks [M] into its decompiler. There's a horrible crunching noise.</span>","<span class='danger'>It's a bit of a struggle, but you manage to suck [M] into your decompiler. It makes a series of visceral crunching noises.</span>")
 			new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
+			playsound(src.loc, 'sound/effects/squelch1.ogg')
 			qdel(M)
 			if(wood)
 				wood.add_charge(2000)
@@ -123,9 +124,6 @@
 				wood.add_charge(4000)
 		else if(istype(W,/obj/item/pipe))
 			// This allows drones and engiborgs to clear pipe assemblies from floors.
-		else if(istype(W,/obj/item/weapon/broken_bottle))
-			if(glass)
-				glass.add_charge(2000)
 		else
 			continue
 

--- a/html/changelogs/doxx - squelch.yml
+++ b/html/changelogs/doxx - squelch.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Adds a sound effect to decompiler when used on a mob, and enables it to decompile slightly larger pests."


### PR DESCRIPTION
Decompiler now plays a noise when used to decompile small pests. _Cronch._

Also adjusted the decompiler to be used on more pests besides rats and lizards. It now handles simple mobs up to size 3 (which includes tindalos, diyaab, yithian, etc). This will help bots keep things clean. 

I've excluded cats specifically (size 2.5) because we really don't need maint drones memeing around sucking up station pets. Dogs (even puppies) are excluded by default due to size. 