### PR TITLE
Clamps fire alarm timers

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -207,7 +207,7 @@
 	else if (href_list["state"] == "inactive")
 		src.reset()
 	if (href_list["tmr"] == "set")
-		time = max(0, input(usr, "Enter time delay", "Fire Alarm Delayed Activation", time) as num)
+		time = Clamp(input(usr, "Enter time delay", "Fire Alarm Delayed Activation", time) as num, 0, 600)
 	else if (href_list["tmr"] == "start")
 		src.timing = 1
 	else if (href_list["tmr"] == "stop")

--- a/html/changelogs/doxxmedearly - firealarm.yml
+++ b/html/changelogs/doxxmedearly - firealarm.yml
@@ -1,0 +1,9 @@
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+changes: 
+  - bugfix: "You can no longer set a fire alarm timer to longer than ten minutes."


### PR DESCRIPTION
Max entry is 600, or approximately ten minutes. Before it was... unlimited. 

Fixes #7851 