### PR TITLE
Health scanner will report rough target radiation level

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -61,6 +61,13 @@
 #define BLOOD_PRESSURE_IDEAL    2
 #define BLOOD_PRESSURE_LOW      1
 
+// total_radiation levels (Note that total_radiation can be above RADS_MAX until handle_mutations_and_radiation() runs)
+#define RADS_NONE 0
+#define RADS_LOW 1
+#define RADS_MED 50
+#define RADS_HIGH 75
+#define RADS_MAX 100
+
 //intent flags, why wasn't this done the first time?
 #define I_HELP		"help"
 #define I_DISARM	"disarm"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -190,10 +190,10 @@ BREATH ANALYZER
 	if(H.getBruteLoss() > 50)
 		dat += "<span class='scan_red'>[b]Severe anatomical damage detected.[endb]</span>"
 
-	var/rad_result = SPAN_NOTICE("Radiation: ")
+	var/rad_result = "Radiation: "
 	switch(H.total_radiation)
 		if(RADS_NONE)
-			rad_result += span("scan_blue", "No radiation detected.")
+			rad_result += span("scan_gren", "No radiation detected.")
 		if(RADS_LOW to RADS_MED)
 			rad_result += span("scan_orange", "Low levels of radiation poisoning detected.")
 		if(RADS_MED to RADS_HIGH)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -190,6 +190,18 @@ BREATH ANALYZER
 	if(H.getBruteLoss() > 50)
 		dat += "<span class='scan_red'>[b]Severe anatomical damage detected.[endb]</span>"
 
+	var/rad_result = SPAN_NOTICE("Radiation: ")
+	switch(H.total_radiation)
+		if(RADS_NONE)
+			rad_result += span("scan_blue", "No radiation detected.")
+		if(RADS_LOW to RADS_MED)
+			rad_result += span("scan_orange", "Low levels of radiation poisoning detected.")
+		if(RADS_MED to RADS_HIGH)
+			rad_result += span("scan_orange", "Severe levels of radiation poisoning detected!")
+		if(RADS_HIGH to INFINITY)
+			rad_result += span("scan_red", "[b]Extreme levels of radiation poisoning detected![endb]")
+	dat += rad_result
+	
 	if(show_limb_damage)
 		var/list/damaged = H.get_damaged_organs(1,1)
 		if(damaged.len)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -193,7 +193,7 @@ BREATH ANALYZER
 	var/rad_result = "Radiation: "
 	switch(H.total_radiation)
 		if(RADS_NONE)
-			rad_result += span("scan_gren", "No radiation detected.")
+			rad_result += span("scan_green", "No radiation detected.")
 		if(RADS_LOW to RADS_MED)
 			rad_result += span("scan_orange", "Low levels of radiation poisoning detected.")
 		if(RADS_MED to RADS_HIGH)

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -3,32 +3,32 @@
 
 /mob/living/carbon/brain/handle_mutations_and_radiation()
 	if (total_radiation)
-		if (total_radiation > 100)
-			total_radiation = 100
+		if (total_radiation > RADS_MAX)
+			total_radiation = RADS_MAX
 			if(!container)//If it's not in an MMI
-				to_chat(src, "<span class='warning'>You feel weak.</span>")
+				to_chat(src, SPAN_WARNING("You feel weak."))
 			else//Fluff-wise, since the brain can't detect anything itself, the MMI handles thing like that
-				to_chat(src, "<span class='warning'>STATUS: CRITICAL AMOUNTS OF RADIATION DETECTED.</span>")
+				to_chat(src, SPAN_WARNING("STATUS: CRITICAL AMOUNTS OF RADIATION DETECTED."))
 
 		switch(total_radiation)
-			if(1 to 49)
+			if(RADS_LOW to RADS_MED-1)
 				apply_radiation(-1)
 				if(prob(25))
 					adjustToxLoss(1)
 					updatehealth()
 
-			if(50 to 74)
+			if(RADS_MED to RADS_HIGH-1)
 				apply_radiation(-2)
 				adjustToxLoss(1)
 				if(prob(5))
 					apply_radiation(-5)
 					if(!container)
-						to_chat(src, "<span class='warning'>You feel weak.</span>")
+						to_chat(src, SPAN_WARNING("You feel weak."))
 					else
-						to_chat(src, "<span class='danger'>STATUS: DANGEROUS LEVELS OF RADIATION DETECTED.</span>")
+						to_chat(src, SPAN_DANGER("STATUS: DANGEROUS LEVELS OF RADIATION DETECTED."))
 				updatehealth()
 
-			if(75 to 100)
+			if(RADS_HIGH to RADS_MAX)
 				apply_radiation(-3)
 				adjustToxLoss(3)
 				updatehealth()

--- a/html/changelogs/rad_scanner.yml
+++ b/html/changelogs/rad_scanner.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - rscadd: "Health analyzer will now report a rough radiation level for a scanned patient."


### PR DESCRIPTION
The ability to do this with the PDA Halogen Scanner was removed by [one of the brainmed PRs](https://github.com/Aurorastation/Aurora.3/pull/7502). And I expect was supposed to be readded elsewhere but forgotten about amongst the huge number of brainmed changes.

So I've added a rough radiation level readout to the handheld medical analyzer (and therefore also the PDA health analyzer).