### PR TITLE
Drink vanish bugfix

### DIFF
--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -9,7 +9,7 @@
 	var/filling_color = "#FFFFFF" //Used by sandwiches
 	var/trash = null
 	var/is_liquid = TRUE
-	
+
 /obj/item/reagent_containers/food/self_feed_message(var/mob/user)
 	to_chat(user, "<span class='notice'>You [is_liquid ? "drink from" : "eat"] \the [src].</span>")
 
@@ -21,10 +21,10 @@
 
 /obj/item/reagent_containers/food/proc/on_consume(var/mob/user, var/mob/target)
 	if(!reagents.total_volume)
-		user.drop_from_inventory(src)	//so trash actually stays in the active hand.
 		if(trash)
+			user.drop_from_inventory(src)	//so trash actually stays in the active hand.
 			var/obj/item/TrashItem = new trash(user)
 			user.put_in_hands(TrashItem)
 			target.visible_message(span("notice", "[target] finishes [is_liquid ? "drinking" : "eating"] \the [src]."),
 								   span("notice","You finish [is_liquid ? "drinking" : "eating"] \the [src]."))
-		qdel(src)
+			qdel(src)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -50,7 +50,6 @@
 	if(!is_open_container())
 		to_chat(user, "<span class='notice'>You need to open \the [src]!</span>")
 		return 1
-	on_consume(target,user)
 	return ..()
 
 /obj/item/reagent_containers/food/drinks/standard_dispenser_refill(var/mob/user, var/obj/structure/reagent_dispensers/target)

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -19,7 +19,7 @@
 	var/rag_underlay = "rag"
 
 /obj/item/reagent_containers/food/drinks/bottle/Initialize()
-	..()
+	. = ..()
 	if(isGlass)
 		unacidable = 1
 
@@ -115,7 +115,7 @@
 	update_icon()
 
 /obj/item/reagent_containers/food/drinks/bottle/open(mob/user)
-	if(rag) 
+	if(rag)
 		return
 	..()
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -40,10 +40,13 @@
 /obj/item/reagent_containers/food/snacks/standard_splash_mob(var/mob/user, var/mob/target)
 	return 1 //Returning 1 will cancel everything else in a long line of things it should do.
 
-/obj/item/reagent_containers/food/snacks/on_consume()
-	..()
-	if(!reagents.total_volume)
+/obj/item/reagent_containers/food/snacks/on_consume(mob/user, mob/target)
+	if(!reagents.total_volume && !trash)
+		target.visible_message(SPAN_NOTICE("[target] finishes [is_liquid ? "drinking" : "eating"] \the [src]."),
+					 SPAN_NOTICE("You finish [is_liquid ? "drinking" : "eating"] \the [src]."))
 		qdel(src)
+	else
+		..()
 
 /obj/item/reagent_containers/food/snacks/attack_self(mob/user as mob)
 	return
@@ -132,9 +135,9 @@
 			msg_admin_attack("[key_name_admin(user)] fed [key_name_admin(target)] with [name] Reagents: [contained] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)",ckey=key_name(user),ckey_target=key_name(target))
 			reagents.trans_to_mob(target, min(reagents.total_volume,bitesize), CHEM_INGEST)
 
-	feed_sound(target,user)
+	feed_sound(target)
 	bitecount++
-	on_consume(target,user)
+	on_consume(user, target)
 
 	return 1
 

--- a/html/changelogs/doxx - fooddrinkfix.yml
+++ b/html/changelogs/doxx - fooddrinkfix.yml
@@ -1,0 +1,16 @@
+
+
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Drinks should no longer disappear when empty."
+  - bugfix: "Fixed wrong messages and invisible items when feeding others."


### PR DESCRIPTION
Fixes a couple bugs caused by food/drink refactor.
on_consume() caused drinking glasses to disappear when empty due to being defined on the food parent path. Removed on_consume() from the drink path for now because it's a headache. You would get the "finishes the drink" message every time you tried to drink an empty bottle or glass with how it was before. If someone wants to re-add on_consume() or something to drinks, it would prrrrobably after to go after standard_feed_mob is resolved. Idk. I'm just here to fix the disappearing glasses ASAP.

Also user and target were backwards in every call of on_consume, which gave the person feeding the wrong message, and caused some weird interactions like the feeder getting invisible, empty food. Fixed for food, irrelevant for drinks since that's removed.

Fixed Initialize() for bottles, too. This isn't New(). 

Fixes #8353 

tested with drinks, bottles, glasses, food w/ trash and food w/o trash, both while feeding to self and feeding to others. Seems to work fine.