### PR TITLE
Attemps to make vampire draining a bit less lethal

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -127,7 +127,7 @@
 
 			to_chat(src, update_msg)
 		check_vampire_upgrade()
-		T.vessel.remove_reagent("blood", 25)
+		T.vessel.remove_reagent("blood", 5)
 
 	vampire.status &= ~VAMP_DRAINING
 

--- a/html/changelogs/alberyk-vampirefix.yml
+++ b/html/changelogs/alberyk-vampirefix.yml
@@ -3,5 +3,4 @@ author: Alberyk
 delete-after: True
 
 changes: 
-  - tweak: "Vampire blood draining should remove less blood, reducing the chances of brain damage due to low oxygen.
-
+  - tweak: "Vampire blood draining should remove less blood, reducing the chances of brain damage due to low oxygen."

--- a/html/changelogs/alberyk-vampirefix.yml
+++ b/html/changelogs/alberyk-vampirefix.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Vampire blood draining should remove less blood, reducing the chances of brain damage due to low oxygen.
+


### PR DESCRIPTION
Turns out that draining some blood will cause people to get a lot of brain damage, resulting in the complete shutdown of their organs. This pr reduces the bloodloss caused by vampire draining, making it a bit less lethal.