### PR TITLE
Mech Survivability Buff

### DIFF
--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -14,6 +14,8 @@
 #define SPAN_BOLD(X) "<span class='bold'>[X]</span>"
 #define SPAN_SUBTLE(X) "<span class='subtle'>[X]</span>"
 
+#define FONT_COLOR(color, text) "<font color='[color]'>[text]</font>"
+
 #define FONT_SMALL(X) "<font size='1'>[X]</font>"
 #define FONT_NORMAL(X) "<font size='2'>[X]</font>"
 #define FONT_LARGE(X) "<font size='3'>[X]</font>"

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -1,6 +1,6 @@
 #define CHARS_PER_LINE 5
 #define FONT_SIZE "5pt"
-#define FONT_COLOR "#09f"
+#define TEXT_COLOR "#09f"
 #define FONT_STYLE "Arial Black"
 
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
@@ -393,7 +393,7 @@
 //Checks to see if there's 1 line or 2, adds text-icons-numbers/letters over display
 // Stolen from status_display
 /obj/machinery/door_timer/proc/update_display(var/line1, var/line2)
-	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
+	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[TEXT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text
 
@@ -440,6 +440,6 @@
 	id = "Cell 6"
 
 #undef FONT_SIZE
-#undef FONT_COLOR
+#undef TEXT_COLOR
 #undef FONT_STYLE
 #undef CHARS_PER_LINE

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -1,5 +1,5 @@
 #define FONT_SIZE "5pt"
-#define FONT_COLOR "#09f"
+#define TEXT_COLOR "#09f"
 #define FONT_STYLE "Arial Black"
 #define SCROLL_SPEED 2
 
@@ -160,7 +160,7 @@
 	add_overlay(picture_state)
 
 /obj/machinery/status_display/proc/update_display(line1, line2)
-	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
+	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[TEXT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text
 
@@ -239,6 +239,6 @@
 	update()
 
 #undef FONT_SIZE
-#undef FONT_COLOR
+#undef TEXT_COLOR
 #undef FONT_STYLE
 #undef SCROLL_SPEED

--- a/code/modules/heavy_vehicle/components/_components.dm
+++ b/code/modules/heavy_vehicle/components/_components.dm
@@ -170,7 +170,7 @@
 	user.visible_message(SPAN_NOTICE("\The [user] begins slathering nanopaste on \the [src]..."))
 
 	if((burn_damage || brute_damage) && do_after(user, 30, TRUE, src))
-		if(QDELETED(CC) || QDELETED(src) || !CC.use(needed_amount))
+		if(QDELETED(N) || QDELETED(src) || !N.use(needed_amount))
 			return
 		repair_burn_damage(25)
 		repair_brute_damage(25)

--- a/code/modules/heavy_vehicle/components/body.dm
+++ b/code/modules/heavy_vehicle/components/body.dm
@@ -1,3 +1,5 @@
+#define CHASSIS_DAMAGE_MOD 0.25
+
 /obj/item/mech_component/chassis
 	name = "body"
 	icon_state = "loader_body"
@@ -119,3 +121,23 @@
 		C.forceMove(src)
 		update_components()
 	else . = ..()
+
+/obj/item/mech_component/chassis/repair_brute_damage(var/amt)
+	take_brute_damage(-(amt / CHASSIS_DAMAGE_MOD))
+
+/obj/item/mech_component/chassis/repair_burn_damage(var/amt)
+	take_burn_damage(-(amt / CHASSIS_DAMAGE_MOD))
+
+/obj/item/mech_component/chassis/take_brute_damage(var/amt)
+	brute_damage = max(0, brute_damage + (amt * CHASSIS_DAMAGE_MOD))
+	update_health()
+	if(total_damage == max_damage)
+		take_component_damage((amt * CHASSIS_DAMAGE_MOD), 0)
+
+/obj/item/mech_component/chassis/take_burn_damage(var/amt)
+	burn_damage = max(0, burn_damage + (amt * CHASSIS_DAMAGE_MOD))
+	update_health()
+	if(total_damage == max_damage)
+		take_component_damage(0, (amt * CHASSIS_DAMAGE_MOD))
+
+#undef CHASSIS_DAMAGE_MOD

--- a/code/modules/heavy_vehicle/mech_life.dm
+++ b/code/modules/heavy_vehicle/mech_life.dm
@@ -33,12 +33,14 @@
 		get_cell()?.drain_power(0, 0, calc_power_draw())
 
 	updatehealth()
-	if(health <= 0 && stat != DEAD)
-		death()
+	if(health <= 0 && health_lockdown == FALSE)
+		ToggleHealthLockdown()
+	else if(health > 0 && health_lockdown == TRUE)
+		ToggleHealthLockdown()
 
 	..()
 
-	lying = 0 // Fuck off, carp.
+	lying = FALSE // Fuck off, carp.
 	handle_vision()
 	handle_hud_icons()
 

--- a/code/modules/heavy_vehicle/mecha.dm
+++ b/code/modules/heavy_vehicle/mecha.dm
@@ -51,6 +51,7 @@
 	var/hardpoints_locked
 	var/maintenance_protocols
 	var/lockdown
+	var/health_lockdown = FALSE
 
 	// Material
 	var/material/material
@@ -127,16 +128,28 @@
 	for(var/obj/item/mech_component/thing in list(arms, legs, head, body))
 		if(!thing)
 			continue
-		var/damage_string = "destroyed"
-		switch(thing.damage_state)
-			if(1)
-				damage_string = "undamaged"
-			if(2)
-				damage_string = "<span class='warning'>damaged</span>"
-			if(3)
-				damage_string = "<span class='warning'>badly damaged</span>"
-			if(4)
-				damage_string = "<span class='danger'>almost destroyed</span>"
+		var/damage_string
+		if(istype(thing, /obj/item/mech_component/propulsion))
+			var/obj/item/mech_component/propulsion/P = thing
+			if(!P.motivator || !P.motivator.is_functional())
+				damage_string = SPAN_DANGER("disabled")
+		if(istype(thing, /obj/item/mech_component/manipulators))
+			var/obj/item/mech_component/manipulators/M = thing
+			if(!M.motivator || !M.motivator.is_functional())
+				damage_string = SPAN_DANGER("disabled")
+		if(istype(thing, /obj/item/mech_component/chassis))
+			if(body.total_damage == body.max_damage)
+				damage_string = SPAN_DANGER("torn open")
+		if(!damage_string)
+			switch(thing.damage_state)
+				if(1)
+					damage_string = FONT_COLOR(COLOR_GREEN, "undamaged")
+				if(2)
+					damage_string = FONT_COLOR(COLOR_YELLOW, "damaged")
+				if(3)
+					damage_string = FONT_COLOR(COLOR_ORANGE, "badly damaged")
+				if(4)
+					damage_string = FONT_COLOR(COLOR_RED, "badly damaged")
 		to_chat(user, "Its <b>[thing.name]</b> [thing.gender == PLURAL ? "are" : "is"] [damage_string].")
 
 /mob/living/heavy_vehicle/Topic(href,href_list[])

--- a/code/modules/heavy_vehicle/mecha.dm
+++ b/code/modules/heavy_vehicle/mecha.dm
@@ -137,9 +137,8 @@
 			var/obj/item/mech_component/manipulators/M = thing
 			if(!M.motivator || !M.motivator.is_functional())
 				damage_string = SPAN_DANGER("disabled")
-		if(istype(thing, /obj/item/mech_component/chassis))
-			if(body.total_damage == body.max_damage)
-				damage_string = SPAN_DANGER("torn open")
+		if(istype(thing, /obj/item/mech_component/chassis) && body.total_damage == body.max_damage)
+			damage_string = SPAN_DANGER("torn open")
 		if(!damage_string)
 			switch(thing.damage_state)
 				if(1)

--- a/html/changelogs/geeves-mech_mech_mech.yml
+++ b/html/changelogs/geeves-mech_mech_mech.yml
@@ -1,0 +1,12 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "You can now repair mech components with nanopaste too."
+  - tweak: "Repairing mech components now take three seconds per repair."
+  - tweak: "Repairing mech components with welders now take a bit of fuel."
+  - tweak: "Mechs now take much less damage than they usually did. Burning and lasers do more damage than straight brute damage."
+  - rscadd: "Shooting mechs now properly have the potential of transferring the bullet to the pilot."
+  - rscadd: "Mechs no longer die, they just go into an inactive servolock when their health goes below 0. Repair the mech to releash it from the lockdown."
+  - rscadd: "Examining a mech now properly tells you whether the legs, arms, and body are damaged to its maximum damage level. If the legs or arms are no longer functional, they will display 'Disabled' in bold red."


### PR DESCRIPTION
* You can now repair mech components with nanopaste too.
* Repairing mech components now take three seconds per repair.
* Repairing mech components with welders now take a bit of fuel.
* Mechs now take much less damage than they usually did. Burning and lasers do more damage than straight brute damage.
* Shooting mechs now properly have the potential of transferring the bullet to the pilot.
* Mechs no longer die, they just go into an inactive servolock when their health goes below 0. Repair the mech to releash it from the lockdown.
* Examining a mech now properly tells you whether the legs, arms, and body are damaged to its maximum damage level. If the legs or arms are no longer functional, they will display 'Disabled' in bold red.