### PR TITLE
Space A/C buff (People use these?)

### DIFF
--- a/html/changelogs/doxxmedearly - spaceheater.yml
+++ b/html/changelogs/doxxmedearly - spaceheater.yml
@@ -1,0 +1,46 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Space A/Cs will now start with a heavy duty cell instead of a basic cell that dies in half a minute."
+  - tweak: "Space A/Cs now heat and cool slightly faster."
+  - rscadd: "Space A/Cs can now be emagged, which increases the range they can heat and cool, as well as improving their efficiency. Temperature-sensitive species, Tremble!"
+  - tweak: "Interacting with space A/Cs is slightly different. If the panel is closed and you click it, it brings up the interface menu, which allows you to turn it on and off, as well as adjust the temperature. Before, the panel needed to be opened for you to adjust the temperature."
+  - tweak: "Power cells in space A/Cs are no longer removed via menu; if the panel is open, you only need to click with an empty hand to remove it, or click with a cell in-hand to insert it."
+  - bugfix: "Borgs should now be able to change the power cells of space A/Cs."


### PR DESCRIPTION
All about space A/Cs! 
-Starts with a heavy duty cell (5000) instead of the default one (1000) that depletes after like half a minute.
-Heats and cools very slightly faster.
-Adds emag functionality: Enables a much wider temperature range (hot and cold), which becomes dangerous for everyone, especially Tajara and Unathi. Also increases its efficiency slightly so it can actually reach these ranges in a cell charge. Will it be used much? Probably not. Is more emag stuff fun? Absolutely. 
-Interacting with it is different now. When the panel is not open and you use it, it brings up the menu, which allows you to adjust the temperature and switch it on and off. Previously, you would need to open the panel to access temperature changes. 
-Cells are no longer removed via menu. You just open the panel and click it with an empty hand to remove it, or click it with a cell to insert a cell.
-Borgs should be able to add cells now.  (Addresses #2871)