### PR TITLE
Borer Tweaks and Changes

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1573,6 +1573,7 @@
 #include "code\modules\ghostroles\spawner\human\responseteams\response_team.dm"
 #include "code\modules\ghostroles\spawner\human\responseteams\syndicate.dm"
 #include "code\modules\ghostroles\spawner\human\responseteams\tcfl.dm"
+#include "code\modules\ghostroles\spawner\simplemob\borer.dm"
 #include "code\modules\ghostroles\spawner\simplemob\maintdrone.dm"
 #include "code\modules\ghostroles\spawner\simplemob\rat.dm"
 #include "code\modules\ghostroles\spawner\simplemob\spider.dm"

--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -2,7 +2,7 @@
 
 /datum/controller/subsystem/ghostroles
 	name = "Ghost Roles"
-	init_order = SS_INIT_MISC_FIRST
+	init_order = SS_INIT_JOBS
 	flags = SS_NO_FIRE
 
 	var/list/list/spawnpoints = list() //List of the available spawnpoints by spawnpoint type

--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -2,6 +2,7 @@
 
 /datum/controller/subsystem/ghostroles
 	name = "Ghost Roles"
+	init_order = SS_INIT_MISC_FIRST
 	flags = SS_NO_FIRE
 
 	var/list/list/spawnpoints = list() //List of the available spawnpoints by spawnpoint type
@@ -9,6 +10,10 @@
 		//           -> spawnpoint 2
 
 	var/list/spawners = list() //List of the available spawner datums
+
+	// For special spawners that have mobile or object spawnpoints
+	var/list/spawn_types = list("Golems", "Borers")
+	var/list/spawn_atom = list()
 
 /datum/controller/subsystem/ghostroles/Recover()
 	src.spawnpoints = SSghostroles.spawnpoints
@@ -35,6 +40,9 @@
 	for (var/identifier in spawnpoints)
 		CHECK_TICK
 		update_spawnpoint_status_by_identifier(identifier)
+
+	for(var/spawn_type in spawn_types)
+		spawn_atom[spawn_type] = list()
 
 //Adds a spawnpoint to the spawnpoint list
 /datum/controller/subsystem/ghostroles/proc/add_spawnpoints(var/obj/effect/ghostspawpoint/P)
@@ -177,3 +185,14 @@
 			for(var/i in S.spawnpoints)
 				update_spawnpoint_status_by_identifier(i)
 	return
+
+/datum/controller/subsystem/ghostroles/proc/add_spawn_atom(var/atom/added_atom, var/atom_list)
+	if(added_atom && atom_list)
+		spawn_atom[atom_list].Add(added_atom)
+
+/datum/controller/subsystem/ghostroles/proc/remove_spawn_atom(var/atom/removed_atom, var/atom_list)
+	if(removed_atom && atom_list)
+		spawn_atom[atom_list].Remove(removed_atom)
+
+/datum/controller/subsystem/ghostroles/proc/get_spawn_atom(var/atom_list)
+	return spawn_atom[atom_list]

--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -32,7 +32,7 @@
 			log_ss("ghostroles","Spawner [G.type] got removed from selection because of missing data")
 			continue
 		//Check if we have a spawnpoint on the current map
-		if(!G.select_spawnpoint(FALSE))
+		if(!G.select_spawnpoint(FALSE) && !G.uses_spawn_atoms)
 			log_debug("ghostroles","Spawner [G.type] got removed from selection because of missing spawnpoint")
 			continue
 		spawners[G.short_name] = G
@@ -186,13 +186,24 @@
 				update_spawnpoint_status_by_identifier(i)
 	return
 
-/datum/controller/subsystem/ghostroles/proc/add_spawn_atom(var/atom/added_atom, var/atom_list)
-	if(added_atom && atom_list)
-		spawn_atom[atom_list].Add(added_atom)
+/datum/controller/subsystem/ghostroles/proc/add_spawn_atom(var/ghost_role_name, var/atom/spawn_atom)
+	if(ghost_role_name && spawn_atom)
+		var/datum/ghostspawner/G = spawners[ghost_role_name]
+		if(G)
+			G.spawn_atoms += spawn_atom
+			if(length(G.spawn_atoms) == 1)
+				G.enable()
 
