### PR TITLE
Refactor the borg access function to account for all ID locations

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -799,7 +799,7 @@
 		var/mob/living/silicon/robot/R = M
 		if(check_access(R.get_active_hand()) || istype(R.get_active_hand(), /obj/item/card/robot))
 			return 1
-	else
+	else if(istype(M, /mob/living))
 		var/id = M.GetIdCard()
 		// Check if the ID card the user has (if any) has access
 		if(id)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -791,18 +791,19 @@
 	return ..(user,Floor(damage/2),attack_message)
 
 /mob/living/silicon/robot/proc/allowed(mob/M)
-	//check if it doesn't require any access at all
+	// Check if the borg doesn't require any access at all
 	if(check_access(null))
 		return 1
-	if(istype(M, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = M
-		//if they are holding or wearing a card that has access, that works
-		if(check_access(H.get_active_hand()) || check_access(H.wear_id))
-			return 1
-	else if(istype(M, /mob/living/silicon/robot))
+	// Borgs should be handled a bit differently, since their IDs are not really IDs
+	if(istype(M, /mob/living/silicon/robot))
 		var/mob/living/silicon/robot/R = M
 		if(check_access(R.get_active_hand()) || istype(R.get_active_hand(), /obj/item/card/robot))
 			return 1
+	else
+		var/id = M.GetIdCard()
+		// Check if the ID card the user has (if any) has access
+		if(id)
+			return check_access(id)
 	return 0
 
 /mob/living/silicon/robot/proc/check_access(obj/item/card/id/I)

--- a/html/changelogs/aleksix-borg_pda_access.yml
+++ b/html/changelogs/aleksix-borg_pda_access.yml
@@ -1,0 +1,6 @@
+author: aleksix
+
+delete-after: True
+
+changes: 
+  - refactor: "Borgs ID access code has been refactored to the normal ID access code. Now they properly check for access in PDAs, hands and such."


### PR DESCRIPTION
Borg ID access code was mostly self-contained and didn't have support for checking PDA IDs, even though they should.