### PR TITLE
Fixes to IC list pin editing

### DIFF
--- a/html/changelogs/aleksix-ic_list_pin_editing.yml
+++ b/html/changelogs/aleksix-ic_list_pin_editing.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+  
+author: aleksix
+
+delete-after: True
+
+changes: 
+  - bugfix: "Integrated Circuit list elements can now be properly edited in-place"
+  - rscadd: "Edit/Remove buttons for editing Integrated Circuits lists"


### PR DESCRIPTION
Fixes the integrated circuits list item editing. Before, half the functions were broken (not allowing in-place modifications of any kind), the other half unused. This PR fixes in-place editing and adds buttons for selecting items to edit.