-/datum/controller/subsystem/ghostroles/proc/remove_spawn_atom(var/atom/removed_atom, var/atom_list)
-	if(removed_atom && atom_list)
-		spawn_atom[atom_list].Remove(removed_atom)
+/datum/controller/subsystem/ghostroles/proc/remove_spawn_atom(var/ghost_role_name, var/atom/spawn_atom)
+	if(ghost_role_name && spawn_atom)
+		var/datum/ghostspawner/G = spawners[ghost_role_name]
+		if(G)
+			G.spawn_atoms -= spawn_atom
+			if(!length(G.spawn_atoms))
+				G.disable()
 
-/datum/controller/subsystem/ghostroles/proc/get_spawn_atom(var/atom_list)
-	return spawn_atom[atom_list]
+/datum/controller/subsystem/ghostroles/proc/get_spawn_atoms(var/ghost_role_name)
+	var/datum/ghostspawner/G = spawners[ghost_role_name]
+	if(G)
+		return G.spawn_atoms
+	return list()

--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -32,7 +32,7 @@
 			log_ss("ghostroles","Spawner [G.type] got removed from selection because of missing data")
 			continue
 		//Check if we have a spawnpoint on the current map
-		if(!G.select_spawnpoint(FALSE) && !G.uses_spawn_atoms)
+		if(!G.select_spawnpoint(FALSE))
 			log_debug("ghostroles","Spawner [G.type] got removed from selection because of missing spawnpoint")
 			continue
 		spawners[G.short_name] = G

--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -13,7 +13,7 @@
 
 	// For special spawners that have mobile or object spawnpoints
 	var/list/spawn_types = list("Golems", "Borers")
-	var/list/list/spawn_atom = list()
+	var/list/spawn_atom = list()
 
 /datum/controller/subsystem/ghostroles/Recover()
 	src.spawnpoints = SSghostroles.spawnpoints

--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -13,7 +13,7 @@
 
 	// For special spawners that have mobile or object spawnpoints
 	var/list/spawn_types = list("Golems", "Borers")
-	var/list/spawn_atom = list()
+	var/list/list/spawn_atom = list()
 
 /datum/controller/subsystem/ghostroles/Recover()
 	src.spawnpoints = SSghostroles.spawnpoints

--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -4,7 +4,7 @@ var/datum/antagonist/xenos/borer/borers
 	id = MODE_BORER
 	role_text = "Cortical Borer"
 	role_text_plural = "Cortical Borers"
-	mob_path = /mob/living/simple_animal/borer
+	mob_path = /mob/living/simple_animal/borer/roundstart
 	bantype = "Borer"
 	welcome_text = "Use your Infest power to crawl into the ear of a host and fuse with their brain. You can only take control temporarily, and at risk of hurting your host, so be clever and careful; your host is encouraged to help you however they can. Talk to your fellow borers with ,x."
 	antag_indicator = "brainworm"

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -122,6 +122,9 @@ var/list/whitelist = list()
 	if (!istype(C) || C.holder)
 		return 0
 
+	if(!dbcon.IsConnected())
+		return TRUE
+
 	var/age_to_beat = 0
 
 	// Assume it's an antag role.

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -68,18 +68,19 @@ BREATH ANALYZER
 		else
 			. = "moderate"
 
