### PR TITLE
Cult Manifest Runes can only summon ghosts who previously were cultists

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -437,12 +437,10 @@ var/list/sacrificed = list()
 /////////////////////////////////////////ELEVENTH RUNE
 
 /obj/effect/rune/proc/manifest(var/mob/living/user)
-	var/obj/effect/rune/this_rune = src
-	if(user.loc!=this_rune.loc)
-		return this_rune.fizzle(user)
+	if(user.loc!=src.loc)
+		return src.fizzle(user)
 	var/mob/abstract/observer/ghost
-	for(var/mob/abstract/observer/O in this_rune.loc)
-		if(!O.client) continue
+	for(var/mob/abstract/observer/O in src.loc)
 		if(!O.MayRespawn()) continue
 		if(jobban_isbanned(O, "cultist")) continue
 		if(O.mind)
@@ -453,16 +451,16 @@ var/list/sacrificed = list()
 		ghost = O
 		break
 	if(!ghost)
-		return this_rune.fizzle(user)
+		return src.fizzle(user)
 
 	user.say("Gal'h'rfikk harfrandid mud[pick("'","`")]gib!")
-	var/mob/living/carbon/human/apparition/D = new(this_rune.loc)
+	var/mob/living/carbon/human/apparition/D = new(src.loc)
 	user.visible_message("<span class='warning'>A shape forms in the center of the rune. A shape of... a man.</span>", \
 	"<span class='warning'>A shape forms in the center of the rune. A shape of... a man.</span>", \
 	"<span class='warning'>You hear liquid flowing.</span>")
 
 	var/chose_name = 0
-	for(var/obj/item/paper/P in this_rune.loc)
+	for(var/obj/item/paper/P in src.loc)
 		if(P.info)
 			D.real_name = copytext(P.info, findtext(P.info,">")+1, findtext(P.info,"<",2) )
 			chose_name = 1
@@ -480,7 +478,7 @@ var/list/sacrificed = list()
 
 	log_and_message_admins("used a manifest rune.")
 
-	while(this_rune && user && user.stat==CONSCIOUS && user.client && user.loc==this_rune.loc)
+	while(src && user && user.stat==CONSCIOUS && user.client && user.loc==src.loc)
 		user.take_organ_damage(1, 0)
 		sleep(30)
 	if(D)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -442,14 +442,17 @@ var/list/sacrificed = list()
 		return this_rune.fizzle(user)
 	var/mob/abstract/observer/ghost
 	for(var/mob/abstract/observer/O in this_rune.loc)
-		if(!O.client)	continue
+		if(!O.client) continue
 		if(!O.MayRespawn()) continue
-		if(O.mind && O.mind.current && O.mind.current.stat != DEAD)	continue
+		if(jobban_isbanned(O, "cultist")) continue
+		if(O.mind)
+			if(O.mind.current && O.mind.current.stat != DEAD)
+				continue
+			if(!(O.mind in cult.current_antagonists))
+				continue
 		ghost = O
 		break
 	if(!ghost)
-		return this_rune.fizzle(user)
-	if(jobban_isbanned(ghost, "cultist"))
 		return this_rune.fizzle(user)
 
 	user.say("Gal'h'rfikk harfrandid mud[pick("'","`")]gib!")

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -437,7 +437,7 @@ var/list/sacrificed = list()
 /////////////////////////////////////////ELEVENTH RUNE
 
 /obj/effect/rune/proc/manifest(var/mob/living/user)
-	if(user.loc!=src.loc)
+	if(user.loc!=loc)
 		return src.fizzle(user)
 	var/mob/abstract/observer/ghost
 	for(var/mob/abstract/observer/O in src.loc)

--- a/html/changelogs/burgerbb - cult ghost.yml
+++ b/html/changelogs/burgerbb - cult ghost.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: BurgerBB
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Cult Manifest Runes can only summon ghosts who previously were cultists."
+  - bugfix: "Fixed a hilarious bug that prevented Cult Manifest Runes from working if there was a cultbanned ghost on it."


### PR DESCRIPTION
# What this does
Cult Manifest Runes now only summon ghosts who previously were cultists.
Fixed a hilarious bug that prevented Cult Manifest Runes from working if there was a cultbanned ghost on it.

# Why it's good for the game
Cult manifest spam was extremely terrible. Players don't seem to care about abusing it, so now it's getting a "nerf".

This PR reduces that possibility of exploitation by making it so that only those who were previously cultists could be summoned by manifest. This encourages players to convert more and for them to not instantly use and abuse it whenever they think they are """losing""".

Also, I think that this will make accepting conversions more viable as now you have life insurance, pretty much.