### PR TITLE
Stops Mine Drones from bleeding

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -148,3 +148,5 @@
 /mob/living/bot/proc/explode()
 	qdel(src)
 
+/mob/living/bot/get_bullet_impact_effect_type(var/def_zone)
+	return BULLET_IMPACT_METAL

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -301,3 +301,6 @@
 			if (!underdoor)
 				spawn(3)//A slight delay to let us finish walking out from under the door
 					layer = initial(layer)
+
+/mob/living/simple_animal/spiderbot/get_bullet_impact_effect_type(var/def_zone)
+	return BULLET_IMPACT_METAL

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
@@ -175,5 +175,5 @@
 	visible_message("<span class='danger'>\The [src] bounces harmlessly on its inflated wheels.</span>")
 	return FALSE
 
-mob/living/simple_animal/hostile/retaliate/minedrone/get_bullet_impact_effect_type(var/def_zone)
+/mob/living/simple_animal/hostile/retaliate/minedrone/get_bullet_impact_effect_type(var/def_zone)
 	return BULLET_IMPACT_METAL

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
@@ -174,3 +174,6 @@
 /mob/living/simple_animal/hostile/retaliate/minedrone/fall_impact()
 	visible_message("<span class='danger'>\The [src] bounces harmlessly on its inflated wheels.</span>")
 	return FALSE
+
+mob/living/simple_animal/hostile/retaliate/minedrone/get_bullet_impact_effect_type(var/def_zone)
+	return BULLET_IMPACT_METAL

--- a/html/changelogs/cursed_drone.yml
+++ b/html/changelogs/cursed_drone.yml
@@ -10,4 +10,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - bugfix: "🦀 Mine drones no longer bleed when shot. 🦀"
+  - bugfix: "Mine drones and other bots no longer bleed when shot."

--- a/html/changelogs/cursed_drone.yml
+++ b/html/changelogs/cursed_drone.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: SpaceBaa
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "🦀 Mine drones no longer bleed when shot. 🦀"


### PR DESCRIPTION
Mine drones inherit the simple animal code instead of silicon so they bled blood and it was terrifying.
What did NanoTrasen put in there?!
Fixes #8643 