### PR TITLE
Cryo time_till_despawn adjustment

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -262,7 +262,7 @@
 			if(!find_control_computer(urgent=1))
 				return
 
-		if(!occupant.client && occupant.stat<2) //Occupant is living and has no client.
+		if(!occupant.client && occupant.stat != DEAD) //Occupant is living and has no client.
 			despawn_occupant()
 
 		else if(world.time - time_entered > time_till_force_cryo)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -169,8 +169,8 @@
 	var/disallow_occupant_types = list()
 
 	var/mob/occupant = null         // Person waiting to be despawned.
-	var/time_till_despawn = 600     // One minute safe period before being despawned.
-	var/time_till_force_cryo = 1800 // Three minutes safe period until they're despawned even if active.
+	var/time_till_despawn = 1200     // Two minute safe period before being despawned.
+	var/time_till_force_cryo = 3000 // Five minutes safe period until they're despawned even if active.
 	var/time_entered = 0            // Used to keep track of the safe period.
 	var/obj/item/device/radio/intercom/announce
 
@@ -255,7 +255,7 @@
 //Lifted from Unity stasis.dm and refactored. ~Zuhayr
 /obj/machinery/cryopod/machinery_process()
 	if(occupant)
-		//Allow a one minute gap between entering the pod and actually despawning.
+		//Allow a two minute gap between entering the pod and actually despawning.
 		if((world.time - time_entered < time_till_despawn) && occupant.ckey)
 			return
 		if(!control_computer)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -169,7 +169,7 @@
 	var/disallow_occupant_types = list()
 
 	var/mob/occupant = null       // Person waiting to be despawned.
-	var/time_till_despawn = 9000  // 15 minutes-ish safe period before being despawned.
+	var/time_till_despawn = 600   // One minute safe period before being despawned.
 	var/time_entered = 0          // Used to keep track of the safe period.
 	var/obj/item/device/radio/intercom/announce //
 
@@ -254,7 +254,7 @@
 //Lifted from Unity stasis.dm and refactored. ~Zuhayr
 /obj/machinery/cryopod/machinery_process()
 	if(occupant)
-		//Allow a ten minute gap between entering the pod and actually despawning.
+		//Allow a one minute gap between entering the pod and actually despawning.
 		if((world.time - time_entered < time_till_despawn) && occupant.ckey)
 			return
 

--- a/html/changelogs/geeves - cryoGhost.yml
+++ b/html/changelogs/geeves - cryoGhost.yml
@@ -3,4 +3,5 @@ author: Geeves
 delete-after: True
 
 changes: 
-  - tweaking: "The safety timeperiod between entering cryo and being cryo'd has been changed from 10 minutes to 1 minute, due to people not ghosting."
+  - tweak: "The safety timeperiod between entering cryo and being cryo'd has been changed from 10 minutes to 1 minute, due to people not ghosting."
+  - rscadd: "If you are in cryo for 3 minutes, you will be despawned even if you're still logged on."

--- a/html/changelogs/geeves - cryoGhost.yml
+++ b/html/changelogs/geeves - cryoGhost.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweaking: "The safety timeperiod between entering cryo and being cryo'd has been changed from 10 minutes to 1 minute, due to people not ghosting."

--- a/html/changelogs/geeves - cryoGhost.yml
+++ b/html/changelogs/geeves - cryoGhost.yml
@@ -3,5 +3,5 @@ author: Geeves
 delete-after: True
 
 changes: 
-  - tweak: "The safety timeperiod between entering cryo and being cryo'd has been changed from 10 minutes to 1 minute, due to people not ghosting."
-  - rscadd: "If you are in cryo for 3 minutes, you will be despawned even if you're still logged on."
+  - tweak: "The safety timeperiod between entering cryo and being cryo'd has been changed from 10 minutes to 2 minutes, due to people not ghosting."
+  - rscadd: "If you are in cryo for 5 minutes, you will be despawned even if you're still logged on."


### PR DESCRIPTION
* The safety timeperiod between entering cryo and being cryo'd has been changed from 10 minutes to 1 minute, due to people not ghosting.
* If you are in cryo for 3 minutes, you will be despawned even if you're still logged on.