### PR TITLE
Showers don't update on-mob icons.

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -226,8 +226,9 @@
 	..()
 
 //Yes, showers are super powerful as far as washing goes.
-/obj/machinery/shower/proc/wash(atom/movable/O as obj|mob)
-	if(!on) return
+/obj/machinery/shower/proc/wash(atom/movable/O)
+	if(!on)
+		return
 
 	var/obj/effect/effect/water/W = new(O)
 	W.create_reagents(spray_amount)
@@ -235,6 +236,8 @@
 	W.set_up(O, spray_amount)
 
 	if(iscarbon(O))
+		var/update_icons_required = FALSE
+
 		var/mob/living/carbon/M = O
 		if(M.r_hand)
 			M.r_hand.clean_blood()
@@ -275,39 +278,53 @@
 			if(H.head)
 				if(H.head.clean_blood())
 					H.update_inv_head(0)
+					update_icons_required = TRUE
 			if(H.wear_suit)
 				if(H.wear_suit.clean_blood())
 					H.update_inv_wear_suit(0)
+					update_icons_required = TRUE
 			else if(H.w_uniform)
 				if(H.w_uniform.clean_blood())
 					H.update_inv_w_uniform(0)
+					update_icons_required = TRUE
 			if(H.gloves && washgloves)
 				if(H.gloves.clean_blood())
 					H.update_inv_gloves(0)
+					update_icons_required = TRUE
 			if(H.shoes && washshoes)
 				if(H.shoes.clean_blood())
 					H.update_inv_shoes(0)
+					update_icons_required = TRUE
 			if(H.wear_mask && washmask)
 				if(H.wear_mask.clean_blood())
 					H.update_inv_wear_mask(0)
+					update_icons_required = TRUE
 			if(H.glasses && washglasses)
 				if(H.glasses.clean_blood())
 					H.update_inv_glasses(0)
+					update_icons_required = TRUE
 			if(H.l_ear && washears)
 				if(H.l_ear.clean_blood())
 					H.update_inv_ears(0)
+					update_icons_required = TRUE
 			if(H.r_ear && washears)
 				if(H.r_ear.clean_blood())
 					H.update_inv_ears(0)
+					update_icons_required = TRUE
 			if(H.belt)
 				if(H.belt.clean_blood())
 					H.update_inv_belt(0)
+					update_icons_required = TRUE
 			H.clean_blood(washshoes)
 		else
 			if(M.wear_mask)						//if the mob is not human, it cleans the mask without asking for bitflags
 				if(M.wear_mask.clean_blood())
 					M.update_inv_wear_mask(0)
+					update_icons_required = TRUE
 			M.clean_blood()
+
+		if (update_icons_required)
+			M.update_icons()
 	else
 		O.clean_blood()
 
@@ -330,10 +347,10 @@
 				qdel(E)
 
 /obj/machinery/shower/machinery_process()
-	if(!on) 
+	if(!on)
 		return
 	wash_floor()
-	if(!mobpresent)	
+	if(!mobpresent)
 		return
 	for(var/mob/living/L in loc)
 		wash(L) // Why was it not here before?
@@ -350,7 +367,7 @@
 		is_washing = 0
 
 /obj/machinery/shower/proc/process_heat(mob/living/M)
-	if(!on || !istype(M)) 
+	if(!on || !istype(M))
 		return
 
 	var/temperature = temperature_settings[watertemp]
@@ -418,7 +435,7 @@
 		return TRUE
 	busy = 0
 
-	if(!Adjacent(user)) 
+	if(!Adjacent(user))
 		return		//Person has moved away from the sink
 
 	user.clean_blood()

--- a/html/changelogs/skull132_showers.yml
+++ b/html/changelogs/skull132_showers.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: true
+
+changes:
+  - bugfix: "Fixes a roughly 6+ year old bug where showering doesn't immediately update your mob's icon."


### PR DESCRIPTION
Bug: Showering will update the OBJECT sprites of everything you're wearing, to represent them being clean, but the MOB sprite does not get updated and still shows everything as bloody until you force an icon update via other interactions.

Cause: Every specific update icon call in the shower chain was called with a `update_icons = FALSE` flag to "cache" the changes. Since there is potentially a lot of them to be done in one tick in this case. But the code doesn't then invoke `update_icons()`, as is necessary, to _actually apply_ the cached changes. Resulting in the icons never being updated.

Solution: call `update_icons()` as is appropriate.