### PR TITLE
WetSkrell.NT 2 Electric Boogaloo

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1898,6 +1898,7 @@
 #include "code\modules\mob\living\carbon\human\species\station\ipc\ipc.dm"
 #include "code\modules\mob\living\carbon\human\species\station\ipc\ipc_subspecies.dm"
 #include "code\modules\mob\living\carbon\human\species\station\skrell\skrell.dm"
+#include "code\modules\mob\living\carbon\human\species\station\skrell\skrellstate.dm"
 #include "code\modules\mob\living\carbon\human\species\station\tajara\tajara.dm"
 #include "code\modules\mob\living\carbon\human\species\station\tajara\tajaran_subspecies.dm"
 #include "code\modules\mob\living\carbon\human\species\station\unathi\unathi.dm"

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -323,3 +323,9 @@
 #define SURGERY_SUCCESS 2 // Proceed with surgery
 #define SURGERY_FAIL 1 // Autofail surgery
 #define SURGERY_IGNORE 0 // Ignore surgery completely and just attack
+
+// Moisture levels, for Skrell
+#define MOISTURE_MAX 3600
+#define MOISTURE_NORMAL 1800
+#define MOISTURE_LOW 900
+#define MOISTURE_NONE 0

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -223,6 +223,11 @@
 			if(o.applied_pressure == src)
 				msg += "<span class='warning'>[T.He] [T.is] applying pressure to [T.his] [o.name]!</span>\n"
 
+	//moisture
+	if(istype(ST))
+		if(ST.moisture < MOISTURE_LOW)
+			msg += "<span class='warning'>[T.He] looks dried out!</span>\n"
+
 	if(mSmallsize in mutations)
 		msg += "[T.He] [T.is] small halfling!\n"
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -112,3 +112,5 @@
 	var/datum/unarmed_attack/default_attack	//default unarmed attack
 
 	var/datum/martial_art/martial_art = null
+
+	var/datum/skrellstate/ST = null

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -425,6 +425,11 @@
 /datum/species/proc/can_understand(var/mob/other)
 	return
 
+/datum/species/proc/adjustBruteLoss(var/mob/living/carbon/C, var/amount)
+	return 1
+/datum/species/proc/adjustBurnLoss(var/mob/living/carbon/C, var/amount)
+	return 1
+
 // Called when using the shredding behavior.
 /datum/species/proc/can_shred(var/mob/living/carbon/human/H, var/ignore_intent)
 

--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
@@ -63,30 +63,30 @@
 
 /datum/species/skrell/handle_environment_special(var/mob/living/carbon/human/H)
 	var/old_moisture = H.ST.moisture
-	H.ST.moisture = max(0, H.ST.moisture - rand(-0.8, 1.3))			// Reduce moisture a little.
-	if(H.fire_stacks && H.ST.moisture > 1800)						// Flaming moist skrell can reduce their flame
+	H.ST.moisture = max(MOISTURE_NONE, H.ST.moisture - rand(8, 13)/10)			// Reduce moisture a little.
+	if(H.fire_stacks && H.ST.moisture > MOISTURE_NORMAL)			// Flaming moist skrell can reduce their flame
 		H.fire_stacks--
 		H.ST.moisture -= rand(150, 350)								// Lost a lot of moisture
-	var/pain_limit = (1800-H.ST.moisture) * (40 / 1800)				// The max halloss damage to do based on current moisture. At 0, this is 30. At 1800 or higher, this is 0.
+	var/pain_limit = (MOISTURE_NORMAL-H.ST.moisture) * (40 / MOISTURE_NORMAL)	// The max halloss damage to do based on current moisture. At 0, this is 30. At 1800 or higher, this is 0.
 	
 	// Add more pain damage if they need it.
-	var setPain = max(H.getHalLoss(), pain_limit)
+	var/setPain = max(H.getHalLoss(), pain_limit)
 	H.adjustHalLoss(setPain - H.getHalLoss())
 	
 	// Skrell hydration is directly tied to their moisture.
