### PR TITLE
Fixed duplicate logs from moving z-levels

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -10,7 +10,7 @@
 	set category = "IC"
 
 	if(zMove(UP))
-		to_chat(usr, "<span class='notice'>You move upwards.</span>")
+		visible_message(span("notice", "[src] has moved upwards."), span("notice", "You move upwards."))
 
 /**
  * Verb for the mob to move down a z-level if possible.
@@ -20,7 +20,7 @@
 	set category = "IC"
 
 	if(zMove(DOWN))
-		to_chat(usr, "<span class='notice'>You move down.</span>")
+		visible_message(span("notice", "[src] has moved downwards."), span("notice", "You move downwards."))
 
 /**
  * Used to check if a mob can move up or down a Z-level and to then actually do the move.
@@ -71,9 +71,6 @@
 		if (!A.CanPass(src, start, 1.5, 0))
 			to_chat(src, "<span class='warning'>\The [A] blocks you.</span>")
 			return FALSE
-
-	var/txt_dir = direction & UP ? "upwards" : "downwards"
-	start.visible_message(span("notice", "[src] moves [txt_dir]."))
 
 	// Actually move.
 	Move(destination)

--- a/html/changelogs/Aboshehab - Tidied up z-level movement.yml
+++ b/html/changelogs/Aboshehab - Tidied up z-level movement.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Aboshehab
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed duplicate logs from going up and down z-levels."


### PR DESCRIPTION
The user no longer gets duplicate logs.

Previously they would get both
1- "x has moved upwards"
2- "you move upwards"