### PR TITLE
IPC rework

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1153,3 +1153,47 @@ mob/living/carbon/human/proc/change_monitor()
 		for(var/line in airInfo)
 			to_chat(src, span("notice", "[line]"))
 		return
+
+/mob/living/carbon/human/proc/crush()
+	set category = "Abilities"
+	set name = "Crush"
+	set desc = "While grabbing someone aggressively, crush them with your arms."
+
+	if(last_special > world.time)
+		to_chat(src, "<span class='warning'>Your arms are still recovering!</span>")
+		return
+
+	if(stat || paralysis || stunned || weakened || lying)
+		to_chat(src, "<span class='warning'>You cannot do that in your current state.</span>")
+		return
+
+	var/obj/item/grab/G = locate() in src
+	if(!G || !istype(G))
+		to_chat(src, "<span class='warning'>You are not grabbing anyone.</span>")
+		return
+
+	if(G.state < GRAB_AGGRESSIVE)
+		to_chat(src, "<span class='warning'>You must have an aggressive grab to crush your prey!</span>")
+		return
+
+	if(istype(G.affecting,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = G.affecting
+		var/hit_zone = zone_sel.selecting
+		var/obj/item/organ/external/affected = H.get_organ(hit_zone)
+
+		if(!affected || affected.is_stump())
+			to_chat(H, "<span class='danger'>They are missing that limb!</span>")
+			return
+
+		H.apply_damage(40, BRUTE, hit_zone)
+		visible_message("<span class='warning'><b>\The [src]</b> viciously crushes \the [G.affecting]'s [affected] with its metallic arms!</span>")
+		msg_admin_attack("[key_name_admin(src)] crushed [key_name_admin(H)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)",ckey=key_name(src),ckey_target=key_name(H))
+	else
+		var/mob/living/M = G.affecting
+		if(!istype(M))
+			return
+		M.apply_damage(40,BRUTE)
+		visible_message("<span class='warning'><b>\The [src]</b> viciously crushes \the [G.affecting]'s flesh with its metallic arms!</span>")
+		msg_admin_attack("[key_name_admin(src)] mandible'd [key_name_admin(M)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)",ckey=key_name(src),ckey_target=key_name(M))
+	playsound(src.loc, 'sound/weapons/heavysmash.ogg', 50, 1)
+	last_special = world.time + 200

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1163,16 +1163,15 @@ mob/living/carbon/human/proc/change_monitor()
 		to_chat(src, "<span class='warning'>Your arms are still recovering!</span>")
 		return
 
-	if(stat || paralysis || stunned || weakened || lying)
-		to_chat(src, "<span class='warning'>You cannot do that in your current state.</span>")
+	if(use_check_and_message(usr))
 		return
 
-	var/obj/item/grab/G = locate() in src
+	var/obj/item/grab/G = src.get_active_hand()
 	if(!G || !istype(G))
 		to_chat(src, "<span class='warning'>You are not grabbing anyone.</span>")
 		return
 
-	if(G.state < GRAB_AGGRESSIVE)
+	if(G.state < GRAB_NECK)
 		to_chat(src, "<span class='warning'>You must have an aggressive grab to crush your prey!</span>")
 		return
 
@@ -1186,14 +1185,14 @@ mob/living/carbon/human/proc/change_monitor()
 			return
 
 		H.apply_damage(40, BRUTE, hit_zone)
-		visible_message("<span class='warning'><b>\The [src]</b> viciously crushes \the [G.affecting]'s [affected] with its metallic arms!</span>")
+		visible_message("<span class='warning'><b>\The [src]</b> viciously crushes [G.affecting]'s in \the [affected] with its metallic arms!</span>")
 		msg_admin_attack("[key_name_admin(src)] crushed [key_name_admin(H)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)",ckey=key_name(src),ckey_target=key_name(H))
 	else
 		var/mob/living/M = G.affecting
 		if(!istype(M))
 			return
 		M.apply_damage(40,BRUTE)
-		visible_message("<span class='warning'><b>\The [src]</b> viciously crushes \the [G.affecting]'s flesh with its metallic arms!</span>")
+		visible_message("<span class='warning'><b>\The [src]</b> viciously crushes [G.affecting]'s flesh with its metallic arms!</span>")
 		msg_admin_attack("[key_name_admin(src)] mandible'd [key_name_admin(M)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)",ckey=key_name(src),ckey_target=key_name(M))
 	playsound(src.loc, 'sound/weapons/heavysmash.ogg', 50, 1)
-	last_special = world.time + 200
+	last_special = world.time + 100

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1157,7 +1157,7 @@ mob/living/carbon/human/proc/change_monitor()
 /mob/living/carbon/human/proc/crush()
 	set category = "Abilities"
 	set name = "Crush"
-	set desc = "While grabbing someone aggressively, crush them with your arms."
+	set desc = "While grabbing someone in a neck grab, crush them with your arms."
 
 	if(last_special > world.time)
 		to_chat(src, "<span class='warning'>Your arms are still recovering!</span>")
@@ -1172,7 +1172,7 @@ mob/living/carbon/human/proc/change_monitor()
 		return
 
 	if(G.state < GRAB_NECK)
-		to_chat(src, "<span class='warning'>You must have a neck grab to crush your prey!</span>")
+		to_chat(src, "<span class='warning'>You must have a stronger grab to crush your prey!</span>")
 		return
 
 	if(istype(G.affecting,/mob/living/carbon/human))
@@ -1185,7 +1185,7 @@ mob/living/carbon/human/proc/change_monitor()
 			return
 
 		H.apply_damage(40, BRUTE, hit_zone)
-		visible_message("<span class='warning'><b>\The [src]</b> viciously crushes [G.affecting]'s in \the [affected] with its metallic arms!</span>")
+		visible_message("<span class='warning'><b>\The [src]</b> viciously crushes [affected] of [G.affecting] with its metallic arms!</span>")
 		msg_admin_attack("[key_name_admin(src)] crushed [key_name_admin(H)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)",ckey=key_name(src),ckey_target=key_name(H))
 	else
 		var/mob/living/M = G.affecting

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -29,7 +29,7 @@
 mob/living/carbon/human/proc/change_monitor()
 	set name = "Change IPC Screen"
 	set desc = "Change the display on your screen."
-	set category = "IC"
+	set category = "Abilities"
 
 	if(f_style)
 		var/datum/sprite_accessory/facial_hair/screen_style = facial_hair_styles_list[f_style]
@@ -1015,7 +1015,7 @@ mob/living/carbon/human/proc/change_monitor()
 /mob/living/carbon/human/proc/self_diagnostics()
 	set name = "Self-Diagnostics"
 	set desc = "Run an internal self-diagnostic to check for damage."
-	set category = "IC"
+	set category = "Abilities"
 
 	if(stat == DEAD) return
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1193,6 +1193,6 @@ mob/living/carbon/human/proc/change_monitor()
 			return
 		M.apply_damage(40,BRUTE)
 		visible_message("<span class='warning'><b>\The [src]</b> viciously crushes [G.affecting]'s flesh with its metallic arms!</span>")
-		msg_admin_attack("[key_name_admin(src)] mandible'd [key_name_admin(M)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)",ckey=key_name(src),ckey_target=key_name(M))
+		msg_admin_attack("[key_name_admin(src)] crushed [key_name_admin(M)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)",ckey=key_name(src),ckey_target=key_name(M))
 	playsound(src.loc, 'sound/weapons/heavysmash.ogg', 50, 1)
 	last_special = world.time + 100

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1172,7 +1172,7 @@ mob/living/carbon/human/proc/change_monitor()
 		return
 
 	if(G.state < GRAB_NECK)
-		to_chat(src, "<span class='warning'>You must have an aggressive grab to crush your prey!</span>")
+		to_chat(src, "<span class='warning'>You must have a neck grab to crush your prey!</span>")
 		return
 
 	if(istype(G.affecting,/mob/living/carbon/human))

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1167,7 +1167,7 @@ mob/living/carbon/human/proc/change_monitor()
 		return
 
 	var/obj/item/grab/G = src.get_active_hand()
-	if(!G || !istype(G))
+	if(!istype(G))
 		to_chat(src, "<span class='warning'>You are not grabbing anyone.</span>")
 		return
 
@@ -1175,7 +1175,7 @@ mob/living/carbon/human/proc/change_monitor()
 		to_chat(src, "<span class='warning'>You must have a stronger grab to crush your prey!</span>")
 		return
 
-	if(istype(G.affecting,/mob/living/carbon/human))
+	if(ishuman(G.affecting))
 		var/mob/living/carbon/human/H = G.affecting
 		var/hit_zone = zone_sel.selecting
 		var/obj/item/organ/external/affected = H.get_organ(hit_zone)

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -92,24 +92,27 @@
 	playsound(user.loc, attack_sound, 25, 1, -1)
 
 /datum/unarmed_attack/punch/ipc
-	damage = 4
+	damage = 3
 
 /datum/unarmed_attack/kick/ipc
-	damage = 4
+	damage = 3
 
 /datum/unarmed_attack/stomp/ipc
-	damage = 4
+	damage = 3
 
 /datum/unarmed_attack/industrial
 	attack_verb = list("pulverized", "crushed", "pounded")
 	attack_noun = list("heavy fist")
-	damage = 8
+	damage = 7
 	attack_sound = 'sound/weapons/smash.ogg'
 	attack_name = "heavy fist"
+	shredding = 1
 
 /datum/unarmed_attack/industrial/heavy
 	damage = 10
-	shredding = 1
+
+/datum/unarmed_attack/industrial/xion
+	damage = 5
 
 /datum/unarmed_attack/terminator
 	attack_verb = list("pulverized", "crushed", "pounded")

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -91,15 +91,24 @@
 	user.visible_message("<span class='warning'>[user] jumped up and down on \the [target]'s [affecting.name]!</span>")
 	playsound(user.loc, attack_sound, 25, 1, -1)
 
+/datum/unarmed_attack/punch/ipc
+	damage = 4
+
+/datum/unarmed_attack/kick/ipc
+	damage = 4
+
+/datum/unarmed_attack/stomp/ipc
+	damage = 4
+
 /datum/unarmed_attack/industrial
 	attack_verb = list("pulverized", "crushed", "pounded")
 	attack_noun = list("heavy fist")
-	damage = 6
+	damage = 8
 	attack_sound = 'sound/weapons/smash.ogg'
 	attack_name = "heavy fist"
 
 /datum/unarmed_attack/industrial/heavy
-	damage = 8
+	damage = 10
 	shredding = 1
 
 /datum/unarmed_attack/terminator

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -103,16 +103,16 @@
 /datum/unarmed_attack/industrial
 	attack_verb = list("pulverized", "crushed", "pounded")
 	attack_noun = list("heavy fist")
-	damage = 6
+	damage = 7
 	attack_sound = 'sound/weapons/smash.ogg'
 	attack_name = "heavy fist"
 	shredding = 1
 
 /datum/unarmed_attack/industrial/heavy
-	damage = 8
+	damage = 9
 
 /datum/unarmed_attack/industrial/xion
-	damage = 4
+	damage = 5
 	shredding = 0
 
 /datum/unarmed_attack/terminator

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -103,16 +103,16 @@
 /datum/unarmed_attack/industrial
 	attack_verb = list("pulverized", "crushed", "pounded")
 	attack_noun = list("heavy fist")
-	damage = 7
+	damage = 6
 	attack_sound = 'sound/weapons/smash.ogg'
 	attack_name = "heavy fist"
 	shredding = 1
 
 /datum/unarmed_attack/industrial/heavy
-	damage = 10
+	damage = 8
 
 /datum/unarmed_attack/industrial/xion
-	damage = 5
+	damage = 4
 	shredding = 0
 
 /datum/unarmed_attack/terminator

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -113,6 +113,7 @@
 
 /datum/unarmed_attack/industrial/xion
 	damage = 5
+	shredding = 0
 
 /datum/unarmed_attack/terminator
 	attack_verb = list("pulverized", "crushed", "pounded")

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -91,6 +91,17 @@
 	user.visible_message("<span class='warning'>[user] jumped up and down on \the [target]'s [affecting.name]!</span>")
 	playsound(user.loc, attack_sound, 25, 1, -1)
 
+/datum/unarmed_attack/industrial
+	attack_verb = list("pulverized", "crushed", "pounded")
+	attack_noun = list("heavy fist")
+	damage = 6
+	attack_sound = 'sound/weapons/smash.ogg'
+	attack_name = "heavy fist"
+
+/datum/unarmed_attack/industrial/heavy
+	damage = 8
+	shredding = 1
+
 /datum/unarmed_attack/terminator
 	attack_verb = list("pulverized", "crushed", "pounded")
 	attack_noun = list("power fist")

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
@@ -19,9 +19,9 @@
 	light_power = 0.5
 	meat_type = /obj/item/stack/material/steel
 	unarmed_types = list(
-		/datum/unarmed_attack/punch,
-		/datum/unarmed_attack/stomp,
-		/datum/unarmed_attack/kick)
+		/datum/unarmed_attack/punch/ipc,
+		/datum/unarmed_attack/stomp/ipc,
+		/datum/unarmed_attack/kick/ipc)
 	rarity_value = 2
 
 	inherent_eye_protection = FLASH_PROTECTION_MAJOR

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
@@ -57,9 +57,9 @@
 	cold_level_2 = -1
 	cold_level_3 = -1
 
-	heat_level_1 = 500		// Gives them about 25 seconds in space before taking damage
-	heat_level_2 = 1000
-	heat_level_3 = 2000
+	heat_level_1 = 600		
+	heat_level_2 = 1200
+	heat_level_3 = 2400
 
 	body_temperature = null
 	passive_temp_gain = 10  // This should cause IPCs to stabilize at ~80 C in a 20 C environment.
@@ -102,7 +102,7 @@
 	)
 
 
