### PR TITLE
Remove use of to_chat(alert())

### DIFF
--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -107,7 +107,7 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 				alert(src, "You have not saved your character yet. Please do so before readying up.")
 				return
 			if(client.unacked_warning_count > 0)
-				to_chat(src, alert("You can not ready up, because you have unacknowledged warnings. Acknowledge your warnings in OOC->Warnings and Notifications."))
+				alert(src, "You can not ready up, because you have unacknowledged warnings. Acknowledge your warnings in OOC->Warnings and Notifications.")
 				return
 
 			ready = text2num(href_list["ready"])
@@ -175,11 +175,11 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 		if(!check_rights(R_ADMIN, 0))
 			var/datum/species/S = all_species[client.prefs.species]
 			if((S.spawn_flags & IS_WHITELISTED) && !is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
-				to_chat(src, alert("You are currently not whitelisted to play [client.prefs.species]."))
+				to_chat(usr, "<span class='danger'>You are currently not whitelisted to play [client.prefs.species].</span>")
 				return 0
 
 			if(!(S.spawn_flags & CAN_JOIN))
-				to_chat(src, alert("Your current species, [client.prefs.species], is not available for play on the station."))
+				to_chat(usr, "<span class='danger'>Your current species, [client.prefs.species], is not available for play on the station.</span>")
 				return 0
 
 		LateChoices()
@@ -197,16 +197,16 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			return
 
 		if(client.unacked_warning_count > 0)
-			to_chat(src, alert("You can not join the game, because you have unacknowledged warnings. Acknowledge your warnings in OOC->Warnings and Notifications."))
+			alert(usr, "You can not join the game, because you have unacknowledged warnings. Acknowledge your warnings in OOC->Warnings and Notifications.")
 			return
 
 		var/datum/species/S = all_species[client.prefs.species]
 		if((S.spawn_flags & IS_WHITELISTED) && !is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
-			to_chat(src, alert("You are currently not whitelisted to play [client.prefs.species]."))
+			to_chat(usr, "<span class='danger'>You are currently not whitelisted to play [client.prefs.species].</span>")
 			return 0
 
 		if(!(S.spawn_flags & CAN_JOIN))
-			to_chat(src, alert("Your current species, [client.prefs.species], is not available for play on the station."))
+			to_chat(usr, "<span class='danger'>Your current species, [client.prefs.species], is not available for play on the station.</span>")
 			return 0
 
 		AttemptLateSpawn(href_list["SelectedJob"],client.prefs.spawnpoint)
@@ -306,10 +306,10 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 		to_chat(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
 		return 0
 	if(config.sql_saves && !client.prefs.current_character)
-		alert(src, "You have not saved your character yet. Please do so before attempting to join.")
+		alert(usr, "You have not saved your character yet. Please do so before attempting to join.")
 		return 0
 	if(!IsJobAvailable(rank))
-		to_chat(src, alert("[rank] is not available. Please try another."))
+		to_chat(usr, "<span class='notice'>[rank] is not available. Please try another.</span>")
 		return 0
 
 	spawning = 1

--- a/code/modules/mob/living/carbon/alien/diona/progression.dm
+++ b/code/modules/mob/living/carbon/alien/diona/progression.dm
@@ -2,7 +2,7 @@
 
 	//Whitelist requirement for evolution experimentally removed
 	if(!is_alien_whitelisted(src, "Diona") && config.usealienwhitelist)
-		to_chat(src, alert("You are currently not whitelisted to play as a full diona."))
+		to_chat(src, "<span class='warning'>You are currently not whitelisted to play as a full diona.</span>")
 		return null
 
 	var/response = alert(src, "A worker gestalt is a large, slow, and durable humanoid form. You will lose the ability to ventcrawl and devour animals, but you will gain hand-like tendrils and the ability to wear things.You have enough biomass, are you certain you're ready to form a new gestalt?","Confirm Gestalt","Growth!","Patience...")


### PR DESCRIPTION
`alert() `is a inbuilt byond proc that shows a popup message to the user.
`to_chat(alert())` shows the popup message to the user and then prints the result (what button they pressed) into their chat.
