### PR TITLE
Inventory Click Drag QoL

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -269,9 +269,9 @@
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
 	// We don't even know if it's a middle click
 	if(!usr.canClick())
-		return 1
-	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
-		return 1
+		return TRUE
+	if(use_check_and_message(usr))
+		return TRUE
 	switch(name)
 		if(BP_R_HAND)
 			if(iscarbon(usr))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -424,7 +424,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 /obj/item/device/pda/MouseDrop(obj/over_object as obj, src_location, over_location)
 	var/mob/M = usr
-	if((!istype(over_object, /obj/screen)) && !use_check(M))
+	if(!istype(over_object, /obj/screen) && !use_check(M) && !(over_object == src))
 		return attack_self(M)
 
 /obj/item/device/pda/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -52,29 +52,29 @@
 	QDEL_NULL(closer)
 	return ..()
 
-/obj/item/storage/MouseDrop(obj/over_object as obj)
-
+/obj/item/storage/MouseDrop(obj/over_object)
 	if(!canremove)
 		return
-
-	if (ishuman(usr) || issmall(usr)) //so monkeys can take off their backpacks -- Urist
-
+	if(!over_object || over_object == src)
+		return
+	if(istype(over_object, /obj/screen/inventory))
+		var/obj/screen/inventory/S = over_object
+		if(S.slot_id == src.equip_slot)
+			return
+	if(ishuman(usr) || issmall(usr)) //so monkeys can take off their backpacks -- Urist
 		if(over_object == usr && Adjacent(usr)) // this must come before the screen objects only block
 			src.open(usr)
 			return
-
-		if (!( istype(over_object, /obj/screen) ))
+		if(!(istype(over_object, /obj/screen)))
 			return ..()
 
 		//makes sure that the storage is equipped, so that we can't drag it into our hand from miles away.
 		//there's got to be a better way of doing this.
-		if (!(src.loc == usr) || (src.loc && src.loc.loc == usr))
+		if(!(src.loc == usr) || (src.loc && src.loc.loc == usr))
 			return
-
-		if (( usr.restrained() ) || ( usr.stat ))
+		if(use_check_and_message(usr))
 			return
-
-		if ((src.loc == usr) && !usr.unEquip(src))
+		if((src.loc == usr) && !usr.unEquip(src))
 			return
 
 		switch(over_object.name)
@@ -85,7 +85,6 @@
 				usr.u_equip(src)
 				usr.put_in_l_hand(src,FALSE)
 		src.add_fingerprint(usr)
-
 
 /obj/item/storage/proc/return_inv()
 	. = contents.Copy()

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -40,22 +40,26 @@
 	return ..()
 
 /obj/item/clothing/MouseDrop(var/obj/over_object)
-	if (ishuman(usr) || issmall(usr))
+	if(ishuman(usr) || issmall(usr))
 		//makes sure that the clothing is equipped so that we can't drag it into our hand from miles away.
-		if (!(src.loc == usr))
+		if(!(src.loc == usr))
 			return
 
-		if(!over_object)
+		if(!over_object || over_object == src)
 			return
 
-		if (( usr.restrained() ) || ( usr.stat ))
+		if(istype(over_object, /obj/screen/inventory))
+			var/obj/screen/inventory/S = over_object
+			if(S.slot_id == src.equip_slot)
+				return
+
+		if(use_check_and_message(usr))
 			return
 
-		if (!usr.canUnEquip(src))
+		if(!usr.canUnEquip(src))
 			return
 
 		var/obj/item/clothing/C = src
-
 		usr.unEquip(C)
 
 		switch(over_object.name)

--- a/html/changelogs/geeves-click_drag_QoL.yml
+++ b/html/changelogs/geeves-click_drag_QoL.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscdel: "Dragging a PDA onto itself no longer opens its menu. Over PDA dragging actions still function as normal."
+  - tweak: "Dragging an item onto itself, or onto the slot it's equipped to, doesn't drop it to the floor anymore."


### PR DESCRIPTION
* Dragging a PDA onto itself no longer opens its menu. Over PDA dragging actions still function as normal.
* Dragging an item onto itself, or onto the slot it's equipped to, doesn't drop it to the floor anymore.

Resolves https://github.com/Aurorastation/Aurora.3/issues/7020