### PR TITLE
Light ICs work inside clothing assemblies

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies/clothing.dm
+++ b/code/modules/integrated_electronics/core/assemblies/clothing.dm
@@ -18,6 +18,9 @@
 /obj/item/device/electronic_assembly/clothing/resolve_ui_host()
 	return clothing
 
+/obj/item/device/electronic_assembly/clothing/get_assembly_holder()
+	return clothing
+
 /obj/item/device/electronic_assembly/clothing/update_icon()
 	..()
 	clothing.icon_state = icon_state

--- a/code/modules/integrated_electronics/core/assemblies/generic.dm
+++ b/code/modules/integrated_electronics/core/assemblies/generic.dm
@@ -249,3 +249,6 @@
 	w_class = ITEMSIZE_TINY
 	max_components = IC_COMPONENTS_BASE / 2
 	max_complexity = IC_COMPLEXITY_BASE / 2
+
+/obj/item/device/electronic_assembly/proc/get_assembly_holder()
+	return src

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -65,9 +65,9 @@
 	outputs = list()
 	activators = list("toggle light" = IC_PINTYPE_PULSE_IN)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	var/light_toggled = 0
+	var/light_toggled = FALSE
 	var/light_brightness = 3
-	var/light_rgb = "#FFFFFF"
+	var/light_rgb = COLOR_WHITE
 	power_draw_idle = 0 // Adjusted based on brightness.
 
 /obj/item/integrated_circuit/output/light/do_work()
@@ -75,12 +75,12 @@
 	update_lighting()
 
 /obj/item/integrated_circuit/output/light/proc/update_lighting()
-	if(light_toggled)
-		if(assembly)
-			assembly.set_light(l_range = light_brightness, l_power = light_brightness, l_color = light_rgb)
-	else
-		if(assembly)
-			assembly.set_light(0)
+	if(assembly)
+		var/atom/atom_holder = assembly.get_assembly_holder()
+		if(light_toggled)
+			atom_holder.set_light(l_range = light_brightness, l_power = light_brightness, l_color = light_rgb)
+		else
+			atom_holder.set_light(0)
 	power_draw_idle = light_toggled ? light_brightness * 2 : 0
 
 /obj/item/integrated_circuit/output/light/disconnect_all()

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -69,6 +69,7 @@
 	var/light_brightness = 3
 	var/light_rgb = COLOR_WHITE
 	power_draw_idle = 0 // Adjusted based on brightness.
+	light_wedge = LIGHT_WIDE
 
 /obj/item/integrated_circuit/output/light/do_work()
 	light_toggled = !light_toggled
@@ -78,7 +79,7 @@
 	if(assembly)
 		var/atom/atom_holder = assembly.get_assembly_holder()
 		if(light_toggled)
-			atom_holder.set_light(l_range = light_brightness, l_power = light_brightness, l_color = light_rgb)
+			atom_holder.set_light(l_range = light_brightness, l_power = light_brightness, l_color = light_rgb, uv = 0, angle = light_wedge)
 		else
 			atom_holder.set_light(0)
 	power_draw_idle = light_toggled ? light_brightness * 2 : 0

--- a/html/changelogs/lights_in_clothes.yml
+++ b/html/changelogs/lights_in_clothes.yml
@@ -4,3 +4,5 @@ delete-after: True
 
 changes: 
   - bugfix: "Lights will now work properly when inside clothing assemblies."
+  - tweak: "Lighting ICs now only illuminate a cone infront of them, like flashlights."
+  - balance: "Lighting ICs now do not produce UV."

--- a/html/changelogs/lights_in_clothes.yml
+++ b/html/changelogs/lights_in_clothes.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Lights will now work properly when inside clothing assemblies."


### PR DESCRIPTION
Fixes #8185 

Also light ICs no longer produce UV for Dionas to bask in
Light ICs now project a cone like flashlights rather than an omnidirectional light