### PR TITLE
Fixes Beaker Breaking

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -104,7 +104,7 @@
 	center_of_mass = list("x" = 15,"y" = 11)
 	matter = list("glass" = 500)
 	drop_sound = 'sound/items/drop/glass.ogg'
-	fragile = 2
+	fragile = 4
 
 /obj/item/reagent_containers/glass/beaker/Initialize()
 	. = ..()
@@ -160,7 +160,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,60,120)
 	flags = OPENCONTAINER
-	fragile = 4 
+	fragile = 2 
 
 /obj/item/reagent_containers/glass/beaker/bowl
 	name = "mixing bowl"
@@ -211,7 +211,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25)
 	flags = OPENCONTAINER
-	fragile = 1
+	fragile = 5
 
 /obj/item/reagent_containers/glass/beaker/cryoxadone
 /obj/item/reagent_containers/glass/beaker/cryoxadone/Initialize()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -60,7 +60,7 @@
 		shatter()
 		return
 	if(speed < hardness)
-		if (prob(25 * (speed)))
+		if(prob(25 * (speed)))
 			shatter()
 
 /obj/item/reagent_containers/glass/proc/shatter(var/mob/user)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -54,13 +54,20 @@
 
 /obj/item/reagent_containers/glass/throw_impact(atom/hit_atom, var/speed)
 	. = ..()
-	if(speed > fragile && !no_shatter)
+	if(no_shatter)
+		return
+	if(speed > fragile)
 		shatter()
+		return
+	if  (speed <= fragile)
+		if (prob(50))
+			shatter()
 
 /obj/item/reagent_containers/glass/proc/shatter(var/mob/user)
 	if(reagents.total_volume)
 		reagents.splash(src.loc, reagents.total_volume) // splashes the mob holding it or the turf it's on
 	audible_message("\The [src] shatters with a resounding crash!", "\The [src] breaks.")
+	playsound(src, "shatter", 40, 1)
 	new /obj/item/material/shard(loc, "glass")
 	qdel(src)
 
@@ -97,7 +104,7 @@
 	center_of_mass = list("x" = 15,"y" = 11)
 	matter = list("glass" = 500)
 	drop_sound = 'sound/items/drop/glass.ogg'
-	fragile = 4
+	fragile = 1
 
 /obj/item/reagent_containers/glass/beaker/Initialize()
 	. = ..()
@@ -153,7 +160,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,60,120)
 	flags = OPENCONTAINER
-	fragile = 6 // a bit sturdier
+	fragile = 2 
 
 /obj/item/reagent_containers/glass/beaker/bowl
 	name = "mixing bowl"
@@ -179,6 +186,7 @@
 	amount_per_transfer_from_this = 10
 	flags = OPENCONTAINER | NOREACT
 	fragile = 0
+	no_shatter = TRUE
 
 /obj/item/reagent_containers/glass/beaker/bluespace
 	name = "bluespace beaker"
@@ -191,6 +199,7 @@
 	possible_transfer_amounts = list(5,10,15,25,30,60,120,300)
 	flags = OPENCONTAINER
 	fragile = 0
+	no_shatter = TRUE
 
 /obj/item/reagent_containers/glass/beaker/vial
 	name = "vial"
@@ -281,6 +290,7 @@ obj/item/reagent_containers/glass/bucket/wood
 	icon_state = "woodbucket"
 	item_state = "woodbucket"
 	center_of_mass = list("x" = 16,"y" = 8)
+	no_shatter = TRUE
 	matter = list("wood" = 50)
 	drop_sound = 'sound/items/drop/wooden.ogg'
 	carving_weapon = /obj/item/material/hatchet

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -59,7 +59,7 @@
 	if(speed >= hardness)
 		shatter()
 		return
-	if  (speed < hardness)
+	if(speed < hardness)
 		if (prob(25 * (speed)))
 			shatter()
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -15,7 +15,7 @@
 	accuracy = 0.1
 	w_class = 2
 	flags = OPENCONTAINER
-	var/fragile = 1 // most glassware is super fragile
+	var/hardness = 1 
 	var/no_shatter = FALSE //does this container shatter?
 	unacidable = 1 //glass doesn't dissolve in acid
 	drop_sound = 'sound/items/drop/bottle.ogg'
@@ -56,11 +56,11 @@
 	. = ..()
 	if(no_shatter)
 		return
-	if(speed > fragile)
+	if(speed >= hardness)
 		shatter()
 		return
