### PR TITLE
Adds check for cryopods for buckled mobs being moved in.

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -400,6 +400,9 @@
 		return
 	var/mob/living/L = O
 
+	if (!L.bucklecheck(user)) //We must make sure the person is unbuckled before they go in
+		return
+
 	if(L.stat == DEAD)
 		to_chat(user, "<span class='notice'>Dead people can not be put into stasis.</span>")
 		return

--- a/html/changelogs/cryopod_buckle_check.yml
+++ b/html/changelogs/cryopod_buckle_check.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Can no longer move buckled mobs into cryopods."


### PR DESCRIPTION
Fixes #6834

Similar machines (bodyscanner, medical cryo) have this check, but the cryopod was missing it.