### PR TITLE
Airlock Electronics QoL

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -122,13 +122,20 @@
 			locked = !locked
 			last_configurator = I.registered_name
 			to_chat(user, SPAN_NOTICE("You swipe your ID over \the [src], [locked ? "locking" : "unlocking"] it."))
+		else
+			to_chat(user, SPAN_WARNING("Access denied."))
 	else if(istype(W, /obj/item/device/pda))
 		var/obj/item/device/pda/P = W
 		var/obj/item/card/id/I = P.id
-		if(I && src.check_access(I))
+		if(!I)
+			to_chat(user, SPAN_WARNING("Your PDA doesn't have an ID in it!"))
+			return
+		if(check_access(I))
 			locked = !locked
 			last_configurator = I.registered_name
 			to_chat(user, SPAN_NOTICE("You swipe your PDA over \the [src], [locked ? "locking" : "unlocking"] it."))
+		else
+			to_chat(user, SPAN_WARNING("Access denied."))
 	else
 		..()
 

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -54,7 +54,7 @@
 
 /obj/item/airlock_electronics/Topic(href, href_list)
 	..()
-	if(usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
+	if(use_check_and_message(usr, USE_DISALLOW_SILICONS))
 		return
 	if(href_list["close"])
 		usr << browse(null, "window=airlock")

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -13,7 +13,7 @@
 	var/one_access = FALSE //if set to TRUE, door would receive req_one_access instead of req_access
 	var/last_configurator
 	var/locked = TRUE
-	var/in_use = FALSE // no double-spending
+	var/is_installed = FALSE // no double-spending
 
 /obj/item/airlock_electronics/attack_self(mob/user)
 	if(!ishuman(user) && !istype(user,/mob/living/silicon/robot))

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -13,6 +13,7 @@
 	var/one_access = FALSE //if set to TRUE, door would receive req_one_access instead of req_access
 	var/last_configurator
 	var/locked = TRUE
+	var/in_use = FALSE // no double-spending
 
 /obj/item/airlock_electronics/attack_self(mob/user)
 	if(!ishuman(user) && !istype(user,/mob/living/silicon/robot))

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -1,38 +1,29 @@
-//This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
-// Please do not use relative paths.
-
 /obj/item/airlock_electronics
 	name = "airlock electronics"
 	icon = 'icons/obj/doors/door_assembly.dmi'
 	icon_state = "door_electronics"
-	w_class = 2.0 //It should be tiny! -Agouri
+	w_class = ITEMSIZE_TINY
 
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 50)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
 	req_access = list(access_engine)
 
-	var/secure = 0 //if set, then wires will be randomized and bolts will drop if the door is broken
-	var/list/conf_access = null
-	var/one_access = 0 //if set to 1, door would receive req_one_access instead of req_access
-	var/last_configurator = null
-	var/locked = 1
-	var/inuse = 0 // no double-spending
+	var/secure = FALSE //if set, then wires will be randomized and bolts will drop if the door is broken
+	var/list/conf_access
+	var/one_access = FALSE //if set to TRUE, door would receive req_one_access instead of req_access
+	var/last_configurator
+	var/locked = TRUE
 
-/obj/item/airlock_electronics/attack_self(mob/user as mob)
-	if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
+/obj/item/airlock_electronics/attack_self(mob/user)
+	if(!ishuman(user) && !istype(user,/mob/living/silicon/robot))
 		return ..(user)
-
-	var/mob/living/carbon/human/H = user
-	if(H.getBrainLoss() >= 60)
-		return
 
 	var/t1 = text("<B>Access control</B><br>\n")
 
-
-	if (last_configurator)
+	if(last_configurator)
 		t1 += "Operator: [last_configurator]<br>"
 
-	if (locked)
+	if(locked)
 		t1 += "<a href='?src=\ref[src];login=1'>Swipe ID</a><hr>"
 	else
 		t1 += "<a href='?src=\ref[src];logout=1'>Block</a><hr>"
@@ -45,10 +36,10 @@
 		t1 += "<br>"
 
 		var/list/accesses = get_all_station_access()
-		for (var/acc in accesses)
+		for(var/acc in accesses)
 			var/aname = get_access_desc(acc)
 
-			if (!conf_access || !conf_access.len || !(acc in conf_access))
+			if(!conf_access?.len || !(acc in conf_access))
 				t1 += "<a href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
 			else if(one_access)
 				t1 += "<a style='color: green' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
@@ -62,58 +53,87 @@
 
 /obj/item/airlock_electronics/Topic(href, href_list)
 	..()
