### PR TITLE
Move silicon istype() checks to helper macros, destroy loose code spaghetti

### DIFF
--- a/code/_onclick/hud/screen_object_types/ai_screen_objs.dm
+++ b/code/_onclick/hud/screen_object_types/ai_screen_objs.dm
@@ -24,7 +24,7 @@
 	mod_pos = 3
 
 /obj/screen/module/Click()
-	if (!istype(usr, /mob/living/silicon/robot))
+	if (!isrobot(usr))
 		return
 
 	ASSERT(mod_pos != null)

--- a/code/datums/diseases/magnitis.dm
+++ b/code/datums/diseases/magnitis.dm
@@ -22,7 +22,7 @@
 					if(!M.anchored && (M.flags & CONDUCT))
 						step_towards(M,affected_mob)
 				for(var/mob/living/silicon/S in orange(2,affected_mob))
-					if(istype(S, /mob/living/silicon/ai)) continue
+					if(isAI(S)) continue
 					step_towards(S,affected_mob)
 						/*
 						if(M.x > affected_mob.x)
@@ -47,7 +47,7 @@
 						for(i=0,i<iter,i++)
 							step_towards(M,affected_mob)
 				for(var/mob/living/silicon/S in orange(4,affected_mob))
-					if(istype(S, /mob/living/silicon/ai)) continue
+					if(isAI(S)) continue
 					var/i
 					var/iter = rand(1,2)
 					for(i=0,i<iter,i++)
@@ -75,7 +75,7 @@
 						for(i=0,i<iter,i++)
 							step_towards(M,affected_mob)
 				for(var/mob/living/silicon/S in orange(6,affected_mob))
-					if(istype(S, /mob/living/silicon/ai)) continue
+					if(isAI(S)) continue
 					var/i
 					var/iter = rand(1,3)
 					for(i=0,i<iter,i++)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -390,7 +390,7 @@
 					log_admin("[key_name_admin(usr)] has unemag'ed [R].",admin_key=key_name(usr),ckey_target=key_name(R))
 
 			if("unemagcyborgs")
-				if (istype(current, /mob/living/silicon/ai))
+				if (isAI(current))
 					var/mob/living/silicon/ai/ai = current
 					for (var/mob/living/silicon/robot/R in ai.connected_robots)
 						R.emagged = 0

--- a/code/datums/trading/trade.dm
+++ b/code/datums/trading/trade.dm
@@ -179,7 +179,7 @@
 		var/mob/living/carbon/human/H = user
 		if(H.species)
 			specific = H.species.name
-	else if(istype(user, /mob/living/silicon))
+	else if(issilicon(user))
 		specific = "silicon"
 	if(!speech["hail_[specific]"])
 		specific = "generic"

--- a/code/datums/trading/vox.dm
+++ b/code/datums/trading/vox.dm
@@ -74,7 +74,7 @@
 				disposition = 1000
 				hailed_vox = 1
 			specific = H.species.name
-	else if(istype(user, /mob/living/silicon))
+	else if(issilicon(user))
 		specific = "silicon"
 	if(!speech["hail_[specific][hailed_vox]"])
 		specific = "generic"

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -24,7 +24,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 
 /datum/wires/airlock/CanUse(var/mob/living/L)
 	var/obj/machinery/door/airlock/A = holder
-	if(!istype(L, /mob/living/silicon))
+	if(!issilicon(L))
 		if(A.isElectrified())
 			if(A.shock(L, 100))
 				return 0

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -14,7 +14,7 @@ var/const/SMARTFRIDGE_WIRE_HEATING 		= 16
 
 /datum/wires/smartfridge/CanUse(var/mob/living/L)
 	var/obj/machinery/smartfridge/S = holder
-	if(!istype(L, /mob/living/silicon))
+	if(!issilicon(L))
 		if(S.seconds_electrified)
 			if(S.shock(L, 100))
 				return 0

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -8,7 +8,7 @@ var/const/SUIT_STORAGE_WIRE_LOCKED		= 4
 
 /datum/wires/suit_storage_unit/CanUse(var/mob/living/L)
 	var/obj/machinery/suit_cycler/S = holder
-	if(!istype(L, /mob/living/silicon))
+	if(!issilicon(L))
 		if(S.electrified)
 			if(S.shock(L, 100))
 				return 0

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -13,7 +13,7 @@ var/const/VENDING_WIRE_HEATING = 32
 
 /datum/wires/vending/CanUse(var/mob/living/L)
 	var/obj/machinery/vending/V = holder
-	if(!istype(L, /mob/living/silicon))
+	if(!issilicon(L))
 		if(V.seconds_electrified)
 			if(V.shock(L, 100))
 				return 0

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -83,7 +83,7 @@ var/datum/antagonist/traitor/traitors
 	return
 
 /datum/antagonist/traitor/equip(var/mob/living/carbon/human/traitor_mob)
-	if(istype(traitor_mob, /mob/living/silicon)) // this needs to be here because ..() returns false if the mob isn't human
+	if(issilicon(traitor_mob)) // this needs to be here because ..() returns false if the mob isn't human
 		add_law_zero(traitor_mob)
 		if(isrobot(traitor_mob))
 			var/mob/living/silicon/robot/R = traitor_mob

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -47,7 +47,7 @@
 //return flags that should be added to the viewer's sight var.
 //Otherwise return a negative number to indicate that the view should be cancelled.
 /atom/proc/check_eye(user as mob)
-	if (istype(user, /mob/living/silicon/ai)) // WHYYYY
+	if (isAI(user)) // WHYYYY
 		return 0
 	return -1
 

--- a/code/game/gamemodes/events/dust.dm
+++ b/code/game/gamemodes/events/dust.dm
@@ -98,7 +98,7 @@ The "dust" will damage the hull of the station causin minor hull breaches.
 		spawn(0)
 			if(prob(50))
 				for(var/mob/M in range(10, src))
-					if(!M.stat && !istype(M, /mob/living/silicon/ai))
+					if(!M.stat && !isAI(M))
 						shake_camera(M, 3, 1)
 			if (A)
 				playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)

--- a/code/game/gamemodes/meme/meme.dm
+++ b/code/game/gamemodes/meme/meme.dm
@@ -9,8 +9,8 @@
 	votable = 0 // temporarily disable this mode for voting
 	end_on_antag_death = 1
 
-	var/var/list/datum/mind/first_hosts = list()
-	var/var/list/assigned_hosts = list()
+	var/list/datum/mind/first_hosts = list()
+	var/list/assigned_hosts = list()
 
 /datum/game_mode/meme/announce()
 	to_world("<B>The current game mode is - Meme!</B>")

--- a/code/game/gamemodes/newobjective.dm
+++ b/code/game/gamemodes/newobjective.dm
@@ -1068,7 +1068,7 @@ datum
 					if(steal_target)
 						for(var/obj/item/device/aicard/C in owner.current.get_contents())
 							for(var/mob/living/silicon/ai/M in C)
-								if(istype(M, /mob/living/silicon/ai) && M.stat != 2)
+								if(isAI(M) && M.stat != 2)
 									return 1
 						for(var/mob/living/silicon/ai/M in silicon_mob_list)
 							if(istype(M.loc, /turf))

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -520,7 +520,7 @@ datum/objective/steal
 
 				for(var/obj/item/weapon/aicard/C in all_items) //Check for ai card
 					for(var/mob/living/silicon/ai/M in C)
-						if(istype(M, /mob/living/silicon/ai) && M.stat != 2) //See if any AI's are alive inside that card.
+						if(isAI(M) && M.stat != 2) //See if any AI's are alive inside that card.
 							return 1
 
 				for(var/mob/living/silicon/ai/ai in silicon_mob_list)

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -37,7 +37,7 @@
 /obj/machinery/ai_slipper/attackby(obj/item/weapon/W, mob/user)
 	if(stat & (NOPOWER|BROKEN))
 		return
-	if (istype(user, /mob/living/silicon))
+	if (issilicon(user))
 		return src.attack_hand(user)
 	else // trying to unlock the interface
 		if (src.allowed(usr))
@@ -62,7 +62,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 	if ( (get_dist(src, user) > 1 ))
-		if (!istype(user, /mob/living/silicon))
+		if (!issilicon(user))
 			to_chat(user, text("Too far away."))
 			user.unset_machine()
 			user << browse(null, "window=ai_slipper")
@@ -78,7 +78,7 @@
 	var/area/area = loc
 	var/t = "<TT><B>AI Liquid Dispenser</B> ([area.name])<HR>"
 
-	if(src.locked && (!istype(user, /mob/living/silicon)))
+	if(src.locked && (!issilicon(user)))
 		t += "<I>(Swipe ID card to unlock control panel.)</I><BR>"
 	else
 		t += text("Dispenser [] - <A href='?src=\ref[];toggleOn=1'>[]?</a><br>\n", src.disabled?"deactivated":"activated", src, src.disabled?"Enable":"Disable")
@@ -91,7 +91,7 @@
 /obj/machinery/ai_slipper/Topic(href, href_list)
 	..()
 	if (src.locked)
-		if (!istype(usr, /mob/living/silicon))
+		if (!issilicon(usr))
 			to_chat(usr, "Control panel is locked!")
 			return
 	if (href_list["toggleOn"])

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -266,7 +266,7 @@ update_flag
 		src.add_fingerprint(user)
 		healthcheck()
 
-	if(istype(user, /mob/living/silicon/robot) && istype(W, /obj/item/weapon/tank/jetpack))
+	if(isrobot(user) && istype(W, /obj/item/weapon/tank/jetpack))
 		var/datum/gas_mixture/thejetpack = W:air_contents
 		var/env_pressure = thejetpack.return_pressure()
 		var/pressure_delta = min(10*ONE_ATMOSPHERE - env_pressure, (air_contents.return_pressure() - env_pressure)/2)

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -65,7 +65,7 @@
 /obj/machinery/meter/examine(mob/user)
 	var/t = "A gas flow meter. "
 
-	if(get_dist(user, src) > 3 && !(istype(user, /mob/living/silicon/ai) || istype(user, /mob/abstract)))
+	if(get_dist(user, src) > 3 && !(isAI(user) || istype(user, /mob/abstract)))
 		t += "<span class='warning'>You are too far away to read it.</span>"
 
 	else if(stat & (NOPOWER|BROKEN))
@@ -84,7 +84,7 @@
 
 /obj/machinery/meter/Click()
 
-	if(istype(usr, /mob/living/silicon/ai)) // ghosts can call ..() for examine
+	if(isAI(usr)) // ghosts can call ..() for examine
 		usr.examinate(src)
 		return 1
 

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -237,7 +237,7 @@
 		return
 	if (usr.stat)
 		return
-	if ((in_range(src, usr) && istype(src.loc, /turf)) || (istype(usr, /mob/living/silicon)))
+	if ((in_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr)))
 		usr.set_machine(src)
 
 		switch(href_list["op"])
@@ -678,7 +678,7 @@
 	if(!wires.MobAvoid())		//usually just bumps, but if avoidance disabled knock over mobs
 		var/mob/M = obs
 		if(ismob(M))
-			if(istype(M,/mob/living/silicon/robot))
+			if(isrobot(M))
 				src.visible_message("<span class='warning'>[src] bumps into [M]!</span>")
 			else
 				src.visible_message("<span class='warning'>[src] knocks over [M]!</span>")

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -219,7 +219,7 @@
 
 /obj/machinery/camera/proc/deactivate(user as mob, var/choice = 1)
 	// The only way for AI to reactivate cameras are malf abilities, this gives them different messages.
-	if(istype(user, /mob/living/silicon/ai))
+	if(isAI(user))
 		user = null
 
 	if(choice != 1)
@@ -383,7 +383,7 @@
 	return 0
 
 /obj/machinery/camera/interact(mob/living/user as mob)
-	if(!panel_open || istype(user, /mob/living/silicon/ai))
+	if(!panel_open || isAI(user))
 		return
 
 	if(stat & BROKEN)

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -27,7 +27,7 @@
 					lostTarget(target)
 
 /obj/machinery/camera/proc/newTarget(var/mob/target)
-	if (istype(target, /mob/living/silicon/ai)) return 0
+	if (isAI(target)) return 0
 	if (detectTime == 0)
 		detectTime = world.time // start the clock
 	if (!(target in motionTargets))

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -78,7 +78,7 @@
 		update_icon()
 
 /obj/machinery/cell_charger/attack_ai(mob/user)
-	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Borgs can remove the cell if they are near enough
+	if(isrobot(user) && Adjacent(user)) // Borgs can remove the cell if they are near enough
 		if(!src.charging)
 			return
 		user.put_in_hands(charging)

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -35,7 +35,7 @@
 
 /obj/machinery/computer/operating/interact(mob/user)
 	if ( (get_dist(src, user) > 1 ) || (stat & (BROKEN|NOPOWER)) )
-		if (!istype(user, /mob/living/silicon))
+		if (!issilicon(user))
 			user.unset_machine()
 			user << browse(null, "window=op")
 			return
@@ -74,7 +74,7 @@
 /obj/machinery/computer/operating/Topic(href, href_list)
 	if(..())
 		return 1
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
 		usr.set_machine(src)
 	return
 

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -23,7 +23,7 @@
 	return attack_hand(user)
 
 /obj/machinery/computer/security/check_eye(var/mob/user as mob)
-	if (user.stat || ((get_dist(user, src) > 1 || !( user.canmove ) || user.blinded) && !istype(user, /mob/living/silicon))) //user can't see - not sure why canmove is here.
+	if (user.stat || ((get_dist(user, src) > 1 || !( user.canmove ) || user.blinded) && !issilicon(user))) //user can't see - not sure why canmove is here.
 		return -1
 	if(!current_camera)
 		return 0
@@ -72,7 +72,7 @@
 		return 1
 	if(href_list["switch_camera"])
 		if(src.z>6 || stat&(NOPOWER|BROKEN)) return
-		if(usr.stat || ((get_dist(usr, src) > 1 || !( usr.canmove ) || usr.blinded) && !istype(usr, /mob/living/silicon))) return
+		if(usr.stat || ((get_dist(usr, src) > 1 || !( usr.canmove ) || usr.blinded) && !issilicon(usr))) return
 		var/obj/machinery/camera/C = locate(href_list["switch_camera"]) in cameranet.cameras
 		if(!C)
 			return
@@ -83,13 +83,13 @@
 		return 1
 	else if(href_list["switch_network"])
 		if(src.z>6 || stat&(NOPOWER|BROKEN)) return
-		if(usr.stat || ((get_dist(usr, src) > 1 || !( usr.canmove ) || usr.blinded) && !istype(usr, /mob/living/silicon))) return
+		if(usr.stat || ((get_dist(usr, src) > 1 || !( usr.canmove ) || usr.blinded) && !issilicon(usr))) return
 		if(href_list["switch_network"] in network)
 			current_network = href_list["switch_network"]
 		return 1
 	else if(href_list["reset"])
 		if(src.z>6 || stat&(NOPOWER|BROKEN)) return
-		if(usr.stat || ((get_dist(usr, src) > 1 || !( usr.canmove ) || usr.blinded) && !istype(usr, /mob/living/silicon))) return
+		if(usr.stat || ((get_dist(usr, src) > 1 || !( usr.canmove ) || usr.blinded) && !issilicon(usr))) return
 		reset_current()
 		usr.reset_view(current_camera)
 		return 1
@@ -119,7 +119,7 @@
 		A.client.eye = A.eyeobj
 		return 1
 
-	if (!C.can_use() || user.stat || (get_dist(user, src) > 1 || user.machine != src || user.blinded || !( user.canmove ) && !istype(user, /mob/living/silicon)))
+	if (!C.can_use() || user.stat || (get_dist(user, src) > 1 || user.machine != src || user.blinded || !( user.canmove ) && !issilicon(user)))
 		return 0
 	set_current(C)
 	user.reset_view(current_camera)

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -15,7 +15,7 @@
 	set category = "Object"
 	set name = "Access Computer's Internals"
 	set src in oview(1)
-	if(get_dist(src, usr) > 1 || usr.restrained() || usr.lying || usr.stat || istype(usr, /mob/living/silicon))
+	if(get_dist(src, usr) > 1 || usr.restrained() || usr.lying || usr.stat || issilicon(usr))
 		return
 
 	opened = !opened

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -131,7 +131,7 @@
 			else
 				for(var/n = ++i; n <= optioncount; n++)
 					dat += "<dd><font color='blue'>&#09;[n]. ---------------</font><br></dd>"
-			if((istype(user, /mob/living/silicon/ai) || istype(user, /mob/living/silicon/robot)) && (user.mind.special_role && user.mind.original == user))
+			if((isAI(user) || isrobot(user)) && (user.mind.special_role && user.mind.original == user))
 				//Malf/Traitor AIs can bruteforce into the system to gain the Key.
 				dat += "<dd><A href='?src=\ref[src];hack=1'><i><font color='Red'>*&@#. Bruteforce Key</font></i></font></a><br></dd>"
 			else
@@ -161,7 +161,7 @@
 			dat += "</table>"
 		//Hacking screen.
 		if(2)
-			if(istype(user, /mob/living/silicon/ai) || istype(user, /mob/living/silicon/robot))
+			if(isAI(user) || isrobot(user))
 				dat += "Brute-forcing for server key.<br> It will take 20 seconds for every character that the password has."
 				dat += "In the meantime, this console can reveal your true intentions if you let someone access it. Make sure no humans enter the room during that time."
 			else
@@ -296,7 +296,7 @@
 		return
 	if(!istype(usr, /mob/living))
 		return
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
 		//Authenticate
 		if (href_list["auth"])
 			if(auth)
@@ -370,7 +370,7 @@
 
 		//Hack the Console to get the password
 		if (href_list["hack"])
-			if((istype(usr, /mob/living/silicon/ai) || istype(usr, /mob/living/silicon/robot)) && (usr.mind.special_role && usr.mind.original == usr))
+			if((isAI(usr) || isrobot(usr)) && (usr.mind.special_role && usr.mind.original == usr))
 				src.hacking = 1
 				src.screen = 2
 				update_icon()

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -103,7 +103,7 @@
 /obj/machinery/computer/pod/Topic(href, href_list)
 	if(..())
 		return 1
-	if((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (issilicon(usr)))
 		usr.set_machine(src)
 		if(href_list["power"])
 			var/t = text2num(href_list["power"])

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -69,7 +69,7 @@
 	Topic(href, href_list)
 		if(..())
 			return
-		if((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+		if((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
 			usr.set_machine(src)
 
 			if(href_list["inject1"])

--- a/code/game/machinery/computer/prisonshuttle.dm
+++ b/code/game/machinery/computer/prisonshuttle.dm
@@ -80,7 +80,7 @@ var/prison_shuttle_timeleft = 0
 		if(..())
 			return
 
-		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
 			usr.set_machine(src)
 
 		if (href_list["sendtodock"])

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -113,7 +113,7 @@
 			return
 
 		// Antag AI checks
-		if(!istype(user, /mob/living/silicon/ai) || !(user.mind.special_role && user.mind.original == user))
+		if(!isAI(user) || !(user.mind.special_role && user.mind.original == user))
 			to_chat(user, "Access Denied")
 			return
 
@@ -135,7 +135,7 @@
 
 	// Arms the emergency self-destruct system
 	else if(href_list["arm"])
-		if(istype(user, /mob/living/silicon))
+		if(issilicon(user))
 			to_chat(user, "Access Denied")
 			return
 
@@ -144,7 +144,7 @@
 
 	// Destroys all accessible cyborgs if safety is disabled
 	else if(href_list["nuke"])
-		if(istype(user, /mob/living/silicon))
+		if(issilicon(user))
 			to_chat(user, "Access Denied")
 			return
 		if(safety)
@@ -202,7 +202,7 @@
 		robot["master_ai"] = R.connected_ai ? R.connected_ai.name : "None"
 		robot["hackable"] = 0
 		// Antag AIs know whether linked cyborgs are hacked or not.
-		if(operator && istype(operator, /mob/living/silicon/ai) && (R.connected_ai == operator) && (operator.mind.special_role && operator.mind.original == operator))
+		if(operator && isAI(operator) && (R.connected_ai == operator) && (operator.mind.special_role && operator.mind.original == operator))
 			robot["hacked"] = R.emagged ? 1 : 0
 			robot["hackable"] = R.emagged? 0 : 1
 		robots.Add(list(robot))

--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -276,7 +276,7 @@ var/specops_shuttle_timeleft = 0
 	if(..())
 		return 1
 
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (issilicon(usr)))
 		usr.machine = src
 
 	if (href_list["sendtodock"])

--- a/code/game/machinery/computer/syndicate_specops_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_specops_shuttle.dm
@@ -219,7 +219,7 @@ var/syndicate_elite_shuttle_timeleft = 0
 	if(..())
 		return 1
 
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (issilicon(usr)))
 		usr.set_machine(src)
 
 	if (href_list["sendtodock"])

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -776,7 +776,7 @@ About the new airlock wires panel:
 	return ..()
 
 /obj/machinery/door/airlock/attack_hand(mob/user as mob)
-	if(!istype(usr, /mob/living/silicon))
+	if(!issilicon(usr))
 		if(src.isElectrified())
 			if(src.shock(user, 100))
 				return
@@ -1008,7 +1008,7 @@ About the new airlock wires panel:
 	return (ChainSawVar.powered && density && hashatch)
 
 /obj/machinery/door/airlock/attackby(var/obj/item/C, mob/user as mob)
-	if(!istype(usr, /mob/living/silicon))
+	if(!issilicon(usr))
 		if(src.isElectrified())
 			if(src.shock(user, 75))
 				return

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -19,7 +19,7 @@
 	var/inuse = 0 // no double-spending
 
 /obj/item/weapon/airlock_electronics/attack_self(mob/user as mob)
-	if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
+	if (!ishuman(user) && !isrobot(user))
 		return ..(user)
 
 	var/mob/living/carbon/human/H = user
@@ -62,14 +62,14 @@
 
 /obj/item/weapon/airlock_electronics/Topic(href, href_list)
 	..()
-	if (usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
+	if (usr.stat || usr.restrained() || (!ishuman(usr) && !issilicon(usr)))
 		return
 	if (href_list["close"])
 		usr << browse(null, "window=airlock")
 		return
 
 	if (href_list["login"])
-		if(istype(usr,/mob/living/silicon))
+		if(issilicon(usr))
 			src.locked = 0
 			src.last_configurator = usr.name
 		else

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -195,7 +195,7 @@
 		if(mover.checkpass(PASSGLASS))
 			return !opacity
 		if(density && hashatch && mover.checkpass(PASSDOORHATCH))
-			if (istype(mover, /mob/living/silicon/pai))
+			if (ispAI(mover))
 				var/mob/living/silicon/pai/P = mover
 				if (allowed(P))
 					open_hatch(mover)

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -63,7 +63,7 @@
 		visible_message("\The [src] shuts down.")
 
 /obj/machinery/floodlight/attack_ai(mob/user as mob)
-	if(istype(user, /mob/living/silicon/robot) && Adjacent(user))
+	if(isrobot(user) && Adjacent(user))
 		return attack_hand(user)
 
 	if(on)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -69,7 +69,7 @@ datum/track/New(var/title_name, var/audio)
 			add_overlay("[state_base]-running")
 
 /obj/machinery/media/jukebox/Topic(href, href_list)
-	if(..() || !(Adjacent(usr) || istype(usr, /mob/living/silicon)))
+	if(..() || !(Adjacent(usr) || issilicon(usr)))
 		return
 
 	if(!anchored)

--- a/code/game/machinery/kitchen/cooking_machines/cereal.dm
+++ b/code/game/machinery/kitchen/cooking_machines/cereal.dm
@@ -41,7 +41,7 @@
 
 	var/list/images = list()
 	var/num = 0
-	for (var/obj/item/I in CI.container).
+	for (var/obj/item/I in CI.container)
 		if (istype(I, /obj/item/weapon/reagent_containers/food/snacks/variable/cereal))
 			//Images of cereal boxes on cereal boxes is dumb
 			continue

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -173,7 +173,7 @@
 	src.updateUsrDialog()
 
 /obj/machinery/microwave/attack_ai(mob/user as mob)
-	if(istype(user, /mob/living/silicon/robot) && Adjacent(user))
+	if(isrobot(user) && Adjacent(user))
 		attack_hand(user)
 
 /obj/machinery/microwave/attack_hand(mob/user as mob)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -255,12 +255,12 @@ Class Procs:
 	if(user.lying || user.stat)
 		return 1
 	if ( ! (istype(usr, /mob/living/carbon/human) || \
-			istype(usr, /mob/living/silicon)))
+			issilicon(usr)))
 		to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return 1
 /*
 	//distance checks are made by atom/proc/DblClick
-	if ((get_dist(src, user) > 1 || !istype(src.loc, /turf)) && !istype(user, /mob/living/silicon))
+	if ((get_dist(src, user) > 1 || !istype(src.loc, /turf)) && !issilicon(user))
 		return 1
 */
 	if (ishuman(user))
