### PR TITLE
Fix atmos tech utility belts

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -133,7 +133,7 @@
 	jobtype = /datum/job/atmos
 
 	uniform = /obj/item/clothing/under/rank/atmospheric_technician
-	belt = /obj/item/storage/belt/utility/atmostech
+	belt = /obj/item/storage/belt/utility
 	pda = /obj/item/device/pda/atmos
 	id = /obj/item/card/id/silver
 	shoes = /obj/item/clothing/shoes/workboots

--- a/html/changelogs/johnwildkins-utilitybeltfix2.yml
+++ b/html/changelogs/johnwildkins-utilitybeltfix2.yml
@@ -1,0 +1,4 @@
+author: JohnWildkins
+delete-after: True
+changes: 
+  - bugfix: "Fix atmos tech utility belt tool overflow on spawn."


### PR DESCRIPTION
makes it so they don't double spawn with tools
forgot they had a different belt so deleting `belt/utility/full` from the engineers wasn't good enough