### PR TITLE
Fixes issue with removing old GPS tags from GPS_list

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -62,7 +62,7 @@ var/list/GPS_list = list()
 	if(!data)
 		. = data = list()
 
-	VUEUI_SET_CHECK(data["own_tag"], gpstag, . , data)
+	data["own_tag"] = gpstag
 
 	var/list/tracking_list = list()
 	for(var/tracking_tag in sortList(tracking))
@@ -73,7 +73,9 @@ var/list/GPS_list = list()
 		if(AreConnectedZLevels(loc.z, GPS_list[tracking_tag]["pos_z"]))
 			tracking_list[tracking_tag] = (GPS_list[tracking_tag])
 
-	VUEUI_SET_CHECK(data["tracking_list"], tracking_list, ., data)
+	data["tracking_list"] = tracking_list
+
+	return data // should update constantly
 
 /obj/item/device/gps/attack_self(mob/user)
 	if(!emped)
@@ -99,7 +101,7 @@ var/list/GPS_list = list()
 
 		if(loc == usr)
 			if(!GPS_list[set_tag])
-				GPS_list[gpstag] = null
+				GPS_list -= gpstag
 				gpstag = set_tag
 				name = "global positioning system ([gpstag])"
 
@@ -121,10 +123,10 @@ var/list/GPS_list = list()
 		
 		if(GPS_list[new_tag])
 			tracking |= new_tag
-			return TRUE
 		else
 			to_chat(usr, "Could not locate GPS tag.")
-			return TRUE
+		
+		return TRUE
 
 	if(href_list["remove_tag"])
 		tracking -= href_list["remove_tag"]
@@ -149,6 +151,7 @@ var/list/GPS_list = list()
 /obj/item/device/gps/proc/update_position()
 	var/turf/T = get_turf(src)
 	GPS_list[gpstag] = list("tag" = gpstag, "pos_x" = T.x, "pos_y" = T.y, "pos_z" = T.z, "area" = "[get_area(src).name]", "emped" = emped)
+	SSvueui.check_uis_for_change(src)
 
 /obj/item/device/gps/proc/next_initial_tag()
 	if(!LAZYACCESS(gps_count, gps_prefix))

--- a/html/changelogs/gpsbugfix.yml
+++ b/html/changelogs/gpsbugfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes some bugs with GPSes that caused 'track all' and other features to function incorrectly sometimes."


### PR DESCRIPTION
Was improperly removing old list elements from GPS_list, resulting in runtimes.

Also tweaked the update thing a bit. It was updating constantly anyway, since there's not a vueui helper for looking for changes in lists of lists. So I've just made it update constantly without pointless checks.

Fixes #8224 