### PR TITLE
War on Christmas: Endgame, Removes some leftover cloning circuits

### DIFF
--- a/html/changelogs/Ferner-191229-mapping_endingchristmas.yml
+++ b/html/changelogs/Ferner-191229-mapping_endingchristmas.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - maptweak: "The station's christmas decor has been removed, did some misc map fixes including adding some missing shutters, access and other things. Added a no-smoking sign to the kitchen."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -555,77 +555,54 @@
 /turf/simulated/floor/holofloor/desert,
 /area/holodeck/source_desert)
 "abw" = (
-/obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/floor_decal/spline/fancy/wood/corner,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "abx" = (
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "aby" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/holofloor/desert,
 /area/holodeck/source_picnicarea)
 "abz" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 4
-	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 4
 	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "abA" = (
-/obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "abB" = (
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	icon_state = "spline_fancy_corner";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "abC" = (
 /obj/effect/landmark/costume,
@@ -684,12 +661,9 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "abO" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -700,20 +674,18 @@
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "abP" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/structure/flora/grass/green,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "abQ" = (
 /obj/effect/landmark{
@@ -778,21 +750,18 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/grass/green,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "acd" = (
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 9
+/obj/effect/floor_decal/spline/fancy/wood/cee{
+	icon_state = "spline_fancy_cee";
+	dir = 8
 	},
-/obj/structure/flora/grass/brown,
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "ace" = (
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -800,21 +769,18 @@
 	icon_state = "spline_fancy_corner";
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	icon_state = "spline_fancy_corner";
-	dir = 4
-	},
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "acf" = (
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 5
+/obj/effect/floor_decal/spline/fancy/wood/cee{
+	icon_state = "spline_fancy_cee";
+	dir = 4
 	},
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "acg" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -825,12 +791,9 @@
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/structure/flora/grass/brown,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "ach" = (
 /obj/structure/bed/chair/holochair,
@@ -1586,24 +1549,18 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "adM" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+/obj/effect/floor_decal/spline/fancy/wood/cee{
+	icon_state = "spline_fancy_cee";
+	dir = 8
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 10
-	},
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "adN" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -1615,20 +1572,18 @@
 	icon_state = "spline_fancy_corner";
 	dir = 8
 	},
-/obj/structure/flora/grass/brown,
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "adO" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+/obj/effect/floor_decal/spline/fancy/wood/cee{
+	icon_state = "spline_fancy_cee";
+	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 6
-	},
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "adP" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -1639,12 +1594,9 @@
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "adQ" = (
 /obj/effect/floor_decal/carpet{
@@ -1937,22 +1889,22 @@
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_chapel)
 "aeB" = (
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 5
 	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "aeC" = (
-/obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 9
 	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "aeD" = (
 /obj/structure/bed/chair/holochair{
@@ -11803,10 +11755,6 @@
 /turf/unsimulated/floor,
 /area/centcom/holding)
 "aCn" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /obj/item/modular_computer/console/preset/security,
 /turf/unsimulated/floor{
 	dir = 8;
@@ -12090,7 +12038,6 @@
 	name = "Holding Cell";
 	req_access = list(2)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor,
 /area/centcom/holding)
 "aDa" = (
@@ -12127,7 +12074,6 @@
 	opacity = 1;
 	req_access = list(101)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -12211,7 +12157,6 @@
 	name = "Holding Cell";
 	req_access = list(2)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -12224,20 +12169,12 @@
 	name = "Arrivals Processing";
 	req_access = list(101)
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/centcom/holding)
 "aDq" = (
 /obj/item/modular_computer/console/preset/command,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -12307,7 +12244,6 @@
 	c_tag = "Crescent Arrivals North";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights,
 /obj/item/modular_computer/console/preset/security,
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -12336,10 +12272,6 @@
 /area/centcom/holding)
 "aDD" = (
 /obj/structure/table/reinforced,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "red"
@@ -12405,14 +12337,6 @@
 /area/holodeck/source_battlemonsters)
 "aDK" = (
 /obj/item/modular_computer/console/preset/security,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/escape/centcom)
 "aDL" = (
@@ -12430,10 +12354,6 @@
 /area/centcom/ferry)
 "aDN" = (
 /obj/structure/banner,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/unsimulated/floor{
 	icon_state = "green";
 	dir = 8
@@ -12445,10 +12365,6 @@
 	},
 /area/centcom/holding)
 "aDP" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/unsimulated/floor{
 	icon_state = "blue";
 	dir = 5
@@ -12552,8 +12468,8 @@
 	},
 /area/centcom/ferry)
 "aDZ" = (
-/obj/structure/flora/grass/brown,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
 /area/centcom/holding)
 "aEa" = (
 /obj/structure/bed/chair{
@@ -12660,8 +12576,8 @@
 	icon_state = "tube1";
 	dir = 8
 	},
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/grass,
 /area/centcom/holding)
 "aEp" = (
 /turf/unsimulated/floor{
@@ -12724,10 +12640,6 @@
 "aEx" = (
 /obj/structure/bed/chair,
 /obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 1
 	},
 /turf/simulated/floor/shuttle,
@@ -12817,7 +12729,6 @@
 /area/shuttle/transport1/centcom)
 "aEJ" = (
 /obj/machinery/door/unpowered/shuttle,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/shuttle,
 /area/shuttle/transport1/centcom)
 "aEK" = (
@@ -12868,10 +12779,6 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/unsimulated/floor{
 	icon_state = "greencorner";
 	dir = 1
@@ -12916,7 +12823,6 @@
 	opacity = 1;
 	req_access = list(101)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -12963,7 +12869,6 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/shuttle,
 /area/shuttle/transport1/centcom)
 "aFc" = (
@@ -12988,7 +12893,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "Arrivals Bar"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -13061,10 +12965,6 @@
 	icon_state = "spline_plain";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/escape/centcom)
 "aFo" = (
@@ -13101,10 +13001,6 @@
 /area/centcom/holding)
 "aFq" = (
 /obj/item/modular_computer/console/preset/command/captain,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/shuttle/red,
 /area/shuttle/escape/centcom)
 "aFr" = (
@@ -13115,25 +13011,7 @@
 /area/centcom/holding)
 "aFs" = (
 /obj/machinery/computer/shuttle_control/emergency,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/shuttle/red,
-/area/shuttle/escape/centcom)
-"aFt" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/shuttle/white,
 /area/shuttle/escape/centcom)
 "aFu" = (
 /obj/structure/bed/chair/office/bridge,
@@ -13577,7 +13455,6 @@
 /obj/machinery/door/airlock/glass_medical{
 	name = "Arrivals Medbay"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -13883,7 +13760,6 @@
 	opacity = 1;
 	req_access = list(109)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -14237,7 +14113,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "NMSS Odin Cryogenic Storage"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	dir = 4;
 	icon_state = "whitegreenfull"
@@ -14253,7 +14128,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "NMSS Odin Sports Megacenter"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -14534,7 +14408,6 @@
 	name = "Secure Holding";
 	req_access = list(1)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/escape/centcom)
 "aID" = (
@@ -14979,10 +14852,6 @@
 /obj/item/storage/box/masks{
 	pixel_x = 0;
 	pixel_y = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 4;
@@ -15435,7 +15304,6 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Unisex Restroom"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor";
 	dir = 2
@@ -15460,7 +15328,6 @@
 /obj/machinery/door/airlock/centcom{
 	name = "To: Arrivals Deck"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor,
 /area/centcom/spawning)
 "aKz" = (
@@ -15530,20 +15397,12 @@
 /area/shuttle/arrival/centcom)
 "aKH" = (
 /obj/structure/closet/emcloset,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/centcom)
 "aKI" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera/network/civilian_east{
 	c_tag = "Surface - Arrivals Shuttle"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/centcom)
@@ -16335,7 +16194,6 @@
 /area/syndicate_mothership/raider_base)
 "aMo" = (
 /obj/machinery/door/airlock/glass,
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -16454,10 +16312,6 @@
 	c_tag = "Crescent Arrivals North";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -16466,10 +16320,6 @@
 /obj/machinery/camera/network/crescent{
 	c_tag = "Crescent Arrivals - Holding Cell";
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -16501,7 +16351,6 @@
 /obj/machinery/door/airlock/centcom{
 	name = "To: NMSS Odin Hab Complex"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor,
 /area/centcom/spawning)
 "aMJ" = (
@@ -16599,7 +16448,6 @@
 	},
 /area/centcom/spawning)
 "aMV" = (
-/obj/structure/sign/christmas/lights,
 /turf/unsimulated/floor{
 	icon_state = "green";
 	dir = 10
@@ -16611,7 +16459,6 @@
 	},
 /area/centcom/spawning)
 "aMX" = (
-/obj/structure/sign/christmas/lights,
 /turf/unsimulated/floor{
 	icon_state = "green";
 	dir = 6
@@ -16773,7 +16620,6 @@
 	opacity = 1;
 	req_access = list(109)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -16793,7 +16639,6 @@
 	opacity = 1;
 	req_access = newlist()
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -16928,10 +16773,6 @@
 /area/centcom/spawning)
 "aNJ" = (
 /obj/structure/banner/unmovable,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/unsimulated/floor{
 	icon_state = "blue";
 	dir = 9
@@ -17175,10 +17016,6 @@
 /obj/structure/flora/pottedplant/random{
 	anchored = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/unsimulated/floor{
 	icon_state = "blue";
 	dir = 4
@@ -17308,13 +17145,12 @@
 /area/centcom/spawning)
 "aOC" = (
 /obj/structure/bed/chair,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "aOD" = (
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /obj/machinery/light,
 /obj/structure/sign/directions/dock{
 	dir = 1;
@@ -17325,7 +17161,7 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	icon_state = "floor"
+	icon_state = "wood_siding2"
 	},
 /area/centcom/spawning)
 "aOE" = (
@@ -17452,7 +17288,6 @@
 	name = "Cockpit";
 	req_access = list(19)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "aOY" = (
@@ -17465,8 +17300,8 @@
 	icon_state = "rwindow";
 	dir = 8
 	},
-/obj/structure/flora/grass/brown,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/grass,
 /area/centcom/spawning)
 "aOZ" = (
 /obj/structure/window/reinforced/crescent{
@@ -17475,8 +17310,7 @@
 	},
 /obj/structure/window/reinforced/crescent,
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/centcom/spawning)
 "aPa" = (
 /obj/structure/window/reinforced/crescent{
@@ -17484,18 +17318,8 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/crescent,
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
-/area/centcom/spawning)
-"aPb" = (
-/obj/structure/window/reinforced/crescent{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced/crescent,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/grass,
 /area/centcom/spawning)
 "aPd" = (
 /obj/structure/window/reinforced/crescent{
@@ -17508,8 +17332,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/brown,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/centcom/spawning)
 "aPe" = (
 /obj/structure/window/reinforced,
@@ -17523,10 +17346,6 @@
 /obj/machinery/camera/network/crescent{
 	c_tag = "Crescent Departures";
 	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "blue";
@@ -17564,13 +17383,16 @@
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/escape/centcom)
 "aPj" = (
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 1
 	},
 /obj/structure/bed/chair/unmovable,
 /turf/unsimulated/floor{
-	icon_state = "floor"
+	icon_state = "wood_siding1"
 	},
 /area/centcom/spawning)
 "aPk" = (
@@ -17835,7 +17657,6 @@
 	opacity = 1;
 	req_access = list(109)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -18162,7 +17983,6 @@
 	opacity = 1;
 	req_access = list(109)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -18200,7 +18020,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "Cryogenic Storage"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor";
 	dir = 2
@@ -18210,7 +18029,6 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Unisex Restroom"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor";
 	dir = 2
@@ -18493,7 +18311,6 @@
 	opacity = 1;
 	req_access = list(109)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -18694,7 +18511,6 @@
 	name = "Real Fake Doors! and Co";
 	opacity = 1
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -18718,7 +18534,6 @@
 	opacity = 1;
 	req_access = list(109)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -20332,14 +20147,6 @@
 /area/shuttle/escape/centcom)
 "aVC" = (
 /obj/item/modular_computer/console/preset/medical,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/escape/centcom)
 "aVD" = (
@@ -20354,7 +20161,6 @@
 	name = "Cockpit";
 	req_access = list(19)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "aVF" = (
@@ -20366,10 +20172,6 @@
 /area/shuttle/escape/centcom)
 "aVG" = (
 /obj/item/modular_computer/console/preset/research,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/escape/centcom)
 "aVH" = (
@@ -20391,10 +20193,6 @@
 /area/shuttle/escape/centcom)
 "aVK" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/shuttle/yellow,
 /area/shuttle/escape/centcom)
 "aVL" = (
@@ -20422,7 +20220,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "Emergency Supplies"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/shuttle/yellow,
 /area/shuttle/escape/centcom)
 "aVO" = (
@@ -20493,14 +20290,9 @@
 /area/shuttle/escape/centcom)
 "aVX" = (
 /obj/structure/bed/chair,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/escape/centcom)
 "aVZ" = (
-/obj/structure/sign/christmas/lights,
 /obj/item/modular_computer/console/preset/security,
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -20515,17 +20307,12 @@
 	opacity = 1;
 	req_access = list(101)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/centcom/checkpoint/fore)
 "aWb" = (
 /obj/structure/banner,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -20658,7 +20445,6 @@
 	name = "Medical Bay";
 	req_access = list(5)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/escape/centcom)
 "aWt" = (
@@ -20688,16 +20474,11 @@
 	opacity = 1;
 	req_access = list(101)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/centcom/checkpoint/aft)
 "aWz" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /obj/item/modular_computer/console/preset/security,
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -20712,25 +20493,16 @@
 	opacity = 1;
 	req_access = list(101)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/centcom/checkpoint/aft)
 "aWB" = (
 /obj/structure/closet/crate/freezer/rations,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/shuttle/yellow,
 /area/shuttle/escape/centcom)
 "aWC" = (
 /obj/structure/flora/pottedplant/random,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "aWD" = (
@@ -20819,10 +20591,6 @@
 	icon_state = "sleeper_0";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/escape/centcom)
 "aWS" = (
@@ -20835,10 +20603,6 @@
 /area/shuttle/escape/centcom)
 "aWT" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/escape/centcom)
 "aWU" = (
@@ -20889,10 +20653,6 @@
 /obj/machinery/light{
 	dir = 4;
 	status = 2
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/escape/centcom)
@@ -21006,7 +20766,6 @@
 	opacity = 1;
 	req_access = list(109)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -21838,7 +21597,6 @@
 	},
 /area/centcom/legion)
 "bmH" = (
-/obj/structure/sign/christmas/lights,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 5
@@ -22001,10 +21759,6 @@
 /obj/item/material/ashtray/glass,
 /obj/item/storage/fancy/cigarettes/dromedaryco,
 /obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -22129,13 +21883,6 @@
 /obj/item/storage/wallet/random,
 /turf/simulated/floor/carpet/blue,
 /area/shuttle/merchant/start)
-"ckG" = (
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	icon_state = "rampbottom";
-	dir = 4
-	},
-/area/centcom/spawning)
 "clq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warning{
@@ -22660,10 +22407,6 @@
 	icon_state = "floor"
 	},
 /area/centcom/ferry)
-"dpr" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/centcom)
 "dql" = (
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/ramp/bottom,
@@ -22684,25 +22427,6 @@
 "drL" = (
 /turf/space/transit/east/shuttlespace_ew10,
 /area/shuttle/distress/transit)
-"dsF" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/unsimulated/floor{
-	icon_state = "green";
-	dir = 8
-	},
-/area/centcom/spawning)
-"dxJ" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/centcom/evac)
 "dzu" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
@@ -22728,12 +22452,6 @@
 	},
 /turf/unsimulated/wall/darkshuttlewall,
 /area/centcom/legion)
-"dAS" = (
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	icon_state = "blue"
-	},
-/area/centcom/spawning)
 "dBk" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/loot{
@@ -22750,12 +22468,6 @@
 	dir = 5
 	},
 /area/centcom/distress_prep)
-"dBG" = (
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	icon_state = "grimy"
-	},
-/area/centcom/holding)
 "dCz" = (
 /obj/structure/window/reinforced/crescent,
 /obj/structure/window/reinforced/crescent{
@@ -22871,16 +22583,6 @@
 	icon_state = "wood_light"
 	},
 /area/centcom/legion/hangar5)
-"dNA" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "whitegreencorner"
-	},
-/area/centcom/holding)
 "dPt" = (
 /obj/structure/flora/pottedplant/random,
 /turf/unsimulated/floor{
@@ -22903,14 +22605,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/merchant/start)
-"dQM" = (
-/obj/structure/bed/chair,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/transport1/centcom)
 "dTj" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
@@ -22940,18 +22634,6 @@
 	icon_state = "floor"
 	},
 /area/centcom/checkpoint/aft)
-"dUQ" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 8
-	},
-/obj/structure/flora/grass/green,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
-/area/holodeck/source_dininghall)
 "dUW" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -23171,6 +22853,15 @@
 	icon_state = "floor"
 	},
 /area/centcom/ferry)
+"eyb" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/holofloor/grass,
+/area/holodeck/source_picnicarea)
 "eyw" = (
 /obj/machinery/telecomms/processor/preset_cent,
 /turf/unsimulated/floor{
@@ -23239,12 +22930,10 @@
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/structure/flora/grass/brown,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "eQJ" = (
 /obj/structure/lattice/catwalk/indoor,
@@ -23557,12 +23246,8 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/brown,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_dininghall)
 "fiE" = (
 /turf/simulated/floor/tiled/ramp/bottom,
@@ -23592,20 +23277,6 @@
 	icon_state = "floor3"
 	},
 /area/centcom/legion/hangar5)
-"flk" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/escape/centcom)
 "flX" = (
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/shuttle/black,
@@ -23618,12 +23289,8 @@
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_dininghall)
 "frl" = (
 /obj/machinery/chemical_dispenser/ert{
@@ -23768,17 +23435,6 @@
 	icon_state = "floor3"
 	},
 /area/centcom/legion)
-"fNp" = (
-/obj/structure/banner/unmovable,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "blue";
-	dir = 5
-	},
-/area/centcom/spawning)
 "fPC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark{
@@ -23811,24 +23467,6 @@
 "fQF" = (
 /turf/space/transit/east/shuttlespace_ew9,
 /area/shuttle/distress/transit)
-"fRk" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/escape/centcom)
 "fRx" = (
 /obj/machinery/door/window/southleft{
 	desc = "A strong door. An angry note is taped to the front.";
@@ -24070,14 +23708,6 @@
 	},
 /turf/simulated/floor/shuttle/red,
 /area/shuttle/distress/centcom)
-"gmK" = (
-/obj/item/modular_computer/console/preset/research,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/shuttle/white,
-/area/shuttle/escape/centcom)
 "gmT" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion";
@@ -24120,18 +23750,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/legion)
-"grt" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
-	},
-/area/centcom/holding)
 "grY" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp{
@@ -24304,10 +23922,6 @@
 	icon_state = "wood"
 	},
 /area/centcom/legion/hangar5)
-"gDe" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/shuttle,
-/area/shuttle/escape/centcom)
 "gDh" = (
 /obj/machinery/telecomms/receiver/preset_cent,
 /turf/unsimulated/floor{
@@ -24356,13 +23970,8 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_dininghall)
 "gLr" = (
 /obj/machinery/door/airlock/centcom{
@@ -24455,6 +24064,14 @@
 	icon_state = "floor"
 	},
 /area/centcom/legion)
+"gXh" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/grass,
+/area/holodeck/source_dininghall)
 "gXE" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -24743,13 +24360,8 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_dininghall)
 "hEN" = (
 /obj/structure/table/reinforced,
@@ -24840,16 +24452,6 @@
 /obj/item/folder/blue,
 /turf/simulated/floor/carpet,
 /area/merchant_station)
-"hOG" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "green";
-	dir = 8
-	},
-/area/centcom/holding)
 "hRs" = (
 /obj/structure/table/reinforced/steel,
 /obj/structure/window/reinforced{
@@ -24912,12 +24514,6 @@
 	icon_state = "cafeteria"
 	},
 /area/centcom/legion)
-"hTf" = (
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/centcom/ferry)
 "hVm" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
@@ -25139,28 +24735,6 @@
 	icon_state = "panelscorched"
 	},
 /area/centcom/legion/hangar5)
-"ijP" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/centcom/checkpoint/fore)
-"ikg" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/green,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
-/area/holodeck/source_dininghall)
 "imz" = (
 /turf/simulated/floor/lino,
 /area/merchant_station)
@@ -25236,26 +24810,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/legion/hangar5)
-"ivH" = (
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "siding4"
-	},
-/area/centcom/holding)
-"iwx" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "blue";
-	dir = 4
-	},
-/area/centcom/spawning)
 "izN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/floor{
@@ -25348,10 +24902,6 @@
 /area/centcom/legion/hangar5)
 "iIs" = (
 /obj/structure/table/wood,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /obj/item/modular_computer/laptop/preset/command,
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -25371,16 +24921,6 @@
 	icon_state = "floor"
 	},
 /area/centcom/distress_prep)
-"iLu" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "blue";
-	dir = 5
-	},
-/area/centcom/spawning)
 "iLV" = (
 /obj/machinery/light/spot{
 	icon_state = "tube1";
@@ -25449,19 +24989,6 @@
 	icon_state = "cafeteria"
 	},
 /area/centcom/legion)
-"iRF" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/escape/centcom)
 "iRS" = (
 /obj/effect/floor_decal/industrial/loading{
 	icon_state = "loadingarea";
@@ -25597,26 +25124,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/legion)
-"jap" = (
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	icon_state = "blue";
-	dir = 6
-	},
-/area/centcom/spawning)
-"jaG" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/unsimulated/floor{
-	icon_state = "green";
-	dir = 8
-	},
-/area/centcom/holding)
 "jaZ" = (
 /turf/unsimulated/wall/riveted,
 /area/syndicate_mothership/elite_squad)
@@ -25727,7 +25234,6 @@
 	opacity = 0;
 	req_access = list(19)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -25781,20 +25287,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/legion)
-"jss" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/brown,
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
-/area/holodeck/source_dininghall)
 "jxm" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
@@ -26019,15 +25511,6 @@
 	icon_state = "cafeteria"
 	},
 /area/centcom/legion)
-"jRD" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/centcom/holding)
 "jSZ" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
@@ -26152,13 +25635,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/merchant/start)
-"kis" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/shuttle,
-/area/shuttle/transport1/centcom)
 "klF" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -26197,12 +25673,6 @@
 	name = "plating"
 	},
 /area/centcom/legion/hangar5)
-"ksz" = (
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
-/area/centcom/holding)
 "ktR" = (
 /turf/unsimulated/floor{
 	icon_state = "green";
@@ -26221,19 +25691,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/legion)
-"kxm" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/centcom/holding)
-"kys" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_dininghall)
 "kzV" = (
 /obj/structure/toilet{
 	pixel_x = 0;
@@ -26250,15 +25707,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/legion/hangar5)
-"kBF" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/centcom/holding)
 "kBJ" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/carpet/blue,
@@ -26457,17 +25905,9 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_dininghall)
 "kUG" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -26963,16 +26403,6 @@
 "mfg" = (
 /turf/space/transit/east/shuttlespace_ew7,
 /area/shuttle/legion/transit)
-"mfM" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/centcom/holding)
 "mjX" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
@@ -27070,8 +26500,9 @@
 	},
 /area/centcom/legion/hangar5)
 "mud" = (
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
 /area/centcom/holding)
 "mvu" = (
 /obj/machinery/recharger/wallcharger{
@@ -27153,19 +26584,6 @@
 	icon_state = "tiles"
 	},
 /area/centcom/legion/hangar5)
-"mCI" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/holofloor/snow,
-/area/holodeck/source_picnicarea)
 "mDX" = (
 /obj/machinery/computer/shuttle_control/merchant,
 /obj/machinery/button/remote/blast_door{
@@ -27195,6 +26613,9 @@
 	icon_state = "dark"
 	},
 /area/centcom/legion)
+"mKw" = (
+/turf/simulated/floor/holofloor/desert,
+/area/holodeck/source_picnicarea)
 "mLc" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -27332,13 +26753,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/merchant/start)
-"mWr" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/escape/centcom)
 "mZZ" = (
 /obj/structure/closet/secure_closet/merchant,
 /obj/structure/window/reinforced{
@@ -27356,13 +26770,6 @@
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_dininghall)
-"naO" = (
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	icon_state = "blue";
-	dir = 10
-	},
-/area/centcom/spawning)
 "nco" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -27596,13 +27003,15 @@
 	icon_state = "floor3"
 	},
 /area/centcom/legion/hangar5)
-"npP" = (
-/obj/structure/banner,
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	icon_state = "floor"
+"nrk" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 4
 	},
-/area/centcom/evac)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
+/area/holodeck/source_picnicarea)
 "nte" = (
 /turf/space/transit/east/shuttlespace_ew5,
 /area/shuttle/distress/transit)
@@ -27618,16 +27027,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/merchant_station)
-"nuU" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/unsimulated/floor{
-	icon_state = "greencorner";
-	dir = 8
-	},
-/area/centcom/holding)
 "nvT" = (
 /obj/structure/sign/flag/biesel/left{
 	dir = 8;
@@ -27914,19 +27313,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/merchant_station)
-"nQF" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/centcom/evac)
 "nRm" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	name = "legion weapon cabinet";