@@ -386,7 +386,7 @@ Class Procs:
 		update_icon()
 	else
 		to_chat(user, "<span class='notice'>Following parts detected in the machine:</span>")
-		for(var/var/obj/item/C in component_parts)
+		for(var/obj/item/C in component_parts)
 			to_chat(user, "<span class='notice'>    [C.name]</span>")
 	return 1
 

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -182,7 +182,7 @@
 						step_towards(M, center)
 
 				for(var/mob/living/silicon/S in orange(magnetic_field, center))
-					if(istype(S, /mob/living/silicon/ai)) continue
+					if(isAI(S)) continue
 					step_towards(S, center)
 
 			use_power(electricity_level * 5)

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -190,7 +190,7 @@ Transponder Codes:<UL>"}
 		..()
 		if (usr.stat)
 			return
-		if ((in_range(src, usr) && istype(src.loc, /turf)) || (istype(usr, /mob/living/silicon)))
+		if ((in_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr)))
 			if(open && !locked)
 				usr.set_machine(src)
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -136,7 +136,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 	if(!user.IsAdvancedToolUser())
 		return 0
 
-	if(istype(user, /mob/living/carbon/human) || istype(user,/mob/living/silicon) )
+	if(istype(user, /mob/living/carbon/human) || issilicon(user) )
 		var/mob/living/human_or_robot_user = user
 		var/dat
 		dat = text("<H3>Newscaster Unit #[src.unit_no]</H3>")