-	if  (speed <= fragile)
-		prob(20 * (fragile - speed))
+	if  (speed < hardness)
+		if (prob(25 * (speed)))
 			shatter()
 
 /obj/item/reagent_containers/glass/proc/shatter(var/mob/user)
@@ -85,7 +85,7 @@
 			update_name_label()
 		return
 	. = ..() // in the case of nitroglycerin, explode BEFORE it shatters
-	if(!(W.flags & NOBLUDGEON) && fragile && (W.force > fragile))
+	if(!(W.flags & NOBLUDGEON) && hardness && (W.force < hardness))
 		shatter()
 		return
 
@@ -104,7 +104,7 @@
 	center_of_mass = list("x" = 15,"y" = 11)
 	matter = list("glass" = 500)
 	drop_sound = 'sound/items/drop/glass.ogg'
-	fragile = 4
+	hardness = 3
 
 /obj/item/reagent_containers/glass/beaker/Initialize()
 	. = ..()
@@ -160,7 +160,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,60,120)
 	flags = OPENCONTAINER
-	fragile = 2 
+	hardness = 4 
 
 /obj/item/reagent_containers/glass/beaker/bowl
 	name = "mixing bowl"
@@ -185,7 +185,7 @@
 	volume = 60
 	amount_per_transfer_from_this = 10
 	flags = OPENCONTAINER | NOREACT
-	fragile = 0
+	hardness = 0
 	no_shatter = TRUE
 
 /obj/item/reagent_containers/glass/beaker/bluespace
@@ -198,7 +198,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,60,120,300)
 	flags = OPENCONTAINER
-	fragile = 0
+	hardness = 0
 	no_shatter = TRUE
 
 /obj/item/reagent_containers/glass/beaker/vial
@@ -211,7 +211,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25)
 	flags = OPENCONTAINER
-	fragile = 5
+	hardness = 2
 
 /obj/item/reagent_containers/glass/beaker/cryoxadone
 /obj/item/reagent_containers/glass/beaker/cryoxadone/Initialize()
@@ -244,7 +244,7 @@
 	var/carving_weapon = /obj/item/wirecutters
 	var/helmet_type = /obj/item/clothing/head/helmet/bucket
 	no_shatter = TRUE
-	fragile = 0
+	hardness = 0
 
 /obj/item/reagent_containers/glass/bucket/attackby(var/obj/D, mob/user as mob)
 	if(isprox(D))

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -60,7 +60,7 @@
 		shatter()
 		return
 	if  (speed <= fragile)
-		if (prob(50))
+		prob(20 * (fragile - speed))
 			shatter()
 
 /obj/item/reagent_containers/glass/proc/shatter(var/mob/user)
@@ -104,7 +104,7 @@
 	center_of_mass = list("x" = 15,"y" = 11)
 	matter = list("glass" = 500)
 	drop_sound = 'sound/items/drop/glass.ogg'
-	fragile = 1
+	fragile = 2
 
 /obj/item/reagent_containers/glass/beaker/Initialize()
 	. = ..()
@@ -160,7 +160,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,60,120)
 	flags = OPENCONTAINER
-	fragile = 2 
+	fragile = 4 
 
 /obj/item/reagent_containers/glass/beaker/bowl
 	name = "mixing bowl"

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -11,7 +11,7 @@
 	possible_transfer_amounts = list(5,10,15,25,30,60)
 	flags = 0
 	volume = 60
-	fragile = 4
+	hardness = 3
 	var/list/reagents_to_add
 
 /obj/item/reagent_containers/glass/bottle/on_reagent_change()

--- a/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
@@ -4,7 +4,8 @@
 	possible_transfer_amounts = list(5,10,15,25,30,50,100)
 	flags = OPENCONTAINER
 	volume = 60
-	fragile = 0 // do NOT shatter
+	hardness = 0
+	no_shatter = TRUE
 	var/reagent = ""
 
 

--- a/html/changelogs/Kaedwuff - Tougher Beakers.yml
+++ b/html/changelogs/Kaedwuff - Tougher Beakers.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Non-glass beakers no longer break when thrown. Additionally, glass beakers have been made more fragile, as they were nearly impossible to break by throwing."


### PR DESCRIPTION
Due to some of the, er, _interesting_ decisions made when writing the code for beakers shattering when you throw them, not only was it possible to shatter containers made of non-glass materials into glass fragments  - such as cryostasis and bluespace beakers, and _wooden buckets_ - but most of the actual glass beakers were impossible to break with your bare hands.

I have corrected both these issues in addition to making it possible for glass beakers that are tougher to still shatter even if you don't throw them with the force of a mass driver.  And they make a noisy shatter sound now, too.