### PR TITLE
Prevents players from joining with unackd warnings

### DIFF
--- a/code/modules/admin/verbs/warning.dm
+++ b/code/modules/admin/verbs/warning.dm
@@ -276,6 +276,19 @@
 	return data
 
 /*
+ * A proc used to gather if someone has Unacknowledged Warnings
+ */
+/client/proc/unacked_warning_count()
+	establish_db_connection(dbcon)
+	if (!dbcon.IsConnected())
+		return
+	var/list/client_details = list("ckey" = ckey, "computer_id" = computer_id, "address" = address)
+	var/DBQuery/query = dbcon.NewQuery("SELECT COUNT(*) FROM ss13_warnings WHERE (visible = 1 AND acknowledged = 0 AND expired = 0) AND (ckey = :ckey: OR computerid = :computer_id: OR ip = :address:)")
+	query.Execute(client_details)
+	if(query.NextRow())
+		return text2num(query.item[1])
+
+/*
  * A proc for an admin/moderator to look up a member's warnings.
  */
 

--- a/code/modules/admin/verbs/warning.dm
+++ b/code/modules/admin/verbs/warning.dm
@@ -222,6 +222,7 @@
 	query.Execute(list("warning_id" = warning_id))
 
 	warnings_check()
+	fetch_unacked_warning_count()
 
 /client/proc/notifications_acknowledge(var/id)
 	if(!id)
@@ -278,15 +279,15 @@
 /*
  * A proc used to gather if someone has Unacknowledged Warnings
  */
-/client/proc/unacked_warning_count()
+/client/proc/fetch_unacked_warning_count()
 	establish_db_connection(dbcon)
 	if (!dbcon.IsConnected())
 		return
-	var/list/client_details = list("ckey" = ckey, "computer_id" = computer_id, "address" = address)
-	var/DBQuery/query = dbcon.NewQuery("SELECT COUNT(*) FROM ss13_warnings WHERE (visible = 1 AND acknowledged = 0 AND expired = 0) AND (ckey = :ckey: OR computerid = :computer_id: OR ip = :address:)")
-	query.Execute(client_details)
-	if(query.NextRow())
-		return text2num(query.item[1])
+	var/DBQuery/warning_count_query = dbcon.NewQuery("SELECT COUNT(*) FROM ss13_warnings WHERE (visible = 1 AND acknowledged = 0 AND expired = 0) AND (ckey = :ckey: OR computerid = :computer_id: OR ip = :address:)")
+	warning_count_query.Execute(list("ckey" = ckey, "computer_id" = computer_id, "address" = address))
+	if(warning_count_query.NextRow())
+		unacked_warning_count = text2num(warning_count_query.item[1])
+		return unacked_warning_count
 
 /*
  * A proc for an admin/moderator to look up a member's warnings.

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -57,6 +57,7 @@
 	var/need_saves_migrated = "Requires database"	//Used to determine whether or not the ckey needs their saves migrated over to the database. Default is 0 upon successful connection.
 	var/account_age = -1							// Age on the BYOND account in days.
 	var/account_join_date = null					// Date of the BYOND account creation in ISO 8601 format.
+	var/unacked_warning_count = 0
 
 	preload_rsc = 1
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -380,6 +380,10 @@
 	if(SStheming)
 		SStheming.apply_theme_from_perfs(src)
 
+	// Server greeting shenanigans.
+	if (server_greeting.find_outdated_info(src, 1))
+		server_greeting.display_to_client(src)
+
 /client/proc/InitClient()
 	if(initialized)
 		return
@@ -436,14 +440,12 @@
 
 	send_resources()
 
-	// Server greeting shenanigans.
-	if (server_greeting.find_outdated_info(src, 1))
-		server_greeting.display_to_client(src)
-
 	// Check code/modules/admin/verbs/antag-ooc.dm for definition
 	add_aooc_if_necessary()
 
 	check_ip_intel()
+
+	fetch_unacked_warning_count()
 
 	initialized = TRUE
 

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -106,8 +106,8 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			if (config.sql_saves && !client.prefs.current_character)
 				alert(src, "You have not saved your character yet. Please do so before readying up.")
 				return
-			if(client.unacked_warning_count() > 0)
-				to_chat(src, alert("You can not ready up, because you have unacknowledged warnings. Acknowledge your warnings in OOC->Warnings and Notifications"))
+			if(client.unacked_warning_count > 0)
+				to_chat(src, alert("You can not ready up, because you have unacknowledged warnings. Acknowledge your warnings in OOC->Warnings and Notifications."))
 				return
 
 			ready = text2num(href_list["ready"])
@@ -196,8 +196,8 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			to_chat(usr, "<span class='danger'>The station is currently exploding. Joining would go poorly.</span>")
 			return
 
-		if(client.unacked_warning_count() > 0)
-			to_chat(src, alert("You can not join the game, because you have unacknowledged warnings. Acknowledge your warnings in OOC->Warnings and Notifications"))
+		if(client.unacked_warning_count > 0)
+			to_chat(src, alert("You can not join the game, because you have unacknowledged warnings. Acknowledge your warnings in OOC->Warnings and Notifications."))
 			return
 
 		var/datum/species/S = all_species[client.prefs.species]

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -106,6 +106,9 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			if (config.sql_saves && !client.prefs.current_character)
 				alert(src, "You have not saved your character yet. Please do so before readying up.")
 				return
+			if(client.unacked_warning_count() > 0)
+				to_chat(src, alert("You can not ready up, because you have unacknowledged warnings. Acknowledge your warnings in OOC->Warnings and Notifications"))
+				return
 
 			ready = text2num(href_list["ready"])
 		else
@@ -191,6 +194,10 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			return
 		else if(SSticker.mode && SSticker.mode.explosion_in_progress)
 			to_chat(usr, "<span class='danger'>The station is currently exploding. Joining would go poorly.</span>")
+			return
+
+		if(client.unacked_warning_count() > 0)
+			to_chat(src, alert("You can not join the game, because you have unacknowledged warnings. Acknowledge your warnings in OOC->Warnings and Notifications"))
 			return
 
 		var/datum/species/S = all_species[client.prefs.species]

--- a/html/changelogs/arrow768-no-unack-join.yml
+++ b/html/changelogs/arrow768-no-unack-join.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "You are no longer able to join the game with unacknowledged warnings."

--- a/html/changelogs/arrow768-no-unack-join.yml
+++ b/html/changelogs/arrow768-no-unack-join.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - tweak: "You are no longer able to join the game with unacknowledged warnings."
+  - bugfix: "Fixes the MoTD not showing."


### PR DESCRIPTION
ToDo:

- [x] Testing
- [x] (opt) See if that count can be cached somewhere
- [ ] (opt) See if its possible to provide a link to the warning/notifications menu
- [x] (opt) Figure out why the motd isnt showing