### PR TITLE
Hallucinations part 2: Chem Factor

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -64,7 +64,7 @@
 #define CE_PAINKILLER   "painkiller"
 #define CE_PULSE        "xcardic"		// increases or decreases heartrate
 #define CE_UNDEXTROUS "undextrous" // arms no work right
-#define CE_ANTIHALLUCINATE  "antihallucinogen"	//Makes hallucinations stronger or weaker
+#define CE_HALLUCINATE  "hallucinogen"	//Makes hallucinations stronger or weaker
 
 // Apply healing effects
 #define CE_ANTIBIOTIC   "antibiotic"	// Thetamycin

--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -64,7 +64,7 @@
 #define CE_PAINKILLER   "painkiller"
 #define CE_PULSE        "xcardic"		// increases or decreases heartrate
 #define CE_UNDEXTROUS "undextrous" // arms no work right
-#define CE_MIND         "mental"		//Makes hallucinations stronger or weaker
+#define CE_ANTIHALLUCINATE  "antihallucinogen"	//Makes hallucinations stronger or weaker
 
 // Apply healing effects
 #define CE_ANTIBIOTIC   "antibiotic"	// Thetamycin

--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -64,6 +64,7 @@
 #define CE_PAINKILLER   "painkiller"
 #define CE_PULSE        "xcardic"		// increases or decreases heartrate
 #define CE_UNDEXTROUS "undextrous" // arms no work right
+#define CE_MIND         "mental"		//Makes hallucinations stronger or weaker
 
 // Apply healing effects
 #define CE_ANTIBIOTIC   "antibiotic"	// Thetamycin

--- a/code/controllers/subsystems/hallucinations.dm
+++ b/code/controllers/subsystems/hallucinations.dm
@@ -29,9 +29,6 @@
 	var/list/candidates = list()
 	for(var/T in all_hallucinations)
 		var/datum/hallucination/H = new T
-		if(isnull(H))
-			log_debug("Null hallucination found while creating new in subsystem.")
-			continue
 		if(H.can_affect(C))
 			candidates += H
 	if(candidates.len)

--- a/code/controllers/subsystems/hallucinations.dm
+++ b/code/controllers/subsystems/hallucinations.dm
@@ -29,6 +29,9 @@
 	var/list/candidates = list()
 	for(var/T in all_hallucinations)
 		var/datum/hallucination/H = new T
+		if(isnull(H))
+			log_debug("Null hallucination found while creating new in subsystem.")
+			continue
 		if(H.can_affect(C))
 			candidates += H
 	if(candidates.len)

--- a/code/modules/hallucinations/hallucinations.dm
+++ b/code/modules/hallucinations/hallucinations.dm
@@ -1,6 +1,6 @@
 #define NO_THOUGHT 1	//Hallucinated thoughts will not occur on this hallucination's end()
 #define NO_EMOTE 2		//User will not emote to others when this hallucination ends
-#define HEARING_DEPENDENT 3	//deaf characters will not experience this hallucination
+#define HEARING_DEPENDENT 4	//deaf characters will not experience this hallucination
 
 //Power Defines
 #define HAL_POWER_LOW 30

--- a/code/modules/hallucinations/mob.dm
+++ b/code/modules/hallucinations/mob.dm
@@ -22,10 +22,10 @@
 	hallucination -= 1	//Tick down the duration
 
 	//Good/bad chems affecting duration
-	if(chem_effects[CE_MIND] > 0)
-		hallucination -= chem_effects[CE_MIND]	
-	if(chem_effects[CE_MIND] < 0 && prob(abs(chem_effects[CE_MIND]*20)))
-		hallucination += abs(chem_effects[CE_MIND])
+	if(chem_effects[CE_ANTIHALLUCINATE] > 0)
+		hallucination -= chem_effects[CE_ANTIHALLUCINATE]	
+	if(chem_effects[CE_ANTIHALLUCINATE] < 0 && prob(abs(chem_effects[CE_ANTIHALLUCINATE]*20)))
+		hallucination += abs(chem_effects[CE_ANTIHALLUCINATE])
 
 	if(!hallucination)  //We're done
 		return
