### PR TITLE
Operating Tables don't make IPCs sleep

### DIFF
--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -8,6 +8,8 @@
 #define SPAN_CULT(X) "<span class='cult'>[X]</span>"
 #define SPAN_GOOD(X) "<span class='good'>[X]</span>"
 #define SPAN_ALIEN(X) "<span class='alium'>[X]</span>"
+#define SPAN_ITALIC(X) "<span class='italic'>[X]</span>"
+#define SPAN_BOLD(X) "<span class='bold'>[X]</span>"
 
 #define FONT_SMALL(X) "<font size='1'>[X]</font>"
 #define FONT_NORMAL(X) "<font size='2'>[X]</font>"

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -4,9 +4,9 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "table2-idle"
 	var/modify_state = "table2"
-	density = 1
-	anchored = 1
-	use_power = 1
+	density = TRUE
+	anchored = TRUE
+	use_power = TRUE
 	idle_power_usage = 1
 	active_power_usage = 5
 	component_types = list(
@@ -15,78 +15,67 @@
 		)
 
 	var/mob/living/carbon/human/victim = null
-	var/strapped = 0.0
 	var/suppressing = FALSE
 
 	var/obj/machinery/computer/operating/computer = null
 
 /obj/machinery/optable/Initialize()
 	. = ..()
-	for(dir in list(NORTH,EAST,SOUTH,WEST))
+	for(dir in cardinal)
 		computer = locate(/obj/machinery/computer/operating, get_step(src, dir))
-		if (computer)
+		if(computer)
 			computer.table = src
 			break
 
 /obj/machinery/optable/examine(var/mob/user)
 	. = ..()
-	to_chat(user, span("notice", "The neural suppressors are switched [suppressing ? "on" : "off"]."))
+	to_chat(user, SPAN_NOTICE("The neural suppressors are switched [suppressing ? "on" : "off"]."))
 
 /obj/machinery/optable/ex_act(severity)
-
 	switch(severity)
 		if(1.0)
-			//SN src = null
 			qdel(src)
 			return
 		if(2.0)
-			if (prob(50))
-				//SN src = null
+			if(prob(50))
 				qdel(src)
 				return
 		if(3.0)
-			if (prob(25))
-				src.density = 0
-		else
+			if(prob(25))
+				density = FALSE
 	return
 
 /obj/machinery/optable/attack_hand(mob/user)
-	if (HULK in user.mutations)
-		visible_message(span("danger", "\The [user] destroys \the [src]!"))
-		src.density = 0
+	if(HULK in user.mutations)
+		visible_message(SPAN_DANGER("\The [user] destroys \the [src]!"))
+		density = FALSE
 		qdel(src)
 		return
 
 	if(!victim)
-		to_chat(user, span("warning", "There is nobody on \the [src]. It would be pointless to turn the suppressor on."))
+		to_chat(user, SPAN_WARNING("There is nobody on \the [src]. It would be pointless to turn the suppressor on."))
 		return TRUE
 
 	if(user != victim && !use_check_and_message(user)) // Skip checks if you're doing it to yourself or turning it off, this is an anti-griefing mechanic more than anything.
-		user.visible_message(span("warning", "\The [user] begins switching [suppressing ? "off" : "on"] \the [src]'s neural suppressor."))
+		user.visible_message(SPAN_WARNING("\The [user] begins switching [suppressing ? "off" : "on"] \the [src]'s neural suppressor."))
 		if(!do_after(user, 30, src))
 			return
 		if(!victim)
-			to_chat(user, span("warning", "There is nobody on \the [src]. It would be pointless to turn the suppressor on."))
+			to_chat(user, SPAN_WARNING("There is nobody on \the [src]. It would be pointless to turn the suppressor on."))
 
 		suppressing = !suppressing
-		user.visible_message(span("notice", "\The [user] switches [suppressing ? "on" : "off"] \the [src]'s neural suppressor."))
-		playsound(src.loc, "switchsounds", 50, 1)
+		user.visible_message(SPAN_NOTICE("\The [user] switches [suppressing ? "on" : "off"] \the [src]'s neural suppressor."))
+		playsound(loc, "switchsounds", 50, 1)
 
