### PR TITLE
Refactoring 'borg overlay stuff back to add_overlay

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -822,20 +822,13 @@
 	return FALSE
 
 /mob/living/silicon/robot/updateicon()
-	overlays.Cut() // The new way the overlays are applied requires this overlays.Cut difference to remove
-// correctly
-
-//The below lines up to the panels are how the 'borgs get their overlays now. It's made cleaner
-// via the vars below.
-
-	var/overlay_help = image(icon,"eyes-[module_sprites[icontype]]-help", EFFECTS_ABOVE_LIGHTING_LAYER)
-	var/overlay_harm = image(icon,"eyes-[module_sprites[icontype]]-harm", EFFECTS_ABOVE_LIGHTING_LAYER)
+	cut_overlays()
 
 	if(stat == CONSCIOUS)
 		if(a_intent == I_HELP)
-			overlays += overlay_help
+			add_overlay(image(icon, "eyes-[module_sprites[icontype]]-help", layer = EFFECTS_ABOVE_LIGHTING_LAYER))
 		else
-			overlays += overlay_harm
+			add_overlay(image(icon, "eyes-[module_sprites[icontype]]-harm", layer = EFFECTS_ABOVE_LIGHTING_LAYER))
 
 	if(opened)
 		var/panelprefix = custom_sprite ? src.ckey : "ov"

--- a/html/changelogs/borgeyerefactor.yml
+++ b/html/changelogs/borgeyerefactor.yml
@@ -37,6 +37,6 @@ delete-after: True
 # SCREW THIS UP AND IT WON'T WORK.
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
-changes:   
+changes: 
   - tweak: "Moved the help/harm overlays for 'borgs back to add_overlay."
   - bugfix: "Fixed a bug that caused ss_overlays to blank the 'borg eyes if they had another overlay added to them."

--- a/html/changelogs/borgeyerefactor.yml
+++ b/html/changelogs/borgeyerefactor.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.  
-author: Chada1
+author: chada1
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -37,6 +37,6 @@ delete-after: True
 # SCREW THIS UP AND IT WON'T WORK.
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
-changes: 
+changes:   
   - tweak: "Moved the help/harm overlays for 'borgs back to add_overlay."
   - bugfix: "Fixed a bug that caused ss_overlays to blank the 'borg eyes if they had another overlay added to them."

--- a/html/changelogs/borgeyerefactor.yml
+++ b/html/changelogs/borgeyerefactor.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.  
-author: ChangeMe
+author: Chada1
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - tweak: "Moved the help/harm overlays for 'borgs back to add_overlay."
+  - bugfix: "Fixed a bug that caused ss_overlays to blank the 'borg eyes if they had another overlay added to them."

--- a/html/changelogs/example.yml
+++ b/html/changelogs/example.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."


### PR DESCRIPTION
What it says on the tin, this is technically a bugfix since it corrects the issue of SS_overlays instantly blanking a 'borgs eyes if they have an add_overlay placed on them in the current way of doing it.

Matt was right that I should've moved this back to add_overlay to begin with 👀 