### PR TITLE
K'lax Bug Fixing

### DIFF
--- a/code/modules/ghostroles/spawner/human/ert.dm
+++ b/code/modules/ghostroles/spawner/human/ert.dm
@@ -194,6 +194,7 @@
 	outfit = /datum/outfit/admin/ert/kataphract/klax
 	mob_name_prefix = "Zosaa "
 	uses_species_whitelist = TRUE // Kataphract K'lax would be more difficult
+	req_species_whitelist = "Vaurca"
 	possible_species = list("Vaurca Warrior")
 	extra_languages = list(LANGUAGE_VAURCA)
 

--- a/code/modules/ghostroles/spawner/human/ert.dm
+++ b/code/modules/ghostroles/spawner/human/ert.dm
@@ -193,8 +193,7 @@
 	max_count = 1
 	outfit = /datum/outfit/admin/ert/kataphract/klax
 	mob_name_prefix = "Zosaa "
-	uses_species_whitelist = TRUE // Kataphract K'lax would be more difficult
-	req_species_whitelist = "Vaurca"
+	req_species_whitelist = "Vaurca" // Kataphract K'lax would be more difficult
 	possible_species = list("Vaurca Warrior")
 	extra_languages = list(LANGUAGE_VAURCA)
 

--- a/html/changelogs/geeves - kataphractfixes.yml
+++ b/html/changelogs/geeves - kataphractfixes.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Kataphract K'lax now properly need a species whitelist to join."


### PR DESCRIPTION
You now properly need a vaurca whitelist to join as a Kataphract K'lax.