### PR TITLE
Makes diona immune to viruses

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -91,6 +91,8 @@
 
 	reagent_tag = IS_DIONA
 
+	virus_immune = TRUE
+
 	stamina = -1	// Diona sprinting uses energy instead of stamina
 	sprint_speed_factor = 0.5	//Speed gained is minor
 	sprint_cost_factor = 0.8

--- a/html/changelogs/diona_virus_immunity.yml
+++ b/html/changelogs/diona_virus_immunity.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Humanoid Diona are now immune to viruses."


### PR DESCRIPTION
Currently diona can get viruses, but are unable to have the virus cured. So they're a walking health hazard.

This change makes it so that Diona cannot be infected by viruses. 

Also, I think most of the virus effects do not make sense for Diona due to being weird plant aliens, e.g. sneezing, hair falling out, osteoporosis.

Fixes #7875 