@@ -404,7 +404,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 /obj/machinery/newscaster/Topic(href, href_list)
 	if(..())
 		return
-	if ((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (issilicon(usr)))
 		usr.set_machine(src)
 		if(href_list["set_channel_name"])
 			src.channel_name = sanitizeSafe(input(usr, "Provide a Feed Channel Name", "Network Channel Handler", ""), MAX_LNAME_LEN)
@@ -761,7 +761,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		var/obj/item/photo = user.get_active_hand()
 		user.drop_from_inventory(photo,src)
 		photo_data = new(photo, 0)
-	else if(istype(user,/mob/living/silicon))
+	else if(issilicon(user))
 		var/mob/living/silicon/tempAI = user
 		var/obj/item/weapon/photo/selection = tempAI.GetPicture()
 		if (!selection)

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -82,7 +82,7 @@
 		update_icon()
 
 /obj/machinery/recharger/attack_hand(mob/user as mob)
-	if(istype(user,/mob/living/silicon))
+	if(issilicon(user))
 		return
 
 	add_fingerprint(user)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -259,7 +259,7 @@
 
 
 /obj/machinery/recharge_station/MouseDrop_T(var/atom/movable/C, mob/user)
-	if (istype(C, /mob/living/silicon/robot))
+	if (isrobot(C))
 		var/mob/living/silicon/robot/R = C
 		if (!user.Adjacent(R) || !Adjacent(user))
 			to_chat(user, span("danger", "You need to get closer if you want to put [C] into that charger!"))

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -113,7 +113,7 @@
 /obj/machinery/space_heater/Topic(href, href_list)
 	if (usr.stat)
 		return
-	if ((in_range(src, usr) && istype(src.loc, /turf)) || (istype(usr, /mob/living/silicon)))
+	if ((in_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr)))
 		usr.set_machine(src)
 
 		switch(href_list["op"])

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -171,7 +171,7 @@
 /obj/machinery/suit_storage_unit/Topic(href, href_list) //I fucking HATE this proc
 	if(..())
 		return
