### PR TITLE
Limb-B-Gone

### DIFF
--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -17,6 +17,7 @@
 /datum/uplink_item/item/implants/imp_explosive
 	name = "Explosive Implant (DANGER!)"
 	item_cost = 10
+	desc = "A box containing an explosive implant and implanter. Use the implant in-hand to set the explosion size and trigger phrase."
 	path = /obj/item/storage/box/syndie_kit/imp_explosive
 
 /datum/uplink_item/item/implants/imp_uplink

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -248,10 +248,9 @@ Implant Specifics:<BR>"}
 		explosion(get_turf(src), -1, 0, 2, 4)
 	if(ishuman(imp_in) && part)
 		//No tearing off these parts since it's pretty much killing. Mangle them. 
-		if(istype(part,/obj/item/organ/external/chest) ||	\
-				istype(part,/obj/item/organ/external/groin) ||	\
-				istype(part,/obj/item/organ/external/head))
-			part.createwound(BRUISE, 60)
+		if(part.vital && !istype(part, /obj/item/organ/external/head)) //Head explodes
+			part.createwound(BRUISE, 70)
+			part.add_pain(50)
 			imp_in.visible_message(SPAN_WARNING("[imp_in]'s [part.name] bursts open with a horrible ripping noise!"),
 									SPAN_DANGER("Your [part.name] bursts open with a horrible ripping noise!"),
 									SPAN_WARNING("You hear a horrible ripping noise."))

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -27,7 +27,7 @@
 	// What does the implant do upon injection?
 	// return 0 if the implant fails (ex. Revhead and loyalty implant.)
 	// return 1 if the implant succeeds (ex. Nonrevhead and loyalty implant.)
-/obj/item/implant/proc/implanted(var/mob/source)
+/obj/item/implant/proc/implanted(var/mob/source, mob/user)
 	return 1
 
 /obj/item/implant/proc/get_data()
@@ -271,11 +271,12 @@ Implant Specifics:<BR>"}
 	data.z_transfer = z_transfer
 	SSexplosives.queue(data)
 
-/obj/item/implant/explosive/implanted(mob/source)
+/obj/item/implant/explosive/implanted(mob/source, mob/user)
 	if(!phrase)
 		phrase = fallback_phrase
-	usr.mind.store_memory("\The [src] in [source] can be activated by saying something containing the phrase ''[phrase]'', <B>say [phrase]</B> to attempt to activate.", 0, 0)
-	to_chat(usr, "The implanted explosive implant in [source] can be activated by saying something containing the phrase ''[phrase]'', <B>say [phrase]</B> to attempt to activate.")
+	if(user.mind)
+		user.mind.store_memory("\The [src] in [source] can be activated by saying something containing the phrase ''[phrase]'', <B>say [phrase]</B> to attempt to activate.", 0, 0)
+	to_chat(usr, "\The [src] in [source] can be activated by saying something containing the phrase ''[phrase]'', <B>say [phrase]</B> to attempt to activate.")
 	return TRUE
 
 /obj/item/implant/explosive/attack_self(mob/user)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -180,7 +180,7 @@ Implant Specifics:<BR>"}
 			to_chat(user, SPAN_NOTICE("\The [implanter] already has an implant loaded."))
 			return // It's full.
 		if(!phrase)
-			var/choice = alert("Implant settings have not been changed. Continue?", "Ready for Implantation", "Yes", "Cancel")
+			var/choice = alert("Implant settings have not been changed. Continue?", "Ready for Implantation?", "Yes", "Cancel")
 			if(choice == "Cancel")
 				return
 			else
@@ -205,12 +205,12 @@ Implant Specifics:<BR>"}
 	if(malfunction == MALFUNCTION_PERMANENT)
 		return
 
-	var/turf/F = get_turf(imp_in)	
 	if(!imp_in)
 		small_countdown()
-	else
-		message_admins("Explosive implant triggered in [imp_in] ([imp_in.key]). (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[imp_in.x];Y=[imp_in.y];Z=[imp_in.z]'>JMP</a>) ")
-		log_game("Explosive implant triggered in [imp_in] ([imp_in.key]).")
+		return
+
+	message_admins("Explosive implant triggered in [imp_in] ([imp_in.key]). (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[imp_in.x];Y=[imp_in.y];Z=[imp_in.z]'>JMP</a>) ")
+	log_game("Explosive implant triggered in [imp_in] ([imp_in.key]).")
 	if(ishuman(imp_in))
 		var/mob/living/carbon/human/T = imp_in
 		if(elevel == "Localized Limb" && part)
@@ -225,7 +225,8 @@ Implant Specifics:<BR>"}
 	else if(ismob(imp_in))
 		var/mob/M = imp_in
 		M.gib()
