### PR TITLE
Bluespace Mining

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1743,6 +1743,7 @@
 #include "code\modules\mining\mint.dm"
 #include "code\modules\mining\ore.dm"
 #include "code\modules\mining\ore_datum.dm"
+#include "code\modules\mining\ore_satchel.dm"
 #include "code\modules\mining\satchel_ore_boxdm.dm"
 #include "code\modules\mining\drilling\drill.dm"
 #include "code\modules\mining\drilling\scanner.dm"

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -116,26 +116,6 @@
 	drop_sound = 'sound/items/drop/wrapper.ogg'
 
 // -----------------------------
-//        Mining Satchel
-// -----------------------------
-
-/obj/item/storage/bag/ore
-	name = "mining satchel"
-	desc = "This little bugger can be used to store and transport ores."
-	icon = 'icons/obj/mining.dmi'
-	icon_state = "satchel"
-	slot_flags = SLOT_BELT | SLOT_POCKET
-	w_class = 3
-	max_storage_space = 100
-	max_w_class = 3
-	can_hold = list(/obj/item/ore)
-
-/obj/item/storage/bag/ore/drone
-	// this used to be 400. The inventory system FUCKING DIED at this.
-	max_storage_space = 200
-
-
-// -----------------------------
 //          Plant bag
 // -----------------------------
 

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -56,6 +56,7 @@
 	spark_system = bind_spark(src, 3)
 
 /obj/machinery/mining/drill/Destroy()
+	QDEL_NULL(attached_satchel)
 	QDEL_NULL(spark_system)
 	return ..()
 

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -8,6 +8,7 @@
 /obj/machinery/mining/drill
 	name = "mining drill head"
 	desc = "A large industrial drill. Its bore does not penetrate deep enough to access the sublevels."
+	description_info = "You can upgrade this machine with better matter bins, capacitors, micro lasers, and power cells. You can also attach a mining satchel that has a warp pack and a linked ore box to it, to bluespace teleport any mined ore directly into the linked ore box."
 	icon_state = "mining_drill"
 	obj_flags = OBJ_FLAG_ROTATABLE
 	var/braces_needed = 2
@@ -34,6 +35,7 @@
 	var/capacity
 	var/charge_use
 	var/obj/item/cell/cell
+	var/obj/item/storage/bag/ore/attached_satchel
 
 	//Flags
 	var/need_update_field = FALSE
@@ -84,6 +86,10 @@
 		var/turf/unsimulated/floor/asteroid/T = get_turf(src)
 		if(!T.dug)
 			T.gets_dug()
+			for(var/obj/item/ore/ore in range(1, src)) // gets_dug causes ore to spawn, this picks that ore up as well
+				ore.forceMove(src)
+				if(attached_satchel?.linked_box)
+					attached_satchel.insert_into_storage(ore)
 	else if(istype(get_turf(src), /turf/simulated/floor))
 		var/turf/simulated/floor/T = get_turf(src)
 		T.ex_act(2.0)
@@ -98,7 +104,7 @@
 			resource_field -= harvesting
 			harvesting = pick(resource_field)
 
-		if(!harvesting) 
+		if(!harvesting)
 			return
 
 		var/total_harvest = harvest_speed //Ore harvest-per-tick.
@@ -132,7 +138,9 @@
 
 				for(var/i = 1, i <= create_ore, i++)
 					var/oretype = ore_types[ore]
-					new oretype(src)
+					var/obj/stored_ore = new oretype(src)
+					if(attached_satchel?.linked_box)
+						attached_satchel.insert_into_storage(stored_ore)
 
 		if(!found_resource)
 			harvesting.has_resources = FALSE
@@ -152,6 +160,8 @@
 	if(panel_open)
 		to_chat(user, "The power cell is [cell ? "installed" : "missing"].")
 	to_chat(user, "The cell charge meter reads [cell ? round(cell.percent(),1) : 0]%")
+	if(attached_satchel && user.Adjacent(src))
+		to_chat(user, FONT_SMALL(SPAN_NOTICE("It has a [attached_satchel] attached to it.")))
 	return
 
 
@@ -169,6 +179,32 @@
 				return
 	if(active) 
 		return ..()
