### PR TITLE
Non-verbal Ghost Hearing Fix

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -27,7 +27,7 @@
 
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
 	if (language && (language.flags & NONVERBAL))
-		if (!speaker || (src.sdisabilities & BLIND || src.blinded) || !(speaker in view(src)))
+		if((!speaker || (src.sdisabilities & BLIND || src.blinded) || !(speaker in view(src))) && !isobserver(src))
 			message = stars(message)
 
 	if(!(language && (language.flags & INNATE))) // skip understanding checks for INNATE languages

--- a/html/changelogs/geeves-nonverbal_ghosts.yml
+++ b/html/changelogs/geeves-nonverbal_ghosts.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Ghosts can now hear non-verbal speaking from afar without stars appearing."


### PR DESCRIPTION
* Ghosts can now hear non-verbal speaking from afar without stars appearing.

Fixes https://github.com/Aurorastation/Aurora.3/issues/7749