### PR TITLE
Misc small shuttle fixes

### DIFF
--- a/code/controllers/subsystems/responseteam.dm
+++ b/code/controllers/subsystems/responseteam.dm
@@ -140,12 +140,12 @@
 	SSresponseteam.trigger_armed_response_team(choice)
 
 
-/hook/shuttle_moved/proc/close_response_blastdoors(var/area/departing, var/area/destination)
+/hook/shuttle_moved/proc/close_response_blastdoors(var/obj/effect/shuttle_landmark/start_location, var/obj/effect/shuttle_landmark/destination)
 	//Check if we are departing from the Odin
-	if(istype(departing,/area/shuttle/specops/centcom))
+	if(start_location.landmark_tag == "nav_ert_start")
 		SSresponseteam.close_ert_blastdoors()
 
 	//Check if we are departing from the TCFL base
-	else if(istype(departing,/area/shuttle/legion/centcom))
+	else if(start_location.landmark_tag == "nav_legion_start")
 		SSresponseteam.close_tcfl_blastdoors()
 	return TRUE

--- a/code/modules/shuttles/departmental.dm
+++ b/code/modules/shuttles/departmental.dm
@@ -14,10 +14,10 @@
 	req_access = list(access_research)
 	circuit = /obj/item/circuitboard/research_shuttle
 
-/datum/shuttle/autodock/ferry/research
+/datum/shuttle/autodock/ferry/research_aurora
 	var/triggered_away_sites = FALSE
 
-/datum/shuttle/autodock/ferry/research/shuttle_moved()
+/datum/shuttle/autodock/ferry/research_aurora/shuttle_moved()
 	. = ..()
 	if(!triggered_away_sites)
 		for(var/s in SSghostroles.spawners)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -71,7 +71,10 @@
 /datum/shuttle/proc/short_jump(var/obj/effect/shuttle_landmark/destination)
 	if(moving_status != SHUTTLE_IDLE) return
 
+	var/obj/effect/shuttle_landmark/start_location = current_location
+
 	moving_status = SHUTTLE_WARMUP
+	callHook("shuttle_moved", list(start_location,destination))
 	if(sound_takeoff)
 		playsound(current_location, sound_takeoff, 50, 20, is_global = TRUE)
 	spawn(warmup_time*10)
@@ -95,6 +98,7 @@
 	var/obj/effect/shuttle_landmark/start_location = current_location
 
 	moving_status = SHUTTLE_WARMUP
+	callHook("shuttle_moved", list(start_location, destination))
 	if(sound_takeoff)
 		playsound(current_location, sound_takeoff, 100, 20, is_global = TRUE)
 	spawn(warmup_time*10)

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -25,9 +25,7 @@
 	emergency_shuttle.launch_time = world.time
 
 /datum/shuttle/autodock/ferry/emergency/shuttle_moved()
-	if (next_location != waypoint_station)	//leaving the station
-		emergency_shuttle.departed = TRUE
-
+	if (!emergency_shuttle.departed && next_location != waypoint_station) //leaving the station
 		var/list/replacements = list(
 			"%ETA%" = round(emergency_shuttle.estimate_arrival_time()/60,1),
 			"%dock%" = current_map.dock_name
@@ -36,6 +34,7 @@
 			priority_announcement.Announce(replacemany(current_map.emergency_shuttle_leaving_dock, replacements))
 		else
 			priority_announcement.Announce(replacemany(current_map.shuttle_leaving_dock, replacements))
+		emergency_shuttle.departed = TRUE
 	..()
 
 /datum/shuttle/autodock/ferry/emergency/can_launch(var/user)

--- a/html/changelogs/Ferner-200411-bugfix_miscshuttlestuff.yml
+++ b/html/changelogs/Ferner-200411-bugfix_miscshuttlestuff.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Fixed the transfer shuttle sending an announcement twice. Fixed the research shuttle not triggering away site ghost spawners. Fixed ert/tcfl shuttles not triggering blastdoors containing their areas."


### PR DESCRIPTION
 - Fixes the transfer shuttle sending a particular announcement twice.
 - Fixes the ert/tcfl shuttles not closing their equipment blastdoors on departure.
 - Fixes the research shuttle not enabling the away site ghost spawners on departure from the station.