### PR TITLE
Fixed the wiki link on the changelog

### DIFF
--- a/html/changelog.html
+++ b/html/changelog.html
@@ -4,7 +4,7 @@
 		<td valign='top'>
 			<div align='center'><font size='3'><b>Space Station 13</b></font></div>
 			
-			<p><div align='center'><font size='3'><a href="https://aurorastation.org/wiki/index.php?title=Main_Page">Wiki</a> | <a href="https://github.com/Aurorastation/Aurora.3">Source code</a></font></div></p>
+			<p><div align='center'><font size='3'><a href="https://wiki.aurorastation.org/">Wiki</a> | <a href="https://github.com/Aurorastation/Aurora.3">Source code</a></font></div></p>
             <font size='2'>Code licensed under <a href="http://www.gnu.org/licenses/agpl.html">AGPLv3</a>. Content licensed under <a href="http://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>.<br><br>
 			</td>
 	</tr>

--- a/html/changelogs/changelog_wiki_link.yml
+++ b/html/changelogs/changelog_wiki_link.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Changelog Changelog - Fixed changelog wiki link."


### PR DESCRIPTION
[This old wiki link](https://aurorastation.org/wiki/index.php?title=Main_Page) is all 404y.

Long live the new wiki link.