### PR TITLE
Significantly Reduces the Power of Ninja Self-Destruct

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -220,6 +220,7 @@
 /obj/item/rig_module/self_destruct/engage(var/skip_check)
 	if(!skip_check && usr && alert(usr, "Are you sure you want to push that button?", "Self-destruct", "No", "Yes") == "No")
 		return
+	explosion(get_turf(src), explosion_values[1], explosion_values[2], explosion_values[3], explosion_values[4])
 	if(holder && holder.wearer)
 		holder.wearer.gib()
 		holder.wearer.drop_from_inventory(src)

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -194,12 +194,12 @@
 
 	interface_name = "dead man's switch"
 	interface_desc = "An integrated self-destruct module. When the wearer dies, so does the surrounding area. Do not press this button."
-	var/list/explosion_values = list(0,0,8,12)
+	var/list/explosion_values = list(-1,0,8,12)
 
 	category = MODULE_SPECIAL
 
 /obj/item/rig_module/self_destruct/small
-	explosion_values = list(0,0,4,8)
+	explosion_values = list(-1,0,4,8)
 
 /obj/item/rig_module/self_destruct/activate()
 	return

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -194,12 +194,12 @@
 
 	interface_name = "dead man's switch"
 	interface_desc = "An integrated self-destruct module. When the wearer dies, so does the surrounding area. Do not press this button."
-	var/list/explosion_values = list(3,4,5,6)
+	var/list/explosion_values = list(0,0,8,12)
 
 	category = MODULE_SPECIAL
 
 /obj/item/rig_module/self_destruct/small
-	explosion_values = list(1,2,3,4)
+	explosion_values = list(0,0,4,8)
 
 /obj/item/rig_module/self_destruct/activate()
 	return
@@ -220,7 +220,6 @@
 /obj/item/rig_module/self_destruct/engage(var/skip_check)
 	if(!skip_check && usr && alert(usr, "Are you sure you want to push that button?", "Self-destruct", "No", "Yes") == "No")
 		return
-	explosion(get_turf(src), explosion_values[1], explosion_values[2], explosion_values[3], explosion_values[4])
 	if(holder && holder.wearer)
 		holder.wearer.gib()
 		holder.wearer.drop_from_inventory(src)

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -124,7 +124,7 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/datajack,
-		/obj/item/rig_module/self_destruct,
+		/obj/item/rig_module/self_destruct/light,
 		/obj/item/rig_module/actuators/combat
 		)
 

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -124,7 +124,7 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/datajack,
-		/obj/item/rig_module/self_destruct/light,
+		/obj/item/rig_module/self_destruct,
 		/obj/item/rig_module/actuators/combat
 		)
 

--- a/html/changelogs/burgerbb - ninja nerf.yml
+++ b/html/changelogs/burgerbb - ninja nerf.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Significantly reduces the explosion range from the ninja's built in self-destruct to the equivalence to a frag grenade."


### PR DESCRIPTION
## What this does.
Reduces the explosion strength of ninja's self destruct from 3,4,5,6 to -1,0,8,12

## Why this is good for the game
Ninja self-destruct no longer fulfills its purpose. The original purpose was to prevent security from validhunting, but this no longer does this as actual validhunters have either gotten banned or have adapted to wear EVA suits when engaging the ninja.

Even if it did fulfill the purpose, the end result makes all the wrong people suffer. The massive destruction range from it will kill any unfortunate non-sec in its massive 3x3 total devastation and 4x4 heavy range. Any caught in the area are sure to suffer from atmos as well because the explosion is guaranteed to breach the floor.

If a ninja wants to explode, then have them put the effort into making a deadman switch + bomb, or buy an explosive implant.