### PR TITLE
Sound Loops Always 100 Volume Fix and SM Sounds Fix

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -251,6 +251,7 @@ var/list/glasscrack_sound = list(
 	S.frequency = frequency
 	S.falloff = fall_off || FALLOFF_SOUNDS
 	S.environment = environment
+	S.volume = volume
 
 	return S
 

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -195,8 +195,10 @@
 		return  //Yeah just stop.
 
 	if(power)
-		soundloop.volume = min(40, (round(power/100)/50)+1)
-
+		soundloop.volume = min(100, (round(power/7)+1))
+	else
+		soundloop.volume = 0
+	
 	if(damage > explosion_point)
 		if(!exploded)
 			if(!istype(L, /turf/space))

--- a/html/changelogs/talkarcabbage-sm-noises-fix.yml
+++ b/html/changelogs/talkarcabbage-sm-noises-fix.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Talkarcabbage
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed sound loops ignoring volume setting."
+  - tweak: "Adjusted supermatter crystal sounds and fix issue where it always plays at 100 volume."


### PR DESCRIPTION
Fixes an issue with the playsound_get_sound proc not copying over the original sound's volume, causing it to be played at 100. This fixed an issue with the behavior of the supermatter crystal audio loop (which was then volume-adjusted to reflect the bug being fixed. Without the tweak, it would be fairly inaudible at any non-adminbus number of shots). 

It also has implications for any other places sound loops were used with volumes that may have been balanced incorrectly or had their volumes non-default. It should never cause a volume _increase_ as the default is 100, but in theory could cause some sound loops to be quieter if using the same procs.
