### PR TITLE
Alcohol/Liver adjustments

### DIFF
--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -59,10 +59,12 @@
 		filter_strength = INTOX_FILTER_BRUISED
 	if(is_broken())
 		filter_strength = INTOX_FILTER_DAMAGED
+	if(BP_IS_ROBOTIC(src))
+		filter_strength *= 1.1
 
 	if (owner.intoxication > 0)
-		owner.intoxication -= min(owner.intoxication, filter_strength*PROCESS_ACCURACY)
-		if (!owner.intoxication)
+		owner.intoxication -= min(owner.intoxication, filter_strength*1.5)
+		if(!owner.intoxication)
 			owner.handle_intoxication()
 
 	if(toxin_type in owner.chem_effects)

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -63,7 +63,7 @@
 		filter_strength *= 1.1
 
 	if (owner.intoxication > 0)
-		owner.intoxication -= min(owner.intoxication, filter_strength*1.5)
+		owner.intoxication -= min(owner.intoxication, filter_strength)
 		if(!owner.intoxication)
 			owner.handle_intoxication()
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -153,7 +153,7 @@
 /datum/reagent/alcohol/affect_ingest(mob/living/carbon/M, alien, removed)
 
 	if(alien != IS_DIONA)
-		M.intoxication += (strength / 100) * removed * 3.5
+		M.intoxication += (strength / 100) * removed * 3.75
 
 		if (druggy != 0)
 			M.druggy = max(M.druggy, druggy)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -153,7 +153,7 @@
 /datum/reagent/alcohol/affect_ingest(mob/living/carbon/M, alien, removed)
 
 	if(alien != IS_DIONA)
-		M.intoxication += (strength / 100) * removed * 3.75
+		M.intoxication += (strength / 100) * removed * 3.15
 
 		if (druggy != 0)
 			M.druggy = max(M.druggy, druggy)

--- a/html/changelogs/doxxmedearly - dregbuffs.yml
+++ b/html/changelogs/doxxmedearly - dregbuffs.yml
@@ -1,0 +1,9 @@
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+changes: 
+  - tweak: "Made adjustments to liver filtration and alcohol strength. You should be able to get drunk again and will stay drunk slightly longer."

--- a/html/changelogs/doxxmedearly - dregbuffs.yml
+++ b/html/changelogs/doxxmedearly - dregbuffs.yml
@@ -7,3 +7,4 @@ delete-after: True
 # Any changes you've made.  See valid prefix list above.
 changes: 
   - tweak: "Made adjustments to liver filtration and alcohol strength. You should be able to get drunk again and will stay drunk slightly longer."
+  - tweak: "Robotic/assisted livers are now very slightly better at filtering out booze."


### PR DESCRIPTION
Liver was filtering out 3.5 intoxication a second, which outpaced even 100 strength drinks. 
I've adjusted two numbers here and tested them out.
First, the liver filters much slower now. This will leave a person drunk longer and make it so they can become drunk if they keep imbibing. It seems like going 1/10 is a lot but in practice, it filters out pretty quickly still, since other factors like eating also help reduce intoxication. 
Secondly, I've lowered the effective strength of drinks' effect on intoxication VERY slightly.
Together it feels like a decent balance when testing with moderate and high strength drinks. Unsure whether or not to call this a bugfix since it's pretty unintended behavior that you can't get intoxicated on even the strongest drinks. Devs' call. 

Also made robotic livers sliiiiiightly better at removing intoxication