-/proc/health_scan_mob(var/mob/M, var/mob/living/user, var/show_limb_damage = TRUE)
-	if (((user.is_clumsy()) || (DUMB in user.mutations)) && prob(50))
-		user.visible_message("<span class='notice'>\The [user] runs the scanner over the floor.</span>", "<span class='notice'>You run the scanner over the floor.</span>", "<span class='notice'>You hear metal repeatedly clunking against the floor.</span>")
-		to_chat(user, "<span class='notice'><b>Scan results for the floor:</b></span>")
-		to_chat(user, "Overall Status: Healthy</span>")
-		return
+/proc/health_scan_mob(var/mob/M, var/mob/living/user, var/show_limb_damage = TRUE, var/just_scan = FALSE)
+	if(!just_scan)
+		if (((user.is_clumsy()) || (DUMB in user.mutations)) && prob(50))
+			user.visible_message("<span class='notice'>\The [user] runs the scanner over the floor.</span>", "<span class='notice'>You run the scanner over the floor.</span>", "<span class='notice'>You hear metal repeatedly clunking against the floor.</span>")
+			to_chat(user, "<span class='notice'><b>Scan results for the floor:</b></span>")
+			to_chat(user, "Overall Status: Healthy</span>")
+			return
 
-	if(!usr.IsAdvancedToolUser())
-		to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return
+		if(!usr.IsAdvancedToolUser())
+			to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
+			return
 
-	user.visible_message("<span class='notice'>[user] runs the scanner over [M].</span>","<span class='notice'>You run the scanner over [M].</span>")
+		user.visible_message("<span class='notice'>[user] runs the scanner over [M].</span>","<span class='notice'>You run the scanner over [M].</span>")
 
 	if(!istype(M, /mob/living/carbon/human))
 		to_chat(user, "<span class='warning'>This scanner is designed for humanoid patients only.</span>")

--- a/code/modules/ghostroles/spawner/base.dm
+++ b/code/modules/ghostroles/spawner/base.dm
@@ -9,7 +9,6 @@
 	//Vars regarding the spawnpoints and conditions of the spawner
 	var/list/spawnpoints = null //List of the applicable spawnpoints (by name)
 	var/list/spawn_atoms = list() // List of atoms you can spawn at
-	var/uses_spawn_atoms = FALSE
 	var/landmark_name = null //Alternatively you can specify a landmark name
 	var/max_count = 0 //How often can this spawner be used
 	var/count = 0 //How ofen has this spawner been used
@@ -38,8 +37,6 @@
 		jobban_job = name
 	if(!isnull(enable_chance))
 		enabled = prob(enable_chance)
-	if(uses_spawn_atoms && !length(spawn_atoms))
-		disable()
 
 //Return a error message if the user CANT see the ghost spawner. Otherwise FALSE
 /datum/ghostspawner/proc/cant_see(mob/user) //If the user can see the spawner in the menu

--- a/code/modules/ghostroles/spawner/base.dm
+++ b/code/modules/ghostroles/spawner/base.dm
@@ -8,6 +8,8 @@
 
 	//Vars regarding the spawnpoints and conditions of the spawner
 	var/list/spawnpoints = null //List of the applicable spawnpoints (by name)
+	var/list/spawn_atoms = list() // List of atoms you can spawn at
+	var/uses_spawn_atoms = FALSE
 	var/landmark_name = null //Alternatively you can specify a landmark name
 	var/max_count = 0 //How often can this spawner be used
 	var/count = 0 //How ofen has this spawner been used
@@ -36,6 +38,8 @@
 		jobban_job = name
 	if(!isnull(enable_chance))
 		enabled = prob(enable_chance)
+	if(uses_spawn_atoms && !length(spawn_atoms))
+		disable()
 
 //Return a error message if the user CANT see the ghost spawner. Otherwise FALSE
 /datum/ghostspawner/proc/cant_see(mob/user) //If the user can see the spawner in the menu
@@ -94,6 +98,11 @@
 
 //This proc selects the spawnpoint to use.
 /datum/ghostspawner/proc/select_spawnpoint(var/use=TRUE)
+	if(length(spawn_atoms))
+		var/chosen_spawn_atom = pick(spawn_atoms)
+		var/turf/T = get_turf(chosen_spawn_atom)
+		if(T)
+			return T
 	if(!isnull(spawnpoints))
 		for(var/spawnpoint in spawnpoints) //Loop through the applicable spawnpoints
 			var/turf/T = SSghostroles.get_spawnpoint(spawnpoint, use) //Gets the first matching spawnpoint or null if none are available

