### PR TITLE
Fixes powered crossbow not consuming its energy cell

### DIFF
--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -160,7 +160,7 @@
 
 	if(istype(W, /obj/item/cell))
 		if(!cell)
-			user.drop_from_inventory(cell,src)
+			user.drop_from_inventory(W, src)
 			cell = W
 			to_chat(user, "<span class='notice'>You jam [cell] into [src] and wire it to the firing coil.</span>")
 			superheat_rod(user)
@@ -180,12 +180,16 @@
 		..()
 
 /obj/item/gun/launcher/crossbow/proc/superheat_rod(var/mob/user)
-	if(!user || !cell || !bolt) return
-	if(cell.charge < 500) return
-	if(bolt.throwforce >= 15) return
-	if(!istype(bolt,/obj/item/arrow/rod)) return
+	if(!user || !cell || !bolt)
+		return
+	if(cell.charge < 500)
+		return
+	if(bolt.throwforce >= 15)
+		return
+	if(!istype(bolt,/obj/item/arrow/rod))
+		return
 
-	to_chat(user, "<span class='notice'>[bolt] plinks and crackles as it begins to glow red-hot.</span>")
+	to_chat(user, "<span class='warning'>[bolt] plinks and crackles as it begins to glow red-hot.</span>")
 	bolt.throwforce = 15
 	bolt.icon_state = "metal-rod-superheated"
 	cell.use(500)

--- a/html/changelogs/skull132-crossbows.yml
+++ b/html/changelogs/skull132-crossbows.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - bugfix: "Powered crossbow now properly consumes the energy cell when applied."


### PR DESCRIPTION
The energy cell doesn't get moved to the crossbow when used on it. The rest works, though.

I also made the message about the rod getting supercharged stand out a bit more.