### PR TITLE
Quick round of fail2topic fixes

### DIFF
--- a/code/controllers/subsystems/fail2topic.dm
+++ b/code/controllers/subsystems/fail2topic.dm
@@ -32,6 +32,7 @@ var/datum/controller/subsystem/fail2topic/SSfail2topic
 
 	if (!enabled)
 		suspended = TRUE
+		flags |= SS_NO_FIRE
 
 	. = ..()
 
@@ -72,7 +73,7 @@ var/datum/controller/subsystem/fail2topic/SSfail2topic
 
 		if (isnull(failures))
 			fail_counts[ip] = 1
-			return FALSE
+			return TRUE
 		else if (failures > max_fails)
 			BanFromFirewall(ip)
 			return TRUE

--- a/code/world.dm
+++ b/code/world.dm
@@ -118,7 +118,7 @@ var/list/world_api_rate_limit = list()
 		response["response"] = "Rate limited."
 		return json_encode(response)
 
-	if (length(T) > 500)
+	if (length(T) > 2000)
 		response["statuscode"] = 413
 		response["response"] = "Payload too large."
 		return json_encode(response)


### PR DESCRIPTION
* Fixes one case where rate-limit allows one too many tries pass.
* Adjusts max content length to handle things like faxes and admin announces better.