--- a/code/modules/ghostroles/spawner/human/golem.dm
+++ b/code/modules/ghostroles/spawner/human/golem.dm
@@ -17,7 +17,7 @@
 	var/obj/effect/golemrune/rune
 	var/list/global_runes = list()
 
-	for(var/obj/effect/golemrune/eligible_rune in golem_runes)
+	for(var/obj/effect/golemrune/eligible_rune in SSghostroles.get_spawn_atom("Golems"))
 		global_runes += eligible_rune
 
 	if(!length(global_runes))

--- a/code/modules/ghostroles/spawner/human/golem.dm
+++ b/code/modules/ghostroles/spawner/human/golem.dm
@@ -7,7 +7,6 @@
 	respawn_flag = ANIMAL
 	enabled = FALSE
 
-	uses_spawn_atoms = TRUE
 	spawn_mob = /mob/living/carbon/human/golem
 
 /datum/ghostspawner/human/golem/select_spawnpoint(var/use)

--- a/code/modules/ghostroles/spawner/human/golem.dm
+++ b/code/modules/ghostroles/spawner/human/golem.dm
@@ -7,6 +7,7 @@
 	respawn_flag = ANIMAL
 	enabled = FALSE
 
+	uses_spawn_atoms = TRUE
 	spawn_mob = /mob/living/carbon/human/golem
 
 /datum/ghostspawner/human/golem/select_spawnpoint(var/use)
@@ -14,18 +15,12 @@
 
 //The proc to actually spawn in the user
 /datum/ghostspawner/human/golem/spawn_mob(mob/user)
-	var/obj/effect/golemrune/rune
-	var/list/global_runes = list()
-
-	for(var/obj/effect/golemrune/eligible_rune in SSghostroles.get_spawn_atom("Golems"))
-		global_runes += eligible_rune
-
-	if(!length(global_runes))
+	if(!length(spawn_atoms))
 		to_chat(user, span("danger", "There are no available golem runes to spawn at!"))
 		return FALSE
 
-	rune = pick(global_runes)
+	var/obj/effect/golemrune/rune = pick(spawn_atoms)
 
-	if(user)
+	if(user && rune)
 		return rune.spawn_golem(user)
 	return FALSE

--- a/code/modules/ghostroles/spawner/simplemob/borer.dm
+++ b/code/modules/ghostroles/spawner/simplemob/borer.dm
@@ -4,7 +4,8 @@
 	desc = "Infest crew, reproduce, repeat."
 	tags = list("Antagonist")
 
-	uses_spawn_atoms = TRUE
+	enabled = FALSE
+
 	spawn_mob = /mob/living/simple_animal/borer
 
 /datum/ghostspawner/simplemob/borer/select_spawnpoint(var/use)

--- a/code/modules/ghostroles/spawner/simplemob/borer.dm
+++ b/code/modules/ghostroles/spawner/simplemob/borer.dm
@@ -1,0 +1,28 @@
+/datum/ghostspawner/simplemob/borer
+	short_name = "borer"
+	name = "Cortical Borer"
+	desc = "Infest crew, reproduce, repeat."
+	tags = list("Antagonist")
+
+	spawn_mob = /mob/living/simple_animal/borer
+
+/datum/ghostspawner/simplemob/borer/select_spawnpoint(var/use)
+	return TRUE //We just fake it here, since the spawnpoint is selected if someone is spawned in.
+
+//The proc to actually spawn in the user
+/datum/ghostspawner/simplemob/borer/spawn_mob(mob/user)
+	var/mob/living/simple_animal/borer/spawn_borer
+	var/list/borer_list = list()
+
+	for(var/mob/living/simple_animal/borer/eligible_borers in SSghostroles.get_spawn_atom("Borers"))
+		borer_list += eligible_borers
+
+	if(!length(borer_list))
+		to_chat(user, SPAN_DANGER("There are no available borers to spawn at!"))
+		return FALSE
+
+	spawn_borer = pick(borer_list)
+
+	if(user && spawn_borer)
+		return spawn_borer.spawn_into_borer(user)
+	return FALSE

