### PR TITLE
Fixes long hair not being caught in some machines

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -103,15 +103,7 @@
 		qdel(W)
 		user.visible_message("<span class='danger'>\The [user] feeds \the [W] into \the [src], obliterating it.</span>")
 
-	if(istype(user, /mob/living/carbon/human))
-		var/mob/living/carbon/human/M = user
-		if(M.h_style == "Floorlength Braid" || M.h_style == "Very Long Hair")
-			if(prob(10))
-				M.apply_damage(30, BRUTE, BP_HEAD)
-				M.apply_damage(45, PAIN)
-				M.visible_message("<span class='danger'>[user]'s hair catches in the [src]!</span>", "<span class='danger'>Your hair gets caught in the [src]!</span>")
-				M.say("*scream")
-
+	do_hair_pull(user)
 
 /obj/machinery/gibber/MouseDrop_T(mob/target, mob/user)
 	if(user.stat || user.restrained())

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -420,7 +420,7 @@ Class Procs:
 	paper.forceMove(loc)
 	printing = FALSE
 
-/obj/machinery/proc/do_hair_pull(mob/living/carbon/human/H, var/do_damage = TRUE)
+/obj/machinery/proc/do_hair_pull(mob/living/carbon/human/H)
 	if(!ishuman(H))
 		return
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -420,9 +420,10 @@ Class Procs:
 	paper.forceMove(loc)
 	printing = FALSE
 
-/obj/machinery/proc/do_hair_pull(mob/living/carbon/human/H)
+/obj/machinery/proc/do_hair_pull(mob/living/carbon/human/H, var/do_damage = TRUE)
 	if(!ishuman(H))
 		return
+
 	if(isskrell(H)) //for whatever reason, skrell's tentacles have a really long length
 		return
 
@@ -436,7 +437,7 @@ Class Procs:
 
 	if(hair_style.length >= 4)
 		if(prob(25))
-			H.apply_damage(30, BRUTE, "head")
+			H.apply_damage(30, BRUTE, BP_HEAD)
 			H.visible_message("<span class='danger'>[H]'s hair catches in the [src]!</span>", "<span class='danger'>Your hair gets caught in the [src]!</span>")
 			if(H.can_feel_pain())
 				H.emote("scream")

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -438,7 +438,7 @@ Class Procs:
 	if(hair_style.length >= 4)
 		if(prob(25))
 			H.apply_damage(30, BRUTE, BP_HEAD)
-			H.visible_message("<span class='danger'>[H]'s hair catches in the [src]!</span>", "<span class='danger'>Your hair gets caught in the [src]!</span>")
+			H.visible_message("<span class='danger'>[H]'s hair catches in \the [src]!</span>", "<span class='danger'>Your hair gets caught in \the [src]!</span>")
 			if(H.can_feel_pain())
 				H.emote("scream")
 				H.apply_damage(45, PAIN)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -419,3 +419,25 @@ Class Procs:
 /obj/machinery/proc/print_move_paper(obj/paper)
 	paper.forceMove(loc)
 	printing = FALSE
+
+/obj/machinery/proc/do_hair_pull(mob/living/carbon/human/H)
+	if(!ishuman(H))
+		return
+	if(isskrell(H)) //for whatever reason, skrell's tentacles have a really long length
+		return
+
+	if(isunathi(H)) //horns would not get caught in the machine
+		return
+
+	var/datum/sprite_accessory/hair/hair_style = hair_styles_list[H.h_style]
+	for(var/obj/item/protection in list(H.head))
+		if(protection && (protection.flags_inv & BLOCKHAIR))
+			return
+
+	if(hair_style.length >= 4)
+		if(prob(25))
+			H.apply_damage(30, BRUTE, "head")
+			H.visible_message("<span class='danger'>[H]'s hair catches in the [src]!</span>", "<span class='danger'>Your hair gets caught in the [src]!</span>")
+			if(H.can_feel_pain())
+				H.emote("scream")
+				H.apply_damage(45, PAIN)

--- a/code/game/machinery/mecha_fabricator.dm
+++ b/code/game/machinery/mecha_fabricator.dm
@@ -201,24 +201,30 @@
 	if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || istype(user, /mob/living/silicon/ai))
 		return
 	if(target == user)
-		if(target.h_style == "Floorlength Braid" || target.h_style == "Very Long Hair")
-			user.visible_message(span("notice", "[user] looks like they're about to feed their own hair into the [src], but think better of it."), span("notice", "You grasp your hair and are about to feed it into the [src], but stop and come to your senses."))
-			return
+		return
 	src.add_fingerprint(user)
 	var/target_loc = target.loc
