### PR TITLE
Enforces species jobs restrictions through mechanics

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -22,6 +22,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 
 	outfit = /datum/outfit/job/captain
 
+	allowed_species = list("Human", "Skrell")
+
 /datum/outfit/job/captain
 	name = "Captain"
 	jobtype = /datum/job/captain
@@ -45,6 +47,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	satchel = /obj/item/storage/backpack/satchel_cap
 	dufflebag = /obj/item/storage/backpack/duffel/cap
 	messengerbag = /obj/item/storage/backpack/messenger/com
+
+	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
 
 /datum/outfit/job/captain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -22,7 +22,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 
 	outfit = /datum/outfit/job/captain
 
-	allowed_species = list("Human", "Skrell")
+	blacklisted_species = list("Off-Worlder Human", "Tajara", "M'sai Tajara", "Zhan-Khazan Tajara", "Unathi", "Aut'akh Unathi", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame", "Vaurca Worker", "Vaurca Warrior")
 
 /datum/outfit/job/captain
 	name = "Captain"
@@ -95,7 +95,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			            access_chapel_office, access_library, access_research, access_mining, access_mining_station, access_janitor,
 			            access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_weapons, access_journalist)
 
-	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+	blacklisted_species = list("M'sai Tajara", "Zhan-Khazan Tajara", "Aut'akh Unathi", "Diona", "Vaurca Worker", "Vaurca Warrior")
 
 /datum/outfit/job/hop
 	name = "Head of Personnel"

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -48,8 +48,6 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	dufflebag = /obj/item/storage/backpack/duffel/cap
 	messengerbag = /obj/item/storage/backpack/messenger/com
 
-	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
-
 /datum/outfit/job/captain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(H && H.w_uniform)
@@ -96,6 +94,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics,
 			            access_chapel_office, access_library, access_research, access_mining, access_mining_station, access_janitor,
 			            access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_weapons, access_journalist)
+
+	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
 
 /datum/outfit/job/hop
 	name = "Head of Personnel"

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -22,7 +22,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 
 	outfit = /datum/outfit/job/captain
 
