### PR TITLE
Fixes cultify behaviour with asteroid turfs

### DIFF
--- a/code/game/gamemodes/cult/cultify/turf.dm
+++ b/code/game/gamemodes/cult/cultify/turf.dm
@@ -30,6 +30,12 @@
 /turf/unsimulated/wall/cultify()
 	cultify_wall()
 
+/turf/unsimulated/floor/asteroid/cultify()
+	return
+
+/turf/simulated/mineral/cultify()
+	return
+
 /turf/proc/cultify_floor()
 	if((icon_state != "cult")&&(icon_state != "cult-narsie"))
 		icon = 'icons/turf/flooring/cult.dmi'

--- a/html/changelogs/Ferner-200304-bugfix_cultifyasteroid.yml
+++ b/html/changelogs/Ferner-200304-bugfix_cultifyasteroid.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Fixed cultify behaving oddly with the asteroid."


### PR DESCRIPTION
Title
Nar'sie was summoned on z-level 5 and started creating holes in the station ceiling leading to a lot of lag on a recent round.