### PR TITLE
Dead people don't have heartbeats

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -30,7 +30,7 @@
 	..()
 
 /obj/item/organ/internal/heart/proc/handle_pulse()
-	if((species && species.flags & NO_BLOOD) || BP_IS_ROBOTIC(src)) //No heart, no pulse, buddy. Or if the heart is robotic.
+	if(owner.stat == DEAD || (species && species.flags & NO_BLOOD) || BP_IS_ROBOTIC(src)) //No heart, no pulse, buddy. Or if the heart is robotic. Or you're dead.
 		pulse = PULSE_NONE
 		return
 

--- a/html/changelogs/no_pulse_if_dead.yml
+++ b/html/changelogs/no_pulse_if_dead.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Dying now properly stops your heartbeat."


### PR DESCRIPTION
Sets pulse to zero when the owner is dead, so we don't get weird readings on medical scans of the recently deceased.

Fixes #7720 
