### PR TITLE
Causes remains to crumble when touched by a robot or pulled by anyone.

### DIFF
--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -36,3 +36,7 @@
 
 /obj/effect/decal/remains/robot/attack_hand(mob/user as mob)
 	return
+
+/obj/effect/decal/remains/attack_ai(mob/user)
+	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Robots can open/close it, but not the AI.
+		attack_hand(user)

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -27,16 +27,26 @@
 	desc = "They look like the remains of a small reptile."
 	icon_state = "lizard"
 
-/obj/effect/decal/remains/attack_hand(mob/user as mob)
-	to_chat(user, "<span class='notice'>[src] sinks together into a pile of ash.</span>")
-	var/turf/simulated/floor/F = get_turf(src)
+//Target turns to ash.
+/proc/crumble(user, source)
+	to_chat(user, "<span class='notice'>[source] sinks together into a pile of ash.</span>")
+	var/turf/simulated/floor/F = get_turf(source)
 	if (istype(F))
 		new /obj/effect/decal/cleanable/ash(F)
-	qdel(src)
+	qdel(source)
 
-/obj/effect/decal/remains/robot/attack_hand(mob/user as mob)
-	return
+/obj/effect/decal/remains/Move()
+	if(src.pulledby)
+		crumble(pulledby, src)
+	else
+		return
+
+/obj/effect/decal/remains/attack_hand(mob/user as mob)
+	crumble(user, src)
 
 /obj/effect/decal/remains/attack_ai(mob/user)
 	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Remains crumble when robots touch, but not the AI.
-		attack_hand(user)
+		crumble(user, src)
+
+/obj/effect/decal/remains/robot/attack_hand(mob/user as mob)
+	return

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -27,26 +27,26 @@
 	desc = "They look like the remains of a small reptile."
 	icon_state = "lizard"
 
-//Target turns to ash.
-/proc/crumble(user, source)
-	to_chat(user, "<span class='notice'>[source] sinks together into a pile of ash.</span>")
-	var/turf/simulated/floor/F = get_turf(source)
-	if (istype(F))
-		new /obj/effect/decal/cleanable/ash(F)
-	qdel(source)
+//Target turns to ash or oil.
+/obj/effect/decal/remains/proc/crumble()
+	var/turf/simulated/floor/F = get_turf(src)
+	if (icon_state == "remainsrobot")
+		visible_message(SPAN_NOTICE("[src] degrades into a pool of oil."))
+		if (istype(F))
+			new /obj/effect/decal/cleanable/blood/oil(F)
+	else
+		visible_message(SPAN_NOTICE("[src] sinks together into a pile of ash."))
+		if (istype(F))
+			new /obj/effect/decal/cleanable/ash(F)
+	qdel(src)
 
 /obj/effect/decal/remains/Move()
-	if(src.pulledby)
-		crumble(pulledby, src)
-	else
-		return
+	if(pulledby)
+		crumble()
 
-/obj/effect/decal/remains/attack_hand(mob/user as mob)
-	crumble(user, src)
+/obj/effect/decal/remains/attack_hand(mob/user)
+	crumble()
 
 /obj/effect/decal/remains/attack_ai(mob/user)
-	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Remains crumble when robots touch, but not the AI.
-		crumble(user, src)
-
-/obj/effect/decal/remains/robot/attack_hand(mob/user as mob)
-	return
+	if(isrobot(user) && Adjacent(user)) // Remains crumble when robots touch, but not the AI.
+		crumble()

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -27,17 +27,20 @@
 	desc = "They look like the remains of a small reptile."
 	icon_state = "lizard"
 
-//Target turns to ash or oil.
+//Target turns to ash.
 /obj/effect/decal/remains/proc/crumble()
 	var/turf/simulated/floor/F = get_turf(src)
-	if (icon_state == "remainsrobot")
-		visible_message(SPAN_NOTICE("[src] degrades into a pool of oil."))
-		if (istype(F))
-			new /obj/effect/decal/cleanable/blood/oil(F)
-	else
-		visible_message(SPAN_NOTICE("[src] sinks together into a pile of ash."))
-		if (istype(F))
-			new /obj/effect/decal/cleanable/ash(F)
+	visible_message(SPAN_NOTICE("\The [src] sink together into a pile of ash."))
+	if (istype(F))
+		new /obj/effect/decal/cleanable/ash(F)
+	qdel(src)
+
+//Target turns to oil.
+/obj/effect/decal/remains/robot/crumble()
+	var/turf/simulated/floor/F = get_turf(src)
+	visible_message(SPAN_NOTICE("\The [src] degrade into a pool of oil."))
+	if (istype(F))
+		new /obj/effect/decal/cleanable/blood/oil(F)
 	qdel(src)
 
 /obj/effect/decal/remains/Move()

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -38,5 +38,5 @@
 	return
 
 /obj/effect/decal/remains/attack_ai(mob/user)
-	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Robots can open/close it, but not the AI.
+	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Remains crumble when robots touch, but not the AI.
 		attack_hand(user)

--- a/html/changelogs/drone_skele_crumble.yml
+++ b/html/changelogs/drone_skele_crumble.yml
@@ -1,0 +1,4 @@
+author: SpaceBaa
+delete-after: True
+changes: 
+  - tweak: "Remains now crumble when touched by robots, or pulled by anyway."

--- a/html/changelogs/drone_skele_crumble.yml
+++ b/html/changelogs/drone_skele_crumble.yml
@@ -2,3 +2,4 @@ author: SpaceBaa
 delete-after: True
 changes: 
   - tweak: "Remains now crumble when touched by robots, or pulled by anyone."
+  - tweak: "Robot remains now degrade into a pool of oil instead of nothing."

--- a/html/changelogs/drone_skele_crumble.yml
+++ b/html/changelogs/drone_skele_crumble.yml
@@ -1,4 +1,4 @@
 author: SpaceBaa
 delete-after: True
 changes: 
-  - tweak: "Remains now crumble when touched by robots, or pulled by anyway."
+  - tweak: "Remains now crumble when touched by robots, or pulled by anyone."


### PR DESCRIPTION
So, remains don't fall down Z-Levels, reported in this bug: #4491
I noticed that normally when you touch remains they just crumble into dust so it shouldn't matter really, however they don't crumble when a Cyborg touches them (which means they cannot be cleaned up by drones and janiborgs), and that they can be pulled around.

I wasn't sure what the best solution was so I've stolen some code from closet.dm and messed with the move() proc.

I'm hoping that this will make it very rare that remains are ever placed above a Z-Level and will not have an opportunity to fall down.

![remains2](https://user-images.githubusercontent.com/9057997/79272564-8d10b580-7e99-11ea-96ae-e396e003eb61.gif)

I checked just in case but AI's cannot crumble them still:
![skele-ai](https://user-images.githubusercontent.com/9057997/79272604-9732b400-7e99-11ea-9a9d-41e6eef19372.gif)

I thought this would be a lot easier than adding gravity to remains, an alternative might just be to convert them to /obj instead of /effect?