### PR TITLE
Fixes async HTTP for getting pins

### DIFF
--- a/code/__defines/rust_g.dm
+++ b/code/__defines/rust_g.dm
@@ -2,9 +2,9 @@
 #define RUST_G "rust_g"
 #define WRITE_LOG(log, text) call(RUST_G, "log_write")(log, text) // Using Rust g dll to log faster with less CPU usage.
 
-#define RUSTG_JOB_NO_RESULTS_YET "NO_RESULTS_YET"
-#define RUSTG_JOB_NO_SUCH_JOB "NO_SUCH_JOB"
-#define RUSTG_JOB_ERROR "JOB_PANICKED"
+#define RUSTG_JOB_NO_RESULTS_YET "NO RESULTS YET"
+#define RUSTG_JOB_NO_SUCH_JOB "NO SUCH JOB"
+#define RUSTG_JOB_ERROR "JOB PANICKED"
 
 #define rustg_udp_shipper_send(addr, text) call(RUST_G, "udp_shipper_send")(addr, text)
 

--- a/code/controllers/subsystems/http.dm
+++ b/code/controllers/subsystems/http.dm
@@ -75,6 +75,7 @@ var/datum/controller/subsystem/http/SShttp
 	if (r == RUSTG_JOB_NO_RESULTS_YET)
 		return FALSE
 	else
+		log_debug("Finished rustg http: [r]")
 		_raw_response = r
 		in_progress = FALSE
 		return TRUE

--- a/code/controllers/subsystems/http.dm
+++ b/code/controllers/subsystems/http.dm
@@ -61,7 +61,12 @@ var/datum/controller/subsystem/http/SShttp
 		crash_with("Attempted to re-use a request object.")
 
 	id = rustg_http_request_async(method, url, body, headers)
-	in_progress = TRUE
+
+	if (isnull(text2num(id)))
+		crash_with("Proc error: [id]")
+		_raw_response = "Proc error: [id]"
+	else
+		in_progress = TRUE
 
 /datum/http_request/proc/is_complete()
 	if (isnull(id))
@@ -75,7 +80,6 @@ var/datum/controller/subsystem/http/SShttp
 	if (r == RUSTG_JOB_NO_RESULTS_YET)
 		return FALSE
 	else
-		log_debug("Finished rustg http: [r]")
 		_raw_response = r
 		in_progress = FALSE
 		return TRUE

--- a/code/datums/discord/bot.dm
+++ b/code/datums/discord/bot.dm
@@ -345,7 +345,7 @@ var/datum/discord_bot/discord_bot = null
  *						  Num upon failure.
  */
 /datum/discord_channel/proc/get_pins(var/token)
-	var/datum/http_request/req = SShttp.get("https://discordapp.com/api/channels/[id]/pins", headers = list("Authorization", "Bot [token]"))
+	var/datum/http_request/req = SShttp.get("https://discordapp.com/api/channels/[id]/pins", headers = list("Authorization" = "Bot [token]"))
 
 	req.begin_async()
 	UNTIL(req.is_complete())

--- a/code/datums/discord/bot.dm
+++ b/code/datums/discord/bot.dm
@@ -168,9 +168,11 @@ var/datum/discord_bot/discord_bot = null
  */
 /datum/discord_bot/proc/retreive_pins()
 	if (!active || !auth_token)
+		testing("one")
 		return list()
 
 	if (!channels.len || isnull(channels_to_group["channel_pins"]))
+		testing("two")
 		if (robust_debug)
 			log_debug("BOREALIS: No pins channel group.")
 		return list()
@@ -189,6 +191,8 @@ var/datum/discord_bot/discord_bot = null
 
 	if (robust_debug)
 		log_debug("BOREALIS: Finished acquiring pins.")
+
+	testing("finished: [output]")
 
 	return output
 

--- a/code/datums/discord/bot.dm
+++ b/code/datums/discord/bot.dm
@@ -168,11 +168,9 @@ var/datum/discord_bot/discord_bot = null
  */
 /datum/discord_bot/proc/retreive_pins()
 	if (!active || !auth_token)
-		testing("one")
 		return list()
 
 	if (!channels.len || isnull(channels_to_group["channel_pins"]))
-		testing("two")
 		if (robust_debug)
 			log_debug("BOREALIS: No pins channel group.")
 		return list()
@@ -187,12 +185,12 @@ var/datum/discord_bot/discord_bot = null
 		if (isnull(output["[channel.pin_flag]"]))
 			output["[channel.pin_flag]"] = list()
 
-		output["[channel.pin_flag]"] += channel.get_pins(auth_token)
+		var/ch_pins = channel.get_pins(auth_token)
+		if (length(ch_pins))
+			output["[channel.pin_flag]"] += ch_pins
 
 	if (robust_debug)
 		log_debug("BOREALIS: Finished acquiring pins.")
-
-	testing("finished: [output]")
 
 	return output
 

--- a/code/datums/server_greeting.dm
+++ b/code/datums/server_greeting.dm
@@ -91,6 +91,8 @@
 		var/list/memos = temp_list[A]
 		var/flag = text2num(A)
 
+		log_debug("Adding memo: [json_encode(memos)]")
+
 		memo_list += new /datum/memo_datum(memos, flag)
 
 /*

--- a/code/datums/server_greeting.dm
+++ b/code/datums/server_greeting.dm
@@ -91,8 +91,6 @@
 		var/list/memos = temp_list[A]
 		var/flag = text2num(A)
 
-		log_debug("Adding memo: [json_encode(memos)]")
-
 		memo_list += new /datum/memo_datum(memos, flag)
 
 /*


### PR DESCRIPTION
A few issues:
* Async response enums were bad.
* Async requests didn't handle an unforeseen error properly.
* Get pins were sending an input which would cause a crash of the DLL. (DLL is now fixed to not crash due to this.)