### PR TITLE
Fixes Some Species always spawning with Sandals

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/tajara/tajara.dm
+++ b/code/modules/mob/living/carbon/human/species/station/tajara/tajara.dm
@@ -72,8 +72,10 @@
 
 	zombie_type = "Tajara Zombie"
 
-/datum/species/tajaran/before_equip(var/mob/living/carbon/human/H)
+/datum/species/tajaran/after_equip(var/mob/living/carbon/human/H)
 	. = ..()
+	if(H.shoes)
+		return
 	var/obj/item/clothing/shoes/sandal/S = new /obj/item/clothing/shoes/sandal(H)
 	if(H.equip_to_slot_or_del(S,slot_shoes))
 		S.autodrobe_no_remove = 1

--- a/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
@@ -90,8 +90,10 @@
 
 	zombie_type = "Unathi Zombie"
 
-/datum/species/unathi/before_equip(var/mob/living/carbon/human/H)
+/datum/species/unathi/after_equip(var/mob/living/carbon/human/H)
 	. = ..()
+	if(H.shoes)
+		return
 	var/obj/item/clothing/shoes/sandal/S = new /obj/item/clothing/shoes/sandal(H)
 	if(H.equip_to_slot_or_del(S,slot_shoes))
 		S.autodrobe_no_remove = 1

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -122,12 +122,16 @@
 /datum/species/bug/before_equip(var/mob/living/carbon/human/H)
 	. = ..()
 	H.gender = NEUTER
-	var/obj/item/clothing/shoes/sandal/S = new /obj/item/clothing/shoes/sandal(H)
-	if(H.equip_to_slot_or_del(S,slot_shoes))
-		S.autodrobe_no_remove = 1
 	var/obj/item/clothing/mask/breath/M = new /obj/item/clothing/mask/breath(H)
 	if(H.equip_to_slot_or_del(M, slot_wear_mask))
 		M.autodrobe_no_remove = 1
+
+/datum/species/bug/after_equip(var/mob/living/carbon/human/H)
+	if(H.shoes)
+		return
+	var/obj/item/clothing/shoes/sandal/S = new /obj/item/clothing/shoes/sandal(H)
+	if(H.equip_to_slot_or_del(S,slot_shoes))
+		S.autodrobe_no_remove = 1
 
 /datum/species/bug/equip_later_gear(var/mob/living/carbon/human/H)
 	if(istype(H.get_equipped_item(slot_back), /obj/item/storage/backpack))

--- a/html/changelogs/geeves - sandals.yml
+++ b/html/changelogs/geeves - sandals.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Unathi, Vaurca and Tajara no longer always spawn with sandals, loadout shoes will replace them properly."


### PR DESCRIPTION
* Unathi, Vaurca and Tajara no longer always spawn with sandals, loadout shoes will replace them properly.