### PR TITLE
Sensible Utensil and Meat Interactions

### DIFF
--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -10,8 +10,8 @@
 	thrown_force_divisor = 1
 	origin_tech = list(TECH_MATERIAL = 1)
 	attack_verb = list("attacked", "stabbed", "poked")
-	sharp = 1
-	edge = 1
+	sharp = FALSE
+	edge = FALSE
 	force_divisor = 0.1 // 6 when wielded with hardness 60 (steel)
 	thrown_force_divisor = 0.25 // 5 when thrown with weight 20 (steel)
 	var/loaded      //Descriptive string for currently loaded food object.
@@ -25,7 +25,7 @@
 	create_reagents(5)
 	return
 
-/obj/item/material/kitchen/utensil/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
+/obj/item/material/kitchen/utensil/attack(mob/living/carbon/M, mob/user, var/target_zone)
 	if(!istype(M))
 		return ..()
 
@@ -69,6 +69,7 @@
 	name = "fork"
 	desc = "It's a fork. Sure is pointy."
 	icon_state = "fork"
+	sharp = TRUE
 
 /obj/item/material/kitchen/utensil/fork/plastic
 	default_material = "plastic"
@@ -91,9 +92,9 @@
 	desc = "A knife for eating with. Can cut through any food."
 	icon_state = "knife"
 	force_divisor = 0.1 // 6 when wielded with hardness 60 (steel)
-	scoop_food = 0
-	sharp = 1
-	edge = 1
+	scoop_food = FALSE
+	sharp = TRUE
+	edge = TRUE
 
 // Identical to the tactical knife but nowhere near as stabby.
 // Kind of like the toy esword compared to the real thing.
@@ -106,7 +107,7 @@
 	applies_material_colour = 0
 	unbreakable = 1
 
-/obj/item/material/kitchen/utensil/knife/attack(target as mob, mob/living/user as mob, var/target_zone)
+/obj/item/material/kitchen/utensil/knife/attack(target, mob/living/user, var/target_zone)
 	if ((user.is_clumsy()) && prob(50))
 		to_chat(user, span("warning", "You accidentally cut yourself with \the [src]."))
 		user.take_organ_damage(20)
@@ -130,7 +131,7 @@
 	thrown_force_divisor = 1 // as above
 	drop_sound = 'sound/items/drop/wooden.ogg'
 
-/obj/item/material/kitchen/rollingpin/attack(mob/living/M as mob, mob/living/user as mob, var/target_zone)
+/obj/item/material/kitchen/rollingpin/attack(mob/living/M, mob/living/user, var/target_zone)
 	if ((user.is_clumsy()) && prob(50))
 		to_chat(user, span("warning", "\The [src] slips out of your hand and hits your head."))
 		user.drop_from_inventory(src)

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -107,7 +107,7 @@
 	applies_material_colour = 0
 	unbreakable = 1
 
-/obj/item/material/kitchen/utensil/knife/attack(target, mob/living/user, var/target_zone)
+/obj/item/material/kitchen/utensil/knife/attack(mob/target, mob/living/user, var/target_zone)
 	if ((user.is_clumsy()) && prob(50))
 		to_chat(user, span("warning", "You accidentally cut yourself with \the [src]."))
 		user.take_organ_damage(20)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -172,7 +172,7 @@
 	else
 		to_chat(user, span("notice", "\The [src] was bitten multiple times!"))
 
-/obj/item/reagent_containers/food/snacks/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/attackby(obj/item/W, mob/living/user)
 
 	if(istype(W,/obj/item/pen))
 
@@ -238,12 +238,12 @@
 					qdel(src)
 				return
 
-	if (is_sliceable())
+	if(is_sliceable())
 		//these are used to allow hiding edge items in food that is not on a table/tray
 		var/can_slice_here = isturf(src.loc) && ((locate(/obj/structure/table) in src.loc) || (locate(/obj/machinery/optable) in src.loc) || (locate(/obj/item/tray) in src.loc))
 		var/hide_item = !has_edge(W) || !can_slice_here
 
-		if (hide_item)
+		if(hide_item && user.a_intent == I_HURT)
 			if (W.w_class >= src.w_class || is_robot_module(W))
 				return
 
@@ -254,13 +254,13 @@
 			contents += W
 			return
 
