### PR TITLE
Unconscious in Stasis

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -232,6 +232,9 @@
 		// Next, the method to induce stasis has some adverse side-effects, manifesting
 		// as cloneloss
 		adjustCloneLoss(0.1)
+		if(stat != DEAD)
+			blinded = TRUE
+			stat = UNCONSCIOUS
 
 /mob/living/carbon/human/handle_mutations_and_radiation()
 	if(in_stasis)
@@ -756,8 +759,8 @@
 				src.visible_message("<B>[src]</B> [species.halloss_message]")
 			Paralyse(10)
 
-		if(paralysis || sleeping)
-			blinded = 1
+		if(paralysis || sleeping || in_stasis)
+			blinded = TRUE
 			stat = UNCONSCIOUS
 
 			adjustHalLoss(-3)
@@ -783,7 +786,7 @@
 
 
 		//CONSCIOUS
-		else
+		else if(!in_stasis)
 			stat = CONSCIOUS
 			willfully_sleeping = FALSE
 

--- a/html/changelogs/doxxmedearly - stasis.yml
+++ b/html/changelogs/doxxmedearly - stasis.yml
@@ -1,0 +1,8 @@
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - bugfix: "Being in a stasis bag will properly render you unconscious."


### PR DESCRIPTION
No more will people be able to unzip themselves from bags, or talk. The stasis bag prevents pain or shock from being processed so people were totally fine and conscious when put in it, even with a stopped heart. 
Fixes #8393 