### PR TITLE
Vaurca Bite Nerf

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -337,43 +337,43 @@ mob/living/carbon/human/proc/change_monitor()
 	set desc = "While grabbing someone aggressively, tear into them with your mandibles."
 
 	if(last_special > world.time)
-		to_chat(src, "<span class='warning'>Your mandibles still ache!</span>")
+		to_chat(src, SPAN_WARNING("Your mandibles still ache!"))
 		return
 
-	if(stat || paralysis || stunned || weakened || lying)
-		to_chat(src, "<span class='warning'>You cannot do that in your current state.</span>")
+	if(use_check_and_message(usr))
 		return
 
 	var/obj/item/grab/G = locate() in src
 	if(!G || !istype(G))
-		to_chat(src, "<span class='warning'>You are not grabbing anyone.</span>")
+		to_chat(src, SPAN_WARNING("You are not grabbing anyone."))
 		return
 
-	if(G.state < GRAB_AGGRESSIVE)
-		to_chat(src, "<span class='warning'>You must have an aggressive grab to gut your prey!</span>")
+	if(G.state < GRAB_KILL)
+		to_chat(src, SPAN_WARNING("You must have an strangling grip to bite someone!"))
 		return
 
-	if(istype(G.affecting,/mob/living/carbon/human))
+	if(istype(G.affecting, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = G.affecting
 		var/hit_zone = zone_sel.selecting
 		var/obj/item/organ/external/affected = H.get_organ(hit_zone)
 
 		if(!affected || affected.is_stump())
-			to_chat(H, "<span class='danger'>They are missing that limb!</span>")
+			to_chat(H, SPAN_WARNING("They are missing that limb!"))
 			return
 
-		H.apply_damage(25, BRUTE, hit_zone, sharp = 1, edge = 1)
-		visible_message("<span class='warning'><b>\The [src]</b> rips viciously at \the [G.affecting]'s [affected] with its mandibles!</span>")
+		H.apply_damage(25, BRUTE, hit_zone, sharp = TRUE, edge = TRUE)
+		visible_message(SPAN_WARNING("<b>\The [src]</b> rips viciously at \the [G.affecting]'s [affected] with its mandibles!"))
 		msg_admin_attack("[key_name_admin(src)] mandible'd [key_name_admin(H)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)",ckey=key_name(src),ckey_target=key_name(H))
 	else
 		var/mob/living/M = G.affecting
 		if(!istype(M))
 			return
-		M.apply_damage(25,BRUTE, sharp=1, edge=1)
-		visible_message("<span class='warning'><b>\The [src]</b> rips viciously at \the [G.affecting]'s flesh with its mandibles!</span>")
+		M.apply_damage(25, BRUTE, sharp = TRUE, edge = TRUE)
+		visible_message(SPAN_WARNING("<b>\The [src]</b> rips viciously at \the [G.affecting]'s flesh with its mandibles!"))
 		msg_admin_attack("[key_name_admin(src)] mandible'd [key_name_admin(M)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)",ckey=key_name(src),ckey_target=key_name(M))
-	playsound(src.loc, 'sound/weapons/slash.ogg', 50, 1)
-	last_special = world.time + 25
+	qdel(G)
+	playsound(get_turf(src), 'sound/weapons/slash.ogg', 50, TRUE)
+	last_special = world.time + 50
 
 /mob/living/carbon/human/proc/detonate_flechettes()
 	set category = "Military Frame"

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -356,8 +356,8 @@ mob/living/carbon/human/proc/change_monitor()
 		to_chat(src, SPAN_WARNING("You are not grabbing anyone."))
 		return
 
-	if(G.state < GRAB_NECK)
-		to_chat(src, SPAN_WARNING("You must have a neck grip to bite someone!"))
+	if(G.state < GRAB_KILL)
+		to_chat(src, SPAN_WARNING("You must have a strangling grip to bite someone!"))
 		return
 
 	if(ishuman(G.affecting))
@@ -379,9 +379,8 @@ mob/living/carbon/human/proc/change_monitor()
 		M.apply_damage(25, BRUTE, sharp = TRUE, edge = TRUE)
 		visible_message(SPAN_WARNING("<b>\The [src]</b> rips viciously at \the [G.affecting]'s flesh with its mandibles!"))
 		msg_admin_attack("[key_name_admin(src)] mandible'd [key_name_admin(M)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)",ckey=key_name(src),ckey_target=key_name(M))
-	qdel(G)
 	playsound(get_turf(src), 'sound/weapons/slash.ogg', 50, TRUE)
-	last_special = world.time + 50
+	last_special = world.time + 100
 
 /mob/living/carbon/human/proc/detonate_flechettes()
 	set category = "Military Frame"

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -343,6 +343,14 @@ mob/living/carbon/human/proc/change_monitor()
 	if(use_check_and_message(usr))
 		return
 
+	if(wear_mask?.flags_inv & HIDEFACE)
+		to_chat(src, SPAN_WARNING("You have a mask covering your mandibles!"))
+		return
+
+	if(head?.flags_inv & HIDEFACE)
+		to_chat(src, SPAN_WARNING("You have something on your head covering your mandibles!"))
+		return
+
 	var/obj/item/grab/G = locate() in src
 	if(!G || !istype(G))
 		to_chat(src, SPAN_WARNING("You are not grabbing anyone."))

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -356,8 +356,8 @@ mob/living/carbon/human/proc/change_monitor()
 		to_chat(src, SPAN_WARNING("You are not grabbing anyone."))
 		return
 
-	if(G.state < GRAB_KILL)
-		to_chat(src, SPAN_WARNING("You must have an strangling grip to bite someone!"))
+	if(G.state < GRAB_NECK)
+		to_chat(src, SPAN_WARNING("You must have a neck grip to bite someone!"))
 		return
 
 	if(ishuman(G.affecting))

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -360,7 +360,7 @@ mob/living/carbon/human/proc/change_monitor()
 		to_chat(src, SPAN_WARNING("You must have an strangling grip to bite someone!"))
 		return
 
-	if(istype(G.affecting, /mob/living/carbon/human))
+	if(ishuman(G.affecting))
 		var/mob/living/carbon/human/H = G.affecting
 		var/hit_zone = zone_sel.selecting
 		var/obj/item/organ/external/affected = H.get_organ(hit_zone)

--- a/html/changelogs/geeves-vaurca_grab_bite_nerf.yml
+++ b/html/changelogs/geeves-vaurca_grab_bite_nerf.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes: 
   - tweak: "Vaurca warriors now need a choking grip to mandible bite someone. Doing the attack drops the grab, preventing a headbutt. The hard cooldown has increased to five seconds."
+  - bugfix: "Vaurca warriors can no longer do the mandible bite through face-covering helmets and masks."

--- a/html/changelogs/geeves-vaurca_grab_bite_nerf.yml
+++ b/html/changelogs/geeves-vaurca_grab_bite_nerf.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Vaurca warriors now need a choking grip to mandible bite someone. Doing the attack drops the grab, preventing a headbutt. The hard cooldown has increased to five seconds."

--- a/html/changelogs/geeves-vaurca_grab_bite_nerf.yml
+++ b/html/changelogs/geeves-vaurca_grab_bite_nerf.yml
@@ -3,5 +3,5 @@ author: Geeves
 delete-after: True
 
 changes: 
-  - tweak: "Vaurca warriors now need a choking grip to mandible bite someone. Doing the attack drops the grab, preventing a headbutt. The hard cooldown has increased to five seconds."
+  - tweak: "Vaurca warriors now need a neck grip to mandible bite someone. Doing the attack drops the grab, preventing a headbutt. The hard cooldown has increased to five seconds."
   - bugfix: "Vaurca warriors can no longer do the mandible bite through face-covering helmets and masks."

--- a/html/changelogs/geeves-vaurca_grab_bite_nerf.yml
+++ b/html/changelogs/geeves-vaurca_grab_bite_nerf.yml
@@ -3,5 +3,5 @@ author: Geeves
 delete-after: True
 
 changes: 
-  - tweak: "Vaurca warriors now need a neck grip to mandible bite someone. Doing the attack drops the grab, preventing a headbutt. The hard cooldown has increased to five seconds."
+  - tweak: "Vaurca warriors now need a strangling grip to mandible bite someone. The hard cooldown has increased to ten seconds."
   - bugfix: "Vaurca warriors can no longer do the mandible bite through face-covering helmets and masks."


### PR DESCRIPTION
* Vaurca warriors now need a choking grip to mandible bite someone. Doing the attack drops the grab, preventing a headbutt. The hard cooldown has increased to five seconds.