### PR TITLE
Fixes all the remaining floors on centcomm levels with the wrong icon

### DIFF
--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -3,6 +3,11 @@
 	icon = 'icons/turf/total_floors.dmi'
 	icon_state = "floor3"
 
+/turf/unsimulated/floor/plating
+	name = "plating"
+	icon = 'icons/turf/floors.dmi'
+	icon_state = "plating"
+
 /turf/unsimulated/floor/xmas
 	name = "snow"
 	icon = 'icons/turf/snow.dmi'
@@ -19,7 +24,7 @@
 		return
 
 	new N(src)
-	
+
 /turf/unsimulated/chasm_mask
 	name = "chasm mask"
 	icon = 'icons/turf/walls.dmi'

--- a/html/changelogs/Ferner-200229-bugfix_centcomfloors.yml
+++ b/html/changelogs/Ferner-200229-bugfix_centcomfloors.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Fixed the floors at centcom that had become white instead of being plating."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -3609,9 +3609,7 @@
 	})
 "ajU" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership{
 	name = "\improper Ninja Base"
 	})
@@ -3944,9 +3942,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership/elite_squad)
 "akJ" = (
 /obj/machinery/door/airlock/external{
@@ -3964,39 +3960,29 @@
 /turf/simulated/floor/shuttle/red,
 /area/shuttle/syndicate_elite/mothership)
 "akK" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership/elite_squad)
 "akL" = (
 /obj/machinery/door/airlock/external{
 	req_access = list(150)
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership/elite_squad)
 "akM" = (
 /obj/machinery/computer/teleporter,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership{
 	name = "\improper Ninja Base"
 	})
 "akN" = (
 /obj/machinery/teleport/station,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership{
 	name = "\improper Ninja Base"
 	})
 "akO" = (
 /obj/machinery/teleport/hub,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership{
 	name = "\improper Ninja Base"
 	})
@@ -4032,9 +4018,7 @@
 	icon_state = "rwindow";
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership{
 	name = "\improper Ninja Base"
 	})
@@ -4055,17 +4039,13 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_l"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership{
 	name = "\improper Ninja Base"
 	})
 "akW" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership{
 	name = "\improper Ninja Base"
 	})
@@ -4073,9 +4053,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_r"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership{
 	name = "\improper Ninja Base"
 	})