--- a/code/modules/ghostroles/spawner/simplemob/borer.dm
+++ b/code/modules/ghostroles/spawner/simplemob/borer.dm
@@ -4,6 +4,7 @@
 	desc = "Infest crew, reproduce, repeat."
 	tags = list("Antagonist")
 
+	uses_spawn_atoms = TRUE
 	spawn_mob = /mob/living/simple_animal/borer
 
 /datum/ghostspawner/simplemob/borer/select_spawnpoint(var/use)
@@ -11,17 +12,11 @@
 
 //The proc to actually spawn in the user
 /datum/ghostspawner/simplemob/borer/spawn_mob(mob/user)
-	var/mob/living/simple_animal/borer/spawn_borer
-	var/list/borer_list = list()
-
-	for(var/mob/living/simple_animal/borer/eligible_borers in SSghostroles.get_spawn_atom("Borers"))
-		borer_list += eligible_borers
-
-	if(!length(borer_list))
+	if(!length(spawn_atoms))
 		to_chat(user, SPAN_DANGER("There are no available borers to spawn at!"))
 		return FALSE
 
-	spawn_borer = pick(borer_list)
+	var/mob/living/simple_animal/borer/spawn_borer = pick(spawn_atoms)
 
 	if(user && spawn_borer)
 		return spawn_borer.spawn_into_borer(user)

--- a/code/modules/mob/living/carbon/slime/items.dm
+++ b/code/modules/mob/living/carbon/slime/items.dm
@@ -231,21 +231,11 @@
 	. = ..()
 	START_PROCESSING(SSprocessing, src)
 	announce_to_ghosts()
-	SSghostroles.add_spawn_atom(src, "Golems")
-	if(length(SSghostroles.get_spawn_atom("Golems")) == 1)
-		for(var/role_spawner in SSghostroles.spawners)
-			if(role_spawner == "golem")
-				var/datum/ghostspawner/human/golem/golem_spawner = SSghostroles.spawners[role_spawner]
-				golem_spawner.enable()
+	SSghostroles.add_spawn_atom("golem", src)
 
 /obj/effect/golemrune/Destroy()
-	. = ..()
-	SSghostroles.remove_spawn_atom(src, "Golems")
-	if(!length(SSghostroles.get_spawn_atom("Golems")))
-		for(var/role_spawner in SSghostroles.spawners)
-			if(role_spawner == "golem")
-				var/datum/ghostspawner/human/golem/golem_spawner = SSghostroles.spawners[role_spawner]
-				golem_spawner.disable()
+	SSghostroles.remove_spawn_atom("golem", src)
+	return ..()
 
 /obj/effect/golemrune/process()
 	var/mob/abstract/observer/ghost

--- a/code/modules/mob/living/carbon/slime/items.dm
+++ b/code/modules/mob/living/carbon/slime/items.dm
@@ -216,8 +216,6 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle17"
 
-var/list/global/golem_runes = list()
-
 /obj/effect/golemrune
 	anchored = TRUE
 	desc = "A strange rune used to create golems. It glows when spirits are nearby."
@@ -233,8 +231,8 @@ var/list/global/golem_runes = list()
 	. = ..()
 	START_PROCESSING(SSprocessing, src)
 	announce_to_ghosts()
-	golem_runes += src
-	if(length(golem_runes) == 1)
+	SSghostroles.add_spawn_atom(src, "Golems")
+	if(length(SSghostroles.get_spawn_atom("Golems")) == 1)
 		for(var/role_spawner in SSghostroles.spawners)
 			if(role_spawner == "golem")
 				var/datum/ghostspawner/human/golem/golem_spawner = SSghostroles.spawners[role_spawner]
@@ -242,8 +240,8 @@ var/list/global/golem_runes = list()
 
 /obj/effect/golemrune/Destroy()
 	. = ..()
