### PR TITLE
Alt Click Turf Menu Fix

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -239,8 +239,10 @@
 /obj/AltClick(var/mob/user)
 	if(obj_flags & OBJ_FLAG_ROTATABLE)
 		rotate(user)
+		return
 	if(obj_flags & OBJ_FLAG_ROTATABLE_ANCHORED)
 		rotate(user, TRUE)
+		return
 	..()
 
 /obj/examine(mob/user)

--- a/html/changelogs/geeves-alt_turf_view.yml
+++ b/html/changelogs/geeves-alt_turf_view.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Alt clicking a rotatable item doesn't open the turf menu anymore."


### PR DESCRIPTION
* Alt clicking a rotatable item doesn't open the turf menu anymore.

Resolves https://github.com/Aurorastation/Aurora.3/issues/8582