### PR TITLE
Strip Menu Additions

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -571,13 +571,19 @@
 /obj/item/clothing/mask/proc/filter_air(datum/gas_mixture/air)
 	return
 
-/obj/item/clothing/mask/proc/adjust_mask(mob/user)
+/obj/item/clothing/mask/proc/adjust_mask(mob/user, var/self = TRUE)
 	set name = "Adjust Mask"
 	set category = "Object"
+
 	if(!adjustable)
 		return
-	if(use_check_and_message(user))
-		return
+
+	if(self)
+		if(use_check_and_message(user))
+			return
+	else
+		if(use_check_and_message(user, USE_ALLOW_NON_ADJACENT))
+			return
 
 	hanging = !hanging
 
@@ -587,7 +593,8 @@
 		icon_state = "[icon_state]down"
 		item_flags = down_item_flags
 		flags_inv = down_flags_inv
-		user.visible_message(span("notice", "[user] pulls \the [src] down to hang around \his neck."), span("notice", "You pull \the [src] down to hang around your neck."))
+		if(self)
+			user.visible_message(span("notice", "[user] pulls \the [src] down to hang around \his neck."), span("notice", "You pull \the [src] down to hang around your neck."))
 	else
 		gas_transfer_coefficient = initial(gas_transfer_coefficient)
 		body_parts_covered = initial(body_parts_covered)
@@ -595,7 +602,8 @@
 		item_state = initial(icon_state)
 		item_flags = initial(item_flags)
 		flags_inv = initial(flags_inv)
-		user.visible_message(span("notice", "[user] pulls \the [src] up to cover \his face."), span("notice", "You pull \the [src] up to cover your face."))
+		if(self)
+			user.visible_message(span("notice", "[user] pulls \the [src] up to cover \his face."), span("notice", "You pull \the [src] up to cover your face."))
 	usr.update_action_buttons()
 	update_clothing_icon()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -322,7 +322,7 @@
 	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"
 
 	if(internals)
-		dat += "<B>Internals: [internal ? "On" : "Off"]</span></B><BR>"
+		dat += "<B>Internals: [internal ? "On" : "Off"]</B><BR>"
 
 	if(suit)
 		var/list/modes = list("Off" = 1, "Binary Sensors" = 2, "Vitals Tracker" = 3, "Tracking Beacon" = 4)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -311,15 +311,25 @@
 
 
 /mob/living/carbon/human/show_inv(mob/user as mob)
-	if(user.incapacitated()  || !user.Adjacent(src))
+	if(user.incapacitated() || !user.Adjacent(src))
 		return
 
 	var/obj/item/clothing/under/suit = null
-	if (istype(w_uniform, /obj/item/clothing/under))
+	if(istype(w_uniform, /obj/item/clothing/under))
 		suit = w_uniform
 
 	user.set_machine(src)
 	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"
+
+	if(internals)
+		dat += "<B>Internals: [internal ? "On" : "Off"]</span></B><BR>"
+
+	if(suit)
+		var/list/modes = list("Off" = 1, "Binary Sensors" = 2, "Vitals Tracker" = 3, "Tracking Beacon" = 4)
+		dat += "<B>Suit Sensors: [modes[suit.sensor_mode + 1]]</B><BR>"
+	
+	if(internals || suit)
+		dat += "<HR>"
 
 	for(var/entry in species.hud.gear)
 		var/list/slot_ref = species.hud.gear[entry]
@@ -334,10 +344,22 @@
 		dat += "<BR><b>Left hand:</b> <A href='?src=\ref[src];item=[slot_l_hand]'>[istype(l_hand) ? l_hand : "nothing"]</A>"
 		dat += "<BR><b>Right hand:</b> <A href='?src=\ref[src];item=[slot_r_hand]'>[istype(r_hand) ? r_hand : "nothing"]</A>"
 
