### PR TITLE
Cult Rework - Corruption Cult

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -441,6 +441,7 @@
 #include "code\game\gamemodes\changeling\implements\powers\stings.dm"
 #include "code\game\gamemodes\changeling\implements\powers\suck.dm"
 #include "code\game\gamemodes\cult\cult.dm"
+#include "code\game\gamemodes\cult\cult_corruption.dm"
 #include "code\game\gamemodes\cult\cult_items.dm"
 #include "code\game\gamemodes\cult\cult_structures.dm"
 #include "code\game\gamemodes\cult\hell_universe.dm"

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/cult
 	name = "Cult"
 	round_description = "Some crewmembers are attempting to start a cult!"
-	extended_round_description = "The station has been infiltrated by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
+	extended_round_description = "The station has been infiltrated by a fanatical group of death-cultists! They will use powers from beyond your comprehension to rob you of your sanity and plunge the whole station into madness! Try to survive!"
 	config_tag = "cult"
 	required_players = 9
 	required_enemies = 4

--- a/code/game/gamemodes/cult/cult_corruption.dm
+++ b/code/game/gamemodes/cult/cult_corruption.dm
@@ -1,0 +1,25 @@
+/datum/brain_trauma/corruption
+	var/last_message
+
+/datum/brain_trauma/corruption/ten
+	name = "corruption_ten"
+	desc = "Patient is showing signs of very unusual brain activity."
+	scan_desc = "Unknown anomaly detected in patients brain. Severity: slight."
+	gain_text = "<span class='notice'>You seem to have developed a slight, but very persistent headache.</span>"
+	lose_text = "<span class='notice'>Everything feels normal again.</span>"
+
+	var/list/messages = list(
+
+	"You feel a light pain in your head.",
+	"You feel another headache coming on.",
+	"You feel a throbbing pain right behind your eyes.",
+	"Your eyes feel dry and itchy, as if you haven't slept in days",
+	"Did you hear something? Must have been the wind.",
+
+	)
+
+/datum/brain_trauma/corruption/ten/on_life()
+	if(world.time - last_message > 300) // at least 5 min cooldown between messages
+		if(prob(10)) //10% chance to get the message after cooldown is up
+			to_chat(owner, span("notice", "[pick(messages)]")) //pick one of the messages and send as notice
+	..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -440,4 +440,3 @@
 		return FALSE
 
 	return TRUE
-

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1076,14 +1076,14 @@
 		return
 
 	var/obj/item/organ/internal/lungs/L = internal_organs_by_name[species_organ]
-	
+
 	if(!L)
 		losebreath += 15 //No lungs, how do you breathe?
 		adjustOxyLoss(15)
 		failed_last_breath = TRUE
 	else
 		failed_last_breath = L.handle_breath(breath)
-	
+
 	return !failed_last_breath
 
 /mob/living/carbon/human/proc/is_lung_ruptured()
@@ -1626,3 +1626,45 @@
 /mob/living/carbon/human/proc/pulse()
 	var/obj/item/organ/internal/heart/H = internal_organs_by_name[BP_HEART]
 	return H ? H.pulse : PULSE_NONE
+
+//Proc for Cultmode to apply corruption to the mob
+//TODO: Add cooldown.
+/mob/living/carbon/human/proc/corrupt(var/amount)
+	src.corruption += amount
+	var/obj/item/organ/internal/brain/B = internal_organs_by_name[BP_BRAIN]
+	switch(corruption)
+		if(90 to 99)
+			if(src.corruptionlevel == 8) //checks if mob is on the corruption level under this one
+				to_chat(src, "<span class='notice'>corruption level 90+</span>") //effect
+				src.corruptionlevel = 9 //increments corruption level, so effect only happens once upon reaching new level
+		if(80 to 89)
+			if(src.corruptionlevel == 7)
+				src.corruptionlevel = 8
+		if(70 to 79)
+			if(src.corruptionlevel == 6)
+				src.corruptionlevel = 7
+		if(60 to 69)
+			if(src.corruptionlevel == 5)
+				src.corruptionlevel = 6
+		if(50 to 59)
+			if(src.corruptionlevel == 4)
+				src.corruptionlevel = 5
+		if(40 to 49)
+			if(src.corruptionlevel == 3)
+				src.corruptionlevel = 4
+		if(30 to 39)
+			if(src.corruptionlevel == 2)
+				src.corruptionlevel = 3
+		if(20 to 29)
+			if(src.corruptionlevel == 1)
+				src.corruptionlevel = 2
+		if(10 to 19)
+			if(src.corruptionlevel == 0)
+				B.gain_trauma(/datum/brain_trauma/corruption/ten,TRUE) //Give the affected mob's brain the coresponding trauma
+				src.corruptionlevel = 1
+	return
+
+//Proc for Cultmode to subtract corruption from the mob
+/mob/living/carbon/human/proc/uncorrupt(var/amount)
+	src.corruption -= amount
+	return

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -239,3 +239,5 @@
 
 	var/authed = TRUE
 	var/player_age = "Requires database"
+	var/corruption = 0 //Used in cultrounds to track how corrupted a mob is
+	var/corruptionlevel = 0 //Used to track the highest 10 level increment of corruption the mob has reached

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -826,3 +826,29 @@
 /datum/reagent/bottle_lightning/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(prob(25))
 		tesla_zap(M, 6, 1500)
+
+//Relevant for Cult
+/datum/reagent/blood_of_narsie
+	name = "Blood of Nar-Sie"
+	id = "narsie-blood"
+	description = "A viscous, slightly sticky liquid."
+	reagent_state = LIQUID
+	color = "#70838A"
+	taste_description = "rotting blood"
+	metabolism = REM/20
+	metabolism_min = 0.005
+	ingest_mul = 1
+	ingest_met = REM/10
+	taste_mult = 5 //You can taste it in your food very easily
+	touch_met = REM*2 //splashing on people corrupts also
+	fallback_specific_heat = 1.5
+
+/datum/reagent/blood_of_narsie/initial_effect(var/mob/living/carbon/M, var/alien)
+	to_chat(M, "<span class='warning'>An overwhelming feeling of disgust nearly makes you vomit.</span>")
+	M.make_dizzy(120)
+	return
+
+/datum/reagent/blood_of_narsie/affect_blood(var/mob/living/carbon/human/M, var/alien, var/removed)
+	. = ..()
+	M.corrupt(0.05) //Not a lot, but it adds up over the time the stuff metabolizes
+	return


### PR DESCRIPTION
Alright here it is - the basis for my planned cult rework

See this forum thread for general info https://forums.aurorastation.org/topic/13293-cult-rework-corruption-cult/

Done:

- Humans have a corruption stat and 10 distinct levels of corruption they can reach
- Corruption can be added
- Corruption modelled as incurable (through normal means) brain traumas
- Blood of Nar-Sie added. A reagent that can be ingested or injected and corrupts as it metabolizes
- Started adding new cult items that corrupt. For now: Idol (corrupts on pickup and as long as it's on you), Chaos Orb (corrupts everyone in view. IUf you touch it it glows brightly and blows up after a few seconds)

Todo;

- Sprites for the new stuff
- fill out the different levels of being corrupted with symptoms. Mental traumas, damage, unique messages, etc
- Come up with more items/ways to corrupt the crew
- Change pylon, so it corrupts in a large radius after blood sacrifice
- Remove/change conversion rune
- Change Nar-Sie summon as described in forum thread
- Balance corruption so people do get corrupted, but not in 5 minutes
- Possibly add protection against corruption to crew religious symbols
- Probably lots of other stuff