### PR TITLE
Modular Computer Cleanup

### DIFF
--- a/code/controllers/subsystems/news.dm
+++ b/code/controllers/subsystems/news.dm
@@ -40,12 +40,35 @@
 		catch(var/exception/ec)
 			log_debug("SSnews: Error when loading channel: [ec]")
 			continue
+
+		//Load the expired news into the modular computers first
+		var/news_count = 1
+		var/DBQuery/news_query_expired = dbcon.NewQuery("SELECT body FROM ss13_news_stories WHERE deleted_at IS NULL AND channel_id = :channel_id: AND publish_at < NOW() AND (publish_until <= NOW()) AND approved_at IS NOT NULL ORDER BY publish_at DESC")
+		news_query_expired.Execute(list("channel_id" = channel_query.item[1]))
+		while(news_query_expired.NextRow())
+			CHECK_TICK
+			try
+				var/datum/computer_file/data/news_article/news = new()
+				news.filename = "[channel.channel_name] vol. [news_count]"
+				news.archived = 1
+				news.stored_data = news_query_expired.item[1]
+				ntnet_global.available_news.Add(news)
+				news_count += 1
+			catch(var/exception/em)
+				log_debug("SSnews: Error when loading news: [em]")
+
 		var/DBQuery/news_query = dbcon.NewQuery("SELECT body, author, is_admin_message, message_type, ic_timestamp, url FROM ss13_news_stories WHERE deleted_at IS NULL AND channel_id = :channel_id: AND publish_at < NOW() AND (publish_until > NOW() OR publish_until IS NULL) AND approved_at IS NOT NULL ORDER BY publish_at DESC")
 		news_query.Execute(list("channel_id" = channel_query.item[1]))
 		while(news_query.NextRow())
 			CHECK_TICK
 			try
 				SubmitArticle(news_query.item[1], news_query.item[2], channel, null, text2num(news_query.item[3]), news_query.item[4], news_query.item[5])
+				var/datum/computer_file/data/news_article/news = new()
+				news.filename = "[channel.channel_name] vol. [news_count]"
+				news.archived = 0
+				news.stored_data = news_query.item[1]
+				ntnet_global.available_news.Add(news)
+				news_count += 1
 			catch(var/exception/en)
 				log_debug("SSnews: Error when loading news: [en]")
 
@@ -71,7 +94,7 @@
 	if(!channel)
 		log_debug("SSnews: Attempted to submit a article from [author] without a proper channel",SEVERITY_ERROR)
 		return
-	
+
 	var/datum/feed_message/newMsg = new /datum/feed_message
 	newMsg.author = author
 	newMsg.body = msg
@@ -106,7 +129,7 @@
 		if (P.toff)
 			continue
 		receiving_pdas += P
-		
+
 	for(var/obj/item/device/pda/PDA in receiving_pdas)
 		PDA.new_news(annoncement)
 

--- a/code/modules/client/preference_setup/loadout/loadout_computer.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_computer.dm
@@ -1,6 +1,6 @@
 /datum/gear/computer
 	display_name = "tablet"
-	path = /obj/item/modular_computer/tablet/preset/custom_loadout/advanced // for card slots
+	path = /obj/item/modular_computer/tablet/preset/custom_loadout/cheap
 	sort_category = "Modular Computers"
 	cost = 2
 
@@ -11,7 +11,7 @@
 
 /datum/gear/computer/wristbound
 	display_name = "wristbound computer"
-	path = /obj/item/modular_computer/wristbound/preset/advanced/generic
+	path = /obj/item/modular_computer/wristbound/preset/cheap/generic
 
 /datum/gear/computer/wristbound/cargo
 	display_name = "wristbound computer (Cargo)"

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -54,6 +54,8 @@
 	if(enrolled)
 		var/programs = get_preset_programs(_app_preset_type)
 		for(var/datum/computer_file/program/prog in programs)
+			if(!prog.is_supported_by_hardware(hardware_flag, FALSE))
+				return
 			hard_drive.store_file(prog)
 
 /obj/item/modular_computer/Initialize()

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -123,7 +123,7 @@
 		if(!hard_drive)
 			to_chat(user, SPAN_WARNING("You cannot reset a device that has no hard drive."))
 			return
-		enrolled = FALSE
+		enrolled = 0
 		hard_drive.reset_drive()
 		visible_message("\icon[src.icon] <b>[src]</b> pings, <span class='notice'>\"Enrollment status reset! Have a NanoTrasen day.\"</span>")
 	if(istype(W, /obj/item/card/id)) // ID Card, try to insert it.

