### PR TITLE
Implements Antag Player Client Age Restriction

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -3,7 +3,8 @@
 	// Text shown when becoming this antagonist.
 	var/list/restricted_jobs =     list()   // Jobs that cannot be this antagonist (depending on config)
 	var/list/protected_jobs =      list()   // As above.
-	var/list/restricted_species =   list()   // species that cannot be this antag - Ryan784
+	var/list/restricted_species =   list()  // species that cannot be this antag - Ryan784
+	var/required_age = null                 // how old should player clients be before being allowed to play this antag
 
 	// Strings.
 	var/welcome_text = "Cry havoc and let slip the dogs of war!"
@@ -105,12 +106,14 @@
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Simple animals cannot be this role!")
 		else if(player.special_role)
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They already have a special role ([player.special_role])!")
-		else if (player in pending_antagonists)
+		else if(player in pending_antagonists)
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They have already been selected for this role!")
 		else if(!can_become_antag(player))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are blacklisted for this role!")
 		else if(player_is_antag(player))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist!")
+		else if(required_age && required_age > player.current.client?.player_age)
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: Their playtime age is too low!")
 		else
 			candidates += player
 

--- a/code/game/antagonist/mutiny/mutineer.dm
+++ b/code/game/antagonist/mutiny/mutineer.dm
@@ -7,7 +7,7 @@ var/datum/antagonist/mutineer/mutineers
 	id = MODE_MUTINEER
 	antag_indicator = "mutineer"
 	restricted_jobs = list("Captain")
-	required_age = 3
+	required_age = 10
 
 /datum/antagonist/mutineer/New(var/no_reference)
 	..()

--- a/code/game/antagonist/mutiny/mutineer.dm
+++ b/code/game/antagonist/mutiny/mutineer.dm
@@ -7,6 +7,7 @@ var/datum/antagonist/mutineer/mutineers
 	id = MODE_MUTINEER
 	antag_indicator = "mutineer"
 	restricted_jobs = list("Captain")
+	required_age = 3
 
 /datum/antagonist/mutineer/New(var/no_reference)
 	..()

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -12,7 +12,7 @@ var/datum/antagonist/mercenary/mercs
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_HAS_NUKE | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER
 	id_type = /obj/item/weapon/card/id/syndicate
 	antaghud_indicator = "hudoperative"
-	required_age = 7
+	required_age = 10
 
 	hard_cap = 4
 	hard_cap_round = 8

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -12,6 +12,7 @@ var/datum/antagonist/mercenary/mercs
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_HAS_NUKE | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER
 	id_type = /obj/item/weapon/card/id/syndicate
 	antaghud_indicator = "hudoperative"
+	required_age = 7
 
 	hard_cap = 4
 	hard_cap_round = 8

--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -10,6 +10,7 @@ var/datum/antagonist/ninja/ninjas
 	restricted_species = list("Diona")
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_RANDSPAWN | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE
 	antaghud_indicator = "hudninja"
+	required_age = 7
 
 	initial_spawn_req = 2
 	initial_spawn_target = 2

--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -10,7 +10,7 @@ var/datum/antagonist/ninja/ninjas
 	restricted_species = list("Diona")
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_RANDSPAWN | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE
 	antaghud_indicator = "hudninja"
-	required_age = 7
+	required_age = 10
 
 	initial_spawn_req = 2
 	initial_spawn_target = 2

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -10,6 +10,7 @@ var/datum/antagonist/raider/raiders
 	welcome_text = "Use :H to talk on your encrypted channel."
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER
 	antaghud_indicator = "hudmutineer"
+	required_age = 5
 
 	hard_cap = 6
 	hard_cap_round = 10

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -10,7 +10,7 @@ var/datum/antagonist/raider/raiders
 	welcome_text = "Use :H to talk on your encrypted channel."
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER
 	antaghud_indicator = "hudmutineer"
-	required_age = 5
+	required_age = 10
 
 	hard_cap = 6
 	hard_cap_round = 10

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -9,7 +9,7 @@ var/datum/antagonist/wizard/wizards
 	welcome_text = "You will find a list of available spells in your spell book. Choose your magic arsenal carefully.<br>In your pockets you will find a teleport scroll. Use it as needed."
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE
 	antaghud_indicator = "hudwizard"
-	required_age = 5
+	required_age = 10
 
 	hard_cap = 1
 	hard_cap_round = 3

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -9,6 +9,7 @@ var/datum/antagonist/wizard/wizards
 	welcome_text = "You will find a list of available spells in your spell book. Choose your magic arsenal carefully.<br>In your pockets you will find a teleport scroll. Use it as needed."
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE
 	antaghud_indicator = "hudwizard"
+	required_age = 5
 
 	hard_cap = 1
 	hard_cap_round = 3

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -16,6 +16,7 @@
 		"Zeng-Hu Mobility Frame",
 		"Bishop Accessory Frame"
 	)
+	required_age = 5
 
 	welcome_text = "Use say \"#g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you perform a Full DNA Extraction them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -16,7 +16,7 @@
 		"Zeng-Hu Mobility Frame",
 		"Bishop Accessory Frame"
 	)
