### PR TITLE
centcomm timeout no longer spawns your items (again)

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -438,7 +438,7 @@
 		global_announcer.autosay("[real_name], [mind.role_alt_title], [spawnpos.msg].", "Cryogenic Oversight")
 		if(!src.megavend)
 			var/rank= src.mind.assigned_role
-			SSjobs.EquipRank(src, rank, 1)
+			SSjobs.EquipRank(src, rank, 1, megavend = TRUE)
 			src.megavend = TRUE
 	else
 		SSjobs.centcomm_despawn_mob(src) //somehow they can't spawn at cryo, so this is the only recourse of action.

--- a/html/changelogs/no_centcomm_timeout_duplicate.yml
+++ b/html/changelogs/no_centcomm_timeout_duplicate.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Spawning on Aurora via the centcomm timeout will no longer duplicate your character's items."


### PR DESCRIPTION
`centcomm_timeout()` doesn't need to spawn your loadout items, just the job items.

Fixes #8199
Fixes #8142 