-	heat_discomfort_level = 373.15
+	heat_discomfort_level = 500 //This will be 100 below the first heat level
 	heat_discomfort_strings = list(
 		"Your CPU temperature probes warn you that you are approaching critical heat levels!"
 		)

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -110,6 +110,8 @@
 	bald = 1
 	bodytype = "Heavy Machine"
 
+	unarmed_types = list(/datum/unarmed_attack/industrial)
+
 	brute_mod = 0.8
 	burn_mod = 1.1
 
@@ -288,6 +290,9 @@
 	preview_icon = 'icons/mob/human_races/ipc/ind_hephaestus_preview.dmi'
 
 	eyes = "heph_eyes"
+
+	unarmed_types = list(/datum/unarmed_attack/industrial/heavy)
+
 	slowdown = 6
 	brute_mod = 0.7
 	grab_mod = 0.7 // Bulkier and bigger than the G1
@@ -298,6 +303,11 @@
 	heat_level_3 = 4000
 
 	heat_discomfort_level = 900
+
+	inherent_verbs = list(
+		/mob/living/carbon/human/proc/self_diagnostics,
+		/mob/living/carbon/human/proc/crush
+	)
 
 	examine_color = "#688359"
 
@@ -330,6 +340,11 @@
 	deform = 'icons/mob/human_races/ipc/r_ind_xion.dmi'
 	preview_icon = 'icons/mob/human_races/ipc/ind_xion_preview.dmi'
 
