### PR TITLE
Fixes missing return values in a few Destroy() procs

### DIFF
--- a/code/modules/heavy_vehicle/equipment/medical.dm
+++ b/code/modules/heavy_vehicle/equipment/medical.dm
@@ -126,7 +126,7 @@
 
 /obj/item/mecha_equipment/crisis_drone/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
-	..()
+	. = ..()
 
 /obj/item/mecha_equipment/crisis_drone/uninstalled()
 	. = ..()

--- a/code/modules/lock/lock.dm
+++ b/code/modules/lock/lock.dm
@@ -16,7 +16,7 @@
 
 /datum/lock/Destroy()
 	holder = null
-	..()
+	. = ..()
 
 /datum/lock/proc/unlock(var/key = "", var/mob/user)
 	if(status ^ LOCK_LOCKED)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -914,7 +914,7 @@ var/list/total_extraction_beacons = list()
 
 /obj/structure/extraction_point/Destroy()
 	total_extraction_beacons -= src
-	..()
+	. = ..()
 
 /**********************Resonator**********************/
 


### PR DESCRIPTION
Moondancer pointed out that a few of our Destroy() procs don't return a valid value. This fixes this.

Shouldn't change much gameplay wise.