### PR TITLE
Avoids drafting being overly reliant on voters

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -597,11 +597,17 @@ var/global/list/additional_antag_types = list()
 
 		// If we don't have enough antags, draft people who voted for the round.
 		if(candidates.len < required_enemies)
+			var/initial_candidates = candidates.len
+
 			for(var/mob/abstract/new_player/player in players)
 				if(player.ckey in SSvote.round_voters)
 					log_debug("[player.key] voted for this round, so we are drafting them.")
 					candidates += player.mind
 					players -= player
+
+					if (candidates.len >= required_enemies)
+						log_debug("Drafted [candidates.len - initial_candidates] new antags from voters.")
+						break
 
 	return candidates		// Returns: The number of people who had the antagonist role set to yes, regardless of recomended_enemies, if that number is greater than required_enemies
 							//			required_enemies if the number of people with that role set to yes is less than recomended_enemies,

--- a/html/changelogs/skull132-antags_reliance.yml
+++ b/html/changelogs/skull132-antags_reliance.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - tweak: "Antag drafting from voters is now limited to just the bare minimum required to boot the round. Previous iteration could over-saturate the pool, making most of the antags be voters and not those who had the round enabled."


### PR DESCRIPTION
Scenario:

* 30 people vote for secret.
* 6 antags are required.
* 5 people have antag status enabled, only 1 extra is required.

Currently, this is resolved by drafting EVERYONE who voted. So we now have a pool of 30 to pick from, from where only 5/30th are willing. The likelihood of all of the willing ones being picked is slim to none.

The better way to resolve this is to draft only as many as you need. So you still (hopefully) have a majority of antags who actually want to be the round type.