### PR TITLE
Miscellaneous borer/bughunt fixes.

### DIFF
--- a/code/game/gamemodes/mixed/bughunt.dm
+++ b/code/game/gamemodes/mixed/bughunt.dm
@@ -1,6 +1,6 @@
 /datum/game_mode/bughunt
 	name = "Bughunt (merc+borer)"
-	round_description = "A mercenary strike force is approaching to eradicate a borer infestation!"
+	round_description = "A mercenary strike force is approaching at the same time as a borer infestation!"
 	extended_round_description = "Mercenaries and borers spawn in this game mode."
 	config_tag = "bughunt"
 	required_players = 20
@@ -9,4 +9,3 @@
 	antag_tags = list(MODE_BORER, MODE_MERCENARY)
 	require_all_templates = TRUE
 	votable = TRUE
-	ert_disabled = TRUE

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -11,7 +11,7 @@
 	item_state = "brainslug"
 	icon_living = "brainslug"
 	icon_dead = "brainslug_dead"
-	speed = 5
+	speed = 6
 	a_intent = I_HURT
 	stop_automated_movement = 1
 	status_flags = CANPUSH
@@ -24,7 +24,7 @@
 	universal_understand = 1
 	holder_type = /obj/item/holder/borer
 	mob_size = 1
-	nutrition_step = 0
+	hunger_enabled = FALSE
 
 	var/used_dominate
 	var/chemicals = 10                      // Chemicals used for reproduction and spitting neurotoxin.

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -24,6 +24,7 @@
 	universal_understand = 1
 	holder_type = /obj/item/holder/borer
 	mob_size = 1
+	nutrition_step = 0
 
 	var/used_dominate
 	var/chemicals = 10                      // Chemicals used for reproduction and spitting neurotoxin.
@@ -137,6 +138,7 @@
 		borers.remove_antagonist(host.mind)
 
 	forceMove(get_turf(host))
+	host -= src
 
 	reset_view(null)
 	machine = null
@@ -144,7 +146,6 @@
 	host.reset_view(null)
 	host.machine = null
 
-	var/mob/living/H = host
 	H.status_flags &= ~PASSEMOTES
 	host = null
 	return

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -138,7 +138,9 @@
 		borers.remove_antagonist(host.mind)
 
 	forceMove(get_turf(host))
-	host -= src
+	var/obj/item/organ/external/head = host.get_organ(BP_HEAD)
+	if(head)
+		head.implants -= src
 
 	reset_view(null)
 	machine = null
@@ -146,7 +148,7 @@
 	host.reset_view(null)
 	host.machine = null
 
-	H.status_flags &= ~PASSEMOTES
+	host.status_flags &= ~PASSEMOTES
 	host = null
 	return
 

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -205,7 +205,7 @@
 		to_chat(src, span("warning", "You don't have enough chemicals!"))
 		return
 
-	var/chem = input("Select a chemical to secrete.", "Chemicals") as null|anything in list("Inaprovaline", "Bicaridine", "Hyperzine", "Synaptizine", "Peridaxon", "Tramadol", "Oxycodone", "Fluvoxamine")
+	var/chem = input("Select a chemical to secrete.", "Chemicals") as null|anything in list("Inaprovaline", "Norepinephrine", "Bicaridine", "Kelotane", "Dylovene", "Hyperzine", "Peridaxon", "Tramadol", "Fluvoxamine")
 
 	if(!chem || chemicals < 20 || !host || controlling || !src || stat) //Sanity check.
 		return

--- a/code/modules/mob/living/simple_animal/borer/say.dm
+++ b/code/modules/mob/living/simple_animal/borer/say.dm
@@ -38,7 +38,7 @@
 			chosen_sayer.say(message)
 		return
 
-	to_chat(src, "You drop words into [host]'s mind: \"[message]\"")
+	to_chat(src, "<b>You drop words into [host]'s mind:</b> \"[message]\"")
 	to_chat(host, "<b>Your own thoughts speak:</b> \"[message]\"")
 
 	for(var/mob/M in player_list)

--- a/code/modules/mob/living/simple_animal/borer/say.dm
+++ b/code/modules/mob/living/simple_animal/borer/say.dm
@@ -39,7 +39,7 @@
 		return
 
 	to_chat(src, "You drop words into [host]'s mind: \"[message]\"")
-	to_chat(host, "Your own thoughts speak: \"[message]\"")
+	to_chat(host, "<b>Your own thoughts speak:</b> \"[message]\"")
 
 	for(var/mob/M in player_list)
 		if(istype(M, /mob/abstract/new_player))

--- a/html/changelogs/mattatlas-borerfix.yml
+++ b/html/changelogs/mattatlas-borerfix.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Borers no longer get teleported out of a host if they're manually removed after leaving the host."
+  - tweak: "Removed synaptizine from borer chems. Added dylovene, kelotane, norepinephrine instead."
+  - bugfix: "You can now call ERTs on Bughunt."
+  - bugfix: "Borers no longer have nutrition loss."


### PR DESCRIPTION
  - Borers no longer get teleported out of a host if they're manually removed after leaving the host.
  - Removed synaptizine from borer chems. Added dylovene, kelotane, norepinephrine instead.
  - You can now call ERTs on Bughunt.
  - Borers no longer have nutrition loss.