### PR TITLE
Chair Rotate Fix

### DIFF
--- a/code/__defines/obj.dm
+++ b/code/__defines/obj.dm
@@ -1,1 +1,2 @@
-#define OBJ_FLAG_ROTATABLE       (1<<1) //Can this object be rotated?
+#define OBJ_FLAG_ROTATABLE          (1<<1) //Can this object be rotated?
+#define OBJ_FLAG_ROTATABLE_ANCHORED (1<<2) // This object can be rotated even while anchored

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -225,11 +225,11 @@
 	animate(src, transform = turn(matrix(), 8*shake_dir), pixel_x = init_px + 2*shake_dir, time = 1)
 	animate(transform = null, pixel_x = init_px, time = 6, easing = ELASTIC_EASING)
 
-/obj/proc/rotate(var/mob/user)
+/obj/proc/rotate(var/mob/user, var/anchored_ignore = FALSE)
 	if(use_check_and_message(user))
 		return
 	
-	if(anchored)
+	if(anchored && !anchored_ignore)
 		to_chat(user, SPAN_WARNING("\The [src] is bolted down to the floor!"))
 		return
 	
@@ -239,9 +239,11 @@
 /obj/AltClick(var/mob/user)
 	if(obj_flags & OBJ_FLAG_ROTATABLE)
 		rotate(user)
+	if(obj_flags & OBJ_FLAG_ROTATABLE_ANCHORED)
+		rotate(user, TRUE)
 	..()
 
 /obj/examine(mob/user)
 	. = ..()
-	if((obj_flags & OBJ_FLAG_ROTATABLE))
+	if((obj_flags & OBJ_FLAG_ROTATABLE) || (obj_flags & OBJ_FLAG_ROTATABLE_ANCHORED))
 		to_chat(user, SPAN_SUBTLE("Can be rotated with alt-click."))

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -6,7 +6,7 @@
 	base_icon = "chair"
 	buckle_dir = 0
 	buckle_lying = 0 //force people to sit up in chairs when buckled
-	obj_flags = OBJ_FLAG_ROTATABLE
+	obj_flags = OBJ_FLAG_ROTATABLE_ANCHORED
 	var/propelled = 0 // Check for fire-extinguisher-driven chairs
 
 /obj/structure/bed/chair/attackby(obj/item/W as obj, mob/user as mob)

--- a/html/changelogs/geeves-comfy_chair_rotate.yml
+++ b/html/changelogs/geeves-comfy_chair_rotate.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "You can now rotate anchored chairs, such as comfy chairs and the such."


### PR DESCRIPTION
* You can now rotate anchored chairs, such as comfy chairs and the such.

Resolves https://github.com/Aurorastation/Aurora.3/issues/8483