### PR TITLE
KA fix and small refactor

### DIFF
--- a/code/modules/custom_ka/core.dm
+++ b/code/modules/custom_ka/core.dm
@@ -240,7 +240,6 @@
 
 	if(ispath(installed_barrel.projectile_type, /obj/item/projectile/kinetic))
 		var/obj/item/projectile/kinetic/shot_projectile = new installed_barrel.projectile_type(get_turf(src))
-		new installed_barrel.projectile_type(get_turf(src))
 		shot_projectile.damage = damage_increase
 		shot_projectile.range = range_increase
 		shot_projectile.aoe = aoe_increase

--- a/html/changelogs/Sindorman.yml
+++ b/html/changelogs/Sindorman.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Kinnetic accelerator no longer creates phantom projectile on turf of user."


### PR DESCRIPTION
- Kinnetic accelerator no longer leaves phantom projectile on user's turf.

- Refactored projectile code to not override `Collide`

- Projectile now creates new projectiles in AOE instead of colliding to all atoms, which avoids it to cause GC/qdel issues.