### PR TITLE
Adds sidearms to all command lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -36,6 +36,8 @@
 	new /obj/item/device/flash(src)
 	new /obj/item/taperoll/engineering(src)
 	new /obj/item/clothing/accessory/storage/overalls/chief(src)
+	new /obj/item/gun/energy/pistol(src)
+	new /obj/item/gun/projectile/sec/flash(src)
 
 /obj/structure/closet/secure_closet/engineering_chief2
 	name = "chief engineer's attire"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -118,6 +118,8 @@
 	new /obj/item/clothing/suit/storage/toggle/labcoat/cmoalt(src)
 	new /obj/item/storage/box/inhalers(src)
 	new /obj/item/clothing/glasses/hud/health/aviator(src)
+	new /obj/item/gun/energy/pistol(src)
+	new /obj/item/gun/projectile/sec/flash(src)
 
 /obj/structure/closet/secure_closet/CMO2
 	name = "chief medical officer's attire"

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -46,6 +46,8 @@
 	new /obj/item/device/flash(src)
 	new /obj/item/storage/box/firingpinsRD(src)
 	new /obj/item/device/pin_extractor(src)
+	new /obj/item/gun/energy/pistol(src)
+	new /obj/item/gun/projectile/sec/flash(src)
 
 /obj/structure/closet/secure_closet/RD2
 	name = "research director's attire"

--- a/html/changelogs/Cnaym-GunsForCommand.yml
+++ b/html/changelogs/Cnaym-GunsForCommand.yml
@@ -1,0 +1,5 @@
+  
+author: Cnaym
+delete-after: True
+changes: 
+  - tweak: "Added a laser gun and a .45 signale pistole to the CMO, CE and RD locker. Sidearms for all, even antags."


### PR DESCRIPTION
Gives the CMO, CE and RD the same sidearms that the head of personnel starts out with. Fair play and more smaller weapons for everyone. Goal is to enable the antags easier to grab sidearms (not the armory & bridge ones) while giving the poor command members a fighting chance against the almighty carp.

https://forums.aurorastation.org/topic/13850-sidearms-for-all-of-command/