### PR TITLE
Rechargers charge faster

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -8,7 +8,7 @@
 	idle_power_usage = 5
 	active_power_usage = 90000	//90 kW. (this the power drawn when charging)
 	power_channel = EQUIP
-	var/charging_efficiency = 0.92
+	var/charging_efficiency = 1.38
 	var/obj/item/cell/charging = null
 	var/chargelevel = -1
 

--- a/code/game/machinery/mech_recharger.dm
+++ b/code/game/machinery/mech_recharger.dm
@@ -7,12 +7,12 @@
 	density = 0
 	layer = TURF_LAYER + 0.1
 	anchored = 1
-	idle_power_usage = 200	// Some electronics, passive drain.
-	active_power_usage = 60 KILOWATTS // When charging
+	idle_power_usage = 300	// Some electronics, passive drain.
+	active_power_usage = 90 KILOWATTS // When charging
 
 	var/mob/living/heavy_vehicle/charging
-	var/base_charge_rate = 60 KILOWATTS
-	var/repair_power_usage = 10 KILOWATTS		// Per 1 HP of health.
+	var/base_charge_rate = 90 KILOWATTS
+	var/repair_power_usage = 15 KILOWATTS		// Per 1 HP of health.
 	var/repair = 0
 	var/charge
 

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -7,9 +7,9 @@
 	icon_state = "recharger0"
 	anchored = 1
 	use_power = 1
-	idle_power_usage = 4
-	active_power_usage = 30 KILOWATTS
-	var/charging_efficiency = 0.85
+	idle_power_usage = 6
+	active_power_usage = 45 KILOWATTS
+	var/charging_efficiency = 1.3
 	//Entropy. The charge put into the cell is multiplied by this
 	var/obj/item/charging
 
@@ -158,7 +158,7 @@
 	desc = "A heavy duty wall recharger specialized for energy weaponry."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "wrecharger0"
-	active_power_usage = 50 KILOWATTS	//50 kW , It's more specialized than the standalone recharger (guns and batons only) so make it more powerful
+	active_power_usage = 75 KILOWATTS
 	allowed_devices = list(
 		/obj/item/gun/energy,
 		/obj/item/melee/baton
@@ -167,4 +167,4 @@
 	icon_state_charging = "wrecharger1"
 	icon_state_idle = "wrecharger0"
 	portable = 0
-	charging_efficiency = 0.8
+	charging_efficiency = 1.3

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -6,13 +6,13 @@
 	density = 1
 	anchored = 1
 	use_power = 1
-	idle_power_usage = 50
+	idle_power_usage = 75
 	has_special_power_checks = TRUE
 	var/mob/occupant = null
 	var/obj/item/cell/cell = null
 	var/icon_update_tick = 0	// Used to rebuild the overlay only once every 10 ticks
 	var/charging = 0
-	var/charging_efficiency = 0.85//Multiplier applied to all operations of giving power to cells, represents entropy. Efficiency increases with upgrades
+	var/charging_efficiency = 1.3//Multiplier applied to all operations of giving power to cells, represents entropy. Efficiency increases with upgrades
 	var/charging_power			// W. Power rating drawn from internal cell to recharge occupant's cell 60 kW unupgraded
 	var/restore_power_active	// W. Power drawn from APC to recharge internal cell when an occupant is charging. 40 kW if un-upgraded
 	var/restore_power_passive	// W. Power drawn from APC to recharge internal cell when idle. 7 kW if un-upgraded
@@ -153,7 +153,7 @@
 			man_rating += P.rating
 	cell = locate(/obj/item/cell) in component_parts
 
-	charging_efficiency = 0.85 + 0.015 * cap_rating
+	charging_efficiency = 1.3 + 0.030 * cap_rating
 	charging_power = 30000 + 12000 * cap_rating
 	restore_power_active = 10000 + 10000 * cap_rating
 	restore_power_passive = 5000 + 1000 * cap_rating

--- a/html/changelogs/27nov19-rechargers.yml
+++ b/html/changelogs/27nov19-rechargers.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Rechargers, including wall chargers, cyborg rechargers and heavy duty cell chargers - have had their recharge speed increased by 50%. Their power demand has been increased by the same proportion. Their energy efficiency is roughly the same, they are just faster."

--- a/html/changelogs/27nov19-rechargers.yml
+++ b/html/changelogs/27nov19-rechargers.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.  
-author: ChangeMe
+author: Scheveningen
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
Rechargers of almost all kinds now charge 50% faster, but demand 50% more passive power and 50% more power when active.

Why: Things with high capacity generally charge extremely slowly at the moment, so this is a buff to make improved capacity cells not take an eon to charge just one.

Only the heavy duty cell charger was unchanged in its power demand, because it already draws 90kw from the grid. It sorely needed the buff the most while not changing its power demand.