+	unarmed_types = list(
+		/datum/unarmed_attack/punch,
+		/datum/unarmed_attack/stomp,
+		/datum/unarmed_attack/kick)
+
 	brute_mod = 0.9
 	grab_mod = 0.9 
 	resist_mod = 8 
@@ -347,7 +362,7 @@
 
 	examine_color = "#bc4b00"
 
-	blurb = "The Xion Manufacturing Group, being a subsidiary of Hephaestus Industries, saw the original Industrial models and wanted to develop their own chassis based off of the original design. The result is the Xion Industrial model. Sturdy and strong, this chassis is quite powerful and equally durable, with an ample power cell and improved actuators for carrying the increased weight of the body. The Xion model also retains sturdiness without covering the chassis in plating, allowing for the cooling systems to vent heat much easier than the Hephaestus-brand model. This unit cannot perform EVA without a suit."
+	blurb = "The Xion Manufacturing Group, being a subsidiary of Hephaestus Industries, saw the original Industrial models and wanted to develop their own chassis based off of the original design. The result is the Xion Industrial model. Sturdy and strong, this chassis is quite powerful and equally durable, with an ample power cell and improved actuators for carrying the increased weight of the body. The Xion model also retains sturdiness without covering the chassis in plating, allowing for the cooling systems to vent heat much easier than the Hephaestus-brand model. This unit can perform EVA without assistance."
 
 	has_limbs = list(
 		BP_CHEST  = list("path" = /obj/item/organ/external/chest/industrial/xion),

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -349,7 +349,7 @@
 
 	brute_mod = 0.9
 	grab_mod = 0.9 
-	resist_mod = 8 
+	resist_mod = 8
 
 	heat_level_1 = 700
 	heat_level_2 = 1400

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -345,9 +345,7 @@
 	preview_icon = 'icons/mob/human_races/ipc/ind_xion_preview.dmi'
 
 	unarmed_types = list(
-		/datum/unarmed_attack/punch/ipc,
-		/datum/unarmed_attack/stomp/ipc,
-		/datum/unarmed_attack/kick/ipc)
+		/datum/unarmed_attack/industrial/xion)
 
 	brute_mod = 0.9
 	grab_mod = 0.9 

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -23,9 +23,9 @@
 	light_range = 0
 	light_power = 0
 	unarmed_types = list(
-		/datum/unarmed_attack/stomp,
-		/datum/unarmed_attack/kick,
-		/datum/unarmed_attack/punch,
+		/datum/unarmed_attack/punch/ipc,
+		/datum/unarmed_attack/stomp/ipc,
+		/datum/unarmed_attack/kick/ipc,
 		/datum/unarmed_attack/bite
 	)
 