+
+	if(istype(O, /obj/item/storage/bag/ore))
+		var/obj/item/storage/bag/ore/S = O
+		if(attached_satchel)
+			to_chat(user, SPAN_WARNING("\The [src] already has a satchel attached to it!"))
+			return
+		if(!S.linked_beacon)
+			to_chat(user, SPAN_WARNING("\The [S] doesn't have an extraction pack in it!"))
+			return
+		if(!S.linked_box)
+			to_chat(user, SPAN_WARNING("\The [S] doesn't have a linked ore box!"))
+			return
+		user.drop_from_inventory(S, src)
+		attached_satchel = S
+		to_chat(user, SPAN_NOTICE("You attach \the [S] to \the [src]."))
+		return
+
+	if(O.iswrench())
+		if(!attached_satchel)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't have a satchel attached to it!"))
+			return
+		attached_satchel.forceMove(get_turf(user))
+		user.put_in_hands(attached_satchel)
+		to_chat(user, SPAN_NOTICE("You detach \the [attached_satchel]."))
+		attached_satchel = null
+		return
 
 	if(O.iscrowbar())
 		if (panel_open)
@@ -340,17 +376,18 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(usr.stat) return
+	if(use_check_and_message(usr))
+		return
 
 	var/obj/structure/ore_box/B = locate() in orange(1)
 	if(B)
 		for(var/obj/item/ore/O in contents)
 			O.forceMove(B)
-		to_chat(usr, "<span class='notice'>You unload the drill's storage cache into the ore box.</span>")
+		to_chat(usr, SPAN_NOTICE("You unload \the [src]'s storage cache into the ore box."))
 	else
 		for(var/obj/item/ore/O in contents)
-			O.forceMove(src.loc)
-		to_chat(usr, "<span class='notice'>You spill the content's of the drill's storage box all over the ground. Idiot.</span>")
+			O.forceMove(get_turf(src))
+		to_chat(usr, SPAN_NOTICE("You spill the contents of \the [src]'s storage box all over the ground"))
 
 
 /obj/machinery/mining/brace

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -851,8 +851,10 @@ var/list/total_extraction_beacons = list()
 		beacon = A
 
 /obj/item/extraction_pack/afterattack(atom/movable/A, mob/living/carbon/human/user)
+	if(istype(A, /obj/item/storage/bag/ore))
+		return
 	if(!beacon)
-		to_chat(user, "\The [src] is not linked to a beacon, and cannot be used.")
+		to_chat(user, SPAN_WARNING("\The [src] is not linked to a beacon, and cannot be used."))
 		return
 	if(!istype(A))
 		return
@@ -885,6 +887,7 @@ var/list/total_extraction_beacons = list()
 /obj/item/warp_core
 	name = "warp extraction beacon signaller"
 	desc = "Emits a signal which Warp-Item recovery devices can lock onto. Activate in hand to create a beacon."
+	description_info = "You can activate this item in-hand to create a static beacon, or you can click on an ore box with it to allow the ore box to be linked to warp packed mining satchels."
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "subspace_amplifier"
 	origin_tech = list(TECH_BLUESPACE = 1, TECH_PHORON = 1, TECH_ENGINEERING = 2)

