### PR TITLE
Gunshots now show up on autopsies

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -62,7 +62,7 @@
 	return 0
 
 
-/mob/living/bullet_act(var/obj/item/projectile/P, var/def_zone)
+/mob/living/bullet_act(var/obj/item/projectile/P, var/def_zone, var/used_weapon = null)
 
 	//Being hit while using a cloaking device
 	var/obj/item/cloaking_device/C = locate(/obj/item/cloaking_device) in src
@@ -96,7 +96,7 @@
 		proj_edge = 0
 
 	if(!P.nodamage)
-		apply_damage(P.damage, P.damage_type, def_zone, absorb, 0, P, sharp=proj_sharp, edge=proj_edge, damage_flags = P.damage_flags)
+		apply_damage(P.damage, P.damage_type, def_zone, absorb, 0, P, sharp=proj_sharp, edge=proj_edge, damage_flags = P.damage_flags, used_weapon = "\the [P.shot_from] [P.name]")
 	P.on_hit(src, absorb, def_zone)
 	return absorb
 

--- a/html/changelogs/crosarius-autopsy-fixes.yml
+++ b/html/changelogs/crosarius-autopsy-fixes.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Bullet_act now passes on the fact that the weapon used is a bullet, as well as the weapon that fired said bullet. This means that autopsies will now show gunshot wounds."

--- a/html/changelogs/crosarius-autopsy-fixes.yml
+++ b/html/changelogs/crosarius-autopsy-fixes.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.  
-author: ChangeMe
+author: Crosarius
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
This makes gunshots (yes, both lasers and ballistics) actually pass on the correct information that allows autopsy data to show up. Now when you shoot people with guns, an autopsy will show them the fact that they were shot, as well as the gun that was used to shoot them (Otherwise it would just say "the bullet")

Previously you could shoot someone dead and the autopsy would come up with absolutely nothing.

A big thankyou to mattatlas for getting me to install VSC, which helped me track down bullet_act, and toPoZe for letting me know that both .shot_from and .name are a thing.