### PR TITLE
Idris contractors can join forensic roles

### DIFF
--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -34,6 +34,7 @@
 	allowed_role_types = list(
 		/datum/job/officer,
 		/datum/job/detective,
+		/datum/job/forensics,
 		/datum/job/bartender,
 		/datum/job/chef,
 		/datum/job/hydro,
@@ -52,6 +53,8 @@
 
 	titles_to_loadout = list(
 		"Security Officer" = /datum/outfit/job/officer/idris,
+		"Forensics Technician" = /datum/outfit/job/forensics/idris,
+		"Crime Scene Investigator" = /datum/outfit/job/forensics/idris,
 		"Bartender" = /datum/outfit/job/bartender/idris,
 		"Chef" = /datum/outfit/job/chef/idris,
 		"Cook" = /datum/outfit/job/chef/idris,
@@ -70,6 +73,11 @@
 
 /datum/outfit/job/detective/idris
 	name = "Detective - Idris"
+	uniform = /obj/item/clothing/under/rank/security/idris
+	id = /obj/item/card/id/idris/sec
+
+/datum/outfit/job/forensics/idris
+	name = "Forensics Technician - Idris"
 	uniform = /obj/item/clothing/under/rank/security/idris
 	id = /obj/item/card/id/idris/sec
 

--- a/html/changelogs/Aboshehab - Idris can join as Forensics.yml
+++ b/html/changelogs/Aboshehab - Idris can join as Forensics.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Aboshehab
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Idris contractors can join forensic roles."


### PR DESCRIPTION
Requested by Schwann (Human Lore Deputy).

Idris contractors can now join for forensic roles. 

Tested, but I can fix anything I've missed, but it should be fine. 