### PR TITLE
Debugger Improvements

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -186,12 +186,19 @@
 
 /obj/machinery/vending/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/device/debugger))
-		if(shoot_inventory || !shut_up)
-			to_chat(user, SPAN_WARNING("\The [W] reads, \"Software Error Detected. Rectifying.\""))
+		if(!shut_up)
+			to_chat(user, SPAN_WARNING("\The [W] reads, \"Software error detected. Rectifying.\"."))
+			if(do_after(user, 100 / W.toolspeed, act_target = src))
+				to_chat(user, SPAN_NOTICE("\The [W] reads, \"Solution found. Fix applied. Have a NanoTrasen day!\"."))
+				shut_up = TRUE
+		if(shoot_inventory)
+			if(wires.IsIndexCut(VENDING_WIRE_THROW))
+				to_chat(user, SPAN_WARNING("\The [W] reads, \"Hardware error detected. Manual repair required.\"."))
+				return
+			to_chat(user, SPAN_WARNING("\The [W] reads, \"Software error detected. Rectifying.\"."))
 			if(do_after(user, 100 / W.toolspeed, act_target = src))
 				to_chat(user, SPAN_NOTICE("\The [W] reads, \"Solution found. Fix applied. Have a NanoTrasen day!\"."))
 				shoot_inventory = FALSE
-				shut_up = TRUE
 		else
 			to_chat(user, SPAN_NOTICE("\The [W] reads, \"All systems nominal.\"."))
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -189,7 +189,7 @@
 		if(!shut_up)
 			to_chat(user, SPAN_WARNING("\The [W] reads, \"Software error detected. Rectifying.\"."))
 			if(do_after(user, 100 / W.toolspeed, act_target = src))
-				to_chat(user, SPAN_NOTICE("\The [W] reads, \"Solution found. Fix applied. [shoot_inventory ? "Additional errors present, standby." : "Have a NanoTrasen day!"]\"."))
+				to_chat(user, SPAN_NOTICE("\The [W] reads, \"Solution found. Fix applied.\"."))
 				shut_up = TRUE
 		if(shoot_inventory)
 			if(wires.IsIndexCut(VENDING_WIRE_THROW))

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -184,7 +184,16 @@
 		to_chat(user, "You short out the product lock on \the [src]")
 		return 1
 
-/obj/machinery/vending/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/vending/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/device/debugger))
+		if(shoot_inventory || !shut_up)
+			to_chat(user, SPAN_WARNING("\The [W] reads, \"Software Error Detected. Rectifying.\""))
+			if(do_after(user, 100 / W.toolspeed, act_target = src))
+				to_chat(user, SPAN_NOTICE("\The [W] reads, \"Solution found. Fix applied. Have a NanoTrasen day!\"."))
+				shoot_inventory = FALSE
+				shut_up = TRUE
+		else
+			to_chat(user, SPAN_NOTICE("\The [W] reads, \"All systems nominal.\"."))
 
 	var/obj/item/card/id/I = W.GetID()
 	var/datum/money_account/vendor_account = SSeconomy.get_department_account("Vendor")

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -189,7 +189,7 @@
 		if(!shut_up)
 			to_chat(user, SPAN_WARNING("\The [W] reads, \"Software error detected. Rectifying.\"."))
 			if(do_after(user, 100 / W.toolspeed, act_target = src))
-				to_chat(user, SPAN_NOTICE("\The [W] reads, \"Solution found. Fix applied. Have a NanoTrasen day!\"."))
+				to_chat(user, SPAN_NOTICE("\The [W] reads, \"Solution found. Fix applied. [shoot_inventory ? "Additional errors present, standby." : "Have a NanoTrasen day!"]\"."))
 				shut_up = TRUE
 		if(shoot_inventory)
 			if(wires.IsIndexCut(VENDING_WIRE_THROW))

--- a/code/game/objects/items/devices/debugger.dm
+++ b/code/game/objects/items/devices/debugger.dm
@@ -5,12 +5,12 @@
 	icon = 'icons/obj/hacktool.dmi'
 	icon_state = "hacktool-g"
 	flags = CONDUCT
-	force = 5.0
-	w_class = 2.0
-	throwforce = 5.0
+	force = 5
+	w_class = ITEMSIZE_SMALL
+	throwforce = 5
 	throw_range = 15
 	throw_speed = 3
 
-	matter = list(DEFAULT_WALL_MATERIAL = 50,"glass" = 20)
+	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20)
 
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -661,25 +661,25 @@
 	else if (istype(W, /obj/item/device/debugger))
 		if(emagged || hacker || infected)
 			to_chat(user, "<span class='warning'>There is a software error with the device. Attempting to fix...</span>")
-			if(do_after(user, 10/W.toolspeed SECONDS, act_target = src))
+			if(do_after(user, 5/W.toolspeed SECONDS, act_target = src))
 				to_chat(user, "<span class='notice'>Problem diagnosed, searching for solution...</span>")
-				if(do_after(user, 30/W.toolspeed SECONDS, act_target = src))
+				if(do_after(user, 15/W.toolspeed SECONDS, act_target = src))
 					to_chat(user, "<span class='notice'>Solution found. Applying fixes...</span>")
-					if(do_after(user, 60/W.toolspeed SECONDS, act_target = src))
+					if(do_after(user, 30/W.toolspeed SECONDS, act_target = src))
 						if(prob(15))
 							to_chat(user, "<span class='warning'>Error while applying fixes. Please try again.</span>")
 							return
 					to_chat(user, "<span class='notice'>Applied default software. Restarting APC...</span>")
-					if(do_after(user, 10/W.toolspeed SECONDS, act_target = src))
+					if(do_after(user, 5/W.toolspeed SECONDS, act_target = src))
 						to_chat(user, "<span class='notice'>APC Reset. Fixes applied.</span>")
 						if(hacker)
 							hacker.hacked_apcs -= src
 							hacker = null
 							update_icon()
 						if(emagged)
-							emagged = 0
+							emagged = FALSE
 						if(infected)
-							infected = 0
+							infected = FALSE
 			else
 				to_chat(user, "<span class='notice'>There has been a connection issue.</span>")
 				return

--- a/html/changelogs/geeves-debuggers_worth_a_damn.yml
+++ b/html/changelogs/geeves-debuggers_worth_a_damn.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Debuggers can now fix software errors in vending machines, shooting their inventory and advertising aggressively."
+  - tweak: "The time it takes for the debugger to fix APCs have been reduced by half."


### PR DESCRIPTION
* Debuggers can now fix software errors in vending machines, shooting their inventory and advertising aggressively.
* The time it takes for the debugger to fix APCs have been reduced by half.