### PR TITLE
Removes deadly stuff from the vent clog event

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -9,27 +9,25 @@
 		"water",
 		"carbon",
 		"flour",
-		"radium",
-		"toxin",
 		"cleaner",
 		"nutriment",
 		"condensedcapsaicin",
 		"mindbreaker",
 		"lube",
-		"plantbgone",
+		"red_paint",
+		"yellow_paint",
 		"banana",
 		"space_drugs",
 		"holywater",
-		"ethanol",
 		"hot_coco",
-		"sacid",
 		"hyperzine",
 		"paint",
 		"luminol",
 		"fuel",
 		"blood",
 		"sterilizine",
-		"ipecac"
+		"ipecac".
+		"monoammoniumphosphate"
 	)
 
 

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -26,7 +26,7 @@
 		"fuel",
 		"blood",
 		"sterilizine",
-		"ipecac".
+		"ipecac",
 		"monoammoniumphosphate"
 	)
 
@@ -65,4 +65,3 @@
 
 /datum/event/vent_clog/announce()
 	command_announcement.Announce("The scrubbers network is experiencing a backpressure surge. Some ejection of contents may occur.", "Atmospherics alert", new_sound = 'sound/AI/scrubbers.ogg')
-

--- a/html/changelogs/alberyk-ventclog.yml
+++ b/html/changelogs/alberyk-ventclog.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Removed the deadly stuff from the vent clog event, replaced some of them with more interesting choices."


### PR DESCRIPTION
-Removes: toxins, radium, plantbgone, ethanol and acid from the vent clog event reagent options. 
-Replaces the broken paint reagent with yellow and red paint. 
-Adds monoammoniumphosphate to the list, should just lower the temperature a bit.