@@ -93,7 +93,11 @@
 		"surge"   = /obj/item/organ/internal/surge/advanced
 	)
 
-	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick,  /datum/unarmed_attack/terminator, /datum/unarmed_attack/bite/strong)
+	unarmed_types = list(
+		/datum/unarmed_attack/stomp/ipc, 
+		/datum/unarmed_attack/kick/ipc,  
+		/datum/unarmed_attack/terminator, 
+		/datum/unarmed_attack/bite/strong)
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/leap,
@@ -341,9 +345,9 @@
 	preview_icon = 'icons/mob/human_races/ipc/ind_xion_preview.dmi'
 
 	unarmed_types = list(
-		/datum/unarmed_attack/punch,
-		/datum/unarmed_attack/stomp,
-		/datum/unarmed_attack/kick)
+		/datum/unarmed_attack/punch/ipc,
+		/datum/unarmed_attack/stomp/ipc,
+		/datum/unarmed_attack/kick/ipc)
 
 	brute_mod = 0.9
 	grab_mod = 0.9 

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -354,7 +354,7 @@
 	heat_level_3 = 2800
 
 	heat_discomfort_level = 600
-	slowdown = 4
+	slowdown = 3
 
 	eyes = "xion_eyes"
 	flags = IS_IPC

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -34,9 +34,9 @@
 
 	max_nutrition_factor = 0.8
 
