### PR TITLE
Changeling Arm only functions as crowbar with help intent active

### DIFF
--- a/code/game/gamemodes/changeling/implements/items.dm
+++ b/code/game/gamemodes/changeling/implements/items.dm
@@ -48,7 +48,8 @@
 		QDEL_IN(src, 1)
 
 /obj/item/melee/arm_blade/iscrowbar()
-	return TRUE
+	if(creator.a_intent == I_HELP) return TRUE
+	return FALSE
 
 /obj/item/melee/arm_blade/resolve_attackby(atom/A, mob/living/user, var/click_parameters)
 	if(istype(A,/turf/simulated/floor) && user.a_intent != I_HELP)

--- a/html/changelogs/synystersparx-PR-7477.yml
+++ b/html/changelogs/synystersparx-PR-7477.yml
@@ -1,0 +1,4 @@
+author: SynysterSparx
+delete-after: True
+changes: 
+  - bugfix: "Changeling arm can now be used to attack robots. Still able to open robot maintenance hatch and other crowbar things with it if in help mode."


### PR DESCRIPTION
Fixes #7477 

I tested this with attacking a robot and a regular wall with help intent on/off. It seems there's something custom with walls for changeling so please consider any side effects of changing the iscrowbar logic.

One thing is, even with help intent you will attack humans when clicking them. While this fix allows robots to be attacked by the changeling arm, it can not do so on help, which may seem inconsistent.