### PR TITLE
Psychics can into Srom + Srom neural suppressor fix.

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -100,7 +100,7 @@
 		if(suppressing && victim.sleeping < 3)
 			victim.Sleeping(3 - victim.sleeping)
 			if(!victim.willfully_sleeping) //While we're suppressing, we don't want them to go into srom 3 billion times.
-				willfully_sleeping = FALSE
+				victim.willfully_sleeping = FALSE
 		return 1
 	icon_state = "[modify_state]-idle"
 	return 0

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -99,8 +99,7 @@
 	if(victim)
 		if(suppressing && victim.sleeping < 3)
 			victim.Sleeping(3 - victim.sleeping)
-			if(!victim.willfully_sleeping) //While we're suppressing, we don't want them to go into srom 3 billion times.
-				victim.willfully_sleeping = FALSE
+			victim.willfully_sleeping = FALSE
 		return 1
 	icon_state = "[modify_state]-idle"
 	return 0

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -99,6 +99,8 @@
 	if(victim)
 		if(suppressing && victim.sleeping < 3)
 			victim.Sleeping(3 - victim.sleeping)
+			if(!victim.willfully_sleeping) //While we're suppressing, we don't want them to go into srom 3 billion times.
+				willfully_sleeping = FALSE
 		return 1
 	icon_state = "[modify_state]-idle"
 	return 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -112,7 +112,7 @@
 		else if(client && willfully_sleeping)
 			visible_message(span("notice", "[M] [action] [src] waking [t_him] up!"))
 			sleeping = 0
-			willfully_sleeping = 0
+			willfully_sleeping = FALSE
 
 	for(var/datum/disease/D in viruses)
 
@@ -401,7 +401,7 @@
 		to_chat(usr, span("warning", "You are already sleeping"))
 		return
 	if(alert(src,"You sure you want to sleep for a while?","Sleep","Yes","No") == "Yes")
-		willfully_sleeping = 1
+		willfully_sleeping = TRUE
 		usr.sleeping = 20 //Short nap
 
 /mob/living/carbon/Collide(atom/A)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -23,7 +23,7 @@
 			if(H.health / H.maxHealth < 0.5)
 				H.bg.awaken_impl(TRUE)
 				sleeping = 0
-				willfully_sleeping = 0
+				willfully_sleeping = FALSE
 			else
 				to_chat(H, span("danger", "You sense great disturbance to your physical body!"))
 		else
@@ -31,7 +31,7 @@
 	else if(client && willfully_sleeping)
 		visible_message(span("danger", "[src] is hit by [AM] waking [t_him] up!"))
 		sleeping = 0
-		willfully_sleeping = 0
+		willfully_sleeping = FALSE
 
 /mob/living/carbon/bullet_act(var/obj/item/projectile/P, var/def_zone)
 	..(P, def_zone)
@@ -51,7 +51,7 @@
 			if(H.health / H.maxHealth < 0.5)
 				H.bg.awaken_impl(TRUE)
 				sleeping = 0
-				willfully_sleeping = 0
+				willfully_sleeping = FALSE
 			else
 				to_chat(H, span("danger", "You sense great disturbance to your physical body!"))
 		else
@@ -59,7 +59,7 @@
 	else if(client && willfully_sleeping)
 		visible_message("<span class='danger'>[P] hit [src] waking [t_him] up!</span>")
 		sleeping = 0
-		willfully_sleeping = 0
+		willfully_sleeping = FALSE
 
 /mob/living/carbon/standard_weapon_hit_effects(obj/item/I, mob/living/user, var/effective_force, var/blocked, var/hit_zone)
 	var/t_him = "it"
@@ -77,7 +77,7 @@
 			if(H.health / H.maxHealth < 0.5)
 				H.bg.awaken_impl(TRUE)
 				sleeping = 0
-				willfully_sleeping = 0
+				willfully_sleeping = FALSE
 			else
 				to_chat(H, span("danger", "You sense great disturbance to your physical body!"))
 		else
@@ -87,7 +87,7 @@
 		user.visible_message("<span class='danger'>[user] attacked [src] with [I] waking [t_him] up!</span>", \
 				    "<span class='danger'>You attack [src] with [I], waking [t_him] up!</span>")
 		sleeping = 0
-		willfully_sleeping = 0
+		willfully_sleeping = FALSE
 
 
 	if(!effective_force || blocked >= 100)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -31,7 +31,7 @@
 
 	var/coughedtime = null // should only be useful for carbons as the only thing using it has a carbon arg.
 
-	var/willfully_sleeping = 0
+	var/willfully_sleeping = FALSE
 	var/consume_nutrition_from_air = FALSE // used by Diona
 
 	var/help_up_offer = 0 //if they have their hand out to offer someone up from the ground.

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -329,7 +329,7 @@
 					else if(H.client && H.willfully_sleeping)
 						message = "<span class='danger'>slaps [M] across the face, waking them up. Ouch!</span>"
 						H.sleeping = 0
-						H.willfully_sleeping = 0
+						H.willfully_sleeping = FALSE
 					else
 						message = "<span class='danger'>slaps [M] across the face. Ouch!</span>"
 				else

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -223,7 +223,10 @@ mob/living/carbon/human/proc/change_monitor()
 	return FALSE
 
 /mob/living/carbon/human/can_commune()
-	return species ? species.can_commune() : FALSE
+	if(psi)
+		return TRUE
+	else
+		return species ? species.can_commune() : FALSE
 
 /mob/living/carbon/human/proc/commune()
 	set category = "Abilities"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -784,7 +784,7 @@
 		//CONSCIOUS
 		else
 			stat = CONSCIOUS
-			willfully_sleeping = 0
+			willfully_sleeping = FALSE
 
 		// Check everything else.
 

--- a/code/modules/shareddream/brainghost.dm
+++ b/code/modules/shareddream/brainghost.dm
@@ -31,7 +31,7 @@
 
 	if(body.willfully_sleeping)
 		body.sleeping = max(body.sleeping - 5, 0)
-		body.willfully_sleeping = 0
+		body.willfully_sleeping = FALSE
 		if(force_awaken)
 			to_chat(src, "<span class='notice'>You suddenly feel like your connection to the dream is breaking up by the outside force.</span>")
 		else

--- a/html/changelogs/mattatlas-sromania.yml
+++ b/html/changelogs/mattatlas-sromania.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Psychics can now access the Srom."
+  - bugfix: "You should no longer get put into Srom 3 billion times while under the effects of the neural suppressor."


### PR DESCRIPTION
the title is an intentional joke

Psychics can now utilize the Srom and other commune procs.
Being under the effects of a neural suppressor should no longer spam-slam you into the Srom and back into the mortal world.
