### PR TITLE
janitor jobs added

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -217,6 +217,7 @@
 	selection_color = "#C0C0C0"
 	access = list(access_janitor, access_maint_tunnels, access_engine, access_research, access_sec_doors, access_medical)
 	minimal_access = list(access_janitor, access_engine, access_research, access_sec_doors, access_medical)
+	alt_titles = list("Sanitation Technician", "Appliances Technician")
 	outfit = /datum/outfit/job/janitor
 
 /datum/outfit/job/janitor


### PR DESCRIPTION
* Adds two new alt titles for the Janitor job:
- Sanitation Technician
- Appliances Technician

https://forums.aurorastation.org/topic/13885-add-two-alternate-titles-to-janitor

### IC changelog
Earlier today, CentComm's HR Department announced that new positions would open on the Civilian Department regarding janitorial work. The Council decided to open NSS Aurora's doors to certified Sanitation Technicians as a part of our new program for Total Hygiene onboard the station. Furthermore, we signed a contract with our subsidiary companies to hire more Appliances Technicians too, given that we found out that vending machines and other equipments onboard NSS Aurora require extensive maintenance. The new workforce will start their shifts onboard NSS Aurora starting this week.