### PR TITLE
Forced holocalls added, Holopad ID added

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -59,8 +59,8 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 	return -1
 
-/obj/machinery/hologram/holopad/New()
-	..()
+/obj/machinery/hologram/holopad/Initialize()
+	. = ..()
 	desc = "It's a floor-mounted device for projecting holographic images. Its ID is '[loc.loc]'"
 
 /obj/machinery/hologram/holopad/attack_hand(var/mob/living/carbon/human/user) //Carn: Hologram requests.
@@ -98,7 +98,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 			if(last_request + 200 < world.time) //don't spam other people with requests either, you jerk!
 				last_request = world.time
 				var/obj/item/card/id/I = user.GetIdCard()
-				if(!user.GetIdCard())
+				if(!I)
 					to_chat(user, span("notice", "You need authorization to use the holocall system. Please equip a valid ID card."))
 				var/forcedcall = 0
 				if(access_heads in I.access) //Special functions for command level people

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -100,6 +100,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 				var/obj/item/card/id/I = user.GetIdCard()
 				if(!I)
 					to_chat(user, span("notice", "You need authorization to use the holocall system. Please equip a valid ID card."))
+					return
 				var/forcedcall = 0
 				if(access_heads in I.access) //Special functions for command level people
 					switch(alert(user,"Command level authorization detected. Additional functions available", "Command level menu", "Forced call","Regular call"))

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -13,7 +13,6 @@ AI clicks again on the holopad to display a hologram. Hologram stays as long as 
 AI can use the directional keys to move the hologram around, provided the above conditions are met and the AI in question is the holopad's master.
 Only one AI may project from a holopad at any given time.
 AI may cancel the hologram at any time by clicking on the holopad once more.
-
 Possible to do for anyone motivated enough:
 	Give an AI variable for different hologram icons.
 	Itegrate EMP effect to disable the unit.
@@ -51,6 +50,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	var/mob/living/caller_id
 	var/obj/machinery/hologram/holopad/sourcepad
 	var/obj/machinery/hologram/holopad/targetpad
+	var/obj/machinery/hologram/holopad/forced
 	var/last_message
 
 /obj/machinery/hologram/holopad/check_eye(mob/user)
@@ -58,6 +58,10 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 		return 0
 
 	return -1
+
+/obj/machinery/hologram/holopad/New()
+	..()
+	desc = "It's a floor-mounted device for projecting holographic images. Its ID is '[loc.loc]'"
 
 /obj/machinery/hologram/holopad/attack_hand(var/mob/living/carbon/human/user) //Carn: Hologram requests.
 	if(!istype(user))
@@ -68,6 +72,9 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 			visible_message("The pad flashes an error message. The caller has left their holopad.")
 			return
 		take_call(user)
+		return
+	else if(caller_id && !incoming_connection && forced)
+		audible_message("Access denied. Terminating a command level transmission locally is not permitted.")
 		return
 	else if(caller_id && !incoming_connection)
 		visible_message("Severing connection to distant holopad.")
@@ -90,6 +97,14 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 				return
 			if(last_request + 200 < world.time) //don't spam other people with requests either, you jerk!
 				last_request = world.time
+				var/obj/item/card/id/I = user.GetIdCard()
+				if(!user.GetIdCard())
+					to_chat(user, "<span class='notice'>You need authorization to use the holocall system. please equip a valid ID card.</span>")
+				var/forcedcall = 0
+				if(access_heads in I.access) //Special functions for command level people
+					switch(alert(user,"Command level authorization detected. Additional functions available", "Command level menu", "Forced call","Regular call"))
+						if("Forced call")
+							forcedcall = 1
 				var/list/holopadlist = list()
 				for(var/obj/machinery/hologram/holopad/H in SSmachinery.processing_machines)
 					if((H.z in current_map.map_levels) && H.operable())
@@ -101,17 +116,24 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 					to_chat(user, "<span class='info'>Using such sophisticated technology, just to talk to yourself seems a bit silly.</span>")
 					return
 				if(targetpad)
-					make_call(targetpad, user)
+					make_call(targetpad, user, forcedcall)
 
-/obj/machinery/hologram/holopad/proc/make_call(var/obj/machinery/hologram/holopad/targetpad, var/mob/living/carbon/user)
+/obj/machinery/hologram/holopad/proc/make_call(var/obj/machinery/hologram/holopad/targetpad, var/mob/living/carbon/user, forcedcall)
 	targetpad.last_request = world.time
 	targetpad.sourcepad = src //This marks the holopad you are making the call from
 	targetpad.caller_id = user //This marks you as the caller
 	targetpad.incoming_connection = 1
 	playsound(targetpad.loc, 'sound/machines/chime.ogg', 25, 5)
 	targetpad.icon_state = "holopad1"
