### PR TITLE
Xenoarch fixes

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/effect.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effect.dm
@@ -106,7 +106,7 @@ proc/GetAnomalySusceptibility(var/mob/living/carbon/human/H)
 		protected += 0.2
 
 	//latex gloves and science goggles also give a bit of bonus protection
-	if(istype(H.gloves,/obj/item/clothing/gloves/latex))
+	if(istype(H.gloves,/obj/item/clothing/gloves/latex/nitrile))
 		protected += 0.1
 	/*
 	If you have Anomaly Suit, Anomaly Hood, Latex Gloves AND Science Goggles, you will have

--- a/html/changelogs/Leudoberct1-xenoarchatriumfix.yml
+++ b/html/changelogs/Leudoberct1-xenoarchatriumfix.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - maptweak: "Fixes a disconnected vent in the Xenoarch atrium"
+  - maptweak: "Fixes a disconnected vent in the Xenoarch atrium, fixes an issue with the anomaly scanner in the pit, adds a bookcase."

--- a/html/changelogs/Leudoberct1-xenoarchatriumfix.yml
+++ b/html/changelogs/Leudoberct1-xenoarchatriumfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Leudoberct1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Fixes a disconnected vent in the Xenoarch atrium"

--- a/html/changelogs/Leudoberct1-xenoarchatriumfix.yml
+++ b/html/changelogs/Leudoberct1-xenoarchatriumfix.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - maptweak: "Fixes a disconnected vent in the Xenoarch atrium, fixes an issue with the anomaly scanner in the pit, adds a bookcase."
+  - tweak: "Fixes the protection check in effect.dm to recognise nitrile gloves."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -11974,6 +11974,23 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
+"atU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/mauve{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/xenoarch_atrium)
 "atX" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -61047,7 +61064,7 @@ ayW
 ayW
 ayW
 ayW
-ayW
+atU
 aqG
 atf
 atq

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -3930,20 +3930,12 @@
 	},
 /area/maintenance/substation/engineering_sublevel)
 "ahX" = (
-/obj/machinery/artifact_scanpad,
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 9
-	},
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 6
-	},
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
 	dir = 1
 	},
-/turf/simulated/floor/greengrid,
+/obj/structure/bookcase/manuals/xenoarchaeology,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "ahY" = (
 /turf/simulated/floor/plating,
@@ -11990,6 +11982,18 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
+/area/rnd/xenoarch_atrium)
+"atV" = (
+/obj/machinery/artifact_scanpad,
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 9
+	},
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 6
+	},
+/turf/simulated/floor/greengrid,
 /area/rnd/xenoarch_atrium)
 "atX" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -62085,8 +62089,8 @@ awN
 akl
 ash
 alp
-ahX
-azR
+alq
+atV
 azR
 azR
 azR
@@ -62342,7 +62346,7 @@ asr
 aqH
 aiL
 alQ
-alq
+ahX
 azR
 azR
 azR


### PR DESCRIPTION
Fixes a disconnected vent in xenoarch, fixes the anomaly scanner in the pit scanning a window, adds a bookcase to make up for the empty space created. Fixed a protection check to recognise nitrile gloves now that we use them instead of latex.