--- a/code/modules/mining/ore_satchel.dm
+++ b/code/modules/mining/ore_satchel.dm
@@ -1,0 +1,71 @@
+/obj/item/storage/bag/ore
+	name = "mining satchel"
+	desc = "This little bugger can be used to store and transport ores."
+	description_info = "You can attach a warp extraction pack to it, then click on an ore box that has a warp extraction beacon signaller attached to it to link them. Then ore put into this will be bluespace teleported into the ore box."
+	icon = 'icons/obj/mining.dmi'
+	icon_state = "satchel"
+	slot_flags = SLOT_BELT | SLOT_POCKET
+	w_class = 3
+	max_storage_space = 100
+	max_w_class = 3
+	can_hold = list(/obj/item/ore)
+	var/obj/structure/ore_box/linked_box
+	var/linked_beacon = FALSE // can't hold an actual beacon beclause storage code a shit
+	var/linked_beacon_uses = 3 // to hold the amount of uses the beacon had, storage code a shit.
+
+/obj/item/storage/bag/ore/examine(mob/user)
+	..()
+	if(user.Adjacent(src))
+		to_chat(user, FONT_SMALL(SPAN_NOTICE("It has a <b>warp extraction pack</b> inside.")))
+
+/obj/item/storage/bag/ore/drone
+	// this used to be 400. The inventory system FUCKING DIED at this.
+	max_storage_space = 200
+
+/obj/item/storage/bag/ore/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/extraction_pack))
+		var/obj/item/extraction_pack/E = W
+		if(linked_beacon)
+			to_chat(user, SPAN_WARNING("\The [src] already has a warp extraction pack!"))
+			return
+		linked_beacon = TRUE
+		linked_beacon_uses = E.uses_left
+		to_chat(user, SPAN_NOTICE("You attach \the [E] to \the [src]."))
+		qdel(E)
+	else if(W.isscrewdriver())
+		if(!linked_beacon)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't have a linked extraction pack!"))
+			return
+		var/obj/item/extraction_pack/E = new /obj/item/extraction_pack(get_turf(user))
+		E.uses_left = linked_beacon_uses
+		user.put_in_hands(linked_beacon)
+		to_chat(user, SPAN_NOTICE("You detach the warp extraction pack."))
+		linked_box = null
+		linked_beacon = FALSE
+	else
+		..()
+
+// called when you click on a turf to pick up ores
+/obj/item/storage/bag/ore/handle_storage_deferred(mob/user)
+	if(linked_box)
+		if(!linked_box.warp_core)
+			to_chat(user, SPAN_WARNING("\The [linked_box] lost its warp beacon!"))
+			linked_box = null
+			..()
+			return
+		for(var/obj/ore in contents)
+			remove_from_storage_deferred(ore, get_turf(src))
+			ore.forceMove(linked_box)
+	..()
+
+// called when you attack the bag with the ore to put one in
+/obj/item/storage/bag/ore/handle_item_insertion(obj/item/W as obj, prevent_warning = 0, mob/user = usr)
+	..()
+	if(linked_box)
+		if(!linked_box.warp_core)
+			to_chat(user, SPAN_WARNING("\The [linked_box] lost its warp beacon!"))
+			linked_box = null
+			return
+		for(var/obj/ore in contents)
+			remove_from_storage_deferred(ore, get_turf(src))
+			ore.forceMove(linked_box)

--- a/code/modules/mining/ore_satchel.dm
+++ b/code/modules/mining/ore_satchel.dm
@@ -5,9 +5,7 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "satchel"
 	slot_flags = SLOT_BELT | SLOT_POCKET
-	w_class = 3
 	max_storage_space = 100
-	max_w_class = 3
 	can_hold = list(/obj/item/ore)
 	var/obj/structure/ore_box/linked_box
 	var/linked_beacon = FALSE // can't hold an actual beacon beclause storage code a shit
@@ -21,6 +19,11 @@
 /obj/item/storage/bag/ore/drone
 	// this used to be 400. The inventory system FUCKING DIED at this.
 	max_storage_space = 200
+
+/obj/item/storage/bag/ore/Destroy()
+	linked_box = null
+	linked_beacon = FALSE
+	return ..()
 
 /obj/item/storage/bag/ore/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/extraction_pack))
@@ -47,25 +50,25 @@
 
 // called when you click on a turf to pick up ores
 /obj/item/storage/bag/ore/handle_storage_deferred(mob/user)
-	if(linked_box)
-		if(!linked_box.warp_core)
-			to_chat(user, SPAN_WARNING("\The [linked_box] lost its warp beacon!"))
-			linked_box = null
-			..()
-			return
-		for(var/obj/ore in contents)
-			remove_from_storage_deferred(ore, get_turf(src))
-			ore.forceMove(linked_box)
+	if(check_linked_box(user))
+		move_ore_to_ore_box()
 	..()
 
 // called when you attack the bag with the ore to put one in
-/obj/item/storage/bag/ore/handle_item_insertion(obj/item/W as obj, prevent_warning = 0, mob/user = usr)
+/obj/item/storage/bag/ore/handle_item_insertion(obj/item/W, prevent_warning = FALSE, mob/user = usr)
 	..()
+	if(check_linked_box(user))
+		move_ore_to_ore_box()
+
+/obj/item/storage/bag/ore/proc/check_linked_box(var/mob/user)
 	if(linked_box)
 		if(!linked_box.warp_core)
 			to_chat(user, SPAN_WARNING("\The [linked_box] lost its warp beacon!"))
 			linked_box = null
