### PR TITLE
Fixing GC issues with pipes

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -45,10 +45,6 @@ Pipelines + Other Objects -> Pipe network
 	if (mapload)
 		return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/atmospherics/Destroy()
-	..()
-	return QDEL_HINT_HARDDEL	// fuck it
-
 /obj/machinery/atmospherics/proc/atmos_init()
 
 // atmos_init() and Initialize() must be separate, as atmos_init() can be called multiple times after the machine has been initialized.

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -54,6 +54,10 @@
 
 /obj/machinery/atmospherics/unary/vent_scrubber/Destroy()
 	unregister_radio(src, frequency)
+	if(initial_loc)
+		initial_loc.air_scrub_info -= id_tag
+		initial_loc.air_scrub_names -= id_tag
+
 	return ..()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/update_icon(var/safety = 0)
@@ -310,9 +314,4 @@
 	if(welded)
 		to_chat(user, "It seems welded shut.")
 
-/obj/machinery/atmospherics/unary/vent_scrubber/Destroy()
-	if(initial_loc)
-		initial_loc.air_scrub_info -= id_tag
-		initial_loc.air_scrub_names -= id_tag
 
-	return ..()

--- a/code/ATMOSPHERICS/datum_pipe_network.dm
+++ b/code/ATMOSPHERICS/datum_pipe_network.dm
@@ -84,7 +84,7 @@
 	line_members = null
 
 	for (var/obj/machinery/atmospherics/thing in normal_members)
-		thing.remove_network(src)
+		thing.reassign_network(src, null)
 
 	normal_members = null
 

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -20,6 +20,8 @@
 	for (var/obj/machinery/atmospherics/pipe/thing in members)
 		thing.parent = null
 
+	members = null
+
 	return ..()
 
 /datum/pipeline/process()//This use to be called called from the pipe networks

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -67,7 +67,6 @@
 	QDEL_NULL(parent)
 	if(air_temporary)
 		loc.assume_air(air_temporary)
-		QDEL_NULL(air_temporary)
 
 	return ..()
 
@@ -233,11 +232,10 @@
 /obj/machinery/atmospherics/pipe/simple/Destroy()
 	if(node1)
 		node1.disconnect(src)
+		node1 = null
 	if(node2)
 		node2.disconnect(src)
-
-	node1 = null
-	node2 = null
+		node2 = null
 
 	return ..()
 
@@ -467,14 +465,13 @@
 /obj/machinery/atmospherics/pipe/manifold/Destroy()
 	if(node1)
 		node1.disconnect(src)
+		node1 = null
 	if(node2)
 		node2.disconnect(src)
+		node2 = null
 	if(node3)
 		node3.disconnect(src)
-
-	node1 = null
-	node2 = null
-	node3 = null
+		node3 = null
 
 	return ..()
 
@@ -712,17 +709,16 @@
 /obj/machinery/atmospherics/pipe/manifold4w/Destroy()
 	if(node1)
 		node1.disconnect(src)
+		node1 = null
 	if(node2)
 		node2.disconnect(src)
+		node2 = null
 	if(node3)
 		node3.disconnect(src)
+		node3 = null
 	if(node4)
 		node4.disconnect(src)
-
-	node1 = null
-	node2 = null
-	node3 = null
-	node4 = null
+		node4 = null
 
 	return ..()
 

--- a/html/changelogs/Sindorman-pipes.yml
+++ b/html/changelogs/Sindorman-pipes.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - backend: "Pipes no longer call hard delete when destroyed. This makes them not slowdown/freeze server during explosions due to them no longer being deleted immediately, but rather use queued delete."


### PR DESCRIPTION
- Lohikar suggested that Bay has fixes issue with GC of pipes. This ports their fixes from PR https://github.com/Baystation12/Baystation12/pull/23457

Essentially:

- All atoms Pipes are now properly destroyed

- Atmos pipes no longer call hard del whenever you destroy them. Making this improve performance a lot during explosions.