### PR TITLE
Adds an engineer role for the freelancer mercenaries, purges a lot of their access

### DIFF
--- a/code/datums/outfits/ert/ert.dm
+++ b/code/datums/outfits/ert/ert.dm
@@ -162,7 +162,7 @@
 	)
 
 /datum/outfit/admin/ert/mercenary/get_id_access()
-	return get_distress_access()
+	return get_distress_access_lesser()
 
 /datum/outfit/admin/ert/mercenary/specialist
 	name = "Mercenary Freelancer Medic"
@@ -184,6 +184,32 @@
 		/obj/item/stack/medical/advanced/ointment = 1,
 		/obj/item/reagent_containers/glass/bottle/thetamycin = 1
 	)
+
+/datum/outfit/admin/ert/mercenary/engineer
+	name = "Mercenary Freelancer Combat Engineer"
+
+	back = /obj/item/storage/backpack/duffel
+	belt = /obj/item/storage/belt/utility/full
+	gloves = /obj/item/clothing/gloves/yellow
+	accessory = /obj/item/clothing/accessory/storage/brown_vest
+	accessory_contents = list(
+								/obj/item/plastique = 5
+							)
+
+	backpack_contents = list(
+		/obj/item/material/knife/trench = 1,
+		/obj/item/shield/energy = 1,
+		/obj/item/handcuffs/ziptie = 1,
+		/obj/item/tank/oxygen = 1,
+		/obj/item/device/multitool = 1,
+		/obj/item/weldingtool/hugetank = 1,
+		/obj/item/gun/projectile/shotgun/pump/combat/sol = 1,
+		/obj/item/storage/box/shotgunshells = 1,
+		/obj/item/landmine/frag = 1,
+		/obj/item/landmine/emp = 1
+	)
+
+	belt_contents = null
 
 /datum/outfit/admin/ert/mercenary/leader
 	name = "Mercenary Freelancer Leader"

--- a/code/datums/outfits/ert/ert.dm
+++ b/code/datums/outfits/ert/ert.dm
@@ -203,6 +203,7 @@
 		/obj/item/tank/oxygen = 1,
 		/obj/item/device/multitool = 1,
 		/obj/item/weldingtool/hugetank = 1,
+		/obj/item/clothing/glasses/welding/superior = 1,
 		/obj/item/gun/projectile/shotgun/pump/combat/sol = 1,
 		/obj/item/storage/box/shotgunshells = 1,
 		/obj/item/landmine/frag = 1,

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -84,6 +84,9 @@
 /proc/get_distress_access()
 	return list(access_legion, access_distress, access_maint_tunnels, access_external_airlocks, access_security, access_engine, access_engine_equip, access_medical, access_research, access_atmospherics, access_medical_equip)
 
+/proc/get_distress_access_lesser()
+	return list(access_distress, access_external_airlocks)
+
 /var/list/datum/access/priv_all_access_datums
 /proc/get_all_access_datums()
 	if(!priv_all_access_datums)

--- a/code/modules/ghostroles/spawner/human/ert.dm
+++ b/code/modules/ghostroles/spawner/human/ert.dm
@@ -115,6 +115,13 @@
 	desc = "The only medic of the freelancer mercenary team."
 	outfit = /datum/outfit/admin/ert/mercenary/specialist
 
+/datum/ghostspawner/human/ert/mercenary/engineer
+	name = "Mercenary Combat Engineer"
+	short_name = "merce"
+	max_count = 1
+	desc = "The only dedicated engineer of the freelancer mercenary team."
+	outfit = /datum/outfit/admin/ert/mercenary/engineer
+
 /datum/ghostspawner/human/ert/mercenary/leader
 	name = "Mercenary Leader"
 	short_name = "mercl"

--- a/html/changelogs/Ferner-191231-coding_freelancerengineer.yml
+++ b/html/changelogs/Ferner-191231-coding_freelancerengineer.yml
@@ -1,0 +1,5 @@
+author: Ferner
+delete-after: True
+changes: 
+  - rscadd: "Added a combat engineer role for the freelancer mercenary team."
+  - tweak: "Removed most of the station access freelancer mercenaries got."


### PR DESCRIPTION
 - Added an engineer role for the freelancer mercenary team which has been requested a bunch,
 - Made it so freelancers don't get the same access as other ert teams, they're supposed to be totally unaffiliated to nanotrasen so their access should reflect that. The dedicated engineer role should help remedy the lessened access, plus, I decided to keep the external airlock access as there's really no smooth way to hack those.