### PR TITLE
Adds Players "high" job preference next to their name, once they ready up in lobby

### DIFF
--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -87,8 +87,28 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			stat("Players: [totalPlayers]", "Players Ready: [totalPlayersReady]")
 			totalPlayers = 0
 			totalPlayersReady = 0
-			for(var/mob/abstract/new_player/player in player_list)
-				stat("[player.key]", (player.ready)?("(Playing)"):(null))
+
+			//Determine high job and display it next to "ready"
+			var/highjob
+			for(var/mob/abstract/new_player/player in player_list) //for every player on the server
+				for(var/datum/job/job in SSjobs.occupations) //for every job available
+					var/job_flag
+					switch(job.department_flag)
+						if(CIVILIAN)
+							job_flag = player.client.prefs.job_civilian_high
+						if(MEDSCI)
+							job_flag = player.client.prefs.job_medsci_high
+						if(ENGSEC)
+							job_flag = player.client.prefs.job_engsec_high
+					if(job.flag == job_flag) //Checks if that job is the players high choice
+						highjob = job.title
+						break
+					if(player.client.prefs.job_civilian_low & ASSISTANT) // Need to do a separate check for assistant or it will show as blank
+						highjob = "Assistant"
+						break
+				if(!highjob) //If you have no high preference, you get "No preference"
+					highjob = "No preference"
+				stat("[player.key]", (player.ready)?("(Playing as [highjob])"):(null))
 				totalPlayers++
 				if(player.ready)
 					totalPlayersReady++

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -89,8 +89,8 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			totalPlayersReady = 0
 
 			//Determine high job and display it next to "ready"
-			var/highjob
 			for(var/mob/abstract/new_player/player in player_list) //for every player on the server
+				var/highjob
 				for(var/datum/job/job in SSjobs.occupations) //for every job available
 					var/job_flag
 					switch(job.department_flag)

--- a/html/changelogs/Nero-07.yml
+++ b/html/changelogs/Nero-07.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added Players high job preference next to their name in the lobby, once they ready up. No high preference shows as "No preference""
+  - rscadd: "Added Players high job preference next to their name in the lobby, once they ready up. No high preference shows as No preference"

--- a/html/changelogs/Nero-07.yml
+++ b/html/changelogs/Nero-07.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Nero-07
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added Players high job preference next to their name in the lobby, once they ready up. No high preference shows as "No preference""


### PR DESCRIPTION
So you can get an idea how hotly contested your desired role is and may switch to another character if there's already a janitor readied up.

Should theoretically lead to people getting their choice more often.

Looks like this: https://cdn.discordapp.com/attachments/157531783779319808/658357234757140496/unknown.png