### PR TITLE
Manhack fix for ninjas

### DIFF
--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -17,6 +17,8 @@ var/datum/antagonist/ninja/ninjas
 	hard_cap = 2
 	hard_cap_round = 3
 
+	faction = "syndicate"
+
 	id_type = /obj/item/card/id/syndicate
 
 /datum/antagonist/ninja/New()

--- a/html/changelogs/Aboshehab - Manhacks no longer attack ninjas.yml
+++ b/html/changelogs/Aboshehab - Manhacks no longer attack ninjas.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Aboshehab
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Manhacks no longer attack ninjas."
+


### PR DESCRIPTION
In line with how Alberyk handled it for the other antag types, I added ninjas to the syndicate faction mechanically. 

Now manhacks don't attack ninjas.