### PR TITLE
Removes Soylent

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -30,10 +30,10 @@
 			amount = list(1,2,3,4,5),
 			emag = 0
 		),
-		"soylenviridians" = list(
-			name = "Soylent Viridians",
+		"soywafers" = list(
+			name = "Soy Wafers",
 			class = "Food",
-			object = /obj/item/reagent_containers/food/snacks/soylenviridians,
+			object = /obj/item/reagent_containers/food/snacks/soywafers,
 			cost = 150,
 			amount = list(1,2,3,4,5),
 			emag = 0
@@ -301,14 +301,6 @@
 			object = /obj/item/stack/material/animalhide/human,
 			cost = 50,
 			amount = list(1,5,10,25,50),
-			emag = 1
-		),
-		"soylentgreen" = list(
-			name = "Soylent Green",
-			class = "!@#$%^&*()",
-			object = /obj/item/reagent_containers/food/snacks/soylentgreen,
-			cost = 150,
-			amount = list(1,2,3,4,5),
 			emag = 1
 		),
 		"syndie" = list(

--- a/code/modules/cargo/bounties/chef.dm
+++ b/code/modules/cargo/bounties/chef.dm
@@ -112,12 +112,6 @@
 	required_count = 3
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/variable/kebab)
 
-/datum/bounty/item/chef/soylentgreen
-	name = "Soylent Green"
-	description = "%BOSSSHORT has heard wonderful things about the product 'Soylent Green', and would love to try some. If you endulge them, expect a pleasant bonus."
-	reward = 5000
-	wanted_types = list(/obj/item/reagent_containers/food/snacks/soylentgreen)
-
 /datum/bounty/item/chef/pancakes
 	name = "Pancakes"
 	description = "Here at %COMPNAME we consider employees to be family. And you know what families love? Pancakes. Ship a baker's dozen."

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -161,20 +161,11 @@
 		)
 	result = /obj/item/reagent_containers/food/snacks/eggplantparm
 
-/datum/recipe/soylenviridians
+/datum/recipe/soywafers
 	fruit = list("soybeans" = 1)
 	reagents = list("flour" = 10)
 	reagent_mix = RECIPE_REAGENT_REPLACE
-	result = /obj/item/reagent_containers/food/snacks/soylenviridians
-
-/datum/recipe/soylentgreen
-	reagents = list("flour" = 10)
-	reagent_mix = RECIPE_REAGENT_REPLACE
-	items = list(
-		/obj/item/reagent_containers/food/snacks/meat/human,
-		/obj/item/reagent_containers/food/snacks/meat/human
-	)
-	result = /obj/item/reagent_containers/food/snacks/soylentgreen
+	result = /obj/item/reagent_containers/food/snacks/soywafers
 
 /datum/recipe/berryclafoutis
 	fruit = list("berries" = 1)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1326,29 +1326,15 @@
 	. = ..()
 	reagents.add_reagent("cheese", 5)
 
-/obj/item/reagent_containers/food/snacks/soylentgreen
-	name = "soylent green"
-	desc = "Not made of people. Honest." //Totally people.
-	icon_state = "soylent_green"
-	trash = /obj/item/trash/waffles
-	drop_sound = 'sound/items/trayhit1.ogg'
-	filling_color = "#B8E6B5"
-	center_of_mass = list("x"=15, "y"=11)
-	bitesize = 2
-
-/obj/item/reagent_containers/food/snacks/soylentgreen/Initialize()
-	. = ..()
-	reagents.add_reagent("protein", 10)
-
-/obj/item/reagent_containers/food/snacks/soylenviridians
-	name = "soylen virdians"
-	desc = "Not made of people. Honest." //Actually honest for once.
+/obj/item/reagent_containers/food/snacks/soywafers
+	name = "Soy Wafers"
+	desc = "Simple pressed soy wafers."
 	icon_state = "soylent_yellow"
 	trash = /obj/item/trash/waffles
 	drop_sound = 'sound/items/trayhit1.ogg'
 	filling_color = "#E6FA61"
 	center_of_mass = list("x"=15, "y"=11)
-	nutriment_desc = list("some sort of protein" = 5)
+	nutriment_desc = list("bland dry soy" = 5)
 	nutriment_amt = 10
 	bitesize = 2
 

--- a/html/changelogs/Kaedwuff - No Soylent.yml
+++ b/html/changelogs/Kaedwuff - No Soylent.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removes Soylent Green from the game."
+  - tweak: "Soylent Viridians has been changed to simply Soy Wafers."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -13904,7 +13904,7 @@
 /obj/structure/table/wood{
 	dir = 5
 	},
-/obj/item/reagent_containers/food/snacks/soylenviridians,
+/obj/item/reagent_containers/food/snacks/soywafers,
 /turf/unsimulated/floor{
 	icon_state = "wood"
 	},

--- a/maps/exodus/exodus-2_centcomm.dmm
+++ b/maps/exodus/exodus-2_centcomm.dmm
@@ -9924,7 +9924,7 @@
 /obj/structure/table/wood{
 	dir = 5
 	},
-/obj/item/reagent_containers/food/snacks/soylenviridians,
+/obj/item/reagent_containers/food/snacks/soywafers,
 /turf/unsimulated/floor{
 	icon_state = "wood"
 	},


### PR DESCRIPTION
The meme is old and tired.  Soylent green serves absolutely no story purpose except to rely on knowledge of a reference to an old movie to provide cheap shock value.  It also looks really stupid, I mean, come on - human meat makes green waffles? That doesn't even make sense, where does the green come from, other than that's the color the object was in the movie.

We have the tools now to tag any food made from human meat as such. Even if it's not made of human  meat at all.  We shouldn't be encouraging people to commit questionably legal acts for the sake of making the special human meat item.

Soylent Viridians has been renamed to "Soy Wafers" to better reflect what they are without relying on a referential joke.

I left the green waffles sprite in the game, in case someone wants to use it for like, veggie waffles or something in the future.