### PR TITLE
Some ghostspawner fixes

### DIFF
--- a/code/modules/ghostroles/spawner/base.dm
+++ b/code/modules/ghostroles/spawner/base.dm
@@ -27,7 +27,7 @@
 	var/mob_name_pick_message = "Pick a name."
 	var/mob_name_prefix = null //The prefix that should be applied to the mob (i.e. CCIAA, Tpr., Cmdr.)
 	var/mob_name_suffix = null //The suffix that should be applied to the mob name
-	
+
 /datum/ghostspawner/New()
 	. = ..()
 	if(!jobban_job)
@@ -45,13 +45,13 @@
 
 	if(req_head_whitelist && !check_whitelist(user))
 		return "Missing Head of Staff Whitelist"
-	
+
 	if(req_species_whitelist && !is_alien_whitelisted(user, req_species_whitelist))
 		return "Missing Species Whitelist"
 
 	if(jobban_job && jobban_isbanned(user,jobban_job))
 		return "Job Banned"
-	
+
 	if(!enabled && !can_edit(user)) //If its not enabled and the user cant edit it, dont show it
 		return "Currently Disabled"
 
@@ -83,10 +83,10 @@
 	return FALSE
 
 //Proc executed before someone is spawned in
-/datum/ghostspawner/proc/pre_spawn(mob/user) 
+/datum/ghostspawner/proc/pre_spawn(mob/user)
 	count++ //Increment the spawned in mob count
 	if(max_count && count >= max_count)
-		disable()
+		enabled = FALSE
 	return TRUE
 
 //This proc selects the spawnpoint to use.
@@ -114,6 +114,8 @@
 
 //Proc executed after someone is spawned in
 /datum/ghostspawner/proc/post_spawn(mob/user)
+	if(max_count && count >= max_count)
+		disable()
 	if(welcome_message)
 		to_chat(user, span("notice", welcome_message))
 	return TRUE

--- a/code/modules/ghostroles/spawner/human/ert.dm
+++ b/code/modules/ghostroles/spawner/human/ert.dm
@@ -169,7 +169,6 @@
 	mob_name_prefix = "Zosaa "
 	uses_species_whitelist = FALSE // Anyone should be able to play a Kataphract Unathi
 	possible_species = list("Unathi")
-	default_species = "Unathi"
 
 /datum/ghostspawner/human/ert/kataphract/specialist
 	name = "Kataphract-Hopeful Specialist"

--- a/code/modules/ghostroles/spawner/human/ert.dm
+++ b/code/modules/ghostroles/spawner/human/ert.dm
@@ -169,6 +169,7 @@
 	mob_name_prefix = "Zosaa "
 	uses_species_whitelist = FALSE // Anyone should be able to play a Kataphract Unathi
 	possible_species = list("Unathi")
+	default_species = "Unathi"
 
 /datum/ghostspawner/human/ert/kataphract/specialist
 	name = "Kataphract-Hopeful Specialist"

--- a/code/modules/ghostroles/spawner/human/human.dm
+++ b/code/modules/ghostroles/spawner/human/human.dm
@@ -14,7 +14,6 @@
 	var/list/species_outfits = list() //Outfit overwrite for the species
 	var/uses_species_whitelist = TRUE //Do you need the whitelist to play the species?
 	var/possible_species = list("Human")
-	var/default_species = "Human"
 	var/possible_genders = list(MALE,FEMALE)
 	var/allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
@@ -65,7 +64,7 @@
 
 	var/picked_species = input(user,"Select your species") as null|anything in species_selection
 	if(!picked_species)
-		picked_species = default_species
+		picked_species = possible_species[1]
 
 	//Get the name / age from them first
 	var/mname = get_mob_name(user, picked_species)

--- a/code/modules/ghostroles/spawner/human/human.dm
+++ b/code/modules/ghostroles/spawner/human/human.dm
@@ -14,6 +14,7 @@
 	var/list/species_outfits = list() //Outfit overwrite for the species
 	var/uses_species_whitelist = TRUE //Do you need the whitelist to play the species?
 	var/possible_species = list("Human")
+	var/default_species = "Human"
 	var/possible_genders = list(MALE,FEMALE)
 	var/allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
@@ -64,7 +65,7 @@
 
 	var/picked_species = input(user,"Select your species") as null|anything in species_selection
 	if(!picked_species)
-		picked_species = "Human"
+		picked_species = default_species
 
 	//Get the name / age from them first
 	var/mname = get_mob_name(user, picked_species)

--- a/html/changelogs/191113-bugfix_ghostspawners.yml
+++ b/html/changelogs/191113-bugfix_ghostspawners.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Ferner
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed an issue with single slot ghost spawners being disabled preemptively. Made the Kataphracts truly unathi exclusive."


### PR DESCRIPTION
 - Fixed an issue wherein single slot ghostspawners could disable its own spawnpoint before the mob had time to spawn.
 - Gave ghostspawners a default_species var, so you can't play as a human kataphract by cancelling out of species selection.