-/obj/machinery/optable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0)) return 1
+/obj/machinery/optable/CanPass(atom/movable/mover, turf/target, height = 0, air_group = 0)
+	if(air_group || (height == 0)) 
+		return FALSE
 
-	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
-	else
-		return 0
+	return istype(mover) && mover.checkpass(PASSTABLE)
 
-
-/obj/machinery/optable/MouseDrop_T(obj/O as obj, mob/user as mob)
-
-	if (!istype(O, /obj/item))
-		return
-	user.drop_from_inventory(O,get_turf(src))
-	return
+/obj/machinery/optable/MouseDrop_T(obj/O, mob/user)
+	if(istype(O, /obj/item))
+		user.drop_from_inventory(O,get_turf(src))
 
 /obj/machinery/optable/proc/check_victim()
 	if(!victim || !victim.lying || victim.loc != loc)
@@ -101,51 +90,48 @@
 		if(suppressing && victim.sleeping < 3)
 			victim.Sleeping(3 - victim.sleeping)
 			victim.willfully_sleeping = FALSE
-		return 1
+		return TRUE
 	icon_state = "[modify_state]-idle"
-	return 0
+	return FALSE
 
 /obj/machinery/optable/machinery_process()
 	check_victim()
 
-/obj/machinery/optable/proc/take_victim(mob/living/carbon/C, mob/living/carbon/user as mob)
-	if (C == user)
-		user.visible_message("[user] climbs on \the [src].","You climb on \the [src].")
+/obj/machinery/optable/proc/take_victim(mob/living/carbon/C, mob/living/carbon/user)
+	if(C == user)
+		user.visible_message("\The [user] climbs on \the [src].","You climb on \the [src].")
 	else
-		visible_message(span("notice", "\The [C] has been laid on \the [src] by [user]."))
-	if (C.client)
+		visible_message(SPAN_NOTICE("\The [C] has been laid on \the [src] by \the [user]."))
+	if(C.client)
 		C.client.perspective = EYE_PERSPECTIVE
 		C.client.eye = src
-	C.resting = 1
-	C.forceMove(src.loc)
-	src.add_fingerprint(user)
+	C.resting = TRUE
+	C.forceMove(loc)
+	add_fingerprint(user)
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
-		src.victim = H
+		victim = H
 		icon_state = H.pulse() ? "[modify_state]-active" : "[modify_state]-idle"
 	else
 		icon_state = "[modify_state]-idle"
 
 /obj/machinery/optable/MouseDrop_T(mob/target, mob/user)
-
 	var/mob/living/M = user
-	if(user.stat || user.restrained() ||  !iscarbon(target))
+	if(user.stat || user.restrained() || !iscarbon(target))
 		return
 	if(istype(M))
-
 		var/mob/living/L = target
 		var/bucklestatus = L.bucklecheck(user)
 
-		if (!bucklestatus)//We must make sure the person is unbuckled before they go in
+		if(!bucklestatus)//We must make sure the person is unbuckled before they go in
 			return
 
-
 		if(L == user)
-			user.visible_message(span("notice", "[user] starts climbing onto [src]."), span("notice", "You start climbing onto [src]."), range = 3)
+			user.visible_message(SPAN_NOTICE("\The [user] starts climbing onto \the [src]."), SPAN_NOTICE("You start climbing onto \the [src]."), range = 3)
 		else
-			user.visible_message(span("notice", "[user] starts putting [L] onto [src]."), span("notice", "You start putting [L] onto [src]."), range = 3)
-		if (do_mob(user, L, 10, needhand = 0))
-			if (bucklestatus == 2)
+			user.visible_message(SPAN_NOTICE("\The [user] starts putting [L] onto \the [src]."), SPAN_NOTICE("You start putting \the [L] onto \the [src]."), range = 3)
+		if(do_mob(user, L, 10, needhand = FALSE))
+			if(bucklestatus == 2)
 				var/obj/structure/LB = L.buckled
 				LB.user_unbuckle_mob(user)
 			take_victim(target,user)
