### PR TITLE
Makes Reishi and Ambrosia More Easily Obtainable

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -583,6 +583,7 @@
 		/obj/item/seeds/potatoseed = 3,
 		/obj/item/seeds/pumpkinseed = 3,
 		/obj/item/seeds/riceseed = 3,
+		/obj/item/seeds/reishimycelium = 3,
 		/obj/item/seeds/shandseed = 3,
 		/obj/item/seeds/soyaseed = 3,
 		/obj/item/seeds/sugarcaneseed = 3,
@@ -602,7 +603,7 @@
 		/obj/item/seeds/glowshroom = 3,
 		/obj/item/seeds/libertymycelium = 3,
 		/obj/item/seeds/nettleseed = 3,
-		/obj/item/seeds/reishimycelium = 3
+
 	)
 	premium = list(
 		/obj/item/seeds/ambrosiadeusseed = 3

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -602,7 +602,7 @@
 		/obj/item/seeds/amanitamycelium = 3,
 		/obj/item/seeds/glowshroom = 3,
 		/obj/item/seeds/libertymycelium = 3,
-		/obj/item/seeds/nettleseed = 3,
+		/obj/item/seeds/nettleseed = 3
 
 	)
 	premium = list(

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -550,6 +550,7 @@
 	icon_state = "seeds"
 	vend_id = "seeds"
 	products = list(
+		/obj/item/seeds/ambrosiavulgarisseed = 3,		
 		/obj/item/seeds/appleseed = 3,
 		/obj/item/seeds/bananaseed = 3,
 		/obj/item/seeds/berryseed = 3,
@@ -598,7 +599,6 @@
 		/obj/item/seeds/wulumunushaseed = 2
 	)
 	contraband = list(
-		/obj/item/seeds/ambrosiavulgarisseed = 3,
 		/obj/item/seeds/amanitamycelium = 3,
 		/obj/item/seeds/glowshroom = 3,
 		/obj/item/seeds/libertymycelium = 3,
@@ -609,6 +609,7 @@
 		/obj/item/seeds/ambrosiadeusseed = 3
 	)
 	prices = list(
+		/obj/item/seeds/ambrosiavulgarisseed = 70,		
 		/obj/item/seeds/appleseed = 50,
 		/obj/item/seeds/bananaseed = 60,
 		/obj/item/seeds/berryseed = 40,

--- a/html/changelogs/furrycactus - reishi.yml
+++ b/html/changelogs/furrycactus - reishi.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Reishi mycelium is now regularly available in the MegaSeed Servitor vendors, rather than being contraband, due to their legality. This means you can vend them in Hydroponics or purchase them in the surface garden without hacking the vendors."
+  - tweak: "Reishi mycelium and Ambrosia Vulgaris are now regularly available in the MegaSeed Servitor vendors, rather than being contraband, due to their legality. This means you can vend them in Hydroponics or purchase them in the surface garden without hacking the vendors."

--- a/html/changelogs/furrycactus - reishi.yml
+++ b/html/changelogs/furrycactus - reishi.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Reishi mycelium is now regularly available in the MegaSeed Servitor vendors, rather than being contraband, due to their legality. This means you can vend them in Hydroponics or purchase them in the surface garden without hacking the vendors."


### PR DESCRIPTION
Removes Reishi mycelium from the contraband list of MegaSeed Servitors and puts them in the regular stock list. Now they can be vended in hydroponics and purchased in the surface garden without machine hacking.