--- a/code/modules/modular_computers/computers/modular_computer/variables.dm
+++ b/code/modules/modular_computers/computers/modular_computer/variables.dm
@@ -17,7 +17,7 @@
 	var/apc_powered = FALSE									// Set automatically. Whether the computer used APC power last tick.
 	var/base_active_power_usage = 50						// Power usage when the computer is open (screen is active) and can be interacted with. Remember hardware can use power too.
 	var/base_idle_power_usage = 5							// Power usage when the computer is idle and screen is off (currently only applies to laptops)
-	var/enrolled = FALSE									// Weather the computer is enrolled in the company device management or not. 0 - unconfigured 1 - enrolled (work device) 2 - unenrolled (private device)
+	var/enrolled = 0									// Weather the computer is enrolled in the company device management or not. 0 - unconfigured 1 - enrolled (work device) 2 - unenrolled (private device)
 	var/_app_preset_type									// Used for specifying the software preset of the console
 	var/ambience_last_played								// Last time sound was played
 

--- a/code/modules/modular_computers/computers/subtypes/preset_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_console.dm
@@ -24,29 +24,29 @@
 /obj/item/modular_computer/console/preset/engineering
 	name = "engineering console"
 	_app_preset_type = /datum/modular_computer_app_presets/engineering
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/console/preset/engineering/ce
 	name = "engineering console"
 	_app_preset_type = /datum/modular_computer_app_presets/engineering/ce
-	enrolled = TRUE
+	enrolled = 1
 
 // Medical
 /obj/item/modular_computer/console/preset/medical
 	name = "medical console"
 	_app_preset_type = /datum/modular_computer_app_presets/medical
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/console/preset/medical/cmo
 	name = "medical console"
 	_app_preset_type = /datum/modular_computer_app_presets/medical/cmo
-	enrolled = TRUE
+	enrolled = 1
 
 // Research
 /obj/item/modular_computer/console/preset/research
 	name = "research console"
 	_app_preset_type = /datum/modular_computer_app_presets/research
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/console/preset/research/install_default_hardware()
 	..()
@@ -56,7 +56,7 @@
 /obj/item/modular_computer/console/preset/command
 	name = "command console"
 	_app_preset_type = /datum/modular_computer_app_presets/command
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/console/preset/command/install_default_hardware()
 	..()
@@ -68,40 +68,40 @@
 /obj/item/modular_computer/console/preset/command/captain
 	name = "captain's console"
 	_app_preset_type = /datum/modular_computer_app_presets/captain
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/console/preset/command/hop
 	name = "command console"
 	_app_preset_type = /datum/modular_computer_app_presets/command/hop
-	enrolled = TRUE
+	enrolled = 1
 
 // Security
 /obj/item/modular_computer/console/preset/security
 	name = "security console"
 	_app_preset_type = /datum/modular_computer_app_presets/security
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/console/preset/security/investigations
 	name = "investigations console"
 	_app_preset_type = /datum/modular_computer_app_presets/security/investigations
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/console/preset/security/hos
 	name = "head of security's console"
 	_app_preset_type = /datum/modular_computer_app_presets/security/hos
-	enrolled = TRUE
+	enrolled = 1
 
 // Civilian
 /obj/item/modular_computer/console/preset/civilian
 	name = "civilian console"
 	_app_preset_type = /datum/modular_computer_app_presets/civilian
-	enrolled = TRUE
+	enrolled = 1
 
 // Supply
 /obj/item/modular_computer/console/preset/supply
 	name = "supply console"
 	_app_preset_type = /datum/modular_computer_app_presets/supply
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/console/preset/supply/install_default_hardware()
 	..()

--- a/code/modules/modular_computers/computers/subtypes/preset_laptop.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_laptop.dm
@@ -22,7 +22,7 @@
 	name = "engineering laptop"
 	desc = "A portable computer belonging to the engineering department. It appears to have been used as a door stop at one point or another."
 	_app_preset_type = /datum/modular_computer_app_presets/engineering
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/laptop/preset/engineering/ce
 	name = "chief engineer's laptop"
@@ -34,7 +34,7 @@
 	name = "medical laptop"
 	desc = "A portable computer belonging to the medical department."
 	_app_preset_type = /datum/modular_computer_app_presets/medical
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/laptop/preset/medical/cmo
 	name = "chief medical officer's laptop"
@@ -46,7 +46,7 @@
 	name = "research laptop"
 	desc = "A portable computer belonging to the research department."
 	_app_preset_type = /datum/modular_computer_app_presets/research
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/laptop/preset/research/install_default_hardware()
 	..()
@@ -61,7 +61,7 @@
 /obj/item/modular_computer/laptop/preset/command
 	name = "command laptop"
 	_app_preset_type = /datum/modular_computer_app_presets/command
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/laptop/preset/command/hop
 	name = "head of personnel's laptop"