-	heat_level_1 = 400
-	heat_level_2 = 800
-	heat_level_3 = 1600
+	heat_level_1 = 500
+	heat_level_2 = 1000
+	heat_level_3 = 2000
 
 	heat_discomfort_level = 400
 	heat_discomfort_strings = list(
@@ -144,11 +144,11 @@
 	flags = IS_IPC | ACCEPTS_COOLER
 	appearance_flags = HAS_EYE_COLOR
 
-	heat_level_1 = 600
-	heat_level_2 = 1200
-	heat_level_3 = 2400
+	heat_level_1 = 800
+	heat_level_2 = 1600
+	heat_level_3 = 3200
 
-	heat_discomfort_level = 800
+	heat_discomfort_level = 700
 
 	max_nutrition_factor = 1.25
 	nutrition_loss_factor = 2
@@ -290,6 +290,14 @@
 	eyes = "heph_eyes"
 	slowdown = 6
 	brute_mod = 0.7
+	grab_mod = 0.7 // Bulkier and bigger than the G1
+	resist_mod = 12 // Overall stronger than G1
+
+	heat_level_1 = 1000
+	heat_level_2 = 2000
+	heat_level_3 = 4000
+
+	heat_discomfort_level = 900
 
 	examine_color = "#688359"
 
@@ -322,9 +330,20 @@
 	deform = 'icons/mob/human_races/ipc/r_ind_xion.dmi'
 	preview_icon = 'icons/mob/human_races/ipc/ind_xion_preview.dmi'
 
+	brute_mod = 0.9
+	grab_mod = 0.9 
+	resist_mod = 8 
+
+	heat_level_1 = 700
+	heat_level_2 = 1400
+	heat_level_3 = 2800
+
+	heat_discomfort_level = 600
+	slowdown = 4
+
 	eyes = "xion_eyes"
 	flags = IS_IPC
-	passive_temp_gain = 5
+	passive_temp_gain = 0
 
 	examine_color = "#bc4b00"
 
@@ -351,7 +370,6 @@
 /datum/species/machine/zenghu
 	name = "Zeng-Hu Mobility Frame"
 	short_name = "zhf"
-	bodytype = null
 
 	icobase = 'icons/mob/human_races/ipc/r_ind_zenghu.dmi'
 	deform = 'icons/mob/human_races/ipc/r_ind_zenghu.dmi'
@@ -363,6 +381,8 @@
 
 	grab_mod = 1.1 // Smooth, fast
 	resist_mod = 4 // Not super strong, but still rather strong
+
+	slowdown = -1.2
 
 	appearance_flags = HAS_EYE_COLOR
 
@@ -395,7 +415,7 @@
 /datum/species/machine/bishop
 	name = "Bishop Accessory Frame"
 	short_name = "bcf"
-	bodytype = null
+	bodytype = "Human"
 
 	icobase = 'icons/mob/human_races/ipc/r_ind_bishop.dmi'
 	deform = 'icons/mob/human_races/ipc/r_ind_bishop.dmi'

--- a/html/changelogs/Aboshehab - IPC Rework.yml
+++ b/html/changelogs/Aboshehab - IPC Rework.yml
@@ -1,0 +1,51 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Aboshehab
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Adjusted heat tolerances of all IPC species to differentiate between types, letting it be more forgiving."
+  - tweak: "Brute, resist and grab modifier changes to species dependant on type."
+  - tweak: "Moves IPC abilities to their own tab for visibility and ease of use."
+  - rscadd: "Adds a crush verb that is usable by G2."
+  - rscadd: "Implements a variety new attack options to IPC species."
+  - tweak: "Makes heat discomfort levels universally to be 100 units under the first heat level for all IPC species."
+  - bugfix: "Sorts out issues with voidsuit/hardsuit for Bishops and Zeng-Hu."
+  - tweak: "Adjusts Zeng-Hu Frame speed to be more inline with their lore."
+  - tweak: "Adjusts Xion Frame speed to be slightly faster than the G1 and G2 to emphasize it being lighter."
+  - tweak: "Xions can now go EVA indefinitely."
+  - tweak: "Adjustments to fluff blurbs of IPC subspecies to account for mechanical changes."


### PR DESCRIPTION
The **goal** is to make tangible differences between the subspecies with pros and cons that are in line with lore. Effectively, the IPC species felt too similar, many of which using equal stats in certain fields that made no sense to be equal in, this rework as stated previously aims to remedy this.

These changes were requested by Kyres, NiennaB and Tailson of the lore team.

changes: 
  - tweak: "Adjusted heat tolerances of all IPC species to differentiate between types, letting it be more forgiving."
  - tweak: "Brute, resist and grab modifier changes to species dependant on type."
  - tweak: "Moves IPC abilities to their own tab for visibility and ease of use."
  - rscadd: "Adds a crush verb that is usable by G2."
  - rscadd: "Implements a variety new attack options to IPC species."
  - tweak: "Makes heat discomfort levels universally to be 100 units under the first heat level for all IPC species."
  - bugfix: "Sorts out issues with voidsuit/hardsuit for Bishops and Zeng-Hu."
  - tweak: "Adjusts Zeng-Hu Frame speed to be more inline with their lore."
  - tweak: "Adjusts Xion Frame speed to be slightly faster than the G1 and G2 to emphasize it being lighter."
  - tweak: "Xions can now go EVA indefinitely."
  - tweak: "Adjustments to fluff blurbs of IPC subspecies to account for mechanical changes."