### PR TITLE
Examine tweaks

### DIFF
--- a/code/modules/clothing/masks/voice.dm
+++ b/code/modules/clothing/masks/voice.dm
@@ -5,8 +5,6 @@
 	var/active
 
 /obj/item/clothing/mask/gas/voice
-	name = "gas mask"
-	desc = "A face-covering mask that can be connected to an air supply. It seems to house some odd electronics."
 	var/obj/item/voice_changer/changer
 	origin_tech = list(TECH_ILLEGAL = 4)
 

--- a/code/modules/clothing/masks/voice.dm
+++ b/code/modules/clothing/masks/voice.dm
@@ -7,6 +7,7 @@
 /obj/item/clothing/mask/gas/voice
 	var/obj/item/voice_changer/changer
 	origin_tech = list(TECH_ILLEGAL = 4)
+	description_antag = "This mask can be used to change the owner's voice."
 
 /obj/item/clothing/mask/gas/voice/verb/Toggle_Voice_Changer()
 	set category = "Object"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -80,6 +80,8 @@
 
 
 /obj/item/cell/examine(mob/user)
+	. = ..()
+
 	if(get_dist(src, user) > 1)
 		return
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -545,6 +545,8 @@
 
 /obj/item/gun/examine(mob/user)
 	..()
+	if(get_dist(src, user) > 1)
+		return
 	if(needspin)
 		if(pin)
 			to_chat(user, "\The [pin] is installed in the trigger mechanism.")

--- a/code/modules/projectiles/guns/alien.dm
+++ b/code/modules/projectiles/guns/alien.dm
@@ -38,8 +38,6 @@
 
 /obj/item/gun/launcher/spikethrower/examine(mob/user)
 	..(user)
-	if(get_dist(src, user) > 1)
-		return
 	to_chat(user, "It has [spikes] spike\s remaining.")
 
 /obj/item/gun/launcher/spikethrower/update_icon()

--- a/code/modules/projectiles/guns/alien.dm
+++ b/code/modules/projectiles/guns/alien.dm
@@ -38,6 +38,8 @@
 
 /obj/item/gun/launcher/spikethrower/examine(mob/user)
 	..(user)
+	if(get_dist(src, user) > 1)
+		return
 	to_chat(user, "It has [spikes] spike\s remaining.")
 
 /obj/item/gun/launcher/spikethrower/update_icon()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -92,6 +92,8 @@
 
 /obj/item/gun/energy/examine(mob/user)
 	..(user)
+	if(get_dist(src, user) > 1)
+		return
 	var/shots_remaining = round(power_supply.charge / charge_cost)
 	to_chat(user, "Has [shots_remaining] shot\s remaining.")
 	return

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -92,8 +92,6 @@
 
 /obj/item/gun/energy/examine(mob/user)
 	..(user)
-	if(get_dist(src, user) > 1)
-		return
 	var/shots_remaining = round(power_supply.charge / charge_cost)
 	to_chat(user, "Has [shots_remaining] shot\s remaining.")
 	return

--- a/code/modules/projectiles/guns/energy/modular.dm
+++ b/code/modules/projectiles/guns/energy/modular.dm
@@ -28,6 +28,8 @@
 
 /obj/item/gun/energy/laser/prototype/examine(mob/user)
 	..(user)
+	if(get_dist(src, user) > 1)
+		return
 	if(gun_mods.len)
 		for(var/obj/item/laser_components/modifier/modifier in gun_mods)
 			to_chat(user, "You can see \the [modifier] attached.")

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -365,4 +365,6 @@
 /obj/item/gun/launcher/crossbow/RFD/examine(var/user)
 	. = ..()
 	if(.)
+		if(get_dist(src, user) > 1)
+			return
 		to_chat(user, "It currently holds [stored_matter]/[max_stored_matter] matter-units.")

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -234,6 +234,8 @@
 
 /obj/item/gun/projectile/examine(mob/user)
 	..(user)
+	if(get_dist(src, user) > 1)
+		return
 	if(is_jammed)
 		to_chat(user, "<span class='warning'>It looks jammed.</span>")
 	if(ammo_magazine)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -234,8 +234,6 @@
 
 /obj/item/gun/projectile/examine(mob/user)
 	..(user)
-	if(get_dist(src, user) > 1)
-		return
 	if(is_jammed)
 		to_chat(user, "<span class='warning'>It looks jammed.</span>")
 	if(ammo_magazine)

--- a/html/changelogs/alberyk-examine.yml
+++ b/html/changelogs/alberyk-examine.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Gun's extra examine information is now only displayed when you are next to it."
+  - bugfix: "Fixed powercell examining not returning any text when you were far enough."


### PR DESCRIPTION
-fixes powercell examines being really funky
-removed the voice changer unique examine, now that you can examine what people are wearing
-makes so that you can only see guns ammo, settings and etc if you are examining when close to it