@@ -86,7 +86,7 @@
 	name = "security laptop"
 	desc = "A portable computer belonging to the security department."
 	_app_preset_type = /datum/modular_computer_app_presets/security
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/laptop/preset/security/hos
 	name = "head of security's laptop"
@@ -96,18 +96,18 @@
 // Civilian
 /obj/item/modular_computer/laptop/preset/civilian
 	_app_preset_type = /datum/modular_computer_app_presets/civilian
-	enrolled = TRUE
+	enrolled = 1
 
 // Supply
 /obj/item/modular_computer/laptop/preset/supply
 	name = "supply laptop"
 	desc = "A portable computer belonging to cargo."
 	_app_preset_type = /datum/modular_computer_app_presets/supply
-	enrolled = TRUE
+	enrolled = 1
 
 // Representative
 /obj/item/modular_computer/laptop/preset/representative
 	name = "representative's laptop"
 	desc = "A portable computer belonging to the representative's office."
 	_app_preset_type = /datum/modular_computer_app_presets/representative
-	enrolled = TRUE
+	enrolled = 1

--- a/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
@@ -20,4 +20,4 @@
 // Cargo Delivery
 /obj/item/modular_computer/tablet/preset/custom_loadout/advanced/cargo_delivery
 	_app_preset_type = /datum/modular_computer_app_presets/cargo_delivery
-	enrolled = TRUE
+	enrolled = 1

--- a/code/modules/modular_computers/computers/subtypes/preset_telescreen.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_telescreen.dm
@@ -7,8 +7,8 @@
 
 /obj/item/modular_computer/telescreen/preset/generic
 	_app_preset_type = /datum/modular_computer_app_presets/wall_generic
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/telescreen/preset/trashcompactor
 	_app_preset_type = /datum/modular_computer_app_presets/trashcompactor
-	enrolled = TRUE
+	enrolled = 1

--- a/code/modules/modular_computers/computers/subtypes/preset_wristbound.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_wristbound.dm
@@ -19,35 +19,36 @@
 /obj/item/modular_computer/wristbound/preset/advanced/cargo
 	icon_state = "wristbound_supply"
 	_app_preset_type = /datum/modular_computer_app_presets/cargo_delivery
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/wristbound/preset/advanced/engineering
 	icon_state = "wristbound_engineering"
 	_app_preset_type = /datum/modular_computer_app_presets/engineering
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/wristbound/preset/advanced/medical
 	icon_state = "wristbound_medical"
 	_app_preset_type = /datum/modular_computer_app_presets/medical
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/wristbound/preset/advanced/security
 	icon_state = "wristbound_security"
 	_app_preset_type = /datum/modular_computer_app_presets/security
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/wristbound/preset/advanced/security/investigations
 	_app_preset_type = /datum/modular_computer_app_presets/security/investigations
+	enrolled = 1
 
 /obj/item/modular_computer/wristbound/preset/advanced/research
 	icon_state = "wristbound_science"
 	_app_preset_type = /datum/modular_computer_app_presets/research
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/wristbound/preset/advanced/command
 	icon_state = "wristbound_command"
 	_app_preset_type = /datum/modular_computer_app_presets/command
-	enrolled = TRUE
+	enrolled = 1
 
 /obj/item/modular_computer/wristbound/preset/advanced/command/ce
 	_app_preset_type = /datum/modular_computer_app_presets/engineering/ce
@@ -69,7 +70,8 @@
 
 /obj/item/modular_computer/wristbound/preset/advanced/generic
 	_app_preset_type = /datum/modular_computer_app_presets/civilian
+	enrolled = 1
 
 /obj/item/modular_computer/wristbound/preset/advanced/representative
 	_app_preset_type = /datum/modular_computer_app_presets/representative
-	enrolled = TRUE
+	enrolled = 1

--- a/code/modules/modular_computers/computers/subtypes/preset_wristbound.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_wristbound.dm
@@ -6,6 +6,9 @@
 	battery_module = new /obj/item/computer_hardware/battery_module/nano(src)
 	battery_module.charge_to_full()
 
+/obj/item/modular_computer/wristbound/preset/cheap/generic
+	_app_preset_type = /datum/modular_computer_app_presets/civilian
+
 /obj/item/modular_computer/wristbound/preset/advanced/install_default_hardware()
 	..()
 	processor_unit = new /obj/item/computer_hardware/processor_unit/small(src)
@@ -70,7 +73,6 @@
 
 /obj/item/modular_computer/wristbound/preset/advanced/generic
 	_app_preset_type = /datum/modular_computer_app_presets/civilian
-	enrolled = 1
 
 /obj/item/modular_computer/wristbound/preset/advanced/representative
 	_app_preset_type = /datum/modular_computer_app_presets/representative

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -59,7 +59,7 @@
 		return computer.add_log(text)
 	return FALSE
 
