### PR TITLE
Removes engineering alt titles

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -80,7 +80,6 @@
 
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction)
-	alt_titles = list("Maintenance Technician","Engine Technician","Electrician")
 	outfit = /datum/outfit/job/engineer
 
 /datum/outfit/job/engineer

--- a/html/changelogs/alberyk-engineeringaccess.yml
+++ b/html/changelogs/alberyk-engineeringaccess.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - rscdel: "Removed station engineer alt titles."


### PR DESCRIPTION
What it says in the title. Why: because they just exist to cause confusion. There is no real mechanical differences or expectation between them to warrant their existence.