### PR TITLE
Vox thrower buff - belt slot

### DIFF
--- a/code/modules/projectiles/guns/alien.dm
+++ b/code/modules/projectiles/guns/alien.dm
@@ -9,6 +9,7 @@
 	var/max_spikes = 3
 	var/spikes = 3
 	release_force = 30
+	slot_flags = SLOT_BELT|SLOT_BACK
 	icon = 'icons/obj/gun.dmi'
 	icon_state = "spikethrower3"
 	item_state = "spikethrower"

--- a/html/changelogs/VoxSpikeThrowerBuff-Naelynn.yml
+++ b/html/changelogs/VoxSpikeThrowerBuff-Naelynn.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Naelynn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Allows Vox spike throwers to be worn on the belt slot."
+


### PR DESCRIPTION
Allows the Vox Spike Thrower to be worn in the belt slot.

Vox are supposed to be efficient with how they use items and not waste any resources. This is hard to do when their back slot is occupied with air tank and suit slot with spike thrower. With this change, they'd be able to wear backpacks, allowing them to actually collect items and act as RAIDERS during raider game mode.