### PR TITLE
Removes playable vox

### DIFF
--- a/html/changelogs/alberyk-novox.yml
+++ b/html/changelogs/alberyk-novox.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - rscdel: "Removed playable vox from the merchant and heist gamemode."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -6377,13 +6377,8 @@
 /turf/simulated/floor/tiled,
 /area/merchant_station)
 "apu" = (
-/obj/structure/closet/wardrobe{
-	name = "vox apparel"
-	},
-/obj/item/clothing/under/vox/vox_robes,
-/obj/item/clothing/under/vox/vox_casual,
-/obj/random/voidsuit/vox,
-/obj/random/voidsuit/vox,
+/obj/structure/closet/gmcloset,
+/obj/random/backpack,
 /turf/simulated/floor/wood,
 /area/merchant_station)
 "apv" = (
@@ -14721,14 +14716,6 @@
 /obj/item/clothing/gloves/yellow/vox,
 /obj/item/clothing/suit/space/vox/stealth,
 /obj/item/clothing/head/helmet/space/vox/stealth,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
-/area/syndicate_mothership/raider_base)
-"aIW" = (
-/obj/item/tape/engineering{
-	icon_state = "engineering_v"
-	},
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
 	},
@@ -30002,8 +29989,8 @@
 	},
 /area/centcom/legion)
 "rqm" = (
-/obj/structure/mirror/merchant{
-	pixel_y = 28
+/obj/structure/mirror{
+	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
 /area/merchant_station)
@@ -31342,11 +31329,8 @@
 	},
 /area/centcom/legion)
 "ueV" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/item/tank/nitrogen,
-/obj/item/tank/nitrogen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
+/obj/structure/table/wood,
+/obj/random/plushie,
 /turf/simulated/floor/wood,
 /area/merchant_station)
 "ugy" = (
@@ -36455,8 +36439,8 @@ aHj
 aGR
 aGg
 aFT
-aIW
-aIW
+aFT
+aFT
 aGz
 aGz
 aGz
@@ -36713,8 +36697,8 @@ aGh
 aGh
 aGg
 aGh
-aGh
 aFT
+aGz
 ahV
 ahV
 ahV
@@ -36971,7 +36955,7 @@ aGh
 aGh
 aGg
 aFT
-aFT
+aGz
 ahV
 aaM
 ald


### PR DESCRIPTION
Removes the mirror from the heist base and the merchant ship.
Why: because the vox species is an unwhitelist alien species with zero effort being put into. They exist in a really nebulous zone, that we can't really enforce standards without a whitelist, and no one really cares to do anything about them.

feedback topic: https://forums.aurorastation.org/topic/13361-removing-playable-vox/