### PR TITLE
Curtain and Flap (De)construction

### DIFF
--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -8,6 +8,8 @@
 	layer = SHOWER_OPEN_LAYER
 	opacity = 1
 	density = 0
+	anchored = TRUE //curtains start secured in place
+	var/manipulating = FALSE //prevents queuing up multiple deconstructs and returning a bunch of cloth
 
 /obj/structure/curtain/open
 	icon_state = "open"
@@ -29,6 +31,49 @@
 /obj/structure/curtain/attack_ai(mob/user)
 	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Robots can open/close it, but not the AI.
 		attack_hand(user)
+
+/obj/structure/curtain/attackby(obj/item/W, mob/user)
+
+	if(W.iswirecutter())
+		if(manipulating)	return
+		manipulating = TRUE
+		visible_message(span("notice", "[user] begins cutting down \the [src]."),
+					span("notice", "You begin cutting down \the [src]."))
+		if(!do_after(user, 30/W.toolspeed))
+			manipulating = FALSE
+			return
+		playsound(src.loc, 'sound/items/Wirecutter.ogg', 50, 1)
+		visible_message(span("notice", "[user] cuts down \the [src]."),
+					span("notice", "You cut down \the [src]."))
+		if(istype(src, /obj/structure/curtain/open/medical))
+			new/obj/item/stack/material/plastic(src.loc)
+		else
+			new/obj/item/stack/material/cloth(src.loc, 2)
+		qdel(src)
+	else if(W.sharp && !W.noslice)
+		if(manipulating)	return
+		manipulating = TRUE
+		visible_message(span("notice", "[user] begins cutting down \the [src]."),
+					span("notice", "You begin cutting down \the [src]."))
+		if(!do_after(user, 30))
+			manipulating = FALSE
+			return
+		playsound(src.loc, pick('sound/items/rip1.ogg','sound/items/rip2.ogg'), 50, 1)
+		visible_message(span("notice", "[user] cuts down \the [src]."),
+					span("notice", "You cut down \the [src]."))
+		if(!istype(src, /obj/structure/curtain/open/medical))
+			new/obj/item/stack/material/cloth(src.loc, 1)
+		qdel(src)
+
+	if(W.isscrewdriver()) //You can anchor/unanchor curtains
+		anchored = !anchored
+		var/obj/structure/curtain/C
+		for(C in src.loc)
+			if(C != src && C.anchored) //Can't secure more than one curtain in a tile
+				to_chat(user, "There is already a curtain secured here!")
+				return
+		playsound(src.loc, W.usesound, 50, 1)
+		visible_message(span("notice", "\The [src] has been [anchored ? "secured in place" : "unsecured"] by \the [user]."))
 
 /obj/structure/curtain/proc/toggle()
 	src.set_opacity(!src.opacity)

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -91,11 +91,13 @@
 /obj/structure/curtain/medical
 	name = "plastic curtain"
 	color = "#B8F5E3"
+	anchored = FALSE
 	alpha = 200
 
 /obj/structure/curtain/open/medical
 	name = "plastic curtain"
 	color = "#B8F5E3"
+	anchored = FALSE
 	alpha = 200
 
 /obj/structure/curtain/open/bed
@@ -105,6 +107,7 @@
 /obj/structure/curtain/open/privacy
 	name = "privacy curtain"
 	color = "#B8F5E3"
+	anchored = FALSE
 
 /obj/structure/curtain/open/shower
 	name = "shower curtain"

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -46,9 +46,9 @@
 		visible_message(span("notice", "[user] cuts down \the [src]."),
 					span("notice", "You cut down \the [src]."))
 		if(istype(src, /obj/structure/curtain/open/medical))
-			new/obj/item/stack/material/plastic(src.loc)
+			new /obj/item/stack/material/plastic(src.loc)
 		else
-			new/obj/item/stack/material/cloth(src.loc, 2)
+			new /obj/item/stack/material/cloth(src.loc, 2)
 		qdel(src)
 	else if(W.sharp && !W.noslice)
 		if(manipulating)	return
