### PR TITLE
Changes loyalty implants to mind shields

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -361,7 +361,7 @@
 
 		switch(href_list["implant"])
 			if("remove")
-				for(var/obj/item/implant/loyalty/I in H.contents)
+				for(var/obj/item/implant/mindshield/I in H.contents)
 					for(var/obj/item/organ/external/organs in H.organs)
 						if(I in organs.implants)
 							qdel(I)

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -187,7 +187,7 @@
 	)
 
 	implants = list(
-		/obj/item/implant/loyalty
+		/obj/item/implant/mindshield
 	)
 
 /datum/outfit/admin/nt/protection_detail/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -229,7 +229,7 @@
 	)
 
 	implants = list(
-		/obj/item/implant/loyalty
+		/obj/item/implant/mindshield
 	)
 
 /datum/outfit/admin/nt/tcfl_legate
@@ -301,7 +301,7 @@
 	)
 
 	implants = list(
-		/obj/item/implant/loyalty
+		/obj/item/implant/mindshield
 	)
 
 /datum/outfit/admin/nt/odinsec/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -330,7 +330,7 @@
 	r_pocket = /obj/item/flame/lighter/zippo
 
 	implants = list(
-		/obj/item/implant/loyalty
+		/obj/item/implant/mindshield
 	)
 
 	id_access = "Death Commando"

--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -3,7 +3,7 @@
 	set category = "Abilities"
 	if(!M.mind)
 		return
-	for (var/obj/item/implant/loyalty/I in M)
+	for (var/obj/item/implant/mindshield/I in M)
 		if (I.implanted)
 			to_chat(src, "<span class='warning'>[M] is too loyal to the company!</span>")
 			return

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -102,7 +102,7 @@ var/datum/antagonist/cultist/cult
 /datum/antagonist/cultist/can_become_antag(var/datum/mind/player, ignore_role = 1)
 	if(!..())
 		return FALSE
-	for(var/obj/item/implant/loyalty/L in player.current)
+	for(var/obj/item/implant/mindshield/L in player.current)
 		if(L?.imp_in == player.current)
 			return FALSE
 	return TRUE

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -51,7 +51,7 @@ var/datum/antagonist/revolutionary/revs
 /datum/antagonist/revolutionary/can_become_antag(var/datum/mind/player)
 	if(!..())
 		return FALSE
-	for(var/obj/item/implant/loyalty/L in player.current)
+	for(var/obj/item/implant/mindshield/L in player.current)
 		if(L?.imp_in == player.current)
 			return FALSE
 	return TRUE

--- a/code/game/gamemodes/cult/runes/conversion.dm
+++ b/code/game/gamemodes/cult/runes/conversion.dm
@@ -67,7 +67,7 @@
 				to_chat(target, span("cult", "Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind, something sinister takes root."))
 				to_chat(target, span("cult", "And you were able to force it out of your mind. Though the memory of that dark, horrible vision will surely haunt you for decades to come."))
 				var/has_implant // we don't want people with loy implants to just get gibbed
-				for(var/obj/item/implant/loyalty/L in target)
+				for(var/obj/item/implant/mindshield/L in target)
 					if(L?.imp_in == target)
 						has_implant = TRUE
 				if(!has_implant)

--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -91,7 +91,7 @@
 			to_chat(src, "<span class='warning'>\The [T]'s mind is too strong to be affected by our powers!</span>")
 		return FALSE
 	if (account_loyalty_implant)
-		for (var/obj/item/implant/loyalty/I in T)
+		for (var/obj/item/implant/mindshield/I in T)
 			if (I.implanted)
 				if (notify)
 					to_chat(src, "<span class='warning'>You feel that [T]'s mind is unreachable due to forced loyalty.</span>")

--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -94,7 +94,7 @@
 		for (var/obj/item/implant/mindshield/I in T)
 			if (I.implanted)
 				if (notify)
-					to_chat(src, "<span class='warning'>You feel that [T]'s mind is unreachable due to forced loyalty.</span>")
+					to_chat(src, "<span class='warning'>You feel that [T]'s mind is protected from our powers.</span>")
 				return FALSE
 
 	return TRUE

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -40,7 +40,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	)
 
 	implants = list(
-		/obj/item/implant/loyalty
+		/obj/item/implant/mindshield
 	)
 
 	backpack = /obj/item/storage/backpack/captain

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -46,7 +46,7 @@
 	)
 
 	implants = list(
-		/obj/item/implant/loyalty
+		/obj/item/implant/mindshield
 	)
 
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -44,7 +44,7 @@
 	)
 
 	implants = list(
-		/obj/item/implant/loyalty
+		/obj/item/implant/mindshield
 	)
 
 	backpack = /obj/item/storage/backpack/security

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -239,7 +239,7 @@
 
 /obj/machinery/body_scanconsole
 	var/obj/machinery/bodyscanner/connected