@@ -42,13 +42,13 @@
 			hall_delay *= 0.75
 		if(400 to INFINITY)		//This should only be possible in cult conversions. Very low delay to represent your flayed mind.
 			hall_delay *= 0.25
-	if(chem_effects[CE_MIND] > 0)
-		if(prob(chem_effects[CE_MIND]*40)) //Chance to skip effects entirely if you're medicated properly
+	if(chem_effects[CE_ANTIHALLUCINATE] > 0)
+		if(prob(chem_effects[CE_ANTIHALLUCINATE]*40)) //Chance to skip effects entirely if you're medicated properly
 			return
 		else
-			hall_delay *= min(1.25, chem_effects[CE_MIND]) //if CE_mind is 1, 25% more time between
-	if(chem_effects[CE_MIND] < 0)
-		hall_delay /= max(1.25, abs(chem_effects[CE_MIND])) //if CE_MIND is -1, 25% less time between
+			hall_delay *= min(1.25, chem_effects[CE_ANTIHALLUCINATE]) //if CE_ANTIHALLUCINATE is 1, 25% more time between
+	if(chem_effects[CE_ANTIHALLUCINATE] < 0)
+		hall_delay /= max(1.25, abs(chem_effects[CE_ANTIHALLUCINATE])) //if CE_ANTIHALLUCINATE is -1, 25% less time between
 
 	next_hallucination = world.time + hall_delay
 	var/datum/hallucination/H = SShallucinations.get_hallucination(src)

--- a/code/modules/hallucinations/mob.dm
+++ b/code/modules/hallucinations/mob.dm
@@ -20,12 +20,21 @@
 //Main handling proc, called in life()
 /mob/living/carbon/proc/handle_hallucinations()
 	hallucination -= 1	//Tick down the duration
+
+	//Good/bad chems affecting duration
+	if(chem_effects[CE_MIND] > 0)
+		hallucination -= chem_effects[CE_MIND]	
+	if(chem_effects[CE_MIND] < 0 && prob(abs(chem_effects[CE_MIND]*20)))
+		hallucination += abs(chem_effects[CE_MIND])
+
 	if(!hallucination)  //We're done
 		return
 	if(!client || stat || world.time < next_hallucination)
 		return
 
-	var/hall_delay = rand(180,250)	//Time between hallucinations, modified by switch below.
+	var/hall_delay = rand(180,250)	//Time between hallucinations, modified below.
+	
+	//Modifying time between effects based on strength and chemicals
 	switch(hallucination)	//26-149 are intentionally left off, as they do not modify the delay. This is a pretty common range for hallucinations.
 		if(1 to 25)		//Winding down, less frequent.
 			hall_delay *= 2
@@ -33,9 +42,19 @@
 			hall_delay *= 0.75
 		if(400 to INFINITY)		//This should only be possible in cult conversions. Very low delay to represent your flayed mind.
 			hall_delay *= 0.25
+	if(chem_effects[CE_MIND] > 0)
+		if(prob(chem_effects[CE_MIND]*40)) //Chance to skip effects entirely if you're medicated properly
+			return
+		else
+			hall_delay *= min(1.25, chem_effects[CE_MIND]) //if CE_mind is 1, 25% more time between
+	if(chem_effects[CE_MIND] < 0)
+		hall_delay /= max(1.25, abs(chem_effects[CE_MIND])) //if CE_MIND is -1, 25% less time between
 
 	next_hallucination = world.time + hall_delay
 	var/datum/hallucination/H = SShallucinations.get_hallucination(src)
+	if(isnull(H))
+		log_debug("Returned null hallucination for [src]")
+		return
 	H.holder = src
 	H.activate()
 

--- a/code/modules/hallucinations/mob.dm
+++ b/code/modules/hallucinations/mob.dm
@@ -22,10 +22,10 @@
 	hallucination -= 1	//Tick down the duration
 
 	//Good/bad chems affecting duration