-	blacklisted_species = list("Off-Worlder Human", "Tajara", "M'sai Tajara", "Zhan-Khazan Tajara", "Unathi", "Aut'akh Unathi", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame", "Vaurca Worker", "Vaurca Warrior")
+	blacklisted_species = list("Off-Worlder Human", "Tajara", "M'sai Tajara", "Zhan-Khazan Tajara", "Unathi", "Aut'akh Unathi", "Diona", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame", "Vaurca Worker", "Vaurca Warrior")
 
 /datum/outfit/job/captain
 	name = "Captain"

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -27,6 +27,8 @@
 	minimal_player_age = 7
 	outfit = /datum/outfit/job/chief_engineer
 
+allowed_species = list("Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Diona", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+
 /datum/outfit/job/chief_engineer
 	name = "Chief Engineer"
 	jobtype = /datum/job/chief_engineer

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -27,7 +27,7 @@
 	minimal_player_age = 7
 	outfit = /datum/outfit/job/chief_engineer
 
-	allowed_species = list("Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Diona", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+	blacklisted_species = list("Off-Worlder Human", "M'sai Tajara", "Zhan-Khazan Tajara", "Aut'akh Unathi", "Vaurca Worker", "Vaurca Warrior")
 
 /datum/outfit/job/chief_engineer
 	name = "Chief Engineer"

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -27,7 +27,7 @@
 	minimal_player_age = 7
 	outfit = /datum/outfit/job/chief_engineer
 
-allowed_species = list("Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Diona", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+	allowed_species = list("Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Diona", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
 
 /datum/outfit/job/chief_engineer
 	name = "Chief Engineer"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -30,6 +30,7 @@
 
 	var/datum/outfit/outfit = null
 	var/list/alt_outfits = null           // A list of special outfits for the alt titles list("alttitle" = /datum/outfit)
+	var/list/allowed_species = null		  // A list of species that can be this job, usually used for head of staff, this uses species names
 
 //Only override this proc
 /datum/job/proc/after_spawn(mob/living/carbon/human/H)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -30,7 +30,7 @@
 
 	var/datum/outfit/outfit = null
 	var/list/alt_outfits = null           // A list of special outfits for the alt titles list("alttitle" = /datum/outfit)
-	var/list/allowed_species = null		  // A list of species that can be this job, usually used for head of staff, this uses species names
+	var/list/blacklisted_species = null		  // A blacklist of species that can't be this job
 
 //Only override this proc
 /datum/job/proc/after_spawn(mob/living/carbon/human/H)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -26,7 +26,7 @@
 	ideal_character_age = 50
 	outfit = /datum/outfit/job/cmo
 
-	blacklisted_species = list("M'sai Tajara", "Zhan-Khazan Tajara", "Aut'akh Unathi", "Diona", "Vaurca Worker", "Vaurca Warrior")
+	blacklisted_species = list("M'sai Tajara", "Zhan-Khazan Tajara", "Aut'akh Unathi", "Vaurca Worker", "Vaurca Warrior")
 
 /datum/outfit/job/cmo
 	name = "Chief Medical Officer"

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -26,6 +26,8 @@
 	ideal_character_age = 50
 	outfit = /datum/outfit/job/cmo
 
+allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Diona", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+
 /datum/outfit/job/cmo
 	name = "Chief Medical Officer"
 	jobtype = /datum/job/cmo

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -26,7 +26,7 @@
 	ideal_character_age = 50
 	outfit = /datum/outfit/job/cmo
 
-	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Diona", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+	blacklisted_species = list("M'sai Tajara", "Zhan-Khazan Tajara", "Aut'akh Unathi", "Diona", "Vaurca Worker", "Vaurca Warrior")
 
 /datum/outfit/job/cmo
 	name = "Chief Medical Officer"

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -26,7 +26,7 @@
 	ideal_character_age = 50
 	outfit = /datum/outfit/job/cmo
 
-allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Diona", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Diona", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
 
 /datum/outfit/job/cmo
 	name = "Chief Medical Officer"

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -226,6 +226,8 @@
 	outfit = /datum/outfit/job/paramedic
 	alt_outfits = list("Emergency Medical Technician"=/datum/outfit/job/paramedic/emt)
 
+	blacklisted_species = list("Diona")
+
 /datum/outfit/job/paramedic
 	name = "Paramedic"
 	base_name = "Paramedic"

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -18,6 +18,8 @@
 	outfit = /datum/outfit/job/representative
 	alt_titles = list("Consular Officer")
 
+	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+
 /datum/job/representative/get_outfit(mob/living/carbon/human/H, alt_title = null)
 	if(H.mind?.role_alt_title == "Consular Officer" || alt_title == "Consular Officer")
 		var/datum/citizenship/citizenship = SSrecords.citizenships[H.citizenship]

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -18,7 +18,7 @@
 	outfit = /datum/outfit/job/representative
 	alt_titles = list("Consular Officer")
 
-	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame", "Vaurca Worker", "Vaurca Warrior")
 
 /datum/job/representative/get_outfit(mob/living/carbon/human/H, alt_title = null)
 	if(H.mind?.role_alt_title == "Consular Officer" || alt_title == "Consular Officer")

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -18,7 +18,7 @@
 	outfit = /datum/outfit/job/representative
 	alt_titles = list("Consular Officer")
 
-	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame", "Vaurca Worker", "Vaurca Warrior")
+	blacklisted_species = list("M'sai Tajara", "Zhan-Khazan Tajara", "Aut'akh Unathi")
 
 /datum/job/representative/get_outfit(mob/living/carbon/human/H, alt_title = null)
 	if(H.mind?.role_alt_title == "Consular Officer" || alt_title == "Consular Officer")

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -25,7 +25,7 @@
 	ideal_character_age = 50
 	outfit = /datum/outfit/job/rd
 
-	blacklisted_species = list("M'sai Tajara", "Zhan-Khazan Tajara", "Aut'akh Unathi", "Diona", "Vaurca Worker", "Vaurca Warrior")
+	blacklisted_species = list("M'sai Tajara", "Zhan-Khazan Tajara", "Aut'akh Unathi", "Vaurca Worker", "Vaurca Warrior")
 
 /datum/outfit/job/rd
 	name = "Research Director"

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -25,7 +25,7 @@
 	ideal_character_age = 50
 	outfit = /datum/outfit/job/rd
 
-	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Diona", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+	blacklisted_species = list("M'sai Tajara", "Zhan-Khazan Tajara", "Aut'akh Unathi", "Diona", "Vaurca Worker", "Vaurca Warrior")
 
 /datum/outfit/job/rd
 	name = "Research Director"

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -25,7 +25,7 @@
 	ideal_character_age = 50
 	outfit = /datum/outfit/job/rd
 
-allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Diona", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+	allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Diona", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
 
 /datum/outfit/job/rd
 	name = "Research Director"

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -25,6 +25,8 @@
 	ideal_character_age = 50
 	outfit = /datum/outfit/job/rd
 
+allowed_species = list("Human", "Off-Worlder Human", "Skrell", "Unathi", "Tajara", "Diona", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Hephaestus G2 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+
 /datum/outfit/job/rd
 	name = "Research Director"
 	jobtype = /datum/job/rd

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -26,6 +26,8 @@
 	minimal_player_age = 14
 	outfit = /datum/outfit/job/hos
 
+allowed_species = list("Human", "Skrell", "Unathi", "M'sai Tajara", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+
 /datum/outfit/job/hos
 	name = "Head of Security"
 	jobtype = /datum/job/hos

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -26,7 +26,7 @@
 	minimal_player_age = 14
 	outfit = /datum/outfit/job/hos
 
-	allowed_species = list("Human", "Skrell", "Unathi", "M'sai Tajara", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+	blacklisted_species = list("Off-Worlder Human", "Zhan-Khazan Tajara", "Aut'akh Unathi", "Diona", "Hephaestus G2 Industrial Frame", "Vaurca Worker", "Vaurca Warrior")
 
 /datum/outfit/job/hos
 	name = "Head of Security"

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -26,7 +26,7 @@
 	minimal_player_age = 14
 	outfit = /datum/outfit/job/hos
 
-allowed_species = list("Human", "Skrell", "Unathi", "M'sai Tajara", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
+	allowed_species = list("Human", "Skrell", "Unathi", "M'sai Tajara", "Tajara", "Baseline Frame", "Hephaestus G1 Industrial Frame", "Xion Industrial Frame", "Zeng-Hu Mobility Frame", "Bishop Accessory Frame", "Shell Frame")
 
 /datum/outfit/job/hos
 	name = "Head of Security"

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -179,6 +179,11 @@
 		if(ban_reason == "WHITELISTED")
 			dat += "<del>[dispRank]</del></td><td><b> \[WHITELISTED]</b></td></tr>"
 			continue
+		else if(job.allowed_species) // check for restricted species
+			var/datum/species/S = all_species[pref.species]
+			if(!(S.name in job.allowed_species))
+				dat += "<del>[dispRank]</del></td><td><b> \[SPECIES RESTRICTED]</b></td></tr>"
+				continue
 		else if (ban_reason == "AGE WHITELISTED")
 			var/available_in_days = player_old_enough_for_role(user.client, rank)
 			dat += "<del>[dispRank]</del></td><td> \[IN [(available_in_days)] DAYS]</td></tr>"

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -179,9 +179,9 @@
 		if(ban_reason == "WHITELISTED")
 			dat += "<del>[dispRank]</del></td><td><b> \[WHITELISTED]</b></td></tr>"
 			continue
-		else if(job.allowed_species) // check for restricted species
+		else if(job.blacklisted_species) // check for restricted species
 			var/datum/species/S = all_species[pref.species]
-			if(!(S.name in job.allowed_species))
+			if(S.name in job.blacklisted_species)
 				dat += "<del>[dispRank]</del></td><td><b> \[SPECIES RESTRICTED]</b></td></tr>"
 				continue
 		else if (ban_reason == "AGE WHITELISTED")

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -286,6 +286,11 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 	if (jobban_isbanned(src,rank))
 		return FALSE
 
+	if(job.blacklisted_species) // check for restricted species
+		var/datum/species/S = all_species[client.prefs.species]
+		if(S.name in job.blacklisted_species)
+			return FALSE
+
 	var/datum/faction/faction = SSjobs.name_factions[client.prefs.faction] || SSjobs.default_faction
 	if (!(job.type in faction.allowed_role_types))
 		return FALSE

--- a/html/changelogs/alberyk-speciesstuff.yml
+++ b/html/changelogs/alberyk-speciesstuff.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - rscadd: "Species job restrictions are now enforced in the occupation panel."


### PR DESCRIPTION
This pr stops species that can't be a certain job from selecting it in the job panel.
This also takes in consideration subspecies and etc.
The following jobs only allow those species to select it:

Captain:
-human
-skrells

Head of personnel
-human
-off worlder humans
-skrell
-tajara
-unathi
-all ipc species

Chief engineer:
-human
-skrell
-tajara
-unathi
-diona
-all ipc species

Head of security:
-human
-skrell
-tajara
-m'sai tajara
-unathi
-all ipc species except the g2 industrial

Research Director:
-human
-skrell
-off worlder human
-tajara
-unathi
-diona
-all ipc species

Chief medical officer:
-human
-skrell
-off worlder human
-tajara
-unathi
-diona
-all ipc species

Representative
-human
-off worlder human
-skrells
-tajara
-unathi
-diona
-vaurca worker
-vaurca warrior
-all ipc species