### PR TITLE
Stop spraying yourself.

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -77,6 +77,8 @@
 	return
 
 /obj/item/reagent_containers/spray/proc/Spray_at(atom/A as mob|obj, mob/user as mob, proximity)
+	if(istype(A, /obj) && A.loc == user)
+		return
 	if (A.density && proximity)
 		A.visible_message("[user] sprays [A] with [src].")
 		reagents.splash(A, amount_per_transfer_from_this)
@@ -166,12 +168,6 @@
 	safety = !safety
 	to_chat(user, "<span class = 'notice'>You switch the safety [safety ? "on" : "off"].</span>")
 	playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
-
-/obj/item/reagent_containers/spray/pepper/Spray_at(atom/A as mob|obj, mob/user)
-	if(safety)
-		to_chat(user, "<span class = 'warning'>The safety is on!</span>")
-		return
-	..()
 
 /obj/item/reagent_containers/spray/waterflower
 	name = "water flower"

--- a/html/changelogs/doxxmedearly - spraymemes.yml
+++ b/html/changelogs/doxxmedearly - spraymemes.yml
@@ -1,0 +1,9 @@
+
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - bugfix: "You'll no longer spray yourself with bottles or pepperspray when placing it into your bag, jacket, webbing, or a container you're holding, even with the safety off."


### PR DESCRIPTION
Fixes #7666 
Since you can spray people and objects, it would spray your coat (and therefore you) if you clicked on it.
Added a check to make sure the thing you're spraying isn't on your person. 

Removed redundant safety checks for pepperspray.