### PR TITLE
Adjusts Diona Resist Modifier

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -46,7 +46,7 @@
 	water and other radiation."
 
 	grab_mod = 0.8 // Viney Tentacles and shit to cling onto
-	resist_mod = 3 // Pretty stronk tho, can break out
+	resist_mod = 2 // Reasonably stronk, not moreso than an Unathi or robot.
 
 	has_organ = list(
 		"nutrient channel"   = /obj/item/organ/internal/diona/nutrients,

--- a/html/changelogs/paradoxspace-floralfury.yml
+++ b/html/changelogs/paradoxspace-floralfury.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: ParadoxSpace
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Dionae resist modifier has been nerfed from 3 to 2. It should be easier to hold them in place now."


### PR DESCRIPTION
Adjusts Dionae resist modifier from 3 to 2.
For reference, the default is 1.
Slimes have 0.25
Skrell have 0.5
Offworlders have 0.75
Vaurca have 1.75
Baselines have 2, so do Zhan and golems
Unathi have 2.5