### PR TITLE
Circuitboard Back and Forth

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -379,7 +379,7 @@
 	desc = "Heavy-duty switching circuits for power control."
 	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
-/obj/item/module/power_control/attackby(/obj/item/W, /mob/user)
+/obj/item/module/power_control/attackby(obj/item/W, mob/user)
 	if(W.ismultitool())
 		var/obj/item/circuitboard/ghettosmes/new_circuit = new /obj/item/circuitboard/ghettosmes(get_turf(src))
 		to_chat(user, SPAN_NOTICE("You modify \the [src] into a makeshift PSU circuitboard."))

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -277,19 +277,6 @@
 	name = "disk"
 	icon = 'icons/obj/items.dmi'
 
-/*
-/obj/item/game_kit
-	name = "Gaming Kit"
-	icon = 'icons/obj/items.dmi'
-	icon_state = "game_kit"
-	var/selected = null
-	var/board_stat = null
-	var/data = ""
-	var/base_url = "http://svn.slurm.us/public/spacestation13/misc/game_kit"
-	item_state = "sheet-metal"
-	w_class = 5.0
-*/
-
 /obj/item/gift
 	name = "gift"
 	desc = "A wrapped item."
@@ -315,25 +302,6 @@
 	w_class = 3.0
 	origin_tech = list(TECH_MATERIAL = 1)
 	var/breakouttime = 300	//Deciseconds = 30s = 0.5 minute
-
-/*/obj/item/syndicate_uplink
-	name = "station bounced radio"
-	desc = "Remain silent about this..."
-	icon = 'icons/obj/radio.dmi'
-	icon_state = "radio"
-	var/temp = null
-	var/uses = 10.0
-	var/selfdestruct = 0.0
-	var/traitor_frequency = 0.0
-	var/mob/currentUser = null
-	var/obj/item/device/radio/origradio = null
-	flags = CONDUCT | ONBELT
-	w_class = 2.0
-	item_state = "radio"
-	throw_speed = 4
-	throw_range = 20
-	matter = list("metal" = 100
-	origin_tech = list(TECH_MAGNET = 2, TECH_ILLEGAL = 3)*/
 
 /obj/item/SWF_uplink
 	name = "station-bounced radio"
@@ -411,11 +379,12 @@
 	desc = "Heavy-duty switching circuits for power control."
 	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 
-/obj/item/module/power_control/attackby(var/obj/item/W as obj, var/mob/user as mob)
-	if (W.ismultitool())
-		var/obj/item/circuitboard/ghettosmes/newcircuit = new/obj/item/circuitboard/ghettosmes(user.loc)
+/obj/item/module/power_control/attackby(/obj/item/W, /mob/user)
+	if(W.ismultitool())
+		var/obj/item/circuitboard/ghettosmes/new_circuit = new /obj/item/circuitboard/ghettosmes(get_turf(src))
+		to_chat(user, SPAN_NOTICE("You modify \the [src] into a makeshift PSU circuitboard."))
 		qdel(src)
-		user.put_in_hands(newcircuit)
+		user.put_in_hands(new_circuit)
 
 /obj/item/module/id_auth
 	name = "\improper ID authentication module"

--- a/code/game/objects/items/weapons/circuitboards/machinery/power.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/power.dm
@@ -18,7 +18,14 @@
 
 /obj/item/circuitboard/ghettosmes
 	name = T_BOARD("makeshift PSU")
-	desc = "An APC circuit repurposed into some power storage device controller"
+	desc = "An APC circuit repurposed into some power storage device controller."
 	build_path = "/obj/machinery/power/smes/batteryrack/makeshift"
 	board_type = "machine"
 	req_components = list("/obj/item/cell" = 3)
+
+/obj/item/circuitboard/ghettosmes/attackby(/obj/item/W, /mob/user)
+	if(W.ismultitool())
+		var/obj/item/module/power_control/new_circuit = new /obj/item/module/power_control(get_turf(src))
+		to_chat(user, SPAN_NOTICE("You modify \the [src] into an APC power control module."))
+		qdel(src)
+		user.put_in_hands(new_circuit)

--- a/code/game/objects/items/weapons/circuitboards/machinery/power.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/power.dm
@@ -23,7 +23,7 @@
 	board_type = "machine"
 	req_components = list("/obj/item/cell" = 3)
 
-/obj/item/circuitboard/ghettosmes/attackby(/obj/item/W, /mob/user)
+/obj/item/circuitboard/ghettosmes/attackby(obj/item/W, mob/user)
 	if(W.ismultitool())
 		var/obj/item/module/power_control/new_circuit = new /obj/item/module/power_control(get_turf(src))
 		to_chat(user, SPAN_NOTICE("You modify \the [src] into an APC power control module."))

--- a/html/changelogs/geeves-circuitboard_backandforth.yml
+++ b/html/changelogs/geeves-circuitboard_backandforth.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "You can now convert ghetto PSU boards back into standard APC power control modules by using a multi-tool."


### PR DESCRIPTION
* You can now convert ghetto PSU boards back into standard APC power control modules by using a multi-tool.