### PR TITLE
Station Safe bugfix

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -28,7 +28,12 @@ FLOOR SAFES
 
 	tumbler_2_pos = rand(0, 72)
 	tumbler_2_open = rand(0, 72)
-
+	
+	while(tumbler_1_open - tumbler_2_open > 34 || tumbler_2_open - tumbler_1_open > 34)
+		if(tumbler_1_open > tumbler_2_open)
+			tumbler_2_open++
+		else
+			tumbler_1_open++
 
 /obj/structure/safe/Initialize()
 	. = ..()

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -13,8 +13,8 @@ FLOOR SAFES
 	anchored = 1
 	density = 1
 	var/open = 0		//is the safe open?
-	var/tumbler_1_pos	//the tumbler position- from 0 to 72
-	var/tumbler_1_open	//the tumbler position to open at- 0 to 72
+	var/tumbler_1_pos	//the tumbler position- from 0 to 71
+	var/tumbler_1_open	//the tumbler position to open at- 0 to 71
 	var/tumbler_2_pos
 	var/tumbler_2_open
 	var/dial = 0		//where is the dial pointing?
@@ -23,17 +23,12 @@ FLOOR SAFES
 
 
 /obj/structure/safe/New()
-	tumbler_1_pos = rand(0, 72)
-	tumbler_1_open = rand(0, 72)
+	tumbler_1_pos = rand(0, 71)
+	tumbler_1_open = rand(0, 71)
 
-	tumbler_2_pos = rand(0, 72)
-	tumbler_2_open = rand(0, 72)
-	
-	while(tumbler_1_open - tumbler_2_open > 34 || tumbler_2_open - tumbler_1_open > 34)
-		if(tumbler_1_open > tumbler_2_open)
-			tumbler_2_open++
-		else
-			tumbler_1_open++
+	tumbler_2_pos = rand(0, 71)
+	tumbler_2_open = min(71 , max( 1 , abs(tumbler_1_open + rand(-34, 34))))
+
 
 /obj/structure/safe/Initialize()
 	. = ..()

--- a/html/changelogs/StationSafeBugfix.yml
+++ b/html/changelogs/StationSafeBugfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Naelynn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Fixed a rare bug making station safe impossible to crack."


### PR DESCRIPTION
Fixes a bug where station safe could be impossible to open if certain tumbler_open values were rolled.

The bug in question is caused by tumbler rolling which is a core process of the safe-cracking minigame. 

After testing it on private server, I have determined that changing tumbler rolling values creates way more newer issues, and as such solved the rare glitch by making sure that any and all values rolled by a safe on initiation are possible to be solved within confines of tumbler rolling 

[35 differential value between tumbler_open 1 and 2] = Max of tumbler rolling.

Station Safes now check on initiation if the differential is bigger than 34. If yes, they reduce the differential to 34, making the otherwise impossible station safe spawn possible to crack.