### PR TITLE
Gun safeties stop suicides.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -503,6 +503,11 @@
 			user.visible_message(span("warning", "*click click*"))
 			mouthshoot = FALSE
 			return
+		if(safety() && user.a_intent != I_HURT)
+			user.visible_message(SPAN_WARNING("The safety was on. How anticlimatic!"))
+			handle_click_empty(user)
+			mouthshoot = FALSE
+			return
 		if(silenced)
 			playsound(user, fire_sound, 10, 1)
 		else

--- a/html/changelogs/doxxmedearly - safetysuicide.yml
+++ b/html/changelogs/doxxmedearly - safetysuicide.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Gun safeties should prevent suicides if the user is not on harm intent."


### PR DESCRIPTION
Safeties now stop suicides unless on harm intent. 

Fixes #8378 