-	required_age = 5
+	required_age = 10
 
 	welcome_text = "Use say \"#g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you perform a Full DNA Extraction them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -32,7 +32,7 @@ var/datum/antagonist/cultist/cult
 	initial_spawn_req = 4
 	initial_spawn_target = 6
 	antaghud_indicator = "hudcultist"
-	required_age = 3
+	required_age = 10
 
 	faction = "cult"
 

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -32,6 +32,7 @@ var/datum/antagonist/cultist/cult
 	initial_spawn_req = 4
 	initial_spawn_target = 6
 	antaghud_indicator = "hudcultist"
+	required_age = 3
 
 	faction = "cult"
 

--- a/code/game/antagonist/station/loyalist.dm
+++ b/code/game/antagonist/station/loyalist.dm
@@ -28,6 +28,7 @@ var/datum/antagonist/loyalists/loyalists
 	faction_indicator = "loyal"
 	faction_invisible = 1
 	restricted_jobs = list("AI", "Cyborg")
+	required_age = 7 // Head Loy important
 
 /datum/antagonist/loyalists/New()
 	..()

--- a/code/game/antagonist/station/loyalist.dm
+++ b/code/game/antagonist/station/loyalist.dm
@@ -28,7 +28,7 @@ var/datum/antagonist/loyalists/loyalists
 	faction_indicator = "loyal"
 	faction_invisible = 1
 	restricted_jobs = list("AI", "Cyborg")
-	required_age = 7 // Head Loy important
+	required_age = 31
 
 /datum/antagonist/loyalists/New()
 	..()

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -30,7 +30,7 @@ var/datum/antagonist/revolutionary/revs
 
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Security Cadet", "Warden", "Detective", "Forensic Technician", "Head of Personnel", "Chief Engineer", "Research Director", "Chief Medical Officer", "Captain", "Head of Security", "Internal Affairs Agent")
-	required_age = 7 // head rev important
+	required_age = 31
 
 /datum/antagonist/revolutionary/New()
 	..()

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -30,6 +30,7 @@ var/datum/antagonist/revolutionary/revs
 
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Security Cadet", "Warden", "Detective", "Forensic Technician", "Head of Personnel", "Chief Engineer", "Research Director", "Chief Medical Officer", "Captain", "Head of Security", "Internal Affairs Agent")
+	required_age = 7 // head rev important
 
 /datum/antagonist/revolutionary/New()
 	..()

--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -15,7 +15,7 @@ var/datum/antagonist/rogue_ai/malf
 	initial_spawn_req = 1
 	initial_spawn_target = 1
 	antaghud_indicator = "hudmalai"
-	required_age = 14 // arguably most important antag, needs a looong playtime
+	required_age = 31
 
 /datum/antagonist/rogue_ai/New()
 	..()

--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -15,6 +15,7 @@ var/datum/antagonist/rogue_ai/malf
 	initial_spawn_req = 1
 	initial_spawn_target = 1
 	antaghud_indicator = "hudmalai"
+	required_age = 14 // arguably most important antag, needs a looong playtime
 
 /datum/antagonist/rogue_ai/New()
 	..()

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -6,6 +6,7 @@ var/datum/antagonist/traitor/traitors
 	restricted_jobs = list("Internal Affairs Agent", "Head of Security", "Captain", "AI")
 	protected_jobs = list("Security Officer", "Security Cadet", "Warden", "Detective", "Forensic Technician")
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
+	required_age = 3
 
 	faction = "syndicate"
 

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -6,7 +6,7 @@ var/datum/antagonist/traitor/traitors
 	restricted_jobs = list("Internal Affairs Agent", "Head of Security", "Captain", "AI")
 	protected_jobs = list("Security Officer", "Security Cadet", "Warden", "Detective", "Forensic Technician")
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
-	required_age = 3
+	required_age = 10
 
 	faction = "syndicate"
 

--- a/code/game/antagonist/station/vampire.dm
+++ b/code/game/antagonist/station/vampire.dm
@@ -19,6 +19,7 @@ var/datum/antagonist/vampire/vamp = null
 		"Zeng-Hu Mobility Frame",
 		"Bishop Accessory Frame"
 	)
+	required_age = 5
 
 	welcome_text = "You are a Vampire! Use the \"<b>Vampire Help</b>\" command to learn about the backstory and mechanics! Stay away from the Chaplain, and use the darkness to your advantage."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE

--- a/code/game/antagonist/station/vampire.dm
+++ b/code/game/antagonist/station/vampire.dm
@@ -19,7 +19,7 @@ var/datum/antagonist/vampire/vamp = null
 		"Zeng-Hu Mobility Frame",
 		"Bishop Accessory Frame"
 	)
-	required_age = 5
+	required_age = 10
 
 	welcome_text = "You are a Vampire! Use the \"<b>Vampire Help</b>\" command to learn about the backstory and mechanics! Stay away from the Chaplain, and use the darkness to your advantage."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE

--- a/html/changelogs/geeves - antagAge.yml
+++ b/html/changelogs/geeves - antagAge.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Antagonist roles are now restricted by player account (on Aurora) age."


### PR DESCRIPTION
Adds limits to how old a client should be on Aurora before they can possibly roll for an antag. Variable for each antagonist, based on difficulty and importance to round.