-	// Do they get an option to set internals?
-	if(istype(wear_mask, /obj/item/clothing/mask) || istype(head, /obj/item/clothing/head/helmet/space))
-		if(istype(back, /obj/item/tank) || istype(belt, /obj/item/tank) || istype(s_store, /obj/item/tank))
-			dat += "<BR><A href='?src=\ref[src];item=internals'>Toggle internals.</A>"
+	var/has_mask // 0, no mask | 1, mask but it's down | 2, mask and it's ready
+	var/has_helmet
+	if(istype(wear_mask, /obj/item/clothing/mask))
+		var/obj/item/clothing/mask/M = wear_mask
+		has_mask = 1
+		if(!M.hanging)
+			has_mask = 2
+	if(istype(head, /obj/item/clothing/head/helmet/space))
+		has_helmet = TRUE
+
+	var/has_tank
+	if(istype(back, /obj/item/tank) || istype(belt, /obj/item/tank) || istype(s_store, /obj/item/tank))
+		has_tank = TRUE
+
+	if((has_mask == 2|| has_helmet) && has_tank)
+		dat += "<BR><A href='?src=\ref[src];item=internals'>Toggle internals [internal ? "off" : "on"]</A>"
 
 	// Other incidentals.
 	if(istype(suit) && suit.has_sensor == 1)
@@ -347,6 +369,12 @@
 	if(legcuffed)
 		dat += "<BR><A href='?src=\ref[src];item=[slot_legcuffed]'>Legcuffed</A>"
 
+	if(has_mask)
+		var/obj/item/clothing/mask/M = wear_mask
+		if(M.adjustable)
+			dat += "<BR><A href='?src=\ref[src];item=mask'>Adjust mask</A>"
+	if(has_tank && internal)
+		dat += "<BR><A href='?src=\ref[src];item=tank'>Check air tank</A>"
 	if(suit && LAZYLEN(suit.accessories))
 		dat += "<BR><A href='?src=\ref[src];item=tie'>Remove accessory</A>"
 	dat += "<BR><A href='?src=\ref[src];item=splints'>Remove splints</A>"

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -1,16 +1,28 @@
-/mob/living/carbon/human/proc/handle_strip(var/slot_to_strip,var/mob/living/user)
-
+/mob/living/carbon/human/proc/handle_strip(var/slot_to_strip, var/mob/living/user)
 	if(!slot_to_strip || !istype(user) || ispAI(user) || (isanimal(user) && !istype(user, /mob/living/simple_animal/hostile) ) )
-		return 0
+		return FALSE
 
-	if(user.incapacitated()  || !user.Adjacent(src))
+	if(user.incapacitated() || !user.Adjacent(src))
 		user << browse(null, text("window=mob[src.name]"))
-		return 0
+		return FALSE
 
 	var/obj/item/target_slot = get_equipped_item(text2num(slot_to_strip))
 
 	switch(slot_to_strip)
 		// Handle things that are part of this interface but not removing/replacing a given item.
+		if("mask")
+			visible_message(span("warning", "\The [user] is trying to adjust \the [src]'s mask!"))
+			if(do_after(user,HUMAN_STRIP_DELAY, act_target = src))
+				var/obj/item/clothing/mask/M = wear_mask
+				M.adjust_mask(user, FALSE)
+			return TRUE
+		if("tank")
+			visible_message(span("warning", "\The [user] is taking a look at \the [src]'s air tank."))
+			if(do_after(user,HUMAN_STRIP_DELAY, act_target = src))
+				var/obj/item/tank/T = internal
+				to_chat(user, span("notice", "\The [T] has [T.air_contents.return_pressure()] kPA left."))
+				to_chat(user, span("notice", "The [T] is set to release [T.distribute_pressure] kPA."))
+			return TRUE
 		if("pockets")
 			visible_message("<span class='danger'>\The [user] is trying to empty \the [src]'s pockets!</span>")
 			if(do_after(user,HUMAN_STRIP_DELAY, act_target = src))

--- a/html/changelogs/geeves-stripmenuthings.yml
+++ b/html/changelogs/geeves-stripmenuthings.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added an internals and suit sensors indicator to the strip menu."
+  - tweak: "Toggle internals in the strip menu now displays whether you're toggling it on or off."
+  - rscadd: "Added an adjust mask and tank pressure check to the strip menu."


### PR DESCRIPTION
* Added an internals and suit sensors indicator to the strip menu.
* Toggle internals in the strip menu now displays whether you're toggling it on or off.
* Added an adjust mask and tank pressure check to the strip menu.

![image](https://user-images.githubusercontent.com/22774890/72899241-3d08d380-3d2e-11ea-9615-c924e0fb0033.png)