### PR TITLE
Unathi Consular Weapon Tweaks

### DIFF
--- a/code/modules/background/citizenship/unathi.dm
+++ b/code/modules/background/citizenship/unathi.dm
@@ -39,6 +39,7 @@
 	name = "Izweski Hegemony Consular Officer"
 
 	uniform = /obj/item/clothing/under/unathi
+	accessory = /obj/item/clothing/accessory/holster/waist
 	suit = /obj/item/clothing/suit/unathi/mantle
 	backpack_contents = list(/obj/item/device/camera = 1)
-	belt = /obj/item/material/sword/dao
+	belt = /obj/item/gun/energy/pistol/hegemony

--- a/code/modules/background/citizenship/unathi.dm
+++ b/code/modules/background/citizenship/unathi.dm
@@ -39,7 +39,6 @@
 	name = "Izweski Hegemony Consular Officer"
 
 	uniform = /obj/item/clothing/under/unathi
-	accessory = /obj/item/clothing/accessory/holster/waist
 	suit = /obj/item/clothing/suit/unathi/mantle
 	backpack_contents = list(/obj/item/device/camera = 1)
 	belt = /obj/item/gun/energy/pistol/hegemony

--- a/html/changelogs/geeves-unathi_consular.yml
+++ b/html/changelogs/geeves-unathi_consular.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Replaced the Izweski Hegemony Consular's Chinese Dao with a standard Hegemony Energy Pistol."
+  - rscadd: "Gave the above Consular a waist holster."

--- a/html/changelogs/geeves-unathi_consular.yml
+++ b/html/changelogs/geeves-unathi_consular.yml
@@ -4,4 +4,3 @@ delete-after: True
 
 changes: 
   - tweak: "Replaced the Izweski Hegemony Consular's Chinese Dao with a standard Hegemony Energy Pistol."
-  - rscadd: "Gave the above Consular a waist holster."


### PR DESCRIPTION
* Replaced the Izweski Hegemony Consular's Chinese Dao with a standard Hegemony Energy Pistol.
* Gave the above Consular a waist holster.