-	golem_runes -= src
-	if(!length(golem_runes))
+	SSghostroles.remove_spawn_atom(src, "Golems")
+	if(!length(SSghostroles.get_spawn_atom("Golems")))
 		for(var/role_spawner in SSghostroles.spawners)
 			if(role_spawner == "golem")
 				var/datum/ghostspawner/human/golem/golem_spawner = SSghostroles.spawners[role_spawner]

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -21,7 +21,7 @@
 	maxHealth = 40
 	health = 40
 	pass_flags = PASSTABLE
-	universal_understand = 1
+	universal_understand = TRUE
 	holder_type = /obj/item/holder/borer
 	mob_size = 1
 	hunger_enabled = FALSE
@@ -33,10 +33,10 @@
 	var/mob/living/captive_brain/host_brain // Used for swapping control of the body back and forth.
 	var/controlling                         // Used in human death check.
 	var/has_reproduced
-	var/roundstart
+	var/request_player = TRUE
 
 /mob/living/simple_animal/borer/roundstart
-	roundstart = TRUE
+	request_player = FALSE
 
 /mob/living/simple_animal/borer/Login()
 	..()
@@ -52,15 +52,33 @@
 	verbs += /mob/living/proc/hide
 
 	truename = "[pick("Primary","Secondary","Tertiary","Quaternary")]-[rand(1000,9999)]"
-	if(!roundstart)
-		request_player()
+	if(request_player && !ckey && !client)
+		SSghostroles.add_spawn_atom(src, "Borers")
+		if(length(SSghostroles.get_spawn_atom("Borers")) == 1)
+			for(var/role_spawner in SSghostroles.spawners)
+				if(role_spawner == "borer")
+					var/datum/ghostspawner/simplemob/borer/borer_spawner = SSghostroles.spawners[role_spawner]
+					borer_spawner.enable()
+		var/area/A = get_area(src)
+		if(A)
+			say_dead_direct("A borer has been birthed in [A.name]! Spawn in as it by using the ghost spawner menu in the ghost tab.")
+
+/mob/living/simple_animal/borer/death(gibbed, deathmessage)
+	SSghostroles.remove_spawn_atom(src, "Borers")
+	if(!length(SSghostroles.get_spawn_atom("Borers")))
+		for(var/role_spawner in SSghostroles.spawners)
+			if(role_spawner == "borer")
+				var/datum/ghostspawner/simplemob/borer/borer_spawner = SSghostroles.spawners[role_spawner]
+				borer_spawner.disable()
+	return ..(gibbed,deathmessage)
 
 /mob/living/simple_animal/borer/Life()
 	..()
 	if(host)
-		if(!stat && !host.stat)
+		if(!stat && host.stat != DEAD)
 			if(chemicals < 250)
 				chemicals++
+		if(host && !host.stat)
 			if(controlling && prob(host.getBrainLoss()/20))
 				host.say("*[pick(list("blink","blink_r","choke","drool","twitch","twitch_s","gasp"))]")
 
@@ -152,10 +170,15 @@
 	host = null
 	return
 
-//Procs for grabbing players.
-/mob/living/simple_animal/borer/proc/request_player()
-	var/datum/ghosttrap/G = get_ghost_trap("cortical borer")
-	G.request_player(src, "A cortical borer needs a player.")
+/mob/living/simple_animal/borer/proc/spawn_into_borer(var/mob/user)
+	ckey = user.ckey
+	qdel(user)
+	SSghostroles.remove_spawn_atom(src, "Borers")
+	if(!length(SSghostroles.get_spawn_atom("Borers")))
+		for(var/role_spawner in SSghostroles.spawners)
+			if(role_spawner == "borer")
+				var/datum/ghostspawner/simplemob/borer/borer_spawner = SSghostroles.spawners[role_spawner]
+				borer_spawner.disable()
 
 /mob/living/simple_animal/borer/cannot_use_vents()
 	return

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -53,23 +53,13 @@
 
 	truename = "[pick("Primary","Secondary","Tertiary","Quaternary")]-[rand(1000,9999)]"
 	if(request_player && !ckey && !client)
