### PR TITLE
Allows sending mindless mobs via the cargo shuttle if they are part of a bounty

### DIFF
--- a/code/controllers/subsystems/cargo.dm
+++ b/code/controllers/subsystems/cargo.dm
@@ -559,7 +559,15 @@ var/datum/controller/subsystem/cargo/SScargo
 //To stop things being sent to centcomm which should not be sent to centcomm. Recursively checks for these types.
 /datum/controller/subsystem/cargo/proc/forbidden_atoms_check(atom/A)
 	if(istype(A,/mob/living))
-		return 1
+		var/mob/living/mob_to_send = A
+		var/mob_is_for_bounty = FALSE
+		if(!mob_to_send.mind)
+			for(var/bounty in bounties_list)
+				var/datum/bounty/B = bounty
+				if(B.applies_to(mob_to_send))
+					mob_is_for_bounty = TRUE
+		if(!mob_is_for_bounty)
+			return 1
 	if(istype(A,/obj/item/disk/nuclear))
 		return 1
 	if(istype(A,/obj/machinery/nuclearbomb))

--- a/html/changelogs/bounty_mobs.yml
+++ b/html/changelogs/bounty_mobs.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Cargo shuttle can now send NPC mobs if they are part of an active bounty."


### PR DESCRIPTION
Bounties for various bots can now be filled properly.

Fixes #7959