### PR TITLE
Removes the Ripley APLU construction manual from robotics

### DIFF
--- a/html/changelogs/LEUDOBERCT1-PR-7593.yml
+++ b/html/changelogs/LEUDOBERCT1-PR-7593.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Leudoberct1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Removes the Ripley APLU construction guide in robotics due to being obsolete."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -261,6 +261,15 @@
 /obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
+"aaC" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/reagent_dispensers/acid{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/glass/beaker/sulphuric,
+/turf/simulated/floor/tiled/white,
+/area/assembly/robotics)
 "aaD" = (
 /obj/structure/table/rack,
 /obj/random/loot,
@@ -37499,16 +37508,6 @@
 /area/assembly/robotics)
 "bmg" = (
 /obj/machinery/mineral/rigpress,
-/turf/simulated/floor/tiled/white,
-/area/assembly/robotics)
-"bmh" = (
-/obj/structure/table/standard,
-/obj/item/book/manual/ripley_build_and_repair,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/reagent_dispensers/acid{
-	pixel_y = 32
-	},
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
 "bmi" = (
@@ -94124,7 +94123,7 @@ aKT
 aKT
 aKT
 baE
-bmh
+aaC
 bnE
 bpb
 bqn


### PR DESCRIPTION
This removes the book in robotics on the table by the fabricators that details how to build a Ripley. The book is no longer applicable as we now use Baystation code for mechs, where a Ripley is not a thing.