### PR TITLE
Fixes the mercenary loadout crates not showing up on the uplink

### DIFF
--- a/code/datums/outfits/outfit_antag.dm
+++ b/code/datums/outfits/outfit_antag.dm
@@ -35,8 +35,9 @@
 
 	var/obj/item/device/radio/uplink/U = H.r_store
 	if(istype(U))
-		U.hidden_uplink.uplink_owner = "[H.key]"
+		U.hidden_uplink.uplink_owner = H.mind
 		U.hidden_uplink.uses = uplink_uses
+		U.hidden_uplink.nanoui_menu = 1
 
 /datum/outfit/admin/syndicate/get_id_access()
 	return get_syndicate_access(id_access)

--- a/html/changelogs/alberyk-cratefix.yml
+++ b/html/changelogs/alberyk-cratefix.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed the gear crates not showing up in the mercenary uplink."


### PR DESCRIPTION
What it says in the title.