### PR TITLE
Adds a status_flag for mobs to prevent them being selected by auto-tator

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -14,6 +14,7 @@
 #define FAKEDEATH   0x2000  // Replaces stuff like changeling.changeling_fakedeath.
 #define DISFIGURED  0x4000  // Set but never checked. Remove this sometime and replace occurences with the appropriate organ code
 #define XENO_HOST   0x8000  // Tracks whether we're gonna be a baby alien's mummy.
+#define NO_ANTAG    0x10000  // Players are restricted from gaining antag roles when occupying this mob
 
 // Grab levels.
 #define GRAB_PASSIVE    1

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -13,6 +13,8 @@
 			return FALSE
 		if(player.current.client.prefs && player.current.client.prefs.species in restricted_species)
 			return FALSE
+		if(player.current && (player.current.status_flags & NO_ANTAG))
+			return FALSE
 	return TRUE
 
 /datum/antagonist/proc/antags_are_dead()

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -142,6 +142,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	dna.real_name = real_name
 	if(mind)
 		mind.name = real_name
+	status_flags |= NO_ANTAG
 
 	remote_network = "remoterobots"
 	SSvirtualreality.add_robot(src, remote_network)
@@ -160,6 +161,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	dna.real_name = real_name
 	if(mind)
 		mind.name = real_name
+	status_flags |= NO_ANTAG
 
 /mob/living/carbon/human/industrial_xion_remote_mech/Stat()
 	..()
@@ -175,6 +177,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	dna.real_name = real_name
 	if(mind)
 		mind.name = real_name
+	status_flags |= NO_ANTAG
 
 	equip_to_slot_or_del(new /obj/item/clothing/under/assistantformal(src), slot_w_uniform)
 	equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest(src), slot_wear_suit)
@@ -225,6 +228,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	dna.real_name = real_name
 	if(mind)
 		mind.name = real_name
+	status_flags |= NO_ANTAG
 
 	remote_network = "remoterobots"
 	SSvirtualreality.add_robot(src, remote_network)
@@ -243,6 +247,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	dna.real_name = real_name
 	if(mind)
 		mind.name = real_name
+	status_flags |= NO_ANTAG
 
 	equip_to_slot_or_del(new /obj/item/clothing/under/assistantformal(src), slot_w_uniform)
 	equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest(src), slot_wear_suit)

--- a/html/changelogs/remotes_no_autotraitor.yml
+++ b/html/changelogs/remotes_no_autotraitor.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Remote robots are no longer valid targets for autotraitor."


### PR DESCRIPTION
This already exists for species but not mobs.

Fixes #8274 

Let me know if there are other mobs that should be given this flag and I will include them in this PR.