-	if(chem_effects[CE_ANTIHALLUCINATE] > 0)
-		hallucination -= chem_effects[CE_ANTIHALLUCINATE]	
-	if(chem_effects[CE_ANTIHALLUCINATE] < 0 && prob(abs(chem_effects[CE_ANTIHALLUCINATE]*20)))
-		hallucination += abs(chem_effects[CE_ANTIHALLUCINATE])
+	if(chem_effects[CE_HALLUCINATE] < 0)
+		hallucination -= abs(chem_effects[CE_HALLUCINATE])
+	if(chem_effects[CE_HALLUCINATE] > 0 && prob(chem_effects[CE_HALLUCINATE]*20))
+		hallucination += chem_effects[CE_HALLUCINATE]
 
 	if(!hallucination)  //We're done
 		return
@@ -42,13 +42,13 @@
 			hall_delay *= 0.75
 		if(400 to INFINITY)		//This should only be possible in cult conversions. Very low delay to represent your flayed mind.
 			hall_delay *= 0.25
-	if(chem_effects[CE_ANTIHALLUCINATE] > 0)
-		if(prob(chem_effects[CE_ANTIHALLUCINATE]*40)) //Chance to skip effects entirely if you're medicated properly
+	if(chem_effects[CE_HALLUCINATE] < 0)
+		if(prob(abs(chem_effects[CE_HALLUCINATE]*40))) //Chance to skip effects entirely if you're medicated properly
 			return
 		else
-			hall_delay *= min(1.25, chem_effects[CE_ANTIHALLUCINATE]) //if CE_ANTIHALLUCINATE is 1, 25% more time between
-	if(chem_effects[CE_ANTIHALLUCINATE] < 0)
-		hall_delay /= max(1.25, abs(chem_effects[CE_ANTIHALLUCINATE])) //if CE_ANTIHALLUCINATE is -1, 25% less time between
+			hall_delay *= min(1.25, abs(chem_effects[CE_HALLUCINATE])) //if CE_HALLUCINATE is 1, 25% more time between
+	if(chem_effects[CE_HALLUCINATE] > 0)
+		hall_delay /= max(1.25, chem_effects[CE_HALLUCINATE]) //if CE_HALLUCINATE is -1, 25% less time between
 
 	next_hallucination = world.time + hall_delay
 	var/datum/hallucination/H = SShallucinations.get_hallucination(src)

--- a/code/modules/hallucinations/mob.dm
+++ b/code/modules/hallucinations/mob.dm
@@ -46,9 +46,9 @@
 		if(prob(abs(chem_effects[CE_HALLUCINATE]*40))) //Chance to skip effects entirely if you're medicated properly
 			return
 		else
-			hall_delay *= min(1.25, abs(chem_effects[CE_HALLUCINATE])) //if CE_HALLUCINATE is 1, 25% more time between
+			hall_delay *= min(1.25, abs(chem_effects[CE_HALLUCINATE])) //if CE_HALLUCINATE is -1, 25% more time between
 	if(chem_effects[CE_HALLUCINATE] > 0)
-		hall_delay /= max(1.25, chem_effects[CE_HALLUCINATE]) //if CE_HALLUCINATE is -1, 25% less time between
+		hall_delay /= max(1.25, chem_effects[CE_HALLUCINATE]) //if CE_HALLUCINATE is 1, 25% less time between
 
 	next_hallucination = world.time + hall_delay
 	var/datum/hallucination/H = SShallucinations.get_hallucination(src)

--- a/code/modules/hallucinations/types/basic.dm
+++ b/code/modules/hallucinations/types/basic.dm
@@ -120,8 +120,6 @@
 	t = replace_characters(t, list("you" = "[firstname]"))	//the list contains items that say "you." This replaces "you" with the hallucinator's first name to sell the fact that the person is doing the emote.
 	to_chat(holder, "<b>[pick(hal_target)]</b> [t]")
 
-/datum/hallucination/paranoia/second	//Just so we get another chance at picking this.
-
 /datum/hallucination/skitter
 	max_power = 60
 

--- a/code/modules/hallucinations/types/powers.dm
+++ b/code/modules/hallucinations/types/powers.dm
@@ -59,7 +59,7 @@
 		to_chat(usr, SPAN_WARNING("You're not in any state to use your powers right now!"))
 		return
 
