### PR TITLE
Adminbus Things

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -503,7 +503,7 @@
 
 /obj/item/research
 	name = "research debugging device"
-	desc = "Instant research tool. For testing purposes only."
+	desc = "Instant research tool. For testing purposes only. PUTS ALL RESEARCH TECHS TO MAX, EVEN ILLEGAL AND ARCANE."
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "smes_coil"
 	origin_tech = list(TECH_MATERIAL = 19, TECH_ENGINEERING = 19, TECH_PHORON = 19, TECH_POWER = 19, TECH_BLUESPACE = 19, TECH_BIO = 19, TECH_COMBAT = 19, TECH_MAGNET = 19, TECH_DATA = 19, TECH_ILLEGAL = 19, TECH_ARCANE = 19)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -85,6 +85,11 @@ Contains:
 	apply_sounds = list('sound/items/rip1.ogg','sound/items/rip2.ogg')
 	drop_sound = 'sound/items/drop/gloves.ogg'
 
+/obj/item/stack/medical/bruise_pack/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/medical/bruise_pack/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(..())
 		return 1
@@ -153,6 +158,11 @@ Contains:
 	apply_sounds = list('sound/items/ointment.ogg')
 	drop_sound = 'sound/items/drop/herb.ogg'
 
+/obj/item/stack/medical/ointment/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/medical/ointment/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(..())
 		return 1
@@ -196,6 +206,11 @@ Contains:
 	heal_brute = 8
 	origin_tech = list(TECH_BIO = 1)
 	apply_sounds = list('sound/items/rip1.ogg','sound/items/rip2.ogg','sound/items/tape.ogg')
+
+/obj/item/stack/medical/advanced/bruise_pack/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 /obj/item/stack/medical/advanced/bruise_pack/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(..())
@@ -264,6 +279,11 @@ Contains:
 	origin_tech = list(TECH_BIO = 1)
 	apply_sounds = list('sound/items/ointment.ogg')
 
+/obj/item/stack/medical/advanced/ointment/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/medical/advanced/ointment/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(..())
 		return 1
@@ -306,6 +326,11 @@ Contains:
 	origin_tech = list(TECH_BIO = 4)
 	var/open = 0
 	var/used = 0
+
+/obj/item/stack/medical/advanced/bruise_pack/spaceklot/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 /obj/item/stack/medical/advanced/bruise_pack/spaceklot/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(..())
@@ -353,6 +378,11 @@ Contains:
 	max_amount = 5
 	drop_sound = 'sound/items/drop/hat.ogg'
 	var/list/splintable_organs = list(BP_L_ARM,BP_R_ARM,BP_L_LEG,BP_R_LEG, BP_L_HAND, BP_R_HAND, BP_R_FOOT, BP_L_FOOT)
