### PR TITLE
Fixes DNA switch artifact bug

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_dnaswitch.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_dnaswitch.dm
@@ -15,8 +15,8 @@
 /datum/artifact_effect/dnaswitch/DoEffectTouch(var/mob/toucher)
 	var/weakness = GetAnomalySusceptibility(toucher)
 	if(ishuman(toucher) && prob(weakness * 100))
-		var/DoEffectAuraVariable = "<span class='good'>[pick("You feel a little different.","You feel very strange.","Your stomach churns.","Your skin feels loose.","You feel a stabbing pain in your head.")]</span>"
-		to_chat(toucher, DoEffectAuraVariable)
+		var/DoEffectTouchVariable = "<span class='good'>[pick("You feel a little different.","You feel very strange.","Your stomach churns.","Your skin feels loose.","You feel a stabbing pain in your head.")]</span>"
+		to_chat(toucher, DoEffectTouchVariable)
 		if(prob(75))
 			scramble(1, toucher, weakness * severity)
 		else

--- a/html/changelogs/Leudoberct1-dnaswitchfix.yml
+++ b/html/changelogs/Leudoberct1-dnaswitchfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Leudoberct1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes the DNA switch effect acting like an aura when it should be touch."


### PR DESCRIPTION
For whatever reason, the touch effect check of the DNA switch artifact effect acted as if it was an aura, and also did not have a check for protection, meaning that it caused a DNA switch effect in a large area with absolutely zero way to protect yourself against it. This should fix that.