-	if(chem_effects[CE_ANTIHALLUCINATE] > 0)
+	if(chem_effects[CE_HALLUCINATE] < 0)
 		to_chat(usr, SPAN_WARNING("Chemicals in your blood are disrupting your powers!"))
 		return
 
@@ -147,7 +147,7 @@
 		to_chat(usr, SPAN_WARNING("You're not in any state to use your powers right now!"))
 		return
 
-	if(chem_effects[CE_ANTIHALLUCINATE] > 0)
+	if(chem_effects[CE_HALLUCINATE] < 0)
 		to_chat(usr, SPAN_WARNING("Chemicals in your blood are disrupting your powers!"))
 		return
 

--- a/code/modules/hallucinations/types/powers.dm
+++ b/code/modules/hallucinations/types/powers.dm
@@ -59,6 +59,10 @@
 		to_chat(usr, SPAN_WARNING("You're not in any state to use your powers right now!"))
 		return
 
+	if(chem_effects[CE_MIND] > 0)
+		to_chat(usr, SPAN_WARNING("Chemicals in your blood are disrupting your powers!"))
+		return
+
 	var/list/creatures = list()
 	for(var/mob/living/C in oview(usr))
 		creatures += C
@@ -141,6 +145,10 @@
 
 	if(use_check_and_message(usr))
 		to_chat(usr, SPAN_WARNING("You're not in any state to use your powers right now!"))
+		return
+
+	if(chem_effects[CE_MIND] > 0)
+		to_chat(usr, SPAN_WARNING("Chemicals in your blood are disrupting your powers!"))
 		return
 
 	var/list/creatures = list()

--- a/code/modules/hallucinations/types/powers.dm
+++ b/code/modules/hallucinations/types/powers.dm
@@ -59,7 +59,7 @@
 		to_chat(usr, SPAN_WARNING("You're not in any state to use your powers right now!"))
 		return
 
-	if(chem_effects[CE_MIND] > 0)
+	if(chem_effects[CE_ANTIHALLUCINATE] > 0)
 		to_chat(usr, SPAN_WARNING("Chemicals in your blood are disrupting your powers!"))
 		return
 
@@ -147,7 +147,7 @@
 		to_chat(usr, SPAN_WARNING("You're not in any state to use your powers right now!"))
 		return
 
-	if(chem_effects[CE_MIND] > 0)
+	if(chem_effects[CE_ANTIHALLUCINATE] > 0)
 		to_chat(usr, SPAN_WARNING("Chemicals in your blood are disrupting your powers!"))
 		return
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -78,7 +78,7 @@
 		return
 	M.dizziness = max(150, M.dizziness)//Setting dizziness directly works as long as the make_dizzy proc is called after to spawn the process
 	M.make_dizzy(4)
-	M.add_chemical_effect(CE_MIND, -1)
+	M.add_chemical_effect(CE_ANTIHALLUCINATE, -1)
 	M.confused = max(M.confused, 20)
 
 /datum/reagent/impedrezene
@@ -111,7 +111,7 @@
 
 /datum/reagent/mindbreaker/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.hallucination = max(M.hallucination, 100)
-	M.add_chemical_effect(CE_MIND, -2)
+	M.add_chemical_effect(CE_ANTIHALLUCINATE, -2)
 
 /datum/reagent/psilocybin
 	name = "Psilocybin"
@@ -128,7 +128,7 @@
 	if(istype(H) && (H.species.flags & NO_BLOOD))
 		return
 	M.druggy = max(M.druggy, 30)
-	M.add_chemical_effect(CE_MIND, -1)
+	M.add_chemical_effect(CE_ANTIHALLUCINATE, -1)
 	if(dose < 1)
 		M.apply_effect(3, STUTTER)
 		M.make_dizzy(5)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -78,7 +78,7 @@
 		return
 	M.dizziness = max(150, M.dizziness)//Setting dizziness directly works as long as the make_dizzy proc is called after to spawn the process
 	M.make_dizzy(4)
-	M.add_chemical_effect(CE_ANTIHALLUCINATE, -1)
+	M.add_chemical_effect(CE_HALLUCINATE, 1)
 	M.confused = max(M.confused, 20)
 
 /datum/reagent/impedrezene
