### PR TITLE
Fixes drink trash

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -49,8 +49,12 @@
 /obj/item/reagent_containers/food/drinks/standard_feed_mob(var/mob/user, var/mob/target)
 	if(!is_open_container())
 		to_chat(user, "<span class='notice'>You need to open \the [src]!</span>")
-		return 1
-	return ..()
+		return TRUE
+	if(!..())
+		return FALSE
+	else
+		on_consume(user, target)
+		return TRUE
 
 /obj/item/reagent_containers/food/drinks/standard_dispenser_refill(var/mob/user, var/obj/structure/reagent_dispensers/target)
 	if(!is_open_container())

--- a/html/changelogs/doxxmedearly - trashcomeback.yml
+++ b/html/changelogs/doxxmedearly - trashcomeback.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Drinks with trash states (like vended coffee cups) should now use them again when you finish drinking them."


### PR DESCRIPTION
My initial bugfix for the food/drink refactor had an oversight, where vended drink items with trash states (coffee, ramen) weren't being used. This PR adds on_consume to drinks so trash should spawn again for these items.