### PR TITLE
Detective Gun Rebalance - Flash ammo edition.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -360,7 +360,7 @@
 	new /obj/item/device/radio/headset/headset_sec(src)
 	new /obj/item/device/radio/headset/headset_sec/alt(src)
 	new /obj/item/clothing/suit/storage/vest/detective(src)
-	new /obj/item/ammo_magazine/c45m(src)
+	new /obj/item/ammo_magazine/c45m/rubber(src)
 	new /obj/item/gun/projectile/sec/detective(src)
 	new /obj/item/taperoll/police(src)
 	//Belts

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -360,8 +360,8 @@
 	new /obj/item/device/radio/headset/headset_sec(src)
 	new /obj/item/device/radio/headset/headset_sec/alt(src)
 	new /obj/item/clothing/suit/storage/vest/detective(src)
-	new /obj/item/ammo_magazine/c45m/flash(src)
-	new /obj/item/gun/projectile/sec/detective(src)
+	new /obj/item/ammo_magazine/mc9mm/flash(src)
+	new /obj/item/gun/projectile/pistol/detective(src)
 	new /obj/item/taperoll/police(src)
 	//Belts
 	new /obj/item/clothing/accessory/holster/waist(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -360,7 +360,7 @@
 	new /obj/item/device/radio/headset/headset_sec(src)
 	new /obj/item/device/radio/headset/headset_sec/alt(src)
 	new /obj/item/clothing/suit/storage/vest/detective(src)
-	new /obj/item/ammo_magazine/c45m/rubber(src)
+	new /obj/item/ammo_magazine/c45m/flash(src)
 	new /obj/item/gun/projectile/sec/detective(src)
 	new /obj/item/taperoll/police(src)
 	//Belts

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -260,13 +260,12 @@
 	set category = "Object"
 	set desc = "Rename your gun."
 	
-	var/mob/M = usr
 	var/input = sanitizeSafe(input("What do you want to name the gun?", ,""), MAX_NAME_LEN)
-
-	if(src && input && !M.stat && in_range(M,src))
-		name = input
-		to_chat(M, "You name the gun [input]. Say hello to your new friend.")
-		return 1
+	
+	if(use_check_and_message(usr))
+		return
+	name = input
+	to_chat(M, "You name the gun [input]. Say hello to your new friend.")
 
 /obj/item/gun/projectile/pistol/attack_hand(mob/user as mob)
 	if(user.get_inactive_hand() == src)

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -84,35 +84,6 @@
 	else
 		icon_state = "secgunwood-e"
 
-/obj/item/gun/projectile/sec/detective
-	desc = "A compact NanoTrasen designed sidearm, popular with law enforcement personnel for concealed carry purposes. It has a faux wooden grip. Uses .45 rounds."
-	description_fluff = "The NT Mk21 Blackjack is a ballistic sidearm developed and produced by Nanotrasen. Unlike the related Mk58, the Blackjack is a rather high quality piece - typically issued to higher ranking law enforcement personnel, the Mk21 is compact and chambered in .45 caliber. With all the bells and whistles of a modern, quality police pistol, the Blackjack's main drawback is the notoriously nippy recoil - .45 in such a small package does not play well with the average shooter."
-	name = "compact .45 pistol"
-	icon = 'icons/obj/guns/detgun.dmi'
-	icon_state = "detgun"
-	item_state = "detgun"
-	w_class = ITEMSIZE_SMALL
-	magazine_type = /obj/item/ammo_magazine/c45m/flash
-
-/obj/item/gun/projectile/sec/detective/update_icon()
-	..()
-	if(ammo_magazine?.stored_ammo.len)
-		icon_state = "detgun"
-	else
-		icon_state = "detgunempty"
-
-/obj/item/gun/projectile/sec/detective/verb/rename_gun()
-	set name = "Name Gun"
-	set category = "Object"
-	set desc = "Rename your gun."
-
-	var/input = sanitizeSafe(input("What do you want to name the gun?", ,""), MAX_NAME_LEN)
-
-	if(src && input && !M.stat && in_range(M,src))
-		name = input
-		to_chat(M, "You name the gun [input]. Say hello to your new friend.")
-		return 1
-
 /obj/item/gun/projectile/automatic/x9
 	name = "automatic .45 pistol"
 	desc = "The x9 tactical pistol is a lightweight fast firing handgun. Uses .45 rounds."
@@ -266,6 +237,35 @@
 /obj/item/gun/projectile/pistol/flash
 	name = "9mm signal pistol"
 	magazine_type = /obj/item/ammo_magazine/mc9mm/flash
+
+/obj/item/gun/projectile/pistol/detective
+	desc = "A compact NanoTrasen designed sidearm, popular with law enforcement personnel for concealed carry purposes. It has a faux wooden grip. Uses 9mm rounds."
+	description_fluff = "The NT Mk21 Blackjack is a ballistic sidearm developed and produced by Nanotrasen. Unlike the related Mk58, the Blackjack is a rather high quality piece - typically issued to higher ranking law enforcement personnel, the Mk21 is compact and chambered in 9mm caliber. With all the bells and whistles of a modern, quality police pistol, the Blackjack's main drawback is the notoriously nippy recoil - 9mm in such a small package can be unpleasant for the average shooter."
+	name = "compact 9mm pistol"
+	magazine_type = /obj/item/ammo_magazine/mc9mm/flash
+	icon = 'icons/obj/guns/detgun.dmi'
+	icon_state = "detgun"
+	item_state = "detgun"
+	can_silence = FALSE
+	
+/obj/item/gun/projectile/pistol/detective/update_icon()
+	..()
+	if(ammo_magazine?.stored_ammo.len)
+		icon_state = "detgun"
+	else
+		icon_state = "detgunempty"
+
+/obj/item/gun/projectile/pistol/detective/verb/rename_gun()
+	set name = "Name Gun"
+	set category = "Object"
+	set desc = "Rename your gun."
+
+	var/input = sanitizeSafe(input("What do you want to name the gun?", ,""), MAX_NAME_LEN)
+
+	if(src && input && !M.stat && in_range(M,src))
+		name = input
+		to_chat(M, "You name the gun [input]. Say hello to your new friend.")
+		return 1
 
 /obj/item/gun/projectile/pistol/attack_hand(mob/user as mob)
 	if(user.get_inactive_hand() == src)

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -259,7 +259,8 @@
 	set name = "Name Gun"
 	set category = "Object"
 	set desc = "Rename your gun."
-
+	
+	var/mob/M = usr
 	var/input = sanitizeSafe(input("What do you want to name the gun?", ,""), MAX_NAME_LEN)
 
 	if(src && input && !M.stat && in_range(M,src))

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -92,7 +92,7 @@
 	icon_state = "detgun"
 	item_state = "detgun"
 	w_class = ITEMSIZE_SMALL
-	magazine_type = /obj/item/ammo_magazine/c45m
+	magazine_type = /obj/item/ammo_magazine/c45m/rubber
 
 /obj/item/gun/projectile/sec/detective/update_icon()
 	..()
@@ -100,6 +100,24 @@
 		icon_state = "detgun"
 	else
 		icon_state = "detgunempty"
+
+/obj/item/gun/projectile/sec/detective/verb/rename_gun()
+	set name = "Name Gun"
+	set category = "Object"
+	set desc = "Rename your gun. If you're the detective."
+
+	var/mob/M = usr
+	if(!M.mind)	return 0
+	if(!M.mind.assigned_role == "Detective")
+		to_chat(M, "<span class='notice'>You don't feel cool enough to name this gun, chump.</span>")
+		return 0
+
+	var/input = sanitizeSafe(input("What do you want to name the gun?", ,""), MAX_NAME_LEN)
+
+	if(src && input && !M.stat && in_range(M,src))
+		name = input
+		to_chat(M, "You name the gun [input]. Say hello to your new friend.")
+		return 1
 
 /obj/item/gun/projectile/automatic/x9
 	name = "automatic .45 pistol"

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -92,7 +92,7 @@
 	icon_state = "detgun"
 	item_state = "detgun"
 	w_class = ITEMSIZE_SMALL
-	magazine_type = /obj/item/ammo_magazine/c45m/rubber
+	magazine_type = /obj/item/ammo_magazine/c45m/flash
 
 /obj/item/gun/projectile/sec/detective/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -106,12 +106,6 @@
 	set category = "Object"
 	set desc = "Rename your gun. If you're the detective."
 
-	var/mob/M = usr
-	if(!M.mind)	return 0
-	if(!M.mind.assigned_role == "Detective")
-		to_chat(M, SPAN_NOTICE("You don't feel cool enough to name this gun, chump."))
-		return 0
-
 	var/input = sanitizeSafe(input("What do you want to name the gun?", ,""), MAX_NAME_LEN)
 
 	if(src && input && !M.stat && in_range(M,src))

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -104,7 +104,7 @@
 /obj/item/gun/projectile/sec/detective/verb/rename_gun()
 	set name = "Name Gun"
 	set category = "Object"
-	set desc = "Rename your gun. If you're the detective."
+	set desc = "Rename your gun."
 
 	var/input = sanitizeSafe(input("What do you want to name the gun?", ,""), MAX_NAME_LEN)
 

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -109,7 +109,7 @@
 	var/mob/M = usr
 	if(!M.mind)	return 0
 	if(!M.mind.assigned_role == "Detective")
-		to_chat(M, "<span class='notice'>You don't feel cool enough to name this gun, chump.</span>")
+		to_chat(M, SPAN_NOTICE("You don't feel cool enough to name this gun, chump."))
 		return 0
 
 	var/input = sanitizeSafe(input("What do you want to name the gun?", ,""), MAX_NAME_LEN)

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -265,7 +265,7 @@
 	if(use_check_and_message(usr))
 		return
 	name = input
-	to_chat(M, "You name the gun [input]. Say hello to your new friend.")
+	to_chat(usr, "You name the gun [input]. Say hello to your new friend.")
 
 /obj/item/gun/projectile/pistol/attack_hand(mob/user as mob)
 	if(user.get_inactive_hand() == src)

--- a/html/changelogs/dansemacabre-detgun2.yml
+++ b/html/changelogs/dansemacabre-detgun2.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - balance: "Swaps out the detective's lethal ammo for rubbers, like officers get. Also, you can name his gun now."
+  - balance: "The detective's sidearm has been reworked: It is now a 9mm pistol loading flash ammo by default. You can also rename it, like you could with the revolver."

--- a/html/changelogs/dansemacabre-detgun2.yml
+++ b/html/changelogs/dansemacabre-detgun2.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: DanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - balance: "Swaps out the detective's lethal ammo for rubbers, like officers get. Also, you can name his gun now."


### PR DESCRIPTION
I have seen Geeves' alternative PR and I must say that I do not like it, unfortunately. I think the stun revolver is inferior in flavor and quality balance-wise (I also think it's silly and kinda ugly, but that's neither here nor there.) Anyway, my PR is an alternative to solving the lethal detective problem. Detectives will now get a limited supply of flash ammunition, while keeping their fancy pistol. You can also name the detective's gun, now.

Edit: This PR has changed from giving the detective rubbers, to giving them flash rounds. Why? Flash rounds are the best option for curbing poor detective play, while also not incapacitating them completely. A detective can use rubbers, a stun revolver, whatever, offensively. They cannot use flash ammo offensively, only defensively. This also keeps their offensive capabilities intact.