### PR TITLE
Useful Icarus Drones

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2035,6 +2035,7 @@
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\cavern.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\clown.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\drone.dm"
+#include "code\modules\mob\living\simple_animal\hostile\retaliate\icarus_drone.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\retaliate.dm"
 #include "code\modules\modular_computers\laptop_vendor.dm"
 #include "code\modules\modular_computers\computers\modular_computer\core.dm"

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -25,7 +25,7 @@
 			return 0
 	return 1
 
-/proc/get_random_turf_in_range(var/atom/origin, var/outer_range, var/inner_range)
+/proc/get_random_turf_in_range(var/atom/origin, var/outer_range, var/inner_range, var/check_density = FALSE)
 	origin = get_turf(origin)
 	if(!origin)
 		return
@@ -36,6 +36,8 @@
 				continue
 			if(T.y >= world.maxy-TRANSITIONEDGE || T.y <= TRANSITIONEDGE)
 				continue
+		if(check_density && !turf_clear(T))
+			continue
 		if(!inner_range || get_dist(origin, T) >= inner_range)
 			turfs += T
 	if(turfs.len)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -67,7 +67,7 @@
 	if(!isnull(T))
 		stance = HOSTILE_STANCE_ATTACK
 	if(isliving(T))
-		custom_emote(1, "[attack_emote] [T]")
+		custom_emote(1, "[attack_emote] [T].")
 		if(istype(T, /mob/living/simple_animal/hostile/))
 			var/mob/living/simple_animal/hostile/H = T
 			H.being_targeted(src)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -26,6 +26,9 @@
 	var/list/target_type_validator_map = list()
 	var/attack_emote = "stares menacingly at"
 
+	// Specific targets
+	var/list/valid_living_targets = list()
+
 	var/smart = FALSE // This makes ranged mob check for friendly fire and obstacles
 
 /mob/living/simple_animal/hostile/Initialize()
@@ -350,22 +353,30 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 //////////////////////////////
 
 /mob/living/simple_animal/hostile/proc/validator_living(var/mob/living/L, var/atom/current)
-	if(ismech(L))
-		var/mob/living/heavy_vehicle/M = L
-		if(!M.pilots?.len)
-			return FALSE
-
+	if(L.health <= 0 || L.stat == DEAD)
+		return FALSE
 	if((L.faction == src.faction) && !attack_same)
 		return FALSE
 	if(L in friends)
 		return FALSE
-	if(!L.stat)
-		var/current_health = INFINITY
-		if (isliving(current))
-			var/mob/living/M = current
-			current_health = M.health
-		if(L.health < current_health)
+
+	if(length(valid_living_targets)) // it has a specific list of targets
+		if(is_type_in_list(L, valid_living_targets))
 			return TRUE
+		return FALSE
+	else
+		if(ismech(L))
+			var/mob/living/heavy_vehicle/M = L
+			if(!M.pilots?.len)
+				return FALSE
+
+		if(!L.stat)
+			var/current_health = INFINITY
+			if(isliving(current))
+				var/mob/living/M = current
+				current_health = M.health
+			if(L.health < current_health)
+				return TRUE
 	return FALSE
 
 /mob/living/simple_animal/hostile/proc/validator_bot(var/obj/machinery/bot/B, var/atom/current)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
@@ -55,6 +55,8 @@
 	damage_type = BURN
 	check_armour = "energy"
 	damage = 5
+	no_attack_log = TRUE
+	human_attack_log_override = TRUE
 
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	tracer_type = /obj/effect/projectile/tracer/stun

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -62,6 +62,14 @@
 	ion_trail = new(src)
 	ion_trail.start()
 
+/mob/living/simple_animal/hostile/retaliate/malf_drone/examine(mob/user)
+	..()
+	to_chat(user, SPAN_WARNING("This one seems to be malfunctioning."))
+	if(hostile_drone)
+		to_chat(user, SPAN_WARNING("It's completely lit up, with targetting vanes in place."))
+	else
+		to_chat(user, SPAN_WARNING("Most of its lights are off, and its targetting vanes are retracted."))
+
 /mob/living/simple_animal/hostile/retaliate/malf_drone/Allow_Spacemove(var/check_drift = 0)
 	return 1
 
