### PR TITLE
Fixing Mechs more. The fight between armor and armour

### DIFF
--- a/code/modules/heavy_vehicle/components/armor.dm
+++ b/code/modules/heavy_vehicle/components/armor.dm
@@ -3,24 +3,24 @@
 		damage_flags &= ~(DAM_SHARP | DAM_EDGE)
 	. = ..()*/
 
-/obj/item/robot_parts/robot_component/armor
+/obj/item/robot_parts/robot_component/armor/mech
 	name = "exosuit armor plating"
 	armor = list(melee = 75, bullet = 33, laser = 50, energy = 10, bomb = 25, bio = 100, rad = 0)
 	origin_tech = list(TECH_MATERIAL = 1)
 
-/obj/item/robot_parts/robot_component/armor/radproof
+/obj/item/robot_parts/robot_component/armor/mech/radproof
 	name = "radiation-proof armor plating"
 	desc = "A fully enclosed radiation hardened shell designed to protect the pilot from radiation."
 	armor = list(melee = 75, bullet = 33, laser = 50, energy = 25, bomb = 25, bio = 100, rad = 100)
 	origin_tech = list(TECH_MATERIAL = 3)
 
-/obj/item/robot_parts/robot_component/armor/em
+/obj/item/robot_parts/robot_component/armor/mech/em
 	name = "EM-shielded armor plating"
 	desc = "A shielded plating that sorrounds the eletronics and protects them from electromagnetic radiation."
 	armor = list(melee = 65, bullet = 20, laser = 25, energy = 100, bomb = 10, bio = 100, rad = 60)
 	origin_tech = list(TECH_MATERIAL = 3)
 
-/obj/item/robot_parts/robot_component/armor/combat
+/obj/item/robot_parts/robot_component/armor/mech/combat
 	name = "heavy combat plating"
 	desc = "Plating designed to deflect incoming attacks and explosions."
 	armor = list(melee = 85, bullet = 70, laser = 60, energy = 10, bomb = 70, bio = 100, rad = 0)

--- a/code/modules/heavy_vehicle/components/arms.dm
+++ b/code/modules/heavy_vehicle/components/arms.dm
@@ -5,7 +5,7 @@
 	has_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	power_use = 50
 
-	var/melee_damage = 15
+	var/melee_damage = 20
 	var/action_delay = 15
 	var/obj/item/robot_parts/robot_component/actuator/motivator
 

--- a/code/modules/heavy_vehicle/components/body.dm
+++ b/code/modules/heavy_vehicle/components/body.dm
@@ -98,7 +98,7 @@
 			to_chat(user, "<span class='warning'>\The [src] already has a cell installed.</span>")
 			return
 		if(install_component(thing,user)) cell = thing
-	else if(istype(thing, /obj/item/robot_parts/robot_component/armor))
+	else if(istype(thing, /obj/item/robot_parts/robot_component/armor/mech))
 		if(mech_armor)
 			to_chat(user, "<span class='warning'>\The [src] already has mech_armor installed.</span>")
 			return

--- a/code/modules/heavy_vehicle/mech_construction.dm
+++ b/code/modules/heavy_vehicle/mech_construction.dm
@@ -39,7 +39,8 @@
 			target = hardpoint
 			break
 
-	hardpoints[target] = null
+	if(target)
+		hardpoints[target] = null
 
 	if(target == selected_hardpoint)
 		clear_selected_hardpoint()

--- a/code/modules/heavy_vehicle/premade/combat.dm
+++ b/code/modules/heavy_vehicle/premade/combat.dm
@@ -66,7 +66,7 @@
 
 /obj/item/mech_component/chassis/combat/prebuild()
 	. = ..()
