### PR TITLE
Projectiles will no longer lag the server to death

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -369,6 +369,11 @@
 		transform = M
 	trajectory.increment(trajectory_multiplier)
 	var/turf/T = trajectory.return_turf()
+
+	if (!T) // Nowhere to go. Just die.
+		qdel(src)
+		return
+
 	if(T.z != loc.z)
 		before_move()
 		before_z_change(loc, T)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -362,6 +362,10 @@
 				on_impact(loc)
 			qdel(src)
 		return
+
+	if (QDELETED(src))
+		return
+
 	last_projectile_move = world.time
 	if(!nondirectional_sprite && !hitscanning)
 		var/matrix/M = new
@@ -518,7 +522,8 @@
 		required_moves = SSprojectiles.global_max_tick_moves
 	if(!required_moves)
 		return
-	for(var/i in 1 to required_moves)
+
+	for(var/i = 1; 1 <= required_moves && !QDELETED(src); i++)
 		pixel_move(required_moves)
 
 /obj/item/projectile/proc/setAngle(new_angle)	//wrapper for overrides.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -523,7 +523,7 @@
 	if(!required_moves)
 		return
 
-	for(var/i = 1; 1 <= required_moves && !QDELETED(src); i++)
+	for(var/i = 1; i <= required_moves && !QDELETED(src); i++)
 		pixel_move(required_moves)
 
 /obj/item/projectile/proc/setAngle(new_angle)	//wrapper for overrides.

--- a/html/changelogs/skull132-fixes_projectile_lag.yml
+++ b/html/changelogs/skull132-fixes_projectile_lag.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - bugfix: "Projectiles will no longer lag the server to death if they reach the end of map."


### PR DESCRIPTION
https://media.discordapp.net/attachments/131489773268238336/664528067372384280/unknown.png?width=763&height=684

About 1.1 million instances of this runtime. This fixes all of them. In a somewhat sane manner. There was currently no mechanic which made projectiles stop if they reached the end of the map. This makes them qdel themselves.