### PR TITLE
Fixes round start delay caused by borg name picking code

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -383,14 +383,15 @@
 	if(custom_name)
 		return FALSE
 
-	var/newname
-	newname = sanitizeSafe(input(src, "You are a robot. Enter a name, or leave blank for the default name.", "Name change") as text, MAX_NAME_LEN)
-	if(newname)
-		custom_name = newname
+	spawn(0)
+		var/newname
+		newname = sanitizeSafe(input(src, "You are a robot. Enter a name, or leave blank for the default name.", "Name change") as text, MAX_NAME_LEN)
+		if(newname)
+			custom_name = newname
 
-	updatename()
-	updateicon()
-	SSrecords.reset_manifest()
+			updatename()
+		updateicon()
+		SSrecords.reset_manifest()
 
 // this verb lets cyborgs see the stations manifest
 /mob/living/silicon/robot/verb/cmd_station_manifest()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -389,7 +389,7 @@
 		if(newname)
 			custom_name = newname
 
-			updatename()
+		updatename()
 		updateicon()
 		SSrecords.reset_manifest()
 

--- a/html/changelogs/alberyk-borgname.yml
+++ b/html/changelogs/alberyk-borgname.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed round start delay caused by cyborgs choosing their names."


### PR DESCRIPTION
This time, the spawn(0) had a good reason to be there.