@@ -62,7 +62,7 @@
 		visible_message(span("notice", "[user] cuts down \the [src]."),
 					span("notice", "You cut down \the [src]."))
 		if(!istype(src, /obj/structure/curtain/open/medical))
-			new/obj/item/stack/material/cloth(src.loc, 1)
+			new /obj/item/stack/material/cloth(src.loc, 1)
 		qdel(src)
 
 	if(W.isscrewdriver()) //You can anchor/unanchor curtains

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -34,7 +34,7 @@
 
 /obj/structure/curtain/attackby(obj/item/W, mob/user)
 
-	if(W.iswirecutter())
+	if(W.iswirecutter() || W.sharp && !W.noslice)
 		if(manipulating)	return
 		manipulating = TRUE
 		visible_message(span("notice", "[user] begins cutting down \the [src]."),
@@ -48,21 +48,7 @@
 		if(istype(src, /obj/structure/curtain/open/medical))
 			new /obj/item/stack/material/plastic(src.loc)
 		else
-			new /obj/item/stack/material/cloth(src.loc, 2)
-		qdel(src)
-	else if(W.sharp && !W.noslice)
-		if(manipulating)	return
-		manipulating = TRUE
-		visible_message(span("notice", "[user] begins cutting down \the [src]."),
-					span("notice", "You begin cutting down \the [src]."))
-		if(!do_after(user, 30))
-			manipulating = FALSE
-			return
-		playsound(src.loc, pick('sound/items/rip1.ogg','sound/items/rip2.ogg'), 50, 1)
-		visible_message(span("notice", "[user] cuts down \the [src]."),
-					span("notice", "You cut down \the [src]."))
-		if(!istype(src, /obj/structure/curtain/open/medical))
-			new /obj/item/stack/material/cloth(src.loc, 1)
+			new /obj/item/stack/material/cloth(src.loc, (W.iswirecutter() ? 2 : 1)) //wirecutters return full. Sharp items return half.
 		qdel(src)
 
 	if(W.isscrewdriver()) //You can anchor/unanchor curtains

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -7,6 +7,7 @@
 	anchored = 1
 	layer = 4
 	explosion_resistance = 5
+	var/manipulating = FALSE //Prevents queueing up a ton of deconstructs
 	var/list/mobs_can_pass = list(
 		/mob/living/carbon/slime,
 		/mob/living/simple_animal/rat,
@@ -45,6 +46,20 @@
 		if (3)
 			if (prob(5))
 				qdel(src)
+
+/obj/structure/plasticflaps/attackby(obj/item/W, mob/user)
+	if(manipulating)	return
+	manipulating = TRUE
+	if(W.iswirecutter() || W.sharp && !W.noslice)
+		visible_message(span("notice", "[user] begins cutting down \the [src]."),
+					span("notice", "You begin cutting down \the [src]."))
+		if(!do_after(user, 30/W.toolspeed))
+			manipulating = FALSE
+			return
+		playsound(src.loc, 'sound/items/Wirecutter.ogg', 50, 1)
+		visible_message(span("notice", "[user] cuts down \the [src]."),
+		span("notice", "You cut down \the [src]."))
+		qdel(src)
 
 /obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
 	name = "airtight plastic flaps"

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -158,13 +158,13 @@
 /material/cloth/generate_recipes()
 	..()
 	recipes += new/datum/stack_recipe_list("curtains list",list( \
-		new/datum/stack_recipe("white curtain", /obj/structure/curtain, 2, time = 10), \
-		new/datum/stack_recipe("bed curtain", /obj/structure/curtain/open/bed, 2, time = 10), \
-		new/datum/stack_recipe("black curtain", /obj/structure/curtain/black, 2, time = 10), \
-		new/datum/stack_recipe("shower curtain", /obj/structure/curtain/open/shower, 2, time = 10), \
-		new/datum/stack_recipe("orange shower curtain", /obj/structure/curtain/open/shower/engineering, 2, time = 10), \
-		new/datum/stack_recipe("red shower curtain", /obj/structure/curtain/open/shower/security, 2, time = 10), \
-		new/datum/stack_recipe("privacy curtain", /obj/structure/curtain/open/privacy, 2, time = 10), \
+		new /datum/stack_recipe("white curtain", /obj/structure/curtain, 2, time = 10), \
+		new /datum/stack_recipe("bed curtain", /obj/structure/curtain/open/bed, 2, time = 10), \
+		new /datum/stack_recipe("black curtain", /obj/structure/curtain/black, 2, time = 10), \
+		new /datum/stack_recipe("shower curtain", /obj/structure/curtain/open/shower, 2, time = 10), \
+		new /datum/stack_recipe("orange shower curtain", /obj/structure/curtain/open/shower/engineering, 2, time = 10), \
+		new /datum/stack_recipe("red shower curtain", /obj/structure/curtain/open/shower/security, 2, time = 10), \
+		new /datum/stack_recipe("privacy curtain", /obj/structure/curtain/open/privacy, 2, time = 10), \
 
 		))
 

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -155,6 +155,19 @@
 		new/datum/stack_recipe("yellow folder", /obj/item/folder/yellow), \
 		))
 
