### PR TITLE
Rename Emergency Physician to Trauma Physician

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -62,11 +62,11 @@
 
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_pharmacy, access_virology, access_genetics, access_eva)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_genetics, access_eva)
-	alt_titles = list("Surgeon","Emergency Physician","Nurse")
+	alt_titles = list("Surgeon","Trauma Physician","Nurse")
 	alt_ages = list("Nurse" = 25)
 	outfit = /datum/outfit/job/doctor
 	alt_outfits = list(
-		"Emergency Physician"=/datum/outfit/job/doctor/emergency_physician,
+		"Trauma Physician"=/datum/outfit/job/doctor/trauma_physician,
 		"Surgeon"=/datum/outfit/job/doctor/surgeon,
 		"Nurse"=/datum/outfit/job/doctor/nurse
 		)
@@ -89,8 +89,8 @@
 	dufflebag = /obj/item/storage/backpack/duffel/med
 	messengerbag = /obj/item/storage/backpack/messenger/med
 
-/datum/outfit/job/doctor/emergency_physician
-	name = "Emergency Physician"
+/datum/outfit/job/doctor/trauma_physician
+	name = "Trauma Physician"
 	jobtype = /datum/job/doctor
 
 	suit = /obj/item/clothing/suit/storage/toggle/fr_jacket

--- a/html/changelogs/sierrakomodo - rename emergency physician.yml
+++ b/html/changelogs/sierrakomodo - rename emergency physician.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Renamed Emergency Physician to Trauma Physician, to better reflect their role as a doctor and not an emergency responder."


### PR DESCRIPTION
What it says in the tin.

https://forums.aurorastation.org/topic/13588-rename-emergency-physicians-are-not-paramedics/

### IC changelog
`Due to reported confusion of the intended role of Emergency Physicians, these personnel have had their IDs updated to read Trauma Physician to better reflect their role within the infirmary and not as emergency responders.`