@@ -28045,13 +27431,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/legion)
-"nZz" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/shuttle/white,
-/area/shuttle/escape/centcom)
 "nZO" = (
 /obj/structure/table/standard,
 /obj/item/storage/fancy/donut{
@@ -28217,12 +27596,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/merchant/start)
-"olh" = (
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/centcom/checkpoint/aft)
 "oll" = (
 /obj/machinery/iv_drip,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -28334,28 +27707,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/merchant_station)
-"oya" = (
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	icon_state = "green";
-	dir = 10
-	},
-/area/centcom/holding)
 "oyh" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/structure/flora/grass/green,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_dininghall)
 "oyD" = (
 /obj/item/stool/padded,
@@ -28363,21 +27722,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/legion)
-"ozc" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/escape/centcom)
 "ozg" = (
 /obj/structure/grille/broken,
 /obj/structure/window/reinforced/crescent{
@@ -28507,16 +27851,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/living)
-"oLA" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "green";
-	dir = 1
-	},
-/area/centcom/holding)
 "oMF" = (
 /obj/structure/table/standard,
 /obj/machinery/vending/wallmed1{
@@ -28542,12 +27876,14 @@
 	icon_state = "whitegreen"
 	},
 /area/centcom/legion)
-"oNW" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
+"oNX" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 8
 	},
-/turf/simulated/floor/holofloor/tiled/dark,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_dininghall)
 "oOm" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -28645,16 +27981,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/legion/hangar5)
-"oUJ" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "blue";
-	dir = 9
-	},
-/area/centcom/spawning)
 "oVL" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -28730,6 +28056,15 @@
 "oYt" = (
 /turf/space/transit/east/shuttlespace_ew3,
 /area/shuttle/distress/transit)
+"oYx" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/holofloor/grass,
+/area/holodeck/source_picnicarea)
 "oZy" = (
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
@@ -28782,13 +28117,6 @@
 	},
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/legion/centcom)
-"pgN" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/transport1/centcom)
 "piD" = (
 /obj/machinery/door/window/eastright{
 	req_access = list(110)
@@ -28819,15 +28147,6 @@
 	icon_state = "floor"
 	},
 /area/centcom/living)
-"pkX" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "greencorner"
-	},
-/area/centcom/holding)
 "plA" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
@@ -28960,16 +28279,6 @@
 	dir = 8
 	},
 /area/centcom/legion/hangar5)
-"pFC" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "blue";
-	dir = 1
-	},
-/area/centcom/spawning)
 "pGH" = (
 /obj/structure/closet/wardrobe/orange,
 /turf/unsimulated/floor{
@@ -29158,6 +28467,16 @@
 	icon_state = "dark"
 	},
 /area/centcom/legion)
+"qlC" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/simulated/floor/holofloor/grass,
+/area/holodeck/source_picnicarea)
 "qmV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -29518,10 +28837,6 @@
 /area/centcom/holding)
 "qNk" = (
 /obj/structure/bed/chair/comfy/black,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -29598,16 +28913,6 @@
 	},
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/merchant_station/warehouse)
-"qUu" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/unsimulated/floor{
-	icon_state = "greencorner";
-	dir = 1
-	},
-/area/centcom/holding)
 "qXv" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -29862,16 +29167,6 @@
 	dir = 5
 	},
 /area/centcom/ferry)
-"rpg" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "green";
-	dir = 4
-	},
-/area/centcom/holding)
 "rpT" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/unsimulated/floor{
@@ -29904,18 +29199,6 @@
 	},
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/legion/centcom)
-"rqW" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 4
-	},
-/obj/structure/flora/grass/green,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
-/area/holodeck/source_picnicarea)
 "rug" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/unsimulated/floor{
@@ -29927,13 +29210,6 @@
 	icon_state = "floor"
 	},
 /area/centcom/checkpoint/aft)
-"rxv" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/escape/centcom)
 "rxN" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -29967,16 +29243,6 @@
 	icon_state = "wood"
 	},
 /area/centcom/legion/hangar5)
-"rCK" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	dir = 4;
-	icon_state = "whitegreen"
-	},
-/area/centcom/holding)
 "rEP" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
@@ -30178,17 +29444,13 @@
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/legion/centcom)
 "rYS" = (
-/obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	icon_state = "spline_fancy_corner";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "sdE" = (
 /obj/structure/shuttle/engine/heater{
@@ -30249,7 +29511,6 @@
 	name = "Cryo Storage";
 	req_access = list(38)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -30268,29 +29529,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/merchant_station)
-"siv" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/shuttle/black,
-/area/shuttle/escape/centcom)
-"skj" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/shuttle/black,
-/area/shuttle/escape/centcom)
 "skD" = (
 /obj/machinery/light{
 	dir = 4;
@@ -30827,8 +30065,9 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/crescent,
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
 /area/centcom/spawning)
 "tnJ" = (
 /obj/machinery/vending/snack{
@@ -31015,12 +30254,10 @@
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "tJm" = (
 /turf/unsimulated/floor{
@@ -31154,12 +30391,9 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/grass/brown,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
 "tVX" = (
 /obj/machinery/light/spot{
@@ -31233,27 +30467,15 @@
 /obj/random/plushie,
 /turf/simulated/floor/wood,
 /area/merchant_station)
-"ugy" = (
+"ufi" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
-	dir = 4
-	},
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 8
 	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_dininghall)
-"ujs" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/centcom/evac)
 "ukL" = (
 /obj/effect/decal/warning_stripes,
 /obj/machinery/porta_turret/crescent,
@@ -31349,30 +30571,14 @@
 /turf/simulated/floor/wood,
 /area/merchant_station)
 "uuM" = (
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	icon_state = "spline_fancy_corner";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
-"uzX" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 4
-	},
-/obj/structure/flora/grass/brown,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
-/area/holodeck/source_dininghall)
 "uCD" = (
 /obj/effect/floor_decal/corner/yellow/full,
 /turf/simulated/floor/tiled,
@@ -31398,7 +30604,6 @@
 	opacity = 1;
 	req_access = list(101)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -31537,17 +30742,6 @@
 	icon_state = "wood"
 	},
 /area/centcom/legion/hangar5)
-"uYE" = (
-/obj/structure/banner,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "green";
-	dir = 9
-	},
-/area/centcom/holding)
 "uZl" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
@@ -31602,12 +30796,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station)
-"vdp" = (
-/obj/structure/sign/christmas/lights,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/centcom/evac)
 "vdD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -31684,10 +30872,6 @@
 /area/centcom/checkpoint/aft)
 "vjK" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -31932,20 +31116,6 @@
 	dir = 8
 	},
 /area/centcom/distress_prep)
-"vFh" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/escape/centcom)
 "vFT" = (
 /obj/machinery/acting/changer,
 /turf/unsimulated/floor{
@@ -32525,16 +31695,6 @@
 	dir = 5
 	},
 /area/centcom/distress_prep)
-"wNX" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/unsimulated/floor{
-	icon_state = "blue";
-	dir = 8
-	},
-/area/centcom/spawning)
 "wOb" = (
 /turf/unsimulated/floor{
 	dir = 8;
@@ -32572,12 +31732,9 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/grass/green,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/snow,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_dininghall)
 "wUi" = (
 /obj/structure/janitorialcart{
@@ -32688,16 +31845,6 @@
 	icon_state = "platebot"
 	},
 /area/centcom/distress_prep)
-"xel" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
-	},
-/area/centcom/holding)
 "xgn" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -32753,16 +31900,6 @@
 	name = "plating"
 	},
 /area/centcom/legion/hangar5)
-"xif" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/unsimulated/floor{
-	icon_state = "green";
-	dir = 8
-	},
-/area/centcom/holding)
 "xii" = (
 /turf/unsimulated/wall/fakepdoor,
 /area/centcom/legion/hangar5)
@@ -32870,16 +32007,14 @@
 /obj/item/gun/energy/pistol,
 /turf/simulated/floor/carpet,
 /area/merchant_station)
-"xwi" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
+"xwr" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "greencorner";
-	dir = 4
-	},
-/area/centcom/holding)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/holofloor/grass,
+/area/holodeck/source_dininghall)
 "xws" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
@@ -32932,46 +32067,11 @@
 	},
 /turf/simulated/wall/iron,
 /area/centcom/shared_dream)
-"xxz" = (
-/obj/machinery/porta_turret/crescent,
-/obj/effect/decal/warning_stripes,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/centcom/control)
 "xxW" = (
 /turf/unsimulated/floor{
 	icon_state = "white"
 	},
 /area/centcom/legion)
-"xyw" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/escape/centcom)
-"xAR" = (
-/obj/machinery/door/blast/odin{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "CentComArrivalsCommand";
-	name = "Security Doors";
-	opacity = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/centcom/evac)
 "xBh" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
@@ -33256,16 +32356,6 @@
 "xZs" = (
 /turf/space/transit/east/shuttlespace_ew3,
 /area/shuttle/legion/transit)
-"yeT" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "rampbottom";
-	dir = 4
-	},
-/area/centcom/spawning)
 "ygK" = (
 /turf/unsimulated/floor{
 	dir = 8;
@@ -33284,16 +32374,25 @@
 	name = "Service Airlock"
 	},
 /area/centcom/legion/hangar5)
+"yhw" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/holofloor/grass,
+/area/holodeck/source_dininghall)
 "yhy" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/grass,
 /area/centcom/holding)
 "yhL" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Representative Office";
 	req_access = list(38)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -33324,17 +32423,6 @@
 	icon_state = "floor"
 	},
 /area/centcom/legion/hangar5)
-"yjY" = (
-/obj/structure/banner,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "green";
-	dir = 5
-	},
-/area/centcom/holding)
 "ykk" = (
 /obj/structure/flora/tree/dead,
 /turf/simulated/floor/snow,
@@ -61282,7 +60370,7 @@ aaM
 hHP
 vjK
 raM
-hTf
+otY
 hHP
 aaM
 aaM
@@ -61539,7 +60627,7 @@ aaM
 hHP
 iIs
 gXE
-hTf
+otY
 hHP
 aaM
 aaM
@@ -62310,7 +61398,7 @@ aaM
 hHP
 qNk
 otY
-hTf
+otY
 hHP
 aaM
 aaM
@@ -62567,7 +61655,7 @@ aaM
 hHP
 bPG
 ewG
-hTf
+otY
 hHP
 aaM
 aaM
@@ -64113,7 +63201,7 @@ aDU
 aEf
 aEk
 aEk
-pgN
+aEy
 aEk
 aEk
 aDM
@@ -65654,9 +64742,9 @@ aDM
 aDU
 aEf
 aEl
-dQM
+aEw
 aEy
-kis
+aFa
 aEl
 aDM
 aFv
@@ -65913,7 +65001,7 @@ aEf
 aEm
 aEy
 aEy
-kis
+aFa
 aEl
 aDM
 aEP
@@ -66168,9 +65256,9 @@ aDM
 aDU
 aEf
 aEl
-dQM
+aEw
 aEy
-kis
+aFa
 aEl
 aDM
 aFw
@@ -66707,22 +65795,22 @@ aCq
 aLQ
 aLP
 aMD
-jRD
-jRD
-jRD
-jRD
-jRD
+aLP
+aLP
+aLP
+aLP
+aLP
 aLP
 aOO
 aCq
 aLP
 aLP
 aMD
-jRD
-jRD
-jRD
-jRD
-jRD
+aLP
+aLP
+aLP
+aLP
+aLP
 aLP
 aLQ
 aCq
@@ -66950,9 +66038,9 @@ aFY
 aEP
 aGD
 aHd
-ksz
+aEP
 aDb
-uYE
+aCC
 aIM
 aCM
 aEa
@@ -67207,9 +66295,9 @@ aFL
 aEP
 aFL
 aFL
-ksz
+aEP
 aDb
-oLA
+aIv
 aCo
 aCo
 aCo
@@ -67220,23 +66308,23 @@ aGb
 aCM
 aLR
 aMp
-nuU
-xif
-xif
-xif
-xif
-qUu
+aGb
+aCM
+aCM
+aCM
+aCM
+aCD
 aMp
 aOP
 aCM
 aCD
 aMp
-nuU
-xif
-xif
-xif
-xif
-qUu
+aGb
+aCM
+aCM
+aCM
+aCM
+aCD
 aMp
 aOP
 aCM
@@ -67721,9 +66809,9 @@ aEP
 aGp
 aGp
 aGp
-ivH
+aGp
 aDb
-oLA
+aIv
 aCo
 aCo
 aCo
@@ -67734,23 +66822,23 @@ aLv
 aCN
 aLS
 aMq
-pkX
-rpg
-rpg
-rpg
-rpg
-xwi
+aLv
+aCN
+aCN
+aCN
+aCN
+aOi
 aMq
 aOQ
 aCN
 aOi
 aMq
-pkX
-rpg
-rpg
-rpg
-rpg
-xwi
+aLv
+aCN
+aCN
+aCN
+aCN
+aOi
 aMq
 aOQ
 aCN
@@ -67978,9 +67066,9 @@ azL
 aGq
 aGE
 aGF
-dBG
+aGF
 aDb
-yjY
+aCF
 aIN
 aCN
 aJv
@@ -68249,22 +67337,22 @@ aCq
 aLP
 aLP
 aME
-kxm
-kxm
-kxm
-kxm
-kxm
+aLP
+aLP
+aLP
+aLP
+aLP
 aLP
 aLQ
 aCq
 aLQ
 aLP
 aME
-kxm
-kxm
-kxm
-kxm
-kxm
+aLP
+aLP
+aLP
+aLP
+aLP
 aLP
 aLP
 aCq
@@ -68727,13 +67815,13 @@ ave
 ave
 ave
 ave
-xel
-xel
-xel
 aCj
-grt
-grt
-grt
+aCj
+aCj
+aCj
+aDm
+aDm
+aDm
 aDM
 aDY
 tou
@@ -69242,11 +68330,11 @@ avh
 aBO
 aAf
 aCn
-mfM
-mfM
 aCB
-mfM
-mfM
+aCB
+aCB
+aCB
+aCB
 aDD
 aDM
 aDY
@@ -69768,7 +68856,7 @@ yhy
 aEo
 mud
 aDb
-kBF
+aCo
 aCo
 aCo
 eSC
@@ -70025,7 +69113,7 @@ aDb
 aDb
 aDb
 aDb
-kBF
+aCo
 aCo
 aCo
 aCo
@@ -70273,14 +69361,14 @@ auT
 aCC
 aCM
 aDb
-hOG
-oya
+aCM
+aDw
 aDb
 aDN
-jaG
-jaG
-jaG
-jaG
+aEa
+aEa
+aEa
+aEa
 aEQ
 aCo
 aCo
@@ -71818,7 +70906,7 @@ aaM
 aaM
 aaM
 mbM
-dxJ
+etF
 etF
 nhD
 mRM
@@ -71836,8 +70924,8 @@ aWo
 aHG
 aIb
 aIz
-dNA
-rCK
+aHE
+aIr
 aJB
 aKh
 aCq
@@ -71851,11 +70939,11 @@ aMU
 aNq
 aKx
 aKx
-iwx
-iwx
-iwx
-iwx
-iwx
+aKx
+aKx
+aKx
+aKx
+aKx
 aKx
 aKx
 aNq
@@ -72075,16 +71163,16 @@ aaM
 aaM
 aaM
 mbM
-dxJ
+etF
 oBU
 nhD
 iVE
 mRM
 aVZ
 aWg
-ijP
+mRM
 dCz
-olh
+rwg
 aWr
 aWz
 rwg
@@ -72332,7 +71420,7 @@ ait
 ait
 ait
 oQO
-dxJ
+etF
 etF
 nhD
 aVO
@@ -72350,9 +71438,9 @@ aWo
 aHH
 aIc
 aIA
-dsF
-dsF
-dsF
+aIc
+aIc
+aIc
 aIA
 aKw
 aIc
@@ -72365,11 +71453,11 @@ aMV
 aKZ
 aNJ
 aMT
-wNX
-wNX
-wNX
-wNX
-wNX
+aMT
+aMT
+aMT
+aMT
+aMT
 aMT
 aQi
 aHK
@@ -72589,7 +71677,7 @@ aaM
 aaM
 aaM
 mbM
-dxJ
+etF
 etF
 uIG
 mRM
@@ -72846,7 +71934,7 @@ aaM
 aaM
 aaM
 mbM
-dxJ
+etF
 etF
 nhD
 aVO
@@ -72877,7 +71965,7 @@ aIU
 aMH
 aMX
 aKZ
-fNp
+aNK
 aNW
 aId
 aId
@@ -73103,16 +72191,16 @@ aaM
 aaM
 aaM
 mbM
-dxJ
+etF
 oBU
 nhD
 oda
 mRM
 aVZ
 aWg
-ijP
+mRM
 eZa
-olh
+rwg
 aWr
 aWz
 rwg
@@ -73360,7 +72448,7 @@ ifh
 ifh
 ifh
 lkF
-dxJ
+etF
 etF
 nhD
 mRM
@@ -73394,9 +72482,9 @@ aNs
 aHK
 aNY
 aOl
-ckG
+aOl
 aKZ
-yeT
+aOl
 aOl
 aPO
 aHK
@@ -73617,7 +72705,7 @@ aDe
 wne
 wne
 srl
-xAR
+mak
 mak
 nhD
 nhD
@@ -73651,9 +72739,9 @@ aNt
 aHK
 aMr
 aId
-naO
+aOz
 aKZ
-oUJ
+aMr
 aId
 aOz
 aQk
@@ -73874,12 +72962,12 @@ wne
 wne
 wne
 srl
-dxJ
 etF
 etF
-vdp
+etF
+etF
 srl
-dxJ
+etF
 etF
 etF
 jKW
@@ -73908,9 +72996,9 @@ aNu
 aHK
 aMs
 aOm
-dAS
+aOA
 aKZ
-pFC
+aMs
 aOm
 aOA
 aQl
@@ -74131,10 +73219,10 @@ wne
 wne
 wne
 srl
-nQF
-ujs
-ujs
-vdp
+etF
+etF
+etF
+etF
 srl
 aWb
 aWh
@@ -74142,7 +73230,7 @@ etF
 etF
 etF
 etF
-npP
+aWb
 srl
 bmH
 srl
@@ -74165,9 +73253,9 @@ aNt
 aHK
 aNM
 aId
-jap
+aOB
 aKZ
-iLu
+aNM
 aId
 aOB
 aQm
@@ -74422,9 +73510,9 @@ aNv
 aHK
 aNY
 aOl
-ckG
+aOl
 aKZ
-yeT
+aOl
 aOl
 aPO
 aHK
@@ -74903,7 +73991,7 @@ aCP
 aVG
 aCP
 aOC
-xyw
+aDs
 aVL
 aDs
 aCP
@@ -74933,7 +74021,7 @@ aJH
 aJH
 aJG
 aKZ
-xxz
+axw
 aMs
 aId
 aId
@@ -75156,7 +74244,7 @@ ifh
 aCG
 aCQ
 aCQ
-nZz
+aGQ
 aFZ
 aCP
 aIx
@@ -75164,11 +74252,11 @@ aDs
 aVS
 aVP
 aOX
-rxv
-rxv
+aDs
+aDs
 aVP
-rxv
-rxv
+aDs
+aDs
 aDs
 aDs
 aIC
@@ -75190,7 +74278,7 @@ aKn
 aJH
 aJH
 aNw
-oUJ
+aMr
 aOa
 aId
 aId
@@ -75426,10 +74514,10 @@ aCQ
 aCP
 aCQ
 aCQ
-mWr
-gDe
+aDs
+aDs
 aCQ
-skj
+aWI
 aWV
 aWI
 aXf
@@ -75447,7 +74535,7 @@ aKn
 aJH
 aJH
 aKZ
-pFC
+aMs
 aId
 aId
 aId
@@ -75678,11 +74766,11 @@ aVH
 aCP
 aVQ
 aVU
-iRF
-iRF
+aWc
+aWc
 aWk
-iRF
-flk
+aWc
+aWm
 aDs
 aWF
 aCP
@@ -75704,7 +74792,7 @@ aMz
 aKZ
 aKZ
 aKZ
-pFC
+aMs
 aId
 aId
 aDX
@@ -75941,9 +75029,9 @@ aDs
 aDs
 aDs
 aDs
-gDe
+aDs
 aCQ
-siv
+aWv
 aWW
 aWv
 aXg
@@ -76218,7 +75306,7 @@ aKn
 aKZ
 aKZ
 aKZ
-pFC
+aMs
 aId
 aId
 aOD
@@ -76470,12 +75558,12 @@ aKH
 aKK
 aKK
 aKK
-dpr
+aKK
 aKo
 aJH
 aJH
 aKZ
-pFC
+aMs
 aId
 aId
 aDX
@@ -76712,7 +75800,7 @@ aDs
 aDs
 aDs
 aDs
-gDe
+aDs
 aCQ
 aVX
 aGQ
@@ -76727,16 +75815,16 @@ aKI
 aLi
 aLi
 aLi
-dpr
+aKK
 aKo
 aJH
 aNc
 aNw
-pFC
+aMs
 aId
 aId
 aDX
-aPb
+aOZ
 aEp
 aId
 aId
@@ -76954,7 +76042,7 @@ auT
 ifh
 aCG
 aCQ
-aFt
+aFO
 aFO
 aIg
 aGQ
@@ -76969,7 +76057,7 @@ aWd
 aWd
 aWn
 aDs
-gDe
+aDs
 aCQ
 aVX
 aGQ
@@ -76984,12 +76072,12 @@ aKH
 aLj
 aLj
 aLj
-dpr
+aKK
 aKo
 aJH
 aJH
 aKZ
-pFC
+aMs
 aId
 aId
 aDX
@@ -77226,7 +76314,7 @@ aWc
 aWc
 aWm
 aDs
-gDe
+aDs
 aCQ
 aWR
 aGQ
@@ -77246,7 +76334,7 @@ aKn
 aKZ
 aKZ
 aKZ
-pFC
+aMs
 aId
 aId
 aOD
@@ -77469,7 +76557,7 @@ ifh
 wne
 aCQ
 aCQ
-nZz
+aGQ
 aIf
 aCP
 aVD
@@ -77727,19 +76815,19 @@ wne
 wne
 aCP
 aCP
-gmK
+aVG
 aCP
 aWB
 aVK
 aCP
 aVT
-fRk
-vFh
-vFh
+aVV
+aWd
+aWd
 aWl
-vFh
-ozc
-rxv
+aWd
+aWn
+aDs
 aWD
 aCP
 aWT
@@ -77760,7 +76848,7 @@ aMz
 aKZ
 aKZ
 aKZ
-pFC
+aMs
 aId
 aId
 aDX
@@ -78017,7 +77105,7 @@ aKn
 aJH
 aJH
 aKZ
-pFC
+aMs
 aId
 aId
 aId
@@ -78274,7 +77362,7 @@ aJH
 aJH
 aJH
 aNw
-iLu
+aNM
 aNW
 aId
 aId
@@ -78531,7 +77619,7 @@ aJH
 aJH
 aJH
 aKZ
-xxz
+axw
 aMs
 aId
 aId
@@ -78791,9 +77879,9 @@ aHK
 aHK
 aNK
 aOn
-iwx
+aKx
 aPf
-iwx
+aKx
 aOn
 aPR
 aHK
@@ -80135,13 +79223,13 @@ aed
 aeO
 kTO
 wSA
-uzX
-ugy
+wSA
+wSA
 hEl
 wSA
-uzX
 hEl
-wSA
+yhw
+gXh
 gLc
 aeO
 aaM
@@ -80390,7 +79478,7 @@ acN
 aed
 aez
 aeO
-oNW
+sZi
 pOS
 pOS
 pOS
@@ -80399,7 +79487,7 @@ pOS
 pOS
 pOS
 pOS
-kys
+sZi
 aeO
 aaM
 aaM
@@ -80904,7 +79992,7 @@ adJ
 aee
 aee
 aeO
-oNW
+sZi
 kEF
 whV
 kEF
@@ -80913,7 +80001,7 @@ kEF
 whV
 kEF
 kEF
-kys
+sZi
 aeO
 aaM
 aaM
@@ -81418,7 +80506,7 @@ acO
 aef
 aez
 aeO
-oNW
+sZi
 pOS
 pOS
 pOS
@@ -81427,7 +80515,7 @@ pOS
 pOS
 pOS
 pOS
-kys
+sZi
 aeO
 aaM
 aaM
@@ -81678,13 +80766,13 @@ aeO
 oyh
 fid
 fri
-ikg
 fri
+ufi
+oNX
+xwr
+oyh
 fri
-fri
-dUQ
-fri
-jss
+xwr
 aeO
 aaM
 aaM
@@ -86294,11 +85382,11 @@ abw
 abN
 acc
 tVT
-rqW
-abN
-rqW
-adL
 tVT
+qlC
+tVT
+adL
+nrk
 rYS
 aeP
 aeV
@@ -86805,7 +85893,7 @@ aaM
 (209,1,1) = {"
 aaO
 aby
-aby
+mKw
 acd
 acu
 acW
@@ -87070,8 +86158,8 @@ acW
 acu
 adN
 abO
-mCI
-aeP
+abz
+aaO
 aeV
 aeV
 aeV
@@ -87836,11 +86924,11 @@ abB
 abP
 acg
 tIZ
-abP
-tIZ
+oYx
+oYx
 ePR
 adP
-abP
+eyb
 uuM
 aeP
 aeV

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -8682,8 +8682,9 @@
 	},
 /area/centcom/living)
 "awh" = (
-/turf/unsimulated/wall/riveted,
-/area/centcom/test)
+/obj/effect/wingrille_spawn/reinforced/crescent,
+/turf/template_noop,
+/area/centcom/control)
 "awi" = (
 /obj/machinery/porta_turret/crescent,
 /obj/effect/decal/warning_stripes,
@@ -9043,34 +9044,26 @@
 	},
 /area/centcom/control)
 "awY" = (
-/turf/unsimulated/floor{
-	icon_state = "white"
+/obj/structure/sink{
+	pixel_y = 26
 	},
-/area/centcom/test)
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/control)
 "awZ" = (
-/obj/machinery/dna_scannernew,
+/obj/item/stool/padded,
 /turf/unsimulated/floor{
-	icon_state = "white"
+	icon_state = "dark"
 	},
-/area/centcom/test)
-"axa" = (
-/obj/machinery/computer/scan_consolenew,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/centcom/test)
+/area/centcom/control)
 "axb" = (
-/obj/machinery/computer/cloning,
+/obj/structure/table/reinforced,
+/obj/item/deck/cards,
 /turf/unsimulated/floor{
-	icon_state = "white"
+	icon_state = "dark"
 	},
-/area/centcom/test)
-"axc" = (
-/obj/machinery/clonepod,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/centcom/test)
+/area/centcom/control)
 "axd" = (
 /obj/machinery/light/spot{
 	icon_state = "tube1";
@@ -9262,22 +9255,14 @@
 /area/centcom/control)
 "axy" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Research Facility";
+	name = "Janitorial Closet";
 	opacity = 1;
-	req_access = list(104)
+	req_access = list(107)
 	},
 /turf/unsimulated/floor{
-	icon_state = "delivery"
+	icon_state = "dark"
 	},
