### PR TITLE
Allows bounced radios to be stored in belts. 

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -54,7 +54,8 @@
 		/obj/item/device/analyzer/plant_analyzer,
 		/obj/item/extinguisher/mini,
 		/obj/item/pipewrench,
-		/obj/item/powerdrill
+		/obj/item/powerdrill,
+		/obj/item/device/radio
 		)
 
 
@@ -115,7 +116,8 @@
 		/obj/item/crowbar,
 		/obj/item/device/flashlight,
 		/obj/item/extinguisher/mini,
-		/obj/item/device/antibody_scanner
+		/obj/item/device/antibody_scanner,
+		/obj/item/device/radio
 		)
 
 /obj/item/storage/belt/medical/emt
@@ -155,7 +157,8 @@
 		/obj/item/material/knife/trench,
 		/obj/item/shield/energy,
 		/obj/item/shield/riot/tact,
-		/obj/item/device/holowarrant
+		/obj/item/device/holowarrant,
+		/obj/item/device/radio
 		)
 
 /obj/item/storage/belt/soulstone
@@ -221,7 +224,8 @@
 		/obj/item/card/emag,
 		/obj/item/device/multitool/hacktool,
 		/obj/item/reagent_containers/hypospray/combat,
-		/obj/item/stack/telecrystal
+		/obj/item/stack/telecrystal,
+		/obj/item/device/radio
 		)
 
 /obj/item/storage/belt/military/syndicate
@@ -349,6 +353,7 @@
 		/obj/item/reagent_containers/spray, //includes if you ever wish to get a spraybottle full of other chemicals, Like water
 		/obj/item/device/analyzer/plant_analyzer,
 		/obj/item/clothing/gloves/botanic_leather,
+		/obj/item/device/radio
 	)
 
 /obj/item/storage/belt/ninja //credits to BurgerBB
@@ -387,7 +392,8 @@
 		/obj/item/reagent_containers,
 		/obj/item/stack/telecrystal,
 		/obj/item/material/sword,
-		/obj/item/material/star
+		/obj/item/material/star,
+		/obj/item/device/radio
 	)
 
 /obj/item/storage/belt/fannypack

--- a/html/changelogs/Aboshehab - handheld for belts.yml
+++ b/html/changelogs/Aboshehab - handheld for belts.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Aboshehab
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Station bounced radio can now be stored in most belts."


### PR DESCRIPTION
Added /obj/item/device/radio to the allowed items in the majority of belts that we can expect to see on station usually. Just added the path to the lists.

