### PR TITLE
Give emote message and private pills

### DIFF
--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -5,38 +5,39 @@
 	if(incapacitated())
 		return
 	if(!istype(target) || target.stat || target.lying || target.resting || target.restrained() || target.client == null)
-		to_chat(usr, "<span class='warning'>[target.name] is in no condition to handle items!</span>")
+		to_chat(usr, span("warning", "[target.name] is in no condition to handle items!"))
 		return
 
 	var/obj/item/I = usr.get_active_hand()
 	if(!I)
 		I = usr.get_inactive_hand()
 	if(!I)
-		to_chat(usr, "<span class='warning'>You don't have anything in your hands to give to \the [target].</span>")
+		to_chat(usr, span("warning", "You don't have anything in your hands to give to \the [target]."))
 		return
 
 	if(alert(target,"[usr] wants to give you \a [I]. Will you accept it?",,"Yes","No") == "No")
-		target.visible_message("<span class='notice'>\The [usr] tried to hand \the [I] to \the [target], \
-		but \the [target] didn't want it.</span>")
+		target.visible_message(span("warning", "\The [usr] tried to hand \the [I] to \the [target], \
+		but \the [target] didn't want it."))
 		return
 
 	if(!I) return
 
 	if(!Adjacent(target))
-		to_chat(usr, "<span class='warning'>You need to stay in reaching distance while giving an object.</span>")
-		to_chat(target, "<span class='warning'>\The [usr] moved too far away.</span>")
+		to_chat(usr, span("warning", "You need to stay in reaching distance while giving an object."))
+		to_chat(target, span("warning", "\The [usr] moved too far away."))
 		return
 
 	if(I.loc != usr || (usr.l_hand != I && usr.r_hand != I))
-		to_chat(usr, "<span class='warning'>You need to keep the item in your hands.</span>")
-		to_chat(target, "<span class='warning'>\The [usr] seems to have given up on passing \the [I] to you.</span>")
+		to_chat(usr, span("warning", "You need to keep the item in your hands."))
+		to_chat(target, span("warning", "\The [usr] seems to have given up on passing \the [I] to you."))
 		return
 
 	if(target.r_hand != null && target.l_hand != null)
-		to_chat(target, "<span class='warning'>Your hands are full.</span>")
-		to_chat(usr, "<span class='warning'>Their hands are full.</span>")
+		to_chat(target, span("warning", "Your hands are full."))
+		to_chat(usr, span("warning", "Their hands are full."))
 		return
 
 	if(usr.unEquip(I))
 		target.put_in_hands(I) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
-		target.visible_message("<span class='notice'>\The [usr] handed \the [I] to \the [target].</span>")
+		usr.visible_message(span("notice", "\The [usr] handed \the [I] to \the [target]."), span("notice", "You give \the [I] to \the [target]."))
+

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -25,7 +25,7 @@
 			if(!M.can_eat(src))
 				return
 
-			to_chat(M, "<span class='notice'>You swallow \the [src].</span>")
+			M.visible_message(span("notice", "[M] swallows a pill."), span("notice", "You swallow \the [src]."), null, 2)
 			if(reagents.total_volume)
 				reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 			qdel(src)
@@ -35,13 +35,13 @@
 			if(!M.can_force_feed(user, src))
 				return
 
-			user.visible_message("<span class='warning'>[user] attempts to force [M] to swallow \the [src].</span>")
+			user.visible_message(span("warning", "[user] attempts to force [M] to swallow \the [src]."))
 
 			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			if(!do_mob(user, M))
 				return
 
-			user.visible_message("<span class='warning'>[user] forces [M] to swallow \the [src].</span>")
+			user.visible_message(span("warning", "[user] forces [M] to swallow \the [src]."))
 
 			var/contained = reagentlist()
 			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been fed [name] by [key_name(user)] Reagents: [contained]</font>")
@@ -60,16 +60,16 @@
 
 		if(proximity && target.is_open_container() && target.reagents)
 			if(!target.reagents.total_volume)
-				to_chat(user, "<span class='notice'>[target] is empty. Can't dissolve \the [src].</span>")
+				to_chat(user, span("notice", "[target] is empty. Can't dissolve \the [src]."))
 				return
-			to_chat(user, "<span class='notice'>You dissolve \the [src] in [target].</span>")
+			to_chat(user, span("notice", "You dissolve \the [src] in [target]."))
 
 			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Spiked \a [target] with a pill. Reagents: [reagentlist()]</font>")
 			msg_admin_attack("[user.name] ([user.ckey]) spiked \a [target] with a pill. Reagents: [reagentlist()] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)",ckey=key_name(user),ckey_target=key_name(target))
 
 			reagents.trans_to(target, reagents.total_volume)
 			for(var/mob/O in viewers(2, user))
-				O.show_message("<span class='warning'>[user] puts something in \the [target].</span>", 1)
+				O.show_message(span("warning", "[user] puts something in \the [target]."), 1)
 
 			qdel(src)
 			return

--- a/html/changelogs/wezzy_give_emote.yml
+++ b/html/changelogs/wezzy_give_emote.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Wowzewow (Wezzy), SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Swallowing pills now displays a message to people within a 2 tile radius. This message does not tell them what pill you swallowed."
+  - tweak: "Initiating a give (Right click > Give) now displays a message that you 'hold out an item' to the target."


### PR DESCRIPTION
  - tweak: "Swallowing pills now displays a message to people within a 2 tile radius. This message does not tell them what pill you swallowed."
  - tweak: "Initiating a give (Right click > Give) now displays a message that you 'hold out an item' to the target."

also changes span_class notice to the span proc, because why not

ported from bay 