+/material/cloth/generate_recipes()
+	..()
+	recipes += new/datum/stack_recipe_list("curtains list",list( \
+		new/datum/stack_recipe("white curtain", /obj/structure/curtain, 2, time = 10), \
+		new/datum/stack_recipe("bed curtain", /obj/structure/curtain/open/bed, 2, time = 10), \
+		new/datum/stack_recipe("black curtain", /obj/structure/curtain/black, 2, time = 10), \
+		new/datum/stack_recipe("shower curtain", /obj/structure/curtain/open/shower, 2, time = 10), \
+		new/datum/stack_recipe("orange shower curtain", /obj/structure/curtain/open/shower/engineering, 2, time = 10), \
+		new/datum/stack_recipe("red shower curtain", /obj/structure/curtain/open/shower/security, 2, time = 10), \
+		new/datum/stack_recipe("privacy curtain", /obj/structure/curtain/open/privacy, 2, time = 10), \
+
+		))
+
 /material/hide/xeno/generate_recipes()
 	..()
 	recipes += new/datum/stack_recipe("alien helmet", /obj/item/clothing/head/xenos)

--- a/html/changelogs/doxxmedearly - curtainsflaps.yml
+++ b/html/changelogs/doxxmedearly - curtainsflaps.yml
@@ -40,4 +40,4 @@ delete-after: True
 changes: 
   - rscadd: "Allows players to cut down plastic flaps and curtains, using wirecutters or other cutting objects."
   - rscadd: "Allows you to construct all curtains (except plastic curtains) from cloth, requiring two pieces each."
-  - tweak: "Curtains begin anchored. You can anchor and unanchor curtains with a screwdriver."
+  - tweak: "Most curtains begin anchored (Medical curtains do not). You can anchor and unanchor curtains with a screwdriver."

--- a/html/changelogs/doxxmedearly - curtainsflaps.yml
+++ b/html/changelogs/doxxmedearly - curtainsflaps.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Allows players to cut down plastic flaps and curtains, using wirecutters or other cutting objects."
+  - rscadd: "Allows you to construct all curtains (except plastic curtains) from cloth, requiring two pieces each."
+  - tweak: "Curtains begin anchored. You can anchor and unanchor curtains with a screwdriver."


### PR DESCRIPTION
Plastic flaps and curtains can now be cut down.
Curtains begin anchored in place and can be anchored/unanchored with a screwdriver.
Curtains (except "plastic curtains")  can be constructed from 2 cloth sheets, giving cloth an actual purpose.
Cutting down a curtain with wirecutters returns both sheets (or, if a plastic curtain, 1 plastic sheet). Using a knife or something returns one (or none if plastic curtain).