### PR TITLE
Forensics QOL Fixes

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -158,7 +158,8 @@
 	return attack_hand(user)
 
 /obj/machinery/sleeper/attackby(var/obj/item/I, var/mob/user)
-	add_fingerprint(user)
+	if(!istype(I, /obj/item/forensics))
+		add_fingerprint(user)
 	if(istype(I, /obj/item/reagent_containers/glass))
 		if(!beaker)
 			beaker = I

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -746,7 +746,8 @@
 			return 1
 
 /obj/machinery/alarm/attackby(obj/item/W as obj, mob/user as mob)
-	src.add_fingerprint(user)
+	if(!istype(W, /obj/item/forensics))
+		src.add_fingerprint(user)
 
 	switch(buildstage)
 		if(2)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -263,7 +263,8 @@ update_flag
 	if(!W.iswrench() && !istype(W, /obj/item/tank) && !istype(W, /obj/item/device/analyzer) && !istype(W, /obj/item/device/pda))
 		visible_message("<span class='warning'>\The [user] hits \the [src] with \a [W]!</span>")
 		src.health -= W.force
-		src.add_fingerprint(user)
+		if(!istype(W, /obj/item/forensics))
+			src.add_fingerprint(user)
 		healthcheck()
 
 	if(istype(user, /mob/living/silicon/robot) && istype(W, /obj/item/tank/jetpack))

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -24,6 +24,8 @@
 		to_chat(user, "Error, no route to host.")
 
 /obj/machinery/button/remote/attackby(obj/item/W, mob/user as mob)
+	if(istype(W, /obj/item/forensics))
+		return
 	return src.attack_hand(user)
 
 /obj/machinery/button/remote/emag_act(var/remaining_charges, var/mob/user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1014,7 +1014,8 @@ About the new airlock wires panel:
 				return
 	if(istype(C, /obj/item/taperoll))
 		return
-	src.add_fingerprint(user)
+	if(!istype(C, /obj/item/forensics))
+		src.add_fingerprint(user)
 	if (!repairing && (stat & BROKEN) && src.locked) //bolted and broken
 		if (!cut_bolts(C,user))
 			..()

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -116,7 +116,8 @@
 // Description: If we are clicked with crowbar or wielded fire axe, try to manually open the door.
 // This only works on broken doors or doors without power. Also allows repair with Plasteel.
 /obj/machinery/door/blast/attackby(obj/item/C as obj, mob/user as mob)
-	src.add_fingerprint(user)
+	if(!istype(C, /obj/item/forensics))
+		src.add_fingerprint(user)
 	if((istype(C, /obj/item/material/twohanded/fireaxe) && C:wielded == 1) || (istype(C, /obj/item/melee/hammer)))
 		if (((stat & NOPOWER) || 	(stat & BROKEN)) && !( src.operating ))
 			force_toggle()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -274,7 +274,8 @@
 	..()
 
 /obj/machinery/door/attackby(obj/item/I as obj, mob/user as mob)
-	src.add_fingerprint(user)
+	if(!istype(I, /obj/item/forensics))
+		src.add_fingerprint(user)
 
 	if(istype(I, /obj/item/stack/material) && I.get_material_name() == src.get_material_name())
 		if(stat & BROKEN)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -260,7 +260,8 @@
 		close()
 
 /obj/machinery/door/firedoor/attackby(obj/item/C as obj, mob/user as mob)
-	add_fingerprint(user)
+	if(!istype(C, /obj/item/forensics))
+		add_fingerprint(user)
 	if(operating)
 		return//Already doing something.
 	if(C.iswelder() && !repairing)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -220,8 +220,8 @@
 			take_damage(aforce)
 		return
 
-
-	src.add_fingerprint(user)
+	if(!istype(I, /obj/item/forensics))
+		src.add_fingerprint(user)
 
 	if (src.allowed(user))
 		if (src.density)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -83,7 +83,10 @@
 	..()
 
 /obj/machinery/firealarm/attackby(obj/item/W as obj, mob/user as mob)
-	src.add_fingerprint(user)
+	if(!istype(W, /obj/item/forensics))
+		src.add_fingerprint(user)
+	else
+		return
 
 	if (W.isscrewdriver() && buildstage == 2)
 		if(!wiresexposed)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -164,7 +164,8 @@ datum/track/New(var/title_name, var/audio)
 	qdel(src)
 
 /obj/machinery/media/jukebox/attackby(obj/item/W as obj, mob/user as mob)
-	src.add_fingerprint(user)
+	if(!istype(W, /obj/item/forensics))
+		src.add_fingerprint(user)
 
 	if(W.iswrench())
 		if(playing)

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -99,7 +99,8 @@
 	return
 
 /obj/machinery/pipedispenser/attackby(var/obj/item/W as obj, var/mob/user as mob)
-	src.add_fingerprint(usr)
+	if(!istype(W, /obj/item/forensics))
+		src.add_fingerprint(usr)
 	if (istype(W, /obj/item/pipe) || istype(W, /obj/item/pipe_meter))
 		to_chat(usr, "<span class='notice'>You put [W] back to [src].</span>")
 		user.drop_from_inventory(W,get_turf(src))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -363,7 +363,8 @@
 	W.on_enter_storage(src)
 	if(user)
 		W.dropped(user)
-		add_fingerprint(user)
+		if(!istype(W, /obj/item/forensics))
+			add_fingerprint(user)
 
 		if(!prevent_warning)
 			for(var/mob/M in viewers(user, null))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -440,7 +440,8 @@
 
 	if (istype(user, /mob/living/silicon) && get_dist(src,user)>1)
 		return src.attack_hand(user)
-	src.add_fingerprint(user)
+	if(!istype(W, /obj/item/forensics))
+		src.add_fingerprint(user)
 	if (W.iscrowbar() && opened)
 		if (has_electronics==1)
 			if (terminal)

--- a/html/changelogs/crosarius-forensics-machinery-fix.yml
+++ b/html/changelogs/crosarius-forensics-machinery-fix.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Crosarius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Adds checks to some machinery/airlocks/alarms/buttons to preclude forensics items from applying fibers/fingterprints BEFORE you take a sample."
+  - rscadd: "Stops fire alarms and remote airlock/blastdoor/etc buttons from being triggered when you use a forensics item on them, in addition to the above changes."
+  - rscadd: "Adds a check to the to preclude forensics items from applying fibers/fingterprints BEFORE you take the sample when you put an item in a bag."


### PR DESCRIPTION
Makes it so that using the forensics item on certain machinery such as airlocks, alarms, APCs, buttons, windoors etc doesn't apply fingerprints/fibers. This is necessary because these machines will call add_fingerprint BEFORE the forensic kit is used, thus polluting the sample with your own fibers, which is extremely annoying

Also made it so that using a forensics item on a fire alarm or button doesn't make you trigger them, because that's also really annoying.

Babby's first PR, I'm dead certain that I've done something wrong here, or even many things wrong.