-	var/known_implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/loyalty, /obj/item/implant/tracking)
+	var/known_implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/mindshield, /obj/item/implant/tracking)
 	var/collapse_desc = ""
 	var/broken_desc = ""
 	name = "Body Scanner Console"

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -351,32 +351,20 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		malfunction--
 
 /obj/item/implant/loyalty
-	name = "loyalty implant"
-	desc = "Makes you loyal or such."
+	name = "mind shield implant"
+	desc = "A controversial and debatably unethical neurostimulator and autohypnosis device. When implanted against the amygdala, it ensures the host maintains a consistent personality, preventing outside interference through brainwashing or hypnotic suggestion."
 
 /obj/item/implant/loyalty/get_data()
 	. = {"
 <b>Implant Specifications:</b><BR>
 <b>Name:</b> [current_map.company_name] Employee Management Implant<BR>
 <b>Life:</b> Ten years.<BR>
-<b>Important Notes:</b> Personnel injected with this device tend to be much more loyal to the company.<BR>
+<b>Important Notes:</b> Personnel injected with this device tend to be much more resistant to brain washing and other external influences.<BR>
 <HR>
 <b>Implant Details:</b><BR>
 <b>Function:</b> Contains a small pod of nanobots that manipulate the host's mental functions.<BR>
 <b>Special Features:</b> Will prevent and cure most forms of brainwashing.<BR>
 <b>Integrity:</b> Implant will last so long as the nanobots are inside the bloodstream."}
-
-/obj/item/implant/loyalty/implanted(mob/M)
-	if(!istype(M, /mob/living/carbon/human))	return 0
-	var/mob/living/carbon/human/H = M
-	var/datum/antagonist/antag_data = get_antag_data(H.mind.special_role)
-	if(antag_data && (antag_data.flags & ANTAG_IMPLANT_IMMUNE))
-		H.visible_message("[H] seems to resist the implant!", "You feel the corporate tendrils of [current_map.company_name] try to invade your mind!")
-		return 0
-	else
-		clear_antag_roles(H.mind, 1)
-		to_chat(H, "<span class='notice'>You feel a surge of loyalty towards [current_map.company_name].</span>")
-	return 1
 
 /obj/item/implant/loyalty/emp_act(severity)
 	if (malfunction)
@@ -394,11 +382,10 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		malfunction--
 
 /obj/item/implant/loyalty/ipc
-	name = "loyalty chip"
-	desc = "A device that sets directives programmed for loyalty to NanoTrasen on the synthetic subject. Will not work on organics."
+	name = "software protection chip"
+	desc = "A dedicated processor core designed to identify and terminate malignant software, ensuring a synthetics protection from outside hacking."
 
 /obj/item/implant/loyalty/ipc/implanted(mob/M)
-
 	if (!isipc(M))
 		return
 

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -350,11 +350,11 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	spawn(20)
 		malfunction--
 
-/obj/item/implant/loyalty
+/obj/item/implant/mindshield
 	name = "mind shield implant"
 	desc = "A controversial and debatably unethical neurostimulator and autohypnosis device. When implanted against the amygdala, it ensures the host maintains a consistent personality, preventing outside interference through brainwashing or hypnotic suggestion."
 
-/obj/item/implant/loyalty/get_data()
+/obj/item/implant/mindshield/get_data()
 	. = {"
 <b>Implant Specifications:</b><BR>
 <b>Name:</b> [current_map.company_name] Employee Management Implant<BR>
@@ -366,7 +366,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 <b>Special Features:</b> Will prevent and cure most forms of brainwashing.<BR>
 <b>Integrity:</b> Implant will last so long as the nanobots are inside the bloodstream."}
 
-/obj/item/implant/loyalty/emp_act(severity)
+/obj/item/implant/mindshield/emp_act(severity)
 	if (malfunction)
 		return
 	malfunction = MALFUNCTION_TEMPORARY
@@ -381,21 +381,21 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	spawn(20)
 		malfunction--
 
-/obj/item/implant/loyalty/ipc
+/obj/item/implant/mindshield/ipc
 	name = "software protection chip"
 	desc = "A dedicated processor core designed to identify and terminate malignant software, ensuring a synthetics protection from outside hacking."
 
-/obj/item/implant/loyalty/ipc/implanted(mob/M)
+/obj/item/implant/mindshield/ipc/implanted(mob/M)
 	if (!isipc(M))
 		return
 
 	..()
 
-/obj/item/implant/loyalty/sol
+/obj/item/implant/mindshield/sol
 	name = "loyalty implant"
 	desc = "Makes you loyal to the Sol Alliance, or to a certain individual."
 
-/obj/item/implant/loyalty/sol/implanted(mob/M)
+/obj/item/implant/mindshield/sol/implanted(mob/M)
 	if(!istype(M, /mob/living/carbon/human))	return 0
 	var/mob/living/carbon/human/H = M
 	var/datum/antagonist/antag_data = get_antag_data(H.mind.special_role)
@@ -581,7 +581,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 
 	var/mob/living/carbon/human/H = M
 
-	for(var/obj/item/implant/loyalty/I in H)
+	for(var/obj/item/implant/mindshield/I in H)
 		if(I.implanted)
 			to_chat(H, span("danger", "Rage surges through your body, but the nanobots from your loyalty implant stop it soon after it starts!"))
 			return TRUE

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -583,7 +583,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 
 	for(var/obj/item/implant/mindshield/I in H)
 		if(I.implanted)
-			to_chat(H, span("danger", "Rage surges through your body, but the nanobots from your loyalty implant stop it soon after it starts!"))
+			to_chat(H, span("danger", "Rage surges through your body, but the nanobots from your mind shield implant stop it soon after it starts!"))
 			return TRUE
 
 	var/datum/antagonist/antag_data = get_antag_data(H.mind.special_role)

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -96,8 +96,8 @@
 
 
 /obj/item/implantcase/loyalty
-	name = "glass case - 'loyalty'"
-	desc = "A case containing a loyalty implant."
+	name = "glass case - 'mind shield'"
+	desc = "A case containing a mind shield implant."
 	icon_state = "implantcase-r"
 
 /obj/item/implantcase/loyalty/New()

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -101,7 +101,7 @@
 	icon_state = "implantcase-r"
 
 /obj/item/implantcase/loyalty/New()
-	src.imp = new /obj/item/implant/loyalty( src )
+	src.imp = new /obj/item/implant/mindshield( src )
 	..()
 	return
 

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -66,7 +66,7 @@
 	name = "implanter-loyalty"
 
 /obj/item/implanter/loyalty/New()
-	src.imp = new /obj/item/implant/loyalty( src )
+	src.imp = new /obj/item/implant/mindshield( src )
 	..()
 	update()
 	return

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -265,7 +265,7 @@
 
 /obj/item/storage/box/loyaltypins
 	name = "box of firing pins"
-	desc = "A box of specialised \"loyalty\" authentication pins produced by Nanotrasen; these check to see if the user of the gun it's installed in has been implanted with a loyalty implant. Often used in ERTs."
+	desc = "A box of specialised \"loyalty\" authentication pins produced by Nanotrasen; these check to see if the user of the gun it's installed in has been implanted with a mind shield implant. Often used in ERTs."
 	starts_with = list(/obj/item/device/firing_pin/implant/loyalty = 7)
 
 /obj/item/storage/box/loyaltypins/fill()

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -72,7 +72,7 @@
 		return 1
 
 /obj/item/storage/lockbox/loyalty
-	name = "lockbox of loyalty implants"
+	name = "lockbox of mind shield implants"
 	req_access = list(access_security)
 	starts_with = list(
 		/obj/item/implantcase/loyalty = 3,

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -293,11 +293,11 @@
 /mob/living/carbon/human/proc/implant_loyalty(mob/living/carbon/human/M, override = FALSE) // Won't override by default.
 	if(!config.use_loyalty_implants && !override) return // Nuh-uh.
 
-	var/obj/item/implant/loyalty/L
+	var/obj/item/implant/mindshield/L
 	if(isipc(M))
-		L = new/obj/item/implant/loyalty/ipc(M)
+		L = new/obj/item/implant/mindshield/ipc(M)
 	else
-		L = new/obj/item/implant/loyalty(M)
+		L = new/obj/item/implant/mindshield(M)
 	L.imp_in = M
 	L.implanted = 1
 	var/obj/item/organ/external/affected = M.organs_by_name[BP_HEAD]
@@ -307,7 +307,7 @@
 
 /mob/living/carbon/human/proc/is_loyalty_implanted(mob/living/carbon/human/M)
 	for(var/L in M.contents)
-		if(istype(L, /obj/item/implant/loyalty))
+		if(istype(L, /obj/item/implant/mindshield))
 			for(var/obj/item/organ/external/O in M.organs)
 				if(L in O.implants)
 					return 1

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1120,7 +1120,7 @@
 		custom_pain("[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!", 40, nohalloss = TRUE)
 
 	if (shock_stage >= 60)
-		if(shock_stage == 60) 
+		if(shock_stage == 60)
 			visible_message("[src]'s body becomes limp.", "Your body becomes limp.")
 		if (prob(2))
 			custom_pain("[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!", shock_stage, nohalloss = TRUE)
@@ -1252,7 +1252,7 @@
 			if(I.implanted)
 				if(istype(I,/obj/item/implant/tracking))
 					holder1.icon_state = "hud_imp_tracking"
-				if(istype(I,/obj/item/implant/loyalty))
+				if(istype(I,/obj/item/implant/mindshield))
 					holder2.icon_state = "hud_imp_loyal"
 				if(istype(I,/obj/item/implant/chem))
 					holder3.icon_state = "hud_imp_chem"

--- a/code/modules/mob/living/parasite/meme.dm
+++ b/code/modules/mob/living/parasite/meme.dm
@@ -490,7 +490,7 @@ var/controlling
 
 	if(!host) return
 
-	for (var/obj/item/implant/loyalty/I in host)
+	for (var/obj/item/implant/mindshield/I in host)
 		if (I.implanted)
 			to_chat(src, "<span class='warning'>Your host's mind is shielded!</span>")
 			return
@@ -543,7 +543,7 @@ var/controlling
 		to_chat(src, "<span class='warning'>You cannot do that in your current state.</span>")
 		return
 
-	for (var/obj/item/implant/loyalty/I in host)
+	for (var/obj/item/implant/mindshield/I in host)
 		if (I.implanted)
 			to_chat(src, "<span class='warning'>Your host's mind is shielded!</span>")
 			return

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -250,7 +250,7 @@
 		to_chat(src, span("warning", "You cannot infest someone who is already infested!"))
 		return
 
-	for (var/obj/item/implant/loyalty/I in M)
+	for (var/obj/item/implant/mindshield/I in M)
 		if (I.implanted)
 			to_chat(src, span("warning", "\The [host]'s mind is shielded against your powers."))
 			return
@@ -273,7 +273,7 @@
 		to_chat(src, span("notice", "You cannot do that in your current state."))
 		return
 
-	for (var/obj/item/implant/loyalty/I in host)
+	for (var/obj/item/implant/mindshield/I in host)
 		if (I.implanted)
 			to_chat(src, span("warning", "\The [host]'s mind is shielded against your powers."))
 			return
@@ -429,7 +429,7 @@
 		to_chat(src, span("warning", "You don't have enough chemicals!"))
 		return
 
-	for (var/obj/item/implant/loyalty/I in host)
+	for (var/obj/item/implant/mindshield/I in host)
 		if (I.implanted)
 			to_chat(src, span("warning", "\The [host]'s mind is shielded against your powers."))
 			return
@@ -461,7 +461,7 @@
 		to_chat(src, span("warning", "You don't have enough chemicals!"))
 		return
 
-	for (var/obj/item/implant/loyalty/I in host)
+	for (var/obj/item/implant/mindshield/I in host)
 		if (I.implanted)
 			to_chat(src, span("warning", "\The [host]'s mind is shielded against your powers."))
 			return

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -250,6 +250,11 @@
 		to_chat(src, span("warning", "You cannot infest someone who is already infested!"))
 		return
 
+	for (var/obj/item/implant/loyalty/I in M)
+		if (I.implanted)
+			to_chat(src, span("warning", "\The [host]'s mind is shielded against your powers."))
+			return
+
 	to_chat(src, span("warning", "You focus your psionic lance on [M] and freeze their limbs with a wave of terrible dread."))
 	to_chat(M, span("warning", "You feel a creeping, horrible sense of dread come over you, freezing your limbs and setting your heart racing."))
 	M.Weaken(10)
@@ -267,6 +272,11 @@
 	if(src.stat)
 		to_chat(src, span("notice", "You cannot do that in your current state."))
 		return
+
+	for (var/obj/item/implant/loyalty/I in host)
+		if (I.implanted)
+			to_chat(src, span("warning", "\The [host]'s mind is shielded against your powers."))
+			return
 
 	to_chat(src, span("warning", "You begin delicately adjusting your connection to the host brain..."))
 	to_chat(host, span("warning", "You feel a tingling sensation at the back of your head."))
@@ -419,6 +429,11 @@
 		to_chat(src, span("warning", "You don't have enough chemicals!"))
 		return
 
+	for (var/obj/item/implant/loyalty/I in host)
+		if (I.implanted)
+			to_chat(src, span("warning", "\The [host]'s mind is shielded against your powers."))
+			return
+
 	chemicals -= 150
 	to_chat(src, span("notice", "You probe your tendrils deep within your host's zona bovinae, seeking to unleash their potential."))
 	to_chat(host, span("danger", "You feel some tendrils probe at the back of your head..."))
@@ -445,6 +460,11 @@
 	if(chemicals < 75)
 		to_chat(src, span("warning", "You don't have enough chemicals!"))
 		return
+
+	for (var/obj/item/implant/loyalty/I in host)
+		if (I.implanted)
+			to_chat(src, span("warning", "\The [host]'s mind is shielded against your powers."))
+			return
 
 	var/list/faculties = list(capitalize(PSI_COERCION), capitalize(PSI_REDACTION), capitalize(PSI_ENERGISTICS), capitalize(PSI_PSYCHOKINESIS))
 	var/selected_faculty = input(src, "Choose a faculty to upgrade.") as null|anything in faculties

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -768,7 +768,7 @@
 				to_chat(H, "<span class='danger'>The APC power currents surge eratically, damaging your chassis!</span>")
 				H.adjustFireLoss(10, 0)
 			if(infected)
-				for (var/obj/item/implant/loyalty/ipc/I in H)
+				for (var/obj/item/implant/mindshield/ipc/I in H)
 					if (I.implanted)
 						return
 				if(SOFTREF(H) in hacked_ipcs)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -768,6 +768,9 @@
 				to_chat(H, "<span class='danger'>The APC power currents surge eratically, damaging your chassis!</span>")
 				H.adjustFireLoss(10, 0)
 			if(infected)
+				for (var/obj/item/implant/loyalty/ipc/I in H)
+					if (I.implanted)
+						return
 				if(SOFTREF(H) in hacked_ipcs)
 					return
 				LAZYADD(hacked_ipcs, SOFTREF(H))

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -118,8 +118,8 @@ Pins Below.
 		return 0
 
 /obj/item/device/firing_pin/implant/loyalty
-	name = "loyalty firing pin"
-	desc = "This implant-locked firing pin authorizes the weapon for only loyalty-implanted users."
+	name = "mind shield firing pin"
+	desc = "This implant-locked firing pin authorizes the weapon for only mind shielded users."
 	icon_state = "firing_pin_loyalty"
 	req_implant = /obj/item/implant/loyalty
 

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -121,7 +121,7 @@ Pins Below.
 	name = "mind shield firing pin"
 	desc = "This implant-locked firing pin authorizes the weapon for only mind shielded users."
 	icon_state = "firing_pin_loyalty"
-	req_implant = /obj/item/implant/loyalty
+	req_implant = /obj/item/implant/mindshield
 
 // Honk pin, clown joke item.
 // Can replace other pins. Replace a pin in cap's laser for extra fun! This is generally adminbus only unless someone thinks of a use for it.

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -58,8 +58,13 @@
 		return
 
 	if(target.stat == DEAD || (target.status_flags & FAKEDEATH) || !target.client)
-		to_chat(user, span("warning", "\The [target] is in no state for a mind-ream."))
+		to_chat(user, span("warning", "\The [target] is in no state for a mind-read."))
 		return TRUE
+
+	for (var/obj/item/implant/loyalty/I in target)
+		if (I.implanted)
+			to_chat(user, span("warning", "\The [target]'s mind is protected from the mind-read."))
+			return TRUE
 
 	user.visible_message(span("warning", "\The [user] touches \the [target]'s temple..."))
 	var/question =  input(user, "Say something?", "Read Mind", "Penny for your thoughts?") as null|text
@@ -146,6 +151,11 @@
 		if(!target.mind || !target.key)
 			to_chat(user, "<span class='warning'>\The [target] is mindless!</span>")
 			return TRUE
+		for (var/obj/item/implant/loyalty/I in target)
+			if (I.implanted)
+				to_chat(user, span("warning", "\The [target]'s mind is protected from the mindslaving."))
+				return TRUE
+
 		user.visible_message("<span class='danger'><i>\The [user] seizes the head of \the [target] in both hands...</i></span>")
 		to_chat(user, "<span class='warning'>You plunge your mentality into that of \the [target]...</span>")
 		to_chat(target, "<span class='danger'>Your mind is invaded by the presence of \the [user]! They are trying to make you a slave!</span>")
@@ -250,6 +260,11 @@
 		if (isvaurca(target))
 			to_chat (user, "<span class='cult'>You feel your thoughts pass right through a mind empty of psychic energy.</span>")
 			return
+
+		for (var/obj/item/implant/loyalty/I in target)
+			if (I.implanted)
+				to_chat(user, span("warning", "\The [target]'s mind rejects your attempt to communicate."))
+				return TRUE
 
 		log_say("[key_name(user)] communed to [key_name(target)]: [text]",ckey=key_name(src))
 

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -61,7 +61,7 @@
 		to_chat(user, span("warning", "\The [target] is in no state for a mind-read."))
 		return TRUE
 
-	for (var/obj/item/implant/loyalty/I in target)
+	for (var/obj/item/implant/mindshield/I in target)
 		if (I.implanted)
 			to_chat(user, span("warning", "\The [target]'s mind is protected from the mind-read."))
 			return TRUE
@@ -151,7 +151,7 @@
 		if(!target.mind || !target.key)
 			to_chat(user, "<span class='warning'>\The [target] is mindless!</span>")
 			return TRUE
-		for (var/obj/item/implant/loyalty/I in target)
+		for (var/obj/item/implant/mindshield/I in target)
 			if (I.implanted)
 				to_chat(user, span("warning", "\The [target]'s mind is protected from the mindslaving."))
 				return TRUE
@@ -261,7 +261,7 @@
 			to_chat (user, "<span class='cult'>You feel your thoughts pass right through a mind empty of psychic energy.</span>")
 			return
 
-		for (var/obj/item/implant/loyalty/I in target)
+		for (var/obj/item/implant/mindshield/I in target)
 			if (I.implanted)
 				to_chat(user, span("warning", "\The [target]'s mind rejects your attempt to communicate."))
 				return TRUE

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -163,14 +163,6 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/implantcase/freedom
 	sort_string = "MFAAB"
 
-/datum/design/item/implant/loyalty
-	name = "loyalty"
-	id = "implant_loyal"
-	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 7000)
-	build_path = /obj/item/implantcase/loyalty
-	sort_string = "MFAAC"
-
 /datum/design/item/advanced_light_replacer
 	name = "Advanced Light Replacer"
 	desc = "A specialised light replacer which stores more lights, refills faster from boxes, and sucks up broken bulbs."

--- a/code/modules/spells/targeted/mindcontrol.dm
+++ b/code/modules/spells/targeted/mindcontrol.dm
@@ -42,7 +42,7 @@
 			to_chat(user, "<span class='warning'>\The [H] is brainless!</span>")
 			return FALSE
 
-		for (var/obj/item/implant/loyalty/I in H)
+		for (var/obj/item/implant/mindshield/I in H)
 			if (I.implanted)
 				to_chat(src, "<span class='warning'>[H]'s mind is shielded against your powers!</span>")
 				return FALSE

--- a/html/changelogs/alberyk-loyalty.yml
+++ b/html/changelogs/alberyk-loyalty.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Loyalty implants have been rebranded to be mind shield implants instead."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -5814,10 +5814,6 @@
 	pixel_y = 4
 	},
 /obj/item/storage/box/trackimp,
-/obj/item/storage/lockbox/loyalty{
-	pixel_x = 4;
-	pixel_y = -4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "alG" = (


### PR DESCRIPTION
What it says in the title. Loyalty implants have been rebranded to mind shields, the only real mechanical difference is that they don't display a message to be loyaly to nt, and they now protect the person from malf apc hacks, skrell mind powers and borer mind controlling. Also, removed the case form the armory and rd can't print them.