### PR TITLE
Commune and Psi-Ping no longer give attack logs.

### DIFF
--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -221,6 +221,7 @@
 	min_rank =          PSI_RANK_OPERANT
 	use_sound =         null
 	use_description =   "Target the mouth and click on a creature on disarm intent to psionically send them a message."
+	admin_log = FALSE
 
 /datum/psionic_power/coercion/commune/invoke(var/mob/living/user, var/mob/living/target)
 	if((target == user) || user.zone_sel.selecting != BP_MOUTH)
@@ -285,6 +286,7 @@
 	min_rank =          PSI_RANK_OPERANT
 	use_sound =         null
 	use_description =   "Activate an empty hand on disarm intent to detect nearby psionic signatures."
+	admin_log = FALSE
 
 /datum/psionic_power/coercion/psiping/invoke(var/mob/living/user, var/mob/living/target)
 	if((target && user != target) || user.a_intent != I_HELP)

--- a/html/changelogs/mattatlas-nocommunelogs.yml
+++ b/html/changelogs/mattatlas-nocommunelogs.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Commune and Psiping no longer spam staff logs."


### PR DESCRIPTION
Staff members just don't get the immediate notification spam. It's still logged.