### PR TITLE
Removes safeties from hardsuit mounted weaponry

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -137,6 +137,8 @@
 /obj/item/rig_module/mounted/New()
 	..()
 	gun = new gun_type(src)
+	if(istype(gun, /obj/item/gun))
+		gun.has_safety = FALSE
 
 /obj/item/rig_module/mounted/engage(atom/target)
 

--- a/html/changelogs/hardsuit_gun_fix.yml
+++ b/html/changelogs/hardsuit_gun_fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Hardsuit mounted weaponry no longer have safeties, that weren't possible to disable."


### PR DESCRIPTION
Oversight from #8094 -- Remembered the mech guns but not the hardsuit ones.

I don't think hardsuit guns need a safety since you can enable/disable them just as easily, and their hotkey is not left-click to activate by default.

Fixes #8136

**Note -- This is unnecessary if #8145 is to be merged.**