### PR TITLE
Modular Prototype Sprite Fix

### DIFF
--- a/code/modules/projectiles/guns/energy/modular.dm
+++ b/code/modules/projectiles/guns/energy/modular.dm
@@ -57,6 +57,11 @@
 			item_state = "large_3_wielded"
 		else
 			item_state = "large_3"
+	underlays.Cut()
+	if(length(gun_mods))
+		for(var/obj/item/laser_components/mod in gun_mods)
+			if(mod.gun_overlay)
+				underlays += mod.gun_overlay
 	update_held_icon()
 
 /obj/item/gun/energy/laser/prototype/proc/reset_vars()

--- a/html/changelogs/geeves-prototype_sprite_fix.yml
+++ b/html/changelogs/geeves-prototype_sprite_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Modular Laser Prototypes now correctly get their attachment sprites on the in-hand sprite."


### PR DESCRIPTION
* Modular Laser Prototypes now correctly get their attachment sprites on the in-hand sprite.

Fixes https://github.com/Aurorastation/Aurora.3/issues/8564