### PR TITLE
Changes that the emergency shuttle can only be called after one hour

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -301,6 +301,8 @@ var/list/gamemode_cache = list()
 	var/fail2topic_rule_name = "_DD_Fail2topic"
 	var/fail2topic_enabled = FALSE
 
+	var/time_to_call_emergency_shuttle = 36000  //how many time until the crew can call the transfer shuttle. One hour by default.
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -862,6 +864,9 @@ var/list/gamemode_cache = list()
 
 				if("merchant_chance")
 					config.merchant_chance = text2num(value)
+
+				if("time_to_call_emergency_shuttle")
+					config.time_to_call_emergency_shuttle = text2num(value)
 
 				if("force_map")
 					override_map = value

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -383,7 +383,7 @@ Command action procs
 		to_chat(user, "The emergency shuttle may not be sent at this time. Please try again later.")
 		return 0
 
-	if(world.time < 36000) //Shuttle can now only be recalled after one hour and half into the round.
+	if(world.time < 36000) //Shuttle can now only be recalled after one hour into the round.
 		to_chat(user, "The emergency shuttle is refueling. Please wait another [round((36000-world.time)/600)] minute\s before trying again.")
 		return 0
 

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -383,8 +383,8 @@ Command action procs
 		to_chat(user, "The emergency shuttle may not be sent at this time. Please try again later.")
 		return 0
 
-	if(world.time < 6000) // Ten minute grace period to let the game get going without lolmetagaming. -- TLE
-		to_chat(user, "The emergency shuttle is refueling. Please wait another [round((6000-world.time)/600)] minute\s before trying again.")
+	if(world.time < 36000) //Shuttle can now only be recalled after one hour and half into the round.
+		to_chat(user, "The emergency shuttle is refueling. Please wait another [round((36000-world.time)/600)] minute\s before trying again.")
 		return 0
 
 	if(emergency_shuttle.going_to_centcom())

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -383,8 +383,8 @@ Command action procs
 		to_chat(user, "The emergency shuttle may not be sent at this time. Please try again later.")
 		return 0
 
-	if(world.time < 36000) //Shuttle can now only be recalled after one hour into the round.
-		to_chat(user, "The emergency shuttle is refueling. Please wait another [round((36000-world.time)/600)] minute\s before trying again.")
+	if(world.time < config.time_to_call_emergency_shuttle)
+		to_chat(user, "The emergency shuttle is refueling. Please wait another [round((config.time_to_call_emergency_shuttle-world.time)/600)] minute\s before trying again.")
 		return 0
 
 	if(emergency_shuttle.going_to_centcom())

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -400,6 +400,9 @@ STARLIGHT 0
 ## Chance, in percentage, of the merchant job slot being open at round start
 MERCHANT_CHANCE 20
 
+## How long before the crew can call the emergency shuttle. One hour by default.
+TIME_TO_CALL_EMERGENCY_SHUTTLE 36000
+
 ## Defines which races are allowed to join as ERT, in singular form. If unset, defaults to only human. Casing matters, separate using ;
 ## Example races include: Human, Tajara, Skrell, Unathi
 # ERT_SPECIES Human;Skrell;Unathi

--- a/html/changelogs/alberyk-shuttle.yml
+++ b/html/changelogs/alberyk-shuttle.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "The emergency shuttle can only be called after one hour into the round."

--- a/html/changelogs/alberyk-shuttle.yml
+++ b/html/changelogs/alberyk-shuttle.yml
@@ -3,4 +3,4 @@ author: Alberyk
 delete-after: True
 
 changes: 
-  - tweak: "The emergency shuttle can only be called after one hour into the round."
+  - tweak: "The emergency shuttle can only be called after one hour into the round. This can be changed on the config file."


### PR DESCRIPTION
What it says in the title. You can only call the emergency shuttle after one hour, instead of mere ten minutes.