### PR TITLE
Buffs e-pistols

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -125,7 +125,7 @@
 	item_state = null	//so the human update icon uses the icon_state instead.
 	fire_sound = 'sound/weapons/Taser.ogg'
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
-	max_shots = 5
+	max_shots = 7
 	fire_delay = 4
 	can_turret = 1
 	secondary_projectile_type = /obj/item/projectile/beam/pistol

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -26,7 +26,7 @@
 	eyeblur = 2
 
 /obj/item/projectile/beam/pistol
-	damage = 30
+	damage = 35
 
 /obj/item/projectile/beam/pistol/hegemony
 	icon_state = "hegemony"

--- a/html/changelogs/geeves - epistolbuff.yml
+++ b/html/changelogs/geeves - epistolbuff.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "The e-pistol now has seven shots, up from five."
+  - tweak: "The lethal e-pistol now does 35 damage, up from 30."


### PR DESCRIPTION
* The e-pistol now has seven shots, up from five.
* The lethal e-pistol now does 35 damage, up from 30.

Math time. Let's presume we're two tiles away from a completely nude opponent, giving them zero protection.

`Old e-pistol`
Five shots, 30 burn damage on lethal, 40 halloss damage on stun.
Stun, all shots connected: 200 HALLOSS
Lethal, all shots connected: 150 BURN

`New e-pistol`
Seven shots, 35 burn damage on lethal, 40 halloss on stun.
Stun, all shots connected: 280 HALLOSS
Lethal, all shots connected: 245 BURN

Enough to kill a person, if six of the seven shots connect and they have absolutely no protection. The halloss damage cannot give someone a heart attack, that has been tested already.