### PR TITLE
Bugfixes: spicy clams and heat/cold species messages

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -1116,7 +1116,7 @@
 
 /datum/recipe/spicy_clams
 	fruit = list("chili" = 1, "cabbage" = 1)
-	reagents = list("blackpepper" = 1, "spacespice" = 1)
+	reagents = list("capsaicin" = 1, "spacespice" = 1)
 	items = list(
 		/obj/item/reagent_containers/food/snacks/clam,
 		/obj/item/reagent_containers/food/snacks/clam

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -315,9 +315,9 @@
 		owner.bodytemperature += temp_adj
 
 	else if(breath.temperature >= owner.species.heat_discomfort_level)
-		owner.species.get_environment_discomfort(src,"heat")
+		owner.species.get_environment_discomfort(owner,"heat")
 	else if(breath.temperature <= owner.species.cold_discomfort_level)
-		owner.species.get_environment_discomfort(src,"cold")
+		owner.species.get_environment_discomfort(owner,"cold")
 
 /obj/item/organ/internal/lungs/listen()
 	if(owner.failed_last_breath)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -5156,7 +5156,7 @@
 /obj/item/reagent_containers/food/snacks/spicy_clams/Initialize()
 	. = ..()
 	reagents.add_reagent("seafood", 4)
-	reagents.add_reagent("pepper", 1)
+	reagents.add_reagent("capsaicin", 1)
 
 /obj/item/reagent_containers/food/snacks/tajaran_bread
 	name = "adhomian bread"

--- a/html/changelogs/alberyk-twofixes.yml
+++ b/html/changelogs/alberyk-twofixes.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed species temperature discomfort messages not working."
+  - bugfix: "Fixed the spicy Ras'val clams spawning with a broken reagent, also changed the recipe to match it now; it should use capsaicin instead of black pepper."


### PR DESCRIPTION
- Fixed species temperature discomfort messages not working
- Fixed the spicy Ras'val clams spawning with a broken reagent, also changed the recipe to match it now; it should use capsaicin instead of black pepper
