### PR TITLE
Slime Core Fix

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -129,7 +129,7 @@
 	origin_tech = list(TECH_POWER = 2, TECH_BIO = 4)
 	icon = 'icons/mob/npc/slimes.dmi'
 	icon_state = "yellow slime extract"
-	maxcharge = 10000
+	maxcharge = 15000
 	matter = null
 	var/next_recharge
 
@@ -143,7 +143,7 @@
 
 /obj/item/cell/slime/process()
 	if(next_recharge < world.time)
-		charge += maxcharge / 10
+		charge = min(charge + (maxcharge / 10), maxcharge)
 		next_recharge = world.time + 1 MINUTE
 
 /obj/item/cell/device/emergency_light

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -126,6 +126,7 @@
 /obj/item/cell/slime
 	name = "charged slime core"
 	desc = "A yellow slime core infused with phoron, it crackles with power."
+	description_info = "This slime core is energized with powerful bluespace energies, allowing it to regenerate ten percent of its charge every minute."
 	origin_tech = list(TECH_POWER = 2, TECH_BIO = 4)
 	icon = 'icons/mob/npc/slimes.dmi'
 	icon_state = "yellow slime extract"

--- a/html/changelogs/geeves-slime_core_fix.yml
+++ b/html/changelogs/geeves-slime_core_fix.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed slime core batteries from charging over their maxcharge cap."
+  - tweak: "Increased the slime core battery maxcharge cap from 10K to 15K."

--- a/html/changelogs/geeves-slime_core_fix.yml
+++ b/html/changelogs/geeves-slime_core_fix.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes: 
   - bugfix: "Fixed slime core batteries from charging over their maxcharge cap."
-  - tweak: "Increased the slime core battery maxcharge cap from 10K to 15K."
+  - tweak: "Increased the slime core battery maxcharge cap from 10K to 15K. Added an informational description to the core."


### PR DESCRIPTION
* Fixed slime core batteries from charging over their maxcharge cap.
* Increased the slime core battery maxcharge cap from 10K to 15K.