@@ -111,7 +111,7 @@
 
 /datum/reagent/mindbreaker/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.hallucination = max(M.hallucination, 100)
-	M.add_chemical_effect(CE_ANTIHALLUCINATE, -2)
+	M.add_chemical_effect(CE_HALLUCINATE, 2)
 
 /datum/reagent/psilocybin
 	name = "Psilocybin"
@@ -128,7 +128,7 @@
 	if(istype(H) && (H.species.flags & NO_BLOOD))
 		return
 	M.druggy = max(M.druggy, 30)
-	M.add_chemical_effect(CE_ANTIHALLUCINATE, -1)
+	M.add_chemical_effect(CE_HALLUCINATE, 1)
 	if(dose < 1)
 		M.apply_effect(3, STUTTER)
 		M.make_dizzy(5)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -78,7 +78,7 @@
 		return
 	M.dizziness = max(150, M.dizziness)//Setting dizziness directly works as long as the make_dizzy proc is called after to spawn the process
 	M.make_dizzy(4)
-
+	M.add_chemical_effect(CE_MIND, -1)
 	M.confused = max(M.confused, 20)
 
 /datum/reagent/impedrezene
@@ -111,6 +111,7 @@
 
 /datum/reagent/mindbreaker/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.hallucination = max(M.hallucination, 100)
+	M.add_chemical_effect(CE_MIND, -2)
 
 /datum/reagent/psilocybin
 	name = "Psilocybin"
@@ -127,6 +128,7 @@
 	if(istype(H) && (H.species.flags & NO_BLOOD))
 		return
 	M.druggy = max(M.druggy, 30)
+	M.add_chemical_effect(CE_MIND, -1)
 	if(dose < 1)
 		M.apply_effect(3, STUTTER)
 		M.make_dizzy(5)
@@ -327,7 +329,13 @@
 	color = "#61E2EC"
 	taste_description = "sourness"
 	fallback_specific_heat = 1
+	overdose = 10
 
 /datum/reagent/wulumunusha/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.druggy = max(M.druggy, 100)
 	M.silent = max(M.silent, 5)
+
+/datum/reagent/wulumunusha/overdose(var/mob/living/carbon/M, var/alien, var/removed = 0, var/scale = 1)
+	. = ..()
+	if(isskrell(M))
+		M.hallucination = max(M.hallucination, 10)	//light hallucinations that afflict skrell

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -325,7 +325,7 @@
 /datum/reagent/wulumunusha
 	name = "Wulumunusha Extract"
 	id = "wulumunusha"
-	description = "The extract of the wulumunusha fruit, it can cause hallucionations and muteness."
+	description = "The extract of the wulumunusha fruit, it can cause hallucinations and muteness."
 	color = "#61E2EC"
 	taste_description = "sourness"
 	fallback_specific_heat = 1
@@ -336,6 +336,5 @@
 	M.silent = max(M.silent, 5)
 
 /datum/reagent/wulumunusha/overdose(var/mob/living/carbon/M, var/alien, var/removed = 0, var/scale = 1)
-	. = ..()
 	if(isskrell(M))
-		M.hallucination = max(M.hallucination, 10)	//light hallucinations that afflict skrell
+		M.hallucination = max(M.hallucination, 10 * scale)	//light hallucinations that afflict skrell

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -3237,6 +3237,8 @@
 
 /datum/reagent/alcohol/ethanol/pwine/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
+	M.add_chemical_effect(CE_MIND, -1)
+	M.hallucination = max(M.hallucination, 25)
 	if(dose > 30)
 		M.adjustToxLoss(2 * removed)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -3237,7 +3237,7 @@
 
 /datum/reagent/alcohol/ethanol/pwine/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
