### PR TITLE
Simple animals forbidden foods

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -192,6 +192,7 @@
 	mob_size = 2
 	hunger_enabled = FALSE
 	canbrush = TRUE
+	forbidden_foods = list(/obj/item/reagent_containers/food/snacks/egg)	//Don't cannibalize eggs.
 
 	var/static/chicken_count = 0
 	emote_sounds = list('sound/effects/creatures/chicken.ogg', 'sound/effects/creatures/chicken_bwak.ogg')

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -98,6 +98,7 @@
 	canbrush = TRUE
 	has_udder = TRUE
 	butchering_products = list(/obj/item/stack/material/animalhide = 8)
+	forbidden_foods = list(/obj/item/reagent_containers/food/snacks/egg)
 
 /mob/living/simple_animal/cow/attack_hand(mob/living/carbon/M as mob)
 	if(!stat && M.a_intent == I_DISARM && icon_state != icon_dead)
@@ -192,7 +193,7 @@
 	mob_size = 2
 	hunger_enabled = FALSE
 	canbrush = TRUE
-	forbidden_foods = list(/obj/item/reagent_containers/food/snacks/egg)	//Don't cannibalize eggs.
+	forbidden_foods = list(/obj/item/reagent_containers/food/snacks/egg)
 
 	var/static/chicken_count = 0
 	emote_sounds = list('sound/effects/creatures/chicken.ogg', 'sound/effects/creatures/chicken_bwak.ogg')

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -80,6 +80,7 @@
 	var/bite_factor = 0.4
 	var/digest_factor = 0.2 //A multiplier on how quickly reagents are digested
 	var/stomach_size_mult = 5
+	var/list/forbidden_foods = list()	//Foods this animal should never eat
 
 	//Seeking/Moving behaviour vars
 	var/min_scan_interval = 1//Minimum and maximum number of procs between a scan
@@ -296,6 +297,8 @@
 /mob/living/simple_animal/proc/handle_eating()
 	var/list/food_choices = list()
 	for(var/obj/item/reagent_containers/food/snacks/S in get_turf(src))
+		if(locate(S) in forbidden_foods)
+			continue
 		food_choices += S
 	if(food_choices.len) //Only when sufficiently hungry
 		UnarmedAttack(pick(food_choices))

--- a/html/changelogs/doxxmedearly - no_eggs_for_cows.yml
+++ b/html/changelogs/doxxmedearly - no_eggs_for_cows.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Cows no longer eat eggs and create dough inside themselves. Also added a way to forbid certain foods from being eaten by animals, for the future."


### PR DESCRIPTION
Adds a way to forbid certain animals from eating certain foods.
Right now applied to cows who, upon eating chicken eggs left on the ground, produce dough inside themselves, and also eat that.
Applied it to chickens, too, but since they don't have hunger enabled, there won't be any noticeable difference. Just sort of a precaution for the future