### PR TITLE
Removes unnecessary blast doors from the research sublevel

### DIFF
--- a/html/changelogs/Leudoberct1 - blastdoors.yml
+++ b/html/changelogs/Leudoberct1 - blastdoors.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Leudoberct
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Removes unnecessary blastdoors in the research sublevel."
+

--- a/html/changelogs/Leudoberct1-blastdoors.yml
+++ b/html/changelogs/Leudoberct1-blastdoors.yml
@@ -1,0 +1,6 @@
+ author: Leudoberct
+
+delete-after: True
+
+changes: 
+  - maptweak: "Removes unneeded blast doors from the Research sublevel."

--- a/html/changelogs/Leudoberct1-blastdoors.yml
+++ b/html/changelogs/Leudoberct1-blastdoors.yml
@@ -1,6 +1,0 @@
- author: Leudoberct
-
-delete-after: True
-
-changes: 
-  - maptweak: "Removes unneeded blast doors from the Research sublevel."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -10790,26 +10790,20 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
 "arS" = (
-/obj/machinery/door/firedoor,
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/maintenance/scisublevel)
+/area/rnd/eva)
 "arT" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -12041,6 +12035,19 @@
 /obj/item/pickaxe/drill,
 /turf/simulated/floor/tiled,
 /area/rnd/eva)
+"aua" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/rnd/eva)
 "aub" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -12051,6 +12058,45 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
+"auc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/rnd/eva)
+"aud" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/scisublevel)
+"aue" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/scisublevel)
 "auf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -12667,30 +12713,6 @@
 "avJ" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/eva)
-"avK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/rnd/eva)
 "avL" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -12889,28 +12911,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"awm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/rnd/eva)
 "awn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1;
@@ -13207,25 +13207,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical_sublevel)
-"axq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/rnd/eva)
 "axr" = (
 /obj/effect/floor_decal/corner/mauve{
 	icon_state = "corner_white";
@@ -29951,28 +29932,6 @@
 /obj/structure/closet/secure_closet/medical3,
 /turf/simulated/floor/tiled,
 /area/medical/patient_wing_post2)
-"fSU" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/scisublevel)
 "fTY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36891,26 +36850,6 @@
 "wCR" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/storage_sublevel)
-"wGj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/rnd/eva)
 "wGK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -58490,10 +58429,10 @@ awl
 jlY
 avJ
 avJ
-awm
-axq
-axq
-wGj
+arS
+auc
+auc
+aua
 avJ
 avJ
 kJR
@@ -59000,8 +58939,8 @@ aba
 aba
 avc
 avJ
-awm
-wGj
+arS
+aua
 avJ
 axs
 pFa
@@ -59256,7 +59195,7 @@ aba
 aba
 aba
 aqA
-avK
+awV
 atX
 oFa
 awV
@@ -59770,7 +59709,7 @@ aba
 aba
 alP
 arT
-avK
+awV
 awo
 cdr
 awV
@@ -65179,7 +65118,7 @@ akW
 aiJ
 aiJ
 aiJ
-arS
+aud
 vVq
 baW
 baX
@@ -65436,7 +65375,7 @@ aba
 aba
 aba
 aba
-fSU
+aue
 tkc
 nND
 hQd


### PR DESCRIPTION
This removes the blast doors from the research sublevel EVA prep windows, as well as from the maintenance windows.

Reasoning:

If there is no power, these blast doors fall on the airlock, which can pretty effectively trap anyone inside from leaving or entering. Additionally, these blast doors are pretty damn terrible given that they're on the airlock area of xenoarch. Xenoarch often brings in artifacts with EMP properties, and sometimes, these are activated by oxygen or nitrogen, which is found in the station air. As soon as that airlock fills, it then causes an EMP, which lowers all the blast doors, takes the power from the airlock, and makes it near impossible to get the artifact back out into vacuum to disable it. In one round, we had no option but to cut a wall out into space to get it to deactivate. The blast doors for areas where it makes sense, like xenobotany, have not been removed.