### PR TITLE
RFD-P Storage Use Fix

### DIFF
--- a/code/game/objects/items/weapons/RFD.dm
+++ b/code/game/objects/items/weapons/RFD.dm
@@ -476,7 +476,7 @@ RFD Piping-Class
 	to_chat(user, SPAN_NOTICE("Selected pipe: <b>[pipe_examine]</b>"))
 
 /obj/item/rfd/piping/afterattack(atom/A, mob/user, proximity)
-	if(!proximity)
+	if(!proximity || !isturf(A))
 		return
 	if(istype(get_area(A), /area/shuttle) || istype(get_area(A), /turf/space))
 		to_chat(user, SPAN_WARNING("You can't lay pipe here!"))

--- a/html/changelogs/geeves_rfd-p-fix.yml
+++ b/html/changelogs/geeves_rfd-p-fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "RFD-P will no longer use up their resource if put into a storage container."


### PR DESCRIPTION
* RFD-P will no longer use up their resource if put into a storage container.

Of all the things I tested, I didn't test putting it in a backpack.