### PR TITLE
Hostile mobs update and tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -43,10 +43,6 @@
 
 	flying = TRUE
 
-/mob/living/simple_animal/hostile/carp/Initialize()
-	. = ..()
-	target_type_validator_map[/obj/effect/energy_field] = CALLBACK(src, .proc/validator_e_field)
-
 /mob/living/simple_animal/hostile/carp/Allow_Spacemove(var/check_drift = 0)
 	return 1	//No drifting in space for space carp!	//original comments do not steal
 
@@ -97,14 +93,6 @@
 				obstacle.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
 				return 1
 	return 0
-
-/mob/living/simple_animal/hostile/carp/proc/validator_e_field(var/obj/effect/energy_field/E, var/atom/current)
-	if(isliving(current)) // We prefer mobs over anything else
-		return FALSE
-	if(get_dist(src, E) < get_dist(src, current))
-		return TRUE
-	else
-		return FALSE
 
 /mob/living/simple_animal/hostile/carp/russian
 	name = "Ivan the carp"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -69,7 +69,6 @@
 
 /mob/living/simple_animal/hostile/giant_spider/Initialize(mapload, atom/parent)
 	get_light_and_color(parent)
-	target_type_validator_map[/obj/effect/energy_field] = CALLBACK(src, .proc/validator_e_field)
 	. = ..()
 
 /mob/living/simple_animal/hostile/giant_spider/AttackingTarget()
@@ -109,14 +108,6 @@
 /mob/living/simple_animal/hostile/giant_spider/proc/stop_walking()
 	stop_automated_movement = 0
 	walk(src, 0)
-
-/mob/living/simple_animal/hostile/giant_spider/proc/validator_e_field(var/obj/effect/energy_field/E, var/atom/current)
-	if(isliving(current)) // We prefer mobs over anything else
-		return FALSE
-	if(get_dist(src, E) < get_dist(src, current))
-		return TRUE
-	else
-		return FALSE
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/think()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -13,6 +13,7 @@
 	var/list/friends = list()
 	var/break_stuff_probability = 10
 	stop_automated_movement_when_pulled = 0
+	attacktext = "hits"
 	var/destroy_surroundings = 1
 	a_intent = I_HURT
 	hunger_enabled = 0//Until automated eating mechanics are enabled, disable hunger for hostile mobs
@@ -258,6 +259,8 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 			var/mob/M = V
 			if((M.faction == faction) || (M in friends))
 				return FALSE
+		if(validator_e_field(V, null))
+			target_hit = TRUE
 
 	return target_hit
 
@@ -279,6 +282,14 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 /mob/living/simple_animal/hostile/proc/DestroySurroundings(var/bypass_prob = FALSE)
 	if(prob(break_stuff_probability) || bypass_prob) //bypass_prob is used to make mob destroy things in the way to our target
 		for(var/dir in cardinal) // North, South, East, West
+			var/obj/effect/energy_field/e = locate(/obj/effect/energy_field, get_step(src, dir))
+			if(e)
+				e.Stress(rand(1,2))
+				visible_message("<span class='danger'>\the [src] [attacktext] \the [e]!</span>")
+				src.do_attack_animation(e)
+				target_mob = e
+				stance = HOSTILE_STANCE_ATTACKING
+				return 1
 			for(var/obj/structure/window/obstacle in get_step(src, dir))
 				if(obstacle.dir == reverse_dir[dir]) // So that windows get smashed in the right order
 					obstacle.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
@@ -369,3 +380,11 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 	if(isliving(current)) // We prefer mobs over anything else
 		return FALSE
 	return !(T.health <= 0)
+
+/mob/living/simple_animal/hostile/proc/validator_e_field(var/obj/effect/energy_field/E, var/atom/current)
+	if(isliving(current)) // We prefer mobs over anything else
+		return FALSE
+	if(get_dist(src, E) < get_dist(src, current))
+		return TRUE
+	else
+		return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -122,7 +122,7 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 	return
 
 /mob/living/simple_animal/hostile/proc/see_target()
-	return (target_mob in view(7, src)) ? (TRUE) : (FALSE)
+	return (target_mob in view(10, src)) ? (TRUE) : (FALSE)
 
 /mob/living/simple_animal/hostile/proc/MoveToTarget()
 	stop_automated_movement = 1

--- a/html/changelogs/Sindorman-carps.yml
+++ b/html/changelogs/Sindorman-carps.yml
@@ -40,3 +40,4 @@ delete-after: True
 changes: 
   - tweak: "Carps and spiders no longer targe shields intentionally. They will attack shields only if adjacent or have to get to their target through shields."
   - tweak: "All ranged hostile mobs will now shoot at shields, if their target is behind a shield."
+  - bugfix: "Hostile mobs now try and attack you 10 tiles away. But ranged mobs will still have to get within 6 tiles to shoot."

--- a/html/changelogs/Sindorman-carps.yml
+++ b/html/changelogs/Sindorman-carps.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Carps and spiders no longer targe shields intentionally. They will attack shields only if adjacent or have to get to their target through shields."
+  - tweak: "All ranged hostile mobs will now shoot at shields, if their target is behind a shield."


### PR DESCRIPTION
As requested By Geeves:
  - tweak: "Carps and spiders no longer targe shields intentionally. They will attack shields only if adjacent or have to get to their target through shields."

Also:
  - tweak: "All ranged hostile mobs will now shoot at shields, if their target is behind a shield."
  - bugfix: "Hostile mobs now try and attack you 10 tiles away. But ranged mobs will still have to get within 6 tiles to shoot." Thanks to Ferner for noticing this