### PR TITLE
Player-spawned diona are spawned with neutral gender

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -175,3 +175,7 @@
 	if(H.get_total_health() <= config.health_threshold_dead)
 		return TRUE
 	return FALSE
+
+/datum/species/diona/before_equip(var/mob/living/carbon/human/H)
+	. = ..()
+	H.gender = NEUTER

--- a/html/changelogs/diona_gender_neutral.yml
+++ b/html/changelogs/diona_gender_neutral.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Player-character Diona will now properly be spawned with neutral gender."


### PR DESCRIPTION
Something in the player character prefs setup was overwriting the set gender in `handle_post_spawn()`

Another solution would be to add `NEUTER` to `valid_player_genders` so it doesn't get randomly reset when it finds `NEUTER` to be an invalid gender. But idk how people feel about that.

I could also make a `valid_species_gender` list which might make things cleaner.

But this is the solution already in place for IPCs, Vox etc.