### PR TITLE
Fixes losebreath typo (lung bug)

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -94,7 +94,7 @@
 		var/mob/living/carbon/human/H = locate() in loc
 		if(istype(H))
 			if(H.lying)
-				icon_state = H.is_pulse_present() ? "[modify_state]-active" : "[modify_state]-idle"
+				icon_state = H.pulse() ? "[modify_state]-active" : "[modify_state]-idle"
 				victim = H
 	if(victim)
 		if(suppressing && victim.sleeping < 3)
@@ -120,7 +120,7 @@
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		src.victim = H
-		icon_state = H.is_pulse_present() ? "[modify_state]-active" : "[modify_state]-idle"
+		icon_state = H.pulse() ? "[modify_state]-active" : "[modify_state]-idle"
 	else
 		icon_state = "[modify_state]-idle"
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -225,7 +225,7 @@ BREATH ANALYZER
 				user.show_message("<span class='danger'><i>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl.</i></span> <span class='notice'>Type: [blood_type]</span>")
 			else
 				user.show_message("<span class='notice'>Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]</span>")
-		user.show_message("<span class='notice'>Subject's pulse: <font color='[H.is_pulse_present() == PULSE_THREADY || H.is_pulse_present() == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font></span>")
+		user.show_message("<span class='notice'>Subject's pulse: <font color='[H.pulse() == PULSE_THREADY || H.pulse() == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font></span>")
 		
 /obj/item/device/healthanalyzer/verb/toggle_mode()
 	set name = "Switch Verbosity"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -228,7 +228,7 @@
 			spawn (0)
 				user.visible_message("<b>[user]</b> checks [src]'s pulse.", "You check [src]'s pulse.")
 				if (do_mob(user, src, 15))
-					if(!pulse())
+					if(pulse() == PULSE_NONE)
 						to_chat(user, "<span class='deadsay'>[T.He] [T.has] no pulse[src.client ? "" : " and [T.his] soul has departed"]...</span>")
 					else
 						to_chat(user, "<span class='deadsay'>[T.He] [T.has] a pulse!</span>")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -228,7 +228,7 @@
 			spawn (0)
 				user.visible_message("<b>[user]</b> checks [src]'s pulse.", "You check [src]'s pulse.")
 				if (do_mob(user, src, 15))
-					if(!is_pulse_present())
+					if(!pulse())
 						to_chat(user, "<span class='deadsay'>[T.He] [T.has] no pulse[src.client ? "" : " and [T.his] soul has departed"]...</span>")
 					else
 						to_chat(user, "<span class='deadsay'>[T.He] [T.has] a pulse!</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1184,7 +1184,7 @@
 		usr.visible_message("<span class='notice'>[usr] begins counting their pulse.</span>",\
 		"You begin counting your pulse.")
 
-	if(is_pulse_present())
+	if(pulse())
 		to_chat(usr, "<span class='notice'>[self ? "You have a" : "[src] has a"] pulse! Counting...</span>")
 	else
 		to_chat(usr, "<span class='danger'>[src] has no pulse!</span>")	//it is REALLY UNLIKELY that a dead person would check his own pulse)
@@ -1623,9 +1623,6 @@
 	else
 		return "0"
 
-/mob/living/carbon/human/proc/is_pulse_present()
-	var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
-	if(heart)
-		return heart.pulse
-	else
-		return FALSE
+/mob/living/carbon/human/proc/pulse()
+	var/obj/item/organ/internal/heart/H = internal_organs_by_name[BP_HEART]
+	return H ? H.pulse : PULSE_NONE

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -27,7 +27,7 @@
 			owner.drip(10)
 		if(prob(4))
 			spawn owner.emote("me", 1, "gasps for air!")
-			owner.losebreath += 15
+			owner.losebreath = 1
 
 	if(is_bruised() && rescued)
 		if(prob(4))

--- a/html/changelogs/mattatlas-losebreath.yml
+++ b/html/changelogs/mattatlas-losebreath.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - tweak: "Gasping no longer applies extreme amounts of losebreath. Aka, you should recover much much sooner from popped lungs after they're healed."
+  - bugfix: "Pulse actually fixed now."

--- a/html/changelogs/mattatlas-losebreath.yml
+++ b/html/changelogs/mattatlas-losebreath.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Gasping no longer applies extreme amounts of losebreath. Aka, you should recover much much sooner from popped lungs after they're healed."


### PR DESCRIPTION
Explanation: When you gasp for air after getting a broken lung, 15 stacks of losebreath are applied. If you have positive amounts of losebreath, then your breathing won't work. Each second erodes away one losebreath stack, so organ surgery was never broken, it was just a rogue typo.

Epic.