### PR TITLE
Adds unique bantypes to a bunch of antag roles

### DIFF
--- a/code/game/antagonist/outsider/commando.dm
+++ b/code/game/antagonist/outsider/commando.dm
@@ -10,6 +10,8 @@ var/datum/antagonist/deathsquad/mercenary/commandos
 
 	faction = "syndicate"
 
+	bantype = "syndicate-commando"
+
 /datum/antagonist/ert/create_default(var/mob/source)
 	var/mob/living/carbon/human/M = ..()
 	if(istype(M)) M.age = rand(25,45)

--- a/code/game/antagonist/outsider/deathsquad.dm
+++ b/code/game/antagonist/outsider/deathsquad.dm
@@ -14,6 +14,8 @@ var/datum/antagonist/deathsquad/deathsquad
 
 	var/deployed = FALSE
 
+	bantype = "deathsquad"
+
 /datum/antagonist/ert/create_default(var/mob/source)
 	var/mob/living/carbon/human/M = ..()
 	if(istype(M)) M.age = rand(25,45)

--- a/code/game/antagonist/station/highlander.dm
+++ b/code/game/antagonist/station/highlander.dm
@@ -12,6 +12,8 @@ var/datum/antagonist/highlander/highlanders
 	initial_spawn_req = 3
 	initial_spawn_target = 5
 
+	bantype = "highlander"
+
 /datum/antagonist/highlander/New()
 	..()
 	highlanders = src

--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -14,6 +14,8 @@ var/datum/antagonist/renegade/renegades
 	initial_spawn_req = 3
 	initial_spawn_target = 6
 
+	bantype = "renegade"
+
 	var/list/spawn_guns = list(
 		/obj/item/gun/energy/gun,
 		/obj/item/gun/energy/retro,

--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -16,6 +16,7 @@ var/datum/antagonist/rogue_ai/malf
 	initial_spawn_target = 1
 	antaghud_indicator = "hudmalai"
 	required_age = 31
+	bantype = "rogue-ai"
 
 /datum/antagonist/rogue_ai/New()
 	..()

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -9,6 +9,7 @@ var/datum/antagonist/traitor/traitors
 	required_age = 10
 
 	faction = "syndicate"
+	bantype = "traitor"
 
 /datum/antagonist/traitor/New()
 	..()

--- a/html/changelogs/overzealous_banning.yml
+++ b/html/changelogs/overzealous_banning.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - admin: "Fixed a bug where banning someone from Malf AI, Renegade, Asset Protection Specialist, Syndicate Commando, Highlander or Traitor would ban someone from all of those roles."


### PR DESCRIPTION
Bunch of antag roles didn't have a unique bantype defined, so banning for one of them banned for all of them.

This *will* cause people who are banned from one of these roles to no longer be banned from those roles. So it will require some tweaking of bans by admins. Hopefully not too many people hold antag bans -- Here is the fix if anyone wants to go through that effort, anyway.

Fixes #7462