### PR TITLE
Turf Harm Intent Tweaks

### DIFF
--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -3,7 +3,7 @@
 	if(!C || !user)
 		return 0
 
-	if(flooring && user.a_intent != I_HARM)
+	if(flooring && user.a_intent != I_HURT)
 		if(C.iscrowbar())
 			if(broken || burnt)
 				to_chat(user, "<span class='notice'>You remove the broken [flooring.descriptor].</span>")

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -3,7 +3,7 @@
 	if(!C || !user)
 		return 0
 
-	if(flooring)
+	if(flooring && user.a_intent != I_HARM)
 		if(C.iscrowbar())
 			if(broken || burnt)
 				to_chat(user, "<span class='notice'>You remove the broken [flooring.descriptor].</span>")

--- a/html/changelogs/geeves-no_floor_ripping.yml
+++ b/html/changelogs/geeves-no_floor_ripping.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "You can no longer rip up floor tiles and such when on floor intent. Beating people with tools is now sadly less humorous."

--- a/html/changelogs/geeves-no_floor_ripping.yml
+++ b/html/changelogs/geeves-no_floor_ripping.yml
@@ -3,4 +3,4 @@ author: Geeves
 delete-after: True
 
 changes: 
-  - tweak: "You can no longer rip up floor tiles and such when on floor intent. Beating people with tools is now sadly less humorous."
+  - tweak: "You can no longer rip up floor tiles and such when on harm intent. Beating people with tools is now sadly less humorous."


### PR DESCRIPTION
* You can no longer rip up floor tiles and such when on harm intent. Beating people with tools is now sadly less humorous.