-	H.hydration = (H.ST.moisture / 3600) * H.max_hydration
+	H.hydration = (H.ST.moisture / MOISTURE_MAX) * H.max_hydration
 
-	if(H.ST.moisture <= 1800 && old_moisture > 1800)
-		H << "<span class='warning'>You are drying out. You should consider moisturizing.</span>"
-	else if(H.ST.moisture <= 900 && old_moisture > 900)
-		H << "<span class='warning'>You are really dry! Your skin feels uncomfortable and flakey!</span>"
-	else if(H.ST.moisture == 0 && old_moisture > 0)
-		H << "<span class='danger'>You are completely dry, this is really painful!</span>"
+	if(H.ST.moisture <= MOISTURE_NORMAL && old_moisture > MOISTURE_NORMAL)
+		to_chat(H, SPAN_WARNING("You are drying out. You should consider moisturizing."))
+	else if(H.ST.moisture <= MOISTURE_LOW && old_moisture > MOISTURE_LOW)
+		to_chat(H, SPAN_WARNING("You are really dry! Your skin feels uncomfortable and flakey!"))
+	else if(H.ST.moisture == MOISTURE_NONE && old_moisture > MOISTURE_NONE)
+		to_chat(H, SPAN_DANGER("You are completely dry, this is really painful!"))
 
 /datum/species/skrell/adjustBurnLoss(var/mob/living/carbon/C, var/amount)
 	if(istype(C,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = C
-		. = (1 - (H.ST.moisture / 3600))*0.6 + 0.7 // At 0 moisture, this is 1.3 At 3600 moisture, this is 0.7. Average of 1.0
+		. = (1 - (H.ST.moisture / MOISTURE_MAX))*0.6 + 0.7 // At 0 moisture, this is 1.3 At 3600 moisture, this is 0.7. Average of 1.0
 		H.ST.moisture = max(0, H.ST.moisture - amount * 30) // Lose 30 * damage in moisture. 100 damage will almost instantly 0 the wettest of skrell
 	else
 		return 1

--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
@@ -61,8 +61,39 @@
 
 	zombie_type = "Skrell Zombie"
 
+/datum/species/skrell/handle_environment_special(var/mob/living/carbon/human/H)
+	var/old_moisture = H.ST.moisture
+	H.ST.moisture = max(0, H.ST.moisture - rand(-0.8, 1.3))			// Reduce moisture a little.
+	if(H.fire_stacks && H.ST.moisture > 1800)						// Flaming moist skrell can reduce their flame
+		H.fire_stacks--
+		H.ST.moisture -= rand(150, 350)								// Lost a lot of moisture
+	var/pain_limit = (1800-H.ST.moisture) * (40 / 1800)				// The max halloss damage to do based on current moisture. At 0, this is 30. At 1800 or higher, this is 0.
+	
+	// Add more pain damage if they need it.
+	var setPain = max(H.getHalLoss(), pain_limit)
+	H.adjustHalLoss(setPain - H.getHalLoss())
+	
+	// Skrell hydration is directly tied to their moisture.
+	H.hydration = (H.ST.moisture / 3600) * H.max_hydration
+
+	if(H.ST.moisture <= 1800 && old_moisture > 1800)
+		H << "<span class='warning'>You are drying out. You should consider moisturizing.</span>"
+	else if(H.ST.moisture <= 900 && old_moisture > 900)
+		H << "<span class='warning'>You are really dry! Your skin feels uncomfortable and flakey!</span>"
+	else if(H.ST.moisture == 0 && old_moisture > 0)
+		H << "<span class='danger'>You are completely dry, this is really painful!</span>"
+
+/datum/species/skrell/adjustBurnLoss(var/mob/living/carbon/C, var/amount)
+	if(istype(C,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = C
+		. = (1 - (H.ST.moisture / 3600))*0.6 + 0.7 // At 0 moisture, this is 1.3 At 3600 moisture, this is 0.7. Average of 1.0
+		H.ST.moisture = max(0, H.ST.moisture - amount * 30) // Lose 30 * damage in moisture. 100 damage will almost instantly 0 the wettest of skrell
+	else
+		return 1
+
 /datum/species/skrell/handle_post_spawn(mob/living/carbon/human/H)
 	H.set_psi_rank(PSI_COERCION, PSI_RANK_OPERANT)
+	H.ST = new()
 
 /datum/species/skrell/can_breathe_water()
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrellstate.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrellstate.dm
@@ -1,2 +1,2 @@
 /datum/skrellstate
-    var/moisture = 3600
+    var/moisture = MOISTURE_MAX

--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrellstate.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrellstate.dm
@@ -1,0 +1,2 @@
+/datum/skrellstate
+    var/moisture = 3600

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -247,7 +247,9 @@
 		return 0
 
 	brute *= brute_mod
+	brute *= (owner.species ? owner.species.adjustBruteLoss(owner, brute) : 1)
 	burn *= burn_mod
+	burn *= (owner.species ? owner.species.adjustBurnLoss(owner, burn) : 1)
 
 	var/laser = (damage_flags & DAM_LASER)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -233,6 +233,10 @@
 
 	if(istype(M) && !istype(M, /mob/abstract))
 		M.color = initial(M.color)
+		if(istype(M, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = M
+			if(istype(H.ST))
+				H.ST.moisture = min(3600, H.ST.moisture + amount * 10)
 
 /datum/reagent/water/affect_touch(var/mob/living/carbon/slime/S, var/alien, var/removed)
 	if(istype(S))

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -71,7 +71,7 @@ If you add a drink with no empty icon sprite, ensure it is flagged as NO_EMPTY_I
 /obj/item/reagent_containers/food/drinks/proc/boom(mob/user as mob)
 	user.visible_message("<span class='danger'>\The [src] explodes all over [user] as they open it!</span>","<span class='danger'>\The [src] explodes all over you as you open it!</span>","You can hear a soda can explode.")
 	playsound(loc,'sound/items/soda_burst.ogg', rand(20,50), 1)
-	reagents.clear_reagents()
+	reagents.splash(user, reagents.total_volume) // Cover the target in whatever's stored.
 	flags |= OPENCONTAINER
 	shaken = 0
 

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -396,6 +396,7 @@ datum/unit_test/mob_damage/skrell/brute
 datum/unit_test/mob_damage/skrell/fire
 	name = "MOB: Skrell Fire Damage Check"
 	damagetype = BURN
+	expected_vulnerability = ARMORED
 
 datum/unit_test/mob_damage/skrell/tox
 	name = "MOB: Skrell Toxins Damage Check"

--- a/html/changelogs/tehflamintaco - WetSkrell.yml
+++ b/html/changelogs/tehflamintaco - WetSkrell.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Skrell now must stay wet."
+  - rscadd: "Skrell now must stay wet. This can be achieved by covering yourself in water, through either showers, water bottles, or the pool. Failing to stay wet will cause skrell to feel pain and slow down, but staying wet reduces burn damage."

--- a/html/changelogs/tehflamintaco - WetSkrell.yml
+++ b/html/changelogs/tehflamintaco - WetSkrell.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Teh Flamin' Taco
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Skrell now must stay wet."


### PR DESCRIPTION
Skrell now need to keep hydrated.
Showers, The Pool, Exploding water bottles, just about anything that allows you to touch water will restore your moisture. Drinking does not.
Skrell do not need to drink, as much like frogs, they get their hydration from their skin.
A Dry skrell also gets a minimum pain damage, causing them slowdown, and making them easier to be dropped by stun weapons.

This is an improvement from the last attempt at this PR, as it uses MUCH cleaner code.