-	if (usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
+	if(usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
 		return
-	if (href_list["close"])
+	if(href_list["close"])
 		usr << browse(null, "window=airlock")
 		return
 
-	if (href_list["login"])
-		if(istype(usr,/mob/living/silicon))
-			src.locked = 0
-			src.last_configurator = usr.name
+	if(href_list["login"])
+		if(istype(usr, /mob/living/silicon))
+			locked = FALSE
+			last_configurator = usr.name
 		else
 			var/obj/item/I = usr.get_active_hand()
-			if (istype(I, /obj/item/device/pda))
+			if(istype(I, /obj/item/device/pda))
 				var/obj/item/device/pda/pda = I
 				I = pda.id
-			if (I && src.check_access(I))
-				src.locked = 0
-				src.last_configurator = I:registered_name
+			if(I && src.check_access(I))
+				locked = FALSE
+				last_configurator = I:registered_name
 
-	if (locked)
+	if(locked)
 		return
 
-	if (href_list["logout"])
-		locked = 1
+	if(href_list["logout"])
+		locked = TRUE
 
-	if (href_list["one_access"])
+	if(href_list["one_access"])
 		one_access = !one_access
 
-	if (href_list["access"])
+	if(href_list["access"])
 		toggle_access(href_list["access"])
 
 	attack_self(usr)
 
 /obj/item/airlock_electronics/proc/toggle_access(var/acc)
-	if (acc == "all")
+	if(acc == "all")
 		conf_access = null
 	else
 		var/req = text2num(acc)
 
-		if (conf_access == null)
+		if(conf_access == null)
 			conf_access = list()
 
-		if (!(req in conf_access))
+		if(!(req in conf_access))
 			conf_access += req
 		else
 			conf_access -= req
-			if (!conf_access.len)
+			if(!conf_access.len)
 				conf_access = null
 
+/obj/item/airlock_electronics/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/airlock_electronics))
+		if(src.locked)
+			to_chat(user, SPAN_WARNING("\The [src] you're trying to set is locked! Swipe your ID to unlock."))
+			return
+		var/obj/item/airlock_electronics/A = W
+		if(A.locked)
+			to_chat(user, SPAN_WARNING("\The [src] you're trying to copy is locked! Swipe your ID to unlock."))
+			return
+		src.conf_access = A.conf_access
+		src.one_access = A.one_access
+		src.last_configurator = A.last_configurator
+		to_chat(user, SPAN_NOTICE("Configuration settings copied successfully."))
+	else if(istype(W, /obj/item/card/id))
+		var/obj/item/card/id/I = W
+		if(check_access(I))
+			locked = !locked
+			last_configurator = I.registered_name
+			to_chat(user, SPAN_NOTICE("You swipe your ID over \the [src], [locked ? "locking" : "unlocking"] it."))
+	else if(istype(W, /obj/item/device/pda))
+		var/obj/item/device/pda/P = W
+		var/obj/item/card/id/I = P.id
+		if(I && src.check_access(I))
+			locked = !locked
+			last_configurator = I.registered_name
+			to_chat(user, SPAN_NOTICE("You swipe your PDA over \the [src], [locked ? "locking" : "unlocking"] it."))
+	else
+		..()
 
 /obj/item/airlock_electronics/secure
 	name = "secure airlock electronics"
-	desc = "designed to be somewhat more resistant to hacking than standard electronics."
+	desc = "Designed to be somewhat more resistant to hacking than standard electronics."
+	description_info = "Whith these electronics, wires will be randomized and bolts will drop if the airlock is broken."
 	origin_tech = list(TECH_DATA = 2)
-	secure = 1
+	secure = TRUE

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -237,12 +237,12 @@
 
 	else if(istype(W, /obj/item/airlock_electronics) && state == 1)
 		var/obj/item/airlock_electronics/EL = W
-		if(!EL.inuse)
+		if(!EL.in_use)
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
-			EL.inuse = 1
+			EL.in_use = 1
 			if(do_after(user, 40/W.toolspeed))
-				EL.inuse = 0
+				EL.in_use = 0
 				if(!src) return
 				user.drop_from_inventory(EL,src)
 				to_chat(user, "<span class='notice'>You installed the airlock electronics!</span>")
@@ -250,7 +250,7 @@
 				src.name = "Near finished Airlock Assembly"
 				src.electronics = EL
 			else
