### PR TITLE
Fixes bug with exosuits leaving an invisible mob after dismantling.

### DIFF
--- a/code/modules/heavy_vehicle/mecha.dm
+++ b/code/modules/heavy_vehicle/mecha.dm
@@ -84,10 +84,6 @@
 	if(remote_network)
 		SSvirtualreality.remove_mech(src, remote_network)
 
-	for(var/thing in hud_elements)
-		qdel(thing)
-	hud_elements.Cut()
-
 	hardpoint_hud_elements = null
 
 	hardpoints = null

--- a/html/changelogs/no_exosuit_ghosts.yml
+++ b/html/changelogs/no_exosuit_ghosts.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Dismantling mech-suits will no longer produce a spooky invisible second mech-suit."


### PR DESCRIPTION
Deleting the `hud_elements` list was already handled on line 82, so it was causing a runtime that lead to the mech never qdeling its mob, when it tried to do it again.

Fixes #8049