### PR TITLE
Golems are no longer told to serve their previous ghostmob

### DIFF
--- a/code/modules/mob/living/carbon/slime/items.dm
+++ b/code/modules/mob/living/carbon/slime/items.dm
@@ -267,7 +267,7 @@ var/list/global/golem_runes = list()
 	G.set_species(golem_type)
 	G.name = G.species.get_random_name()
 	G.real_name = G.name
-	to_chat(G, span("notice", "You are a golem. Serve [user], and assist them in completing their goals at any cost."))
+	to_chat(G, span("notice", "You are a golem. Serve your master, and assist them in completing their goals at any cost."))
 	qdel(src)
 
 /obj/effect/golemrune/proc/announce_to_ghosts()

--- a/html/changelogs/golem_serve_text.yml
+++ b/html/changelogs/golem_serve_text.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Spawning as a golem no longer tells you to serve your ghostmob."


### PR DESCRIPTION
Fixes #8229

Don't see a way to make it print the name of the person who made the rune. So this will do.