@@ -275,6 +283,10 @@
 
 /obj/item/projectile/beam/drone
 	damage = 15
+	no_attack_log = TRUE
+	human_attack_log_override = TRUE
 
 /obj/item/projectile/beam/pulse/drone
 	damage = 10
+	no_attack_log = TRUE
+	human_attack_log_override = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/icarus_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/icarus_drone.dm
@@ -28,7 +28,7 @@
 	var/explode_chance = 1
 	var/disabled = FALSE
 	var/exploding = FALSE
-	var/list/valid_living_targets = list(
+	valid_living_targets = list(
 						/mob/living/simple_animal/hostile/hivebot,
 						/mob/living/simple_animal/hostile/carp,
 						/mob/living/simple_animal/hostile/retaliate/cavern_dweller,

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/icarus_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/icarus_drone.dm
@@ -1,0 +1,272 @@
+// friendly icarus combat drones
+/mob/living/simple_animal/hostile/retaliate/icarus_drone
+	name = "combat drone"
+	desc = "An automated combat drone armed with state of the art weaponry and shielding."
+	icon_state = "drone3"
+	icon_living = "drone3"
+	icon_dead = "drone_dead"
+	ranged = TRUE
+	rapid = TRUE
+	speak_chance = 5
+	turns_per_move = 3
+	response_help = "pokes"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
+	speak = list("ALERT, Icarus Drone active and patrolling!", "Hostile entities in the area!", "Threat parameters nominal.", "Subsystems stable at combat level theta.")
+	emote_see = list("beeps menacingly", "whirrs threateningly", "scans its immediate vicinity")
+	a_intent = I_HURT
+	stop_automated_movement_when_pulled = FALSE
+	health = 300
+	maxHealth = 300
+	speed = 8
+	projectiletype = /obj/item/projectile/beam/drone
+	projectilesound = 'sound/weapons/laser3.ogg'
+	destroy_surroundings = FALSE
+	var/datum/effect_system/ion_trail/ion_trail
+
+	var/turf/patrol_target
+	var/explode_chance = 1
+	var/disabled = FALSE
+	var/exploding = FALSE
+
+	//Drones aren't affected by atmos.
+	min_oxy = 0
+	max_oxy = 0
+	min_tox = 0
+	max_tox = 0
+	min_co2 = 0
+	max_co2 = 0
+	min_n2 = 0
+	max_n2 = 0
+	minbodytemp = 0
+
+	var/has_loot = TRUE
+	faction = "neutral"
+
+	tameable = FALSE
+
+	flying = TRUE
+	smart = TRUE
+
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/Initialize()
+	. = ..()
+	if(prob(5))
+		projectiletype = /obj/item/projectile/beam/pulse/drone
+		projectilesound = 'sound/weapons/pulse2.ogg'
+	ion_trail = new(src)
+	ion_trail.start()
+	visible_message(SPAN_WARNING("\The [src] appears out of thin air!"))
+	spark(src, 3, alldirs)
+	addtimer(CALLBACK(src, .proc/beam_out), 5 MINUTES)
+
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/proc/beam_out()
+	visible_message(SPAN_WARNING("\The [src] disappears into thin air!"))
+	spark(src, 3, alldirs)
+	has_loot = FALSE
+	qdel(src)
+
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/Allow_Spacemove(var/check_drift = 0)
+	return TRUE
+
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/ListTargets()
+	return view(src, 10)
+
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/isSynthetic()
+	return TRUE
+
+//self repair systems have a chance to bring the drone back to life
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/Life()
+	//emps and lots of damage can temporarily shut us down
+	if(disabled > 0)
+		stat = UNCONSCIOUS
+		icon_state = "drone_dead"
+		disabled--
+		wander = 0
+		speak_chance = 0
+		if(disabled <= 0)
+			stat = CONSCIOUS
+			icon_state = "drone0"
+			wander = 1
+			speak_chance = 5
+
+	//repair a bit of damage
+	if(prob(1))
+		src.visible_message(span("alert", "\The [src] shudders and shakes as some of its damaged systems come back online."))
+		spark(src, 3, alldirs)
+		health += rand(25,100)
+
+	if(health / maxHealth > 0.9)
+		icon_state = "drone3"
+		explode_chance = 0
+	else if(health / maxHealth > 0.7)
+		icon_state = "drone2"
+		explode_chance = 0
+	else if(health / maxHealth > 0.5)
+		icon_state = "drone1"
+		explode_chance = 0.5
+	else if(health / maxHealth > 0.3)
+		icon_state = "drone0"
+		explode_chance = 5
+	else if(health > 0)
+		//if health gets too low, shut down
+		icon_state = "drone_dead"
+		exploding = FALSE
+		if(!disabled)
+			visible_message(pick(SPAN_NOTICE("\The [src] suddenly shuts down!"), SPAN_NOTICE("\The [src] suddenly lies still and quiet.")))
+			disabled = rand(150, 600)
+			walk(src, 0)
+
+	if(exploding && prob(20))
+		visible_message(pick(SPAN_WARNING("\The [src] begins to spark and shake violently!"), SPAN_WARNING("\The [src] sparks and shakes like it's about to explode!")))
+		spark(src, 3, alldirs)
+
+	if(!exploding && !disabled && prob(explode_chance))
+		exploding = TRUE
+		stat = UNCONSCIOUS
+		wander = 1
+		walk(src,0)
+		spawn(rand(50, 150))
+			if(!disabled && exploding)
+				explosion(get_turf(src), 0, 1, 4, 7)
+	..()
+
+//ion rifle!
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/emp_act(severity)
+	health -= rand(3,15) * (severity + 1)
+	disabled = rand(150, 600)
+	walk(src,0)
+
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/death()
+	..(null, "suddenly breaks apart.")
+	qdel(src)
+
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/Destroy()
+	QDEL_NULL(ion_trail)
+	//some random debris left behind
+	if(has_loot)
+		spark(src, 3, alldirs)
+		var/obj/O
+
+		//shards
+		O = new /obj/item/material/shard(get_turf(src))
+		step_to(O, get_turf(pick(view(7, src))))
+		if(prob(75))
+			O = new /obj/item/material/shard(get_turf(src))
+			step_to(O, get_turf(pick(view(7, src))))
+		if(prob(50))
+			O = new /obj/item/material/shard(get_turf(src))
+			step_to(O, get_turf(pick(view(7, src))))
+		if(prob(25))
+			O = new /obj/item/material/shard(get_turf(src))
+			step_to(O, get_turf(pick(view(7, src))))
+
+		//rods
+		O = new /obj/item/stack/rods(get_turf(src))
+		step_to(O, get_turf(pick(view(7, src))))
+		if(prob(75))
+			O = new /obj/item/stack/rods(get_turf(src))
+			step_to(O, get_turf(pick(view(7, src))))
+		if(prob(50))
+			O = new /obj/item/stack/rods(get_turf(src))
+			step_to(O, get_turf(pick(view(7, src))))
+		if(prob(25))
+			O = new /obj/item/stack/rods(get_turf(src))
+			step_to(O, get_turf(pick(view(7, src))))
+
+		//plasteel
+		O = new /obj/item/stack/material/plasteel(get_turf(src))
+		step_to(O, get_turf(pick(view(7, src))))
+		if(prob(75))
+			O = new /obj/item/stack/material/plasteel(get_turf(src))
+			step_to(O, get_turf(pick(view(7, src))))
+		if(prob(50))
+			O = new /obj/item/stack/material/plasteel(get_turf(src))
+			step_to(O, get_turf(pick(view(7, src))))
+		if(prob(25))
+			O = new /obj/item/stack/material/plasteel(get_turf(src))
+			step_to(O, get_turf(pick(view(7, src))))
+
+		//also drop dummy circuit boards deconstructable for research (loot)
+		var/obj/item/circuitboard/C
+
+		//spawn 1-4 boards of a random type
+		var/spawnees = 0
+		var/num_boards = rand(1, 4)
+		var/list/options = list(1, 2, 4, 8, 16, 32, 64, 128, 256)
+		for(var/i = 0, i < num_boards, i++)
+			var/chosen = pick(options)
+			options.Remove(options.Find(chosen))
+			spawnees |= chosen
+
+		if(spawnees & 1)
+			C = new(get_turf(src))
+			C.name = "drone CPU motherboard"
+			C.origin_tech = list(TECH_DATA = rand(3, 6))
+
+		if(spawnees & 2)
+			C = new(get_turf(src))
+			C.name = "drone neural interface"
+			C.origin_tech = list(TECH_BIO = rand(3, 6))
+
+		if(spawnees & 4)
+			C = new(get_turf(src))
+			C.name = "drone suspension processor"
+			C.origin_tech = list(TECH_MAGNET = rand(3, 6))
+
+		if(spawnees & 8)
+			C = new(get_turf(src))
+			C.name = "drone shielding controller"
+			C.origin_tech = list(TECH_BLUESPACE = rand(3, 6))
+
+		if(spawnees & 16)
+			C = new(get_turf(src))
+			C.name = "drone power capacitor"
+			C.origin_tech = list(TECH_POWER = rand(3, 6))
+
+		if(spawnees & 32)
+			C = new(get_turf(src))
+			C.name = "drone hull reinforcer"
+			C.origin_tech = list(TECH_MATERIAL = rand(3, 6))
+
+		if(spawnees & 64)
+			C = new(get_turf(src))
+			C.name = "drone auto-repair system"
+			C.origin_tech = list(TECH_ENGINEERING = rand(3, 6))
+
+		if(spawnees & 128)
+			C = new(get_turf(src))
+			C.name = "drone phoron overcharge counter"
+			C.origin_tech = list(TECH_PHORON = rand(3, 6))
+
+		if(spawnees & 256)
+			C = new(get_turf(src))
+			C.name = "drone targetting circuitboard"
+			C.origin_tech = list(TECH_COMBAT = rand(3, 6))
+
+	return ..()
+
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/validator_living(var/mob/living/L, var/atom/current)
+	if(L.health <= 0)
+		return FALSE
+	if(istype(L, /mob/living/simple_animal/hostile/hivebot))
+		return TRUE
+	if(istype(L, /mob/living/simple_animal/hostile/carp))
+		return TRUE
+	if(istype(L, /mob/living/simple_animal/hostile/retaliate/cavern_dweller))
+		return TRUE
+	if(istype(L, /mob/living/simple_animal/hostile/giant_spider))
+		return TRUE
+	if(istype(L, /mob/living/simple_animal/hostile/spider_queen))
+		return TRUE
+	if(istype(L, /mob/living/simple_animal/hostile/retaliate/malf_drone))
+		return TRUE
+	return FALSE
+
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/validator_bot(var/obj/machinery/bot/B, var/atom/current)
+	return FALSE
+
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/validator_turret(var/obj/machinery/porta_turret/T, var/atom/current)
+	return FALSE
+
+/mob/living/simple_animal/hostile/retaliate/icarus_drone/validator_e_field(var/obj/effect/energy_field/E, var/atom/current)
+	return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/icarus_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/icarus_drone.dm
@@ -28,6 +28,14 @@
 	var/explode_chance = 1
 	var/disabled = FALSE
 	var/exploding = FALSE
+	var/list/valid_living_targets = list(
+						/mob/living/simple_animal/hostile/hivebot,
+						/mob/living/simple_animal/hostile/carp,
+						/mob/living/simple_animal/hostile/retaliate/cavern_dweller,
+						/mob/living/simple_animal/hostile/giant_spider,
+						/mob/living/simple_animal/hostile/spider_queen,
+						/mob/living/simple_animal/hostile/retaliate/malf_drone
+										)
 
 	//Drones aren't affected by atmos.
 	min_oxy = 0
@@ -244,23 +252,6 @@
 			C.origin_tech = list(TECH_COMBAT = rand(3, 6))
 
 	return ..()
-
-/mob/living/simple_animal/hostile/retaliate/icarus_drone/validator_living(var/mob/living/L, var/atom/current)
-	if(L.health <= 0)
-		return FALSE
-	if(istype(L, /mob/living/simple_animal/hostile/hivebot))
-		return TRUE
-	if(istype(L, /mob/living/simple_animal/hostile/carp))
-		return TRUE
-	if(istype(L, /mob/living/simple_animal/hostile/retaliate/cavern_dweller))
-		return TRUE
-	if(istype(L, /mob/living/simple_animal/hostile/giant_spider))
-		return TRUE
-	if(istype(L, /mob/living/simple_animal/hostile/spider_queen))
-		return TRUE
-	if(istype(L, /mob/living/simple_animal/hostile/retaliate/malf_drone))
-		return TRUE
-	return FALSE
 
 /mob/living/simple_animal/hostile/retaliate/icarus_drone/validator_bot(var/obj/machinery/bot/B, var/atom/current)
 	return FALSE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -373,11 +373,11 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 
 		if(I_HELP)
 			if (health > 0)
-				M.visible_message("<span class='notice'>[M] [response_help] \the [src]</span>")
+				M.visible_message(SPAN_NOTICE("[M] [response_help] \the [src]."))
 				poke()
 
 		if(I_DISARM)
-			M.visible_message("<span class='notice'>[M] [response_disarm] \the [src]</span>")
+			M.visible_message(SPAN_NOTICE("[M] [response_disarm] \the [src]."))
 			M.do_attack_animation(src)
 			poke(1)
 			//TODO: Push the mob away or something
@@ -399,13 +399,13 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 			G.affecting = src
 			LAssailant = WEAKREF(M)
 
-			M.visible_message("<span class='warning'>[M] has grabbed [src] passively!</span>")
+			M.visible_message(SPAN_WARNING("[M] has grabbed [src] passively!"))
 			M.do_attack_animation(src)
 			poke(1)
 
 		if(I_HURT)
 			apply_damage(harm_intent_damage, BRUTE, used_weapon = "Attack by [M.name]")
-			M.visible_message("<span class='warning'>[M] [response_harm] \the [src]</span>")
+			M.visible_message(SPAN_WARNING("[M] [response_harm] \the [src]!"))
 			M.do_attack_animation(src)
 			poke(1)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -97,6 +97,8 @@
 	var/impact_type
 	var/hit_effect
 
+	var/human_attack_log_override = FALSE // overrides no_attack_log if the person who got shot is a human type
+
 /obj/item/projectile/CanPass()
 	return TRUE
 
@@ -188,7 +190,7 @@
 		target_mob.visible_message("<span class='danger'>\The [target_mob] is hit by \the [src] in the [parse_zone(def_zone)]!</span>", "<span class='danger'><font size='2'>You're hit by \the [src] in the [parse_zone(def_zone)]!</font></span>")//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
 
 	//admin logs
-	if(!no_attack_log)
+	if(!no_attack_log && (!human_attack_log_override || (human_attack_log_override && ishuman(target_mob))))
 		if(istype(firer, /mob))
 
 			var/attacker_message = "shot with \a [src.type]"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -190,7 +190,7 @@
 		target_mob.visible_message("<span class='danger'>\The [target_mob] is hit by \the [src] in the [parse_zone(def_zone)]!</span>", "<span class='danger'><font size='2'>You're hit by \the [src] in the [parse_zone(def_zone)]!</font></span>")//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
 
 	//admin logs
-	if(!no_attack_log && (!human_attack_log_override || (human_attack_log_override && ishuman(target_mob))))
+	if(!no_attack_log || (human_attack_log_override && ishuman(target_mob)))
 		if(istype(firer, /mob))
 
 			var/attacker_message = "shot with \a [src.type]"

--- a/html/changelogs/geeves-useful_icarus.yml
+++ b/html/changelogs/geeves-useful_icarus.yml
@@ -1,0 +1,9 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "The NMV Icarus will now dispatch combat drones to assist with medium to large carp migrations."
+  - tweak: "Interacting with simple mobs now have full stops in the chat menu."
+  - tweak: "For the admins, combat drones and cavern dwellers fighting eachother will no longer make admin messages, unless a human player is hit. In that case, laugh at them."
+  - rscadd: "Malfunctioning Icarus drones now have extended descriptions that tell you a little about what they're doing."


### PR DESCRIPTION
* The NMV Icarus will now dispatch combat drones to assist with medium to large carp migrations.
* Interacting with simple mobs now have full stops in the chat menu.
* For the admins, combat drones and cavern dwellers fighting eachother will no longer make admin messages, unless a human player is hit. In that case, laugh at them.
* Malfunctioning Icarus drones now have extended descriptions that tell you a little about what they're doing.