-	mech_armor = new /obj/item/robot_parts/robot_component/armor/combat(src)
+	mech_armor = new /obj/item/robot_parts/robot_component/armor/mech/combat(src)
 
 /obj/item/mech_component/chassis/combat/Initialize()
 	pilot_positions = list(

--- a/code/modules/heavy_vehicle/premade/combat.dm
+++ b/code/modules/heavy_vehicle/premade/combat.dm
@@ -28,7 +28,7 @@
 	name = "combat arms"
 	exosuit_desc_string = "flexible, advanced manipulators"
 	icon_state = "combat_arms"
-	melee_damage = 5
+	melee_damage = 30
 	action_delay = 10
 	power_use = 5000
 

--- a/code/modules/heavy_vehicle/premade/heavy.dm
+++ b/code/modules/heavy_vehicle/premade/heavy.dm
@@ -27,7 +27,7 @@
 	exosuit_desc_string = "super-heavy reinforced manipulators"
 	icon_state = "heavy_arms"
 	desc = "Designed to function where any other piece of equipment would have long fallen apart, the Hephaestus Superheavy Lifter series can take a beating and excel at delivering it."
-	melee_damage = 25
+	melee_damage = 35
 	action_delay = 15
 	max_damage = 90
 	power_use = 7500

--- a/code/modules/heavy_vehicle/premade/heavy.dm
+++ b/code/modules/heavy_vehicle/premade/heavy.dm
@@ -27,7 +27,7 @@
 	exosuit_desc_string = "super-heavy reinforced manipulators"
 	icon_state = "heavy_arms"
 	desc = "Designed to function where any other piece of equipment would have long fallen apart, the Hephaestus Superheavy Lifter series can take a beating and excel at delivering it."
-	melee_damage = 35
+	melee_damage = 50
 	action_delay = 15
 	max_damage = 90
 	power_use = 7500

--- a/code/modules/heavy_vehicle/premade/heavy.dm
+++ b/code/modules/heavy_vehicle/premade/heavy.dm
@@ -68,7 +68,7 @@
 
 /obj/item/mech_component/chassis/heavy/prebuild()
 	. = ..()
-	mech_armor = new /obj/item/robot_parts/robot_component/armor/combat(src)
+	mech_armor = new /obj/item/robot_parts/robot_component/armor/mech/combat(src)
 
 /obj/item/mech_component/chassis/superheavy
 	name = "reinforced exosuit chassis"
@@ -84,7 +84,7 @@
 /obj/item/mech_component/chassis/superheavy/prebuild()
 	. = ..()
 	cell = new /obj/item/cell/super(src)
-	mech_armor = new /obj/item/robot_parts/robot_component/armor/combat(src)
+	mech_armor = new /obj/item/robot_parts/robot_component/armor/mech/combat(src)
 
 /mob/living/heavy_vehicle/premade/superheavy
 	name = "Marauder"

--- a/code/modules/heavy_vehicle/premade/light.dm
+++ b/code/modules/heavy_vehicle/premade/light.dm
@@ -29,7 +29,7 @@
 	name = "light arms"
 	exosuit_desc_string = "lightweight, segmented manipulators"
 	icon_state = "light_arms"
-	melee_damage = 10
+	melee_damage = 15
 	action_delay = 15
 	max_damage = 40
 	power_use = 3000

--- a/code/modules/heavy_vehicle/premade/light.dm
+++ b/code/modules/heavy_vehicle/premade/light.dm
@@ -29,7 +29,7 @@
 	name = "light arms"
 	exosuit_desc_string = "lightweight, segmented manipulators"
 	icon_state = "light_arms"
-	melee_damage = 5
+	melee_damage = 10
 	action_delay = 15
 	max_damage = 40
 	power_use = 3000

--- a/code/modules/heavy_vehicle/premade/light.dm
+++ b/code/modules/heavy_vehicle/premade/light.dm
@@ -76,7 +76,7 @@
 
 /obj/item/mech_component/chassis/light/prebuild()
 	. = ..()
-	mech_armor = new /obj/item/robot_parts/robot_component/armor/radproof(src)
+	mech_armor = new /obj/item/robot_parts/robot_component/armor/mech/radproof(src)
 
 /obj/item/mech_component/chassis/light/Initialize()
 	pilot_positions = list(

--- a/code/modules/heavy_vehicle/premade/powerloader.dm
+++ b/code/modules/heavy_vehicle/premade/powerloader.dm
@@ -16,7 +16,7 @@
 		body = new /obj/item/mech_component/chassis/ripley(src)
 		body.color = "#ffdc37"
 
-	body.armor = new /obj/item/robot_parts/robot_component/armor(src)
+	body.armor = new /obj/item/robot_parts/robot_component/armor/mech(src)
 
 	. = ..()
 

--- a/code/modules/heavy_vehicle/premade/powerloader.dm
+++ b/code/modules/heavy_vehicle/premade/powerloader.dm
@@ -16,7 +16,7 @@
 		body = new /obj/item/mech_component/chassis/ripley(src)
 		body.color = "#ffdc37"
 
-	body.armor = new /obj/item/robot_parts/robot_component/armour(src)
+	body.armor = new /obj/item/robot_parts/robot_component/armor(src)
 
 	. = ..()
 
@@ -65,7 +65,7 @@
 
 /obj/item/mech_component/chassis/ripley/prebuild()
 	. = ..()
-	armor = new /obj/item/robot_parts/robot_component/armour(src)
+	armor = new /obj/item/robot_parts/robot_component/armor/mech(src)
 
 /obj/item/mech_component/chassis/ripley/Initialize()
 	pilot_positions = list(
@@ -149,7 +149,7 @@
 		body = new /obj/item/mech_component/chassis/ripley(src)
 		body.color = "#849bc1"
 
-		body.mech_armor = new /obj/item/robot_parts/robot_component/armor/combat(src)
+		body.mech_armor = new /obj/item/robot_parts/robot_component/armor/mech/combat(src)
 
 	. = ..()
 

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -77,9 +77,9 @@
 // ARMOUR
 // Protects the cyborg from damage. Usually first module to be hit
 // No power usage
-/datum/robot_component/armour
+/datum/robot_component/armor
 	name = "armour plating"
-	external_type = /obj/item/robot_parts/robot_component/armour
+	external_type = /obj/item/robot_parts/robot_component/armor
 	max_damage = 60
 
 // JETPACK
@@ -232,7 +232,7 @@
 	components["diagnosis unit"] = new/datum/robot_component/diagnosis_unit(src)
 	components["camera"] = new/datum/robot_component/camera(src)
 	components["comms"] = new/datum/robot_component/binary_communication(src)
-	components["armour"] = new/datum/robot_component/armour(src)
+	components["armour"] = new/datum/robot_component/armor(src)
 	components["jetpack"] = new/datum/robot_component/jetpack(src)
 	components["surge"] = new/datum/robot_component/surge(src)
 	jetpackComponent = components["jetpack"]
@@ -297,8 +297,8 @@
 	icon_state = "motor"
 	icon_state_broken = "motor_broken"
 
-/obj/item/robot_parts/robot_component/armour
-	name = "armour plating"
+/obj/item/robot_parts/robot_component/armor
+	name = "armor plating"
 	icon_state = "armor"
 	icon_state_broken = "armor_broken"
 

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -91,7 +91,7 @@
 			to_chat(src, "<span class='warning'>Your shield absorbs some of the impact!</span>")
 
 	if(!emp)
-		var/datum/robot_component/armour/A = get_armour()
+		var/datum/robot_component/armor/A = get_armour()
 		if(A)
 			A.take_damage(brute,burn,sharp,edge)
 			return
@@ -136,7 +136,7 @@
 			burn -= absorb_burn
 			to_chat(src, "<span class='warning'>Your shield absorbs some of the impact!</span>")
 
-	var/datum/robot_component/armour/A = get_armour()
+	var/datum/robot_component/armor/A = get_armour()
 	if(A)
 		A.take_damage(brute,burn,sharp)
 		return

--- a/code/modules/research/designs/mechfab/mechs/designs_exosuits.dm
+++ b/code/modules/research/designs/mechfab/mechs/designs_exosuits.dm
@@ -49,14 +49,14 @@
 /datum/design/item/mechfab/exosuit/basic_armour
 	name = "basic exosuit armour"
 	id = "mech_armour_basic"
-	build_path = /obj/item/robot_parts/robot_component/armour
+	build_path = /obj/item/robot_parts/robot_component/armor/mech
 	time = 30
 	materials = list(DEFAULT_WALL_MATERIAL = 7500)
 
 /datum/design/item/mechfab/exosuit/radproof_armour
 	name = "radiation-proof exosuit armour"
 	id = "mech_armour_radproof"
-	build_path = /obj/item/robot_parts/robot_component/armor/radproof
+	build_path = /obj/item/robot_parts/robot_component/armor/mech/radproof
 	time = 50
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	materials = list(DEFAULT_WALL_MATERIAL = 12500)
@@ -64,7 +64,7 @@
 /datum/design/item/mechfab/exosuit/em_armour
 	name = "EM-shielded exosuit armour"
 	id = "mech_armour_em"
-	build_path = /obj/item/robot_parts/robot_component/armor/em
+	build_path = /obj/item/robot_parts/robot_component/armor/mech/em
 	time = 50
 	req_tech = list(TECH_MATERIAL = 2, TECH_POWER = 2)
 	materials = list(DEFAULT_WALL_MATERIAL = 12500, "silver" = 1000)
@@ -72,7 +72,7 @@
 /datum/design/item/mechfab/exosuit/combat_armour
 	name = "combat exosuit armor"
 	id = "mech_armour_combat"
-	build_path = /obj/item/robot_parts/robot_component/armor/combat
+	build_path = /obj/item/robot_parts/robot_component/armor/mech/combat
 	time = 50
 	req_tech = list(TECH_MATERIAL = 4, TECH_COMBAT = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 20000, "diamond" = 5000)

--- a/code/modules/research/designs/mechfab/robot/robot.dm
+++ b/code/modules/research/designs/mechfab/robot/robot.dm
@@ -97,10 +97,10 @@
 	id = "camera"
 	build_path = /obj/item/robot_parts/robot_component/camera
 
-/datum/design/item/mechfab/robot/component/armour
-	name = "Armour plating"
-	id = "armour"
-	build_path = /obj/item/robot_parts/robot_component/armour
+/datum/design/item/mechfab/robot/component/armor
+	name = "Armor plating"
+	id = "armor"
+	build_path = /obj/item/robot_parts/robot_component/armor
 
 /datum/design/item/mechfab/robot/component/surge
 	name = "Heavy surge prevention module"

--- a/html/changelogs/Sindorman-mech.yml
+++ b/html/changelogs/Sindorman-mech.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Mech printer now prints the right type of regular armor, instead of borg armor."

--- a/html/changelogs/Sindorman-mech.yml
+++ b/html/changelogs/Sindorman-mech.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - bugfix: "Mech printer now prints the right type of regular armor, instead of borg armor."
+  - tweak: "Mech's melee damage has been increased. It depends on manipulator type. Light: 15, Regular: 20, Combat 30, Heavy: 50."


### PR DESCRIPTION
The armour and armor again strikes:

- Apparently original Mech port PR has overridden borg's armor definition and was using it. This fixes it by making mech's armor a child of borg's armor instead.

- renames borg's `armour` to armor references.

- Mech's melee damage has been increased. It depends on manipulator type. Light: 15, Regular: 20, Combat 30, Heavy: 50. Fixes #7665

- Adds missed check in mech's destroy proc