### PR TITLE
Pipe In-Hand Rotation

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -308,6 +308,9 @@ Buildable meters
 	)
 	icon_state = islist[pipe_type + 1]
 
+/obj/item/pipe/attack_self(mob/user)
+	rotate(user)
+
 //called when a turf is attacked with a pipe item
 /obj/item/pipe/afterattack(turf/simulated/floor/target, mob/user, proximity)
 	if(!proximity) return

--- a/html/changelogs/geeves-in-hand_pipe_rotate.yml
+++ b/html/changelogs/geeves-in-hand_pipe_rotate.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "You can rotate pipes in-hand again."


### PR DESCRIPTION
This feature was accidentally removed when the rotate thing was generalized across objects. This re-adds it.