+
+/obj/item/stack/medical/splint/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 /obj/item/stack/medical/splint/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(..())

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -31,6 +31,11 @@ var/global/list/datum/stack_recipe/rod_recipes = list(
 	lock_picking_level = 3
 	drop_sound = 'sound/items/drop/sword.ogg'
 
+/obj/item/stack/rods/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/rods/cyborg
 	name = "metal rod synthesizer"
 	desc = "A device that makes metal rods."

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -10,6 +10,21 @@
 	flags = NOBLUDGEON
 	origin_tech = list(TECH_MATERIAL = 6, TECH_BLUESPACE = 4)
 
+/obj/item/stack/telecrystal/five/Initialize()
+	. = ..()
+	amount = 5
+	update_icon()
+
+/obj/item/stack/telecrystal/twentyfive/Initialize()
+	. = ..()
+	amount = 25
+	update_icon()
+
+/obj/item/stack/telecrystal/fifty/Initialize()
+	. = ..()
+	amount = 50
+	update_icon()
+
 /obj/item/stack/telecrystal/afterattack(var/obj/item/I as obj, mob/user as mob, proximity)
 	if(!proximity)
 		return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1,6 +1,6 @@
 //admin verb groups - They can overlap if you so wish. Only one of each verb will exist in the verbs list regardless
 var/list/admin_verbs_default = list(
-	/datum/admins/proc/show_player_panel,	//shows an interface for individual players, with various links (links require additional flags,
+	/datum/admins/proc/show_player_panel,	//shows an interface for individual players, with various links (links require additional flags),
 	/client/proc/player_panel_modern,
 	/client/proc/toggleadminhelpsound,	/*toggles whether we hear a sound when adminhelps/PMs are used*/
 	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
@@ -41,6 +41,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/admin_call_shuttle,	//allows us to call the emergency shuttle,
 	/client/proc/admin_cancel_shuttle,	//allows us to cancel the emergency shuttle, sending it back to centcomm,
 	/client/proc/cmd_admin_direct_narrate,	//send text directly to a player with no padding. Useful for narratives and fluff-text,
+	/client/proc/cmd_admin_local_narrate,	//sends text to all mobs within 7 tiles of src.mob
 	/client/proc/cmd_admin_world_narrate,	//sends text to all players with no padding,
 	/client/proc/cmd_admin_create_centcom_report,
 	/client/proc/check_ai_laws,			//shows AI and borg laws,
@@ -78,6 +79,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/toggle_antagHUD_use,
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/allow_character_respawn,    // Allows a ghost to respawn ,
+	/client/proc/allow_stationbound_reset,
 	/client/proc/event_manager_panel,
 	/client/proc/empty_ai_core_toggle_latejoin,
 	/client/proc/aooc,
@@ -263,6 +265,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/admin_call_shuttle,
 	/client/proc/admin_cancel_shuttle,
 	/client/proc/cmd_admin_direct_narrate,
+	/client/proc/cmd_admin_local_narrate,
 	/client/proc/cmd_admin_world_narrate,
 	/client/proc/play_local_sound,
 	/client/proc/play_sound,

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -60,7 +60,7 @@
 	bst.equip_to_slot_or_del(new /obj/item/clothing/shoes/black/bst(bst), slot_shoes)
 	bst.equip_to_slot_or_del(new /obj/item/clothing/head/beret(bst), slot_head)
 	bst.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses/bst(bst), slot_glasses)
-	bst.equip_to_slot_or_del(new /obj/item/storage/belt/utility/full(bst), slot_belt)
+	bst.equip_to_slot_or_del(new /obj/item/storage/belt/utility/very_full(bst), slot_belt)
 	bst.equip_to_slot_or_del(new /obj/item/clothing/gloves/swat/bst(bst), slot_gloves)
 	if(bst.backbag == 1)
 		bst.equip_to_slot_or_del(new /obj/item/storage/box/ids(bst), slot_r_hand)
@@ -68,7 +68,8 @@
 		bst.equip_to_slot_or_del(new /obj/item/storage/box/ids(bst.back), slot_in_backpack)
 		bst.equip_to_slot_or_del(new /obj/item/device/t_scanner(bst.back), slot_in_backpack)
 		bst.equip_to_slot_or_del(new /obj/item/device/pda/captain/bst(bst.back), slot_in_backpack)
-		bst.equip_to_slot_or_del(new /obj/item/device/multitool(bst.back), slot_in_backpack)
+		bst.equip_to_slot_or_del(new /obj/item/device/healthanalyzer(bst.back), slot_in_backpack)
+		bst.equip_to_slot_or_del(new /obj/item/research(bst.back), slot_in_backpack)
 
 		var/obj/item/storage/box/pills = new /obj/item/storage/box(null, TRUE)
 		pills.name = "adminordrazine"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -118,6 +118,23 @@
 	message_admins("<span class='notice'>\bold GlobalNarrate: [key_name_admin(usr)] : [msg]<BR></span>", 1)
 	feedback_add_details("admin_verb","GLN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/cmd_admin_local_narrate()
+	set category = "Special Verbs"
+	set name = "Local Narrate"
+
+	if(!holder)
+		to_chat(src, "Only administrators may use this command.")
+		return
+
+	var/msg = html_decode(sanitize(input("Message:", text("Enter the text you wish to appear to everyone within seven tiles of you:")) as text))
+	if(!msg)
+		return
+	for(var/mob/M in range(7, src.mob))
+		to_chat(M, msg)
+	log_admin("LocalNarrate: [key_name(usr)] : [msg]", admin_key = key_name(usr))
+	message_admins("<span class='notice'>\bold LocalNarrate: [key_name_admin(usr)] : [msg]<BR></span>", 1)
+	feedback_add_details("admin_verb", "LCLN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /client/proc/cmd_admin_direct_narrate(var/mob/M)	// Targetted narrate -- TLE
 	set category = "Special Verbs"
 	set name = "Direct Narrate"
@@ -295,6 +312,30 @@ proc/get_ghosts(var/notify = 0,var/what = 2, var/client/C = null)
 	G:show_message(text("<span class='notice'><B>You may now respawn.  You should roleplay as if you learned nothing about the round during your time with the dead.</B></span>"), 1)
 	log_admin("[key_name(usr)] allowed [key_name(G)] to bypass the 30 minute respawn limit",admin_key=key_name(usr),ckey=key_name(G))
 	message_admins("Admin [key_name_admin(usr)] allowed [key_name_admin(G)] to bypass the 30 minute respawn limit", 1)
+
+/client/proc/allow_stationbound_reset(mob/living/silicon/robot/R in range(world.view))
+	set category = "Special Verbs"
+	set name = "Allow Stationbound Reset"
+	set desc = "Select a stationbound to reset its module."
+
+	if(!holder)
+		to_chat(src, SPAN_WARNING("Only administrators may use this command."))
+		return
+	if(!R || !istype(R))
+		return
+
+	R.uneq_all()
+	R.mod_type = initial(R.mod_type)
+	R.hands.icon_state = initial(R.hands.icon_state)
+
+	R.module.Reset(R)
+	QDEL_NULL(R.module)
+	R.updatename("Default")
+
+	to_chat(R, FONT_LARGE(SPAN_NOTICE("An admin has allowed you to reset your module.")))
+
+	log_admin("[key_name(usr)] allowed [key_name(R)] to reset themselves as a stationbound.", admin_key = key_name(usr), ckey = key_name(R))
+	message_admins("Admin [key_name_admin(usr)] allowed [key_name_admin(R)] to reset themselves as a stationbound.", 1)
 
 
 /client/proc/toggle_antagHUD_use()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -122,14 +122,24 @@
 	set category = "Special Verbs"
 	set name = "Local Narrate"
 
-	if(!holder)
-		to_chat(src, "Only administrators may use this command.")
+	if(!check_rights(R_ADMIN, TRUE))
+		return
+	
+	var/list/mob/message_mobs = list()
+	var/choice = alert(usr, "Local narrate will send a plain message to mobs. Do you want the mobs messaged to be only ones that you can see, or ignore blocked vision and message everyone within seven tiles of you?", "Narrate Selection", "In my view", "In range of me", "Cancel")
+	if(choice != "Cancel")
+		if(choice == "In my view")
+			message_mobs = mobs_in_view(7, src.mob)
+		else
+			for(var/mob/M in range(7, src.mob))
+				message_mobs += M
+	else
 		return
 
 	var/msg = html_decode(sanitize(input("Message:", text("Enter the text you wish to appear to everyone within seven tiles of you:")) as text))
 	if(!msg)
 		return
-	for(var/mob/M in range(7, src.mob))
+	for(var/M in message_mobs)
 		to_chat(M, msg)
 	log_admin("LocalNarrate: [key_name(usr)] : [msg]", admin_key = key_name(usr))
 	message_admins("<span class='notice'>\bold LocalNarrate: [key_name_admin(usr)] : [msg]<BR></span>", 1)
@@ -318,8 +328,7 @@ proc/get_ghosts(var/notify = 0,var/what = 2, var/client/C = null)
 	set name = "Allow Stationbound Reset"
 	set desc = "Select a stationbound to reset its module."
 
-	if(!holder)
-		to_chat(src, SPAN_WARNING("Only administrators may use this command."))
+	if(!check_rights(R_ADMIN, TRUE))
 		return
 	if(!R || !istype(R))
 		return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -129,9 +129,9 @@
 	var/choice = alert(usr, "Local narrate will send a plain message to mobs. Do you want the mobs messaged to be only ones that you can see, or ignore blocked vision and message everyone within seven tiles of you?", "Narrate Selection", "In my view", "In range of me", "Cancel")
 	if(choice != "Cancel")
 		if(choice == "In my view")
-			message_mobs = mobs_in_view(7, src.mob)
+			message_mobs = mobs_in_view(view, src.mob)
 		else
-			for(var/mob/M in range(7, src.mob))
+			for(var/mob/M in range(view, src.mob))
 				message_mobs += M
 	else
 		return

--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -19,8 +19,7 @@
 		new /obj/structure/closet/crate/loot(spawn_loc, rarity, quantity)
 		log_and_message_admins("Unusual container spawned at (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[spawn_loc.x];Y=[spawn_loc.y];Z=[spawn_loc.z]'>JMP</a>)")
 	else
-		var/obj/effect/golemrune/rune = new /obj/effect/golemrune(spawn_loc)
-		rune.golem_type = pick(golem_types)
+		var/obj/effect/golemrune/rune = new /obj/effect/golemrune/random_type(spawn_loc)
 		log_and_message_admins("Bluespace Golem rune ([rune.golem_type]) spawned at (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[spawn_loc.x];Y=[spawn_loc.y];Z=[spawn_loc.z]'>JMP</a>)")
 
 	spark(spawn_loc, 10, alldirs)

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -88,6 +88,11 @@
 	default_type = MATERIAL_IRON
 	apply_colour = 1
 
+/obj/item/stack/material/iron/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/sandstone
 	name = "sandstone brick"
 	icon_state = "sheet-sandstone"
@@ -95,11 +100,21 @@
 	icon_has_variants = TRUE
 	drop_sound = 'sound/items/drop/boots.ogg'
 
+/obj/item/stack/material/sandstone/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/marble
 	name = "marble brick"
 	icon_state = "sheet-marble"
 	default_type = MATERIAL_MARBLE
 	drop_sound = 'sound/items/drop/boots.ogg'
+
+/obj/item/stack/material/marble/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 /obj/item/stack/material/diamond
 	name = "diamond"
@@ -107,10 +122,20 @@
 	default_type = MATERIAL_DIAMOND
 	drop_sound = 'sound/items/drop/glass.ogg'
 
+/obj/item/stack/material/diamond/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/uranium
 	name = "uranium"
 	icon_state = "sheet-uranium"
 	default_type = MATERIAL_URANIUM
+
+/obj/item/stack/material/uranium/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 /obj/item/stack/material/phoron
 	name = "solid phoron"
@@ -118,6 +143,11 @@
 	default_type = MATERIAL_PHORON
 	icon_has_variants = TRUE
 	drop_sound = 'sound/items/drop/glass.ogg'
+
+/obj/item/stack/material/phoron/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 /obj/item/stack/material/plastic
 	name = "plastic"
@@ -127,22 +157,42 @@
 	icon_has_variants = TRUE
 	drop_sound = 'sound/items/drop/card.ogg'
 
+/obj/item/stack/material/plastic/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/gold
 	name = "gold"
 	icon_state = "sheet-gold"
 	default_type = MATERIAL_GOLD
 	icon_has_variants = TRUE
 
+/obj/item/stack/material/gold/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/osmium
 	name = "osmium"
 	icon_state = "sheet-silver"
 	default_type = MATERIAL_OSMIUM
+
+/obj/item/stack/material/osmium/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 /obj/item/stack/material/silver
 	name = "silver"
 	icon_state = "sheet-silver"
 	default_type = MATERIAL_SILVER
 	icon_has_variants = TRUE
+
+/obj/item/stack/material/silver/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 //Valuable resource, cargo can sell it.
 /obj/item/stack/material/platinum
@@ -151,11 +201,21 @@
 	default_type = MATERIAL_PLATINUM
 	icon_has_variants = TRUE
 
+/obj/item/stack/material/platinum/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 //Extremely valuable to Research.
 /obj/item/stack/material/mhydrogen
 	name = "metallic hydrogen"
 	icon_state = "sheet-mythril"
 	default_type = MATERIAL_HYDROGEN_METALLIC
+
+/obj/item/stack/material/mhydrogen/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 //Fuel for MRSPACMAN generator.
 /obj/item/stack/material/tritium
@@ -164,17 +224,32 @@
 	default_type = MATERIAL_TRITIUM
 	apply_colour = 1
 
+/obj/item/stack/material/tritium/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/osmium
 	name = "osmium"
 	icon_state = "sheet-silver"
 	default_type = MATERIAL_OSMIUM
 	apply_colour = 1
 
+/obj/item/stack/material/osmium/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/steel
 	name = DEFAULT_WALL_MATERIAL
 	icon_state = "sheet-metal"
 	default_type = DEFAULT_WALL_MATERIAL
 	icon_has_variants = TRUE
+
+/obj/item/stack/material/steel/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 /obj/item/stack/material/plasteel
 	name = "plasteel"
@@ -183,21 +258,41 @@
 	default_type = MATERIAL_PLASTEEL
 	icon_has_variants = TRUE
 
+/obj/item/stack/material/plasteel/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/wood
 	name = "wooden plank"
 	icon_state = "sheet-wood"
 	default_type = MATERIAL_WOOD
 	drop_sound = 'sound/items/drop/wooden.ogg'
 
+/obj/item/stack/material/wood/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/woodlog
 	name = "log"
 	icon_state = "sheet-wood"
 	default_type = MATERIAL_WOOD_LOG
 
+/obj/item/stack/material/woodlog/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/woodbranch
 	name = "branch"
 	icon_state = "sheet-wood"
 	default_type = MATERIAL_WOOD_BRANCH
+
+/obj/item/stack/material/woodbranch/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 
 /obj/item/stack/material/cloth
@@ -206,6 +301,11 @@
 	default_type = MATERIAL_CLOTH
 	icon_has_variants = TRUE
 	drop_sound = 'sound/items/drop/clothing.ogg'
+
+/obj/item/stack/material/cloth/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 /obj/item/stack/material/cloth/attackby(obj/item/I, mob/user)
 	if(is_sharp(I))
@@ -224,6 +324,11 @@
 	default_type = MATERIAL_CARDBOARD
 	drop_sound = 'sound/items/drop/box.ogg'
 
+/obj/item/stack/material/cardboard/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/leather
 	name = "leather"
 	desc = "The by-product of mob grinding."
@@ -232,6 +337,11 @@
 	icon_has_variants = TRUE
 	drop_sound = 'sound/items/drop/leather.ogg'
 
+/obj/item/stack/material/leather/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/glass
 	name = "glass"
 	icon_state = "sheet-glass"
@@ -239,17 +349,32 @@
 	icon_has_variants = TRUE
 	drop_sound = 'sound/items/drop/glass.ogg'
 
+/obj/item/stack/material/glass/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/glass/wired
 	name = "wired glass"
 	icon = 'icons/obj/stacks/tiles.dmi'
 	icon_state = MATERIAL_GLASS_WIRED
 	default_type = "wired glass"
 
+/obj/item/stack/material/glass/wired/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/glass/reinforced
 	name = "reinforced glass"
 	icon_state = "sheet-rglass"
 	item_state = "sheet-rglass"
 	default_type = MATERIAL_GLASS_REINFORCED
+
+/obj/item/stack/material/glass/reinforced/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
 
 /obj/item/stack/material/glass/phoronglass
 	name = "borosilicate glass"
@@ -259,6 +384,11 @@
 	item_state = "sheet-pglass"
 	default_type = MATERIAL_GLASS_PHORON
 
+/obj/item/stack/material/glass/phoronglass/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/glass/phoronrglass
 	name = "reinforced borosilicate glass"
 	desc = "This sheet is special platinum-glass alloy designed to withstand large temperatures. It is reinforced with few rods."
@@ -266,14 +396,30 @@
 	icon_state = "sheet-phoronrglass"
 	item_state = "sheet-prglass"
 	default_type = MATERIAL_GLASS_REINFORCED_PHORON
+
+/obj/item/stack/material/glass/phoronrglass/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/bronze
 	name = "bronze"
 	icon_state = "sheet-brass"
 	default_type = "bronze"
 	icon_has_variants = TRUE
 
+/obj/item/stack/material/bronze/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/titanium
 	name = "titanium"
 	icon_state = "sheet-titanium"
 	default_type = MATERIAL_TITANIUM
 	icon_has_variants = TRUE
+
+/obj/item/stack/material/titanium/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()

--- a/code/modules/mob/living/carbon/slime/items.dm
+++ b/code/modules/mob/living/carbon/slime/items.dm
@@ -240,6 +240,10 @@ var/list/global/golem_runes = list()
 				var/datum/ghostspawner/human/golem/golem_spawner = SSghostroles.spawners[role_spawner]
 				golem_spawner.enable()
 
+/obj/effect/golemrune/random_type/Initialize()
+	. = ..()
+	golem_type = pick(golem_types)
+
 /obj/effect/golemrune/Destroy()
 	. = ..()
 	golem_runes -= src

--- a/html/changelogs/geeves-adminbus_fun.yml
+++ b/html/changelogs/geeves-adminbus_fun.yml
@@ -1,0 +1,10 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "== ADMIN FACING CHANGES =="
+  - rscadd: "Adds full variants of stacks of items in the spawn menu."
+  - rscadd: "Adds local narrate, which allows you to narrate to all mobs in a your view or your view range tile radius."
+  - rscadd: "Allows admins to reset stationbounds via right click or Special Verbs menu."
+  - rscadd: "Adds a random type golem rune to the spawn menu, if an admin wants to adminbus a random golem into a round."


### PR DESCRIPTION
* Adds full variants of stacks of items in the spawn menu.
* Adds local narrate, which allows you to narrate to all mobs in a 7 tile radius.
* Allows admins to reset stationbounds via right click or Special Verbs menu.
* Adds a random type golem rune to the spawn menu, if an admin wants to adminbus a random golem into a round.