### PR TITLE
Husk repair fixes

### DIFF
--- a/code/modules/surgery/facial_surgery.dm
+++ b/code/modules/surgery/facial_surgery.dm
@@ -69,6 +69,7 @@
 	if(head.disfigured || (HUSK in target.mutations))
 		head.disfigured = FALSE
 		target.mutations.Remove(HUSK)
+		target.update_body()
 		user.visible_message("[user] successfully restores [target]'s appearance!", "<span class='notice'>You successfully restore [target]'s appearance.</span>")
 
 	var/getName = sanitize(input(user, "What is your patient's new identity?", "Name change") as null|text, MAX_NAME_LEN)
@@ -208,8 +209,10 @@
 
 /datum/surgery_step/robotics/face/alter_synthface/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/head/head = target.get_organ(target_zone)
-	if(head.disfigured)
+	if(head.disfigured || (HUSK in target.mutations))
 		head.disfigured = FALSE
+		target.mutations.Remove(HUSK)
+		target.update_body()
 		user.visible_message("[user] successfully restores [target]'s appearance!", "<span class='notice'>You successfully restore [target]'s appearance.</span>")
 
 	var/getName = sanitize(input(user, "What is your patient's new identity?", "Name change") as null|text, MAX_NAME_LEN)

--- a/html/changelogs/doxxmedearly - husk.yml
+++ b/html/changelogs/doxxmedearly - husk.yml
@@ -1,0 +1,9 @@
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Plastic surgery should now properly update sprites when fixing a husked individual. This should now work for shells, as well."


### PR DESCRIPTION
Sprites weren't getting updated when surgery was complete unless you actually changed the person's identity. And for shells, it wasn't removing the HUSK mutation. PR fixes both of those. Sprites should look fine without having to go into the appearance editor. 

Fixes #8249 