### PR TITLE
Lexorin recipe + new ODs

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -129,6 +129,15 @@
 	M.add_chemical_effect(CE_OXYGENATED, strength/6) // 1 for dexalin, 2 for dexplus
 	holder.remove_reagent("lexorin", strength/3 * removed)
 
+//Hyperoxia causes brain and eye damage
+/datum/reagent/dexalin/overdose(var/mob/living/carbon/M, var/alien, var/removed)
+	M.add_chemical_effect(CE_NEUROTOXIC, removed * (strength / 6))
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/internal/eyes/E = H.get_eyes(no_synthetic = TRUE)
+		if(E && istype(E))
+			E.damage += removed * (strength / 12)
+
 /datum/reagent/dexalin/plus
 	name = "Dexalin Plus"
 	id = "dexalinp"
@@ -337,6 +346,10 @@
 	M.add_chemical_effect(CE_BRAIN_REGEN, 30*removed)
 	M.add_chemical_effect(CE_PAINKILLER, 10)
 
+/datum/reagent/alkysine/overdose(var/mob/living/carbon/M, var/alien, var/removed)
+	M.hallucination = max(M.hallucination, 25)
+	..()
+
 /datum/reagent/imidazoline
 	name = "Imidazoline"
 	id = "imidazoline"
@@ -357,6 +370,10 @@
 		if(E && istype(E))
 			if(E.damage > 0)
 				E.damage = max(E.damage - 5 * removed, 0)
+
+/datum/reagent/imidazoline/overdose(var/mob/living/carbon/M, var/alien, var/removed)
+	M.hallucination = max(M.hallucination, 15)
+	..()
 
 /datum/reagent/peridaxon
 	name = "Peridaxon"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -136,7 +136,7 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/eyes/E = H.get_eyes(no_synthetic = TRUE)
 		if(E && istype(E))
-			E.damage += removed * (strength / 12)
+			E.take_damage(removed * (strength / 12))
 
 /datum/reagent/dexalin/plus
 	name = "Dexalin Plus"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -570,7 +570,8 @@
 	name = "Lexorin"
 	id = "lexorin"
 	result = "lexorin"
-	required_reagents = list("phoron" = 1, "hydrazine" = 1, "ammonia" = 1)
+	required_reagents = list("tungsten" = 1, "hydrazine" = 1, "ammonia" = 1)
+	catalysts = list("phoron" = 5)
 	result_amount = 3
 
 /datum/chemical_reaction/calomel

--- a/html/changelogs/doxxmedearly - chemrecipes.yml
+++ b/html/changelogs/doxxmedearly - chemrecipes.yml
@@ -1,0 +1,11 @@
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+changes: 
+  - tweak: "The recipe for Lexorin is now a bit more sane. It is now made with a 1:1:1 ratio of tungsten, hydrazine, and ammonia, with 5u of phoron as a catalyst."
+  - rscadd: "Alkysine and Imidazoline overdoses now cause minor hallucinations."
+  - rscadd: "Dexalin and Dexalin+ now cause brain and eye damage if overdosed."


### PR DESCRIPTION
Lexorin's recipe was absurd with the amount of phoron used. Substituted the less-used tungsten to get some ingredient variety for chemists.
Imidazoline and Alkysine now cause light hallucinations on overdose (Meds that affect your eyes and brian make you see funny things, go figure).
Dexalin and Dex+ now cause brain damage and eye damage on overdose.