-	if ((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon/ai)))
+	if ((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr)))
 		usr.set_machine(src)
 		if (href_list["toggleUV"])
 			src.toggleUV(usr)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -22,7 +22,7 @@
 /obj/machinery/syndicate_beacon/attack_hand(var/mob/user as mob)
 	usr.set_machine(src)
 	var/dat = "<font color=#005500><i>Scanning [pick("retina pattern", "voice print", "fingerprints", "dna sequence")]...<br>Identity confirmed,<br></i></font>"
-	if(istype(user, /mob/living/carbon/human) || istype(user, /mob/living/silicon/ai))
+	if(istype(user, /mob/living/carbon/human) || isAI(user))
 		if(is_special_character(user))
 			dat += "<font color=#07700><i>Operative record found. Greetings, Agent [user.name].</i></font><br>"
 		else if(charges < 1)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -516,7 +516,7 @@
 	if(usr.stat || usr.restrained())
 		return
 
-	if(href_list["remove_coin"] && !istype(usr,/mob/living/silicon))
+	if(href_list["remove_coin"] && !issilicon(usr))
 		if(!coin)
 			to_chat(usr, "There is no coin in this machine.")
 			return
@@ -544,7 +544,7 @@
 
 			if(R.price <= 0)
 				src.vend(R, usr)
-			else if(istype(usr,/mob/living/silicon)) //If the item is not free, provide feedback if a synth is trying to buy something.
+			else if(issilicon(usr)) //If the item is not free, provide feedback if a synth is trying to buy something.
 				to_chat(usr, "<span class='danger'>Artificial unit recognized.  Artificial units cannot complete this transaction.  Purchase canceled.</span>")
 				return
 			else

--- a/code/game/machinery/walllockers.dm
+++ b/code/game/machinery/walllockers.dm
@@ -6,7 +6,7 @@
 	anchored = 1
 	var/amount = 3 // spawns each items X times.
 /obj/structure/walllocker/attack_hand(mob/user as mob)
-	if (istype(user, /mob/living/silicon/ai))	//Added by Strumpetplaya - AI shouldn't be able to
+	if (isAI(user))	//Added by Strumpetplaya - AI shouldn't be able to
 		return									//activate emergency lockers.  This fixes that.  (Does this make sense, the AI can't call attack_hand, can it? --Mloc)
 	if(!amount)
 		to_chat(usr, "It's empty..")

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -205,7 +205,7 @@
 		to_chat(user, "The fabricator cannot hold more [sname].")
 
 /obj/machinery/mecha_part_fabricator/MouseDrop_T(mob/living/carbon/human/target as mob, mob/user as mob)
-	if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || istype(user, /mob/living/silicon/ai))
+	if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || isAI(user))
 		return
 	if(target == user)
 		if(target.h_style == "Floorlength Braid" || target.h_style == "Very Long Hair")

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -56,7 +56,7 @@
 /obj/proc/user_buckle_mob(mob/living/M, mob/user)
 	if(!ROUND_IS_STARTED)
 		to_chat(user, "<span class='warning'>You can't buckle anyone in before the game starts.</span>")
-	if(!user.Adjacent(M) || user.restrained() || user.stat || istype(user, /mob/living/silicon/pai))
+	if(!user.Adjacent(M) || user.restrained() || user.stat || ispAI(user))
 		return
 	if(M == buckled_mob)
 		return

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -332,7 +332,7 @@ var/global/list/default_medbay_channels = list(
 		jobname = "Cyborg"
 
 	// --- Personal AI (pAI) ---
-	else if (istype(M, /mob/living/silicon/pai))
+	else if (ispAI(M))
 		jobname = "Personal AI"
 
 	// --- Unidentifiable mob ---

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -26,7 +26,7 @@
 		use_message = capitalize(copytext(sanitize(new_message), 1, MAX_MESSAGE_LEN))
 
 	to_chat(usr, "You configure the hailer to shout \"[use_message]\".")
-/
+
 obj/item/device/hailer/attack_self(mob/living/carbon/user as mob)
 	if (spamcheck)
 		return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -298,7 +298,7 @@
 			law_manager = TRUE
 
 	if(istype(W, /obj/item/device/flash))
-		if(istype(user,/mob/living/silicon/robot))
+		if(isrobot(user))
 			var/current_module = user.get_active_hand()
 			if(current_module == W)
 				to_chat(user, "<span class='warning'>How do you propose to do that?</span>")

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -22,12 +22,12 @@ Contains:
 	var/apply_sounds
 
 /obj/item/stack/medical/attack(mob/living/M as mob, mob/user as mob)
-	if (!istype(M) || istype(M, /mob/living/silicon) || istype(M, /mob/living/simple_animal/spiderbot))
+	if (!istype(M) || issilicon(M) || istype(M, /mob/living/simple_animal/spiderbot))
 		to_chat(user, "<span class='warning'>\The [src] cannot be applied to [M]!</span>")
 		return 1
 
 	if ( ! (istype(user, /mob/living/carbon/human) || \
-			istype(user, /mob/living/silicon)) )
+			issilicon(user)) )
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return 1
 

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -23,7 +23,7 @@
 		return 0
 	if (!can_use(1, user))
 		return 0
-	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs
+	if (isrobot(M))	//Repairing cyborgs
 		var/mob/living/silicon/robot/R = M
 		if (R.getBruteLoss() || R.getFireLoss() )
 			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/game/objects/items/weapons/RFD.dm
+++ b/code/game/objects/items/weapons/RFD.dm
@@ -262,7 +262,7 @@ RFD Service-Class
 	number_of_modes = 5
 
 /obj/item/weapon/rfd/service/resolve_attackby(atom/A, mob/user as mob, var/click_parameters)
-	if(istype(user,/mob/living/silicon/robot))
+	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
 		if(R.stat || !R.cell || R.cell.charge <= 0)
 			return
@@ -323,7 +323,7 @@ RFD Mining-Class
 
 	if(!proximity) return
 
-	if(istype(user,/mob/living/silicon/robot))
+	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
 		if(R.stat || !R.cell || R.cell.charge <= 0)
 			return
@@ -382,7 +382,7 @@ RFD Mining-Class
 
 	if(!proximity) return
 
-	if(istype(user,/mob/living/silicon/robot))
+	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
 		if(R.stat || !R.cell || R.cell.charge <= 0)
 			return

--- a/code/game/objects/items/weapons/implants/implantchair.dm
+++ b/code/game/objects/items/weapons/implants/implantchair.dm
@@ -54,7 +54,7 @@
 
 
 	Topic(href, href_list)
