### PR TITLE
Cosmic Echo Ability Nerf

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -229,30 +229,6 @@
 							to_chat(L, "<span class='danger'>You partially phase into \the [impediment], causing a chunk of you to violently dematerialize!</span>")
 							L.adjustBruteLoss(40)
 
-					if(!newdest && L.mind)
-						var/mob/living/simple_animal/shade/bluespace/BS = new /mob/living/simple_animal/shade/bluespace(destturf)
-						to_chat(L, "<span class='danger'>You feel your spirit violently rip from your body in a flurry of violent extradimensional disarray!</span>")
-						L.mind.transfer_to(BS)
-						to_chat(BS, "<b>You are now a bluespace echo - consciousness imprinted upon wavelengths of bluespace energy. You currently retain no memories of your previous life, but do express a strong desire to return to corporeality. You will die soon, fading away forever. Good luck!</b>")
-						BS.original_body = L
-
-						var/list/turfs_to_teleport = list()
-						for(var/turf/T in orange(20, get_turf(BS)))
-							turfs_to_teleport += T
-						do_teleport(BS, pick(turfs_to_teleport))
-
-						for(var/mob/living/M in L)
-							if(M.mind)
-								var/mob/living/simple_animal/shade/bluespace/more_BS = new /mob/living/simple_animal/shade/bluespace(get_turf(M))
-								to_chat(M, "<span class='danger'>You feel your spirit violently rip from your body in a flurry of violent extradimensional disarray!</span>")
-								M.mind.transfer_to(more_BS)
-								to_chat(more_BS, "<b>You are now a bluespace echo - consciousness imprinted upon wavelengths of bluespace energy. You currently retain no memories of your previous life, but do express a strong desire to return to corporeality. You will die soon, fading away forever. Good luck!</b>")
-								more_BS.original_body = M
-
-								for(var/turf/T in orange(20, get_turf(BS)))
-									turfs_to_teleport += T
-								do_teleport(more_BS, pick(turfs_to_teleport))
-
 				else
 					newdest = destturf
 					valid = 0

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -229,6 +229,30 @@
 							to_chat(L, "<span class='danger'>You partially phase into \the [impediment], causing a chunk of you to violently dematerialize!</span>")
 							L.adjustBruteLoss(40)
 
+					if(!newdest && L.mind)
+						var/mob/living/simple_animal/shade/bluespace/BS = new /mob/living/simple_animal/shade/bluespace(destturf)
+						to_chat(L, "<span class='danger'>You feel your spirit violently rip from your body in a flurry of violent extradimensional disarray!</span>")
+						L.mind.transfer_to(BS)
+						to_chat(BS, "<b>You are now a bluespace echo - consciousness imprinted upon wavelengths of bluespace energy. You currently retain no memories of your previous life, but do express a strong desire to return to corporeality. You will die soon, fading away forever. Good luck!</b>")
+						BS.original_body = L
+
+						var/list/turfs_to_teleport = list()
+						for(var/turf/T in orange(20, get_turf(BS)))
+							turfs_to_teleport += T
+						do_teleport(BS, pick(turfs_to_teleport))
+
+						for(var/mob/living/M in L)
+							if(M.mind)
+								var/mob/living/simple_animal/shade/bluespace/more_BS = new /mob/living/simple_animal/shade/bluespace(get_turf(M))
+								to_chat(M, "<span class='danger'>You feel your spirit violently rip from your body in a flurry of violent extradimensional disarray!</span>")
+								M.mind.transfer_to(more_BS)
+								to_chat(more_BS, "<b>You are now a bluespace echo - consciousness imprinted upon wavelengths of bluespace energy. You currently retain no memories of your previous life, but do express a strong desire to return to corporeality. You will die soon, fading away forever. Good luck!</b>")
+								more_BS.original_body = M
+
+								for(var/turf/T in orange(20, get_turf(BS)))
+									turfs_to_teleport += T
+								do_teleport(more_BS, pick(turfs_to_teleport))
+
 				else
 					newdest = destturf
 					valid = 0

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -268,31 +268,6 @@
 
 	message_countdown = max(0, message_countdown - 20)
 
-/mob/living/simple_animal/shade/bluespace/verb/mass_warp()
-	set category = "Bluespace Echo"
-	set name = "Warp Vortex"
-	set desc = "Teleport items wildly."
-
-	if(possessive)
-		to_chat(src, "<span class='warning'>You cannot affect the world outside your host!</span>")
-		return
-
-	if(message_countdown < 200)
-		to_chat(src, "<span class='warning'>You are too faded to warp an item through bluespace.</span>")
-		return
-
-	var/list/liable_turfs = list()
-
-	for(var/turf/T in view(4, src))
-		liable_turfs += T
-
-	if(liable_turfs.len)
-		visible_message("<span class ='danger'>\The [src] pulses violently!</span>")
-		for(var/atom/movable/M in view(7, src))
-			if(!M.anchored)
-				do_teleport(M, pick(liable_turfs))
-				message_countdown = max(0, message_countdown - 20)
-
 /mob/living/simple_animal/shade/bluespace/verb/lifeline()
 	set category = "Bluespace Echo"
 	set name = "Lifeline"

--- a/html/changelogs/paradoxspace-backagain.yml
+++ b/html/changelogs/paradoxspace-backagain.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: ParadoxSpace
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Echoes can be created through teleportation again."

--- a/html/changelogs/paradoxspace-backagain.yml
+++ b/html/changelogs/paradoxspace-backagain.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Echoes can be created through teleportation again."
+  - rscdel: "Echoes no longer have the mass warp ability."


### PR DESCRIPTION
Since #7245 has been merged recently, it is now easy again to put echoes back in their bodies, making it less punishing. 

Edit: Bluespace echoes are still gone, no longer have the mass warp ability.