### PR TITLE
Hallucination debugs

### DIFF
--- a/code/controllers/subsystems/hallucinations.dm
+++ b/code/controllers/subsystems/hallucinations.dm
@@ -19,7 +19,7 @@
 
 /datum/controller/subsystem/hallucinations/Initialize()
 	. = ..()
-	for(var/T in subtypesof(/datum/hallucination/))
+	for(var/T in subtypesof(/datum/hallucination))
 		all_hallucinations += T
 	hallucinated_phrases = file2list("code/modules/hallucinations/text_lists/hallucinated_phrases.txt")
 	hallucinated_actions = file2list("code/modules/hallucinations/text_lists/hallucinated_actions.txt")	//important note when adding to this file: "you" will always be replaced by the hallucinator's name

--- a/code/modules/hallucinations/mob.dm
+++ b/code/modules/hallucinations/mob.dm
@@ -23,11 +23,12 @@
 
 	//Good/bad chems affecting duration
 	if(chem_effects[CE_HALLUCINATE] < 0)
-		hallucination -= abs(chem_effects[CE_HALLUCINATE])
+		hallucination = max(0, hallucination - abs(chem_effects[CE_HALLUCINATE]))
 	if(chem_effects[CE_HALLUCINATE] > 0 && prob(chem_effects[CE_HALLUCINATE]*20))
 		hallucination += chem_effects[CE_HALLUCINATE]
 
-	if(!hallucination)  //We're done
+	if(hallucination <= 0)  //We're done
+		hallucination = 0
 		return
 	if(!client || stat || world.time < next_hallucination)
 		return

--- a/html/changelogs/doxxmedearly - hallucination_nulls.yml
+++ b/html/changelogs/doxxmedearly - hallucination_nulls.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed hallucination values going negative and causing massive debug logs."


### PR DESCRIPTION
Hallucination debugs were caused by mob's hallucination var going into negative values (thanks Alb). This should fix that.