### PR TITLE
Fixes the corporate iaison minimum_character_age

### DIFF
--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -11,7 +11,7 @@
 	economic_modifier = 7
 	latejoin_at_spawnpoints = TRUE
 
-	minimum_character_age = 25
+	minimum_character_age = 30
 
 	access = list(access_lawyer, access_maint_tunnels)
 	minimal_access = list(access_lawyer)

--- a/html/changelogs/alberyk-represetnatieage.yml
+++ b/html/changelogs/alberyk-represetnatieage.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed the Corporate Liaison's minimum age, it should be 30 now."


### PR DESCRIPTION
What it says in the title. It is now 30 to fit the wiki and what the staff decided.