### PR TITLE
Noporific

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -378,7 +378,6 @@
 	products = list(
 		/obj/item/reagent_containers/glass/bottle/antitoxin = 4,
 		/obj/item/reagent_containers/glass/bottle/norepinephrine = 4,
-		/obj/item/reagent_containers/glass/bottle/stoxin = 4,
 		/obj/item/reagent_containers/glass/bottle/toxin = 4,
 		/obj/item/reagent_containers/glass/bottle/coughsyrup = 4,
 		/obj/item/reagent_containers/syringe = 12,

--- a/html/changelogs/Doxxmedearly - Noporific.yml
+++ b/html/changelogs/Doxxmedearly - Noporific.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+changes: 
+  - rscdel: "Removed soporific from Nanomed vending machines."


### PR DESCRIPTION
Removes soporific from the Nanomeds. It can still be made by chemists if needed.