@@ -162,26 +148,25 @@
 
 	take_victim(usr,usr)
 
-/obj/machinery/optable/attackby(obj/item/W as obj, mob/living/carbon/user as mob)
-	if (istype(W, /obj/item/grab))
+/obj/machinery/optable/attackby(obj/item/W, mob/living/carbon/user)
+	if(istype(W, /obj/item/grab))
 		var/obj/item/grab/G = W
-		if (src.victim)
-			to_chat(usr, span("notice", "<B>The table is already occupied!</B>"))
-			return 0
+		if(victim)
+			to_chat(usr, SPAN_NOTICE(SPAN_BOLD("\The [src] is already occupied!")))
+			return FALSE
 
 		var/mob/living/L = G.affecting
 		var/bucklestatus = L.bucklecheck(user)
 
-		if (!bucklestatus)//We must make sure the person is unbuckled before they go in
+		if(!bucklestatus)//We must make sure the person is unbuckled before they go in
 			return
 
-
 		if(L == user)
-			user.visible_message(span("notice", "[user] starts climbing onto [src]."), span("notice", "You start climbing onto [src]."), range = 3)
+			user.visible_message(SPAN_NOTICE("\The [user] starts climbing onto \the [src]."), SPAN_NOTICE("You start climbing onto \the [src]."), range = 3)
 		else
-			user.visible_message(span("notice", "[user] starts putting [L] onto [src]."), span("notice", "You start putting [L] onto [src]."), range = 3)
-		if (do_mob(user, L, 10, needhand = 0))
-			if (bucklestatus == 2)
+			user.visible_message(SPAN_NOTICE("\The [user] starts putting \the [L] onto \the [src]."), SPAN_NOTICE("You start putting \the [L] onto \the [src]."), range = 3)
+		if(do_mob(user, L, 10, needhand = FALSE))
+			if(bucklestatus == 2)
 				var/obj/structure/LB = L.buckled
 				LB.user_unbuckle_mob(user)
 			take_victim(G.affecting,usr)
@@ -194,12 +179,12 @@
 	if(default_part_replacement(user, W))
 		return
 
-/obj/machinery/optable/proc/check_table(mob/living/carbon/patient as mob)
+/obj/machinery/optable/proc/check_table(mob/living/carbon/patient)
 	check_victim()
-	if(src.victim && get_turf(victim) == get_turf(src) && victim.lying)
-		to_chat(usr, span("warning", "\The [src] is already occupied!"))
-		return 0
+	if(victim?.lying && get_turf(victim) == get_turf(src))
+		to_chat(usr, SPAN_WARNING("\The [src] is already occupied!"))
+		return FALSE
 	if(patient.buckled)
-		to_chat(usr, span("notice", "Unbuckle \the [patient] first!"))
-		return 0
-	return 1
+		to_chat(usr, SPAN_NOTICE("Unbuckle \the [patient] first!"))
+		return FALSE
+	return TRUE

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -97,7 +97,7 @@
 			if(H.lying)
 				icon_state = H.pulse() ? "[modify_state]-active" : "[modify_state]-idle"
 				victim = H
-	if(victim)
+	if(victim && !victim.isSynthetic())
 		if(suppressing && victim.sleeping < 3)
 			victim.Sleeping(3 - victim.sleeping)
 			victim.willfully_sleeping = FALSE

--- a/html/changelogs/no_sleepy_robits.yml
+++ b/html/changelogs/no_sleepy_robits.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Synthetic humans don't get knocked out by Operating Tables anymore. The suppressor will still turn on/off."


### PR DESCRIPTION
Prevents Operating Tables from making synthetic humanoids unconscious. Presumably they are designed to work on organic brains.

Also tidies up OpTable.dm a bit.

Fixes #8244