### PR TITLE
Adjusts the backsurge event to respect welded scrubbers

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -40,7 +40,7 @@
 		if(!temp_vent)
 			continue
 		if(isStationLevel(temp_vent.z))
-			if(temp_vent.network && temp_vent.network.normal_members.len > 20)
+			if(!temp_vent.welded && temp_vent?.network.normal_members.len > 20)
 				vents += temp_vent
 	if(!vents.len)
 		return kill()

--- a/html/changelogs/skull132-scrubbers.yml
+++ b/html/changelogs/skull132-scrubbers.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - tweak: "The scrubber backsurge no longer breaks through unwelded vents."


### PR DESCRIPTION
Apparently they don't yet.

The only thing I suspect that might happen with this is. EVERYONE WELDS VENTS IMMEDIATELY. At which point, we might want to make it LOWER the chances of those vents being considered. (And maybe make them explode due to the backsurge.) But uh, we'll see in-game I guess.