### PR TITLE
Mixed Gems Bugfix

### DIFF
--- a/code/modules/mining/gemstones.dm
+++ b/code/modules/mining/gemstones.dm
@@ -121,7 +121,6 @@
 		return
 	if(src.gemtype != GEM_MIXED)
 		to_chat(user, span("notice", "You mix the gemstones together into a pile."))
-		src.stacksize -= 1
 		G.stacksize -= 1
 		switch(gemsize)
 			if(GEM_SMALL)
@@ -133,6 +132,7 @@
 			if(GEM_LARGE)
 				var/obj/item/precious/gemstone/mixed/large/pile = new(loc, stacksize, gemtype)
 				pile.add_gem(G)
+		qdel(src)
 	else 
 		to_chat(user, span("notice", "You add the [G.gemtype] to the pile."))
 		stack_contents[G.gemtype] += 1
@@ -246,7 +246,7 @@ var/list/gemtype2type = list(
 
 	for (var/gtype in stack_contents)
 		var/realtype = global.gemtype2type[gtype][gemsize]
-		new realtype(loc, stack_contents[gtype])
+		new realtype(get_turf(loc), stack_contents[gtype])
 	to_chat(usr, span("notice", "You separate the gemstone pile into neat, organized stacks of similar gems."))
 	qdel(src)
 

--- a/html/changelogs/Kaedwuff - Stackfix.yml
+++ b/html/changelogs/Kaedwuff - Stackfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Players will no longer eat mixed gemstone stacks when attempting to separate them. It was very unsanitary."


### PR DESCRIPTION
Fixes #7594, gemstones separated from a mixed stack were being shoved inside a mob rather than dropped in neat stacks to the floor.  Additionally, I discovered some errors in calculating stack size.

These have been corrected, pls merge.