### PR TITLE
Removes pain displaying phantom wounds when examining yourself

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -28,7 +28,7 @@
 	bloodstr.clear_reagents()
 	touching.clear_reagents()
 	var/datum/reagents/R = get_ingested_reagents()
-	if(istype(R)) 
+	if(istype(R))
 		R.clear_reagents()
 	breathing.clear_reagents()
 	..()
@@ -212,11 +212,6 @@
 				var/list/status = list()
 				var/brutedamage = org.brute_dam
 				var/burndamage = org.burn_dam
-				if(getHalLoss() > 0)
-					if(prob(30))
-						brutedamage += getHalLoss()
-					if(prob(30))
-						burndamage += getHalLoss()
 				switch(brutedamage)
 					if(1 to 20)
 						status += "bruised"

--- a/html/changelogs/alberyk-pain.yml
+++ b/html/changelogs/alberyk-pain.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Pain should no longer create phantom wounds when examining yourself."


### PR DESCRIPTION
What it says in the title. Because with brainmed giving you pain in any injury now, it becomes way too hard to see where you have been wounded by examining yourself.