### PR TITLE
Unholy Chef Tweaks

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -696,7 +696,7 @@
 	name = "produce box"
 	desc = "A large box of random, leftover produce."
 	icon_state = "largebox"
-	starts_with = list(/obj/random_produce = 12)
+	starts_with = list(/obj/random_produce/box = 15)
 
 /obj/item/storage/box/produce/fill()
 	. = ..()

--- a/code/game/objects/random/produce.dm
+++ b/code/game/objects/random/produce.dm
@@ -43,3 +43,27 @@
 		log_debug("Cannot spawn random produce [seed_chosen]! Fix this by editing [type]'s produce_list!",SEVERITY_ERROR)
 
 	return INITIALIZE_HINT_QDEL
+
+/obj/random_produce/box // produce for spawning in chef produce boxes. better suited for the job
+	produce_list = list(
+			"chili" = 1,
+			"berries" = 0.25,
+			"tomato" = 2,
+			"eggplant" = 0.5,
+			"apple" = 0.25,
+			"mushrooms" = 0.25,
+			"cabbage" = 2,
+			"banana" = 0.5,
+			"corn" = 2,
+			"potato" = 2,
+			"soybean" = 0.5,
+			"rice" = 2,
+			"carrot" = 1,
+			"whitebeet" = 1,
+			"pumpkin" = 0.1,
+			"lime" = 0.25,
+			"lemon" = 0.25,
+			"cacao" = 0.5,
+			"cherry" = 0.25,
+			"onion" = 0.5
+					   )

--- a/html/changelogs/geeves-better_produce_boxes.yml
+++ b/html/changelogs/geeves-better_produce_boxes.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Produce boxes now spawn 15 produce items instead of 12."
+  - tweak: "Reduced the types of produce that spawns in produce boxes to produce that actually have recipes."


### PR DESCRIPTION
* Produce boxes now spawn 15 produce items instead of 12.
* Reduced the types of produce that spawns in produce boxes to produce that actually have recipes.