### PR TITLE
Fixes diona regeneration bug (the re-fixening)

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -1,5 +1,7 @@
 //Updates the mob's health from organs and mob damage variables
 /mob/living/carbon/human/updatehealth()
+	if(is_diona())
+		return ..()
 
 	if(status_flags & GODMODE)
 		health = maxHealth

--- a/html/changelogs/doona_regen_fix.yml
+++ b/html/changelogs/doona_regen_fix.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes issue where diona regeneration triggering would depend upon the presence of brain damage, which they never have."


### PR DESCRIPTION
Opening a new PR because I closed my first one accidentally trying to figure out why Travis was being upset. [Previous PR](https://github.com/Aurorastation/Aurora.3/pull/8045)

Diona regen was depending on a health value calculated from brain damage, which they never had. Therefore it wouldn't trigger properly when the Diona sustained damage.

Fixes #7655