### PR TITLE
Fixes glasses not having their on-mob sprite color overriden when changed via gear_tweak

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -651,6 +651,9 @@ There are several things that need to be remembered:
 		else
 			overlays_raw[GLASSES_LAYER] = image('icons/mob/eyes.dmi', glasses.icon_state)
 
+		if(glasses.color)
+			overlays_raw[GLASSES_LAYER].color = glasses.color
+
 	if(update_icons)
 		update_icons()
 

--- a/html/changelogs/200110-bugfix_glassescolor.yml
+++ b/html/changelogs/200110-bugfix_glassescolor.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Offworlder goggles will now apply the chosen loadout color properly."


### PR DESCRIPTION
The on-mob sprite never switched color even if the icon had the changed color.
I believe right now this only effects the offworlder goggles.