+
 	if(target != user && !user.restrained() && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
-		if(target.h_style != "Cut Hair" || target.h_style != "Short Hair" || target.h_style != "Skinhead" || target.h_style != "Buzzcut" || target.h_style != "Crewcut" || target.h_style != "Bald" || target.h_style != "Balding Hair")
-			user.visible_message("<span class='warning'>[user] starts feeding [target]'s hair into the [src]!</span>", "<span class='warning'>You start feeding [target]'s hair into the [src]!</span>")
+		if(isskrell(target) || isunathi(target))
+			return
+
+		for(var/obj/item/protection in list(target.head))
+			if(protection && (protection.flags_inv & BLOCKHAIR))
+				return
+
+		var/datum/sprite_accessory/hair/hair_style = hair_styles_list[target.h_style]
+		if(hair_style.length < 4)
+			return
+
+		user.visible_message("<span class='warning'>[user] starts feeding [target]'s hair into the [src]!</span>", "<span class='warning'>You start feeding [target]'s hair into the [src]!</span>")
 		if(!do_after(usr, 50))
 			return
 		if(target_loc != target.loc)
 			return
 		if(target != user && !user.restrained() && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
 			user.visible_message(span("warning", "[user] feeds the [target]'s hair into the [src] and flicks it on!"), span("alert", "You turn the [src] on!"))
-			target.apply_damage(30, BRUTE, "head")
-			target.apply_damage(25, PAIN)
-			target.say("*scream")
-
+			do_hair_pull(target)
 			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Has fed [target.name]'s ([target.ckey]) hair into a [src].</font>")
 			target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had their hair fed into [src] by [user.name] ([user.ckey])</font>")
 			msg_admin_attack("[key_name_admin(user)] fed [key_name_admin(target)] in a [src]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)",ckey=key_name(user),ckey_target=key_name(target))
@@ -230,9 +236,7 @@
 			return
 		if(target != user && !user.restrained() && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
 			user.visible_message(span("alert", "[user] starts tugging on [target]'s head as the [src] keeps running!"), span("alert", "You start tugging on [target]'s head!"))
-			target.apply_damage(25, BRUTE, "head")
-			target.apply_damage(10, PAIN)
-			target.say("*scream")
+			do_hair_pull(target)
 			spawn(10)
 			user.visible_message(span("alert", "[user] stops the [src] and leaves [target] resting as they are."), span("alert", "You turn the [src] off and let go of [target]."))
 

--- a/code/game/machinery/mecha_fabricator.dm
+++ b/code/game/machinery/mecha_fabricator.dm
@@ -86,14 +86,7 @@
 		return
 	if(!allowed(user))
 		return
-	if(ishuman(user))
-		var/mob/living/carbon/human/M = user
-		if(M.h_style == "Floorlength Braid" || M.h_style == "Very Long Hair")
-			if(prob(10))
-				M.apply_damage(30, BRUTE, "head")
-				M.apply_damage(45, PAIN)
-				M.visible_message("<span class='danger'>[user]'s hair catches in the [src]!</span>", "<span class='danger'>Your hair gets caught in the [src]!</span>")
-				M.say("*scream")
+	do_hair_pull(user)
 	ui_interact(user)
 
 /obj/machinery/mecha_part_fabricator/ui_interact(var/mob/user, var/ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)

--- a/code/game/machinery/mecha_fabricator.dm
+++ b/code/game/machinery/mecha_fabricator.dm
@@ -217,7 +217,7 @@
 		if(hair_style.length < 4)
 			return
 
-		user.visible_message("<span class='warning'>[user] starts feeding [target]'s hair into the [src]!</span>", "<span class='warning'>You start feeding [target]'s hair into the [src]!</span>")
+		user.visible_message("<span class='warning'>[user] starts feeding [target]'s hair into \the [src]!</span>", "<span class='warning'>You start feeding [target]'s hair into \the [src]!</span>")
 		if(!do_after(usr, 50))
 			return
 		if(target_loc != target.loc)

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -7,7 +7,6 @@
 	icon_state = "space"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
 	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL | AIRTIGHT
-	flags_inv = BLOCKHAIR
 	item_state_slots = list(
 		slot_l_hand_str = "s_helmet",
 		slot_r_hand_str = "s_helmet"

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -641,14 +641,7 @@
 	var/beaker_contents = ""
 	var/dat = ""
 
-	if(istype(user, /mob/living/carbon/human))
-		var/mob/living/carbon/human/M = user
-		if(M.h_style == "Floorlength Braid" || M.h_style == "Very Long Hair")
-			if(prob(10))
-				M.apply_damage(30, BRUTE, BP_HEAD)
-				M.apply_damage(45, PAIN)
-				M.visible_message("<span class='warning'>[user]'s hair catches in the [src]!</span>", "<span class='danger'>Your hair gets caught in the [src]!</span>")
-				M.say("*scream")
+	do_hair_pull(user)
 
 	if(!inuse)
 		for (var/obj/item/O in holdingitems)

--- a/html/changelogs/alberyk-haircatching.yml
+++ b/html/changelogs/alberyk-haircatching.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed gibbers, grinders and robotics fabricator not catching long hair."


### PR DESCRIPTION
This feature was broken due to some hair name changes. The entire stuff was remade to be a proc in the machinery object, that also checks for any hair with a length longer than four.