### PR TITLE
Sheet Loader Changes

### DIFF
--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -264,5 +264,5 @@
 
 	can_hold = list(
 		/obj/item/stack/material,
-		/obj/item/stack/tile,
+		/obj/item/stack/tile
 		)

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -258,10 +258,11 @@
 	return
 
 /obj/item/gripper/no_use/loader //This is used to disallow building with metal.
-	name = "sheet loader"
-	desc = "A specialized loading device, designed to pick up and insert sheets of materials inside machines."
+	name = "sheet holder"
+	desc = "A specialized holding device, designed to hold sheets of material or tiling."
 	icon_state = "gripper-sheet"
 
 	can_hold = list(
-		/obj/item/stack/material
+		/obj/item/stack/material,
+		/obj/item/stack/tile,
 		)

--- a/html/changelogs/houseofsynth-sheetloaderchange.yml
+++ b/html/changelogs/houseofsynth-sheetloaderchange.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: House_Of_Synth
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changed the functionality of the borg sheet holder module. It will now hold sheets and tiles."
+  


### PR DESCRIPTION
Changes the sheet loader to a sheet holder, allowing it to pick up materials like before as well as tiles such as floorboards and carpet. 

