### PR TITLE
Skrell Srom oversight fixes for brain damage + vampire blood drain

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -49,6 +49,8 @@
 	if (T.mind && T.mind.vampire)
 		draining_vamp = T.mind.vampire
 
+	var/target_aware = !!T.client
+
 	var/blood = 0
 	var/blood_total = 0
 	var/blood_usable = 0
@@ -91,7 +93,7 @@
 		var/frenzy_lower_chance = 0
 
 		// Alive and not of empty mind.
-		if (T.stat < 2 && T.client)
+		if (check_drain_target_state(T))
 			blood = min(15, T.vessel.get_reagent_amount("blood"))
 			vampire.blood_total += blood
 			vampire.blood_usable += blood
@@ -135,12 +137,18 @@
 	if(vampire.stealth)
 		endsuckmsg += "They will remember nothing of this occurance, provided they survived."
 	visible_message("<span class='danger'>[src.name] stops biting [T.name]'s neck!</span>", "<span class='notice'>[endsuckmsg]</span>")
-	if(T.stat != 2 && vampire.stealth)
-		to_chat(T, span("warning", "You remember nothing about being fed upon. Instead, you simply remember having a pleasant encounter with [src.name]."))
+	if(target_aware)
 		T.paralysis = 0
-	else if(T.stat != 2)
-		to_chat(T, span("warning", "You remember everything about being fed upon. How you react to [src.name]'s actions is up to you."))
-		T.paralysis = 0
+		if(T.stat != DEAD && vampire.stealth)
+			to_chat(T.find_mob_consciousness(), span("warning", "You remember nothing about being fed upon. Instead, you simply remember having a pleasant encounter with [src.name]."))
+		else if(T.stat != DEAD)
+			to_chat(T.find_mob_consciousness(), span("warning", "You remember everything about being fed upon. How you react to [src.name]'s actions is up to you."))
+
+// Check that our target is alive, logged in, and any other special cases
+/mob/living/carbon/human/proc/check_drain_target_state(var/mob/living/carbon/human/T)
+	if(T.stat < DEAD)
+		if(T.client || (T.bg && T.bg.client))
+			return TRUE
 
 // Small area of effect stun.
 /mob/living/carbon/human/proc/vampire_glare()

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -178,3 +178,10 @@
 
 /mob/living/carbon/human/get_resist_power()
 	return species.resist_mod
+
+// Handle cases where the mob's awareness may reside in another mob, but still cares about how its brain is doing
+/mob/living/carbon/human/proc/find_mob_consciousness()
+	if(istype(bg) && bg.client)
+		return bg
+
+	return src

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -182,7 +182,7 @@
 	if(!owner)
 		return
 	to_chat(owner, "<span class = 'notice' font size='10'><B>What happened...?</B></span>")
-	alert(owner, "You have taken massive brain damage! You will not be able to remember the events leading up to your injury.", "Brain Damaged")
+	alert(owner.find_mob_consciousness(), "You have taken massive brain damage! You will not be able to remember the events leading up to your injury.", "Brain Damaged")
 
 /obj/item/organ/internal/brain/proc/handle_damage_effects()
 	if(owner.stat)

--- a/html/changelogs/dreams_of_head_trauma_and_vampire_bites.yml
+++ b/html/changelogs/dreams_of_head_trauma_and_vampire_bites.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "A vampire's blood drain will now work properly on Skrell who enter Srom during."
+  - bugfix: "Skrell who are in Srom will now properly receive the alert about memory loss due to brain damage to their real body."


### PR DESCRIPTION
Fixes #8021

Skrell in Srom state will properly give their blood to a draining vampire, and will properly receive a message about memory loss if their true body gains sufficient brain damage.

Also makes the vampire succ message appear more intelligently for Srom'd Skrell. (i.e. Not if they're not awake for part of the blood drain, but otherwise it will appear even if they are in their dream)

Accepting suggestions for a better proc name than `get_true_owner()`