### PR TITLE
Representative fixes: records and cartridge

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -259,7 +259,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 /obj/item/device/pda/lawyer
 	icon_state = "pda-lawyer"
-	default_cartridge = /obj/item/cartridge/lawyer
 	inserted_item = /obj/item/pen/fountain
 	ttone = "..."
 

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -67,7 +67,7 @@
 	extended_desc = "Used to view, edit and maintain employment records."
 	record_prefix = "Employment "
 
-	required_access_run = list(access_heads)
+	required_access_run = list(access_heads, access_lawyer)
 	required_access_download = access_heads
 	available_on_ntnet = 1
 

--- a/html/changelogs/alberyk-representative.yml
+++ b/html/changelogs/alberyk-representative.yml
@@ -3,5 +3,5 @@ author: Alberyk
 delete-after: True
 
 changes: 
-  - bugfix: "Fixed corporate liasons and consular officers not having access to employement records."
-  - bugfix: "Fixed corporate liasons and consular officers having a security cartridge on their pda."
+  - bugfix: "Fixed corporate liaisons and consular officers not having access to employment records."
+  - bugfix: "Fixed corporate liaisons and consular officers having a security cartridge on their pda."

--- a/html/changelogs/alberyk-representative.yml
+++ b/html/changelogs/alberyk-representative.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed corporate liasons and consular officers not having access to employement records."
+  - bugfix: "Fixed corporate liasons and consular officers having a security cartridge on their pda."


### PR DESCRIPTION
-fixes corporate liaisons and consular officers not having access to employment records
-fixes corporate liaisons and consular officers having a security cartridge on their pda