-		SSghostroles.add_spawn_atom(src, "Borers")
-		if(length(SSghostroles.get_spawn_atom("Borers")) == 1)
-			for(var/role_spawner in SSghostroles.spawners)
-				if(role_spawner == "borer")
-					var/datum/ghostspawner/simplemob/borer/borer_spawner = SSghostroles.spawners[role_spawner]
-					borer_spawner.enable()
+		SSghostroles.add_spawn_atom("borer", src)
 		var/area/A = get_area(src)
 		if(A)
 			say_dead_direct("A borer has been birthed in [A.name]! Spawn in as it by using the ghost spawner menu in the ghost tab.")
 
 /mob/living/simple_animal/borer/death(gibbed, deathmessage)
-	SSghostroles.remove_spawn_atom(src, "Borers")
-	if(!length(SSghostroles.get_spawn_atom("Borers")))
-		for(var/role_spawner in SSghostroles.spawners)
-			if(role_spawner == "borer")
-				var/datum/ghostspawner/simplemob/borer/borer_spawner = SSghostroles.spawners[role_spawner]
-				borer_spawner.disable()
+	SSghostroles.remove_spawn_atom("borer", src)
 	return ..(gibbed,deathmessage)
 
 /mob/living/simple_animal/borer/Life()
@@ -173,12 +163,7 @@
 /mob/living/simple_animal/borer/proc/spawn_into_borer(var/mob/user)
 	ckey = user.ckey
 	qdel(user)
-	SSghostroles.remove_spawn_atom(src, "Borers")
-	if(!length(SSghostroles.get_spawn_atom("Borers")))
-		for(var/role_spawner in SSghostroles.spawners)
-			if(role_spawner == "borer")
-				var/datum/ghostspawner/simplemob/borer/borer_spawner = SSghostroles.spawners[role_spawner]
-				borer_spawner.disable()
+	SSghostroles.remove_spawn_atom("borer", src)
 
 /mob/living/simple_animal/borer/cannot_use_vents()
 	return

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -437,7 +437,7 @@
 	chemicals -= 150
 	to_chat(src, span("notice", "You probe your tendrils deep within your host's zona bovinae, seeking to unleash their potential."))
 	to_chat(host, span("danger", "You feel some tendrils probe at the back of your head..."))
-	to_chat(host, SPAN_WARNING("You feel something terrible coming on..."))
+	to_chat(host, FONT_LARGE(SPAN_WARNING("You feel something terrible coming on...")))
 	addtimer(CALLBACK(src, .proc/jumpstart_psi), 150)
 
 /mob/living/simple_animal/borer/proc/jumpstart_psi()

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -414,7 +414,7 @@
 /mob/living/simple_animal/borer/verb/awaken_psionics()
 	set category = "Abilities"
 	set name = "Awaken Host Psionics (150)"
-	set desc = "Probe into your host an unlock their psionic potential."
+	set desc = "Probe into your host and unlock their psionic potential. Note, it will give them a seizure as their brain realizes its potential."
 
 	if(!host)
 		to_chat(src, span("notice", "You are not inside a host body."))
@@ -437,7 +437,8 @@
 	chemicals -= 150
 	to_chat(src, span("notice", "You probe your tendrils deep within your host's zona bovinae, seeking to unleash their potential."))
 	to_chat(host, span("danger", "You feel some tendrils probe at the back of your head..."))
-	addtimer(CALLBACK(src, .proc/jumpstart_psi), 100)
+	to_chat(host, SPAN_WARNING("You feel something terrible coming on..."))
+	addtimer(CALLBACK(src, .proc/jumpstart_psi), 150)
 
 /mob/living/simple_animal/borer/proc/jumpstart_psi()
 	to_chat(src, span("notice", "You succeed in interfacing with the host's zona bovinae, this will be a painful process for them."))
@@ -486,3 +487,17 @@
 	to_chat(src, span("notice", "You successfully manage to upgrade your host's [selected_faculty] faculty."))
 	to_chat(host, span("good", "A breeze of fresh air washes over your mind, you feel powerful!"))
 	to_chat(host, span("notice", "You have been psionically enlightened. You are now a [psychic_ranks_to_strings[host.psi.ranks[selected_faculty]]] in the [selected_faculty] faculty."))