-
+		
+	var/turf/F = get_turf(imp_in)	
 	if(F)
 		F.hotspot_expose(3500,125)
 	qdel(src)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -159,7 +159,7 @@ Implant Specifics:<BR>"}
 
 /obj/item/implant/explosive/Initialize()
 	. = ..()
-	fallback_phrase = "[pick("Alpha, Omega, Delta, Theta")] [rand(100, 999)]"
+	fallback_phrase = "[pick("Alpha", "Omega", "Delta", "Theta")] [rand(100, 999)]"
 
 /obj/item/implant/explosive/get_data()
 	. = {"

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -236,10 +236,10 @@ Implant Specifics:<BR>"}
 	if(!imp_in)
 		visible_message(SPAN_WARNING("Something begins beeping..."))
 	if(ishuman(imp_in))
-		var/message = "Something beeps inside of [imp_in][part ? "'s [part.name]" : ""]." //for some reason SPAN_X and span() both hate having this in-line
+		var/message = "Something beeps inside of [imp_in][part ? "'s [part.name]" : ""]..." //for some reason SPAN_X and span() both hate having this in-line
 		imp_in.visible_message(SPAN_WARNING(message))
 	else if(ismob(imp_in))
-		imp_in.visible_message(SPAN_WARNING("Something beeps inside of [imp_in]."))
+		imp_in.visible_message(SPAN_WARNING("Something beeps inside of [imp_in]..."))
 	playsound(loc, 'sound/items/countdown.ogg', 75, 1, -3)
 	addtimer(CALLBACK(src, .proc/small_boom), 25)
 

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -245,7 +245,7 @@ Implant Specifics:<BR>"}
 
 /obj/item/implant/explosive/proc/small_boom()
 	if(!imp_in)
-		explosion(get_turf(src), -1, -1, 1, 3)
+		explosion(get_turf(src), -1, 0, 2, 4)
 	if(ishuman(imp_in) && part)
 		//No tearing off these parts since it's pretty much killing. Mangle them. 
 		if(istype(part,/obj/item/organ/external/chest) ||	\

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -43,7 +43,7 @@
 
 				admin_attack_log(user, M, "Implanted using \the [src.name] ([src.imp.name])", "Implanted with \the [src.name] ([src.imp.name])", "used an implanter, [src.name] ([src.imp.name]), on")
 
-				if(src.imp.implanted(M))
+				if(src.imp.implanted(M, user))
 					src.imp.forceMove(M)
 					src.imp.imp_in = M
 					src.imp.implanted = 1

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -97,7 +97,7 @@
 
 /obj/item/storage/box/syndie_kit/imp_explosive
 	name = "box (E)"
-	starts_with = list(/obj/item/implanter/explosive = 1)
+	starts_with = list(/obj/item/implanter = 1, /obj/item/implant/explosive = 1)
 
 /obj/item/storage/box/syndie_kit/imp_uplink
 	name = "boxed uplink implant (with injector)"

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -832,6 +832,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	victim.updatehealth()
 	victim.UpdateDamageIcon()
 	victim.regenerate_icons()
+	victim.update_body(1)
 	dir = 2
 
 //Handles dismemberment

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -832,7 +832,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	victim.updatehealth()
 	victim.UpdateDamageIcon()
 	victim.regenerate_icons()
-	victim.update_body(1)
 	dir = 2
 
 //Handles dismemberment

--- a/html/changelogs/doxxmedearly - limbexplodey.yml
+++ b/html/changelogs/doxxmedearly - limbexplodey.yml
@@ -1,0 +1,16 @@
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Adjusted how explosive implants are set. You will no longer get the settings prompts when injecting. Use them in-hand to change the settings, instead."
+  - tweak: "When you put an explosive implant into an implanter, it tells you the setting and trigger phrase. If you did not set a phrase, it will generate and give you a fallback code word."
+  - tweak: "Explosive implants now spawn out of the implanter when the box is ordered from the uplink, to make it easier to use in-hand. Uplink description edited to inform people how to use it."
+  - bugfix: "Localized limb settings for explosive implants no longer gib the person. They just explode the limb. They can now explode outside a person's body, but it won't do much."


### PR DESCRIPTION
Fixes "Localized Limb" actually being localized to the limb instead of gibbing the target. 
Changes the way explo implants work. The prompt coming up while injecting was pretty cumbersome. Now you use it in-hand to set it. A fallback phrase was added in case people don't set it, and it can explode outside of a person, too, but it's basically useless. We're not going to make these into grenades. 
Uplink box now has the implant outside of the implanter, so you don't have to take it out, set it, then cram it in. 
Uplink info updated with how to use it now.
Fixes #8345 
Fixes #4120