### PR TITLE
Allows drones to open windoors by walking into them

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -69,7 +69,7 @@
 		return
 	if (src.operating)
 		return
-	if (src.density && (!issmall(AM) || ishuman(AM)) && src.allowed(AM))
+	if (src.density && (!issmall(AM) || ishuman(AM) || isrobot(AM)) && src.allowed(AM))
 		open()
 		//secure doors close faster
 		var/time = check_access(null) ? 50 : 20

--- a/html/changelogs/drone_windoor_fix.yml
+++ b/html/changelogs/drone_windoor_fix.yml
@@ -1,0 +1,4 @@
+author: SpaceBaa
+delete-after: True
+changes: 
+  - bugfix: "Fixed an issue where drones could not open windoors by walking into them."


### PR DESCRIPTION
Adds isrobot() as an exception so should affect all bots.
Fixes #1624


![drone](https://user-images.githubusercontent.com/9057997/79115330-76753c00-7d7d-11ea-93dc-1ca0c2dd7fc1.gif)