-	targetpad.audible_message("<b>\The [src]</b> announces, \"Incoming communications request from [targetpad.sourcepad.loc.loc].\"")
-	to_chat(user, "<span class='notice'>Trying to establish a connection to the holopad in [targetpad.loc.loc]... Please await confirmation from recipient.</span>")
+	if(forcedcall)
+		targetpad.audible_message("<b>\The [src]</b> announces, \"Incoming call with command authorization from [targetpad.sourcepad.loc.loc].\"")
+		to_chat(user, "<span class='notice'>Establishing forced connection to the holopad in [targetpad.loc.loc]</span>")
+		targetpad.forced = 1
+		sleep(80)
+		targetpad.take_call(user)
+	else
+		targetpad.audible_message("<b>\The [src]</b> announces, \"Incoming communications request from [targetpad.sourcepad.loc.loc].\"")
+		to_chat(user, "<span class='notice'>Trying to establish a connection to the holopad in [targetpad.loc.loc]... Please await confirmation from recipient.</span>")
 
 /obj/machinery/hologram/holopad/proc/take_call(mob/living/carbon/user)
 	incoming_connection = 0
@@ -297,6 +319,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 			sourcepad = 0
 	if (caller_id && sourcepad)
 		if(caller_id.loc != sourcepad.loc)
+			forced = 0
 			sourcepad.visible_message("Severing connection to distant holopad.")
 			visible_message("The connection has been terminated by [caller_id].")
 			end_call()
@@ -353,11 +376,9 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /*
 Holographic project of everything else.
-
 /mob/verb/hologram_test()
 	set name = "Hologram Debug New"
 	set category = "CURRENT DEBUG"
-
 	var/obj/effect/overlay/hologram = new(loc)//Spawn a blank effect at the location.
 	var/icon/flat_icon = icon(getFlatIcon(src,0))//Need to make sure it's a new icon so the old one is not reused.
 	flat_icon.ColorTone(rgb(125,180,225))//Let's make it bluish.
@@ -367,7 +388,6 @@ Holographic project of everything else.
 		var/icon/alpha_mask = new('icons/effects/effects.dmi', "[input]")
 		flat_icon.AddAlphaMask(alpha_mask)//Finally, let's mix in a distortion effect.
 		hologram.icon = flat_icon
-
 		to_world("Your icon should appear now.")
 	return
 */

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -50,7 +50,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	var/mob/living/caller_id
 	var/obj/machinery/hologram/holopad/sourcepad
 	var/obj/machinery/hologram/holopad/targetpad
-	var/obj/machinery/hologram/holopad/forced
+	var/forced
 	var/last_message
 
 /obj/machinery/hologram/holopad/check_eye(mob/user)
@@ -74,7 +74,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 		take_call(user)
 		return
 	else if(caller_id && !incoming_connection && forced)
-		audible_message("Access denied. Terminating a command level transmission locally is not permitted.")
+		audible_message("Access denied. Terminating a command-level transmission locally is not permitted.")
 		return
 	else if(caller_id && !incoming_connection)
 		visible_message("Severing connection to distant holopad.")
@@ -99,7 +99,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 				last_request = world.time
 				var/obj/item/card/id/I = user.GetIdCard()
 				if(!user.GetIdCard())
-					to_chat(user, "<span class='notice'>You need authorization to use the holocall system. please equip a valid ID card.</span>")
+					to_chat(user, span("notice", "You need authorization to use the holocall system. Please equip a valid ID card."))
 				var/forcedcall = 0
 				if(access_heads in I.access) //Special functions for command level people
 					switch(alert(user,"Command level authorization detected. Additional functions available", "Command level menu", "Forced call","Regular call"))

--- a/html/changelogs/Nero-07-ForcedHolocalls.yml
+++ b/html/changelogs/Nero-07-ForcedHolocalls.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Nero-07
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added the ability to force a holocall if you have a head id. Forced calls automatically go through and can only be ended by the sender stepping off the pad."


### PR DESCRIPTION
Adds forced holocalls.

If you have an id with head access level, you get an additional pop-up when making a holocall prompting you to choose between regular or forced.

A forced call automatically picks up on the other end (After a short delay so people can hide their drugs and whatnot) and cannot be terminated on the receivers side.

Also added the id of every holopad to its description, which was in the original bay version, but didn't get ported here for some reason. Makes it easier to tell someone where to call you.