### PR TITLE
Merchant bulk buy function

### DIFF
--- a/code/modules/merchant/merchant_programs.dm
+++ b/code/modules/merchant/merchant_programs.dm
@@ -91,7 +91,7 @@
 		last_comms = "ERROR: NUMBER BETWEEN 1 AND 50 EXPECTED"
 		return
 	if(pad)
-		for(var/BulkCounter = 0, BulkCounter<BulkAmount, BulkCounter++)
+		for(var/BulkCounter = 0, BulkCounter < BulkAmount, BulkCounter++)
 			var/response = T.offer_money_for_trade(num, bank)
 			if(istext(response))
 				last_comms = T.get_response(response, "No thank you.")

--- a/code/modules/merchant/merchant_programs.dm
+++ b/code/modules/merchant/merchant_programs.dm
@@ -81,6 +81,28 @@
 			bank -= response
 		return
 	last_comms = "PAD NOT CONNECTED"
+	
+/datum/computer_file/program/merchant/proc/bulk_offer(var/datum/trader/T, var/num)
+	var/BulkCounter = 0
+	var/BulkAmount = input("How many?") as num
+	if(istext(BulkAmount))
+		last_comms = "ERROR: NUMBER EXPECTED"
+		return 
+	if(BulkAmount < 1)
+		last_comms = "ERROR: NUMBER 1 OR GREATER EXPECTED"
+		return
+	if(pad)
+		while(BulkCounter < BulkAmount)
+			var/response = T.offer_money_for_trade(num, bank)
+			if(istext(response))
+				last_comms = T.get_response(response, "No thank you.")
+			else
+				last_comms = T.get_response("trade_complete", "Thank you!")
+				T.trade(null,num, get_turf(pad))
+				bank -= response
+			BulkCounter += 1
+		return
+	last_comms = "PAD NOT CONNECTED"
 
 /datum/computer_file/program/merchant/proc/bribe(var/datum/trader/T, var/amt)
 	if(bank < amt)
@@ -216,6 +238,9 @@
 			if(href_list["PRG_offer_money_for_item"])
 				. = 1
 				offer_money(T, text2num(href_list["PRG_offer_money_for_item"])+1)
+			if (href_list["PRG_bulk_money_for_item"])
+				. = 1
+				bulk_offer(T, text2num(href_list["PRG_bulk_money_for_item"])+1)
 			if(href_list["PRG_what_do_you_want"])
 				. = 1
 				last_comms = T.what_do_you_want()

--- a/code/modules/merchant/merchant_programs.dm
+++ b/code/modules/merchant/merchant_programs.dm
@@ -83,16 +83,15 @@
 	last_comms = "PAD NOT CONNECTED"
 	
 /datum/computer_file/program/merchant/proc/bulk_offer(var/datum/trader/T, var/num)
-	var/BulkCounter = 0
-	var/BulkAmount = input("How many?") as num
+	var/BulkAmount = input("How many items? (1-50)") as num
 	if(istext(BulkAmount))
 		last_comms = "ERROR: NUMBER EXPECTED"
 		return 
-	if(BulkAmount < 1)
-		last_comms = "ERROR: NUMBER 1 OR GREATER EXPECTED"
+	if(BulkAmount < 1 || BulkAmount > 50)
+		last_comms = "ERROR: NUMBER BETWEEN 1 AND 50 EXPECTED"
 		return
 	if(pad)
-		while(BulkCounter < BulkAmount)
+		for(var/BulkCounter = 0, BulkCounter<BulkAmount, BulkCounter++)
 			var/response = T.offer_money_for_trade(num, bank)
 			if(istext(response))
 				last_comms = T.get_response(response, "No thank you.")
@@ -100,7 +99,6 @@
 				last_comms = T.get_response("trade_complete", "Thank you!")
 				T.trade(null,num, get_turf(pad))
 				bank -= response
-			BulkCounter += 1
 		return
 	last_comms = "PAD NOT CONNECTED"
 

--- a/code/modules/merchant/merchant_programs.dm
+++ b/code/modules/merchant/merchant_programs.dm
@@ -83,12 +83,12 @@
 	last_comms = "PAD NOT CONNECTED"
 	
 /datum/computer_file/program/merchant/proc/bulk_offer(var/datum/trader/T, var/num)
-	var/BulkAmount = input("How many items? (1-50)") as num
+	var/BulkAmount = input("How many items? (Buy 1-50 items. 0 to cancel.)") as num
 	if(istext(BulkAmount))
 		last_comms = "ERROR: NUMBER EXPECTED"
 		return 
-	if(BulkAmount < 1 || BulkAmount > 50)
-		last_comms = "ERROR: NUMBER BETWEEN 1 AND 50 EXPECTED"
+	if(BulkAmount < 0 || BulkAmount > 50)
+		last_comms = "ERROR: POSITIVE NUMBER UP TO 50 EXPECTED"
 		return
 	if(pad)
 		for(var/BulkCounter = 0, BulkCounter < BulkAmount, BulkCounter++)

--- a/html/changelogs/MerchantBulkBuy.yml
+++ b/html/changelogs/MerchantBulkBuy.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Naelynn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added bulk-buy function to the merchant. Less spamming click to buy things!"

--- a/nano/templates/merchant.tmpl
+++ b/nano/templates/merchant.tmpl
@@ -29,7 +29,8 @@
 				{{for data.trades}}
 					<tr><td>{{:value}}</td>
 					<td>{{:helper.link('Trade', null, {'PRG_offer_item' : index})}}</td>
-					<td>{{:helper.link('Offer Money', null, {'PRG_offer_money_for_item' : index})}}</td>
+					<td>{{:helper.link('Money', null, {'PRG_offer_money_for_item' : index})}}</td>
+					<td>{{:helper.link('Bulk', null, {'PRG_bulk_money_for_item' : index})}}</td>
 					<td>{{:helper.link('Ask Cost', null, {'PRG_how_much_do_you_want' : index})}}</td>
 				{{/for}}
 				</table>


### PR DESCRIPTION
Adds additional function to the merchant software - Bulk Buy.

Activating this function prompts the user to enter a number. 
   - If text is SOMEHOW entered, returns IC error message.
   - If number lesser than 1 is entered, returns IC error message.
   - Expects numbers equal or greater to 1.

Function then executes standard money-purchase function using a loop. This loop executes X amount of times where X is the number user entered, ensuring they purchase the amount of items they want to buy up to as much money as they actually have
   - This makes sure they cannot abuse this to buy more things than they can afford.

This function greatly reduces lag caused by server spawning excess amount of items and makes merchant much more pleasant to play.

Compiled without errors, tested on up-to-date private server, worked as expected.