@@ -4189,9 +4167,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership)
 "alk" = (
 /obj/structure/bed,
@@ -4221,9 +4197,7 @@
 	dir = 8
 	},
 /obj/structure/grille,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership)
 "alo" = (
 /obj/structure/window/reinforced{
@@ -4234,9 +4208,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership)
 "alp" = (
 /obj/item/device/pda/syndicate,
@@ -4258,9 +4230,7 @@
 	dir = 8
 	},
 /obj/structure/grille,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership)
 "als" = (
 /obj/structure/window/reinforced,
@@ -4268,9 +4238,7 @@
 	dir = 1
 	},
 /obj/structure/grille,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership)
 "alt" = (
 /obj/structure/window/reinforced,
@@ -4281,9 +4249,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership)
 "alu" = (
 /obj/machinery/door/airlock/centcom{
@@ -4745,9 +4711,7 @@
 	dir = 8
 	},
 /obj/structure/grille,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership)
 "amv" = (
 /obj/structure/window/reinforced,
@@ -4758,9 +4722,7 @@
 	dir = 4
 	},
 /obj/structure/grille,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership)
 "amw" = (
 /turf/unsimulated/floor{
@@ -4951,9 +4913,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership)
 "amR" = (
 /obj/machinery/door/airlock/centcom{
@@ -5392,9 +5352,7 @@
 	dir = 8
 	},
 /obj/structure/grille,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/syndicate_mothership)
 "anL" = (
 /obj/structure/table/rack,
@@ -6479,9 +6437,7 @@
 /turf/simulated/floor/shuttle/yellow,
 /area/shuttle/administration/centcom)
 "aqt" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom)
 "aqu" = (
 /turf/unsimulated/floor,
@@ -7217,18 +7173,14 @@
 	},
 /area/centcom/suppy)
 "atf" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/suppy)
 "atg" = (
 /obj/machinery/light/spot{
 	icon_state = "tube1";
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/suppy)
 "ath" = (
 /turf/unsimulated/floor{
@@ -7826,9 +7778,7 @@
 	icon_state = "tube1";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/suppy)
 "auG" = (
 /obj/machinery/light/spot{
@@ -7856,9 +7806,7 @@
 	pixel_y = 0;
 	tag_door = "admin_shuttle_bay_door"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom)
 "auJ" = (
 /turf/unsimulated/floor{
@@ -7906,9 +7854,7 @@
 	id_tag = "admin_shuttle_bay_door";
 	locked = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom)
 "auP" = (
 /obj/machinery/light{
@@ -8020,9 +7966,7 @@
 /area/centcom/control)
 "avd" = (
 /obj/machinery/light/spot,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/suppy)
 "ave" = (
 /turf/unsimulated/wall/riveted,
@@ -8433,9 +8377,7 @@
 /area/centcom/living)
 "avR" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/living)
 "avS" = (
 /obj/machinery/mech_recharger,
@@ -8712,14 +8654,10 @@
 /obj/effect/landmark{
 	name = "Marauder Exit"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "awz" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "awA" = (
 /obj/machinery/door/blast/odin{
@@ -8729,9 +8667,7 @@
 	name = "Launch Bay #3";
 	p_open = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "awB" = (
 /turf/unsimulated/floor{
@@ -9597,9 +9533,7 @@
 	name = "Launch Bay #2";
 	p_open = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "ayp" = (
 /obj/machinery/mass_driver{
@@ -9680,9 +9614,7 @@
 /area/centcom/control)
 "ayw" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/control)
 "ayx" = (
 /turf/unsimulated/floor{
@@ -9922,9 +9854,7 @@
 	name = "Launch Bay #1";
 	p_open = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "ayZ" = (
 /obj/machinery/mass_driver{
@@ -10299,9 +10229,7 @@
 	name = "Launch Bay #0";
 	p_open = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "azP" = (
 /obj/machinery/mass_driver{
@@ -11876,9 +11804,7 @@
 /area/centcom/holding)
 "aDb" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/holding)
 "aDc" = (
 /obj/machinery/door/blast/odin{
@@ -11906,9 +11832,7 @@
 	icon_state = "tube1";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/evac)
 "aDf" = (
 /obj/structure/holostool,
@@ -11937,9 +11861,7 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/evac)
 "aDj" = (
 /obj/structure/table/standard,
@@ -12242,14 +12164,10 @@
 	icon_state = "tube1";
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aDU" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aDV" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
@@ -12260,18 +12178,14 @@
 	pixel_y = 25;
 	tag_door = "centcom_shuttle_bay_door"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aDW" = (
 /obj/machinery/computer/shuttle_control{
 	req_access = list(38);
 	shuttle_tag = "Centcom"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aDX" = (
 /obj/structure/bed/chair/unmovable{
@@ -12544,9 +12458,7 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aEL" = (
 /obj/structure/bed/chair/comfy/brown,
@@ -12707,9 +12619,7 @@
 /area/centcom/holding)
 "aFg" = (
 /obj/machinery/light/spot,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aFh" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -14710,23 +14620,17 @@
 	icon_state = "tube1";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aJH" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aJI" = (
 /obj/machinery/light/spot{
 	icon_state = "tube1";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aJJ" = (
 /obj/structure/table/rack,
@@ -16197,9 +16101,7 @@
 	name = "Arrivals Airlock";
 	req_access = list(13)
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aMO" = (
 /obj/structure/window/reinforced/holowindow{
@@ -16295,15 +16197,11 @@
 /area/centcom/spawning)
 "aNb" = (
 /obj/machinery/megavendor,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aNc" = (
 /obj/machinery/light/spot,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aNd" = (
 /turf/simulated/wall/shuttle/raider,
@@ -19362,9 +19260,7 @@
 /obj/effect/landmark{
 	name = "tdome2"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome2)
 "aUe" = (
 /obj/machinery/door/blast/regular{
@@ -19378,9 +19274,7 @@
 /obj/effect/landmark{
 	name = "tdome1"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome1)
 "aUg" = (
 /obj/structure/table/rack,
@@ -19401,9 +19295,7 @@
 /obj/effect/landmark{
 	name = "tdome2"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome2)
 "aUi" = (
 /obj/machinery/recharger{
@@ -19412,9 +19304,7 @@
 /obj/effect/landmark{
 	name = "tdome1"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome1)
 "aUj" = (
 /turf/unsimulated/wall/fakeglass{
@@ -19436,9 +19326,7 @@
 	c_tag = "Thunderdome - Red Team";
 	invisibility = 101
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome2)
 "aUm" = (
 /turf/simulated/floor/bluegrid,
@@ -19458,9 +19346,7 @@
 	c_tag = "Green Team";
 	invisibility = 101
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome1)
 "aUq" = (
 /obj/machinery/atmospherics/pipe/vent,
@@ -21032,9 +20918,7 @@
 	id = "tcfl_hangar5";
 	name = "Garage"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "bfv" = (
 /obj/item/reagent_containers/glass/bucket{
@@ -21110,9 +20994,7 @@
 "blQ" = (
 /obj/machinery/mech_recharger,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "bmq" = (
 /turf/simulated/floor/tiled/ramp/bottom{
@@ -21206,9 +21088,7 @@
 	name = "Thruster Maintenance Hatch";
 	req_access = list(112)
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "bBd" = (
 /turf/unsimulated/floor{
@@ -21325,9 +21205,7 @@
 	icon_state = "burst_l";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "bUI" = (
 /obj/structure/table/rack,
@@ -21487,9 +21365,7 @@
 	pixel_x = -1;
 	pixel_y = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "cpV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21577,9 +21453,7 @@
 	id = "tcfl_hangar5";
 	name = "Armoury"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "cxK" = (
 /obj/structure/window/reinforced{
@@ -21752,9 +21626,7 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "cKC" = (
 /turf/simulated/floor/carpet,
@@ -21803,9 +21675,7 @@
 "cTG" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/broken_bottle,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "cVA" = (
 /obj/machinery/light{
@@ -21887,9 +21757,7 @@
 	dir = 8
 	},
 /obj/structure/grille,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "ddQ" = (
 /obj/effect/floor_decal/corner/blue/full{
@@ -21915,9 +21783,7 @@
 	icon_state = "spline_plain";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "djI" = (
 /obj/machinery/light{
@@ -22056,9 +21922,7 @@
 	pixel_x = 32;
 	pixel_y = -64
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "dHZ" = (
 /obj/structure/table/standard,
@@ -22217,9 +22081,7 @@
 	pixel_x = -4;
 	pixel_y = 3
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "dWO" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -22488,9 +22350,7 @@
 /area/centcom/legion/hangar5)
 "eLM" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "eNF" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -22526,9 +22386,7 @@
 	icon_state = "bulb1";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "eQO" = (
 /obj/structure/table/rack,
@@ -22721,9 +22579,7 @@
 	},
 /obj/machinery/porta_turret/legion,
 /obj/effect/floor_decal/industrial/warning,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "feQ" = (
 /obj/structure/undies_wardrobe,
@@ -23125,9 +22981,7 @@
 	pixel_y = 6
 	},
 /obj/item/weldingtool/hugetank,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "fTE" = (
 /obj/structure/closet/crate/secure/legion,
@@ -23204,18 +23058,14 @@
 	},
 /area/centcom/shared_dream)
 "gid" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "giC" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Aft Thrusters Access - Deck 1";
 	req_access = null
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "gjo" = (
 /obj/effect/floor_decal/corner/yellow/full{
@@ -23309,9 +23159,7 @@
 	icon_state = "propulsion";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "gnj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23325,9 +23173,7 @@
 	pixel_x = -42;
 	pixel_y = -10
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "gpl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23406,9 +23252,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "gvy" = (
 /obj/machinery/chem_master{
@@ -23712,9 +23556,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "gYs" = (
 /obj/machinery/door/airlock/glass_command{
@@ -23768,9 +23610,7 @@
 	pixel_x = -9;
 	pixel_y = 7
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "hhX" = (
 /obj/machinery/light{
@@ -23821,9 +23661,7 @@
 	icon_state = "phoronrwindow";
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "hmr" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -24058,9 +23896,7 @@
 /area/centcom/living)
 "hHP" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "hJC" = (
 /obj/structure/bed/chair/comfy/brown,
@@ -24244,9 +24080,7 @@
 	pixel_x = 1;
 	pixel_y = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "hYP" = (
 /obj/structure/table/rack,
@@ -24485,9 +24319,7 @@
 /obj/effect/decal/cleanable/dirt{
 	layer = 3.3
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "itb" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -24507,9 +24339,7 @@
 /area/centcom/legion/hangar5)
 "izN" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "iAP" = (
 /turf/simulated/floor/snow,
@@ -24922,9 +24752,7 @@
 	dir = 10;
 	icon_state = "spline_plain"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "jnf" = (
 /turf/simulated/wall/shuttle/legion,
@@ -24954,9 +24782,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "jpq" = (
 /obj/effect/floor_decal/industrial/warning/full,
@@ -24964,9 +24790,7 @@
 	name = "service ladder";
 	pixel_y = 24
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "jpz" = (
 /obj/machinery/mech_recharger,
@@ -25088,9 +24912,7 @@
 	icon_state = "phoronrwindow";
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "jBJ" = (
 /obj/machinery/computer/message_monitor,
@@ -25193,9 +25015,7 @@
 	id = "tcfl_jotun";
 	name = "Superheavy Support Garage"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "jKW" = (
 /obj/machinery/light/spot{
@@ -25281,9 +25101,7 @@
 	name = "Elevator Maintenance Hatch";
 	req_access = list(111)
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "jXZ" = (
 /turf/simulated/floor/tiled/dark,
@@ -25415,9 +25233,7 @@
 	id = "tcfl_hangar5";
 	name = "Armoury"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "ktR" = (
 /turf/unsimulated/floor{
@@ -25477,9 +25293,7 @@
 	icon_state = "rwindow";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "kCZ" = (
 /obj/structure/table/standard,
@@ -25582,9 +25396,7 @@
 	name = "Garage"
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "kLE" = (
 /obj/structure/window/reinforced{
@@ -25601,9 +25413,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "kNH" = (
 /turf/simulated/wall/elevator,
@@ -25696,9 +25506,7 @@
 	id = "tcflcheckpoint";
 	name = "Security Checkpoint"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "kWI" = (
 /obj/machinery/light/small{
@@ -25895,9 +25703,7 @@
 /area/centcom/checkpoint/aft)
 "lBN" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "lEG" = (
 /obj/structure/lattice,
@@ -25970,9 +25776,7 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "lKB" = (
 /obj/structure/table/reinforced/steel,
@@ -26085,9 +25889,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "lXq" = (
 /obj/machinery/porta_turret/crescent,
@@ -26216,9 +26018,7 @@
 	pixel_x = -1;
 	pixel_y = -12
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "mnk" = (
 /obj/machinery/light{
@@ -26333,9 +26133,7 @@
 	id = "tcfl_hangar5";
 	name = "Armoury"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "mxY" = (
 /obj/structure/bed/roller,
@@ -26369,9 +26167,7 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = -28
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "mzf" = (
 /turf/unsimulated/floor{
@@ -26442,9 +26238,7 @@
 	pixel_x = -9;
 	pixel_y = 30
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "mMA" = (
 /obj/structure/flora/tree/jungle,
@@ -26473,9 +26267,7 @@
 	id = "tcfl_hangar5";
 	name = "Armoury"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "mQj" = (
 /turf/unsimulated/floor{
@@ -26690,9 +26482,7 @@
 	icon_state = "warning";
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "nkd" = (
 /obj/machinery/account_database{
@@ -26867,9 +26657,7 @@
 	pixel_x = 16;
 	pixel_y = 32
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "nzS" = (
 /turf/simulated/floor/shuttle/red,
@@ -27036,9 +26824,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "nIY" = (
 /turf/simulated/floor/beach/sand{
@@ -27167,9 +26953,7 @@
 	icon_state = "warning";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "nTN" = (
 /turf/simulated/floor/beach/sand{
@@ -27203,9 +26987,7 @@
 	icon_state = "spline_plain";
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "nXL" = (
 /obj/item/reagent_containers/food/snacks/liquidfood{
@@ -27487,9 +27269,7 @@
 /area/merchant_station)
 "orV" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "otY" = (
 /turf/unsimulated/floor{
@@ -27573,9 +27353,7 @@
 	pixel_y = -4
 	},
 /obj/item/stack/rods,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "ozQ" = (
 /obj/structure/closet/crate/loot{
@@ -27771,9 +27549,7 @@
 	pixel_x = 1;
 	pixel_y = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "oQu" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
@@ -27844,9 +27620,7 @@
 	icon_state = "bulb1";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "oWD" = (
 /obj/machinery/door/airlock/hatch{
@@ -28046,9 +27820,7 @@
 "prH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "ptA" = (
 /turf/simulated/floor/ice,
@@ -28059,9 +27831,7 @@
 	name = "service ladder";
 	pixel_y = 24
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "pBa" = (
 /obj/effect/floor_decal/corner/blue{
@@ -28113,9 +27883,7 @@
 	icon_state = "phoronrwindow";
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "pEJ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -28213,9 +27981,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "pTm" = (
 /obj/structure/window/reinforced{
@@ -28229,9 +27995,7 @@
 	dir = 8
 	},
 /obj/structure/grille,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "pUN" = (
 /obj/structure/bed/chair/office/dark{
@@ -28271,9 +28035,7 @@
 	},
 /area/centcom/legion/hangar5)
 "pWv" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "pWD" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -28313,9 +28075,7 @@
 /area/shuttle/distress/centcom)
 "qgw" = (
 /obj/structure/lattice/catwalk/indoor,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/template_noop)
 "qjm" = (
 /obj/item/gun/energy/blaster{
@@ -29043,9 +28803,7 @@
 	name = "Arrivals Airlock";
 	req_access = list(13)
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/evac)
 "rlP" = (
 /obj/machinery/vending/assist{
@@ -29105,9 +28863,7 @@
 /area/shuttle/legion/centcom)
 "rug" = (
 /obj/effect/decal/cleanable/blood/drip,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "rwg" = (
 /turf/unsimulated/floor{
@@ -29321,9 +29077,7 @@
 	id = "tcflcheckpoint";
 	name = "Security Checkpoint"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "rUc" = (
 /obj/machinery/door/airlock/glass_command{
@@ -29413,9 +29167,7 @@
 	icon_state = "warning";
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "sdL" = (
 /obj/item/airbubble,
@@ -29519,9 +29271,7 @@
 	name = "KEEP CLEAR: DOCKING AREA";
 	pixel_y = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "smH" = (
 /obj/structure/window/reinforced{
@@ -29540,9 +29290,7 @@
 	id = "tcflcheckpoint";
 	name = "Security Checkpoint"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "smI" = (
 /obj/machinery/light{
@@ -29988,9 +29736,7 @@
 	pixel_x = 1;
 	pixel_y = 3
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "tgf" = (
 /obj/structure/flora/rock/pile{
@@ -30228,9 +29974,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/distress_prep)
 "tFU" = (
 /obj/machinery/door/airlock/centcom{
@@ -30514,9 +30258,7 @@
 	icon_state = "burst_r";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "ubz" = (
 /obj/machinery/door/airlock/centcom{
@@ -30580,9 +30322,7 @@
 	pixel_x = 0;
 	pixel_y = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "usy" = (
 /obj/effect/landmark{
@@ -30803,9 +30543,7 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "uVX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -30815,9 +30553,7 @@
 "uWY" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "uXC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30886,9 +30622,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "vdM" = (
 /obj/machinery/light{
@@ -31034,9 +30768,7 @@
 /obj/item/ladder_mobile{
 	pixel_y = 6
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "vre" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -31049,9 +30781,7 @@
 "vsg" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/heavy_vehicle/premade/light/legion,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "vwU" = (
 /obj/structure/table/wood,
@@ -31127,9 +30857,7 @@
 	id = "tcfl_jotun";
 	name = "Superheavy Support Garage"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "vDz" = (
 /obj/structure/table/rack,
@@ -31551,9 +31279,7 @@
 	},
 /area/centcom/legion)
 "wne" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/evac)
 "wnD" = (
 /obj/effect/floor_decal/corner/blue{
@@ -31690,9 +31416,7 @@
 /area/shuttle/distress/transit)
 "wyM" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "wyR" = (
 /obj/structure/table/rack{
@@ -31768,9 +31492,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "wGd" = (
 /obj/machinery/light{
@@ -31869,9 +31591,7 @@
 	icon_state = "cart";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "wUH" = (
 /obj/effect/decal/fake_object{
@@ -31884,9 +31604,7 @@
 	pixel_x = 1;
 	pixel_y = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "wVd" = (
 /turf/simulated/floor/shuttle/red,
@@ -31953,9 +31671,7 @@
 /area/centcom/legion/hangar5)
 "xbU" = (
 /obj/structure/closet/crate/secure/legion,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "xcq" = (
 /obj/structure/table/wood,
@@ -32058,9 +31774,7 @@
 "xia" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/heavy_vehicle/premade/combatripley,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "xii" = (
 /turf/unsimulated/wall/fakepdoor,
@@ -32306,9 +32020,7 @@
 	icon_state = "warning";
 	dir = 5
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "xEw" = (
 /obj/item/device/flashlight/lamp,
@@ -32347,9 +32059,7 @@
 "xFQ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion)
 "xFV" = (
 /obj/structure/table/wood,
@@ -32387,9 +32097,7 @@
 	name = "Garage"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
 "xMg" = (
 /obj/structure/table/rack,

--- a/maps/exodus/exodus-2_centcomm.dmm
+++ b/maps/exodus/exodus-2_centcomm.dmm
@@ -8336,9 +8336,7 @@
 	id_tag = "admin_shuttle_bay_door";
 	locked = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom)
 "ayv" = (
 /turf/unsimulated/floor{
@@ -9016,9 +9014,7 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom)
 "aAC" = (
 /obj/machinery/telecomms/receiver/preset_cent,
@@ -10420,9 +10416,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_r"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "aFv" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -11040,9 +11034,7 @@
 /turf/simulated/floor/plating,
 /area/skipjack_station/start)
 "aHr" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aHu" = (
 /obj/structure/shuttle/engine/heater,
@@ -11170,9 +11162,7 @@
 	pixel_y = 25;
 	tag_door = "centcom_shuttle_bay_door"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aHQ" = (
 /obj/structure/sink{
@@ -11299,9 +11289,7 @@
 /area/centcom/holding)
 "aIi" = (
 /obj/machinery/light,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aIk" = (
 /obj/structure/sign/securearea{
@@ -12402,9 +12390,7 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aLA" = (
 /obj/structure/table/standard,
@@ -12888,9 +12874,7 @@
 /area/centcom/control)
 "aMH" = (
 /obj/machinery/light/spot,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/suppy)
 "aMI" = (
 /obj/structure/sign/directions/medical{
@@ -12956,9 +12940,7 @@
 /area/merchant_station)
 "aMO" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/living)
 "aMP" = (
 /obj/machinery/vending/wallmed1{
@@ -13118,9 +13100,7 @@
 	name = "Arrivals Airlock";
 	req_access = list(13)
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aNg" = (
 /obj/machinery/door/airlock/centcom{
@@ -13161,9 +13141,7 @@
 	icon_state = "tube1";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aNk" = (
 /obj/structure/banner,
@@ -13221,9 +13199,7 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aNt" = (
 /obj/machinery/light{
@@ -13287,9 +13263,7 @@
 	pixel_y = 0;
 	tag_door = "admin_shuttle_bay_door"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom)
 "aNB" = (
 /obj/machinery/autolathe{
@@ -13898,9 +13872,7 @@
 	icon_state = "tube1";
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aOT" = (
 /turf/unsimulated/floor{
@@ -14164,9 +14136,7 @@
 	},
 /area/centcom/control)
 "aPx" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom)
 "aPy" = (
 /obj/machinery/light{
@@ -14293,9 +14263,7 @@
 /obj/effect/landmark{
 	name = "Marauder Exit"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "aPM" = (
 /turf/unsimulated/floor{
@@ -14345,9 +14313,7 @@
 /area/centcom/spawning)
 "aPT" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/holding)
 "aPU" = (
 /obj/machinery/computer/rdservercontrol{
@@ -14595,9 +14561,7 @@
 /turf/simulated/floor/tiled,
 /area/merchant_station)
 "aQw" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "aQx" = (
 /obj/structure/table/wood,
@@ -14647,14 +14611,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aQC" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/holding)
 "aQD" = (
 /turf/simulated/wall/shuttle/dark/corner/underlay{
@@ -14899,9 +14859,7 @@
 /turf/simulated/floor/plating,
 /area/supply/dock)
 "aRf" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aRg" = (
 /obj/machinery/telecomms/bus/preset_cent,
@@ -15044,9 +15002,7 @@
 	icon_state = "tube1";
 	pixel_x = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom)
 "aRx" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -15100,9 +15056,7 @@
 	req_access = list(101);
 	shuttle_tag = "Centcom"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "aRF" = (
 /turf/unsimulated/floor{
@@ -15118,9 +15072,7 @@
 /area/centcom/spawning)
 "aRH" = (
 /obj/machinery/light/spot,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aRI" = (
 /obj/structure/bed/chair{
@@ -15275,9 +15227,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aRX" = (
 /obj/structure/window/reinforced{
@@ -15461,9 +15411,7 @@
 	},
 /area/centcom/living)
 "aSs" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/suppy)
 "aSt" = (
 /obj/structure/bed/chair/comfy/blue{
@@ -15784,9 +15732,7 @@
 	name = "Launch Bay #1";
 	p_open = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "aTe" = (
 /obj/structure/closet/emcloset,
@@ -15869,9 +15815,7 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom)
 "aTl" = (
 /obj/machinery/door/airlock/glass_medical{
@@ -15918,9 +15862,7 @@
 	name = "Launch Bay #0";
 	p_open = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "aTq" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -16474,9 +16416,7 @@
 	icon_state = "tube1";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/suppy)
 "aUC" = (
 /obj/machinery/telecomms/server/presets/centcomm,
@@ -16513,9 +16453,7 @@
 /area/merchant_ship/start)
 "aUH" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aUI" = (
 /obj/structure/holostool,
@@ -16837,18 +16775,14 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aVt" = (
 /obj/machinery/light/spot{
 	icon_state = "tube1";
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/suppy)
 "aVu" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -17281,9 +17215,7 @@
 	icon_state = "tube1";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/holding)
 "aWm" = (
 /obj/machinery/porta_turret,
@@ -17604,9 +17536,7 @@
 	name = "Launch Bay #3";
 	p_open = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "aWV" = (
 /obj/item/modular_computer/console/preset/command,
@@ -17708,9 +17638,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "aXj" = (
 /turf/unsimulated/floor{
@@ -17774,9 +17702,7 @@
 /area/centcom/living)
 "aXs" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "aXt" = (
 /obj/machinery/door/airlock/glass_security{
@@ -17826,9 +17752,7 @@
 	name = "Launch Bay #2";
 	p_open = 0
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/specops)
 "aXA" = (
 /turf/unsimulated/floor{
@@ -17931,9 +17855,7 @@
 /area/centcom/spawning)
 "aXP" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/control)
 "aXQ" = (
 /obj/structure/artilleryplaceholder{
@@ -18739,9 +18661,7 @@
 	icon_state = "heater";
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "aZG" = (
 /turf/unsimulated/floor{
@@ -19547,9 +19467,7 @@
 /obj/effect/landmark{
 	name = "tdome1"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome)
 "eqT" = (
 /obj/machinery/light{
@@ -20366,9 +20284,7 @@
 "hnE" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
 /obj/machinery/status_display/arrivals_display,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/spawning)
 "hnK" = (
 /obj/structure/window/reinforced{
@@ -21063,9 +20979,7 @@
 /obj/effect/landmark{
 	name = "tdome2"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome2)
 "kGz" = (
 /turf/unsimulated/floor{
@@ -21184,9 +21098,7 @@
 /obj/effect/landmark{
 	name = "tdome2"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome)
 "ljh" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -21360,9 +21272,7 @@
 /area/centcom/spawning)
 "mrs" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "mrD" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
@@ -21405,9 +21315,7 @@
 	c_tag = "Thunderdome - Red Team";
 	invisibility = 101
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome2)
 "mIn" = (
 /obj/structure/table/rack,
@@ -21909,9 +21817,7 @@
 /obj/effect/landmark{
 	name = "tdome2"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome2)
 "pyq" = (
 /obj/structure/shuttle/engine/heater,
@@ -21923,9 +21829,7 @@
 	icon_state = "rwindow";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "pCY" = (
 /turf/unsimulated/floor{
@@ -22118,9 +22022,7 @@
 	c_tag = "Green Team";
 	invisibility = 101
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome1)
 "qpo" = (
 /obj/structure/cryofeed{
@@ -22472,9 +22374,7 @@
 	},
 /area/tdome/tdomeobserve)
 "rRd" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/space)
 "rZL" = (
 /obj/machinery/computer/cryopod{
@@ -22528,9 +22428,7 @@
 /obj/effect/landmark{
 	name = "tdome1"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome1)
 "shc" = (
 /turf/unsimulated/wall/fakeglass{
@@ -22625,15 +22523,11 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_l"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "sSH" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "sWB" = (
 /obj/machinery/shieldwallgen,
@@ -22665,9 +22559,7 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/space)
 "tcD" = (
 /obj/item/modular_computer/console/preset/security,
@@ -23088,9 +22980,7 @@
 	name = "Arrivals Airlock";
 	req_access = list(13)
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/holding)
 "uPK" = (
 /obj/structure/flora/pottedplant/random{
@@ -23179,9 +23069,7 @@
 	icon_state = "rwindow";
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "vaK" = (
 /obj/machinery/light/small{
@@ -23236,9 +23124,7 @@
 /obj/effect/landmark{
 	name = "tdome1"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome/tdome1)
 "vqF" = (
 /obj/structure/table/standard,
@@ -23488,9 +23374,7 @@
 /obj/effect/landmark{
 	name = "tdome1"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome)
 "wMr" = (
 /turf/unsimulated/wall/riveted,
@@ -23546,9 +23430,7 @@
 /area/centcom/spawning)
 "xaM" = (
 /obj/effect/wingrille_spawn/reinforced/crescent,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome)
 "xcE" = (
 /obj/machinery/door/airlock/centcom{
@@ -23715,9 +23597,7 @@
 /obj/effect/landmark{
 	name = "tdome2"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/tdome)
 "xNc" = (
 /obj/structure/window/reinforced{


### PR DESCRIPTION
Title
Added an unsimulated plating floortype to prevent this from happening again.