### PR TITLE
Alt. tool-belt fix and cost tweak

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -44,6 +44,16 @@
 	dufflebag = /obj/item/weapon/storage/backpack/duffel/eng
 	messengerbag = /obj/item/weapon/storage/backpack/messenger/engi
 
+	belt_contents = list(
+		/obj/item/weapon/screwdriver = 1,
+		/obj/item/weapon/wrench = 1,
+		/obj/item/weapon/weldingtool = 1,
+		/obj/item/weapon/crowbar = 1,
+		/obj/item/weapon/wirecutters = 1,
+		/obj/item/stack/cable_coil/random = 1,
+		/obj/item/weapon/powerdrill = 1
+	)
+
 /datum/outfit/job/chief_engineer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(istajara(H))
@@ -90,6 +100,16 @@
 	dufflebag = /obj/item/weapon/storage/backpack/duffel/eng
 	messengerbag = /obj/item/weapon/storage/backpack/messenger/engi
 
+	belt_contents = list(
+		/obj/item/weapon/screwdriver = 1,
+		/obj/item/weapon/wrench = 1,
+		/obj/item/weapon/weldingtool = 1,
+		/obj/item/weapon/crowbar = 1,
+		/obj/item/weapon/wirecutters = 1,
+		/obj/item/stack/cable_coil/random = 1,
+		/obj/item/weapon/powerdrill = 1
+	)
+
 /datum/job/atmos
 	title = "Atmospheric Technician"
 	flag = ATMOSTECH
@@ -123,6 +143,15 @@
 	satchel = /obj/item/weapon/storage/backpack/satchel_eng
 	dufflebag = /obj/item/weapon/storage/backpack/duffel/eng
 	messengerbag = /obj/item/weapon/storage/backpack/messenger/engi
+
+	belt_contents = list(
+		/obj/item/weapon/screwdriver = 1,
+		/obj/item/weapon/wrench = 1,
+		/obj/item/weapon/weldingtool = 1,
+		/obj/item/weapon/crowbar = 1,
+		/obj/item/weapon/wirecutters = 1,
+		/obj/item/device/t_scanner = 1
+	)
 
 /datum/job/intern_eng
 	title = "Engineering Apprentice"

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -145,12 +145,22 @@
 	l_ear = /obj/item/device/radio/headset/headset_sci
 	pda = /obj/item/device/pda/roboticist
 	id = /obj/item/weapon/card/id/white
-	belt = /obj/item/weapon/storage/belt/utility/full
+	belt = /obj/item/weapon/storage/belt/utility
 
 	backpack = /obj/item/weapon/storage/backpack/toxins
 	satchel = /obj/item/weapon/storage/backpack/satchel_tox
 	dufflebag = /obj/item/weapon/storage/backpack/duffel/tox
 	messengerbag = /obj/item/weapon/storage/backpack/messenger/tox
+
+	belt_contents = list(
+		/obj/item/weapon/screwdriver = 1,
+		/obj/item/weapon/wrench = 1,
+		/obj/item/weapon/weldingtool = 1,
+		/obj/item/weapon/crowbar = 1,
+		/obj/item/weapon/wirecutters = 1,
+		/obj/item/stack/cable_coil/random = 1,
+		/obj/item/weapon/powerdrill = 1
+	)
 
 /datum/job/intern_sci
 	title = "Lab Assistant"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -85,17 +85,6 @@
 	icon_state = "utilitybelt_alt"
 	item_state = "utility_alt"
 
-/obj/item/weapon/storage/belt/utility/alt/full
-	starts_with = list(
-		/obj/item/weapon/screwdriver = 1,
-		/obj/item/weapon/wrench = 1,
-		/obj/item/weapon/weldingtool = 1,
-		/obj/item/weapon/crowbar = 1,
-		/obj/item/weapon/wirecutters = 1,
-		/obj/item/stack/cable_coil/random = 1,
-		/obj/item/weapon/powerdrill = 1
-	)
-
 /obj/item/weapon/storage/belt/medical
 	name = "medical belt"
 	desc = "Can hold various medical equipment."

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -85,6 +85,17 @@
 	icon_state = "utilitybelt_alt"
 	item_state = "utility_alt"
 
+/obj/item/weapon/storage/belt/utility/alt/full
+	starts_with = list(
+		/obj/item/weapon/screwdriver = 1,
+		/obj/item/weapon/wrench = 1,
+		/obj/item/weapon/weldingtool = 1,
+		/obj/item/weapon/crowbar = 1,
+		/obj/item/weapon/wirecutters = 1,
+		/obj/item/stack/cable_coil/random = 1,
+		/obj/item/weapon/powerdrill = 1
+	)
+
 /obj/item/weapon/storage/belt/medical
 	name = "medical belt"
 	desc = "Can hold various medical equipment."

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -93,6 +93,6 @@
 
 /datum/gear/utility/toolbelt_alt
 	display_name = "tool-belt, alt"
-	cost = 2
-	path = /obj/item/weapon/storage/belt/utility/alt
+	cost = 0
+	path = /obj/item/weapon/storage/belt/utility/alt/full
 	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice", "Roboticist")

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -94,5 +94,5 @@
 /datum/gear/utility/toolbelt_alt
 	display_name = "tool-belt, alt"
 	cost = 0
-	path = /obj/item/weapon/storage/belt/utility/alt/full
+	path = /obj/item/weapon/storage/belt/utility/alt
 	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice", "Roboticist")

--- a/html/changelogs/johnwildkins-beltfix.yml
+++ b/html/changelogs/johnwildkins-beltfix.yml
@@ -1,0 +1,7 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed alternate utility belt not starting with tools when selected from loadout."
+  - tweak: "Alternate utility belt is now free to select."

--- a/html/changelogs/johnwildkins-beltfix.yml
+++ b/html/changelogs/johnwildkins-beltfix.yml
@@ -5,4 +5,4 @@ delete-after: True
 changes: 
   - bugfix: "Fixed alternate utility belt not starting with tools when selected from loadout."
   - tweak: "Alternate utility belt is now free to select. Engineering Apprentices can elect to spawn with one, but it will be empty."
-  - backend: "Job outfits now fill utility belts using belt_contents rather than simply spawning sub-types of utility belt.""
+  - backend: "Job outfits now fill utility belts using belt_contents rather than simply spawning sub-types of utility belt."

--- a/html/changelogs/johnwildkins-beltfix.yml
+++ b/html/changelogs/johnwildkins-beltfix.yml
@@ -4,4 +4,5 @@ delete-after: True
 
 changes: 
   - bugfix: "Fixed alternate utility belt not starting with tools when selected from loadout."
-  - tweak: "Alternate utility belt is now free to select."
+  - tweak: "Alternate utility belt is now free to select. Engineering Apprentices can elect to spawn with one, but it will be empty."
+  - backend: "Job outfits now fill utility belts using belt_contents rather than simply spawning sub-types of utility belt.""


### PR DESCRIPTION
- Alternate utility belts now start with tools
- They're now free since it's literally just a different sprite for the same thing and they're role-locked anyway
- apprentices no longer spawn with free tools they shouldn't have
- job outfit datums use `belt_contents` now instead of spawning `utility/full`