### PR TITLE
Criminal status editing now uses a dropdown menu

### DIFF
--- a/code/datums/records.dm
+++ b/code/datums/records.dm
@@ -190,7 +190,7 @@
 // Record for storing security data
 /datum/record/security
 	var/criminal = "None"
-	var/crimes = "There is no crime convictions."
+	var/crimes = "No criminal record."
 	var/list/incidents = list()
 	var/list/comments = list()
 

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -23,6 +23,7 @@
 	var/record_prefix = ""
 	var/typechoices = list(
 		"physical_status" = list("Active", "*Deceased*", "*SSD*", "Physically Unfit", "Disabled"),
+		"criminal_status" = list("None", "*Arrest*", "Search", "Incarcerated", "Parolled", "Released"),
 		"mental_status" = list("Stable", "*Insane*", "*Unstable*", "*Watch*"),
 		"medical" = list(
 			"blood_type" = list("A-", "B-", "AB-", "O-", "A+", "B+", "AB+", "O+")

--- a/html/changelogs/arrest_dropdown.yml
+++ b/html/changelogs/arrest_dropdown.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - tweak: "Secuity records program now has a dropdown-menu for the criminal status options, instead of a text input field."

--- a/vueui/src/components/view/records/security.vue
+++ b/vueui/src/components/view/records/security.vue
@@ -1,6 +1,12 @@
 <template>
   <view-records-general v-if="active" hide-advanced>
-    <vui-group-item label="Criminal Status:"><view-records-field :editable="(editable & 4) > 0" path="active.security.criminal"/></vui-group-item>
+    <vui-group-item label="Criminal Status:">
+      <view-records-field :editable="(editable & 4) > 0" path="active.security.criminal">
+        <select v-model="$root.$data.state.editingvalue">
+          <option v-for="i in choices.criminal_status" :key="i" :value="i">{{ i }}</option>
+        </select>
+      </view-records-field>
+    </vui-group-item>
     <vui-group-item label="Crimes:"><view-records-field :editable="(editable & 4) > 0" path="active.security.crimes"><textarea v-model="$root.$data.state.editingvalue"/></view-records-field></vui-group-item>
     
     <vui-group-item label="Comments:">


### PR DESCRIPTION
Can now select from a list with possible arrest options instead of typing in your own -- Because people don't need custom criminal status options, and it now matches the security HUD options.

I guess this was missed when porting this program to vue ui? Not sure if it counts as a bug or not, exactly.

Also improves some english in another part of the security records program.

Fixes #7883