### PR TITLE
Janitorial Hologram Cleaning Fix

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -254,6 +254,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/hologram/holopad/proc/create_holo(mob/living/silicon/ai/A, mob/living/carbon/caller_id, turf/T = loc)
 	if(hacked == 0)
 		var/obj/effect/overlay/hologram = new(T)//Spawn a blank effect at the location.
+		hologram.no_clean = TRUE
 		if(caller_id)
 			var/tempicon = getFlatIcon(caller_id)
 
@@ -277,6 +278,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		return 1
 	else if(hacked == 1)
 		var/obj/effect/overlay/hologram = new(T)//Spawn a blank effect at the location.
+		hologram.no_clean = TRUE
 		hologram.mouse_opacity = 0//So you can't click on it.
 		hologram.anchored = 1//So space wind cannot drag it.
 		masters[A] = hologram

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -1,7 +1,8 @@
 /obj/effect/overlay
 	name = "overlay"
 	unacidable = 1
-	var/i_attached//Added for possible image attachments to objects. For hallucinations and the like.
+	var/i_attached //Added for possible image attachments to objects. For hallucinations and the like.
+	var/no_clean = FALSE // Prevents janitorial cyborgs from cleaning this effect
 
 /obj/effect/overlay/Destroy()
 	i_attached = null

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -974,8 +974,13 @@
 					S.color = null
 				for(var/A in tile)
 					if(istype(A, /obj/effect))
-						if(istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/overlay))
+						if(istype(A, /obj/effect/decal/cleanable))
 							qdel(A)
+						if(istype(A, /obj/effect/overlay))
+							var/obj/effect/overlay/O = A
+							if(O.no_clean)
+								continue
+							qdel(O)
 					else if(istype(A, /obj/item))
 						var/obj/item/cleaned_item = A
 						cleaned_item.clean_blood()

--- a/html/changelogs/geeves-clean_holograms.yml
+++ b/html/changelogs/geeves-clean_holograms.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Janitorial Cyborgs can no longer delete holograms by running them over. That's fucking funny."


### PR DESCRIPTION
* Janitorial Cyborgs can no longer delete holograms by running them over.

Fixes https://github.com/Aurorastation/Aurora.3/issues/8379