-/area/centcom/test)
-"axz" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/centcom/test)
+/area/centcom/control)
 "axA" = (
 /obj/structure/artilleryplaceholder/decorative{
 	icon_state = "25"
@@ -9678,18 +9663,18 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	icon_state = "white"
+	icon_state = "dark"
 	},
-/area/centcom/test)
+/area/centcom/control)
 "ayi" = (
 /obj/machinery/light{
 	dir = 4;
 	status = 0
 	},
 /turf/unsimulated/floor{
-	icon_state = "white"
+	icon_state = "dark"
 	},
-/area/centcom/test)
+/area/centcom/control)
 "ayj" = (
 /turf/unsimulated/floor{
 	icon_state = "vault";
@@ -9837,39 +9822,32 @@
 	dir = 4
 	},
 /area/centcom/control)
-"ayz" = (
-/obj/structure/closet/secure_closet/medical3{
-	pixel_x = -5
-	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/centcom/test)
 "ayA" = (
-/obj/structure/closet/secure_closet/medical1{
-	pixel_x = 5
-	},
+/obj/structure/janitorialcart,
 /turf/unsimulated/floor{
-	icon_state = "white"
+	icon_state = "vault";
+	dir = 1
 	},
-/area/centcom/test)
+/area/centcom/control)
 "ayB" = (
-/obj/structure/closet/secure_closet/medical2{
-	pixel_x = 5
-	},
+/obj/structure/closet/jcloset,
 /turf/unsimulated/floor{
-	icon_state = "white"
+	icon_state = "vault";
+	dir = 1
 	},
-/area/centcom/test)
+/area/centcom/control)
 "ayC" = (
 /obj/machinery/sleeper{
 	icon_state = "sleeper_0";
 	dir = 8
 	},
+/obj/structure/mopbucket,
+/obj/item/mop/advanced,
 /turf/unsimulated/floor{
-	icon_state = "white"
+	icon_state = "vault";
+	dir = 1
 	},
-/area/centcom/test)
+/area/centcom/control)
 "ayD" = (
 /turf/space/transit/north/shuttlespace_ns7,
 /area/shuttle/escape/transit)
@@ -10042,11 +10020,6 @@
 	icon_state = "floor"
 	},
 /area/centcom/control)
-"ayV" = (
-/turf/unsimulated/floor{
-	icon_state = "redfull"
-	},
-/area/centcom/test)
 "ayW" = (
 /obj/structure/artilleryplaceholder{
 	icon_state = "11"
@@ -10261,15 +10234,6 @@
 	dir = 1
 	},
 /area/centcom/control)
-"azu" = (
-/obj/structure/sign/securearea,
-/turf/unsimulated/wall/riveted,
-/area/centcom/test)
-"azv" = (
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/centcom/test)
 "azw" = (
 /obj/machinery/light{
 	dir = 1;
@@ -10279,7 +10243,7 @@
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
-/area/centcom/test)
+/area/centcom/control)
 "azx" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Bluespace Artillery Deck";