+
+/mob/living/simple_animal/borer/verb/host_health_scan()
+	set category = "Abilities"
+	set name = "Inspect Host Health"
+	set desc = "Survey your host for injuries, allowing you to better treat them."
+
+	if(!host)
+		to_chat(src, SPAN_WARNING("You have no host to scan."))
+		return
+	if(stat)
+		to_chat(src, SPAN_WARNING("You cannot do that in your current state."))
+		return
+
+	health_scan_mob(host, src, TRUE, TRUE)

--- a/code/modules/shareddream/dream_entry.dm
+++ b/code/modules/shareddream/dream_entry.dm
@@ -8,7 +8,9 @@ var/list/dream_entries = list()
 	// If either changes, they should be nocked back to the real world.
 	if(can_commune() && stat == UNCONSCIOUS && sleeping > 1)
 		if(!istype(bg) && client) // Don't spawn a brainghost if we're not logged in.
-			bg = new(src) // Generate a new brainghost.
+			bg = new /mob/living/brain_ghost(src) // Generate a new brainghost.
+			if(isnull(bg)) // Prevents you from getting kicked if the brain ghost didn't spawn - geeves
+				return
 			bg.ckey = ckey
 			bg.client = client
 			ckey = "@[bg.ckey]"
@@ -27,8 +29,17 @@ var/list/dream_entries = list()
 			log_and_message_admins("has left the shared dream",bg)
 			var/mob/living/brain_ghost/old_bg = bg
 			bg = null
-			ckey = old_bg.ckey
+
+			var/return_text = "You are ripped from the Srom as your body awakens."
+			var/mob/return_mob = src
+
+			var/mob/living/simple_animal/borer/B = has_brain_worms()
+			if(B?.host_brain)
+				return_mob = B.host_brain
+				return_text = "You are ripped from the Srom as you return to the captivity of your own mind."
+
+			return_mob.ckey = old_bg.ckey
 			old_bg.show_message("<span class='notice'>[bg] fades as their connection is severed.</span>")
 			animate(old_bg, alpha=0, time = 200)
 			QDEL_IN(old_bg, 20)
-			to_chat(src, "<span class='warning'>You are ripped from the Srom as your body awakens.</span>")
+			to_chat(return_mob, SPAN_WARNING("[return_text]"))

--- a/html/changelogs/geeves-borer_stuff.yml
+++ b/html/changelogs/geeves-borer_stuff.yml
@@ -1,0 +1,11 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Spawned borers now get added to the Ghostspawner menu, allowing players to inhabit them even if they didn't catch the original request."
+  - rscadd: "Borers have gained the ability to survey their host's health, allowing them to better choose when to administer certain chemicals."
+  - tweak: "Borers now regenerate chemicals even if their host is unconscious."
+  - rscadd: "Awakening psionics now take 15 seconds instead of 10, and the host now gets a message about feeling something bad coming on, allowing them to make a dash to safety and or seclusion."
+  - bugfix: "Skrell returning from Srom no longer eject controlling borers to the lobby by replacing their ckey into the aether."
+  - bugfix: "Skrell no longer spontaneously die when entering Srom on a map that doesn't have a Srom location."


### PR DESCRIPTION
* Spawned borers now get added to the Ghostspawner menu, allowing players to inhabit them even if they didn't catch the original request.
* Borers have gained the ability to survey their host's health, allowing them to better choose when to administer certain chemicals.
* Borers now regenerate chemicals even if their host is unconscious.
* Awakening psionics now take 15 seconds instead of 10, and the host now gets a message about feeling something bad coming on, allowing them to make a dash to safety and or seclusion.
* Skrell returning from Srom no longer eject controlling borers to the lobby by replacing their ckey into the aether.
* Skrell no longer spontaneously die when entering Srom on a map that doesn't have a Srom location.