-	M.add_chemical_effect(CE_ANTIHALLUCINATE, -1)
+	M.add_chemical_effect(CE_HALLUCINATE, 1)
 	M.hallucination = max(M.hallucination, 25)
 	if(dose > 30)
 		M.adjustToxLoss(2 * removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -3237,7 +3237,7 @@
 
 /datum/reagent/alcohol/ethanol/pwine/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
-	M.add_chemical_effect(CE_MIND, -1)
+	M.add_chemical_effect(CE_ANTIHALLUCINATE, -1)
 	M.hallucination = max(M.hallucination, 25)
 	if(dose > 30)
 		M.adjustToxLoss(2 * removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -323,6 +323,7 @@
 	M.hallucination = max(0, M.hallucination - 10)
 	M.adjustToxLoss(5 * removed) // It used to be incredibly deadly due to an oversight. Not anymore!
 	M.add_chemical_effect(CE_PAINKILLER, 40)
+	M.add_chemical_effect(CE_MIND, 1)
 	if (!modifier)
 		modifier = M.add_modifier(/datum/modifier/adrenaline, MODIFIER_REAGENT, src, _strength = 1, override = MODIFIER_OVERRIDE_STRENGTHEN)
 
@@ -867,6 +868,10 @@
 		/datum/brain_trauma/mild/hallucinations = 2
 	)
 
+/datum/reagent/mental/methylphenidate/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.add_chemical_effect(CE_MIND, 1)
+	..()
+
 /datum/reagent/mental/fluvoxamine
 	name = "Fluvoxamine"
 	id = "fluvoxamine"
@@ -1084,6 +1089,10 @@
 		/datum/reagent/mental/escitalopram = 20
 	)
 
+/datum/reagent/mental/risperidone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.add_chemical_effect(CE_MIND, 2)
+	..()
+
 /datum/reagent/mental/olanzapine
 	name = "Olanzapine"
 	id = "olanzapine"
@@ -1120,6 +1129,10 @@
 		/datum/reagent/mental/paroxetine = 20,
 		/datum/reagent/mental/escitalopram = 20
 	)
+
+/datum/reagent/mental/olanzapine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.add_chemical_effect(CE_MIND, 2)
+	..()
 
 /datum/reagent/mental/truthserum
 	name = "Truth serum"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -323,7 +323,7 @@
 	M.hallucination = max(0, M.hallucination - 10)
 	M.adjustToxLoss(5 * removed) // It used to be incredibly deadly due to an oversight. Not anymore!
 	M.add_chemical_effect(CE_PAINKILLER, 40)
-	M.add_up_to_chemical_effect(CE_ANTIHALLUCINATE, 1)
+	M.add_chemical_effect(CE_HALLUCINATE, -1)
 	if (!modifier)
 		modifier = M.add_modifier(/datum/modifier/adrenaline, MODIFIER_REAGENT, src, _strength = 1, override = MODIFIER_OVERRIDE_STRENGTHEN)
 
@@ -869,7 +869,7 @@
 	)
 
 /datum/reagent/mental/methylphenidate/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_up_to_chemical_effect(CE_ANTIHALLUCINATE, 1)
+	M.add_chemical_effect(CE_HALLUCINATE, -1)
 	..()
 
 /datum/reagent/mental/fluvoxamine
@@ -1090,7 +1090,7 @@
 	)
 
 /datum/reagent/mental/risperidone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_up_to_chemical_effect(CE_ANTIHALLUCINATE, 2)
+	M.add_chemical_effect(CE_HALLUCINATE, -2)
 	..()
 
 /datum/reagent/mental/olanzapine
@@ -1131,7 +1131,7 @@
 	)
 
 /datum/reagent/mental/olanzapine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_up_to_chemical_effect(CE_ANTIHALLUCINATE, 2)
+	M.add_chemical_effect(CE_HALLUCINATE, -2)
 	..()
 
 /datum/reagent/mental/truthserum

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -323,7 +323,7 @@
 	M.hallucination = max(0, M.hallucination - 10)
 	M.adjustToxLoss(5 * removed) // It used to be incredibly deadly due to an oversight. Not anymore!
 	M.add_chemical_effect(CE_PAINKILLER, 40)
-	M.add_up_to_chemical_effect(CE_MIND, 1)
+	M.add_up_to_chemical_effect(CE_ANTIHALLUCINATE, 1)
 	if (!modifier)
 		modifier = M.add_modifier(/datum/modifier/adrenaline, MODIFIER_REAGENT, src, _strength = 1, override = MODIFIER_OVERRIDE_STRENGTHEN)
 
