### PR TITLE
Adds support for VueUI uis to use sendToTopicRaw with nested lists

### DIFF
--- a/vueui/src/utils.js
+++ b/vueui/src/utils.js
@@ -4,7 +4,13 @@ export default {
   sendToTopicRaw(data) {
     var sendparams = []
     for(var val in data) {
-      sendparams.push(encodeURIComponent(val) + "=" + encodeURIComponent(data[val]))
+      if (Array.isArray(data[val])) {
+        for (const value in data[val]) {
+          sendparams.push(encodeURIComponent(val) + "=" + encodeURIComponent(value))
+        }
+      } else {
+        sendparams.push(encodeURIComponent(val) + "=" + encodeURIComponent(data[val]))
+      }
     }
     var r = new XMLHttpRequest()
     var sendUrl = "?" + sendparams.join("&")


### PR DESCRIPTION
Adds support for VueUI uis to use sendToTopicRaw with nested lists.
This support is limited due to BYOND being BYOND.

This is supported:
```js
Utils.sendToTopicRaw({ref: myRef, a: [1, 2, 3]})
```
And it's received as:
```dm
href_list["a"] = list(1, 2, 3)
```


While this is **not** supported
```js
Utils.sendToTopicRaw({ref: myRef, a: {b: 1, c: 1, e: 1}})
```
Instead use (and only valid if inside VueUI context and only ui's object can receive it)
```js
Utils.sendToTopic({a: {b: 1, c: 1, e: 1}})
```
And it's received as:
```dm
href_list["a"] = list(b = 1, c = 1, e = 1)
```