@@ -10448,7 +10412,7 @@
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
-/area/centcom/test)
+/area/centcom/control)
 "azL" = (
 /turf/unsimulated/floor{
 	icon_state = "wood"
@@ -26032,10 +25996,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/merchant_station)
-"lkF" = (
-/obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/wall/riveted,
-/area/centcom/evac)
 "lkY" = (
 /obj/structure/bed/chair/shuttle,
 /obj/machinery/light{
@@ -29350,6 +29310,11 @@
 	dir = 4
 	},
 /area/centcom/legion)
+"rOK" = (
+/obj/structure/lattice,
+/obj/effect/wingrille_spawn/reinforced/crescent,
+/turf/template_noop,
+/area/centcom/control)
 "rPy" = (
 /turf/simulated/wall/shuttle,
 /area/shuttle/merchant/start)
@@ -30165,6 +30130,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/merchant_station/warehouse)
+"tym" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket{
+	amount_per_transfer_from_this = 50
+	},
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 1
+	},
+/area/centcom/control)
 "tAQ" = (
 /obj/machinery/door/blast/odin{
 	density = 0;
@@ -71912,13 +71887,13 @@ ktR
 avF
 avP
 apW
-awh
+auT
 axy
-awh
-awh
-ayV
-ayV
-ayV
+auT
+auT
+aAe
+aAe
+aAe
 aAe
 aAe
 auT
@@ -72170,11 +72145,11 @@ apW
 apW
 apW
 awY
-awY
+awj
 ayh
-awh
-awh
-azu
+auT
+auT
+aAf
 azK
 aAf
 auT
@@ -72426,13 +72401,13 @@ aaM
 aaM
 aaM
 awh
-awZ
-awY
-awY
-ayz
-awh
-azv
-azv
+awj
+awj
+awj
+awj
+auT
+awj
+awj
 awj
 aAr
 aaM
@@ -72447,7 +72422,7 @@ ifh
 ifh
 ifh
 ifh
-lkF
+ifh
 etF
 etF
 nhD
@@ -72682,14 +72657,14 @@ apW
 aaM
 aaM
 aaM
-awh
-axa
-axz
-awY
+rOK
+awj
+awj
+awj
 ayA
-awh
-azv
-azv
+auT
+awj
+awj
 awj
 aAr
 aaM
@@ -72941,10 +72916,10 @@ aaM
 aaM
 awh
 awZ
-awY
-awY
+awj
+awj
 ayB
-awh
+auT
 azw
 awi
 awj
@@ -73198,12 +73173,12 @@ aaM
 aaM
 awh
 axb
-axz
-awY
-awY
-awh
-azv
-azv
+awj
+awj
+tym
+auT
+awj
+awj
 awj
 aAr
 ait
@@ -73454,13 +73429,13 @@ aaM
 aaM
 aaM
 awh
-axc
-awY
+awZ
+awj
 ayi
 ayC
-awh
-azv
-azv
+auT
+awj
+awj
 awj
 aAr
 aaM

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -4402,7 +4402,6 @@
 	name = "Break Room";
 	req_one_access = list(11,24)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "aiP" = (
@@ -4751,10 +4750,6 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "ajx" = (
@@ -5086,10 +5081,6 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/coffee/full,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "akn" = (
@@ -5851,10 +5842,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -9812,10 +9799,6 @@
 	dir = 1
 	},
 /obj/item/storage/box/chess_kit,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/medical/patient_wing_library)
 "aqG" = (
@@ -17089,7 +17072,6 @@
 	id = "quarantine_ward_lockdown";
 	name = "Quarantine Blast Doors"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "aGg" = (
@@ -17109,7 +17091,6 @@
 	id = "quarantine_ward_lockdown";
 	name = "Quarantine Blast Doors"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "aGi" = (
@@ -17437,10 +17418,6 @@
 	c_tag = "Medical - Quarantine Ward 1";
 	pixel_x = 20
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "aGZ" = (
@@ -17481,10 +17458,6 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
@@ -17615,7 +17588,6 @@
 	req_access = null;
 	specialfunctions = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/medical/patient_d)
 "aHu" = (
@@ -17919,10 +17891,6 @@
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
@@ -18472,10 +18440,6 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "aJb" = (
@@ -18589,10 +18553,6 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_post1)
 "aJn" = (
@@ -18604,14 +18564,6 @@
 	dir = 5
 	},
 /obj/structure/closet/emcloset,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aJr" = (
@@ -18629,10 +18581,6 @@
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
 	dir = 5
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
@@ -19176,7 +19124,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_post1)
 "aKo" = (
@@ -19193,7 +19140,6 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_post1)
 "aKp" = (
@@ -19221,7 +19167,6 @@
 	pixel_y = 25;
 	req_access = list(66)
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_post1)
 "aKq" = (
@@ -19239,7 +19184,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aKr" = (
@@ -19306,7 +19250,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aKv" = (
@@ -19362,7 +19305,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aKy" = (
@@ -19428,7 +19370,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aKC" = (
@@ -19443,7 +19384,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aKD" = (
@@ -19821,7 +19761,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_hallway)
 "aLr" = (
 /obj/structure/window/reinforced{
@@ -19834,7 +19774,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_hallway)
 "aLs" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -19850,7 +19790,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_hallway)
 "aLv" = (
 /obj/structure/window/reinforced,
@@ -19862,7 +19802,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_hallway)
 "aLw" = (
 /obj/machinery/power/apc{
@@ -20218,43 +20158,26 @@
 "aMo" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner,
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "aMp" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "aMq" = (
 /obj/effect/floor_decal/spline/fancy/wood,
-/obj/structure/flora/grass/green,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/snow,
-/area/medical/patient_wing_picnic)
-"aMr" = (
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "aMs" = (
 /obj/effect/floor_decal/spline/fancy/wood,
-/obj/structure/flora/grass/brown,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "aMt" = (
 /obj/machinery/door/firedoor,
@@ -20274,24 +20197,12 @@
 "aMu" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aMv" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/glass,
 /obj/item/storage/box/cups,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aMw" = (
@@ -20309,23 +20220,11 @@
 "aMy" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/bed/chair/comfy/teal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aMz" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/glass,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aMA" = (
@@ -20755,8 +20654,9 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "aNq" = (
 /turf/simulated/floor/holofloor/desert,
@@ -20840,10 +20740,6 @@
 	icon_state = "comfychair_preview"
 	},
 /obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -21076,7 +20972,6 @@
 	pixel_y = 0
 	},
 /obj/structure/table/reinforced,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "aNW" = (
@@ -21086,14 +20981,12 @@
 	dir = 1;
 	pixel_x = 2
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "aNX" = (
 /obj/effect/floor_decal/corner/pink/full,
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "aNY" = (
@@ -21102,7 +20995,6 @@
 	dir = 10
 	},
 /obj/machinery/iv_drip,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "aNZ" = (
@@ -21189,16 +21081,9 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
-/area/medical/patient_wing_picnic)
-"aOg" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
-	},
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "aOi" = (
 /obj/machinery/door/firedoor/multi_tile{
@@ -21251,10 +21136,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/flora/pottedplant/random,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aOo" = (
@@ -21529,16 +21410,12 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "aOV" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/vending/snack,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "aOW" = (
@@ -21867,8 +21744,9 @@
 	c_tag = "Medical - Patient Wing Picnic Area";
 	dir = 8
 	},
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "aPL" = (
 /obj/effect/decal/cleanable/blood,
@@ -22466,16 +22344,16 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "aQV" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 1
 	},
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "aQX" = (
 /obj/machinery/light{
@@ -22487,8 +22365,8 @@
 	icon_state = "spline_fancy";
 	dir = 1
 	},
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "aQZ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -24235,10 +24113,6 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
 "aWC" = (
@@ -24250,19 +24124,11 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
 "aWD" = (
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -24287,10 +24153,6 @@
 /obj/effect/floor_decal/corner/lime{
 	icon_state = "corner_white";
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay4)
@@ -24456,7 +24318,6 @@
 	name = "Briefing Room";
 	req_access = list(66)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
 "aXm" = (
@@ -25438,14 +25299,6 @@
 "bbF" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/filingcabinet/chestdrawer,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/medical/patient_wing_post2)
 "bbG" = (
@@ -26370,10 +26223,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
 "bfE" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/beach/water/pool,
 /area/medical/patient_wing_gym)
 "bfI" = (
@@ -28245,10 +28094,6 @@
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Patient Wing Processing"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_post1)
 "bwQ" = (
@@ -28260,8 +28105,8 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/flora/grass/brown,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "bDz" = (
 /obj/machinery/door/firedoor,
@@ -28325,13 +28170,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"bSE" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/break_room)
 "bTg" = (
 /turf/simulated/floor/wood,
 /area/medical/patient_wing_library)
@@ -28449,12 +28287,8 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "ceW" = (
 /obj/structure/disposalpipe/segment{
@@ -28550,14 +28384,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/backup_SMES)
-"ctN" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/beach/water/pool,
-/area/medical/patient_wing_gym)
 "cue" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -28596,8 +28422,8 @@
 	icon_state = "spline_fancy";
 	dir = 1
 	},
-/obj/structure/flora/grass/brown,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "cFw" = (
 /turf/simulated/wall,
@@ -28809,10 +28635,6 @@
 	pixel_y = 5;
 	req_access = list(66);
 	specialfunctions = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/medical/patient_wing_post2)
@@ -29089,10 +28911,6 @@
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/item/storage/firstaid/adv,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/medical/patient_wing_post2)
 "dyi" = (
@@ -29149,8 +28967,9 @@
 /area/medical/quarantineaccess)
 "dGd" = (
 /obj/effect/floor_decal/spline/fancy/wood/full,
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "dGF" = (
 /obj/effect/floor_decal/corner/pink/full{
@@ -29159,7 +28978,6 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "dGW" = (
@@ -29279,10 +29097,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_gym)
 "dQy" = (
@@ -29304,7 +29118,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "dSb" = (
@@ -29459,7 +29272,6 @@
 	name = "Supervised Living Center Interior";
 	req_access = list(66)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_post1)
 "dZs" = (
@@ -29608,10 +29420,6 @@
 	icon_state = "tube1";
 	pixel_x = 0
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/medical/patient_wing_picnic)
 "ejU" = (
@@ -29750,14 +29558,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"eCB" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/medical/patient_wing_post2)
 "eCT" = (
 /obj/machinery/microwave{
 	pixel_y = 4
@@ -29976,10 +29776,6 @@
 	dir = 9
 	},
 /obj/structure/closet/emcloset,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "fcg" = (
@@ -30117,7 +29913,6 @@
 	icon_state = "corner_white";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "fvi" = (
@@ -30134,17 +29929,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
-"fxf" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/break_room)
 "fxI" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -30231,10 +30015,6 @@
 "fSE" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/closet/secure_closet/medical3,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/medical/patient_wing_post2)
 "fSU" = (
@@ -30278,7 +30058,6 @@
 	name = "Staff Smoking Lounge";
 	req_one_access = list(11,24)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "fXa" = (
@@ -30738,7 +30517,6 @@
 	icon_state = "body_scanner_0";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "gEo" = (
@@ -30748,10 +30526,6 @@
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
@@ -30947,7 +30721,6 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/medical/patient_wing_library)
 "hsj" = (
@@ -31016,10 +30789,6 @@
 	icon_state = "warning";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "hzi" = (
@@ -31060,14 +30829,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/mine/unexplored)
-"hCs" = (
-/obj/structure/flora/pottedplant/random,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/break_room)
 "hDn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -31274,10 +31035,6 @@
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_y = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/medical/patient_wing_library)
@@ -31618,17 +31375,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"jbQ" = (
-/obj/structure/bed/chair/comfy/beige{
-	icon_state = "comfychair_preview";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/break_room)
 "jcB" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -31811,18 +31557,10 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/medical/patient_wing_post2)
 "jkR" = (
 /obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /obj/item/modular_computer/console/preset/medical,
 /turf/simulated/floor/tiled,
 /area/medical/patient_wing_post2)
@@ -31875,14 +31613,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/scisublevel)
-"jyB" = (
-/obj/structure/table/glass,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/break_room)
 "jAt" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/station_alert,
@@ -32009,11 +31739,6 @@
 	icon_state = "cabinet_closed";
 	name = "Clothing Storage"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_gym)
 "jVg" = (
@@ -32208,10 +31933,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medsublevel)
-"kGH" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing_hallway)
 "kIj" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/corner/red/full{
@@ -32345,14 +32066,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)
-"lbc" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/break_room)
 "lbY" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -32441,10 +32154,6 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/bar_soft/full,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "lmV" = (
@@ -32490,17 +32199,8 @@
 /obj/item/deck/cards,
 /obj/item/storage/card,
 /obj/item/deck/tarot,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/medical/patient_wing_library)
-"lvZ" = (
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
-/area/medical/patient_wing_picnic)
 "lxg" = (
 /obj/structure/bed/chair/office/light{
 	icon_state = "officechair_white";
@@ -32627,6 +32327,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
+"lXe" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
+/area/medical/patient_wing_picnic)
 "lYK" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/break_room)
@@ -32698,10 +32407,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/medical/patient_wing_post2)
@@ -32883,7 +32588,6 @@
 	pixel_y = -32
 	},
 /obj/effect/decal/warning_stripes,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/dark,
 /area/medical/quarantine)
 "mET" = (
@@ -32995,7 +32699,6 @@
 /area/rnd/xenobiology/xenoflora)
 "mWx" = (
 /obj/machinery/light,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "mXF" = (
@@ -33161,7 +32864,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_gym)
 "nkj" = (
@@ -33339,10 +33041,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_gym)
 "nAz" = (
@@ -33473,10 +33171,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/medical/patient_wing_post2)
 "nHQ" = (
@@ -33501,7 +33195,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/medical/patient_d)
 "nJV" = (
@@ -33632,10 +33325,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_post1)
 "odm" = (
@@ -33725,8 +33414,7 @@
 	pixel_y = 26
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "owL" = (
 /turf/simulated/wall,
@@ -33902,7 +33590,6 @@
 	name = "Supervised Living Center Exterior";
 	req_access = list(66)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_post1)
 "oZx" = (
@@ -34053,7 +33740,6 @@
 	req_access = null;
 	specialfunctions = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/medical/patient_a)
 "pFa" = (
@@ -34157,16 +33843,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
-"pRj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/outpost/engineering/hallway)
 "pUs" = (
 /obj/item/frame/fire_alarm,
 /obj/effect/decal/cleanable/dirt,
@@ -34334,12 +34010,9 @@
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/obj/structure/flora/grass/brown,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/medical/patient_wing_picnic)
 "qjw" = (
 /obj/structure/bed/chair{
@@ -34423,10 +34096,6 @@
 /area/medical/quarantine)
 "qqB" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -34546,13 +34215,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"qJA" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing_hallway)
 "qJQ" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -34577,10 +34239,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_gym)
@@ -34640,7 +34298,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/medical/patient_a)
 "qSm" = (
@@ -34760,13 +34417,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engineering/backup_SMES)
-"rbJ" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing_gym)
 "rfa" = (
 /turf/simulated/wall,
 /area/maintenance/scisublevel)
@@ -35243,17 +34893,6 @@
 	icon_state = "plating"
 	},
 /area/maintenance/substation/engineering_sublevel)
-"snl" = (
-/obj/machinery/cryopod{
-	icon_state = "body_scanner_0";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/quarantine)
 "soJ" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
@@ -35384,7 +35023,6 @@
 /obj/effect/floor_decal/corner/lime/full{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "sCY" = (
@@ -35794,7 +35432,6 @@
 	pixel_x = -26;
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_gym)
 "tDN" = (
@@ -35839,10 +35476,6 @@
 	dir = 5
 	},
 /obj/structure/closet/wardrobe/white,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "tMU" = (
@@ -35882,7 +35515,6 @@
 	icon_state = "corner_white";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "tNU" = (
@@ -36568,14 +36200,6 @@
 	dir = 4
 	},
 /area/outpost/research/anomaly_storage)
-"vri" = (
-/obj/structure/bed/chair/comfy/beige,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/break_room)
 "vyW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -36721,7 +36345,6 @@
 	req_access = null;
 	specialfunctions = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/medical/patient_a)
 "vRZ" = (
@@ -36792,10 +36415,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/medical/patient_wing_picnic)
 "vZr" = (
@@ -36860,7 +36479,6 @@
 	req_access = null;
 	specialfunctions = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/medical/patient_c)
 "wba" = (
@@ -37076,7 +36694,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing_hallway)
 "wyg" = (
@@ -37096,15 +36713,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/quarantineaccess)
-"wAf" = (
-/obj/structure/table/glass,
-/obj/item/material/ashtray/bronze,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/break_room)
 "wBT" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
@@ -37407,10 +37015,6 @@
 	},
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/quarantine)
 "xjV" = (
@@ -37447,10 +37051,6 @@
 /obj/machinery/librarypubliccomp{
 	pixel_y = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/medical/patient_wing_library)
 "xoK" = (
@@ -37475,7 +37075,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/medical/patient_c)
 "xrn" = (
@@ -37534,7 +37133,6 @@
 	dir = 1;
 	icon_state = "camera"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/outpost/engineering/hallway)
 "xym" = (
@@ -37721,10 +37319,6 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 8;
 	icon_state = "spline_plain"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/beach/water/pool,
 /area/medical/patient_wing_gym)
@@ -37937,10 +37531,6 @@
 	pixel_x = 1;
 	pixel_y = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "ydL" = (
@@ -37952,17 +37542,6 @@
 /obj/structure/table/reinforced/steel,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/anomaly_storage)
-"yfa" = (
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/break_room)
 "yfN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
@@ -49447,10 +49026,10 @@ ace
 kTB
 abJ
 dkd
-vri
-jyB
-wAf
-jbQ
+jhN
+swb
+akj
+eEH
 alM
 mpr
 lYK
@@ -50218,9 +49797,9 @@ hlD
 ace
 abJ
 gYj
-hCs
-bSE
-bSE
+ajQ
+dkd
+dkd
 dvo
 qqB
 ajQ
@@ -50736,7 +50315,7 @@ ycW
 akm
 lkK
 xNS
-yfa
+ajv
 dbo
 lYK
 aaa
@@ -51245,7 +50824,7 @@ acn
 ahI
 xxd
 uqb
-lbc
+ajs
 bVc
 akn
 akn
@@ -51500,9 +51079,9 @@ ahg
 mlz
 ahg
 eby
-pRj
+ain
 dbr
-lbc
+ajs
 ajT
 rmO
 rmO
@@ -52014,9 +51593,9 @@ agt
 agO
 ahg
 ahK
-pRj
+ain
 uqb
-fxf
+ajv
 xrn
 rmO
 rmO
@@ -52271,7 +51850,7 @@ agu
 agM
 ahg
 ahK
-pRj
+ain
 dbr
 ajw
 ajV
@@ -73155,7 +72734,7 @@ aIa
 aIa
 aNW
 aON
-snl
+qnU
 qnU
 gDH
 wWU
@@ -78038,7 +77617,7 @@ aMo
 aNo
 bzd
 aOR
-aNo
+bzd
 aOf
 aQU
 aLm
@@ -78805,7 +78384,7 @@ vCz
 bvB
 aKo
 aLo
-aMr
+aMq
 fdV
 hHy
 hHy
@@ -79068,7 +78647,7 @@ hHy
 hHy
 fdV
 aNq
-aOg
+cyD
 aLm
 aSK
 aTx
@@ -79319,13 +78898,13 @@ unQ
 vCz
 dYW
 aLm
-lvZ
+aMq
 aNq
 aNq
 aNq
 aNq
 aNq
-aQV
+lXe
 aLm
 aSL
 aSL
@@ -82917,7 +82496,7 @@ aIx
 aJA
 aKB
 gsX
-eCB
+nTr
 nTr
 nTr
 aRD
@@ -84200,7 +83779,7 @@ mnD
 uAS
 gll
 jjF
-kGH
+lLx
 noC
 xLk
 xZp
@@ -84456,8 +84035,8 @@ bTg
 bTg
 hpx
 aqB
-qJA
-kGH
+lLx
+lLx
 bXx
 bfE
 eCm
@@ -84717,8 +84296,8 @@ aJk
 mWx
 lZJ
 bfE
-ctN
-rbJ
+eCm
+wLc
 jVc
 pCk
 aba

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -564,10 +564,6 @@
 	pixel_x = 0
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice2)
 "abg" = (
@@ -591,10 +587,6 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "abi" = (
@@ -811,7 +803,6 @@
 	req_access = list(63)
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice2)
 "abE" = (
@@ -1051,10 +1042,6 @@
 	dir = 4;
 	icon_state = "camera"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice2)
 "acf" = (
@@ -1105,10 +1092,6 @@
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 6
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice2)
@@ -1364,10 +1347,6 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice2)
 "acI" = (
@@ -1500,7 +1479,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice2)
 "acQ" = (
@@ -1607,10 +1585,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice2)
 "acZ" = (
@@ -1646,10 +1620,6 @@
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -4963,7 +4933,6 @@
 	dir = 9
 	},
 /obj/machinery/door/firedoor/multi_tile,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/security/main)
 "ajX" = (
@@ -4981,7 +4950,6 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/security/main)
 "ajY" = (
@@ -5012,7 +4980,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/security/main)
 "aka" = (
@@ -5472,14 +5439,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/security/security_office)
 "akP" = (
@@ -5952,7 +5911,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/security_office)
 "alO" = (
@@ -6465,10 +6423,6 @@
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/security/security_office)
@@ -7766,10 +7720,6 @@
 "aps" = (
 /obj/structure/table/standard,
 /obj/item/material/ashtray,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /obj/item/stack/wrapping_paper,
 /obj/item/stack/wrapping_paper,
 /turf/simulated/floor/tiled,
@@ -8335,7 +8285,6 @@
 /area/security/security_office)
 "aqx" = (
 /obj/machinery/light,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/security/security_office)
 "aqy" = (
@@ -8382,7 +8331,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/security/security_office)
 "aqB" = (
@@ -8411,11 +8359,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/security_office)
@@ -9184,7 +9127,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/security_office)
 "arS" = (
@@ -13250,12 +13192,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "ayt" = (
 /obj/machinery/photocopier,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "ayu" = (
@@ -14500,7 +14440,6 @@
 	name = "Engineering Hallway";
 	req_one_access = list(10)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "aAD" = (
@@ -14563,7 +14502,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
 "aAH" = (
@@ -14581,7 +14519,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "aAJ" = (
@@ -14961,10 +14898,6 @@
 /area/security/brig)
 "aBp" = (
 /obj/structure/bed/chair/comfy/brown,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "aBq" = (
@@ -15002,7 +14935,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "aBt" = (
@@ -15011,18 +14943,6 @@
 	pixel_y = 2
 	},
 /obj/structure/table/wood,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/lawoffice)
-"aBu" = (
-/obj/structure/table/wood,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "aBv" = (
@@ -15332,10 +15252,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aBX" = (
@@ -15360,10 +15276,6 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aBZ" = (
@@ -15395,18 +15307,10 @@
 	dir = 5
 	},
 /obj/item/modular_computer/console/preset/engineering,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aCc" = (
 /obj/machinery/papershredder,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aCd" = (
@@ -15446,10 +15350,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -16058,11 +15958,14 @@
 /turf/simulated/floor/tiled,
 /area/teleporter)
 "aDj" = (
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/grass,
 /area/bridge)
 "aDk" = (
-/obj/structure/flora/grass/brown,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/bridge)
 "aDl" = (
 /obj/structure/grille,
@@ -16195,10 +16098,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /obj/item/modular_computer/laptop/preset/command/captain,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -16220,10 +16119,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "aDy" = (
@@ -16239,14 +16134,6 @@
 	icon_state = "2-4"
 	},
 /obj/item/card/id/captains_spare,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "aDz" = (
@@ -17131,8 +17018,9 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/bridge)
 "aFa" = (
 /obj/structure/grille,
@@ -17276,10 +17164,6 @@
 /obj/machinery/light{
 	dir = 4;
 	status = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -17536,7 +17420,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
 "aFG" = (
@@ -17815,7 +17698,6 @@
 /area/ai_monitored/storage/eva)
 "aGa" = (
 /obj/effect/floor_decal/corner/blue/full,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aGb" = (
@@ -17825,7 +17707,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aGc" = (
@@ -17841,7 +17722,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aGd" = (
@@ -17906,7 +17786,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aGg" = (
@@ -18305,7 +18184,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "aGM" = (
@@ -18427,10 +18305,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/teleporter)
-"aGZ" = (
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
-/area/bridge)
 "aHa" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -18578,10 +18452,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -18804,7 +18674,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
 "aHH" = (
@@ -19081,7 +18950,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/hos)
 "aIf" = (
@@ -19168,7 +19036,6 @@
 	name = "Security Wing";
 	req_access = list(63)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aIk" = (
@@ -19218,7 +19085,6 @@
 	name = "Security Wing";
 	req_access = list(63)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aIm" = (
@@ -19922,19 +19788,11 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aJt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
@@ -19959,10 +19817,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/papershredder,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aJw" = (
@@ -19972,10 +19826,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/suit_cycler/hos,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aJx" = (
@@ -19989,10 +19839,6 @@
 	pixel_x = 24
 	},
 /obj/structure/flora/pottedplant/random,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "aJy" = (
@@ -20038,10 +19884,6 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aJC" = (
@@ -20063,10 +19905,6 @@
 /obj/machinery/status_display{
 	pixel_x = 0;
 	pixel_y = 32
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
@@ -20109,10 +19947,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/blue/full{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 8
 	},
 /obj/item/modular_computer/console/preset/security,
@@ -20370,7 +20204,6 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aKb" = (
@@ -20475,7 +20308,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "aKl" = (
@@ -20638,10 +20470,6 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge)
 "aKz" = (
@@ -20671,10 +20499,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -21776,10 +21600,6 @@
 	pixel_x = 0
 	},
 /obj/structure/table/wood,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge)
 "aMn" = (
@@ -21812,10 +21632,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -22052,10 +21868,6 @@
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 25
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
@@ -22586,10 +22398,6 @@
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/stone/marble,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "aNL" = (
@@ -22683,7 +22491,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "aNV" = (
@@ -22844,10 +22651,6 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge)
 "aOh" = (
@@ -22883,10 +22686,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -22925,10 +22724,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -23066,10 +22861,6 @@
 /area/crew_quarters/heads/chief)
 "aOB" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "aOC" = (
@@ -23098,10 +22889,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -23364,10 +23151,6 @@
 	},
 /obj/effect/floor_decal/corner/blue/full,
 /obj/item/modular_computer/console/preset/security,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aPc" = (
@@ -23590,7 +23373,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/journalistoffice)
 "aPy" = (
@@ -23666,7 +23448,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/hop)
 "aPF" = (
@@ -23814,7 +23595,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "aPO" = (
@@ -23980,10 +23760,6 @@
 	dir = 4;
 	status = 0
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "aPZ" = (
@@ -24082,10 +23858,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "aQk" = (
@@ -24121,10 +23893,6 @@
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -24640,7 +24408,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aRm" = (
@@ -24848,10 +24615,6 @@
 /area/bridge)
 "aRB" = (
 /obj/structure/flora/pottedplant/random,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge)
 "aRC" = (
@@ -24896,11 +24659,6 @@
 	},
 /obj/structure/table/wood,
 /obj/item/stack/packageWrap,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "aRE" = (
@@ -24911,7 +24669,6 @@
 	},
 /obj/structure/table/wood,
 /obj/item/hand_labeler,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "aRF" = (
@@ -25076,10 +24833,6 @@
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -25277,7 +25030,6 @@
 	name = "Chief Engineer's Office";
 	req_access = list(56)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "aRZ" = (
@@ -25351,7 +25103,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/full,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aSe" = (
@@ -25362,7 +25113,6 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aSf" = (
@@ -25384,7 +25134,6 @@
 	dir = 10
 	},
 /obj/machinery/computer/station_alert/engineering,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aSh" = (
@@ -25396,7 +25145,6 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aSi" = (
@@ -25504,10 +25252,6 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aSs" = (
@@ -25536,10 +25280,6 @@
 "aSt" = (
 /obj/machinery/alarm{
 	pixel_y = 23
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
@@ -25744,10 +25484,6 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aSO" = (
@@ -25769,14 +25505,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aSQ" = (
@@ -25810,10 +25538,6 @@
 /area/crew_quarters/heads/hop)
 "aSR" = (
 /obj/item/modular_computer/console/preset/command,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
 "aSS" = (
@@ -25975,7 +25699,6 @@
 	pixel_x = -2;
 	pixel_y = -2
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/chief)
 "aTm" = (
@@ -25985,7 +25708,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/chief)
 "aTn" = (
@@ -25998,11 +25720,6 @@
 	department = "Chief Engineer's Office"
 	},
 /obj/structure/table/standard,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "aTo" = (
@@ -26030,10 +25747,6 @@
 "aTp" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/corner/yellow/full,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aTq" = (
@@ -26051,7 +25764,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aTr" = (
@@ -26099,7 +25811,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/firealarm/east,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aTu" = (
@@ -26378,7 +26089,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aTQ" = (
@@ -26443,7 +26153,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aTV" = (
@@ -26458,10 +26167,6 @@
 /obj/machinery/camera/network/prison{
 	c_tag = "Security - Visitation Area";
 	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
@@ -26503,10 +26208,6 @@
 	c_tag = "Security - Visitation";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "aTY" = (
@@ -26537,7 +26238,6 @@
 	name = "Brig Lockdown Door";
 	opacity = 0
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "aUa" = (
@@ -26758,10 +26458,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aUv" = (
@@ -26776,14 +26472,6 @@
 /area/hallway/primary/starboard)
 "aUw" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aUx" = (
@@ -26817,10 +26505,6 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/hop)
 "aUy" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /obj/item/modular_computer/console/preset/command/hop,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -26979,10 +26663,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/bridge)
 "aUL" = (
@@ -27001,10 +26681,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
@@ -27239,7 +26915,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aVf" = (
@@ -27249,7 +26924,6 @@
 	req_one_access = list(10)
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aVg" = (
@@ -27278,10 +26952,6 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aVj" = (
@@ -27294,10 +26964,6 @@
 "aVk" = (
 /obj/effect/floor_decal/corner/yellow/full{
 	icon_state = "corner_white_full";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -27361,7 +27027,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "aVo" = (
@@ -27431,7 +27096,6 @@
 	desc = "It opens and closes. Hazardous lifeforms ahead. Caution advised!";
 	name = "Security Lobby"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aVu" = (
@@ -27466,16 +27130,11 @@
 	name = "Security Aft Entrance";
 	req_access = list(63)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "aVw" = (
 /obj/machinery/light{
 	icon_state = "tube1";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -27560,10 +27219,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aVF" = (
@@ -27579,10 +27234,6 @@
 /area/hallway/primary/starboard)
 "aVG" = (
 /obj/structure/table/reinforced,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /obj/item/modular_computer/laptop/preset/command/hop,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -27812,28 +27463,16 @@
 	icon_state = "loadingarea";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aWh" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aWi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aWj" = (
@@ -27854,10 +27493,6 @@
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -27889,10 +27524,6 @@
 	icon_state = "corner_white";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aWo" = (
@@ -27901,7 +27532,6 @@
 	name = "Engineering Hallway";
 	req_one_access = null
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aWp" = (
@@ -27956,10 +27586,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "aWv" = (
@@ -27996,7 +27622,6 @@
 /area/hallway/primary/port)
 "aWA" = (
 /obj/machinery/door/airlock/glass,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "aWB" = (
@@ -28100,10 +27725,6 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "aWK" = (
@@ -28177,7 +27798,6 @@
 /area/hallway/primary/central_one)
 "aWQ" = (
 /obj/machinery/door/airlock/glass,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aWR" = (
@@ -28374,10 +27994,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aXn" = (
@@ -28391,10 +28007,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -28438,10 +28050,6 @@
 	},
 /obj/item/toy/figure/corgi,
 /obj/item/device/megaphone,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
 "aXq" = (
@@ -28904,10 +28512,6 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aYa" = (
@@ -28962,10 +28566,6 @@
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
@@ -29098,7 +28698,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "aYk" = (
@@ -29199,7 +28798,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aYq" = (
@@ -29344,7 +28942,6 @@
 	name = "Bridge Blast Doors";
 	opacity = 0
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
 "aYB" = (
@@ -29597,7 +29194,6 @@
 	name = "Custodial Closet";
 	req_access = list(26)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/janitor)
 "aYY" = (
@@ -29771,7 +29367,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "aZn" = (
@@ -29935,7 +29530,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aZC" = (
@@ -30086,7 +29680,6 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "aZN" = (
@@ -30615,10 +30208,6 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "baS" = (
@@ -30654,7 +30243,6 @@
 	name = "Maintenance Access";
 	req_access = list(66)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
 "baV" = (
@@ -30915,7 +30503,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "bbs" = (
@@ -31355,7 +30942,6 @@
 "bcd" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/vending/snack,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "bce" = (
@@ -31368,7 +30954,6 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "bcf" = (
@@ -31377,14 +30962,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "bcg" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/ramp{
 	icon_state = "ramptop";
 	dir = 1
@@ -31432,10 +31012,6 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
 "bck" = (
@@ -31450,10 +31026,6 @@
 /obj/machinery/vending/cigarette,
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - Staff Smoking Lounge"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
@@ -31477,10 +31049,6 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/newscaster{
 	pixel_y = 32
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
@@ -31926,10 +31494,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bdk" = (
@@ -31967,10 +31531,6 @@
 /area/hallway/primary/central_one)
 "bdl" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bdm" = (
@@ -32303,20 +31863,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/primary/starboard)
 "bdN" = (
 /obj/effect/floor_decal/corner/lime/full{
 	icon_state = "corner_white_full";
 	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/primary/starboard)
@@ -32345,10 +31897,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
 "bdQ" = (
@@ -32373,10 +31921,6 @@
 "bdT" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/table/glass,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
 "bdU" = (
@@ -32908,10 +32452,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "beP" = (
@@ -33156,7 +32696,6 @@
 	name = "Examination Room 2";
 	req_one_access = list(5)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 2"
@@ -33170,17 +32709,9 @@
 /area/hallway/primary/starboard)
 "bfm" = (
 /obj/structure/bed/chair/comfy/beige,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
 "bfn" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
 "bfo" = (
@@ -33210,7 +32741,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled{
 	icon_state = "vault";
 	dir = 5
@@ -33677,10 +33207,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bge" = (
@@ -33952,11 +33478,6 @@
 	})
 "bgx" = (
 /obj/effect/floor_decal/corner/lime/full,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/hallway/primary/starboard)
 "bgy" = (
@@ -33964,11 +33485,6 @@
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/hallway/primary/starboard)
 "bgz" = (
@@ -34002,10 +33518,6 @@
 	id = "medlounge";
 	pixel_x = -4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
 "bgB" = (
@@ -34025,10 +33537,6 @@
 	},
 /obj/structure/coatrack{
 	pixel_x = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
@@ -34051,10 +33559,6 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/table/standard,
 /obj/item/storage/box/donkpockets,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
 "bgF" = (
@@ -34575,10 +34079,6 @@
 /obj/structure/table/stone/marble,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bhz" = (
@@ -34671,10 +34171,6 @@
 	pixel_w = 0;
 	pixel_x = 0;
 	pixel_y = 28
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/medical/reception)
@@ -34898,7 +34394,6 @@
 	name = "Examination Room 1";
 	req_one_access = list(5)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room{
 	name = "\improper Medical - Exam Room 1"
@@ -36348,7 +35843,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/medbreak)
 "bkt" = (
@@ -36765,7 +36259,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bkZ" = (
@@ -37308,10 +36801,6 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge)
 "blS" = (
@@ -37344,10 +36833,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
 "blU" = (
@@ -37395,10 +36880,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
 "blY" = (
@@ -37671,10 +37152,6 @@
 "bmy" = (
 /obj/structure/bed/chair{
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
@@ -38081,7 +37558,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "bng" = (
@@ -38156,10 +37632,6 @@
 "bnl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
 "bnm" = (
@@ -38183,10 +37655,6 @@
 "bnp" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
 "bnq" = (
@@ -39134,7 +38602,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "boE" = (
@@ -39178,7 +38645,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "boG" = (
@@ -39205,7 +38671,6 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "boH" = (
@@ -39409,7 +38874,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "boR" = (
@@ -39480,10 +38944,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
@@ -39760,10 +39220,6 @@
 	pixel_y = 6;
 	req_access = list(66)
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/medical/reception)
 "bpx" = (
@@ -40033,7 +39489,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "bpU" = (
@@ -40183,10 +39638,6 @@
 	req_access = list(19)
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
 "bqg" = (
@@ -40489,10 +39940,6 @@
 	icon_state = "tube1";
 	pixel_x = 0
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /obj/item/modular_computer/laptop/preset/medical,
 /turf/simulated/floor/tiled,
 /area/medical/reception)
@@ -40755,10 +40202,6 @@
 	icon_state = "corner_white";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "brb" = (
@@ -40786,20 +40229,12 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "brd" = (
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 5
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
@@ -40864,10 +40299,6 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge)
 "brl" = (
@@ -40876,10 +40307,6 @@
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
 "brm" = (
@@ -40899,11 +40326,6 @@
 "bro" = (
 /obj/machinery/smartfridge/drinks,
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/bridge/minibar)
 "brp" = (
@@ -41083,10 +40505,6 @@
 /area/hallway/primary/central_one)
 "brE" = (
 /obj/effect/floor_decal/corner/lime,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "brF" = (
@@ -41120,10 +40538,6 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "brH" = (
@@ -41139,10 +40553,6 @@
 	id = "medbay_ringer";
 	pixel_x = 26;
 	pixel_y = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
@@ -42705,7 +42115,6 @@
 	opacity = 0
 	},
 /obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "btR" = (
@@ -42723,7 +42132,6 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "btS" = (
@@ -42773,7 +42181,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "btV" = (
@@ -43365,7 +42772,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "buW" = (
@@ -43455,10 +42861,6 @@
 	icon_state = "corner_white";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bvg" = (
@@ -43494,10 +42896,6 @@
 	dir = 1
 	},
 /obj/structure/flora/pottedplant/random,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "bvi" = (
@@ -43565,10 +42963,6 @@
 /obj/structure/flora/pottedplant/random,
 /obj/effect/floor_decal/corner/pink{
 	icon_state = "corner_white";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -43759,8 +43153,9 @@
 	icon_state = "rwindow";
 	dir = 1
 	},
-/obj/structure/flora/grass/brown,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/grass,
 /area/bridge)
 "bvN" = (
 /obj/structure/bed/chair{
@@ -43814,8 +43209,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/bridge)
 "bvS" = (
 /turf/simulated/wall/r_wall,
@@ -44240,8 +43636,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/bridge)
 "bwH" = (
 /obj/structure/bed/chair{
@@ -44283,8 +43680,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/grass,
 /area/bridge)
 "bwM" = (
 /obj/structure/window/reinforced{
@@ -44484,7 +43882,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "bwY" = (
@@ -44752,10 +44149,6 @@
 	},
 /obj/effect/floor_decal/corner/mauve/full{
 	icon_state = "corner_white_full";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -45226,8 +44619,9 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/grass,
 /area/bridge)
 "byf" = (
 /obj/structure/bed/chair{
@@ -45286,8 +44680,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/flora/grass/brown,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/grass,
 /area/bridge)
 "bym" = (
 /obj/machinery/door/airlock/external{
@@ -45465,10 +44860,6 @@
 "byA" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/rdoffice)
 "byB" = (
@@ -45497,10 +44888,6 @@
 "byC" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
@@ -45646,7 +45033,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/medical/emt)
 "byT" = (
@@ -46113,10 +45499,6 @@
 "bzI" = (
 /obj/item/modular_computer/console/preset/research,
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/rdoffice)
 "bzJ" = (
@@ -46616,19 +45998,11 @@
 	pixel_x = 0
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/rdoffice)
 "bAI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
@@ -47203,7 +46577,6 @@
 	name = "Cryogenics Storage";
 	req_access = list(5)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/main)
 "bBR" = (
@@ -47511,10 +46884,6 @@
 "bCv" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/closet/secure_closet/RD,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /obj/item/clothing/gloves/latex/nitrile/tajara,
 /obj/item/clothing/gloves/latex/nitrile/unathi,
 /turf/simulated/floor/tiled/white,
@@ -47658,10 +47027,6 @@
 /obj/machinery/light,
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/mauve/full,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bCL" = (
@@ -47970,7 +47335,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "bDm" = (
@@ -48168,10 +47532,6 @@
 /area/hallway/primary/central_one)
 "bDD" = (
 /obj/machinery/vending/coffee,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bDE" = (
@@ -48428,10 +47788,6 @@
 	icon_state = "corner_white_full";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/research)
 "bEl" = (
@@ -48454,10 +47810,6 @@
 "bEm" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/mauve/full,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "bEo" = (
@@ -48656,10 +48008,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -48952,7 +48300,6 @@
 /obj/machinery/door/firedoor{
 	dir = 2
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_one)
 "bFp" = (
@@ -49006,7 +48353,6 @@
 	icon_state = "corner_white";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bFv" = (
@@ -49053,7 +48399,6 @@
 	name = "Cryogenic Storage"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/main)
 "bFy" = (
@@ -49383,10 +48728,6 @@
 	icon_state = "corner_white";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "bGa" = (
@@ -49647,10 +48988,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -50026,7 +49363,6 @@
 	name = "Conference Room and Lift";
 	req_access = list(47)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/research)
 "bHb" = (
@@ -50334,10 +49670,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/east,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "bHy" = (
@@ -50533,10 +49865,6 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/research)
 "bHT" = (
@@ -50545,10 +49873,6 @@
 	},
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -50663,14 +49987,12 @@
 /area/hallway/primary/central_one)
 "bIe" = (
 /obj/machinery/light,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bIf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bIg" = (
@@ -50688,7 +50010,6 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "bIi" = (
@@ -50795,10 +50116,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bIv" = (
@@ -51139,10 +50456,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bJe" = (
@@ -51453,10 +50766,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/wood,
 /area/library)
 "bJN" = (
@@ -51476,7 +50785,6 @@
 /area/library)
 "bJP" = (
 /obj/machinery/door/airlock/glass,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bJQ" = (
@@ -51488,7 +50796,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bJR" = (
@@ -51504,26 +50811,13 @@
 /area/hydroponics)
 "bJS" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/both,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/snow,
+/obj/structure/flora/pottedplant/random,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "bJT" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/spline/fancy/wood,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "bJU" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -51531,11 +50825,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "bJV" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -51547,7 +50837,7 @@
 	icon_state = "spline_fancy";
 	dir = 6
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "bJW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -51558,10 +50848,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/mechanical,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "bJY" = (
@@ -51589,11 +50875,7 @@
 	icon_state = "spline_fancy";
 	dir = 5
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "bKa" = (
 /obj/effect/floor_decal/corner/green/full{
@@ -51958,10 +51240,6 @@
 	dir = 8;
 	network = list("Service")
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "bKT" = (
@@ -52007,7 +51285,7 @@
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "bKX" = (
 /obj/structure/disposalpipe/segment{
@@ -52199,10 +51477,6 @@
 	c_tag = "Aft Corridor - Camera 4";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bLw" = (
@@ -52253,10 +51527,6 @@
 	dir = 4
 	},
 /obj/structure/table/standard,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "bLE" = (
@@ -52266,11 +51536,7 @@
 	icon_state = "spline_fancy";
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "bLF" = (
 /obj/structure/window/reinforced,
@@ -52646,10 +51912,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bMk" = (
@@ -53213,10 +52475,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/library)
 "bNv" = (
@@ -53237,10 +52495,6 @@
 "bNw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
@@ -53274,7 +52528,7 @@
 	icon_state = "spline_fancy";
 	dir = 1
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "bNE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -53313,7 +52567,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "bNH" = (
@@ -53847,10 +53100,6 @@
 	dir = 1;
 	icon_state = "tube1"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/primary/aft)
 "bOT" = (
@@ -53864,7 +53113,6 @@
 	req_access = list(28)
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bOV" = (
@@ -53876,10 +53124,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -22;
 	pixel_y = 24
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -53895,15 +53139,14 @@
 	pixel_x = 0;
 	pixel_y = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bOZ" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/appliance/cooker/oven,
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 30
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bPa" = (
@@ -54360,7 +53603,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -54477,10 +53719,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bQw" = (
@@ -54595,7 +53833,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/library)
 "bQM" = (
@@ -55099,7 +54336,6 @@
 /obj/machinery/chemical_dispenser/bar_soft/full{
 	pixel_y = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bSr" = (
@@ -55289,10 +54525,6 @@
 	dir = 10
 	},
 /obj/machinery/firealarm/north,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "bSL" = (
@@ -55348,10 +54580,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/rag,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bSQ" = (
@@ -55363,10 +54591,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/cakehat,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bSR" = (
@@ -55378,10 +54602,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bSS" = (
@@ -55394,10 +54614,6 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/matches,
 /obj/item/storage/fancy/candle_box,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bST" = (
@@ -55408,10 +54624,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/vending/cigarette,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bSU" = (
@@ -55479,10 +54691,6 @@
 	dir = 8;
 	network = list("Service")
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/chapel/office)
 "bTd" = (
@@ -55504,10 +54712,6 @@
 /area/chapel/office)
 "bTe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "bTf" = (
@@ -55540,10 +54744,6 @@
 /area/chapel/main)
 "bTj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "bTk" = (
@@ -55626,10 +54826,6 @@
 	pixel_x = -22;
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bTr" = (
@@ -55638,10 +54834,6 @@
 	},
 /obj/structure/table/wood,
 /obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 1
 	},
 /turf/simulated/floor/lino,
@@ -55701,23 +54893,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bTx" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bTy" = (
@@ -55924,10 +55104,6 @@
 	req_access = list(25,28)
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bTZ" = (
@@ -56008,7 +55184,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/locker/locker_toilet)
 "bUg" = (
@@ -56140,7 +55315,6 @@
 	name = "Chaplain's Office";
 	req_access = list(22)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/chapel/office)
 "bUu" = (
@@ -56206,7 +55380,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "bUz" = (
@@ -56304,10 +55477,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "bUJ" = (
@@ -56367,10 +55536,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/chapel/office)
 "bUS" = (
@@ -56380,10 +55545,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "bUT" = (
@@ -56442,7 +55603,6 @@
 	name = "Diner"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "bUY" = (
@@ -56461,7 +55621,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "bUZ" = (
@@ -56490,20 +55649,13 @@
 	pixel_x = 0
 	},
 /obj/machinery/computer/arcade/orion_trail,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bVc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bVd" = (
@@ -56519,10 +55671,6 @@
 	dir = 1
 	},
 /obj/machinery/computer/arcade/battle,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bVf" = (
@@ -56539,10 +55687,6 @@
 	name = "north bump";
 	pixel_x = 0;
 	pixel_y = 24
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -56631,10 +55775,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "bVu" = (
@@ -56669,10 +55809,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bVx" = (
@@ -56684,10 +55820,6 @@
 	c_tag = "Bar - West";
 	dir = 4;
 	network = list("Service")
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -56929,10 +56061,6 @@
 	icon_state = "intact-supply";
 	dir = 9
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "bVW" = (
@@ -57029,7 +56157,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/ramp/bottom{
 	icon_state = "rampbot";
 	dir = 4
@@ -57108,6 +56235,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWq" = (
@@ -57198,10 +56326,6 @@
 	c_tag = "Bar -Theatre";
 	dir = 8;
 	network = list("Service")
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -57365,10 +56489,6 @@
 	icon_state = "tube1";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWM" = (
@@ -57376,10 +56496,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bWN" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/ramp/bottom,
 /area/crew_quarters/bar)
 "bWP" = (
@@ -57389,10 +56505,6 @@
 	},
 /obj/machinery/computer/guestpass{
 	pixel_x = -32
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -57579,10 +56691,6 @@
 /area/crew_quarters/bar)
 "bXp" = (
 /obj/machinery/computer/slot_machine,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "bXq" = (
@@ -57640,10 +56748,6 @@
 	icon_state = "loadingarea";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
 "bXx" = (
@@ -57662,10 +56766,6 @@
 	name = "adjusted light fixture";
 	pixel_y = 16
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
 "bXA" = (
@@ -57683,10 +56783,6 @@
 "bXB" = (
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -57720,10 +56816,6 @@
 "bXE" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
@@ -57788,10 +56880,6 @@
 /area/quartermaster/lobby)
 "bXN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
 "bXO" = (
@@ -57876,10 +56964,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bXU" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/ramp/bottom{
 	icon_state = "rampbot";
 	dir = 4
@@ -57890,10 +56974,6 @@
 	dir = 4
 	},
 /obj/machinery/computer/slot_machine,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "bXX" = (
@@ -57966,6 +57046,10 @@
 "bYi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/structure/bed/chair/wood{
+	icon_state = "wooden_chair";
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -58057,10 +57141,6 @@
 	icon_state = "corner_white";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /obj/structure/bed/chair{
 	dir = 8
 	},
@@ -58070,10 +57150,6 @@
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
@@ -58098,7 +57174,6 @@
 	pixel_x = -15;
 	pixel_y = 15
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bYA" = (
@@ -58220,18 +57295,10 @@
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
 "bYK" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /obj/structure/bed/chair{
 	dir = 8
 	},
@@ -58376,7 +57443,6 @@
 	c_tag = "Bar - Booths";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bYZ" = (
@@ -58492,10 +57558,6 @@
 	icon_state = "map-scrubbers";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
 "bZo" = (
@@ -58557,11 +57619,6 @@
 	},
 /obj/machinery/firealarm/south,
 /obj/machinery/computer/slot_machine,
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "bZx" = (
@@ -58762,7 +57819,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
 "bZN" = (
@@ -59104,10 +58160,6 @@
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/lobby)
 "cam" = (
@@ -59263,7 +58315,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/quartermaster/break_room)
 "caD" = (
@@ -59566,10 +58617,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/break_room)
@@ -60206,10 +59253,6 @@
 "ccA" = (
 /obj/structure/table/standard,
 /obj/item/trash/tray,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/carpet,
 /area/quartermaster/break_room)
 "ccB" = (
@@ -60981,7 +60024,6 @@
 	req_one_access = list(31,48,67)
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/quartermaster/break_room)
 "cea" = (
@@ -63807,13 +62849,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"cty" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/library)
 "ctD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	icon_state = "intact";
@@ -63862,11 +62897,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/rnd/lab)
-"cyO" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
 "czw" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j1";
@@ -63893,19 +62923,8 @@
 	dir = 2;
 	network = list("Civilian Main","Rep_Office")
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
-"cEQ" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
 "cGg" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
@@ -63968,39 +62987,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice)
-"cVI" = (
-/obj/structure/flora/tree/pine/xmas{
-	density = 0;
-	pixel_x = 0;
-	pixel_y = 16
-	},
-/obj/random/gift{
-	pixel_x = 10;
-	pixel_y = 6
-	},
-/obj/random/gift{
-	pixel_x = 13
-	},
-/obj/random/gift{
-	pixel_x = -3;
-	pixel_y = 10
-	},
-/obj/random/gift,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "cXM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"cYO" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
 "cZf" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -64038,6 +63030,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"deX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/chair/wood,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "dfb" = (
 /obj/machinery/light{
 	dir = 8
@@ -64095,14 +63092,6 @@
 /mob/living/simple_animal/rat/hooded,
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
-"dnB" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/rdoffice)
 "dpr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /mob/living/simple_animal/rat/brown,
@@ -64117,13 +63106,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay)
-"dpA" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/bridge)
 "dqb" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -64303,9 +63285,8 @@
 	icon_state = "spline_fancy_corner";
 	dir = 1
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/obj/structure/flora/pottedplant/random,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "dFK" = (
 /obj/machinery/light/small/emergency{
@@ -64343,29 +63324,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
-"dHG" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
-"dIO" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
 "dKk" = (
 /obj/machinery/computer/guestpass{
 	pixel_x = 32
@@ -64376,37 +63334,6 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/airless,
 /area/maintenance/cargo)
-"dLe" = (
-/obj/machinery/door/firedoor{
-	enable_smart_generation = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
-"dLg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/security/brig)
 "dNy" = (
 /turf/simulated/floor/plating,
 /area/maintenance/bridge_elevator)
@@ -64422,11 +63349,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/maintenance/bar)
-"dQK" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/bridge/minibar)
 "dRX" = (
 /turf/simulated/floor/airless{
 	icon_state = "asteroidplating"
@@ -64474,11 +63396,6 @@
 /area/medical/med_office{
 	name = "\improper Medical - Psych Stairway"
 	})
-"dXH" = (
-/obj/item/stool/padded,
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/bar)
 "dXS" = (
 /obj/structure/lattice,
 /turf/unsimulated/floor/asteroid/ash/rocky,
@@ -64493,18 +63410,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"dZk" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
 "eco" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -64557,6 +63462,7 @@
 "eiB" = (
 /obj/machinery/door/blast/shutters{
 	dir = 2;
+	is_critical = 1;
 	name = "shutter"
 	},
 /obj/machinery/conveyor{
@@ -64578,7 +63484,7 @@
 "ekc" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green{
-	pixel_y = 8
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet,
 /area/lawoffice)
@@ -64595,6 +63501,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/maintenance/bar)
+"enp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/table/wood,
+/obj/item/flame/candle{
+	pixel_x = 1;
+	pixel_y = -8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "eqc" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -64633,14 +63558,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"esE" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/quartermaster/lobby)
 "eye" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -64920,7 +63837,7 @@
 	icon_state = "spline_fancy";
 	dir = 10
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "fpa" = (
 /obj/machinery/door/airlock/maintenance{
@@ -65008,7 +63925,6 @@
 /area/maintenance/medbay)
 "fzd" = (
 /obj/machinery/papershredder,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "fBZ" = (
@@ -65292,6 +64208,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/maintenance/bar)
+"gjM" = (
+/obj/structure/bed/chair/wood,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "gmt" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -65370,7 +64290,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
 	req_access = null;
-	req_one_access = list(12,25,28)
+	req_one_access = list(12,25,28,66)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
@@ -65434,16 +64354,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"gHf" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
 "gHJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/medical_wall{
@@ -65504,31 +64414,12 @@
 	temperature = 278
 	},
 /area/crew_quarters/kitchen/freezer)
-"gNU" = (
-/obj/random/gift,
-/obj/random/gift,
-/obj/random/gift{
-	pixel_x = 4
-	},
-/obj/random/gift{
-	pixel_x = 9;
-	pixel_y = -5
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "gOO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
-"gPV" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/research)
 "gSO" = (
 /obj/item/extinguisher,
 /obj/item/extinguisher{
@@ -65562,16 +64453,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
-"gVn" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/library)
 "gVC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -65621,18 +64502,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/vault)
-"haQ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
 "hcd" = (
 /obj/effect/floor_decal/spline/plain{
 	icon_state = "spline_plain";
@@ -65798,11 +64667,6 @@
 /obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"hsc" = (
-/obj/structure/table/wood,
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "htm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -66108,22 +64972,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
-"hUS" = (
-/obj/random/gift{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/random/gift,
-/obj/random/gift{
-	pixel_x = -9;
-	pixel_y = -4
-	},
-/obj/random/gift{
-	pixel_x = -14;
-	pixel_y = -6
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "hUU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -66238,10 +65086,6 @@
 	icon_state = "corner_white";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "izh" = (
@@ -66283,14 +65127,6 @@
 	temperature = 278
 	},
 /area/crew_quarters/kitchen/freezer)
-"iDt" = (
-/obj/structure/table/wood,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/library)
 "iFV" = (
 /turf/simulated/floor/tiled/dark,
 /area/assembly/chargebay)
@@ -66486,27 +65322,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"jvH" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/security/vacantoffice2)
-"jxv" = (
-/obj/machinery/door/firedoor{
-	enable_smart_generation = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
 "jyi" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -66515,14 +65330,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"jAb" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
 "jBK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -66672,20 +65479,6 @@
 /obj/item/clothing/mask/gas/alt,
 /turf/simulated/floor/tiled,
 /area/maintenance/cargo)
-"kan" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/ramp{
-	icon_state = "ramptop";
-	dir = 1
-	},
-/area/hallway/primary/starboard)
 "kaW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -66736,7 +65529,7 @@
 	icon_state = "spline_fancy";
 	dir = 5
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "kcG" = (
 /obj/structure/cable{
@@ -66803,11 +65596,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"kew" = (
-/obj/structure/table/wood,
-/obj/item/flame/candle,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "keE" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -66874,17 +65662,6 @@
 /obj/effect/decal/remains/rat,
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
-"kpa" = (
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
 "kqz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -66898,23 +65675,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
-"ktY" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
-"kuQ" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
 "kuR" = (
 /obj/structure/closet/crate,
 /obj/random/loot,
@@ -66953,15 +65713,6 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/maintenance/bar)
-"kxY" = (
-/obj/structure/table/wood,
-/obj/structure/window/reinforced,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/library)
 "kzl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -66999,7 +65750,6 @@
 "kAL" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/chess_kit,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "kAV" = (
@@ -67012,22 +65762,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/medbreak)
-"kDN" = (
-/obj/random/gift{
-	pixel_y = 13
-	},
-/obj/random/gift{
-	pixel_x = 10;
-	pixel_y = 6
-	},
-/obj/random/gift{
-	pixel_x = -8
-	},
-/obj/random/gift{
-	pixel_y = -4
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "kGv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stool,
@@ -67096,10 +65830,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/atmos_control)
-"kRU" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/security/security_office)
 "kVD" = (
 /obj/item/stool/padded,
 /mob/living/simple_animal/rat/gray,
@@ -67178,6 +65908,21 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"lhV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/bed/chair/wood,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "lhZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -67234,34 +65979,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
-"lkr" = (
-/obj/structure/table/wood,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/library)
 "lmd" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/atmos_control)
-"lnl" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "lnw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -67277,14 +65999,6 @@
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"lpt" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/main)
 "lpw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -67338,14 +66052,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/maintenance/atmos_control)
-"lzM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
 "lAi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -67392,11 +66098,7 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "lGd" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -67542,13 +66244,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"lWd" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
 "lWF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67578,7 +66273,9 @@
 	req_access = list(38);
 	specialfunctions = 4
 	},
-/obj/item/modular_computer/laptop/preset/representative,
+/obj/item/modular_computer/laptop/preset/representative{
+	pixel_y = 8
+	},
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "mbc" = (
@@ -67625,7 +66322,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "mdY" = (
@@ -67709,10 +66405,6 @@
 "mqr" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/carpet,
 /area/quartermaster/break_room)
 "mqT" = (
@@ -67766,13 +66458,6 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/medbay)
-"mzf" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/ramp/bottom,
-/area/quartermaster/lobby)
 "mzO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -67897,6 +66582,24 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
+"mJe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/bed/chair/wood{
+	icon_state = "wooden_chair";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "mJH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -68064,10 +66767,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
-"ndO" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/blue,
-/area/rnd/rdoffice)
 "ndP" = (
 /obj/item/trash/cigbutt,
 /obj/item/trash/cigbutt,
@@ -68191,17 +66890,6 @@
 	},
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
-"nto" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/security/brig)
 "nug" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/white{
@@ -68249,14 +66937,6 @@
 "nHe" = (
 /turf/simulated/wall,
 /area/maintenance/vault)
-"nHF" = (
-/obj/structure/table/wood,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/library)
 "nIc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68348,10 +67028,6 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/research)
 "nQp" = (
@@ -68440,13 +67116,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"ohD" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/hallway/primary/starboard)
 "ohF" = (
 /obj/machinery/conveyor_switch/oneway,
 /obj/effect/decal/cleanable/dirt,
@@ -68496,18 +67165,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"ooO" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
 "opq" = (
 /obj/machinery/button/holosign{
 	id = 2
@@ -68556,6 +67213,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"org" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "oud" = (
 /turf/simulated/wall,
 /area/maintenance/substation/supply)
@@ -68712,20 +67376,12 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/hydroponics,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "oOq" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
 	dir = 6
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/research)
@@ -68740,13 +67396,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
-"oQR" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/chapel/office)
 "oQU" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -69021,10 +67670,6 @@
 	pixel_y = 0;
 	req_access = list(38)
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "pnI" = (
@@ -69040,17 +67685,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/medbay)
-"ppw" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "ppZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -69088,14 +67722,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/maintenance/medbay)
-"puS" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
 "pvB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -69221,18 +67847,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"pJj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/security/vacantoffice2)
 "pKY" = (
 /obj/item/stack/tile/floor_white{
 	pixel_x = 8;
@@ -69293,10 +67907,6 @@
 	pixel_x = -28;
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "pUs" = (
@@ -69323,7 +67933,6 @@
 	pixel_x = 0;
 	pixel_y = 16
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "pYZ" = (
@@ -69395,7 +68004,7 @@
 	icon_state = "spline_fancy";
 	dir = 9
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "qow" = (
 /obj/machinery/button/remote/blast_door{
@@ -69498,13 +68107,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/rnd/misc_lab)
-"qyd" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/port)
 "qCl" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/phoronreinforced{
@@ -69532,13 +68134,6 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"qFs" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/quartermaster/break_room)
 "qGK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -69643,13 +68238,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
-"qQg" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
 "qSv" = (
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -69800,16 +68388,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"rkd" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "rnc" = (
 /obj/structure/largecrate/animal/cow,
 /turf/simulated/floor/plating,
@@ -69842,7 +68420,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "rsk" = (
-/turf/simulated/floor/carpet,
+/obj/structure/table/wood,
+/obj/item/flame/candle{
+	pixel_x = 1;
+	pixel_y = -8
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "rsz" = (
 /turf/simulated/floor/airless,
@@ -69859,13 +68442,6 @@
 /obj/effect/floor_decal/corner/mauve/full,
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
-"rtO" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/bar)
 "rut" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -69913,17 +68489,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/maintenance/engineering)
-"ryd" = (
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
 "rzp" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -70025,14 +68590,6 @@
 /obj/structure/lattice,
 /turf/simulated/open/airless,
 /area/mine/unexplored)
-"rNn" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/hallway/primary/aft)
 "rOK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -70061,7 +68618,6 @@
 	name = "Representative's Reception";
 	req_access = null
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "rUQ" = (
@@ -70136,7 +68692,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "sez" = (
@@ -70227,7 +68782,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "sny" = (
@@ -70571,16 +69125,6 @@
 "tpZ" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/engineering_hallway_main)
-"trA" = (
-/obj/machinery/door/firedoor{
-	enable_smart_generation = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
 "tst" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood{
@@ -70668,13 +69212,6 @@
 "tzU" = (
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
-"tzY" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/security/lobby)
 "tCf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/white{
@@ -70819,13 +69356,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/security_starboard)
-"tHQ" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/security/security_office)
 "tIQ" = (
 /obj/machinery/vending/dinnerware{
 	desc = "A kitchen and restaurant utensil vendor.";
@@ -70868,13 +69398,6 @@
 "tPt" = (
 /turf/simulated/wall/r_wall,
 /area/assembly/robotics_cyborgification)
-"tTi" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
 "tTz" = (
 /obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
@@ -71057,26 +69580,8 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"ueV" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
-"ufn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
 "ufU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71157,13 +69662,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/medbay)
-"upR" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
 "usI" = (
 /obj/structure/table,
 /turf/simulated/floor/plating,
@@ -71190,10 +69688,6 @@
 	},
 /obj/structure/table/standard{
 	name = "plastic table frame"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/primary/aft)
@@ -71243,21 +69737,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"uyz" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
-"uzg" = (
-/obj/structure/bed/chair/office/dark,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/library)
 "uzx" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
@@ -71278,21 +69757,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"uDz" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
-"uEv" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "uKO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -71372,10 +69836,6 @@
 	desc = "A small empty jar that is mostly used for giving a tip.";
 	name = "tip jar"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "uVj" = (
@@ -71397,7 +69857,6 @@
 	icon_state = "2-8"
 	},
 /obj/structure/flora/pottedplant/random,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "uVs" = (
@@ -71411,18 +69870,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"uXc" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/blue,
-/area/rnd/rdoffice)
 "uXj" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -71434,6 +69881,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"vak" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/grass,
+/area/bridge)
 "vap" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -71446,6 +69899,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
+"vaF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/bed/chair/wood{
+	icon_state = "wooden_chair";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "vaK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pipe{
@@ -71515,10 +69986,6 @@
 	icon_state = "direction_evac";
 	pixel_x = 32;
 	pixel_y = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
@@ -71626,19 +70093,6 @@
 /obj/item/material/shard,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"vpK" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Shaft Miner"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/quartermaster/break_room)
 "vvS" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -71687,22 +70141,6 @@
 /obj/random/vendor,
 /turf/simulated/floor/tiled,
 /area/maintenance/cargo)
-"vCV" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
 "vEy" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -71721,10 +70159,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"vEX" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/wood,
-/area/lawoffice)
 "vIC" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/bed/chair/office/light{
@@ -71929,6 +70363,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/maintenance/cargo)
+"vUR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/wood,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "vYh" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -72021,14 +70460,6 @@
 	temperature = 278
 	},
 /area/crew_quarters/kitchen/freezer)
-"woV" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/minibar)
 "wpl" = (
 /obj/machinery/light{
 	dir = 4;
@@ -72039,6 +70470,14 @@
 	temperature = 278
 	},
 /area/maintenance/medbay)
+"wqS" = (
+/obj/structure/table/wood,
+/obj/item/flame/candle{
+	pixel_x = 16;
+	pixel_y = 5
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "wra" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -72062,17 +70501,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"wvT" = (
-/obj/machinery/cryopod{
-	icon_state = "body_scanner";
-	dir = 2
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/main)
 "wxq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -72178,18 +70606,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice)
-"wOm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/wood,
-/area/lawoffice)
 "wOo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/c45/rubber,
@@ -72215,16 +70631,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/icu)
-"wPO" = (
-/obj/machinery/door/firedoor{
-	enable_smart_generation = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
 "wQC" = (
 /obj/machinery/conveyor{
 	backwards = 10;
@@ -72255,17 +70661,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice)
-"wYC" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start{
-	name = "Cargo Technician"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/quartermaster/break_room)
 "wYD" = (
 /obj/structure/girder,
 /turf/simulated/floor/airless,
@@ -72542,13 +70937,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"xBc" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
 "xBY" = (
 /obj/structure/coatrack{
 	pixel_x = -10;
@@ -72560,26 +70948,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/telesci)
-"xCz" = (
-/obj/effect/landmark{
-	name = "JoinLateCryo"
-	},
-/obj/effect/landmark{
-	name = "JoinLateCryo"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/main)
 "xDc" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 1
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "xDh" = (
 /obj/structure/cable{
@@ -72595,11 +70970,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
-"xHc" = (
-/obj/structure/table/wood,
-/obj/item/deck/cards,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "xHy" = (
 /obj/structure/closet/crate/freezer,
 /obj/effect/decal/cleanable/dirt,
@@ -72738,18 +71108,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"xTR" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer)
 "xVv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -72820,13 +71178,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"ygu" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/aft)
 "ykd" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -90187,7 +88538,7 @@ aQe
 aRV
 aTm
 aUZ
-cEQ
+aDY
 aXR
 aYZ
 aQq
@@ -91209,7 +89560,7 @@ aFG
 aHH
 aJh
 aKX
-lzM
+aDW
 aOD
 aQl
 aRZ
@@ -92269,7 +90620,7 @@ byt
 bzB
 bAB
 bBy
-ndO
+bCq
 bDk
 nPy
 bES
@@ -92783,7 +91134,7 @@ byv
 bzD
 bAD
 bBA
-uXc
+bBA
 bDm
 nPy
 bEU
@@ -93013,7 +91364,7 @@ aOH
 aQs
 aSe
 aTv
-kpa
+aVj
 aDY
 aXW
 aDY
@@ -93527,7 +91878,7 @@ aOL
 aQt
 aSg
 aTx
-kpa
+aVj
 aDY
 aXW
 aDY
@@ -93773,7 +92124,7 @@ avV
 axC
 azl
 aAJ
-xTR
+aCf
 aDY
 aDY
 aDY
@@ -94067,7 +92418,7 @@ bwW
 byA
 bzI
 bAH
-dnB
+bAG
 bCv
 bvS
 bEk
@@ -94579,10 +92930,10 @@ bsC
 bvT
 bwY
 byC
-gPV
+bsC
 bAI
-gPV
-gPV
+bsC
+bsC
 bDn
 bEm
 bEZ
@@ -95327,7 +93678,7 @@ aQx
 aHW
 aTB
 aVl
-qyd
+aWs
 aYc
 aZg
 aVq
@@ -95584,7 +93935,7 @@ aFX
 aFX
 aTC
 aVm
-qyd
+aWs
 aYc
 aZg
 aVq
@@ -96098,7 +94449,7 @@ aHW
 aHW
 aTE
 aVo
-qyd
+aWs
 aYe
 aZh
 baD
@@ -97691,7 +96042,7 @@ bRK
 bSh
 bSE
 bTc
-oQR
+bTN
 bUs
 bUR
 bUR
@@ -98948,9 +97299,9 @@ bsL
 bvY
 bxo
 aZs
-ryd
-ryd
-ryd
+bdh
+bdh
+bdh
 bCK
 bvY
 bvY
@@ -99172,7 +97523,7 @@ azv
 asd
 ajR
 auC
-dLg
+aGe
 aIf
 aJv
 aLt
@@ -99187,9 +97538,9 @@ aYl
 aZo
 baF
 bbE
-ryd
-upR
-ryd
+bdh
+aZs
+bdh
 bhr
 biJ
 aZs
@@ -99429,7 +97780,7 @@ amO
 amO
 aCr
 aEe
-dLg
+aGe
 aIg
 aJw
 aLu
@@ -99501,7 +97852,7 @@ bXg
 bXw
 bXN
 bXN
-esE
+bXN
 bYJ
 bWg
 bZm
@@ -99509,11 +97860,11 @@ bZM
 bZm
 caB
 cbd
-wYC
+cbx
 mqr
 ccA
-vpK
-qFs
+ccY
+cds
 cdJ
 caB
 ceo
@@ -99715,16 +98066,16 @@ bqz
 bbG
 bbG
 btS
-ooO
-ooO
+bbG
+bbG
 bxp
-ooO
-ooO
-ooO
-ooO
+bbG
+bbG
+bbG
+bbG
 opW
-ooO
-ooO
+bbG
+bbG
 bFn
 bbG
 bHi
@@ -99985,9 +98336,9 @@ bwb
 baI
 bGn
 bHj
-dHG
+aZs
 bIX
-iDt
+bJN
 bKL
 bLs
 bJL
@@ -100227,7 +98578,7 @@ bdl
 bpp
 aVs
 aZs
-dHG
+aZs
 btT
 bve
 bve
@@ -100240,21 +98591,21 @@ bve
 bve
 bve
 btT
-xBc
+aZs
 bHk
 bIf
 bIX
-lkr
-nHF
-kxY
+bJN
+bJN
+bLp
 bJL
 bMG
 bNu
-cty
-gVn
-uzg
-gVn
-cty
+bJL
+bOO
+bOM
+bOO
+bJL
 bQT
 bIT
 bNn
@@ -100268,7 +98619,7 @@ bVt
 bVU
 bWg
 bWH
-mzf
+bXi
 bXz
 bXQ
 bYd
@@ -100499,7 +98850,7 @@ bve
 baI
 bGo
 bHj
-dHG
+aZs
 bIY
 bJO
 bJO
@@ -100757,29 +99108,29 @@ bFo
 aZs
 bHl
 aZs
-jxv
+aWB
 bJP
-dLe
+bKM
 bLu
 bLw
 bMJ
 bNw
-ygu
-ygu
+bLw
+bLw
 bQs
-ygu
-ygu
+bLw
+bLw
 bQU
 sez
 bLw
 bSj
-ygu
-ygu
+bLw
+bLw
 bKM
 bUz
 bLw
-ygu
-ygu
+bLw
+bLw
 bWh
 bLw
 bNw
@@ -100787,7 +99138,7 @@ bXB
 bXS
 bYf
 bYv
-dLe
+bKM
 dyG
 bZp
 bZQ
@@ -101271,11 +99622,11 @@ btU
 aZs
 bHn
 aZs
-wPO
+aWB
 bJP
-trA
-lWd
-ufn
+bKM
+bLw
+bPz
 vhg
 bNy
 bLw
@@ -101295,9 +99646,9 @@ bUV
 bVv
 bLw
 bMJ
-lWd
-lWd
-lWd
+bLw
+bLw
+bLw
 bLw
 bLw
 vnf
@@ -101490,7 +99841,7 @@ aIi
 aJD
 aLx
 aLx
-tzY
+aLx
 aQK
 aSp
 aTR
@@ -101527,7 +99878,7 @@ bve
 baI
 bGp
 bHo
-dHG
+aZs
 bJa
 bJR
 bJR
@@ -101769,7 +100120,7 @@ bjY
 bjY
 baI
 aZs
-dHG
+aZs
 btT
 bve
 bve
@@ -101782,9 +100133,9 @@ bve
 bve
 bve
 bFp
-xBc
+aZs
 bHj
-dHG
+aZs
 bJb
 bJS
 lCV
@@ -101966,10 +100317,10 @@ abV
 aaJ
 aaU
 aba
-jvH
-jvH
+abw
+abw
 ace
-jvH
+abw
 acH
 acW
 aaU
@@ -102041,7 +100392,7 @@ bwb
 baI
 bGq
 bHq
-dHG
+aZs
 bJb
 bJT
 bKO
@@ -102067,15 +100418,15 @@ bVb
 bVX
 bWl
 bVx
-uEv
-uEv
+bVX
+bVX
 bVX
 bVX
 bWL
 bVX
 bWP
 bXE
-lnl
+bXE
 bSM
 bNO
 cbh
@@ -102285,16 +100636,16 @@ bqA
 bbG
 bbG
 btV
-dZk
-dZk
+bbG
+bbG
 bxq
-dZk
-dZk
-dZk
-dZk
+bbG
+bbG
+bbG
+bbG
 beQ
-dZk
-dZk
+bbG
+bbG
 bFq
 bbG
 bHq
@@ -102328,7 +100679,7 @@ bWM
 bWM
 bWM
 bYi
-bWa
+bZs
 bWa
 bYZ
 bZt
@@ -102555,7 +100906,7 @@ bEB
 bFr
 bFr
 bHr
-dHG
+aZs
 bJb
 bJT
 bKP
@@ -102564,9 +100915,9 @@ bIp
 bMM
 xDc
 bOq
-jAb
-rNn
-rNn
+bOT
+bOT
+bOT
 bQV
 mya
 bOR
@@ -102580,12 +100931,12 @@ bSM
 bVf
 bVZ
 bWn
+gjM
+wqS
+izh
 bWa
-bWa
-bWa
-bWa
-bWa
-bWa
+rsk
+bZT
 bWa
 bYZ
 bZt
@@ -102792,18 +101143,18 @@ aZs
 bdp
 bka
 bdp
-ktY
-gHf
 aZs
-gHf
+bdp
+aZs
+bdp
 brE
 bdp
 btW
 bvf
 bwc
-ktY
+aZs
 byQ
-ktY
+aZs
 bAZ
 bAT
 bEq
@@ -102837,16 +101188,16 @@ uRY
 bVz
 bWa
 bWo
-bZs
-bZs
-bZs
-bZs
-bZs
+gjM
+bZT
+izh
 bWa
+bZU
+bZU
 bWa
 bYZ
-rkd
-ppw
+bZu
+bZu
 bSM
 caN
 cbj
@@ -103079,8 +101430,8 @@ bMN
 kci
 pcB
 bOV
-puS
-puS
+bOR
+bOR
 bOR
 bOR
 bOR
@@ -103094,12 +101445,12 @@ bJd
 bVz
 bWa
 bWo
-bZT
-kew
-bZT
-xHc
-bZT
-izh
+bWa
+bWa
+bWa
+bWa
+bWa
+bWa
 bWa
 bWQ
 bSM
@@ -103350,17 +101701,17 @@ bTu
 bMj
 bVz
 bWa
-bWo
-rsk
-rsk
-rsk
-rsk
-kew
-izh
+vaF
+bZs
 bWa
+bWa
+bWa
+bWa
+bZs
+bZs
 bYZ
 bXE
-lnl
+bXE
 bSM
 caP
 cbi
@@ -103607,14 +101958,14 @@ bTu
 bSP
 bVz
 bWa
-bWo
-rsk
-hUS
-cVI
+enp
+bZT
+bWa
+bWa
+bWa
+bWa
 rsk
 bZT
-izh
-bWa
 bYZ
 bZt
 bYY
@@ -103864,14 +102215,14 @@ bTu
 bSQ
 bVz
 bWa
-bWo
-rsk
-gNU
-kDN
-rsk
-bZT
-izh
+mJe
+bZU
 bWa
+bZs
+bZs
+bWa
+bZU
+bZU
 bYZ
 bZt
 bYy
@@ -104023,9 +102374,9 @@ aaJ
 aaU
 abf
 abC
-pJj
+abC
 ack
-pJj
+abC
 acO
 acY
 aaU
@@ -104122,16 +102473,16 @@ bSR
 bVz
 bWa
 bWo
+bWa
+bWa
 rsk
-rsk
-rsk
-rsk
-kew
-izh
+bZT
+bWa
+bWa
 bWa
 bYZ
-rkd
-ppw
+bZu
+bZu
 bSM
 caR
 cbl
@@ -104379,12 +102730,12 @@ bIt
 bVz
 bWa
 bWo
-bZT
-kew
-bZT
-bZT
-bZT
-izh
+bWa
+bWa
+bZU
+bZU
+bWa
+bWa
 bWa
 bWQ
 bSM
@@ -104537,9 +102888,9 @@ aaM
 aaV
 abh
 abE
-nto
-nto
-nto
+abT
+abT
+abT
 acQ
 ada
 adu
@@ -104636,16 +102987,16 @@ bSS
 bVz
 bWa
 bWo
-bZU
-bZU
-bZU
-bZU
-bZU
+bWa
+bWa
+bWa
+bWa
+bWa
 bWa
 bWa
 bYZ
 bXE
-lnl
+bXE
 bSM
 caS
 bEK
@@ -104863,10 +103214,10 @@ bAc
 bBG
 bBP
 bCM
-wvT
-xCz
+bDF
+bEG
 bFy
-lpt
+bGx
 bBP
 bIo
 bJi
@@ -104884,7 +103235,7 @@ gpm
 dGy
 iBt
 xTH
-dIO
+bSs
 bSN
 bTw
 bUd
@@ -104892,17 +103243,17 @@ bUH
 bST
 bVA
 bWa
-bWo
+lhV
+wqS
+izh
 bWa
-bWa
-bWa
-bWa
-bWa
-bWa
+gjM
+wqS
+izh
 bWa
 bYZ
 bZt
-hsc
+bZt
 bSM
 bGC
 bGC
@@ -105073,7 +103424,7 @@ alP
 akR
 akR
 akR
-kRU
+akR
 arP
 ate
 auQ
@@ -105141,21 +103492,21 @@ bOR
 bOR
 bOR
 bOR
-dIO
+bSs
 bSO
 bTx
 bUe
-cYO
+bTu
 bTY
 bVA
 bWb
 bWp
+vUR
+org
 bWR
-bWR
-bWR
-bWR
+deX
 bVc
-bWa
+izh
 bWa
 bYZ
 bZt
@@ -105416,7 +103767,7 @@ bWS
 bWS
 bZb
 bZu
-ueV
+bZu
 bSM
 bPH
 bGC
@@ -105582,7 +103933,7 @@ ahH
 aiA
 aiA
 ajY
-tHQ
+akR
 alR
 amV
 aob
@@ -105657,7 +104008,7 @@ jPX
 bRU
 bSw
 bkY
-vCV
+bTz
 bUg
 bUI
 bUI
@@ -105913,7 +104264,7 @@ bRg
 jPX
 bRV
 nhV
-cyO
+bOR
 bTA
 bUh
 bUJ
@@ -105930,7 +104281,7 @@ bYB
 bYM
 bZc
 bZc
-dXH
+bZc
 bSM
 bEK
 bEK
@@ -106184,7 +104535,7 @@ bWa
 bWa
 bWv
 bWN
-rtO
+bYN
 bXp
 bXV
 bZw
@@ -109456,7 +107807,7 @@ vLA
 txY
 aKb
 aLN
-tTi
+awK
 aNF
 awK
 aSD
@@ -109972,17 +108323,17 @@ iap
 gfO
 aNH
 azX
-qQg
-qQg
-qQg
+awK
+awK
+awK
 aVw
 awK
 aYu
 aZN
-kuQ
-kan
+baR
+bcg
 bdN
-ohD
+bfk
 bgy
 bhT
 bji
@@ -110223,9 +108574,9 @@ azT
 aBp
 auY
 auY
-vEX
+awE
 cPY
-uyz
+awK
 rGO
 gBi
 aPu
@@ -110998,7 +109349,7 @@ aGM
 atr
 aKf
 fiA
-uDz
+awK
 aPv
 aRb
 aSG
@@ -111251,11 +109602,11 @@ atr
 wJm
 aCX
 awE
-vEX
+awE
 tGq
-uyz
+awK
 aLT
-uDz
+awK
 aPw
 aRc
 aSH
@@ -111503,14 +109854,14 @@ asc
 rgP
 ave
 auY
-wOm
+azV
 azS
 aBt
 gxO
 awJ
-vEX
+awE
 aII
-uyz
+awK
 aLS
 aNL
 aPx
@@ -111762,14 +110113,14 @@ wzv
 awI
 sdW
 azT
-aBu
+gxO
 vvS
 auY
-vEX
+awE
 aII
-uyz
+awK
 aLT
-uDz
+awK
 aPy
 aRe
 aRb
@@ -112024,9 +110375,9 @@ aGN
 cis
 ayt
 ouZ
-uyz
+awK
 aLT
-uDz
+awK
 aPz
 aRf
 aSJ
@@ -114344,7 +112695,7 @@ aPB
 aRm
 aSP
 aUw
-haQ
+aRm
 aXn
 aYA
 aZX
@@ -117162,7 +115513,7 @@ aAb
 aBy
 aDj
 aEY
-aDj
+vak
 aIK
 aKt
 aMi
@@ -117419,7 +115770,7 @@ aAc
 aBz
 aDk
 aDj
-aGZ
+aDj
 aIL
 aKt
 aMj
@@ -118469,9 +116820,9 @@ bie
 aqS
 bkz
 blR
-dpA
+aqS
 boP
-dpA
+aqS
 brk
 bsp
 btx
@@ -118985,7 +117336,7 @@ bkA
 blT
 bnl
 boR
-woV
+bno
 brl
 aoq
 aoq
@@ -119757,7 +118108,7 @@ blW
 bno
 boU
 bno
-dQK
+bno
 bsq
 aab
 aab

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -32245,8 +32245,6 @@
 	pixel_y = 3
 	},
 /obj/item/circuitboard/rdconsole,
-/obj/item/circuitboard/destructive_analyzer,
-/obj/item/circuitboard/protolathe,
 /obj/item/circuitboard/rdserver{
 	pixel_x = 3;
 	pixel_y = -3
@@ -33878,18 +33876,6 @@
 	},
 /obj/item/circuitboard/arcade/battle,
 /obj/item/circuitboard/arcade/orion_trail,
-/turf/simulated/floor/plating,
-/area/storage/tech)
-"bhj" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/circuitboard/cloning{
-	pixel_x = 0
-	},
-/obj/item/circuitboard/clonescanner,
-/obj/item/circuitboard/clonepod,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "bhk" = (
@@ -67121,6 +67107,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/maintenance/cargo)
+"ohL" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/circuitboard/protolathe,
+/obj/item/circuitboard/destructive_analyzer{
+	pixel_y = 8
+	},
+/turf/simulated/floor/plating,
+/area/storage/tech)
 "ois" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90600,9 +90597,9 @@ aZd
 aQq
 bbq
 bcU
+ohL
 beA
 bfO
-bhj
 bit
 bbq
 bkG

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -3205,6 +3205,7 @@
 	req_access = list(50);
 	req_one_access = null
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/interstitial_cargo)
 "gD" = (
@@ -3900,13 +3901,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/investigations)
-"hA" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white_full"
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled/white,
-/area/medical/psych)
 "hC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5718,7 +5712,6 @@
 	},
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/door/firedoor/multi_tile,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "kX" = (
@@ -5882,7 +5875,6 @@
 	req_access = list(64)
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "lk" = (
@@ -5921,10 +5913,6 @@
 	dir = 9
 	},
 /obj/structure/bed/chair,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "lp" = (
@@ -5932,18 +5920,10 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "lq" = (
 /obj/structure/table/wood,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "lr" = (
@@ -5981,10 +5961,6 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 0;
 	pixel_y = 32
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
@@ -6036,10 +6012,6 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "ly" = (
@@ -6065,10 +6037,6 @@
 "lz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "lA" = (
@@ -6160,7 +6128,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/medical/psych)
 "lH" = (
@@ -6239,10 +6206,6 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "lP" = (
@@ -6267,7 +6230,6 @@
 	},
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/door/firedoor/multi_tile,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/psych)
 "lU" = (
@@ -6927,10 +6889,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/stairs)
-"oP" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/open,
-/area/medical/psych)
 "pa" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7679,13 +7637,6 @@
 /obj/item/ladder_mobile,
 /turf/simulated/floor/airless,
 /area/maintenance/interstitial_construction_site/zone_2)
-"sZ" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/psych)
 "ta" = (
 /turf/simulated/wall,
 /area/maintenance/interstitial_construction_site)
@@ -8012,19 +7963,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/virology)
-"vg" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/tiled/white,
-/area/medical/psych)
 "vh" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled,
@@ -8970,6 +8908,7 @@
 	name = "Elevator Maintenance";
 	req_one_access = list(12,50)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/interstitial_cargo)
 "BW" = (
@@ -9884,14 +9823,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"Hg" = (
-/obj/structure/lattice,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/open,
-/area/medical/psych)
 "Hh" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -10121,13 +10052,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_interstitial)
-"Iu" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/psych)
 "Ix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10949,7 +10873,6 @@
 	name = "Psychiatry Wing";
 	req_access = list(5)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/medical/upperlevel)
 "Lr" = (
@@ -11309,7 +11232,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/plating,
 /area/janitor/stairs)
 "Mz" = (
@@ -11422,13 +11344,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/elevator)
-"MY" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/open,
-/area/medical/psych)
 "MZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11501,18 +11416,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"Nz" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/tiled/white,
-/area/medical/psych)
 "NB" = (
 /turf/simulated/wall,
 /area/maintenance/interstitial_construction_site/zone_2)
@@ -12225,17 +12128,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"RI" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white_full";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/psych)
 "RJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -52898,7 +52790,7 @@ hZ
 aa
 hZ
 GT
-oP
+GT
 Nf
 QM
 sl
@@ -53145,17 +53037,17 @@ kE
 hZ
 hZ
 hZ
-MY
-MY
-MY
-MY
-Hg
+GT
+GT
+GT
+GT
+Hm
 GT
 hZ
 aa
 hZ
 GT
-oP
+GT
 qQ
 yO
 sU
@@ -53412,7 +53304,7 @@ hZ
 hZ
 hZ
 kh
-hA
+kR
 ZY
 QM
 sl
@@ -53659,11 +53551,11 @@ kG
 kR
 hZ
 kZ
-Iu
+kL
 ln
 lq
 lx
-Iu
+kL
 lL
 hZ
 lN
@@ -54171,7 +54063,7 @@ kj
 kt
 kI
 kS
-vg
+kX
 kX
 li
 kX
@@ -54179,7 +54071,7 @@ lr
 kX
 lE
 lM
-Nz
+lM
 lV
 mp
 mt
@@ -54432,10 +54324,10 @@ hZ
 II
 kL
 Gm
-sZ
+kL
 lp
 lF
-RI
+ko
 hZ
 lW
 kt

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -788,14 +788,6 @@
 "bt" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bu" = (
@@ -855,7 +847,6 @@
 	name = "Station Shield Control";
 	req_one_access = list(11,19,24)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/storage/shields)
 "bA" = (
@@ -964,10 +955,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bM" = (
@@ -1019,10 +1006,6 @@
 	dir = 1;
 	icon_state = "map"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bR" = (
@@ -1039,10 +1022,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "bT" = (
@@ -1051,10 +1030,6 @@
 	},
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
@@ -1186,10 +1161,6 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "cl" = (
@@ -1248,10 +1219,6 @@
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/blue/full{
 	icon_state = "corner_white_full";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -1434,10 +1401,6 @@
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "cI" = (
@@ -1593,10 +1556,6 @@
 	c_tag = "Surface - Blue Dock Port";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "cZ" = (
@@ -1638,10 +1597,6 @@
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 6
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
@@ -1841,10 +1796,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -2298,7 +2249,6 @@
 	dir = 5;
 	icon_state = "intact"
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "ee" = (
@@ -2314,7 +2264,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "ef" = (
@@ -2370,7 +2319,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "el" = (
@@ -2378,7 +2326,6 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "em" = (
@@ -2559,15 +2506,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/port)
-"eC" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/snow,
-/area/hydroponics/garden)
 "eD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -2620,10 +2558,6 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "eI" = (
@@ -2664,10 +2598,6 @@
 	name = "Pool Cafe"
 	},
 /obj/item/glass_jar,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
 	temperature = 303.15
@@ -2741,10 +2671,6 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "eU" = (
@@ -2757,10 +2683,6 @@
 	},
 /obj/structure/bed/chair{
 	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
@@ -2775,10 +2697,6 @@
 	icon_state = "corner_white_full";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "eW" = (
@@ -2791,10 +2709,6 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "eX" = (
@@ -2806,10 +2720,6 @@
 	},
 /obj/effect/floor_decal/corner/yellow/full{
 	icon_state = "corner_white_full";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -2862,7 +2772,8 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/fore)
 "fb" = (
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/entry/fore)
 "fc" = (
 /obj/machinery/light/small,
@@ -3211,10 +3122,6 @@
 /area/hallway/secondary/entry/fore)
 "fL" = (
 /obj/effect/floor_decal/corner/blue/full,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "fM" = (
@@ -3255,16 +3162,11 @@
 	name = "Blue Dock"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "fP" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "fQ" = (
@@ -3279,7 +3181,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "fR" = (
@@ -3287,10 +3188,6 @@
 /obj/effect/floor_decal/corner/red/full{
 	icon_state = "corner_white_full";
 	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -3314,10 +3211,6 @@
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
 	dir = 5
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -3686,10 +3579,6 @@
 	},
 /obj/machinery/light{
 	icon_state = "tube1";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -4171,10 +4060,6 @@
 	icon_state = "map";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "hp" = (
@@ -4183,13 +4068,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
-"hq" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/aft)
 "hr" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -4558,14 +4436,6 @@
 "ia" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "ib" = (
@@ -4585,7 +4455,6 @@
 	name = "Escape pods and Shuttle Docks";
 	req_one_access = list(19,38,63)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "ic" = (
@@ -4593,7 +4462,6 @@
 	name = "Yellow Dock"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "id" = (
@@ -4695,7 +4563,6 @@
 	name = "Red Dock"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "iq" = (
@@ -4721,10 +4588,6 @@
 "ir" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "is" = (
@@ -4934,7 +4797,6 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "iI" = (
@@ -5141,7 +5003,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "iV" = (
@@ -5291,7 +5152,6 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "jp" = (
@@ -5330,7 +5190,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "ju" = (
@@ -5463,10 +5322,6 @@
 	dir = 8;
 	icon_state = "map"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "jF" = (
@@ -5541,10 +5396,6 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "jM" = (
@@ -5596,7 +5447,6 @@
 	req_access = list(63)
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "jQ" = (
@@ -5641,10 +5491,6 @@
 /area/security/checkpoint2)
 "jS" = (
 /obj/effect/floor_decal/corner/blue/full,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "jT" = (
@@ -5691,10 +5537,6 @@
 	pixel_x = 28;
 	pixel_y = 0;
 	req_one_access = list(13)
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -6057,13 +5899,8 @@
 	name = "Security Checkpoint";
 	req_access = list(63)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/security/bridge_surface_checkpoint)
-"kC" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/emergency)
 "kD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/office/dark,
@@ -6148,10 +5985,6 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "kN" = (
@@ -6194,10 +6027,6 @@
 "kQ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "kR" = (
@@ -6251,10 +6080,6 @@
 /area/security/checkpoint2)
 "kW" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "kX" = (
@@ -6287,7 +6112,6 @@
 /area/hallway/secondary/exit)
 "kZ" = (
 /obj/effect/floor_decal/corner/red/full,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "la" = (
@@ -6388,7 +6212,6 @@
 /area/turret_protected/tcomsat)
 "lj" = (
 /obj/effect/floor_decal/corner/yellow/full,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "lk" = (
@@ -6402,7 +6225,6 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "ll" = (
@@ -6413,7 +6235,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/full,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "lm" = (
@@ -6425,7 +6246,6 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "ln" = (
@@ -6433,7 +6253,6 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
 "lo" = (
@@ -6653,14 +6472,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/store)
-"lF" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/central)
 "lG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7058,10 +6869,6 @@
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mo" = (
@@ -7094,15 +6901,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "mq" = (
 /obj/effect/floor_decal/corner/blue/full{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -7121,13 +6923,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
-"mt" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/sconference_room)
 "mv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2{
@@ -7136,16 +6931,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/store)
-"mw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/central)
 "mx" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector,
@@ -7187,10 +6972,6 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mC" = (
@@ -7200,10 +6981,6 @@
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 5
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
@@ -7341,10 +7118,6 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mQ" = (
@@ -7402,10 +7175,6 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "mX" = (
@@ -7435,27 +7204,12 @@
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
-"mZ" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/stairs)
 "na" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/plating,
 /area/store)
-"nb" = (
-/obj/structure/bed/chair/comfy/beige,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/entry/departure_lounge)
 "nc" = (
 /obj/effect/floor_decal/corner/lime/full,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7519,7 +7273,6 @@
 /obj/effect/floor_decal/corner/lime/full{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "nh" = (
@@ -7622,21 +7375,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge_elevator/surface)
-"np" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/central)
 "nq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -7673,7 +7411,6 @@
 	name = "Docks Air Bypass";
 	req_one_access = list(11,24)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/fore)
 "nu" = (
@@ -7698,7 +7435,6 @@
 	name = "NSS Aurora"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "nw" = (
@@ -7712,7 +7448,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/fore)
 "nx" = (
@@ -7805,14 +7540,6 @@
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-20"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/levela/research_dock)
 "nF" = (
@@ -7828,23 +7555,19 @@
 	icon_state = "spline_fancy";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "nI" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/flora/grass/green,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
 /area/bridge/levela)
 "nJ" = (
 /turf/simulated/wall,
@@ -8062,10 +7785,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/emergency)
-"oc" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/wood,
-/area/sconference_room)
 "od" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -8118,7 +7837,6 @@
 	name = "Docks Air Bypass";
 	req_one_access = list(11,24)
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/fore)
 "oj" = (
@@ -8280,10 +7998,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/lino,
 /area/hallway/secondary/entry/departure_lounge)
 "oz" = (
@@ -8353,14 +8067,6 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/carpet,
 /area/security/vacantoffice)
 "oI" = (
@@ -8408,10 +8114,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/lino,
 /area/hallway/secondary/entry/departure_lounge)
 "oO" = (
@@ -8422,19 +8124,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/lino,
 /area/hallway/secondary/entry/departure_lounge)
-"oQ" = (
-/obj/structure/window/basic{
-	dir = 4
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/security/vacantoffice)
 "oR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/filingcabinet/chestdrawer{
@@ -8502,10 +8191,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
@@ -8577,10 +8262,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/departure_lounge)
@@ -8713,7 +8394,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice)
 "pn" = (
@@ -8949,10 +8629,6 @@
 	spawn_nothing_percentage = 50;
 	spawn_object = /obj/item/flame/lighter
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/departure_lounge)
 "pI" = (
@@ -8979,10 +8655,6 @@
 	name = "randomly spawned cola";
 	spawn_nothing_percentage = 50;
 	spawn_object = /obj/item/reagent_containers/food/drinks/cans/cola
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/departure_lounge)
@@ -9092,10 +8764,6 @@
 "pV" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chips,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/departure_lounge)
 "pW" = (
@@ -9200,10 +8868,6 @@
 	icon_state = "comfychair_preview"
 	},
 /obj/machinery/light,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/departure_lounge)
 "qg" = (
@@ -9441,10 +9105,6 @@
 "qD" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "qE" = (
@@ -9545,7 +9205,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "qN" = (
@@ -9613,10 +9272,6 @@
 "qS" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/watertank,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "qT" = (
@@ -9667,10 +9322,6 @@
 	dir = 4;
 	icon_state = "comfychair_preview"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "qW" = (
@@ -9714,10 +9365,6 @@
 "rb" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "rc" = (
@@ -9744,10 +9391,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "re" = (
@@ -9793,10 +9436,6 @@
 	dir = 8
 	},
 /obj/structure/flora/pottedplant/random,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "rg" = (
@@ -9925,10 +9564,6 @@
 /obj/structure/table/standard,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "rs" = (
@@ -9959,10 +9594,6 @@
 /obj/structure/bed/chair/comfy/teal{
 	dir = 4;
 	icon_state = "comfychair_preview"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
@@ -10038,10 +9669,6 @@
 /obj/structure/table/standard,
 /obj/machinery/recharger{
 	pixel_y = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
@@ -10148,10 +9775,6 @@
 	dir = 8;
 	icon_state = "tube1";
 	pixel_y = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
@@ -10531,7 +10154,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "sC" = (
@@ -10746,10 +10368,6 @@
 /obj/structure/table/standard,
 /obj/item/device/camera,
 /obj/item/device/camera_film,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "ta" = (
@@ -10908,10 +10526,6 @@
 	icon_state = "warning";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "tq" = (
@@ -11014,10 +10628,6 @@
 "tz" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics/garden)
 "tA" = (
@@ -11026,11 +10636,11 @@
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "tB" = (
 /obj/machinery/vending/hydronutrients,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "tC" = (
 /obj/machinery/smartfridge/drying_rack,
@@ -11040,7 +10650,7 @@
 /obj/machinery/camera/network/civilian_surface{
 	c_tag = "Surface - Public Garden"
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "tD" = (
 /obj/structure/table/standard{
@@ -11049,11 +10659,10 @@
 /obj/machinery/reagentgrinder{
 	pixel_y = 12
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "tE" = (
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "tF" = (
 /obj/structure/sink{
@@ -11065,10 +10674,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 0;
 	pixel_y = 32
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics/garden)
@@ -11088,10 +10693,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hydroponics/garden)
-"tI" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/aft)
 "tJ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -11157,10 +10758,6 @@
 "tP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
@@ -11239,10 +10836,6 @@
 	icon_state = "corner_white_full";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "ua" = (
@@ -11272,10 +10865,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -11314,14 +10903,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "uf" = (
@@ -11400,31 +10981,25 @@
 /area/hydroponics/garden)
 "um" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics/garden)
 "un" = (
-/obj/structure/flora/grass/green,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "uo" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "up" = (
-/obj/structure/flora/grass/brown,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "uq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11440,7 +11015,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hydroponics/garden)
 "us" = (
@@ -11477,7 +11051,6 @@
 	icon_state = "warningcee";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/plating,
 /area/bridge/levela/research_dock)
 "uw" = (
@@ -11561,10 +11134,6 @@
 	dir = 1;
 	id = "bridge_surface_checkpoint";
 	name = "Checkpoint Shutters"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/security/bridge_surface_checkpoint)
@@ -11710,19 +11279,15 @@
 	icon_state = "spline_fancy";
 	dir = 8
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "uU" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "uV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics/garden)
@@ -11819,10 +11384,6 @@
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-28"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
 	temperature = 303.15
@@ -11830,10 +11391,6 @@
 /area/crew_quarters/fitness/pool)
 "vh" = (
 /obj/item/stool/padded,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
 	temperature = 303.15
@@ -11896,10 +11453,6 @@
 	},
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-21"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
@@ -12053,10 +11606,6 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/full,
 /obj/structure/closet/emcloset,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "vy" = (
@@ -12120,33 +11669,14 @@
 "vG" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/locker)
-"vH" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "vI" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hydroponics/garden)
-"vJ" = (
-/obj/structure/flora/grass/brown,
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 8
-	},
-/turf/simulated/floor/snow,
 /area/hydroponics/garden)
 "vK" = (
 /obj/machinery/light{
@@ -12165,27 +11695,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
-"vM" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hydroponics/garden)
-"vN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/dock)
 "vO" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12196,7 +11705,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/multi_tile,
 /obj/machinery/door/airlock/multi_tile/glass,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
 "vP" = (
@@ -12259,10 +11767,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
 	temperature = 303.15
@@ -12308,10 +11812,6 @@
 /area/crew_quarters/fitness/pool)
 "vY" = (
 /obj/item/inflatable_duck,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
 	temperature = 303.15
@@ -12344,22 +11844,8 @@
 "wc" = (
 /obj/effect/floor_decal/corner/paleblue/full,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
-"wd" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark{
-	name = "heated dark floor";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/pool)
 "we" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -12468,17 +11954,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
-"wk" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "wm" = (
 /obj/machinery/light{
 	dir = 8
@@ -12580,10 +12055,6 @@
 /obj/item/clothing/shoes/workboots/toeless,
 /obj/item/clothing/shoes/jackboots/toeless,
 /obj/item/clothing/shoes/jackboots/toeless,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/locker)
 "wu" = (
@@ -12661,10 +12132,6 @@
 /obj/machinery/camera/network/civilian_surface{
 	c_tag = "Surface - Corridor Camera 13"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "wD" = (
@@ -12687,7 +12154,6 @@
 "wG" = (
 /obj/structure/punching_bag,
 /obj/effect/floor_decal/corner/red/full,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
 "wH" = (
@@ -12759,8 +12225,12 @@
 "wQ" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
+"wR" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/fore)
 "wS" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
@@ -12780,10 +12250,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
@@ -12834,10 +12300,6 @@
 	dir = 4;
 	id = "bridge_surface_corridor";
 	name = "Shutter"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
@@ -13031,8 +12493,9 @@
 /turf/simulated/floor/plating,
 /area/store)
 "xq" = (
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/entry/fore)
 "xr" = (
 /obj/item/stool/padded,
@@ -13063,10 +12526,6 @@
 /obj/machinery/camera/network/civilian_surface{
 	c_tag = "Surface - Corridor Camera 6";
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
@@ -13119,7 +12578,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hydroponics/garden)
 "xy" = (
@@ -13232,10 +12690,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "xI" = (
@@ -13364,16 +12818,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
-"xV" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/security/vacantoffice)
 "xZ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/cable/green{
@@ -13574,7 +13018,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "yr" = (
-/obj/structure/flora/grass/green,
 /obj/machinery/light,
 /obj/machinery/power/apc{
 	dir = 2;
@@ -13586,8 +13029,7 @@
 	icon_state = "spline_fancy";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "ys" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13623,7 +13065,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "Fitness Center"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
 "yx" = (
@@ -13632,10 +13073,6 @@
 	dir = 2;
 	pixel_x = 18;
 	pixel_y = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
@@ -13666,10 +13103,6 @@
 	icon_state = "map-supply";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
 "yA" = (
@@ -13689,7 +13122,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "Pool"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
 "yB" = (
@@ -13834,13 +13266,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
-"yI" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/security/vacantoffice)
 "yJ" = (
 /turf/simulated/floor/wood,
 /area/security/bridge_surface_checkpoint)
@@ -13936,14 +13361,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/locker)
-"yT" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "yU" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -14068,10 +13485,6 @@
 	dir = 4
 	},
 /obj/structure/flora/pottedplant/random,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
 "zf" = (
@@ -14085,7 +13498,6 @@
 	pixel_y = 0
 	},
 /obj/structure/filingcabinet/chestdrawer,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/security/bridge_surface_checkpoint)
 "zh" = (
@@ -14097,10 +13509,6 @@
 	dir = 1
 	},
 /obj/structure/flora/pottedplant/random,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
 "zi" = (
@@ -14112,10 +13520,6 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/light{
 	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark{
@@ -14193,21 +13597,12 @@
 /area/hallway/secondary/entry/emergency)
 "zq" = (
 /obj/machinery/door/airlock/glass,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "zr" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
-"zs" = (
-/obj/item/stool/padded,
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled/dark{
-	name = "heated dark floor";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/pool)
 "zt" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14228,7 +13623,6 @@
 /area/hallway/secondary/entry/locker)
 "zv" = (
 /obj/machinery/papershredder,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/wood,
 /area/security/bridge_surface_checkpoint)
 "zw" = (
@@ -14361,10 +13755,6 @@
 	desc = "This is how you get Wendy's whistle wet.";
 	name = "lifeguard whistle"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/fitness/pool)
 "zI" = (
@@ -14409,10 +13799,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
 	department = "Surface Bridge"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/security/bridge_surface_checkpoint)
@@ -14468,11 +13854,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
 	pixel_y = 4
-	},
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/security/bridge_surface_checkpoint)
@@ -14537,7 +13918,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "zU" = (
@@ -14704,11 +14084,6 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "Af" = (
@@ -14729,7 +14104,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "Changing Room"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/changing)
 "Ah" = (
@@ -14754,7 +14128,6 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/plasticflaps/airtight,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
 	temperature = 303.15
@@ -15000,10 +14373,6 @@
 	icon_state = "tube1";
 	pixel_x = 0
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "AD" = (
@@ -15031,10 +14400,6 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
 "AF" = (
@@ -15053,16 +14418,8 @@
 /obj/effect/landmark{
 	name = "Space Ruin Paper"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
-"AH" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/central)
 "AI" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/effect/floor_decal/corner/white/diagonal{
@@ -15110,10 +14467,6 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/item/stool/padded,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
 	temperature = 303.15
@@ -15201,7 +14554,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/sleep/bedrooms)
 "AU" = (
@@ -15263,20 +14615,8 @@
 /obj/machinery/door/airlock{
 	name = "Showers"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
-"Bb" = (
-/obj/effect/floor_decal/corner/lime{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "Bc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -15441,7 +14781,6 @@
 	id_tag = "surf_unit_2";
 	name = "Unit 1"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
 "Br" = (
@@ -15601,26 +14940,11 @@
 /obj/machinery/door/airlock{
 	name = "Changing Room"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/changing)
 "BJ" = (
 /turf/unsimulated/floor/asteroid/ash,
 /area/shuttle/distress/station)
-"BK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/emergency)
 "BL" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15795,7 +15119,6 @@
 	id_tag = "surf_unit_1";
 	name = "Unit 2"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
 "Cb" = (
@@ -15856,14 +15179,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/store)
-"Ch" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/aft)
 "Ci" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/mime,
@@ -15935,10 +15250,6 @@
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
@@ -16067,7 +15378,6 @@
 /obj/machinery/door/airlock{
 	name = "Unit 3"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
 "CE" = (
@@ -16195,7 +15505,7 @@
 "CP" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "CQ" = (
 /obj/structure/cable/green{
@@ -16234,18 +15544,6 @@
 "CU" = (
 /turf/simulated/wall,
 /area/hallway/secondary/entry/aft)
-"CV" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	icon_state = "corner_white_full";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/levela/research_dock)
 "CW" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -16273,10 +15571,6 @@
 "CX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
@@ -16345,23 +15639,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/storage/tools)
-"De" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/stairs)
-"Df" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "Dg" = (
 /obj/structure/closet,
 /obj/random/loot,
@@ -16957,10 +16234,6 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/loading)
 "Er" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
@@ -16973,10 +16246,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "Et" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /obj/structure/sign/directions/all{
 	dir = 8;
 	icon_state = "direction_all";
@@ -16990,10 +16259,6 @@
 /area/hallway/secondary/entry/stairs)
 "Ev" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "Ew" = (
@@ -17114,10 +16379,6 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/loading)
 "EI" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
@@ -17255,10 +16516,6 @@
 /obj/machinery/camera/network/supply{
 	c_tag = "Cargo - Auxilliary Entrance";
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /obj/machinery/vending/zora,
 /turf/simulated/floor/tiled,
@@ -17602,7 +16859,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "Fy" = (
@@ -17668,10 +16924,6 @@
 /area/hallway/secondary/entry/aft)
 "FC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "FD" = (
@@ -17896,23 +17148,16 @@
 /area/quartermaster/loading)
 "FT" = (
 /obj/structure/closet/crate/trashcart,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "FU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "FV" = (
 /obj/structure/flora/pottedplant/random,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "FW" = (
@@ -17921,10 +17166,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/south,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "FX" = (
@@ -18174,38 +17415,18 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "Gt" = (
 /obj/structure/filingcabinet,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
 "Gu" = (
 /obj/item/modular_computer/console/preset/supply,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
 "Gv" = (
 /obj/machinery/photocopier,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
 "Gw" = (
@@ -18214,10 +17435,6 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
@@ -18319,10 +17536,6 @@
 	icon_state = "spline_fancy";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
 	temperature = 303.15
@@ -18378,11 +17591,6 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/quartermaster/loading)
 "GL" = (
@@ -18393,10 +17601,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
 "GM" = (
@@ -18676,10 +17880,6 @@
 /turf/simulated/floor/plating,
 /area/bridge/levela/research_dock)
 "Hj" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/ramp{
 	icon_state = "ramptop";
 	dir = 8
@@ -18692,7 +17892,6 @@
 	req_access = list(41)
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
 "Hl" = (
@@ -18838,7 +18037,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
 "Hx" = (
@@ -19046,7 +18244,7 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "HO" = (
 /obj/structure/cable/green{
@@ -19087,13 +18285,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo/surface)
-"HR" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/central)
 "HS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -19189,8 +18380,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/cargo/surface)
 "Ib" = (
-/obj/structure/flora/grass/green,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/entry/fore)
 "Ic" = (
 /obj/structure/cable/green{
@@ -19245,17 +18437,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
-"Ij" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/dock)
 "Il" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -19312,20 +18493,8 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
-"Iq" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/storage/primary)
 "Ir" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
@@ -19335,7 +18504,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "Is" = (
@@ -19573,10 +18741,6 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "IQ" = (
@@ -19590,14 +18754,6 @@
 /area/crew_quarters/fitness)
 "IR" = (
 /obj/structure/closet/emcloset,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "IS" = (
@@ -19778,10 +18934,6 @@
 	pixel_x = 25;
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "Ji" = (
@@ -19802,14 +18954,6 @@
 /obj/machinery/light{
 	dir = 4;
 	status = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -20006,10 +19150,6 @@
 	c_tag = "Surface - Red Dock Command";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "JC" = (
@@ -20021,10 +19161,6 @@
 	c_tag = "Surface - Red Dock Security";
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "JD" = (
@@ -20033,10 +19169,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
 	icon_state = "intact"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -20058,10 +19190,6 @@
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
 	dir = 6
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
@@ -20101,10 +19229,6 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "JK" = (
@@ -20118,7 +19242,6 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "JL" = (
@@ -20136,7 +19259,6 @@
 	icon_state = "tube1";
 	dir = 2
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "JM" = (
@@ -20147,7 +19269,6 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "JN" = (
@@ -20163,7 +19284,6 @@
 	pixel_x = 25;
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "JO" = (
@@ -20422,7 +19542,6 @@
 	name = "Conference Room Antechamber"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/sconference_room)
 "Kq" = (
@@ -20471,7 +19590,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/wood,
 /area/sconference_room)
 "Kw" = (
@@ -20537,10 +19655,6 @@
 /area/sconference_room)
 "KC" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/sconference_room)
 "KD" = (
@@ -20566,14 +19680,6 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet,
 /area/sconference_room)
-"KH" = (
-/obj/structure/table/wood,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/entry/departure_lounge)
 "KI" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -20663,14 +19769,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/sconference_room)
-"KT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/emergency)
 "KU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -20831,10 +19929,6 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/levela/research_dock)
 "Le" = (
@@ -20905,10 +19999,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
@@ -21051,10 +20141,6 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "Lt" = (
@@ -21287,38 +20373,12 @@
 	id = "bridge_surface_corridor";
 	name = "Shutter"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "LN" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/plating,
 /area/shuttle/research/station)
-"LO" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/door/window/westleft,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/levela)
 "LP" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -21365,10 +20425,6 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/wood,
 /area/security/bridge_surface_checkpoint)
 "LS" = (
@@ -21444,15 +20500,12 @@
 	icon_state = "spline_fancy";
 	dir = 6
 	},
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
 /area/bridge/levela)
 "LY" = (
 /obj/machinery/light{
 	icon_state = "tube1";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -21550,20 +20603,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/sleep/cryo)
-"Mj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/bridge/levela)
 "Mk" = (
 /obj/structure/closet/toolcloset,
 /obj/random/tech_supply,
@@ -21633,12 +20672,11 @@
 	},
 /area/mine/explored)
 "Ms" = (
-/obj/structure/flora/grass/both,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 10
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "Mt" = (
 /obj/effect/floor_decal/corner/blue{
@@ -21672,7 +20710,6 @@
 /obj/machinery/door/airlock{
 	name = "Washroom"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
 "My" = (
@@ -21823,10 +20860,6 @@
 	dir = 5
 	},
 /obj/machinery/computer/shuttle_control/research,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
 "MN" = (
@@ -21847,12 +20880,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "MO" = (
-/obj/structure/flora/grass/both,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 6
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "MP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -21998,7 +21030,6 @@
 "Ne" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
 "Nf" = (
@@ -22078,13 +21109,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
-"Nm" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/emergency)
 "Nn" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -22131,10 +21155,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "Nt" = (
@@ -22145,21 +21165,6 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/stairs)
-"Nv" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/aft)
 "Nw" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -22182,17 +21187,6 @@
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
 /area/tcommsat/entrance)
-"Ny" = (
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "Nz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
@@ -22240,10 +21234,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
@@ -22602,14 +21592,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/store)
-"Op" = (
-/obj/structure/flora/grass/both,
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 4
-	},
-/turf/simulated/floor/snow,
-/area/hydroponics/garden)
 "Oq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22629,14 +21611,6 @@
 /obj/item/device/flashlight/lamp,
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white_full";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -22683,10 +21657,6 @@
 	icon_state = "corner_white_full";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
 "Ox" = (
@@ -22726,11 +21696,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
-	},
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
@@ -22772,10 +21737,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
@@ -22854,19 +21815,6 @@
 	temperature = 303.15
 	},
 /area/crew_quarters/fitness/pool)
-"OO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/aft)
 "OP" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -22924,23 +21872,12 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plating,
 /area/shuttle/research/station)
-"OV" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/central)
 "OW" = (
 /turf/simulated/floor/tiled/dark,
 /area/bridge/levela/research_dock)
 "OX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/vending/coffee,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "OY" = (
@@ -22974,10 +21911,6 @@
 /obj/effect/floor_decal/corner/lime/full{
 	icon_state = "corner_white_full";
 	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
@@ -23061,16 +21994,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
-"Pl" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/security/vacantoffice)
 "Pm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -23172,7 +22095,6 @@
 /area/store)
 "Pw" = (
 /obj/machinery/door/airlock/glass_science,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
 "Px" = (
@@ -23194,7 +22116,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "PA" = (
@@ -23219,17 +22140,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/store)
-"PC" = (
-/obj/effect/floor_decal/corner/lime/full{
-	icon_state = "corner_white_full";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "PD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
@@ -23242,10 +22152,6 @@
 	dir = 8;
 	icon_state = "tube1";
 	pixel_x = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	icon_state = "map_scrubber_on";
@@ -23374,7 +22280,6 @@
 	icon_state = "intact"
 	},
 /obj/effect/floor_decal/corner/blue/full,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "PS" = (
@@ -23423,7 +22328,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/christmas/wreath,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/storage/tools)
 "PY" = (
@@ -23436,20 +22341,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/solarmaint)
-"PZ" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 4;
-	status = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/exit)
 "Qa" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -23481,16 +22372,6 @@
 "Qd" = (
 /turf/simulated/wall/shuttle,
 /area/shuttle/research/station)
-"Qe" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark{
-	name = "heated dark floor";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/pool)
 "Qf" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -23498,10 +22379,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	icon_state = "corner_white";
 	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
@@ -23539,14 +22416,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/store)
-"Qj" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/central)
 "Qk" = (
 /obj/structure/table/steel,
 /obj/item/storage/fancy/crayons/chalkbox,
@@ -23680,10 +22549,6 @@
 	id = "poolcafe";
 	name = "Pool Cafe"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
 	temperature = 303.15
@@ -23710,10 +22575,6 @@
 /turf/simulated/floor/plating,
 /area/shuttle/research/station)
 "QA" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/ramp/bottom{
 	icon_state = "rampbot";
 	dir = 1
@@ -23835,7 +22696,7 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/turf/simulated/floor/snow,
+/turf/simulated/floor/grass,
 /area/hydroponics/garden)
 "QO" = (
 /obj/structure/table/rack,
@@ -23893,10 +22754,6 @@
 "QT" = (
 /obj/structure/bed/chair{
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/levela/research_dock)
@@ -24036,16 +22893,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/holofloor/lino,
 /area/store)
-"Rm" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/emergency)
 "Rn" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
@@ -24142,10 +22989,6 @@
 /obj/structure/bed/chair/shuttle{
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
 "Rw" = (
@@ -24203,10 +23046,6 @@
 	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
@@ -24348,10 +23187,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
-"RO" = (
-/obj/structure/flora/grass/both,
-/turf/simulated/floor/snow,
-/area/hydroponics/garden)
 "RP" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -24433,7 +23268,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
 "RZ" = (
@@ -24445,10 +23279,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/dock)
-"Sa" = (
-/obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo)
 "Sb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -24462,16 +23292,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/solarmaint)
-"Sd" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled/dark{
-	name = "heated dark floor";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/pool)
 "Se" = (
 /obj/item/stool/padded,
 /obj/effect/floor_decal/corner/white/diagonal{
@@ -24573,7 +23393,6 @@
 	pixel_x = -22;
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "Sn" = (
@@ -24589,10 +23408,6 @@
 	pixel_x = -2;
 	pixel_y = 32
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "Sp" = (
@@ -24607,13 +23422,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/airless,
 /area/solar/port)
-"Sr" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/fore)
 "Ss" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -24718,6 +23526,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/store)
+"SE" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/fore)
 "SF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24842,10 +23655,6 @@
 	icon_state = "direction_all";
 	pixel_x = 0;
 	pixel_y = 36
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
@@ -25048,23 +23857,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
-"Tf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/emergency)
-"Tg" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/aft)
 "Th" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	icon_state = "corner_white_full";
@@ -25129,16 +23921,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
-"To" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/emcloset,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/port)
 "Tp" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -25222,7 +24004,6 @@
 /obj/machinery/door/airlock{
 	name = "Running Track"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness/running)
 "TA" = (
@@ -25318,10 +24099,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/locker)
 "TK" = (
@@ -25369,10 +24146,6 @@
 	icon_state = "tube1";
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "TP" = (
@@ -25391,14 +24164,6 @@
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Research Shuttle - Cockpit"
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
@@ -25455,10 +24220,6 @@
 	icon_state = "tube1";
 	pixel_x = 0
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
 "TX" = (
@@ -25501,7 +24262,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "Ud" = (
@@ -25511,28 +24271,11 @@
 /area/maintenance/store)
 "Ue" = (
 /obj/structure/bed/chair/comfy/black,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "Uf" = (
 /turf/simulated/wall,
 /area/solar/fore)
-"Ug" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/snow,
-/area/hydroponics/garden)
 "Uh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -25864,10 +24607,6 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_y = -30
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
 "UQ" = (
@@ -26093,6 +24832,10 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/emergency)
+"Vp" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/fore)
 "Vs" = (
 /turf/simulated/floor/plating,
 /area/maintenance/elevator)
@@ -26113,7 +24856,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/mauve,
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/levela/research_dock)
 "Vu" = (
@@ -26132,13 +24874,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
-"Vw" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/sconference_room)
 "Vx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -26209,10 +24944,6 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "VC" = (
@@ -26233,41 +24964,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/levela/research_dock)
-"VD" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/central)
-"VF" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/door/window/westleft,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled,
-/area/bridge/levela)
 "VG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
@@ -26276,12 +24972,15 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/flora/grass/brown,
 /obj/effect/floor_decal/spline/fancy/wood{
 	icon_state = "spline_fancy";
 	dir = 5
 	},
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_x = -7
+	},
+/turf/simulated/floor/grass,
 /area/bridge/levela)
 "VI" = (
 /obj/structure/cable{
@@ -26331,8 +25030,8 @@
 /turf/simulated/floor/plating,
 /area/shuttle/research/station)
 "VN" = (
-/obj/structure/flora/grass/brown,
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/entry/fore)
 "VO" = (
 /obj/effect/floor_decal/corner/paleblue/full,
@@ -26374,32 +25073,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/store)
-"VQ" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/open,
-/area/hallway/secondary/entry/stairs)
-"VR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/loading)
 "VS" = (
 /obj/structure/cable/blue{
 	d1 = 1;
@@ -26641,10 +25314,6 @@
 	pixel_y = 14
 	},
 /obj/item/folder/white,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/security/bridge_surface_checkpoint)
 "Wo" = (
@@ -26738,18 +25407,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/sleep/bedrooms)
-"Ww" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 1;
-	icon_state = "comfychair_preview"
-	},
-/obj/machinery/light,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/entry/departure_lounge)
 "Wx" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
@@ -26961,15 +25618,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/storage/tools)
-"WY" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/emcloset,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/port)
 "WZ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Commissary Maintenance";
@@ -27080,9 +25728,12 @@
 	icon_state = "warningcee";
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/plating,
 /area/bridge/levela/research_dock)
+"Xl" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/fore)
 "Xm" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -27104,17 +25755,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo/surface)
-"Xo" = (
-/obj/effect/floor_decal/corner/blue/full{
-	icon_state = "corner_white_full";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/dock)
 "Xp" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -27183,10 +25823,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
 	temperature = 303.15
@@ -27226,7 +25862,6 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "Xz" = (
@@ -27267,7 +25902,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "Pool"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
 "XD" = (
@@ -27471,10 +26105,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/locker)
 "XX" = (
@@ -27482,10 +26112,6 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	icon_state = "warningcee";
 	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/aft)
@@ -27646,10 +26272,6 @@
 	pixel_x = 30;
 	pixel_y = 30
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/shuttle/research/station)
 "Yo" = (
@@ -27682,19 +26304,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/explored)
-"Yq" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/dock)
 "Yr" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
@@ -27772,7 +26381,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "Yx" = (
@@ -27896,13 +26504,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
-"YJ" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/locker)
 "YK" = (
 /obj/structure/bed/chair,
 /obj/machinery/firealarm/north,
@@ -28076,7 +26677,9 @@
 	icon_state = "spline_fancy";
 	dir = 4
 	},
-/turf/simulated/floor/snow,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
 /area/bridge/levela)
 "Zb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -28218,10 +26821,6 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark{
 	name = "heated dark floor";
 	temperature = 303.15
@@ -28244,9 +26843,13 @@
 /obj/machinery/door/airlock{
 	name = "Changing Room"
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/fitness/changing)
+"Zu" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/fore)
 "Zv" = (
 /obj/structure/table/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -28267,10 +26870,6 @@
 /obj/structure/weightlifter,
 /obj/machinery/alarm{
 	pixel_y = 26
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
@@ -28304,10 +26903,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "ZC" = (
@@ -28321,15 +26916,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
-"ZD" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/dock)
 "ZE" = (
 /obj/structure/ladder{
 	icon_state = "ladder01";
@@ -28433,13 +27019,6 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/tcommsat/entrance)
-"ZO" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/central)
 "ZP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -48220,7 +46799,7 @@ Ko
 nJ
 Vh
 Vh
-kC
+Vh
 NB
 aw
 IJ
@@ -48734,7 +47313,7 @@ Ko
 nJ
 Lv
 QF
-kC
+Vh
 ZW
 Bc
 Vn
@@ -48746,7 +47325,7 @@ IJ
 Ma
 Bc
 OR
-Rm
+Ae
 QI
 nJ
 ag
@@ -49505,7 +48084,7 @@ Ko
 uP
 Vh
 mg
-KT
+RX
 My
 Bc
 Vn
@@ -49517,7 +48096,7 @@ IJ
 Ma
 Bc
 OR
-Nm
+Vh
 yu
 nJ
 ag
@@ -50019,7 +48598,7 @@ nJ
 nJ
 Mg
 TD
-KT
+RX
 Im
 aa
 IJ
@@ -50031,7 +48610,7 @@ IJ
 IJ
 aa
 Im
-Tf
+QF
 Sj
 nJ
 ag
@@ -50533,7 +49112,7 @@ Ko
 uP
 Vh
 Ak
-KT
+RX
 NB
 aa
 aa
@@ -50545,7 +49124,7 @@ IJ
 aa
 aa
 NB
-Tf
+QF
 RX
 nJ
 ag
@@ -51047,7 +49626,7 @@ nJ
 nJ
 ZA
 Ak
-KT
+RX
 TU
 aa
 aa
@@ -51259,8 +49838,8 @@ fB
 gr
 hn
 ia
-WY
-To
+ia
+ia
 jD
 kd
 kL
@@ -51304,7 +49883,7 @@ ag
 nJ
 mY
 Ak
-KT
+RX
 NW
 aa
 aa
@@ -51820,15 +50399,15 @@ BF
 Sg
 Rx
 xH
-BK
-BK
 nn
-BK
+nn
+nn
+nn
 Li
-BK
+nn
 TH
 OD
-BK
+nn
 NG
 Zh
 nK
@@ -53335,7 +51914,7 @@ UV
 oy
 oN
 pe
-nb
+pw
 pH
 pV
 qf
@@ -53581,8 +52160,8 @@ lo
 lJ
 lT
 ml
-Bb
-Bb
+jp
+jp
 mP
 gv
 ns
@@ -53825,7 +52404,7 @@ LT
 ed
 gw
 fb
-VN
+Xl
 gw
 fP
 ht
@@ -54082,16 +52661,16 @@ QH
 ee
 Ot
 xq
-fb
+Vp
 Ot
-PC
+ml
 if
 iK
 jr
 jL
 kh
 kQ
-yT
+kW
 lK
 lT
 mn
@@ -54338,13 +52917,13 @@ Qq
 pY
 PQ
 gx
-fb
-Ib
+Xl
+Zu
 gx
-wk
+ht
 ig
 iL
-Sr
+js
 jM
 jO
 kR
@@ -54355,7 +52934,7 @@ jQ
 mB
 mH
 ju
-vH
+mQ
 nu
 nR
 oh
@@ -54365,8 +52944,8 @@ oP
 pi
 py
 pK
-KH
-Ww
+pI
+qf
 qt
 qD
 qL
@@ -54374,13 +52953,13 @@ qS
 rb
 rr
 rH
-Iq
-Iq
+sc
+sc
 sA
 sZ
 qt
 wt
-YJ
+wu
 vG
 XW
 TJ
@@ -54587,7 +53166,7 @@ aY
 bd
 bk
 bs
-vN
+bO
 cm
 cm
 da
@@ -54852,7 +53431,7 @@ cn
 dN
 eg
 eF
-Ij
+eF
 fL
 fO
 ht
@@ -54871,34 +53450,34 @@ mI
 jv
 mQ
 nv
-HR
+yq
 oj
 oo
 oE
 yq
 pk
 pz
-HR
-lF
-HR
+yq
+oD
+yq
 qu
-HR
+yq
 qN
-HR
-HR
-HR
-HR
+yq
+yq
+yq
+yq
 rQ
-HR
+yq
 sC
-HR
+yq
 tw
-HR
-lF
-HR
-HR
+yq
+oD
+yq
+yq
 xu
-HR
+yq
 yq
 yq
 zY
@@ -54932,7 +53511,7 @@ FQ
 Gf
 Gr
 GJ
-VR
+GU
 GU
 Hu
 DW
@@ -55100,7 +53679,7 @@ az
 aw
 aa
 bl
-ZD
+bt
 bO
 co
 cE
@@ -55141,9 +53720,9 @@ QM
 qv
 NI
 qO
-np
+QM
 rd
-np
+QM
 QM
 QM
 se
@@ -55357,7 +53936,7 @@ az
 aw
 aa
 bl
-Yq
+bt
 bO
 cn
 cE
@@ -55367,7 +53946,7 @@ dN
 ei
 iB
 eH
-Xo
+el
 fO
 ht
 ik
@@ -55385,35 +53964,35 @@ jv
 mT
 YX
 nv
-ZO
-ZO
+yq
+yq
 op
-ZO
-ZO
+yq
+yq
 MN
-ZO
-mw
+yq
+Ol
 oD
 yq
 oj
 yq
-AH
+yq
 qU
 re
 rs
-OV
+yq
 yq
 NV
 yq
 tc
-ZO
-ZO
-Qj
+yq
+yq
+oD
 op
-ZO
+yq
 xw
-ZO
-ZO
+yq
+yq
 yq
 MN
 Au
@@ -55671,7 +54250,7 @@ ww
 xx
 wz
 yW
-OV
+yq
 MN
 Av
 Wi
@@ -55690,9 +54269,9 @@ Vx
 TN
 Wz
 LL
-De
+bc
 PE
-VQ
+Vz
 Vz
 LL
 Er
@@ -55881,12 +54460,12 @@ PK
 ek
 gw
 Ib
-fb
+SE
 gw
-wk
+ht
 im
 iR
-Sr
+js
 jR
 jO
 kR
@@ -55897,16 +54476,16 @@ jN
 mB
 jv
 mT
-vH
+mQ
 gw
 aa
 aa
 or
 oH
-Pl
+oH
 pn
-Pl
-Pl
+oH
+oH
 oq
 qk
 yq
@@ -55928,7 +54507,7 @@ um
 xy
 nH
 yX
-OV
+yq
 MN
 yq
 Wi
@@ -56137,10 +54716,10 @@ cn
 dQ
 ek
 Ot
-fb
-xq
+Ib
+Ib
 Ot
-Ny
+ms
 in
 iS
 ju
@@ -56159,7 +54738,7 @@ gx
 aa
 aa
 os
-xV
+oH
 oV
 po
 pB
@@ -56180,12 +54759,12 @@ te
 tA
 un
 uT
-vJ
+un
 Ms
 xz
-eC
+nH
 yY
-OV
+yq
 Aa
 We
 Wi
@@ -56213,7 +54792,7 @@ Es
 Cp
 Fa
 Cp
-tI
+Cp
 TK
 Gv
 GN
@@ -56395,7 +54974,7 @@ dR
 el
 gx
 VN
-fb
+wR
 gx
 fP
 ht
@@ -56416,7 +54995,7 @@ gv
 aa
 aa
 os
-yI
+oI
 oI
 pp
 oI
@@ -56440,9 +55019,9 @@ uo
 uo
 wQ
 xA
-eC
+nH
 yZ
-OV
+yq
 MN
 Aw
 Wi
@@ -56665,15 +55244,15 @@ lv
 lR
 ma
 ms
-Df
-Df
+jw
+jw
 mW
 gv
 ag
 aa
 aa
 os
-xV
+oH
 pC
 pq
 TI
@@ -56694,7 +55273,7 @@ te
 tC
 tE
 uU
-RO
+tE
 CP
 xB
 yr
@@ -56719,7 +55298,7 @@ AZ
 Ob
 LL
 Et
-mZ
+bc
 DN
 DS
 bc
@@ -56930,7 +55509,7 @@ ag
 aa
 aa
 ot
-oQ
+oJ
 oY
 pr
 oJ
@@ -56954,9 +55533,9 @@ uo
 uo
 wQ
 wy
-eC
+nH
 za
-OV
+yq
 MN
 Ay
 Wi
@@ -57207,21 +55786,21 @@ rv
 te
 HN
 up
-Op
+up
 QN
 MO
 wy
-eC
+nH
 yY
-OV
+yq
 MN
 yq
 BE
 Bn
-Ch
+BE
 BU
 Cn
-OO
+VI
 CL
 Xz
 tQ
@@ -57232,16 +55811,16 @@ VI
 TE
 DG
 BE
-Tg
-Tg
+Cp
+Cp
 DL
 DT
 Xb
-Tg
+Cp
 Cp
 Ac
 FB
-Nv
+FB
 Gl
 Gy
 GQ
@@ -57466,9 +56045,9 @@ tF
 uq
 uV
 vK
-vM
-vM
-Ug
+wy
+wy
+nH
 yX
 SP
 Bk
@@ -57740,13 +56319,13 @@ JT
 Yo
 Cp
 XL
-hq
 Cp
-hq
+Cp
+Cp
 JT
 Cp
 SI
-hq
+Cp
 CX
 ZB
 XX
@@ -57976,14 +56555,14 @@ ql
 sf
 qu
 tf
-HR
+yq
 NV
-HR
+yq
 oD
-HR
-HR
-HR
-HR
+yq
+yq
+yq
+yq
 yq
 pL
 AA
@@ -58254,7 +56833,7 @@ AU
 Uj
 JH
 JU
-Vw
+JZ
 JZ
 KC
 KK
@@ -58494,12 +57073,12 @@ yq
 Ri
 yq
 oD
-ZO
-ZO
+yq
+yq
 yq
 pL
 yq
-ZO
+yq
 AC
 AU
 Bq
@@ -58515,7 +57094,7 @@ Kg
 Kr
 Km
 Km
-oc
+JZ
 RH
 aa
 aa
@@ -58772,7 +57351,7 @@ Kh
 Ks
 Km
 Km
-oc
+JZ
 Pj
 aa
 aa
@@ -58972,7 +57551,7 @@ kp
 iX
 iq
 ir
-PZ
+Jk
 jX
 Jw
 Jx
@@ -59009,7 +57588,7 @@ si
 Mi
 rU
 wC
-VD
+tf
 yq
 YV
 zz
@@ -59778,7 +58357,7 @@ ti
 PI
 sI
 sI
-Sa
+ti
 yq
 NV
 yq
@@ -60057,7 +58636,7 @@ Kj
 KE
 KE
 Km
-oc
+JZ
 KV
 aw
 aw
@@ -60314,7 +58893,7 @@ Kk
 Kw
 KF
 KO
-oc
+JZ
 KW
 aw
 aa
@@ -60571,7 +59150,7 @@ Kk
 Kx
 KG
 KO
-oc
+JZ
 KW
 aw
 aa
@@ -60828,7 +59407,7 @@ Kk
 Ky
 KG
 KO
-oc
+JZ
 KW
 aw
 aw
@@ -61085,7 +59664,7 @@ Kk
 Kz
 KI
 KO
-oc
+JZ
 KW
 aw
 aa
@@ -61342,7 +59921,7 @@ Ym
 KA
 Sk
 Km
-oc
+JZ
 KY
 aw
 aw
@@ -61595,10 +60174,10 @@ Pi
 RG
 JH
 Ke
-mt
-mt
-mt
-mt
+JZ
+JZ
+JZ
+JZ
 KS
 JH
 aa
@@ -62349,7 +60928,7 @@ ag
 uw
 vg
 vU
-wd
+wH
 xN
 yB
 zi
@@ -62614,7 +61193,7 @@ wI
 wI
 wI
 tO
-zs
+vh
 ux
 aa
 aa
@@ -62871,7 +61450,7 @@ xP
 xP
 TC
 ZU
-Sd
+Zr
 uy
 aa
 aa
@@ -63128,7 +61707,7 @@ xQ
 xQ
 QV
 ZU
-zs
+vh
 uz
 aa
 aa
@@ -63642,7 +62221,7 @@ xQ
 xQ
 QV
 Mt
-zs
+vh
 UC
 aa
 aa
@@ -63899,7 +62478,7 @@ IE
 IE
 MV
 Mt
-Sd
+Zr
 uy
 aa
 aa
@@ -64156,7 +62735,7 @@ TR
 Ok
 RE
 Ru
-zs
+vh
 LD
 aa
 aa
@@ -64406,12 +62985,12 @@ uw
 HF
 vY
 Xv
-Qe
+wH
 QA
 ST
 zH
 GF
-Qe
+wH
 tP
 HH
 uw
@@ -74167,7 +72746,7 @@ Th
 HP
 Th
 wv
-CV
+Th
 vk
 wa
 VO
@@ -77255,7 +75834,7 @@ rV
 rV
 tW
 sL
-Mj
+vr
 Uw
 aa
 aa
@@ -77769,7 +76348,7 @@ sN
 tn
 tY
 tS
-Mj
+vr
 Uw
 aa
 aa
@@ -79310,8 +77889,8 @@ su
 sR
 tq
 ue
-LO
-VF
+ue
+ue
 wn
 xg
 yf

--- a/maps/aurora/aurora-7_roof.dmm
+++ b/maps/aurora/aurora-7_roof.dmm
@@ -2773,13 +2773,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/explored)
-"gj" = (
-/obj/structure/sign/christmas/lights,
-/turf/simulated/open{
-	name = "heated open space";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/running)
 "gs" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -2877,20 +2870,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
-"jO" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/open{
-	name = "heated open space";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/running)
 "ka" = (
 /obj/structure/lattice,
 /turf/simulated/open{
@@ -2925,21 +2904,7 @@
 /turf/simulated/floor/airless,
 /area/mine/explored)
 "mb" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
 /turf/simulated/open,
-/area/crew_quarters/fitness/running)
-"na" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
 /area/crew_quarters/fitness/running)
 "nY" = (
 /obj/structure/cable/green{
@@ -2960,10 +2925,6 @@
 /area/crew_quarters/fitness/running)
 "od" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness/running)
 "oH" = (
@@ -3021,14 +2982,6 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness/running)
 "ss" = (
@@ -3049,16 +3002,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/crew_quarters/fitness/running)
-"th" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/open{
-	name = "heated open space";
-	temperature = 303.15
-	},
 /area/crew_quarters/fitness/running)
 "tr" = (
 /obj/machinery/door/firedoor,
@@ -3101,17 +3044,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/mine/explored)
-"uy" = (
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/fitness/running)
 "uI" = (
 /turf/simulated/wall,
 /area/crew_quarters/fitness/running)
@@ -3120,14 +3052,6 @@
 	c_tag = "Surface - Running Track Staircase";
 	dir = 2;
 	pixel_y = 0
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness/running)
@@ -3144,16 +3068,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/fitness/running)
-"vs" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/open{
-	name = "heated open space";
-	temperature = 303.15
-	},
 /area/crew_quarters/fitness/running)
 "vy" = (
 /obj/structure/disposalpipe/segment{
@@ -3225,10 +3139,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness/running)
 "yP" = (
@@ -3250,17 +3160,6 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
-"ze" = (
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/fitness/running)
 "zL" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3268,17 +3167,6 @@
 /obj/random/loot,
 /turf/simulated/floor/reinforced/airless,
 /area/mine/explored)
-"Ae" = (
-/obj/structure/lattice,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/open{
-	name = "heated open space";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/running)
 "Aj" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/reinforced/airless,
@@ -3290,25 +3178,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/mine/explored)
-"As" = (
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/fitness/running)
 "AK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -3323,17 +3192,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
-"AT" = (
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/fitness/running)
 "Ba" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -3342,10 +3200,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
 	dir = 9
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
@@ -3380,14 +3234,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
 "CT" = (
@@ -3453,17 +3299,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
-"EB" = (
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
-	},
-/turf/simulated/open{
-	name = "heated open space";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/running)
 "ED" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -3496,17 +3331,12 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
 "FH" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
 	dir = 6
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
@@ -3602,10 +3432,6 @@
 /obj/machinery/vending/snack{
 	pixel_x = 4
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness/running)
 "Hs" = (
@@ -3627,7 +3453,6 @@
 	icon_state = "intact-scrubbers";
 	dir = 9
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
 "HD" = (
@@ -3656,17 +3481,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tcommsat/lounge)
-"Jx" = (
-/obj/structure/sign/christmas/lights,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/open{
-	name = "heated open space";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/running)
 "JM" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -3681,10 +3495,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light{
 	icon_state = "tube1";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -3743,11 +3553,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
 "Mt" = (
@@ -3770,7 +3575,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
 "MO" = (
@@ -3864,16 +3668,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
-"Pz" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/open{
-	name = "heated open space";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/running)
 "PA" = (
 /obj/effect/floor_decal/industrial/warning/cee{
 	icon_state = "warningcee";
@@ -3921,20 +3715,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
-"Qf" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/fitness/running)
 "Qh" = (
 /obj/machinery/light{
 	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
 	dir = 8
 	},
 /turf/simulated/open,
@@ -3948,17 +3731,6 @@
 	pixel_y = 29
 	},
 /turf/simulated/floor/tiled,
-/area/crew_quarters/fitness/running)
-"QA" = (
-/obj/structure/lattice,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/open{
-	name = "heated open space";
-	temperature = 303.15
-	},
 /area/crew_quarters/fitness/running)
 "Rg" = (
 /obj/machinery/door/firedoor,
@@ -4011,7 +3783,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
 "Uh" = (
@@ -4033,53 +3804,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/fitness/running)
-"UN" = (
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/open{
-	name = "heated open space";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/running)
-"UU" = (
-/obj/structure/lattice,
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 4
-	},
-/turf/simulated/open{
-	name = "heated open space";
-	temperature = 303.15
-	},
-/area/crew_quarters/fitness/running)
-"Vg" = (
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
 "Vw" = (
@@ -4122,17 +3846,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/fitness/running)
-"VV" = (
-/obj/structure/bed/chair/comfy/black{
-	icon_state = "comfychair_preview";
-	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/fitness/running)
 "Wd" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/cable/green{
@@ -4140,7 +3853,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access = list(12)
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -4192,7 +3907,6 @@
 	dir = 1;
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights,
 /turf/simulated/open{
 	name = "heated open space";
 	temperature = 303.15
@@ -4221,10 +3935,6 @@
 	pixel_x = -22;
 	pixel_y = 0
 	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness/running)
 "YJ" = (
@@ -4243,10 +3953,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/sign/christmas/lights{
-	icon_state = "xmaslights";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/running)
@@ -4295,7 +4001,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/fitness/running)
 "ZY" = (
@@ -37593,7 +37298,7 @@ aa
 ab
 ab
 VL
-Qf
+Wx
 FO
 CV
 uI
@@ -37855,14 +37560,14 @@ ED
 nY
 uI
 YJ
-ze
-ze
+AO
+AO
 Mt
-ze
-ze
-ze
-ze
-ze
+AO
+AO
+AO
+AO
+AO
 Mt
 lB
 Es
@@ -38114,13 +37819,13 @@ uI
 SX
 jq
 BY
-As
-As
-As
-As
-As
-As
-As
+BY
+BY
+BY
+BY
+BY
+BY
+BY
 BY
 gs
 Hs
@@ -38626,17 +38331,17 @@ RZ
 Zg
 ZY
 yx
-Vg
+GC
 PJ
-jO
-Ae
-vs
-vs
-vs
-Ae
-EB
+Cb
+ka
+Cb
+Cb
+Cb
+ka
+Cb
 PJ
-AT
+yx
 Pw
 uI
 aa
@@ -38878,22 +38583,22 @@ aa
 aa
 dp
 MO
-VV
+pm
 pm
 pr
 Wx
 yx
-Vg
+GC
 VL
-Pz
+Cb
 ka
 Cb
 Cb
 Cb
 ka
-gj
+Cb
 VL
-AT
+yx
 Mu
 PJ
 aa
@@ -39142,7 +38847,7 @@ YL
 PL
 EX
 VL
-QA
+ka
 ka
 ka
 ka
@@ -39150,7 +38855,7 @@ ka
 ka
 Xd
 VL
-AT
+yx
 Mu
 VL
 aa
@@ -39392,22 +39097,22 @@ aa
 aa
 dp
 PJ
-na
+Pm
 Pm
 kw
 vy
 yx
-uy
+Uu
 VL
-Pz
+Cb
 ka
 Cb
 Cb
 Cb
 ka
-gj
+Cb
 VL
-AT
+yx
 Mu
 MO
 aa
@@ -39649,22 +39354,22 @@ aa
 aa
 dp
 VL
-Qf
+Wx
 Wx
 qS
 Nv
 yx
-uy
+Uu
 MO
-UN
-UU
-th
-th
-th
-UU
-Jx
+Cb
+ka
+Cb
+Cb
+Cb
+ka
+Cb
 MO
-AT
+yx
 Du
 uI
 aa
@@ -40170,13 +39875,13 @@ uI
 zd
 sV
 AO
-ze
-ze
-ze
-ze
-ze
-ze
-ze
+AO
+AO
+AO
+AO
+AO
+AO
+AO
 AO
 Nq
 Mu


### PR DESCRIPTION
 - Deletes all the christmas decor on the station and Odin. Including holodeck rooms.
 - Did some misc fixes to some places, adding missing shutters, missing access requirements.
 - Added a no-smoking sign to the kitchen by request.