### PR TITLE
Fixes examining item not taking in consideration all possible examine information.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -146,8 +146,10 @@
 
 	to_chat(user, "\icon[src] That's [f_name] [suffix]")
 	to_chat(user, desc)
-	if(description_fluff || description_info)
+	if(description_info)
 		to_chat(user, span("notice", "This item has additional examine info. <a href=?src=\ref[src];examine=fluff>\[View\]</a>"))
+	if(description_fluff)
+		to_chat(user, span("notice", "This item has additional lore info. <a href=?src=\ref[src];examine=fluff>\[View\]</a>"))
 	if(description_antag && player_is_antag(user.mind))
 		to_chat(user, span("notice", "This item has additional antag info. <a href=?src=\ref[src];examine=fluff>\[View\]</a>"))
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -146,10 +146,8 @@
 
 	to_chat(user, "\icon[src] That's [f_name] [suffix]")
 	to_chat(user, desc)
-	if(description_info)
+	if(description_info || description_fluff)
 		to_chat(user, span("notice", "This item has additional examine info. <a href=?src=\ref[src];examine=fluff>\[View\]</a>"))
-	if(description_fluff)
-		to_chat(user, span("notice", "This item has additional lore info. <a href=?src=\ref[src];examine=fluff>\[View\]</a>"))
 	if(description_antag && player_is_antag(user.mind))
 		to_chat(user, span("notice", "This item has additional antag info. <a href=?src=\ref[src];examine=fluff>\[View\]</a>"))
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -146,7 +146,7 @@
 
 	to_chat(user, "\icon[src] That's [f_name] [suffix]")
 	to_chat(user, desc)
-	if(description_fluff)
+	if(description_fluff || description_info)
 		to_chat(user, span("notice", "This item has additional examine info. <a href=?src=\ref[src];examine=fluff>\[View\]</a>"))
 	if(description_antag && player_is_antag(user.mind))
 		to_chat(user, span("notice", "This item has additional antag info. <a href=?src=\ref[src];examine=fluff>\[View\]</a>"))

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -8,7 +8,7 @@ LINEN BINS
 	name = "bedsheet"
 	desc = "A surprisingly soft linen bedsheet."
 	description_info = "Click to roll and unroll. Alt-click to fold and unfold. Drag and drop to pick up."
-	description_fluff = "It seems like you can equip it in your backpack slot..."
+	description_info  = "It seems like you can equip it in your backpack slot."
 	icon = 'icons/obj/bedsheets.dmi'
 	icon_state = "sheetwhite"
 	item_state = "sheetwhite"

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -7,8 +7,7 @@ LINEN BINS
 /obj/item/bedsheet
 	name = "bedsheet"
 	desc = "A surprisingly soft linen bedsheet."
-	description_info = "Click to roll and unroll. Alt-click to fold and unfold. Drag and drop to pick up."
-	description_info  = "It seems like you can equip it in your backpack slot."
+	description_info = "Click to roll and unroll. Alt-click to fold and unfold. Drag and drop to pick up. You can equip it in your backpack slot."
 	icon = 'icons/obj/bedsheets.dmi'
 	icon_state = "sheetwhite"
 	item_state = "sheetwhite"

--- a/html/changelogs/alberyk-fixesexamine.yml
+++ b/html/changelogs/alberyk-fixesexamine.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes examining items not taking in consideration all possible extra examine information."


### PR DESCRIPTION
This fixes description_info being ignored. Also fixes the bedsheet using description_fluff instead of description_info.