-		if (has_edge(W))
+		if(has_edge(W))
 			if (!can_slice_here)
 				to_chat(user, span("warning", "You cannot slice \the [src] here! You need a table or at least a tray to do it."))
 				return
 
 			var/slices_lost = 0
-			if (W.w_class > 3)
+			if(W.w_class > 3)
 				user.visible_message(span("notice", "\The [user] crudely slices \the [src] with [W]!"), span("notice", "You crudely slice \the [src] with your [W]!"))
 				slices_lost = rand(1,min(1,round(slices_num/2)))
 			else
@@ -4173,19 +4173,9 @@
 	icon_state = "rawcutlet"
 	bitesize = 1
 	center_of_mass = list("x"=17, "y"=20)
+	slice_path = /obj/item/reagent_containers/food/snacks/rawbacon
+	slices_num = 2
 
-/obj/item/reagent_containers/food/snacks/rawcutlet/Initialize()
-	. = ..()
-	reagents.add_reagent("protein", 1)
-
-/obj/item/reagent_containers/food/snacks/rawcutlet/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/material/knife))
-		new /obj/item/reagent_containers/food/snacks/rawbacon(src)
-		new /obj/item/reagent_containers/food/snacks/rawbacon(src)
-		to_chat(user, "You slice the cutlet into thin strips of bacon.")
-		qdel(src)
-	else
-		..()
 
 /obj/item/reagent_containers/food/snacks/cutlet
 	name = "cutlet"
@@ -4843,9 +4833,6 @@
 	bitesize = 1
 	center_of_mass = list("x"=16, "y"=16)
 
-/obj/item/reagent_containers/food/snacks/rawbacon/Initialize()
-	. = ..()
-	reagents.add_reagent("protein", 0.33)
 
 /obj/item/reagent_containers/food/snacks/bacon
 	name = "bacon"

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -6,22 +6,14 @@
 	filling_color = "#FF1C1C"
 	center_of_mass = list("x"=16, "y"=14)
 	cooked_icon = "meatstake"
+	slice_path = /obj/item/reagent_containers/food/snacks/rawcutlet
+	slices_num = 3
 
 /obj/item/reagent_containers/food/snacks/meat/Initialize()
 	. = ..()
 	reagents.add_reagent("protein", 6)
 	reagents.add_reagent("triglyceride", 2)
 	src.bitesize = 1.5
-
-/obj/item/reagent_containers/food/snacks/meat/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/material/knife))
-		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
-		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
-		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
-		to_chat(user, "You cut the meat into thin strips.")
-		qdel(src)
-	else
-		..()
 
 /obj/item/reagent_containers/food/snacks/meat/cook()
 

--- a/html/changelogs/Doxxmedearly - kitchen_items.yml
+++ b/html/changelogs/Doxxmedearly - kitchen_items.yml
@@ -1,0 +1,13 @@
+
+
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - bugfix: "Meat and cutlets should now be able to be properly sliced by edged items, such as regular kitchen knives, hatchets, and cleavers."
+  - bugfix: "When slicing meat and cutlets, their reagents should now properly transfer to the new products."
+  - tweak: "Slipping items into food has changed slightly to prevent weird interactions. You will now only slip items into food on harm intent. Now you can actually slice things with the cleaver instead of shoving it into that dough or cheese wheel."
+  - bugfix: "You can no longer slice throats with spoons or forks."


### PR DESCRIPTION
Meat and Cutlets can now be sliced with edged items outside of the obj/item/knife path (like every OTHER food item can be), which includes the kitchen knife in the item/utensil path, hatchet, and butcher's cleaver (which is also a hatchet).

For some reason the utensil default was set to true for both edge and sharp, which meant you could cut someone's throat with a spoon. While hilarious, that's been adjusted to make more sense. 

Meat/cutlets, when sliced, transfer reagents properly instead of spawning entirely new items. So now if you inject an entire bottle of vodka into a slab of meat before you cut it, the resulting three cutlets will each have 1/3 of the meat's reagents. This also means that cutlets and bacon have the correct amount of animal protein/triglyceride.

And finally, to prevent the far-too-common instances of "yes I am going to cut this pizza/cheese wheel/dough ball/cake oh whoops I slipped the entire knife in instead of cutting it", it now requires you to be on harm intent to hide the items inside. 
