### PR TITLE
Latespawn AI will have their eye spawn in the correct location

### DIFF
--- a/code/modules/mob/abstract/freelook/ai/eye.dm
+++ b/code/modules/mob/abstract/freelook/ai/eye.dm
@@ -48,9 +48,8 @@
 	if(client)
 		client.eye = new_eye
 
-/mob/living/silicon/ai/proc/create_eyeobj(var/newloc)
+/mob/living/silicon/ai/proc/create_eyeobj(var/newloc = get_turf(src))
 	if(eyeobj) destroy_eyeobj()
-	if(!newloc) newloc = get_turf(src)
 	eyeobj = new /mob/abstract/eye/aiEye(newloc)
 	eyeobj.possess(src)
 

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -336,6 +336,7 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 		empty_playable_ai_cores -= C
 
 		character.forceMove(C.loc)
+		character.eyeobj.forceMove(C.loc)
 
 		AnnounceCyborg(character, rank, "has been downloaded to the empty core in \the [character.loc.loc]")
 		SSticker.mode.handle_latejoin(character)

--- a/html/changelogs/ai_eye_loc_spawn.yml
+++ b/html/changelogs/ai_eye_loc_spawn.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Latespawn AI will spawn with their eye in the right location."


### PR DESCRIPTION
Eye was getting left behind when the AI mob gets `forceMove()`'d into position, since it is created during `/mob/.../Initialize()`

Fixes #8055