### PR TITLE
Replaces the pickaxes in Research EVA prep with mining drills

### DIFF
--- a/html/changelogs/Leudoberct1-xenoarchdrills.yml
+++ b/html/changelogs/Leudoberct1-xenoarchdrills.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Leudoberct1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Replaces the pickaxes in the research EVA preparation area with mining drills."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -11974,6 +11974,44 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
+"atU" = (
+/obj/structure/table/rack,
+/obj/item/pickaxe/drill{
+	pixel_y = 5
+	},
+/obj/item/pickaxe/drill{
+	pixel_y = -5
+	},
+/turf/simulated/floor/airless{
+	icon_state = "asteroidplating"
+	},
+/area/mine/unexplored)
+"atV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/structure/table/steel,
+/obj/item/stack/flag/purple,
+/obj/item/stack/flag/purple,
+/obj/item/storage/box/excavation,
+/obj/item/wrench,
+/obj/item/device/measuring_tape,
+/obj/item/device/suit_cooling_unit/improved,
+/obj/item/device/suit_cooling_unit/improved,
+/obj/item/pickaxe/drill,
+/turf/simulated/floor/tiled,
+/area/rnd/eva)
+"atW" = (
+/obj/structure/table/steel,
+/obj/item/stack/flag/green,
+/obj/item/stack/flag/green,
+/obj/item/storage/box/excavation,
+/obj/item/wrench,
+/obj/item/device/measuring_tape,
+/obj/item/pickaxe/drill,
+/turf/simulated/floor/tiled,
+/area/rnd/eva)
 "atX" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -13336,22 +13374,6 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical_sublevel)
-"axO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/structure/table/steel,
-/obj/item/stack/flag/purple,
-/obj/item/stack/flag/purple,
-/obj/item/storage/box/excavation,
-/obj/item/pickaxe,
-/obj/item/wrench,
-/obj/item/device/measuring_tape,
-/obj/item/device/suit_cooling_unit/improved,
-/obj/item/device/suit_cooling_unit/improved,
-/turf/simulated/floor/tiled,
-/area/rnd/eva)
 "axP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -28972,20 +28994,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"dpL" = (
-/obj/structure/table/rack,
-/obj/item/pickaxe{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/pickaxe{
-	pixel_x = -2;
-	pixel_y = -5
-	},
-/turf/simulated/floor/airless{
-	icon_state = "asteroidplating"
-	},
-/area/mine/unexplored)
 "dqy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/lime{
@@ -32649,16 +32657,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
-"mio" = (
-/obj/structure/table/steel,
-/obj/item/stack/flag/green,
-/obj/item/stack/flag/green,
-/obj/item/storage/box/excavation,
-/obj/item/pickaxe,
-/obj/item/wrench,
-/obj/item/device/measuring_tape,
-/turf/simulated/floor/tiled,
-/area/rnd/eva)
 "mjH" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -57952,7 +57950,7 @@ aba
 aba
 eCz
 ebn
-dpL
+atU
 jbg
 boe
 aba
@@ -58984,8 +58982,8 @@ awl
 jlY
 avJ
 jMR
-axO
-mio
+atV
+atW
 jOy
 nqY
 qNw

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -12029,6 +12029,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/rnd/eva)
+"atY" = (
+/obj/structure/table/rack,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/pickaxe/drill,
+/turf/simulated/floor/plating,
+/area/rnd/xenoarch_storage)
 "aub" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -37177,23 +37195,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_wing_picnic)
-"wKw" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/turf/simulated/floor/plating,
-/area/rnd/xenoarch_storage)
 "wKL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -60520,7 +60521,7 @@ avO
 awp
 adY
 aff
-wKw
+atY
 awp
 avX
 avX


### PR DESCRIPTION
With the changes to research levels, a mining drill can be produced straight away at roundstart with no research required. Because of this, I feel like it's justifiable for the pickaxes in the EVA prep area to be replaced with standard mining drills.