### PR TITLE
Adds a clear button to character record setting

### DIFF
--- a/code/modules/client/preference_setup/general/05_background.dm
+++ b/code/modules/client/preference_setup/general/05_background.dm
@@ -102,11 +102,11 @@
 		dat += "<span class='danger'>You are banned from using character records.</span><br>"
 	else
 		dat += "Medical Records:<br>"
-		dat += "<a href='?src=\ref[src];set_medical_records=1'>[TextPreview(pref.med_record,40)]</a><br><br>"
+		dat += "<a href='?src=\ref[src];set_medical_records=1'>[TextPreview(pref.med_record,40)]</a><a href='?src=\ref[src];clear=medical'>Clear</a><br><br>"
 		dat += "Employment Records:<br>"
-		dat += "<a href='?src=\ref[src];set_general_records=1'>[TextPreview(pref.gen_record,40)]</a><br><br>"
+		dat += "<a href='?src=\ref[src];set_general_records=1'>[TextPreview(pref.gen_record,40)]</a><a href='?src=\ref[src];clear=general'>Clear</a><br><br>"
 		dat += "Security Records:<br>"
-		dat += "<a href='?src=\ref[src];set_security_records=1'>[TextPreview(pref.sec_record,40)]</a><br>"
+		dat += "<a href='?src=\ref[src];set_security_records=1'>[TextPreview(pref.sec_record,40)]</a><a href='?src=\ref[src];clear=security'>Clear</a><br>"
 
 	. = dat.Join()
 
@@ -144,21 +144,35 @@
 
 	else if(href_list["set_medical_records"])
 		var/new_medical = sanitize(input(user,"Enter medical information here.","Character Preference", html_decode(pref.med_record)) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
-		if(!jobban_isbanned(user, "Records") && CanUseTopic(user))
+		if(!isnull(new_medical) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.med_record = new_medical
 		return TOPIC_REFRESH
 
 	else if(href_list["set_general_records"])
 		var/new_general = sanitize(input(user,"Enter employment information here.","Character Preference", html_decode(pref.gen_record)) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
-		if(!jobban_isbanned(user, "Records") && CanUseTopic(user))
+		if(!isnull(new_general) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.gen_record = new_general
 		return TOPIC_REFRESH
 
 	else if(href_list["set_security_records"])
 		var/sec_medical = sanitize(input(user,"Enter security information here.","Character Preference", html_decode(pref.sec_record)) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
-		if(!jobban_isbanned(user, "Records") && CanUseTopic(user))
+		if(!isnull(sec_medical) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.sec_record = sec_medical
 		return TOPIC_REFRESH
+
+	else if(href_list["clear"])
+		if(!jobban_isbanned(user, "Records") && CanUseTopic(user))
+			if(alert(user, "Are you sure you wish to clear the [capitalize(href_list["clear"])] record?", "Clear Record Confirmation","Yes","No") == "No")
+				return TOPIC_NOACTION
+			switch(href_list["clear"])
+				if("medical")
+					pref.med_record = ""
+				if("general")
+					pref.gen_record = ""
+				if("security")
+					pref.sec_record = ""
+			return TOPIC_REFRESH
+
 
 	return ..()
 

--- a/html/changelogs/record_clear_button.yml
+++ b/html/changelogs/record_clear_button.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Character setup record setting options now have a clear button, submitting a blank record or clicking cancel will no longer clear it."


### PR DESCRIPTION
Fixes #8335

Can't differentiate between 'null' from input due to clicking cancel, or submitting a blank record. So got to do this I think.