### PR TITLE
Limits guest pass name length to 26

### DIFF
--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -129,7 +129,7 @@
 	if (href_list["choice"])
 		switch(href_list["choice"])
 			if ("giv_name")
-				var/nam = sanitize(input("Person pass is issued to", "Name", giv_name) as text|null)
+				var/nam = sanitizeName(input("Person pass is issued to", "Name", giv_name) as text|null)
 				if (nam)
 					giv_name = nam
 			if ("reason")

--- a/html/changelogs/guest_pass_name_sanitize.yml
+++ b/html/changelogs/guest_pass_name_sanitize.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Limited guest pass max name length to 26 characters instead of 1024."


### PR DESCRIPTION
It's currently 1024. Someone used the wrong `sanitize()`

Fixes #7852 