### PR TITLE
Removes slowdown due to lack of shoes

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -1,7 +1,5 @@
 #define HUMAN_STRIP_DELAY        40   // Takes 40ds = 4s to strip someone.
 
-#define SHOES_SLOWDOWN          -1.0  // How much shoes slow you down by default. Negative values speed you up.
-
 #define CANDLE_LUM 3 // For how bright candles are.
 
 // Item inventory slot bitmasks.

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -625,7 +625,6 @@
 	var/shoes_under_pants = 0
 
 	permeability_coefficient = 0.50
-	slowdown = SHOES_SLOWDOWN
 	force = 0
 	var/overshoes = 0
 	species_restricted = list("exclude","Unathi","Tajara","Vox","Vaurca","Vaurca Breeder","Vaurca Warform")

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -5,7 +5,7 @@
 	item_state = "galoshes"
 	permeability_coefficient = 0.05
 	item_flags = NOSLIP
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = 1
 	species_restricted = null
 	drop_sound = 'sound/items/drop/rubber.ogg'
 

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -15,7 +15,7 @@
 	drop_sound = 'sound/items/drop/metalboots.ogg'
 
 /obj/item/clothing/shoes/magboots/proc/set_slowdown()
-	slowdown = shoes? max(SHOES_SLOWDOWN, shoes.slowdown): SHOES_SLOWDOWN	//So you can't put on magboots to make you walk faster.
+	slowdown = shoes? max(0, shoes.slowdown): 0	//So you can't put on magboots to make you walk faster.
 	if (magpulse)
 		slowdown += 3
 

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -71,7 +71,7 @@
 	name = "clown shoes"
 	icon_state = "clown"
 	item_state = "clown_shoes"
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = 1
 	var/footstep = 1	//used for squeeks whilst walking
 	species_restricted = null
 
@@ -152,7 +152,7 @@
 	icon_state = "flippers"
 	item_state = "flippers"
 	item_flags = NOSLIP
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = 1
 
 /obj/item/clothing/shoes/footwraps
 	name = "cloth footwraps"

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -55,7 +55,7 @@ RUN_DELAY_MULTIPLIER 1
 VEHICLE_DELAY_MULTIPLIER 1
 
 ## The variables below affect the movement of specific mob types.
-HUMAN_DELAY 1
+HUMAN_DELAY 0
 ROBOT_DELAY 1
 MONKEY_DELAY 1
 ALIEN_DELAY 1

--- a/html/changelogs/no_shirt_no_shoes_no_slowdown.yml
+++ b/html/changelogs/no_shirt_no_shoes_no_slowdown.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - tweak: "Lack of shoes no longer causes a slowdown."


### PR DESCRIPTION
Apparently some people like to run around with their toes out, or without shoes to show off cyberlimbs if they're synthetic. Currently this means they take a 1 point slowdown.

This change removes that slowdown.

This change will require a config change in game_options.txt -- HUMAN_DELAY 1 to 0 to preserve the current speeds of human mobs, as shoes won't be granting a speed boost any longer.