### PR TITLE
Guest Pass Duration Extend

### DIFF
--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -137,9 +137,9 @@
 				if(reas)
 					reason = reas
 			if ("duration")
-				var/dur = input("Duration (in minutes) during which pass is valid (up to 30 minutes).", "Duration") as num|null
+				var/dur = input("Duration (in minutes) during which pass is valid (up to 60 minutes).", "Duration") as num|null
 				if (dur)
-					if (dur > 0 && dur <= 30)
+					if (dur > 0 && dur <= 60)
 						duration = dur
 					else
 						to_chat(usr, "<span class='warning'>Invalid duration.</span>")

--- a/html/changelogs/geeves - guestPassBuff.yml
+++ b/html/changelogs/geeves - guestPassBuff.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "The guest pass terminal can now give guest passes valid for up to an hour (up from 30 minutes)."


### PR DESCRIPTION
They can now last 60 minutes instead of 30.