### PR TITLE
Devour fixes and improvements. Allows dionae to devour.

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2069,6 +2069,7 @@
 #include "code\modules\organs\internal\liver.dm"
 #include "code\modules\organs\internal\lungs.dm"
 #include "code\modules\organs\internal\stomach.dm"
+#include "code\modules\organs\internal\species\diona.dm"
 #include "code\modules\organs\subtypes\autakh.dm"
 #include "code\modules\organs\subtypes\diona.dm"
 #include "code\modules\organs\subtypes\industrial.dm"

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -471,20 +471,20 @@ var/list/diona_banned_languages = list(
 	if (DS.LMS == 1) //If we're full
 		if (DS.EP <= 0.8 && DS.last_lightlevel <= 0) //But at <=80% energy
 			DS.LMS = 2
-			to_chat(src, "<span class='warning'>The darkness makes you uncomfortable.</span>")
+			to_chat(src, "<span class='warning'>The darkness makes you uncomfortable...</span>")
 
 	else if (DS.LMS == 2)
 		if (DS.EP >= 0.99)
 			DS.LMS = 1
-			to_chat(src, "You bask in the light")
+			to_chat(src, "You bask in the light.")
 		else if (DS.EP <= 0.4 && DS.last_lightlevel <= 0)
 			DS.LMS = 3
-			to_chat(src, "<span class='warning'>You feel lethargic as your energy drains away. Find some light soon!</span>")
+			to_chat(src, "<span class='warning'>You feel lethargic as your energy drains away. Find some light!</span>")
 
 	else if (DS.LMS == 3)
 		if (DS.EP >= 0.5)
 			DS.LMS = 2
-			to_chat(src, "You feel a little more energised as you return to the light. Stay awhile.")
+			to_chat(src, "You feel a little more energised as you return to the light. Stay here for a while.")
 		else if (DS.EP <= 0.0 && DS.last_lightlevel <= 0)
 			DS.LMS = 4
 			to_chat(src, "<span class='danger'>You feel sensory distress as your tendrils start to wither in the darkness. You will die soon without light.</span>")

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -476,7 +476,7 @@ var/list/diona_banned_languages = list(
 	else if (DS.LMS == 2)
 		if (DS.EP >= 0.99)
 			DS.LMS = 1
-			to_chat(src, "You bask in the light.")
+			to_chat(src, span("notice", "You bask in the light."))
 		else if (DS.EP <= 0.4 && DS.last_lightlevel <= 0)
 			DS.LMS = 3
 			to_chat(src, "<span class='warning'>You feel lethargic as your energy drains away. Find some light!</span>")

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -352,7 +352,7 @@ var/list/diona_banned_languages = list(
 		for (var/i in species.has_organ)
 			path = species.has_organ[i]
 			var/organ_exists = 0
-			for (var/obj/item/organ/internal/diona/B in internal_organs)
+			for (var/obj/item/organ/internal/B in internal_organs)
 				if (B.type == path)
 					organ_exists = 1
 					break
@@ -376,7 +376,7 @@ var/list/diona_banned_languages = list(
 			var/obj/item/organ/O = new path(src)
 			internal_organs_by_name[O.organ_tag] = O
 			internal_organs.Add(O)
-			to_chat(src, "<span class='danger'>You feel a shifting sensation inside you as your nymphs move apart to make space, forming a new [O.name]</span>")
+			to_chat(src, "<span class='danger'>You feel a shifting sensation inside you as your nymphs move apart to make space, forming a new [O.name].</span>")
 			regenerate_icons()
 			DS.LMS = max(2, DS.LMS) //Prevents a message about darkness in light areas
 			update_dionastats() //Re-find the organs in case they were lost or regained

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -982,8 +982,7 @@
 		if(incapacitated())
 			to_chat(src, span("warning", "You cannot do that right now."))
 			return
-		var/datum/gender/G = gender_datums[gender]
-		visible_message(span("danger", "\The [src] starts sticking a finger down [G.his] own throat. It looks like [G.he] [G.is] trying to throw up!"))
+		visible_message(span("warning", "\The [src] retches a bit..."))
 		if(!do_after(src, 30))
 			return
 		timevomit = max(timevomit, 5)

--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -30,6 +30,8 @@
 	taste_sensitivity = TASTE_DULL
 	mob_size = 12	//Worker gestalts are 150kg
 	remains_type = /obj/effect/decal/cleanable/ash //no bones, so, they just turn into dust
+	gluttonous = GLUT_ITEM_ANYTHING|GLUT_SMALLER
+	stomach_capacity = 10 //Big boys.
 	blurb = "Commonly referred to (erroneously) as 'plant people', the Dionaea are a strange space-dwelling collective \
 	species hailing from Epsilon Ursae Minoris. Each 'diona' is a cluster of numerous cat-sized organisms called nymphs; \
 	there is no effective upper limit to the number that can fuse in gestalt, and reports exist	of the Epsilon Ursae \
@@ -47,7 +49,8 @@
 		"response node"      = /obj/item/organ/internal/diona/node,
 		"gas bladder"        = /obj/item/organ/internal/diona/bladder,
 		"polyp segment"      = /obj/item/organ/internal/diona/polyp,
-		"anchoring ligament" = /obj/item/organ/internal/diona/ligament
+		"anchoring ligament" = /obj/item/organ/internal/diona/ligament,
+		BP_STOMACH           = /obj/item/organ/internal/stomach/diona
 	)
 
 	has_limbs = list(

--- a/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
@@ -16,7 +16,7 @@
 	)
 	primitive_form = "Stok"
 	darksight = 3
-	gluttonous = 2
+	gluttonous = GLUT_SMALLER|GLUT_ITEM_TINY
 	slowdown = 0.5
 
 	brute_mod = 0.8

--- a/code/modules/organs/internal/species/diona.dm
+++ b/code/modules/organs/internal/species/diona.dm
@@ -59,3 +59,5 @@
 /obj/item/organ/internal/stomach/diona
 	name = "digestion chamber"
 	should_process_alcohol = FALSE
+	icon = 'icons/mob/npc/alien.dmi'
+	icon_state = "claw"

--- a/code/modules/organs/internal/species/diona.dm
+++ b/code/modules/organs/internal/species/diona.dm
@@ -1,0 +1,61 @@
+/obj/item/organ/internal/diona/process()
+	return
+
+/obj/item/organ/internal/diona/strata
+	name = "neural strata"
+	parent_organ = BP_CHEST
+	organ_tag = "neural strata"
+
+
+/obj/item/organ/internal/diona/bladder
+	name = "gas bladder"
+	parent_organ = BP_HEAD
+	organ_tag = "gas bladder"
+
+/obj/item/organ/internal/diona/polyp
+	name = "polyp segment"
+	parent_organ = BP_GROIN
+	organ_tag = "polyp segment"
+
+/obj/item/organ/internal/diona/ligament
+	name = "anchoring ligament"
+	parent_organ = BP_GROIN
+	organ_tag = "anchoring ligament"
+
+/obj/item/organ/internal/diona
+	name = "diona nymph"
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "nymph"
+	organ_tag = "special" // Turns into a nymph instantly, no transplanting possible.
+
+/obj/item/organ/internal/diona/removed(var/mob/living/user)
+	var/mob/living/carbon/human/H = owner
+	..()
+	if(!istype(H) || !H.organs || !H.organs.len)
+		H.death()
+
+// These are different to the standard diona organs as they have a purpose in other
+// species (absorbing radiation and light respectively)
+/obj/item/organ/internal/diona/nutrients
+	name = "nutrient channel"
+	parent_organ = BP_CHEST
+	organ_tag = "nutrient channel"
+	icon = 'icons/mob/npc/alien.dmi'
+	icon_state = "claw"
+
+/obj/item/organ/internal/diona/nutrients/removed()
+	return
+
+/obj/item/organ/internal/diona/node
+	name = "response node"
+	parent_organ = BP_HEAD
+	organ_tag = "response node"
+	icon = 'icons/mob/npc/alien.dmi'
+	icon_state = "claw"
+
+/obj/item/organ/internal/diona/node/removed()
+	return
+
+/obj/item/organ/internal/stomach/diona
+	name = "digestion chamber"
+	should_process_alcohol = FALSE

--- a/code/modules/organs/internal/species/diona.dm
+++ b/code/modules/organs/internal/species/diona.dm
@@ -60,4 +60,4 @@
 	name = "digestion chamber"
 	should_process_alcohol = FALSE
 	icon = 'icons/mob/npc/alien.dmi'
-	icon_state = "claw"
+	icon_state = "chitin"

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -7,9 +7,9 @@
 	dead_icon = "stomach"
 	organ_tag = BP_STOMACH
 	parent_organ = BP_GROIN
-	var/stomach_capacity
 	var/datum/reagents/metabolism/ingested
 	var/next_cramp = 0
+	var/should_process_alcohol = TRUE
 
 /obj/item/organ/internal/stomach/Destroy()
 	QDEL_NULL(ingested)
@@ -104,8 +104,7 @@
 		if(functioning)
 			for(var/mob/living/M in contents)
 				if(M.stat == DEAD)
-					qdel(M)
-					continue
+					addtimer(CALLBACK(src, .proc/digest_mob, M), 30 SECONDS, TIMER_UNIQUE)
 
 				M.adjustBruteLoss(3)
 				M.adjustFireLoss(3)
@@ -119,15 +118,21 @@
 			next_cramp = world.time + rand(200,800)
 			owner.custom_pain("Your stomach cramps agonizingly!",1)
 
-		var/alcohol_volume = ingested.get_reagent_amount(/datum/reagent/alcohol/ethanol)
-		
-		// Alcohol counts as double volume for the purposes of vomit probability
-		var/effective_volume = ingested.total_volume + alcohol_volume
-		
-		// Just over the limit, the probability will be low. It rises a lot such that at double ingested it's 64% chance.
-		var/vomit_probability = (effective_volume / STOMACH_VOLUME) ** 6
-		if(prob(vomit_probability))
-			owner.vomit()
+		if(should_process_alcohol)
+
+			var/alcohol_volume = ingested.get_reagent_amount(/datum/reagent/alcohol/ethanol)
+
+			// Alcohol counts as double volume for the purposes of vomit probability
+			var/effective_volume = ingested.total_volume + alcohol_volume
+
+			// Just over the limit, the probability will be low. It rises a lot such that at double ingested it's 64% chance.
+			var/vomit_probability = (effective_volume / STOMACH_VOLUME) ** 6
+			if(prob(vomit_probability))
+				owner.vomit()
+
+/obj/item/organ/internal/stomach/proc/digest_mob(mob/M)
+	if(!QDELETED(M))
+		qdel(M)
 
 #undef STOMACH_VOLUME
 #undef PUKE_ACTION_NAME

--- a/code/modules/organs/subtypes/diona.dm
+++ b/code/modules/organs/subtypes/diona.dm
@@ -25,6 +25,11 @@
 	name = "tendril"
 	limb_flags = 0
 
+/obj/item/organ/external/diona/removed(var/mob/living/user)
+	..()
+	if(spawn_diona_nymph(get_turf(src)))
+		qdel(src)
+
 /obj/item/organ/external/chest/diona
 	name = "core trunk"
 	limb_name = "chest"
@@ -172,66 +177,3 @@
 	joint = "structural ligament"
 	amputation_point = "branch"
 	vital = FALSE // Lore team requested this, not vital organ. We can still live without it.
-
-/obj/item/organ/internal/diona/process()
-	return
-
-/obj/item/organ/internal/diona/strata
-	name = "neural strata"
-	parent_organ = BP_CHEST
-	organ_tag = "neural strata"
-
-
-/obj/item/organ/internal/diona/bladder
-	name = "gas bladder"
-	parent_organ = BP_HEAD
-	organ_tag = "gas bladder"
-
-/obj/item/organ/internal/diona/polyp
-	name = "polyp segment"
-	parent_organ = BP_GROIN
-	organ_tag = "polyp segment"
-
-/obj/item/organ/internal/diona/ligament
-	name = "anchoring ligament"
-	parent_organ = BP_GROIN
-	organ_tag = "anchoring ligament"
-
-/obj/item/organ/internal/diona
-	name = "diona nymph"
-	icon = 'icons/obj/objects.dmi'
-	icon_state = "nymph"
-	organ_tag = "special" // Turns into a nymph instantly, no transplanting possible.
-
-/obj/item/organ/internal/diona/removed(var/mob/living/user)
-	var/mob/living/carbon/human/H = owner
-	..()
-	if(!istype(H) || !H.organs || !H.organs.len)
-		H.death()
-
-/obj/item/organ/external/diona/removed(var/mob/living/user)
-	..()
-	if(spawn_diona_nymph(get_turf(src)))
-		qdel(src)
-
-// These are different to the standard diona organs as they have a purpose in other
-// species (absorbing radiation and light respectively)
-/obj/item/organ/internal/diona/nutrients
-	name = "nutrient channel"
-	parent_organ = BP_CHEST
-	organ_tag = "nutrient channel"
-	icon = 'icons/mob/npc/alien.dmi'
-	icon_state = "claw"
-
-/obj/item/organ/internal/diona/nutrients/removed()
-	return
-
-/obj/item/organ/internal/diona/node
-	name = "response node"
-	parent_organ = BP_HEAD
-	organ_tag = "response node"
-	icon = 'icons/mob/npc/alien.dmi'
-	icon_state = "claw"
-
-/obj/item/organ/internal/diona/node/removed()
-	return

--- a/html/changelogs/mattatlas-devourfixes.yml
+++ b/html/changelogs/mattatlas-devourfixes.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Dionae now have a stomach organ, which means they can devour. It has a bigger capacity than usual."
+  - tweak: "Dionae can now devour big objects as well. Just pick them up and click on yourself while aiming mouth."
+  - bugfix: "Unathi can now actually devour tiny items."
+  - bugfix: "Unathi can now devour any mob smaller than them."


### PR DESCRIPTION
  - Dionae now have a stomach organ, which means they can devour. It has a bigger capacity than usual.
  - Dionae can now devour big objects as well. Just pick them up and click on yourself while aiming mouth.
  - Unathi can now actually devour tiny items.
  - Unathi can now devour any mob smaller than them.