### PR TITLE
Smoke if you got 'em

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -100,6 +100,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/ignitermes = "USER lights NAME with FLAME"
 	var/initial_volume = 0
 	var/burn_rate = 0
+	var/last_drag = 0 //Spam limiter for audio/message when taking a drag of cigarette. 
 	drop_sound = 'sound/items/drop/food.ogg'
 
 /obj/item/clothing/mask/smokable/Initialize()
@@ -253,8 +254,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(blocked)
 			to_chat(H, "<span class='warning'>\The [blocked] is in the way!</span>")
 			return 1
-		H.visible_message("<span class='notice'>[H.name] takes a drag of their [name].</span>")
-		playsound(H, 'sound/items/cigs_lighters/inhale.ogg', 50, 0, -1)
+		if(last_drag <= world.time - 30) //Spam limiter. Only for messages/sound. 
+			last_drag = world.time
+			H.visible_message("<span class='notice'>[H.name] takes a drag of their [name].</span>")
+			playsound(H, 'sound/items/cigs_lighters/inhale.ogg', 50, 0, -1)
+		reagents.trans_to_mob(H, pick(1,1.5,2), CHEM_BREATHE) //Smokes it faster. Slightly random amount. 
 		return 1
 	return ..()
 

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -100,7 +100,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/ignitermes = "USER lights NAME with FLAME"
 	var/initial_volume = 0
 	var/burn_rate = 0
-	var/last_drag = 0 //Spam limiter for audio/message when taking a drag of cigarette. 
+	var/last_drag = 0 //Spam limiter for audio/message when taking a drag of cigarette.
 	drop_sound = 'sound/items/drop/food.ogg'
 
 /obj/item/clothing/mask/smokable/Initialize()
@@ -254,11 +254,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(blocked)
 			to_chat(H, "<span class='warning'>\The [blocked] is in the way!</span>")
 			return 1
-		if(last_drag <= world.time - 30) //Spam limiter. Only for messages/sound. 
+		if(last_drag <= world.time - 30) //Spam limiter. Only for messages/sound.
 			last_drag = world.time
 			H.visible_message("<span class='notice'>[H.name] takes a drag of their [name].</span>")
 			playsound(H, 'sound/items/cigs_lighters/inhale.ogg', 50, 0, -1)
-		reagents.trans_to_mob(H, pick(1,1.5,2), CHEM_BREATHE) //Smokes it faster. Slightly random amount. 
+		reagents.trans_to_mob(H, (rand(10,20)/10), CHEM_BREATHE) //Smokes it faster. Slightly random amount.
 		return 1
 	return ..()
 

--- a/html/changelogs/doxxmedearly - smokings_a_drag.yml
+++ b/html/changelogs/doxxmedearly - smokings_a_drag.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Taking a drag of your cigarette now smokes it slightly faster. Good for finishing up a cig before going into medical."
+  - rscadd: "Added a check to prevent spamming audio/message logs with taking a drag from a cigarette. You can still smoke it down by clicking fast, but it only displays the message/sound if it's been at least three seconds since the last one."


### PR DESCRIPTION
Taking a drag of a cigarette smokes it faster. Amount is slightly randomized, but on average a fresh cigarette can take ten active drags before dying. Shouldn't be noticeable to people who only do it once or twice, but enables people to succ down a smoke really quick before going into a non-smoking area.
This puts a sane limiter on how much you can take a drag from a cigarette instead of it being infinite.

On that same note, I've put a check to limit the spam from messages and audio. Needs about three seconds since the last one before it'll display another message / play another sound. 