-				EL.inuse = 0
+				EL.in_use = 0
 
 	else if(W.iscrowbar() && state == 2 )
 		//This should never happen, but just in case I guess

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -237,12 +237,12 @@
 
 	else if(istype(W, /obj/item/airlock_electronics) && state == 1)
 		var/obj/item/airlock_electronics/EL = W
-		if(!EL.in_use)
+		if(!EL.is_installed)
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
-			EL.in_use = 1
+			EL.is_installed = 1
 			if(do_after(user, 40/W.toolspeed))
-				EL.in_use = 0
+				EL.is_installed = 0
 				if(!src) return
 				user.drop_from_inventory(EL,src)
 				to_chat(user, "<span class='notice'>You installed the airlock electronics!</span>")
@@ -250,7 +250,7 @@
 				src.name = "Near finished Airlock Assembly"
 				src.electronics = EL
 			else
-				EL.in_use = 0
+				EL.is_installed = 0
 
 	else if(W.iscrowbar() && state == 2 )
 		//This should never happen, but just in case I guess

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -168,19 +168,19 @@ obj/structure/windoor_assembly/Destroy()
 			//Adding airlock electronics for access. Step 6 complete.
 			else if(istype(W, /obj/item/airlock_electronics) && W:icon_state != "door_electronics_smoked")
 				var/obj/item/airlock_electronics/EL = W
-				if(!EL.in_use)
+				if(!EL.is_installed)
 					playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 					user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
-					EL.in_use = 1
+					EL.is_installed = 1
 					if(do_after(user, 40))
-						EL.in_use = 0
+						EL.is_installed = 0
 						if(!src) return
 						user.drop_from_inventory(EL,src)
 						to_chat(user, "<span class='notice'>You've installed the airlock electronics!</span>")
 						src.name = "Near finished Windoor Assembly"
 						src.electronics = EL
 					else
-						EL.in_use = 0
+						EL.is_installed = 0
 
 			//Screwdriver to remove airlock electronics. Step 6 undone.
 			else if(W.isscrewdriver() && src.electronics)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -168,19 +168,19 @@ obj/structure/windoor_assembly/Destroy()
 			//Adding airlock electronics for access. Step 6 complete.
 			else if(istype(W, /obj/item/airlock_electronics) && W:icon_state != "door_electronics_smoked")
 				var/obj/item/airlock_electronics/EL = W
-				if(!EL.inuse)
+				if(!EL.in_use)
 					playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 					user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
-					EL.inuse = 1
+					EL.in_use = 1
 					if(do_after(user, 40))
-						EL.inuse = 0
+						EL.in_use = 0
 						if(!src) return
 						user.drop_from_inventory(EL,src)
 						to_chat(user, "<span class='notice'>You've installed the airlock electronics!</span>")
 						src.name = "Near finished Windoor Assembly"
 						src.electronics = EL
 					else
-						EL.inuse = 0
+						EL.in_use = 0
 
 			//Screwdriver to remove airlock electronics. Step 6 undone.
 			else if(W.isscrewdriver() && src.electronics)

--- a/html/changelogs/geeves-engineering_airlock_QoL.yml
+++ b/html/changelogs/geeves-engineering_airlock_QoL.yml
@@ -6,3 +6,4 @@ changes:
   - rscadd: "Clicking an unlocked airlock electronic with another unlocked airlock electronic will now copy the configuration from the one in your active hand to the clicked one."
   - rscadd: "Clicking an airlock electronic with an ID or PDA with an ID in it will now toggle its lock."
   - tweak: "Airlock eletronics are now one size smaller, meaning you can jam more of them into a pack."
+  - rscdel: "Having brain damage no longer prevents you from operating airlock electronics."

--- a/html/changelogs/geeves-engineering_airlock_QoL.yml
+++ b/html/changelogs/geeves-engineering_airlock_QoL.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Clicking an unlocked airlock electronic with another unlocked airlock electronic will now copy the configuration from the one in your active hand to the clicked one."
+  - rscadd: "Clicking an airlock electronic with an ID or PDA with an ID in it will now toggle its lock."
+  - tweak: "Airlock eletronics are now one size smaller, meaning you can jam more of them into a pack."


### PR DESCRIPTION
* Clicking an unlocked airlock electronic with another unlocked airlock electronic will now copy the configuration from the one in your active hand to the clicked one.
* Clicking an airlock electronic with an ID or PDA with an ID in it will now toggle its lock.
* Airlock eletronics are now one size smaller, meaning you can jam more of them into a pack.
* Having brain damage no longer prevents you from operating airlock electronics.