### PR TITLE
Misc Cult Fix

### DIFF
--- a/code/game/gamemodes/cult/runes/hide_runes.dm
+++ b/code/game/gamemodes/cult/runes/hide_runes.dm
@@ -4,8 +4,9 @@
 /obj/effect/rune/hiderunes/do_rune_action(mob/living/user, obj/O = src)
 	var/rune_found
 	for(var/obj/effect/rune/R in orange(4, get_turf(O)))
-		if(R != O)
-			R.invisibility=INVISIBILITY_OBSERVER
+		if(R == O)
+			continue
+		R.invisibility = INVISIBILITY_OBSERVER
 		rune_found = TRUE
 	if(rune_found)
 		if(istype(O,/obj/effect/rune))

--- a/code/game/gamemodes/cult/runes/reveal_runes.dm
+++ b/code/game/gamemodes/cult/runes/reveal_runes.dm
@@ -15,10 +15,10 @@
 		rad = 2
 		reveal = TRUE
 	if(reveal)
-		for(var/obj/effect/rune/R in orange(rad, src))
+		for(var/obj/effect/rune/R in orange(rad, get_turf(src)))
 			if(R == src)
 				continue
-			R.visible = 15
+			R.invisibility = 0
 			did_reveal = TRUE
 	if(did_reveal)
 		if(istype(O, /obj/item/nullrod))

--- a/code/game/gamemodes/cult/runes/rune.dm
+++ b/code/game/gamemodes/cult/runes/rune.dm
@@ -34,7 +34,6 @@ var/global/list/static/rune_types = list(
 	anchored = 1
 	icon = 'icons/obj/rune.dmi'
 	icon_state = "1"
-	var/visible = FALSE
 	unacidable = TRUE
 	layer = AO_LAYER
 
@@ -60,6 +59,7 @@ var/global/list/static/rune_types = list(
 		desc = "A powerful rune drawn with blood magic gifted by Nar'sie Himself."
 		if(cult_description)
 			to_chat(user, "This spell circle reads: <span class='cult'><b><i>[cult_description]</i></b></span>.")
+		to_chat(user, "This rune [can_talisman ? "<span class='cult'><b><i>can</i></b></span>" : "<span class='warning'><b><i>cannot</i></b></span>"] be turned into a talisman.")
 	else
 		desc = "A strange collection of symbols drawn in blood."
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -322,7 +322,7 @@ var/const/enterloopsanity = 100
 			if(istype(O,/obj/effect/rune))
 				var/obj/effect/rune/R = O
 				// Only show message for visible runes
-				if(R.visible)
+				if(!R.invisibility)
 					to_chat(user, span("warning", "No matter how well you wash, the bloody symbols remain!"))
 	else
 		if( !(last_clean && world.time < last_clean + 100) )

--- a/html/changelogs/geeves-talisman_fix.yml
+++ b/html/changelogs/geeves-talisman_fix.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Reveal runes now reveal runes. Joy."
+  - rscadd: "Added an examine to runes that tells you whether you can talismanify them or not, if you're a cultist."


### PR DESCRIPTION
* Reveal runes now reveal runes. Joy.
* Added an examine to runes that tells you whether you can talismanify them or not, if you're a cultist.

I'm classing it as a bugfix because the examine addition is solely to prevent people from thinking a rune not becoming a talisman is a bug.