-		if((get_dist(src, usr) <= 1) || istype(usr, /mob/living/silicon/ai))
+		if((get_dist(src, usr) <= 1) || isAI(usr))
 			if(href_list["implant"])
 				if(src.occupant)
 					injecting = 1

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -19,7 +19,7 @@
 			for (var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
 				return module.jets
 	// See if we have a robot instead, and look for their jetpack.
-	else if (istype(H, /mob/living/silicon/robot))
+	else if (isrobot(H))
 		var/mob/living/silicon/robot/R = H
 		if (R.module)
 			for (var/obj/item/weapon/tank/jetpack/J in R.module.modules)

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -115,7 +115,7 @@
 			for(var/mob/O in viewers(M, null))
 				O.show_message(text("<span class='danger'>[] slams [] with the tray!</span>", user, M), 1)
 		if(prob(10))
-			if(!istype(M,/mob/living/silicon))M.Stun(rand(1,3))
+			if(!issilicon(M))M.Stun(rand(1,3))
 			M.take_organ_damage(3)
 			return
 		else
@@ -152,7 +152,7 @@
 /obj/item/weapon/tray/var/cooldown = 0	//shield bash cooldown. based on world.time
 
 /obj/item/weapon/tray/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (istype(user,/mob/living/silicon/robot))//safety to stop robots losing their items
+	if (isrobot(user))//safety to stop robots losing their items
 		return
 
 	if (istype(W, /obj/item/weapon/tray))//safety to prevent tray stacking

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -103,7 +103,7 @@
 			if ((M.client && M.machine == src))
 				is_in_use = 1
 				src.attack_hand(M)
-		if (istype(usr, /mob/living/silicon/ai) || istype(usr, /mob/living/silicon/robot))
+		if (isAI(usr) || isrobot(usr))
 			if (!(usr in nearby))
 				if (usr.client && usr.machine==src) // && M.machine == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
 					is_in_use = 1

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -323,7 +323,7 @@
 	return
 
 /obj/structure/closet/attack_ai(mob/user)
-	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Robots can open/close it, but not the AI.
+	if(isrobot(user) && Adjacent(user)) // Robots can open/close it, but not the AI.
 		attack_hand(user)
 
 /obj/structure/closet/relaymove(mob/user as mob)

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -230,7 +230,7 @@
 	if(ishuman(usr))
 		add_fingerprint(usr)
 		togglelock(usr)
-	else if(istype(usr, /mob/living/silicon/robot) && Adjacent(usr))
+	else if(isrobot(usr) && Adjacent(usr))
 		togglelock(usr)
 	else
 		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -28,7 +28,7 @@
 	return
 
 /obj/structure/closet/walllocker/emerglocker/attack_hand(mob/user as mob)
-	if (istype(user, /mob/living/silicon/ai))	//Added by Strumpetplaya - AI shouldn't be able to
+	if (isAI(user))	//Added by Strumpetplaya - AI shouldn't be able to
 		return									//activate emergency lockers.  This fixes that.  (Does this make sense, the AI can't call attack_hand, can it? --Mloc)
 	if(!amount)
 		to_chat(usr, "<spawn class='notice'>It's empty..")

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -27,7 +27,7 @@
 	..()
 
 /obj/structure/curtain/attack_ai(mob/user)
-	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Robots can open/close it, but not the AI.
+	if(isrobot(user) && Adjacent(user)) // Robots can open/close it, but not the AI.
 		attack_hand(user)
 
 /obj/structure/curtain/proc/toggle()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -80,7 +80,7 @@
 			else
 				to_chat(user, "<span class='notice'>You need a tighter grip.</span>")
 
-	if(cistern && !istype(user,/mob/living/silicon/robot)) //STOP PUTTING YOUR MODULES IN THE TOILET.
+	if(cistern && !isrobot(user)) //STOP PUTTING YOUR MODULES IN THE TOILET.
 		if(I.w_class > 3)
 			to_chat(user, "<span class='notice'>\The [I] does not fit.</span>")
 			return

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -105,7 +105,7 @@
 /turf/simulated/wall/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	if (!user.)
+	if (!user)
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1126,7 +1126,7 @@ proc/admin_notice(var/message, var/rights)
 		out += "<b>Autotraitor <a href='?src=\ref[SSticker.mode];toggle=autotraitor'>disabled</a></b>.<br/>"
 
 	out += "<b>All antag ids:</b>"
-	if(LAZYLEN(SSticker.mode.antag_templates)).
+	if(LAZYLEN(SSticker.mode.antag_templates))
 		for(var/datum/antagonist/antag in SSticker.mode.antag_templates)
 			antag.update_current_antag_max()
 			out += " <a href='?src=\ref[SSticker.mode];debug_antag=[antag.id]'>[antag.id]</a>"

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -109,7 +109,7 @@ var/datum/vueui_module/player_panel/global_player_panel
 		if(M.real_name)
 			return M.real_name
 		return "Unknown"
-	if(istype(M, /mob/living/silicon/pai))
+	if(ispAI(M))
 		return "pAI"
 	if(istype(M, /mob/abstract/new_player))
 		return "New Player"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -621,7 +621,7 @@
 		if(!ismob(M))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
-		if(istype(M, /mob/living/silicon/ai))
+		if(isAI(M))
 			to_chat(usr, "This cannot be used on instances of type /mob/living/silicon/ai")
 			return
 
@@ -662,7 +662,7 @@
 		if(!ismob(M))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
-		if(istype(M, /mob/living/silicon/ai))
+		if(isAI(M))
 			to_chat(usr, "This cannot be used on instances of type /mob/living/silicon/ai")
 			return
 
@@ -687,7 +687,7 @@
 		if(!ismob(M))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
-		if(istype(M, /mob/living/silicon/ai))
+		if(isAI(M))
 			to_chat(usr, "This cannot be used on instances of type /mob/living/silicon/ai")
 			return
 
@@ -712,7 +712,7 @@
 		if(!ismob(M))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
-		if(istype(M, /mob/living/silicon/ai))
+		if(isAI(M))
 			to_chat(usr, "This cannot be used on instances of type /mob/living/silicon/ai")
 			return
 
@@ -734,7 +734,7 @@
 		if(!ismob(M))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
-		if(istype(M, /mob/living/silicon/ai))
+		if(isAI(M))
 			to_chat(usr, "This cannot be used on instances of type /mob/living/silicon/ai")
 			return
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -23,7 +23,7 @@
 		to_chat(src, "Only administrators may use this command.")
 		return
 	if (ismob(M))
-		if(istype(M, /mob/living/silicon/ai))
+		if(isAI(M))
 			alert("The AI can't be sent to prison you jerk!", null, null, null, null, null)
 			return
 		//strip their stuff before they teleport into a cell :downs:

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -43,10 +43,10 @@
 /obj/machinery/computer/artillerycontrol/proc/announce_and_fire(var/turf/t, var/mob/user)
 	if(!istype(t))
 		return
-	if ((user.contents.Find(src) || (in_range(src, user) && istype(src.loc, /turf))) || (istype(user, /mob/living/silicon)))
+	if ((user.contents.Find(src) || (in_range(src, user) && istype(src.loc, /turf))) || (issilicon(user)))
 		if (user.stat || user.restrained()) return
 		if (src.reload < 180) return
-		if ((user.contents.Find(src) || (in_range(src, user) && istype(src.loc, /turf))) || (istype(user, /mob/living/silicon)))
+		if ((user.contents.Find(src) || (in_range(src, user) && istype(src.loc, /turf))) || (issilicon(user)))
 			command_announcement.Announce("Bluespace artillery fire detected. Brace for impact.")
 			to_world(sound('sound/effects/yamato_fire.ogg'))
 			message_admins("[key_name_admin(usr)] has launched an artillery strike.", 1)

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -67,7 +67,7 @@
 							health += rand(10,30)
 							if(health > maxHealth)
 								health = maxHealth
-				else if(istype(L, /mob/living/silicon))
+				else if(issilicon(L))
 					continue
 				else
 					L.gib()

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -82,7 +82,7 @@
 
 	// Check if there's actually an AI to deal with.
 	var/mob/living/silicon/ai/target_ai
-	if(istype(input_device, /mob/living/silicon/ai))
+	if(isAI(input_device))
 		target_ai = input_device
 	else
 		target_ai = locate(/mob/living/silicon/ai) in input_device.contents
@@ -90,7 +90,7 @@
 	var/obj/item/weapon/aicard/card = ai_card
 
 	// Downloading from/loading to a terminal.
-	if(istype(input_device,/mob/living/silicon/ai) || istype(input_device,/obj/structure/AIcore/deactivated))
+	if(isAI(input_device) || istype(input_device,/obj/structure/AIcore/deactivated))
 
 		// If we're stealing an AI, make sure we have a card for it.
 		if(!card)

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -126,7 +126,7 @@ log transactions
 		..()
 
 /obj/machinery/atm/attack_hand(mob/user as mob)
-	if(istype(user, /mob/living/silicon))
+	if(issilicon(user))
 		to_chat(user, "<span class='warning'>\icon[src] Artificial unit recognized. Artificial units do not currently receive monetary compensation, as per system banking regulation #1005.</span>")
 		return
 	if(get_dist(src,user) <= 1)

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -137,7 +137,7 @@ var/list/event_last_fired = list()
 
 		active_with_role["Any"]++
 
-		if(istype(M, /mob/living/silicon/robot))
+		if(isrobot(M))
 			var/mob/living/silicon/robot/R = M
 			if(R.module)
 				if(istype(R.module, /obj/item/weapon/robot_module/engineering))

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -223,7 +223,7 @@ mob/living/carbon/proc/handle_hallucinations()
 	return start_txt + mocktxt + end_txt + "</TT></BODY></HTML>"
 
 proc/check_panel(mob/M)
-	if (istype(M, /mob/living/carbon/human) || istype(M, /mob/living/silicon/ai))
+	if (istype(M, /mob/living/carbon/human) || isAI(M))
 		if(M.hallucination < 15)
 			return 1
 	return 0*/

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -104,7 +104,7 @@
 	if(..())
 		return 1
 
-	if((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
 
 		if(locked && !allowed(usr))
 			return

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -399,7 +399,7 @@
 
 	if(usr.incapacitated())
 		return
-	if(ishuman(usr) || istype(usr, /mob/living/silicon/robot))
+	if(ishuman(usr) || isrobot(usr))
 		var/new_light = input("Specify a light level.") as null|anything in list(0,1,2,3,4,5,6,7,8,9,10)
 		if(new_light)
 			tray_light = new_light
@@ -596,7 +596,7 @@
 
 /obj/machinery/portable_atmospherics/hydroponics/attack_hand(mob/user as mob)
 
-	if(istype(usr,/mob/living/silicon))
+	if(issilicon(usr))
 		return
 
 	if(harvest)
@@ -665,7 +665,7 @@
 	if(usr.incapacitated())
 		return
 
-	if(ishuman(usr) || istype(usr, /mob/living/silicon/robot))
+	if(ishuman(usr) || isrobot(usr))
 		close_lid(usr)
 	return
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -156,7 +156,7 @@ var/list/mineral_can_smooth_with = list(
 			if(P.autodrill)
 				attackby(H.r_hand,H)
 
-	else if(istype(AM,/mob/living/silicon/robot))
+	else if(isrobot(AM))
 		var/mob/living/silicon/robot/R = AM
 		if(istype(R.module_active,/obj/item/weapon/pickaxe))
 			attackby(R.module_active,R)
@@ -858,7 +858,7 @@ var/list/asteroid_floor_smooth = list(
 
 /turf/unsimulated/floor/asteroid/Entered(atom/movable/M as mob|obj)
 	..()
-	if(istype(M,/mob/living/silicon/robot))
+	if(isrobot(M))
 		var/mob/living/silicon/robot/R = M
 		if(R.module)
 			if(istype(R.module_state_1,/obj/item/weapon/storage/bag/ore))

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -46,7 +46,7 @@
 	to_chat(user, desc)
 
 	// Borgs can now check contents too.
-	if((!istype(user, /mob/living/carbon/human)) && (!istype(user, /mob/living/silicon/robot)))
+	if((!istype(user, /mob/living/carbon/human)) && (!isrobot(user)))
 		return
 
 	if(!Adjacent(user)) //Can only check the contents of ore boxes if you can physically reach them.

--- a/code/modules/mob/abstract/freelook/ai/eye.dm
+++ b/code/modules/mob/abstract/freelook/ai/eye.dm
@@ -63,7 +63,7 @@
 	return ..()
 
 /atom/proc/move_camera_by_click()
-	if(istype(usr, /mob/living/silicon/ai))
+	if(isAI(usr))
 		var/mob/living/silicon/ai/AI = usr
 		if(AI.eyeobj && AI.client.eye == AI.eyeobj)
 			AI.eyeobj.setLoc(src)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -133,7 +133,7 @@
 
 	var/changed_voice
 
-	if(istype(src, /mob/living/silicon/ai) && !hard_to_hear)
+	if(isAI(src) && !hard_to_hear)
 		var/jobname // the mob's "job"
 		var/mob/living/carbon/human/impersonating //The crew member being impersonated, if any.
 
@@ -168,7 +168,7 @@
 			jobname = "AI"
 		else if (isrobot(speaker))
 			jobname = "Cyborg"
-		else if (istype(speaker, /mob/living/silicon/pai))
+		else if (ispAI(speaker))
 			jobname = "Personal AI"
 		else
 			jobname = "Unknown"

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -194,7 +194,7 @@
 			to_chat(player, msg)
 
 /datum/language/bug/check_special_condition(var/mob/other)
-	if(istype(other, /mob/living/silicon))
+	if(issilicon(other))
 		return 1
 
 	var/mob/living/carbon/human/M = other

--- a/code/modules/mob/language/synthetic.dm
+++ b/code/modules/mob/language/synthetic.dm
@@ -41,7 +41,7 @@
 	listening -= src
 
 	for (var/mob/living/M in listening)
-		if(istype(M, /mob/living/silicon) || M.binarycheck())
+		if(issilicon(M) || M.binarycheck())
 			continue
 		M.show_message("<i><span class='game say'><span class='name'>synthesised voice</span> <span class='message'>beeps, \"beep beep beep\"</span></span></i>",2)
 

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -17,7 +17,7 @@
 	return ..()
 
 /mob/living/carbon/brain/say_understands(var/other)//Goddamn is this hackish, but this say code is so odd
-	if (istype(other, /mob/living/silicon/ai))
+	if (isAI(other))
 		if(!(container && istype(container, /obj/item/device/mmi)))
 			return 0
 		else
@@ -27,12 +27,12 @@
 			return 0
 		else
 			return 1
-	else if (istype(other, /mob/living/silicon/pai))
+	else if (ispAI(other))
 		if(!(container && istype(container, /obj/item/device/mmi)))
 			return 0
 		else
 			return 1
-	else if (istype(other, /mob/living/silicon/robot))
+	else if (isrobot(other))
 		if(!(container && istype(container, /obj/item/device/mmi)))
 			return 0
 		else

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -383,7 +383,7 @@
 				return istype(H.glasses, /obj/item/clothing/glasses/hud/health)
 			else
 				return 0
-	else if(istype(M, /mob/living/silicon/robot))
+	else if(isrobot(M))
 		var/mob/living/silicon/robot/R = M
 		switch(hudtype)
 			if("security")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -536,7 +536,7 @@
 								if(istype(usr,/mob/living/carbon/human))
 									var/mob/living/carbon/human/U = usr
 									U.handle_regular_hud_updates()
-								if(istype(usr,/mob/living/silicon/robot))
+								if(isrobot(usr))
 									var/mob/living/silicon/robot/U = usr
 									U.handle_regular_hud_updates()
 
@@ -614,7 +614,7 @@
 				if(istype(usr,/mob/living/carbon/human))
 					var/mob/living/carbon/human/U = usr
 					R.security.comments += text("Made by [U.get_authentification_name()] ([U.get_assignment()]) on [time2text(world.realtime, "DDD MMM DD hh:mm:ss")], [game_year]<BR>[t1]")
-				if(istype(usr,/mob/living/silicon/robot))
+				if(isrobot(usr))
 					var/mob/living/silicon/robot/U = usr
 					R.security.comments += text("Made by [U.name] ([U.modtype] [U.braintype]) on [time2text(world.realtime, "DDD MMM DD hh:mm:ss")], [game_year]<BR>[t1]")
 
@@ -646,7 +646,7 @@
 							if(istype(usr,/mob/living/carbon/human))
 								var/mob/living/carbon/human/U = usr
 								U.handle_regular_hud_updates()
-							if(istype(usr,/mob/living/silicon/robot))
+							if(isrobot(usr))
 								var/mob/living/silicon/robot/U = usr
 								U.handle_regular_hud_updates()
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -61,7 +61,7 @@ mob/living/carbon/human/proc/change_monitor()
 
 	var/list/choices = list()
 	for(var/mob/living/M in view(1,src))
-		if(!istype(M,/mob/living/silicon) && Adjacent(M))
+		if(!issilicon(M) && Adjacent(M))
 			choices += M
 	choices -= src
 
@@ -118,7 +118,7 @@ mob/living/carbon/human/proc/change_monitor()
 	if (!T || issilicon(T)) // Silicon targets require us to rebuild the list.
 		var/list/choices = list()
 		for(var/mob/living/M in view(max_range, src))
-			if(!istype(M,/mob/living/silicon))
+			if(!issilicon(M))
 				choices += M
 		choices -= src
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -51,7 +51,7 @@
 		if (istype(other, /mob/living/carbon/alien/diona))
 			if(other.languages.len >= 2) //They've sucked down some blood and can speak common now.
 				return 1
-		if (istype(other, /mob/living/silicon))
+		if (issilicon(other))
 			return 1
 		if (istype(other, /mob/living/carbon/brain))
 			return 1

--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -311,7 +311,7 @@
 				return
 
 		if(Target.Adjacent(src))
-			if(istype(Target, /mob/living/silicon)) // Glomp the silicons
+			if(issilicon(Target)) // Glomp the silicons
 				if(!Atkcool)
 					a_intent = I_HURT
 					UnarmedAttack(Target)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -221,7 +221,7 @@ default behaviour is:
 				H.UpdateDamageIcon()
 		H.updatehealth()
 		return 1
-	else if(istype(src, /mob/living/silicon/ai))
+	else if(isAI(src))
 		return 0
 
 /mob/living/proc/adjustBodyTemp(actual, desired, incrementboost)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -67,7 +67,7 @@ proc/get_radio_key_from_channel(var/channel)
 
 /mob/living/proc/binarycheck()
 
-	if (istype(src, /mob/living/silicon/pai))
+	if (ispAI(src))
 		return
 
 	if (!ishuman(src))

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -28,7 +28,7 @@
 		return
 
 	var/scan_type
-	if(istype(M, /mob/living/silicon/robot))
+	if(isrobot(M))
 		scan_type = "robot"
 	else if(istype(M, /mob/living/carbon/human))
 		scan_type = "prosthetics"

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -54,7 +54,7 @@
 		to_chat(usr, "<span class='danger'>Access denied.</span>")
 		return
 
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
 		usr.set_machine(src)
 
 	if (href_list["setarea"])

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -769,7 +769,7 @@
 			attack_generic(H, rand(30,50), "slashed")
 			return
 
-	if(opened && !wiresexposed && (!istype(user, /mob/living/silicon)))
+	if(opened && !wiresexposed && (!issilicon(user)))
 		var/datum/robot_component/cell_component = components["power cell"]
 		if(cell)
 			cell.update_icon()
@@ -799,7 +799,7 @@
 		//if they are holding or wearing a card that has access, that works
 		if(check_access(H.get_active_hand()) || check_access(H.wear_id))
 			return 1
-	else if(istype(M, /mob/living/silicon/robot))
+	else if(isrobot(M))
 		var/mob/living/silicon/robot/R = M
 		if(check_access(R.get_active_hand()) || istype(R.get_active_hand(), /obj/item/weapon/card/robot))
 			return 1

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -74,7 +74,7 @@
 	if (!speaking)
 		if (istype(other, /mob/living/carbon))
 			return 1
-		if (istype(other, /mob/living/silicon))
+		if (issilicon(other))
 			return 1
 		if (istype(other, /mob/living/carbon/brain))
 			return 1

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -196,7 +196,7 @@
 	return universal_speak || (speaking in src.speech_synthesizer_langs)	//need speech synthesizer support to vocalize a language
 
 /mob/living/silicon/add_language(var/language, var/can_speak=1)
-	var/var/datum/language/added_language = all_languages[language]
+	var/datum/language/added_language = all_languages[language]
 	if(!added_language)
 		return
 
@@ -206,7 +206,7 @@
 		return 1
 
 /mob/living/silicon/remove_language(var/rem_language)
-	var/var/datum/language/removed_language = all_languages[rem_language]
+	var/datum/language/removed_language = all_languages[rem_language]
 	if(!removed_language)
 		return
 

--- a/code/modules/mob/living/simple_animal/hostile/sarlacc.dm
+++ b/code/modules/mob/living/simple_animal/hostile/sarlacc.dm
@@ -66,7 +66,7 @@
 		else
 			H.gib()
 		originator.sated += 200+H.mob_size //instantly sates the originator
-	else if(istype(L,/mob/living/silicon/robot))
+	else if(isrobot(L))
 		var/mob/living/silicon/robot/R = L
 		L.visible_message(
 			"<span class='danger'>\The [src] spits [R] out with a frustrated screech after failing to swallow.</span>",

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -622,7 +622,7 @@
 	if(M != usr) return
 	if(usr == src) return
 	if(!Adjacent(usr)) return
-	if(istype(M,/mob/living/silicon/ai)) return
+	if(isAI(M)) return
 	show_inv(usr)
 
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -726,7 +726,7 @@ proc/is_blind(A)
 
 /mob/living/proc/bucklecheck(var/mob/living/user)
 	if (buckled && istype(buckled, /obj/structure))
-		if (istype(user,/mob/living/silicon/robot))
+		if (isrobot(user))
 			return 2
 		else
 			to_chat(user, "You must unbuckle the subject first")

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -81,7 +81,7 @@
 	set hidden = 1
 	if(istype(mob, /mob/living/carbon))
 		mob:swap_hand()
-	if(istype(mob,/mob/living/silicon/robot))
+	if(isrobot(mob))
 		var/mob/living/silicon/robot/R = mob
 		R.cycle_modules()
 	return

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -9,7 +9,7 @@ var/const/BLOOD_VOLUME_BAD = 224
 var/const/BLOOD_VOLUME_SURVIVE = 122
 
 /mob/living/carbon/human/var/datum/reagents/vessel	//Container for blood and BLOOD ONLY. Do not transfer other chems here.
-/mob/living/carbon/human/var/var/pale = 0			//Should affect how mob sprite is drawn, but currently doesn't.
+/mob/living/carbon/human/var/pale = 0			//Should affect how mob sprite is drawn, but currently doesn't.
 
 //Initializes blood vessels
 /mob/living/carbon/human/proc/make_blood()

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -169,7 +169,7 @@
 
 			if(P && (P.loc == src) && istype(P, /obj/item/weapon/paper) )
 
-				if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/abstract/observer) || istype(usr, /mob/living/silicon)))
+				if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/abstract/observer) || issilicon(usr)))
 					usr << browse("<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY>[stars(P.info)][P.stamps]</BODY></HTML>", "window=[P.name]")
 					onclose(usr, "[P.name]")
 				else

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -79,7 +79,7 @@
 		else if(href_list["read"])
 			var/obj/item/weapon/paper/P = locate(href_list["read"])
 			if(P && (P.loc == src) && istype(P))
