### PR TITLE
Raider Buff(?)

### DIFF
--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -60,7 +60,6 @@ var/datum/antagonist/raider/raiders
 		/obj/item/gun/projectile/revolver/derringer,
 		/obj/item/gun/projectile/revolver/lemat,
 		/obj/item/gun/projectile/contender,
-		/obj/item/gun/projectile/pirate,
 		/obj/item/gun/projectile/tanto,
 		/obj/item/gun/projectile/shotgun/pump/rifle/vintage
 		)
@@ -205,27 +204,6 @@ var/datum/antagonist/raider/raiders
 
 	var/obj/item/primary = new new_gun(T)
 	var/obj/item/clothing/accessory/holster/holster = null
-
-	//Give some of the raiders a pirate gun as a secondary
-	if(prob(60))
-		var/obj/item/secondary = new /obj/item/gun/projectile/pirate(T)
-		if(!(primary.slot_flags & SLOT_HOLSTER))
-			holster = new new_holster(T)
-			holster.holstered = secondary
-			secondary.forceMove(holster)
-		else
-			player.equip_to_slot_or_del(secondary, slot_belt)
-
-	if(primary.slot_flags & SLOT_HOLSTER)
-		holster = new new_holster(T)
-		holster.holstered = primary
-		primary.forceMove(holster)
-	else if(!player.belt && (primary.slot_flags & SLOT_BELT))
-		player.equip_to_slot_or_del(primary, slot_belt)
-	else if(!player.back && (primary.slot_flags & SLOT_BACK))
-		player.equip_to_slot_or_del(primary, slot_back)
-	else
-		player.put_in_any_hand_if_possible(primary)
 
 	//If they got a projectile gun, give them a little bit of spare ammo
 	equip_ammo(player, primary)

--- a/html/changelogs/averythepanda-changelog.yml
+++ b/html/changelogs/averythepanda-changelog.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Removes the zipgun from Raiders and their RNG loadout."
+  - rscadd: "Removes the zipgun from Raiders and their RNG loadout.."

--- a/html/changelogs/averythepanda-changelog.yml
+++ b/html/changelogs/averythepanda-changelog.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Removes the zipgun from Raiders and their RNG loadout.."
+  - rscadd: "Removes the zipgun from Raiders and their RNG loadout."

--- a/html/changelogs/averythepanda-changelog.yml
+++ b/html/changelogs/averythepanda-changelog.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: ReadThisNamePlz
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Removes the zipgun from Raiders and their RNG loadout."

--- a/html/changelogs/averythepanda-changelog.yml
+++ b/html/changelogs/averythepanda-changelog.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Removes the zipgun from Raiders and their RNG loadout."
+  - rscadd: "Removes the zipgun from Raiders and their RNG loadout, and removes the ability for them to spawn in holsters."


### PR DESCRIPTION
Removes the Zipgun from Raiders, and the ability for it to spawn in their holster. No longer, will raiders be screwed over entirely by RNG. 