### PR TITLE
Medborg Updates

### DIFF
--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -240,9 +240,9 @@
 		)
 
 /obj/item/gripper/chemistry //A gripper designed for chemistry, to allow borgs to work efficiently in the lab
-	name = "chemistry gripper"
+	name = "medical gripper"
 	icon_state = "gripper-sci"
-	desc = "A specialised grasping tool designed for working in chemistry and pharmaceutical labs"
+	desc = "A specialised grasping tool designed for working in medical treatment facilities and pharmaceutical labs."
 
 	can_hold = list(
 		/obj/item/reagent_containers/glass,
@@ -253,7 +253,10 @@
 		/obj/item/storage/pill_bottle,
 		/obj/item/hand_labeler,
 		/obj/item/paper,
-		/obj/item/stack/material/phoron
+		/obj/item/stack/material/phoron,
+		/obj/item/reagent_containers/blood,
+		/obj/item/reagent_containers/food/drinks/sillycup,
+		/obj/item/reagent_containers/food/drinks/medcup
 		)
 
 

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -23,7 +23,7 @@
 	reagent_ids = list("bicaridine", "kelotane", "dylovene", "dexalin", "norepinephrine", "tramadol", "deltamivir", "thetamycin")
 
 /obj/item/reagent_containers/borghypo/rescue
-	reagent_ids = list("tricordrazine", "norepinephrine", "tramadol")
+	reagent_ids = list("tricordrazine", "norepinephrine", "tramadol", "adrenaline")
 
 /obj/item/reagent_containers/borghypo/Initialize()
 	. = ..()

--- a/html/changelogs/doxxmedearly - medborg.yml
+++ b/html/changelogs/doxxmedearly - medborg.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Cyborg rescue module now has adrenaline in its hypospray."
+  - tweak: "Chemistry gripper renamed to medical gripper since it's used for way more than just chemistry."
+  - rscadd: "Medical grippers can now hold blood bags, med cups, and paper cups. 

--- a/html/changelogs/doxxmedearly - medborg.yml
+++ b/html/changelogs/doxxmedearly - medborg.yml
@@ -40,4 +40,4 @@ delete-after: True
 changes: 
   - rscadd: "Cyborg rescue module now has adrenaline in its hypospray."
   - tweak: "Chemistry gripper renamed to medical gripper since it's used for way more than just chemistry."
-  - rscadd: "Medical grippers can now hold blood bags, med cups, and paper cups. 
+  - rscadd: "Medical grippers can now hold blood bags, med cups, and paper cups."


### PR DESCRIPTION
Rescue borgs now have adrenaline. Not added to regular medical borg since they have the ability to create it in chemistry.

Chemistry gripper for med borgs renamed to medical gripper. It's not just used for chemistry.

Medical grippers can now hold blood bags (so they can put them on IVs), medical cups (to give patients liquid medication), and paper cups (to give water for patient care or with pills). 