-			return
-		for(var/obj/ore in contents)
-			remove_from_storage_deferred(ore, get_turf(src))
-			ore.forceMove(linked_box)
+			return FALSE
+		return TRUE
+
+/obj/item/storage/bag/ore/proc/move_ore_to_ore_box()
+	for(var/obj/ore in contents)
+		remove_from_storage_deferred(ore, get_turf(src))
+		ore.forceMove(linked_box)

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -1,11 +1,10 @@
 
 /**********************Ore box**************************/
 
-var/global/list/bluespace_ore_boxes = list()
-
 /obj/structure/ore_box
 	name = "ore box"
 	desc = "A heavy box used for storing ore."
+	description_info = "You can attach a warp extraction beacon signaller to this, then click on it with an ore satchel that has a warp extraction pack attached, to link them."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "orebox0"
 	density = TRUE
@@ -15,15 +14,22 @@ var/global/list/bluespace_ore_boxes = list()
 
 /obj/structure/ore_box/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/ore))
-		user.remove_from_mob(W)
-		src.contents += W
+		user.drop_from_inventory(W, src)
+	if(istype(W, /obj/item/storage/bag/ore))
+		var/obj/item/storage/bag/ore/satchel = W
+		if(satchel.linked_beacon)
+			if(!warp_core)
+				to_chat(user, SPAN_WARNING("\The [src] doesn't have a warp beacon!"))
+				return
+			satchel.linked_box = src
+			to_chat(user, SPAN_NOTICE("You link \the [satchel] to \the [src]."))
+			return
 	if(istype(W, /obj/item/storage))
 		var/obj/item/storage/S = W
 		S.hide_from(user)
 		for(var/obj/item/ore/O in S.contents)
 			S.remove_from_storage_deferred(O, src, user) //This will move the item to this item's contents
 			CHECK_TICK
-
 		S.post_remove_from_storage_deferred(loc, user)
 		to_chat(user, span("notice", "You empty the satchel into the box."))
 	if(istype(W, /obj/item/warp_core))
@@ -32,7 +38,6 @@ var/global/list/bluespace_ore_boxes = list()
 			return
 		user.drop_from_inventory(W, src)
 		warp_core = W
-		bluespace_ore_boxes += src
 		to_chat(user, SPAN_NOTICE("You carefully attach \the [W] to \the [src], connecting it to the bluespace network."))
 
 	update_ore_count()
@@ -42,7 +47,6 @@ var/global/list/bluespace_ore_boxes = list()
 	if(warp_core)
 		warp_core.forceMove(get_turf(user))
 		user.put_in_hands(warp_core)
-		bluespace_ore_boxes -= src
 		to_chat(user, SPAN_NOTICE("You detach \the [warp_core] from \the [src], disconnecting it from the bluespace network."))
 		warp_core = null
 	else
@@ -67,7 +71,7 @@ var/global/list/bluespace_ore_boxes = list()
 	add_fingerprint(user)
 
 	if(warp_core)
-		to_chat(user, SPAN_NOTICE("It has a <b>[warp_core]</b> attached to it."))
+		to_chat(user, FONT_SMALL(SPAN_NOTICE("It has a <b>warp extraction beacon signaller</b> attached to it.")))
 
 	if(!length(contents))
 		to_chat(user, SPAN_NOTICE("It is empty."))

--- a/html/changelogs/geeves-bluespace_mining.yml
+++ b/html/changelogs/geeves-bluespace_mining.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Bluespace mining is now possible, to do so, attach a warp extraction pack to a mining satchel, then a warp extraction beacon signaller to an ore box. Link them by clicking on the ore box with the satchel."
+  - rscadd: "You can attach a linked mining satchel to a mining drill to teleport mined ores to the connected ore box."
+  - rscadd: "Mining satchel beacons can be removed with a screwdriver, mining drill satchels by wrench, and ore box beacons by hand."


### PR DESCRIPTION
Implements bluespace mining, or: How to keep your lousy ore box at home.
While it may sound complex, it's actually fairly simple once you get it down. This is an attempt to make mining a little more 24XX, as well as introducing a way for mining drills to not be awful.

* Bluespace mining is now possible, to do so, attach a warp extraction pack to a mining satchel, then a warp extraction beacon signaller to an ore box. Link them by clicking on the ore box with the satchel.
* You can attach a linked mining satchel to a mining drill to teleport mined ores to the connected ore box.
* Mining satchel beacons can be removed with a screwdriver, mining drill satchels by wrench, and ore box beacons by hand.