### PR TITLE
Kataphract Chapter adjustments

### DIFF
--- a/code/modules/ghostroles/spawner/human/kataphract.dm
+++ b/code/modules/ghostroles/spawner/human/kataphract.dm
@@ -90,9 +90,9 @@
 
 	uniform = /obj/item/clothing/under/unathi
 	belt = /obj/item/melee/energy/sword/hegemony
-	shoes = /obj/item/clothing/shoes/caligae/grey
+	shoes = /obj/item/clothing/shoes/caligae/armor
 	id = /obj/item/card/id/distress/kataphract
-	back = /obj/item/storage/backpack/satchel
+	back = /obj/item/storage/backpack/satchel/hegemony
 
 	backpack_contents = list(
 		/obj/item/storage/box/donkpockets = 1
@@ -111,8 +111,6 @@
 	mask = /obj/item/clothing/mask/breath/vaurca/filter
 	belt = /obj/item/melee/energy/sword/hegemony
 	shoes = /obj/item/clothing/shoes/vaurca
-	id = /obj/item/card/id/distress/kataphract
-	back = /obj/item/storage/backpack/satchel
 
 	l_hand = /obj/item/martial_manual/vaurca
 
@@ -135,7 +133,11 @@
 /datum/outfit/admin/kataphract/knight
 	name = "Kataphract Knight"
 
-	suit = /obj/item/clothing/accessory/poncho/red
+	backpack_contents = list(
+		/obj/item/storage/box/donkpockets = 1,
+		/obj/item/modular_computer/laptop/preset = 1
+	)
+	
 
 /datum/outfit/admin/kataphract/knight/get_id_access()
 	return list(access_kataphract, access_kataphract_knight)
@@ -143,11 +145,21 @@
 /datum/outfit/admin/kataphract/quartermaster
 	name = "Kataphract Quartermaster"
 
+	backpack_contents = list(
+		/obj/item/storage/box/donkpockets = 1,
+		/obj/item/modular_computer/laptop/preset = 1
+	)
+
 /datum/outfit/admin/kataphract/quartermaster/get_id_access()
 	return list(access_kataphract, access_kataphract_quartermaster)
 
 /datum/outfit/admin/kataphract/trader
 	name = "Kataphract Trader"
+
+	backpack_contents = list(
+		/obj/item/storage/box/donkpockets = 1,
+		/obj/item/modular_computer/laptop/preset = 1
+	)
 
 /datum/outfit/admin/kataphract/trader/get_id_access()
 	return list(access_kataphract, access_kataphract_trader)

--- a/code/modules/ghostroles/spawner/human/kataphract.dm
+++ b/code/modules/ghostroles/spawner/human/kataphract.dm
@@ -95,6 +95,7 @@
 	back = /obj/item/storage/backpack/satchel/hegemony
 
 	backpack_contents = list(
+		/obj/item/storage/box/survival = 1,
 		/obj/item/storage/box/donkpockets = 1
 	)
 
@@ -116,6 +117,7 @@
 
 
 	backpack_contents = list(
+		/obj/item/storage/box/vaurca = 1,
 		/obj/item/reagent_containers/food/snacks/koisbar_clean = 3
 	)
 
@@ -134,6 +136,7 @@
 	name = "Kataphract Knight"
 
 	backpack_contents = list(
+		/obj/item/storage/box/survival = 1,
 		/obj/item/storage/box/donkpockets = 1,
 		/obj/item/modular_computer/laptop/preset = 1
 	)
@@ -146,6 +149,7 @@
 	name = "Kataphract Quartermaster"
 
 	backpack_contents = list(
+		/obj/item/storage/box/survival = 1,
 		/obj/item/storage/box/donkpockets = 1,
 		/obj/item/modular_computer/laptop/preset = 1
 	)
@@ -157,6 +161,7 @@
 	name = "Kataphract Trader"
 
 	backpack_contents = list(
+		/obj/item/storage/box/survival = 1,
 		/obj/item/storage/box/donkpockets = 1,
 		/obj/item/modular_computer/laptop/preset = 1
 	)

--- a/html/changelogs/leudoberct1 - chapterfixes.yml
+++ b/html/changelogs/leudoberct1 - chapterfixes.yml
@@ -1,0 +1,7 @@
+author: Leudoberct and Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Updated the Kataphract Chapter to use the new Hegemony gear."
+  - rscadd: "Gave Kataphract Chapter higher-ups laptops."

--- a/maps/space_ruins/kataphract_chapter.dmm
+++ b/maps/space_ruins/kataphract_chapter.dmm
@@ -1396,8 +1396,11 @@
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/office)
 "cW" = (
-/obj/structure/dispenser/oxygen,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/table/rack,
+/obj/item/tank/oxygen/brown,
+/obj/item/tank/oxygen/brown,
+/obj/item/tank/oxygen/brown,
+/obj/item/tank/oxygen/brown,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "cX" = (
@@ -1857,10 +1860,6 @@
 /obj/item/clothing/suit/space/void/kataphract,
 /obj/item/clothing/suit/space/void/kataphract,
 /obj/item/clothing/suit/space/void/kataphract,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
@@ -1869,6 +1868,10 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
+/obj/item/clothing/shoes/magboots/hegemony,
+/obj/item/clothing/shoes/magboots/hegemony,
+/obj/item/clothing/shoes/magboots/hegemony,
+/obj/item/clothing/shoes/magboots/hegemony,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "dW" = (


### PR DESCRIPTION
Adjusts the magboots in their voidsuit locker to be the Hegemony variant, removes the oxygen tank dispesner in favour of a rack with hegemony specific oxygen tanks, and makes the Kataphracts spawn with some extra stuff.