### PR TITLE
Adds the roof to the station's contact levels

### DIFF
--- a/html/changelogs/Ferner-200216-coding_contactlevels.yml
+++ b/html/changelogs/Ferner-200216-coding_contactlevels.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - tweak: "Announcements can now be heard on the roof (z-level 7)."

--- a/maps/aurora/code/aurora.dm
+++ b/maps/aurora/code/aurora.dm
@@ -7,7 +7,7 @@
 
 	station_levels = list(2, 3, 4, 5, 6, 7)
 	admin_levels = list(1)
-	contact_levels = list(3, 4, 5, 6)
+	contact_levels = list(3, 4, 5, 6, 7)
 	player_levels = list(2, 3, 4, 5, 6, 7, 8)
 	restricted_levels = list()
 	accessible_z_levels = list("8" = 10, "7" = 15, "2" = 60)


### PR DESCRIPTION
This makes it so announcements can be heard if you're on the roof, like at telecomms, the running track, the checkpoint tower.

Fixes #8286 