-/datum/computer_file/program/proc/is_supported_by_hardware(var/hardware_flag = 0, var/loud = FALSE, var/mob/user)
+/datum/computer_file/program/proc/is_supported_by_hardware(var/hardware_flag = 0, var/loud = FALSE, var/mob/user = null)
 	if(!(hardware_flag & usage_flags))
 		if(loud && computer && user)
 			to_chat(user, SPAN_WARNING("\The [computer] flashes, \"Hardware Error - Incompatible software\"."))

--- a/code/modules/modular_computers/file_system/programs/civilian/cargo_delivery.dm
+++ b/code/modules/modular_computers/file_system/programs/civilian/cargo_delivery.dm
@@ -2,7 +2,7 @@
 	filename = "cargodelivery"
 	filedesc = "Cargo Delivery"
 	extended_desc = "Application to Control Delivery and Payment of Cargo orders."
-	size = 12
+	size = 6
 	requires_ntnet = TRUE
 	available_on_ntnet = TRUE
 	required_access_download = access_hop
@@ -87,7 +87,7 @@
 				var/transaction_terminal = "Modular Computer #[program.computer.network_card.identification_id]"
 
 				var/status = SSeconomy.transfer_money(id_card.associated_account_number, SScargo.supply_account.account_number,transaction_purpose,transaction_terminal,transaction_amount,null,usr)
-				
+
 				if(status)
 					status_message = status
 					return TRUE
@@ -100,7 +100,7 @@
 				else
 					status_message = co.set_paid(id_card.registered_name)
 				order_details = co.get_list()
-				
+
 			else
 				//TODO: Add a sound effect here
 				//If a payment is not needed and we are at the status shipped, then confirm the delivery

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -3,7 +3,7 @@
 	filedesc = "NTNet Relay Chat Client"
 	program_icon_state = "command"
 	extended_desc = "This program allows communication over the NTNRC network."
-	size = 8
+	size = 2
 	requires_ntnet = TRUE
 	requires_ntnet_feature = NTNET_COMMUNICATION
 	network_destination = "NTNRC server"

--- a/code/modules/modular_computers/file_system/programs/generic/ntsl2_interpreter.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntsl2_interpreter.dm
@@ -3,7 +3,7 @@
 	filedesc = "NTSL2+ Interpreter"
 	extended_desc = "This program is used to run NTSL2+ programs."
 	program_icon_state = "generic"
-	size = 2
+	size = 8
 	requires_ntnet = TRUE
 	available_on_ntnet = TRUE
 

--- a/code/modules/modular_computers/file_system/programs/system/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/system/file_browser.dm
@@ -5,7 +5,7 @@
 	extended_desc = "This program allows management of files."
 	program_icon_state = "generic"
 	color = LIGHT_COLOR_GREEN
-	size = 8
+	size = 4
 	requires_ntnet = FALSE
 	available_on_ntnet = FALSE
 	undeletable = TRUE

--- a/html/changelogs/arrow768-computerchanges.yml
+++ b/html/changelogs/arrow768-computerchanges.yml
@@ -42,4 +42,5 @@ changes:
   - tweak: "Reduced/Adapted the size of various applications."
   - tweak: "The investigations / generic wristbounds are now enrolled aswell."
   - tweak: "Selecting a unenrolled device in the loadout no longer gives you the advanced version of it."
+  - tweak: "Adapts the modular computer news browser to work with our news system"
 

--- a/html/changelogs/arrow768-computerchanges.yml
+++ b/html/changelogs/arrow768-computerchanges.yml
@@ -41,4 +41,5 @@ changes:
   - rscadd: "Incompatible applications are no longer downloaded via the presets."
   - tweak: "Reduced/Adapted the size of various applications."
   - tweak: "The investigations / generic wristbounds are now enrolled aswell."
+  - tweak: "Selecting a unenrolled device in the loadout no longer gives you the advanced version of it."
 

--- a/html/changelogs/arrow768-computerchanges.yml
+++ b/html/changelogs/arrow768-computerchanges.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Incompatible applications are no longer downloaded via the presets."
+  - tweak: "Reduced/Adapted the size of various applications."
+  - tweak: "The investigations / generic wristbounds are now enrolled aswell."
+


### PR DESCRIPTION
```
  - rscadd: "Incompatible applications are no longer downloaded via the presets."
  - tweak: "Reduced/Adapted the size of various applications."
  - tweak: "The investigations / generic wristbounds are now enrolled aswell."
  - tweak: "Selecting a unenrolled device in the loadout no longer gives you the advanced version of it."
  - tweak: "Adapts the modular computer news browser to work with our news system"

```