-				if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/abstract/observer) || istype(usr, /mob/living/silicon)))
+				if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/abstract/observer) || issilicon(usr)))
 					usr << browse("<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY>[stars(P.info)][P.stamps]</BODY></HTML>", "window=[P.name]")
 					onclose(usr, "[P.name]")
 				else

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -101,8 +101,8 @@
 
 
 /obj/item/weapon/paper/proc/show_content(mob/user, forceshow)
-	var/can_read = (istype(user, /mob/living/carbon/human) || isobserver(user) || istype(user, /mob/living/silicon)) || forceshow
-	if(!forceshow && istype(user,/mob/living/silicon/ai))
+	var/can_read = (istype(user, /mob/living/carbon/human) || isobserver(user) || issilicon(user)) || forceshow
+	if(!forceshow && isAI(user))
 		var/mob/living/silicon/ai/AI
 		can_read = get_dist(src, AI.camera) < 2
 	user << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY bgcolor='[color]'>[can_read ? info : stars(info)][stamps]</BODY></HTML>", "window=[name]")

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -118,7 +118,7 @@
 
 	if(istype(pages[page], /obj/item/weapon/paper))
 		var/obj/item/weapon/paper/P = W
-		if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/abstract/observer) || istype(usr, /mob/living/silicon)))
+		if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/abstract/observer) || issilicon(usr)))
 			dat+= "<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY>[stars(P.info)][P.stamps]</BODY></HTML>"
 		else
 			dat+= "<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY>[P.info][P.stamps]</BODY></HTML>"

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -24,8 +24,8 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 /obj/machinery/photocopier/vueui_data_change(var/list/data, var/mob/user, var/datum/vueui/ui)
 	. = ..()
 	data = . || data
