### PR TITLE
De-fangs the Scrubber Backclog event; implements more fun replacements.

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -9,27 +9,17 @@
 		"water",
 		"carbon",
 		"flour",
-		"radium",
-		"toxin",
-		"cleaner",
-		"nutriment",
-		"condensedcapsaicin",
-		"mindbreaker",
-		"lube",
-		"plantbgone",
-		"banana",
-		"space_drugs",
-		"holywater",
-		"ethanol",
-		"hot_coco",
-		"sacid",
-		"hyperzine",
-		"paint",
-		"luminol",
-		"fuel",
 		"blood",
-		"sterilizine",
-		"ipecac"
+		"cornoil",
+		"milk",
+		"egg",
+		"butter",
+		"cream",
+		"cheesewheel",
+		"ketchup",
+		"nuka_cola",
+		"meatshake"
+
 	)
 
 

--- a/html/changelogs/aticius-suddenlyyourfacemelts.yml
+++ b/html/changelogs/aticius-suddenlyyourfacemelts.yml
@@ -1,0 +1,9 @@
+
+author: Aticius
+
+
+delete-after: True
+
+
+changes: 
+  - tweak: the Scrubber Backup event has been tweaked to be far less lethal; though no less !!!FUN!!!. Janitors can begin to cry.


### PR DESCRIPTION
The Vent_Clog event has a lot of harmful reagents in it; from hyperzine, to straight ethanol to even sulphuric acid. Given the nature of how Aurora is laid out; Scrubbers are ubiquitous; and this event can kill people readily. This PR seeks to fix that.

The only "Drug" reagent in this list will be Nuka_Cola, which is harmless; but people probably won't know that.

Also, most of this makes horrible messes. Sorry, Janitors.