### PR TITLE
Pumpkin Spice Season is Over

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -151,8 +151,7 @@
 		/obj/item/reagent_containers/food/drinks/chaitea = 25,
 		/obj/item/reagent_containers/food/drinks/hotcider = 25,
 		/obj/item/reagent_containers/food/drinks/h_chocolate = 25,
-		/obj/item/reagent_containers/food/snacks/donut/normal = 20,
-		/obj/item/reagent_containers/food/drinks/pslatte = 10
+		/obj/item/reagent_containers/food/snacks/donut/normal = 20
 	)
 	contraband = list(
 		/obj/item/reagent_containers/food/drinks/ice = 10,
@@ -165,8 +164,7 @@
 		/obj/item/reagent_containers/food/drinks/chaitea = 25,
 		/obj/item/reagent_containers/food/drinks/hotcider = 28,
 		/obj/item/reagent_containers/food/drinks/h_chocolate = 22,
-		/obj/item/reagent_containers/food/snacks/donut/normal = 6,
-		/obj/item/reagent_containers/food/drinks/pslatte = 25
+		/obj/item/reagent_containers/food/snacks/donut/normal = 6
 	)
 	premium = list(
 		/obj/item/reagent_containers/food/drinks/teapot/ = 5

--- a/html/changelogs/doxxmedearly - PSremove.yml
+++ b/html/changelogs/doxxmedearly - PSremove.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removes seasonal pumpkin spice lattes from the vendors, to return next year."


### PR DESCRIPTION
Unfortunately, the best season is over, and so we must say goodbye to pumpkin spice drinks until it returns.
(These never got removed). 