-	if(data && data["isAI"] != istype(user, /mob/living/silicon))
-		data["isAI"] = istype(user, /mob/living/silicon)
+	if(data && data["isAI"] != issilicon(user))
+		data["isAI"] = issilicon(user)
 		. = data
 	if(data && !isnum(data["copies"]))
 		data["copies"] = 1
@@ -69,7 +69,7 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 			copyitem = null
 			SSvueui.check_uis_for_change(src)
 	else if(href_list["aipic"])
-		if(!istype(usr,/mob/living/silicon)) return
+		if(!issilicon(usr)) return
 		if(stat & (BROKEN|NOPOWER)) return
 
 		if(toner >= 5)

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -289,7 +289,7 @@
 
 /obj/machinery/power/am_control_unit/interact(mob/user)
 	if((get_dist(src, user) > 1) || (stat & (BROKEN|NOPOWER)))
-		if(!istype(user, /mob/living/silicon/ai))
+		if(!isAI(user))
 			user.unset_machine()
 			user << browse(null, "window=AMcontrol")
 			return
@@ -316,7 +316,7 @@
 		"stability" = stored_core_stability,
 		"stored_power" = stored_power,
 		"fueljar" = fueljar_data,
-		"siliconUser" = istype(user, /mob/living/silicon)
+		"siliconUser" = issilicon(user)
 	)
 
 	var/datum/nanoui/ui = SSnanoui.get_open_ui(user, src, ui_key)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -438,7 +438,7 @@
 
 /obj/machinery/power/apc/attackby(obj/item/W, mob/user)
 
-	if (istype(user, /mob/living/silicon) && get_dist(src,user)>1)
+	if (issilicon(user) && get_dist(src,user)>1)
 		return src.attack_hand(user)
 	src.add_fingerprint(user)
 	if (W.iscrowbar() && opened)
@@ -717,7 +717,7 @@
 				"You hear bang")
 			update_icon()
 		else
