### PR TITLE
Jetpack Expectation Fix

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -69,6 +69,7 @@
 	set category = "Object"
 
 	on = !on
+	stabilization_on = !stabilization_on
 	if(on)
 		icon_state = "[icon_state]-on"
 		ion_trail.start()
@@ -81,7 +82,8 @@
 		M.update_inv_back()
 		M.update_action_buttons()
 
-	to_chat(usr, "You toggle the thrusters [on? "on":"off"].")
+	to_chat(usr, span("notice", "You toggle the thrusters [on? "on":"off"]."))
+	to_chat(usr, span("notice", "You toggle the stabilization [stabilization_on? "on":"off"]."))
 
 /obj/item/tank/jetpack/proc/allow_thrust(num, mob/living/user as mob)
 	if(!(src.on))

--- a/html/changelogs/geeves - jetpackfix.yml
+++ b/html/changelogs/geeves - jetpackfix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Jetpacks now properly toggle flight capability when you press the action button."


### PR DESCRIPTION
When you click the jetpack button, you expect the jetpack to be ready to jetpack, but unfortunately the jetpack would not be ready to jetpack, since jetpack stabilization wasn't enabled.
This toggle makes the jetpack ready to jetpack when you press the jetpack button, because it turns the jetpack stabilization on and off when you press the jetpack button.
Have fun jetpacking, jetpackers.