### PR TITLE
Fix greeting window malfunction

### DIFF
--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -73,6 +73,4 @@
 	var/obj/screen/plane_master/parallax_dustmaster/parallax_dustmaster = null
 	var/obj/screen/plane_master/parallax_spacemaster/parallax_spacemaster = null
 
-	var/initialized = FALSE
-
 	var/authed = TRUE

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -358,9 +358,9 @@
 		return m
 		//Do auth shit
 	else
-		. = ..()
 		src.InitClient()
 		src.InitPrefs()
+		. = ..()
 
 /client/proc/InitPrefs()
 	//preferences datum - also holds some persistant data for the client (because we may as well keep these datums to a minimum)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -385,8 +385,6 @@
 		server_greeting.display_to_client(src)
 
 /client/proc/InitClient()
-	if(initialized)
-		return
 	to_chat(src, "<span class='alert'>If the title screen is black, resources are still downloading. Please be patient until the title screen appears.</span>")
 
 	//Admin Authorisation
@@ -446,8 +444,6 @@
 	check_ip_intel()
 
 	fetch_unacked_warning_count()
-
-	initialized = TRUE
 
 //////////////
 //DISCONNECT//

--- a/code/modules/mob/abstract/new_player/login.dm
+++ b/code/modules/mob/abstract/new_player/login.dm
@@ -25,8 +25,6 @@
 	var/client/my_client // Need to keep track of this ourselves, since by the time Logout() is called the client has already been nulled
 
 /mob/abstract/new_player/Login()
-	client.InitClient()
-	client.InitPrefs()
 	update_Login_details()	//handles setting lastKnownIP and computer_id for use by the ban systems as well as checking for multikeying
 
 	to_chat(src, "<div class='info'>Game ID: <div class='danger'>[game_id]</div></div>")

--- a/code/modules/mob/abstract/unauthed/login.dm
+++ b/code/modules/mob/abstract/unauthed/login.dm
@@ -51,11 +51,14 @@
 	if(newkey)
 		client.key = newkey // Try seeting ckey
 	directory[c.ckey] = c
-	// If mob exists for that ckey, then BYOND will transfer client to it.
+	// Init the client and give it a new_player mob.
+	// Note that modifying the key variable does not invoke client/New() or client/Login() again.
+	c.InitClient()
+	c.InitPrefs()
+
 	if(istype(c.mob, /mob/abstract/unauthed))
-		c.mob = new /mob/abstract/new_player() // Else we just treat them as new player
-	c.InitClient() // And now we shall continue client initilization (permissions and stuff)
-	c.InitPrefs() // We init prefs just in case mob transfer didn't
+		c.mob = new /mob/abstract/new_player()
+
 	unauthed -= token
 
 /mob/abstract/unauthed/Topic(href, href_list)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -24,8 +24,6 @@
 						log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).",ckey=key_name(src))
 
 /mob/Login()
-	client.InitClient()
-	client.InitPrefs() // Init perfs in case they wasn't initilized
 	player_list |= src
 	update_Login_details()
 	SSfeedback.update_status()

--- a/html/changelogs/skull132_greeting-window.yml
+++ b/html/changelogs/skull132_greeting-window.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - bugfix: "The greeting window no longer malfunctions."


### PR DESCRIPTION
Fixes the greeting window malfunction message.

**The cause**:
InitPrefs and InitClient are being called relatively hap-hazardly in the client/New and mob/Login chains. Ideally, they would only be called once.

**The fix**:

- `mob/Login` called these two procs "just because lol". I removed it, because client/New is a reliable proc chain. And if it breaks already, then wew we have bigger issues.
- `new_player/Login` called them due to race conditions. This was solved by moving the calls to both to be _before_ we defer to `mob/Login` in the `client/New` stack. This should pull all of the DB information before anything uses it.
- `/mob/abstract/unauthed/proc/ClientLogin` still has to call these two procs. Since setting `client/key` does NOT invoke `client/New` with the new ckey. So we run the chain again, basically. Tested as functional on this count.