### PR TITLE
Modular Computer Examine Fix(?)

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -236,15 +236,14 @@ var/obj/item/card/id/all_access/ghost_all_access
 /mob/living/bot/GetIdCard()
 	return botcard
 
-/mob/living/carbon/human/GetIdCard(var/in_hand = TRUE)
-	if(in_hand)
-		var/obj/item/I = get_active_hand()
-		if(I)
-			var/id = I.GetID()
-			if(id)
-				return id
+/mob/living/carbon/human/GetIdCard()
 	if(wear_id)
 		var/id = wear_id.GetID()
+		if(id)
+			return id
+	var/obj/item/I = get_active_hand()
+	if(I)
+		var/id = I.GetID()
 		if(id)
 			return id
 	if(gloves)

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -236,12 +236,13 @@ var/obj/item/card/id/all_access/ghost_all_access
 /mob/living/bot/GetIdCard()
 	return botcard
 
-/mob/living/carbon/human/GetIdCard()
-	var/obj/item/I = get_active_hand()
-	if(I)
-		var/id = I.GetID()
-		if(id)
-			return id
+/mob/living/carbon/human/GetIdCard(var/in_hand = TRUE)
+	if(in_hand)
+		var/obj/item/I = get_active_hand()
+		if(I)
+			var/id = I.GetID()
+			if(id)
+				return id
 	if(wear_id)
 		var/id = wear_id.GetID()
 		if(id)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -135,10 +135,16 @@
 
 	//gloves
 	if(gloves && !skipgloves)
+		var/gloves_name = gloves
+		if(istype(wear_id, /obj/item/modular_computer))
+			var/obj/item/modular_computer/C = wear_id
+			var/obj/item/card/id/ID = C.GetID()
+			if(ID)
+				gloves_name = "[C.name] ([ID.registered_name] ([ID.assignment]))"
 		if(gloves.blood_color)
-			msg += "<span class='warning'>[T.He] [T.has] \icon[gloves] [gloves.gender==PLURAL?"some":"a"] [fluid_color_type_map(gloves.blood_color)]-stained <a href='?src=\ref[src];lookitem_desc_only=\ref[gloves]'>[gloves.name]</a> on [T.his] hands!</span>\n"
+			msg += "<span class='warning'>[T.He] [T.has] \icon[gloves] [gloves.gender==PLURAL?"some":"a"] [fluid_color_type_map(gloves.blood_color)]-stained <a href='?src=\ref[src];lookitem_desc_only=\ref[gloves]'>[gloves_name]</a> on [T.his] hands!</span>\n"
 		else
-			msg += "[T.He] [T.has] \icon[gloves] <a href='?src=\ref[src];lookitem_desc_only=\ref[gloves]'>\a [gloves]</a> on [T.his] hands.\n"
+			msg += "[T.He] [T.has] \icon[gloves] <a href='?src=\ref[src];lookitem_desc_only=\ref[gloves]'>\a [gloves_name]</a> on [T.his] hands.\n"
 	else if(blood_color)
 		msg += "<span class='warning'>[T.He] [T.has] [fluid_color_type_map(hand_blood_color)]-stained hands!</span>\n"
 
@@ -193,17 +199,13 @@
 
 	//ID
 	if(wear_id)
-		/*var/id
-		if(istype(wear_id, /obj/item/device/pda))
-			var/obj/item/device/pda/pda = wear_id
-			id = pda.owner
-		else if(istype(wear_id, /obj/item/card/id)) //just in case something other than a PDA/ID card somehow gets in the ID slot :c
-			var/obj/item/card/id/idcard = wear_id
-			id = idcard.registered_name
-		if(id && (id != real_name) && (get_dist(src, usr) <= 1) && prob(10))
-			msg += "<span class='warning'>[T.He] [T.is] wearing \icon[wear_id] \a [wear_id] yet something doesn't seem right...</span>\n"
-		else*/
-		msg += "[T.He] [T.is] wearing \icon[wear_id] <a href='?src=\ref[src];lookitem_desc_only=\ref[wear_id]'>\a [wear_id]</a>.\n"
+		var/id_name = wear_id
+		if(istype(wear_id, /obj/item/modular_computer))
+			var/obj/item/modular_computer/C = wear_id
+			var/obj/item/card/id/ID = C.GetID()
+			if(ID)
+				id_name = "[C.name] ([ID.registered_name] ([ID.assignment]))"
+		msg += "[T.He] [T.is] wearing \icon[wear_id] <a href='?src=\ref[src];lookitem_desc_only=\ref[wear_id]'>\a [id_name]</a>.\n"
 
 	//Jitters
 	if(is_jittery)
@@ -354,12 +356,9 @@
 		var/perpname = "wot"
 		var/medical = "None"
 
-		if(wear_id)
-			if(istype(wear_id,/obj/item/card/id))
-				perpname = wear_id:registered_name
-			else if(istype(wear_id,/obj/item/device/pda))
-				var/obj/item/device/pda/tempPda = wear_id
-				perpname = tempPda.owner
+		var/obj/item/card/id/ID = GetIdCard(FALSE)
+		if(ID)
+			perpname = ID.registered_name
 		else
 			perpname = src.name
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -356,7 +356,7 @@
 		var/perpname = "wot"
 		var/medical = "None"
 
-		var/obj/item/card/id/ID = GetIdCard(FALSE)
+		var/obj/item/card/id/ID = GetIdCard()
 		if(ID)
 			perpname = ID.registered_name
 		else

--- a/html/changelogs/geeves-modular_comp_examine.yml
+++ b/html/changelogs/geeves-modular_comp_examine.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Examining someone with a modular computer on their ID or gloves slot will now show the ID info if there's one inside."
+  - bugfix: "Security and medical HUDs now get the proper person info if the person has the ID in their modular computer."

--- a/html/changelogs/geeves-modular_comp_examine.yml
+++ b/html/changelogs/geeves-modular_comp_examine.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes: 
   - bugfix: "Examining someone with a modular computer on their ID or gloves slot will now show the ID info if there's one inside."
   - bugfix: "Security and medical HUDs now get the proper person info if the person has the ID in their modular computer."
+  - tweak: "Things that check your ID will now primarily use the ID in your slot, rather than the one in your hands."


### PR DESCRIPTION
* Examining someone with a modular computer on their ID or gloves slot will now show the ID info if there's one inside.
* Security and medical HUDs now get the proper person info if the person has the ID in their modular computer.

I'm not sure whether we want to maintain the "you can see their ID inside their computing device" thing for modular computers, maintainers can discuss how to go forward with that.