### PR TITLE
Fixes Autoantag spamming that it couldnt spawn antags

### DIFF
--- a/code/game/gamemodes/game_mode_latespawn.dm
+++ b/code/game/gamemodes/game_mode_latespawn.dm
@@ -23,6 +23,7 @@
 
 	if(emergency_shuttle.online())
 		message_admins("[uppertext(name)]: An evac or transfer shuttle is on the way. Aborted.")
+		next_spawn = world.time + min_autotraitor_delay
 		return
 
 	var/list/usable_templates = list()


### PR DESCRIPTION
Delays the next autoantag check by min_autotraitor_delay if a spawn has been attempted while the shuttle is on the way.