-			if (istype(user, /mob/living/silicon))
+			if (issilicon(user))
 				return src.attack_hand(user)
 			if (!opened && wiresexposed && \
 				W.ismultitool() || \
@@ -841,7 +841,7 @@
 	if(!user)
 		return
 
-	if(wiresexposed && !istype(user, /mob/living/silicon/ai))
+	if(wiresexposed && !isAI(user))
 		wires.Interact(user)
 
 	return ui_interact(user)
@@ -863,7 +863,7 @@
 		"totalCharging" = round(lastused_charging),
 		"coverLocked" = coverlocked,
 		"failTime" = failure_timer * 2,
-		"siliconUser" = istype(user, /mob/living/silicon),
+		"siliconUser" = issilicon(user),
 		"emergencyMode" = !emergency_lights,
 		"time" = time,
 		"charge_mode" = charge_mode,
@@ -950,7 +950,7 @@
 		to_chat(user, "<span class='warning'>You must stand to use [src]!</span>")
 		return 0
 	autoflag = 5
-	if (istype(user, /mob/living/silicon))
+	if (issilicon(user))
 		var/permit = 0 // Malfunction variable. If AI hacks APC it can control it even without AI control wire.
 		var/mob/living/silicon/ai/AI = user
 		var/mob/living/silicon/robot/robot = user
@@ -989,7 +989,7 @@
 		update_icon()
 		return 1
 
-	else if(!istype(usr, /mob/living/silicon) && (locked && !emagged))
+	else if(!issilicon(usr) && (locked && !emagged))
 		// Shouldn't happen, this is here to prevent href exploits
 		to_chat(usr, "You must unlock the panel to use this!")
 		return 1
@@ -1039,11 +1039,11 @@
 		update()
 
 	else if (href_list["overload"])
-		if(istype(usr, /mob/living/silicon))
+		if(issilicon(usr))
 			src.overload_lighting()
 
 	else if (href_list["toggleaccess"])
-		if(istype(usr, /mob/living/silicon))
+		if(issilicon(usr))
 			if(emagged || (stat & (BROKEN|MAINT)))
 				to_chat(usr, "The APC does not respond to the command.")
 			else

--- a/code/modules/power/generator_type2.dm
+++ b/code/modules/power/generator_type2.dm
@@ -93,7 +93,7 @@
 
 
 /obj/machinery/power/generator_type2/interact(mob/user)
-	if ( (get_dist(src, user) > 1 ) && (!istype(user, /mob/living/silicon/ai)))
+	if ( (get_dist(src, user) > 1 ) && (!isAI(user)))
 		user.unset_machine()
 		user << browse(null, "window=teg")
 		return

--- a/code/modules/power/pacman2.dm
+++ b/code/modules/power/pacman2.dm
@@ -114,7 +114,7 @@
 	proc
 		interact(mob/user)
 			if (get_dist(src, user) > 1 )
-				if (!istype(user, /mob/living/silicon/ai))
+				if (!isAI(user))
 					user.machine = null
 					user << browse(null, "window=port_gen")
 					return

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -321,9 +321,9 @@
 
 	var/data[0]
 	data["active"] = active
-	if(istype(user, /mob/living/silicon/ai))
+	if(isAI(user))
 		data["is_ai"] = 1
-	else if(istype(user, /mob/living/silicon/robot) && !Adjacent(user))
+	else if(isrobot(user) && !Adjacent(user))
 		data["is_ai"] = 1
 	else
 		data["is_ai"] = 0
@@ -353,7 +353,7 @@
 /*
 /obj/machinery/power/port_gen/pacman/interact(mob/user)
 	if (get_dist(src, user) > 1 )
-		if (!istype(user, /mob/living/silicon/ai))
+		if (!isAI(user))
 			user.unset_machine()
 			user << browse(null, "window=port_gen")
 			return

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -34,7 +34,7 @@
 	return 0
 
 /obj/machinery/containment_field/HasProximity(atom/movable/AM as mob|obj)
-	if(istype(AM,/mob/living/silicon) && prob(40))
+	if(issilicon(AM) && prob(40))
 		shock(AM)
 		return 1
 	if(istype(AM,/mob/living/carbon) && prob(50))

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -82,7 +82,7 @@
 /obj/machinery/particle_accelerator/control_box/Topic(href, href_list)
 	..()
 	//Ignore input if we are broken, !silicon guy cant touch us, or nonai controlling from super far away
-	if(stat & (BROKEN|NOPOWER) || (get_dist(src, usr) > 1 && !istype(usr, /mob/living/silicon)) || (get_dist(src, usr) > 8 && !istype(usr, /mob/living/silicon/ai)))
+	if(stat & (BROKEN|NOPOWER) || (get_dist(src, usr) > 1 && !issilicon(usr)) || (get_dist(src, usr) > 8 && !isAI(usr)))
 		usr.unset_machine()
 		usr << browse(null, "window=pacontrol")
 		return
@@ -234,7 +234,7 @@
 
 /obj/machinery/particle_accelerator/control_box/interact(mob/user)
 	if((get_dist(src, user) > 1) || (stat & (BROKEN|NOPOWER)))
-		if(!istype(user, /mob/living/silicon))
+		if(!issilicon(user))
 			user.unset_machine()
 			user << browse(null, "window=pacontrol")
 			return

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -101,7 +101,7 @@
 		to_chat(usr, "<span class='warning'>Connection error: Destination Unreachable.</span>")
 
 	// Cyborgs standing next to the SMES can play with the wiring.
-	if(istype(usr, /mob/living/silicon/robot) && Adjacent(usr) && open_hatch)
+	if(isrobot(usr) && Adjacent(usr) && open_hatch)
 		wires.Interact(usr)
 
 // Proc: Initialize()

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -150,7 +150,7 @@
 
 /obj/machinery/power/turbine/interact(mob/user)
 
-	if ( (get_dist(src, user) > 1 ) || (stat & (NOPOWER|BROKEN)) && (!istype(user, /mob/living/silicon/ai)) )
+	if ( (get_dist(src, user) > 1 ) || (stat & (NOPOWER|BROKEN)) && (!isAI(user)) )
 		user.machine = null
 		user << browse(null, "window=turbine")
 		return
@@ -180,11 +180,11 @@
 	if (usr.stat || usr.restrained() )
 		return
 	if (usr.IsAdvancedToolUser())
-		if(!istype(usr, /mob/living/silicon/ai))
+		if(!isAI(usr))
 			to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
 			return
 
-	if (( usr.machine==src && ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon/ai)))
+	if (( usr.machine==src && ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr)))
 
 
 		if( href_list["close"] )
@@ -253,7 +253,7 @@
 /obj/machinery/computer/turbine_computer/Topic(href, href_list)
 	if(..())
 		return
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
 		usr.machine = src
 
 		if( href_list["view"] )

--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -20,7 +20,7 @@
 			visible_message("<span class='caution'>\The [src] doesn't seem to affect [M] in any way.</span>")
 			return
 
-		if(istype(M, /mob/living/silicon/robot))
+		if(isrobot(M))
 			var/mob/living/silicon/robot/Robot = M
 			if(Robot.mmi)
 				qdel(Robot.mmi)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -129,7 +129,7 @@
 			playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)
 
 			for(var/mob/M in range(10, src))
-				if(!M.stat && !istype(M, /mob/living/silicon/ai))\
+				if(!M.stat && !isAI(M))\
 					shake_camera(M, 3, 1)
 			qdel(src)
 			return 1

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -775,7 +775,7 @@
 				break
 
 /obj/machinery/reagentgrinder/MouseDrop_T(mob/living/carbon/human/target as mob, mob/user as mob)
-	if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || istype(user, /mob/living/silicon/ai))
+	if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || isAI(user))
 		return
 	if(target == user)
 		if(target.h_style == "Floorlength Braid" || target.h_style == "Very Long Hair")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -139,7 +139,7 @@
 	user.visible_message("<span class='danger'>\The [target] has been splashed with something by \the [user]!</span>", "<span class = 'warning'>You splash the solution onto \the [target].</span>")
 	reagents.splash(target, min(120,reagents.total_volume) ) //Splash Limit
 
-	if (istype(target, /mob/living/silicon/robot))
+	if (isrobot(target))
 		var/mob/living/silicon/robot/R = target
 		R.spark_system.queue()
 

--- a/code/modules/research/xenoarchaeology/artifact/artifact.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact.dm
@@ -118,7 +118,7 @@
 			if(P.autodrill)
 				attackby(H.r_hand,H)
 
-	else if(istype(AM,/mob/living/silicon/robot))
+	else if(isrobot(AM))
 		var/mob/living/silicon/robot/R = AM
 		if(istype(R.module_active,/obj/item/weapon/pickaxe))
 			attackby(R.module_active,R)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
@@ -8,7 +8,7 @@
 
 /datum/artifact_effect/cellcharge/DoEffectTouch(var/mob/user)
 	if(user)
-		if(istype(user, /mob/living/silicon/robot))
+		if(isrobot(user))
 			var/mob/living/silicon/robot/R = user
 			for (var/obj/item/weapon/cell/D in R.contents)
 				D.charge += rand() * 100 + 50

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
@@ -7,7 +7,7 @@
 
 /datum/artifact_effect/celldrain/DoEffectTouch(var/mob/user)
 	if(user)
-		if(istype(user, /mob/living/silicon/robot))
+		if(isrobot(user))
 			var/mob/living/silicon/robot/R = user
 			for (var/obj/item/weapon/cell/D in R.contents)
 				D.charge = max(D.charge - rand() * 100, 0)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_roboheal.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_roboheal.dm
@@ -9,7 +9,7 @@
 
 /datum/artifact_effect/roboheal/DoEffectTouch(var/mob/user)
 	if(user)
-		if (istype(user, /mob/living/silicon/robot))
+		if (isrobot(user))
 			var/mob/living/silicon/robot/R = user
 			to_chat(R, "<span class='notice'>Your systems report damaged components mending by themselves!</span>")
 			R.adjustBruteLoss(rand(-10,-30))

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_robohurt.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_robohurt.dm
@@ -9,7 +9,7 @@
 
 /datum/artifact_effect/robohurt/DoEffectTouch(var/mob/user)
 	if(user)
-		if (istype(user, /mob/living/silicon/robot))
+		if (isrobot(user))
 			var/mob/living/silicon/robot/R = user
 			to_chat(R, "<span class='warning'>Your systems report severe damage has been inflicted!</span>")
 			R.adjustBruteLoss(rand(10,50))

--- a/code/modules/shieldgen/sheldwallgen.dm
+++ b/code/modules/shieldgen/sheldwallgen.dm
@@ -30,7 +30,7 @@
 	if(state != 1)
 		to_chat(user, "<span class='warning'>The shield generator needs to be firmly secured to the floor first.</span>")
 		return 1
-	if(src.locked && !istype(user, /mob/living/silicon))
+	if(src.locked && !issilicon(user))
 		to_chat(user, "<span class='warning'>The controls are locked!</span>")
 		return 1
 	if(power != 1)

--- a/code/modules/shieldgen/shield_capacitor.dm
+++ b/code/modules/shieldgen/shield_capacitor.dm
@@ -72,7 +72,7 @@
 
 /obj/machinery/shield_capacitor/interact(mob/user)
 	if ( (get_dist(src, user) > 1 ) || (stat & (BROKEN)) )
-		if (!istype(user, /mob/living/silicon))
+		if (!issilicon(user))
 			user.unset_machine()
 			user << browse(null, "window=shield_capacitor")
 			return

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -95,7 +95,7 @@
 
 /obj/machinery/shield_gen/interact(mob/user)
 	if ( (get_dist(src, user) > 1 ) || (stat & (BROKEN)) )
-		if (!istype(user, /mob/living/silicon))
+		if (!issilicon(user))
 			user.unset_machine()
 			user << browse(null, "window=shield_generator")
 			return

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -370,7 +370,7 @@
 		if (istype(tool, /obj/item/weapon/melee/chainsword))//Chainswords rip and tear, so the limb removal is not clean
 			clean = 0
 
-		var/var/obj/item/organ/external/parent = affected.parent//Cache the parent organ of the limb before we sever it
+		var/obj/item/organ/external/parent = affected.parent//Cache the parent organ of the limb before we sever it
 		affected.droplimb(clean,DROPLIMB_EDGE)
 
 		if (istype(tool, /obj/item/weapon/melee/energy))//Code for energy weapons cauterising the cut

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -106,7 +106,7 @@
 	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		if(..())
 			var/obj/item/organ/external/affected = target.get_organ(target_zone)
-			if(istype(user,/mob/living/silicon/robot))
+			if(isrobot(user))
 				return
 			if(affected && affected.cavity)
 				var/total_volume = tool.w_class

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -21,7 +21,7 @@
 		pixel_x = 32
 
 /obj/structure/lift/proc/pressed(var/mob/user)
-	if(!istype(user, /mob/living/silicon))
+	if(!issilicon(user))
 		if(user.a_intent == I_HURT)
 			user.visible_message("<span class='danger'>\The [user] hammers on the lift button!</span>")
 		else


### PR DESCRIPTION
welcome tonight to the latest installment of:

![image](https://user-images.githubusercontent.com/6022823/68535358-4d083e00-030f-11ea-8bd9-05c186560a99.png)

no changelog yet because I'm gonna take another look or two at these changes to make sure my regex didn't mess something up