@@ -869,7 +869,7 @@
 	)
 
 /datum/reagent/mental/methylphenidate/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_up_to_chemical_effect(CE_MIND, 1)
+	M.add_up_to_chemical_effect(CE_ANTIHALLUCINATE, 1)
 	..()
 
 /datum/reagent/mental/fluvoxamine
@@ -1090,7 +1090,7 @@
 	)
 
 /datum/reagent/mental/risperidone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_up_to_chemical_effect(CE_MIND, 2)
+	M.add_up_to_chemical_effect(CE_ANTIHALLUCINATE, 2)
 	..()
 
 /datum/reagent/mental/olanzapine
@@ -1131,7 +1131,7 @@
 	)
 
 /datum/reagent/mental/olanzapine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_up_to_chemical_effect(CE_MIND, 2)
+	M.add_up_to_chemical_effect(CE_ANTIHALLUCINATE, 2)
 	..()
 
 /datum/reagent/mental/truthserum

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -323,7 +323,7 @@
 	M.hallucination = max(0, M.hallucination - 10)
 	M.adjustToxLoss(5 * removed) // It used to be incredibly deadly due to an oversight. Not anymore!
 	M.add_chemical_effect(CE_PAINKILLER, 40)
-	M.add_chemical_effect(CE_MIND, 1)
+	M.add_up_to_chemical_effect(CE_MIND, 1)
 	if (!modifier)
 		modifier = M.add_modifier(/datum/modifier/adrenaline, MODIFIER_REAGENT, src, _strength = 1, override = MODIFIER_OVERRIDE_STRENGTHEN)
 
@@ -869,7 +869,7 @@
 	)
 
 /datum/reagent/mental/methylphenidate/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_MIND, 1)
+	M.add_up_to_chemical_effect(CE_MIND, 1)
 	..()
 
 /datum/reagent/mental/fluvoxamine
@@ -1090,7 +1090,7 @@
 	)
 
 /datum/reagent/mental/risperidone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_MIND, 2)
+	M.add_up_to_chemical_effect(CE_MIND, 2)
 	..()
 
 /datum/reagent/mental/olanzapine
@@ -1131,7 +1131,7 @@
 	)
 
 /datum/reagent/mental/olanzapine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_MIND, 2)
+	M.add_up_to_chemical_effect(CE_MIND, 2)
 	..()
 
 /datum/reagent/mental/truthserum

--- a/html/changelogs/Doxxmedearly - Hallucinations_Chems.yml
+++ b/html/changelogs/Doxxmedearly - Hallucinations_Chems.yml
@@ -1,0 +1,10 @@
+ author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - tweak: "Synaptizine, methylphenidate, risperidone and olanzapine will reduce overall hallucination duration, reduce frequency of hallucination effects, and sometimes prevent them entirely. Useful!"
+  - tweak: "Some hallucinogenic drugs and toxins will now increase the duration you hallucinate and make effects happen more frequently."
+  - tweak: "Wulumunusha will now cause skrell to experience light hallucinations (as its description implies) at dosages greater than 10u."
+  - bugfix: "Fixed null hallucinations causing runtimes. Hopefully."

--- a/html/changelogs/Doxxmedearly - Hallucinations_Chems.yml
+++ b/html/changelogs/Doxxmedearly - Hallucinations_Chems.yml
@@ -1,4 +1,4 @@
- author: Doxxmedearly
+author: Doxxmedearly
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
  - tweak: "Synaptizine, methylphenidate, risperidone and olanzapine will reduce overall hallucination duration, reduce frequency of hallucination effects, and sometimes prevent them entirely. Useful!"
  - tweak: "Some hallucinogenic drugs and toxins will now increase the duration you hallucinate and make effects happen more frequently."
  - tweak: "Wulumunusha will now cause skrell to experience light hallucinations (as its description implies) at dosages greater than 10u."
  - bugfix: "Fixed null hallucinations causing runtimes. Hopefully."

Adds the CE_MIND chem effect, which basically makes hallucinations easier to deal with (less duration, less effects) or harder (longer duration, frequent effects). Adds it to the appropriate reagents. Everything else as indicated on the CL. 