### PR TITLE
Admin Ghostrole Fix

### DIFF
--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -410,6 +410,8 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			continue
 		if(!G.enabled)
 			continue
+		if(!isnull(G.req_perms))
+			continue
 		unique_role_available = TRUE
 		break
 

--- a/html/changelogs/geeves-join_game_fix.yml
+++ b/html/changelogs/geeves-join_game_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Invisible admin/CCIA only ghostroles no longer cause the Unique Ghost Role is available prompt."


### PR DESCRIPTION
Stupid oversight on my part, admin and CCIA only ghost roles that didn't appear to players still made the "Unique ghost role is available" prompt visible on the join menu.