### PR TITLE
Generates parity between remote auth login chain and the normal login chain

### DIFF
--- a/code/__defines/spaceman_dmm.dm
+++ b/code/__defines/spaceman_dmm.dm
@@ -6,8 +6,24 @@
 	#define RETURN_TYPE(X) set SpacemanDMM_return_type = X
 	#define SHOULD_CALL_PARENT(X) set SpacemanDMM_should_call_parent = X
 	#define UNLINT(X) SpacemanDMM_unlint(X)
+	#define SHOULD_NOT_OVERRIDE(X) set SpacemanDMM_should_not_override = X
+	#define SHOULD_NOT_SLEEP(X) set SpacemanDMM_should_not_sleep = X
+	#define SHOULD_BE_PURE(X) set SpacemanDMM_should_be_pure = X
+	#define PRIVATE_PROC(X) set SpacemanDMM_private_proc = X
+	#define PROTECTED_PROC(X) set SpacemanDMM_protected_proc = X
+	#define VAR_FINAL var/SpacemanDMM_final
+	#define VAR_PRIVATE var/SpacemanDMM_private
+	#define VAR_PROTECTED var/SpacemanDMM_protected
 #else
 	#define RETURN_TYPE(X)
 	#define SHOULD_CALL_PARENT(X)
 	#define UNLINT(X) X
+	#define SHOULD_NOT_OVERRIDE(X)
+	#define SHOULD_NOT_SLEEP(X)
+	#define SHOULD_BE_PURE(X)
+	#define PRIVATE_PROC(X)
+	#define PROTECTED_PROC(X)
+	#define VAR_FINAL var
+	#define VAR_PRIVATE var
+	#define VAR_PROTECTED var
 #endif

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -53,7 +53,7 @@
 	var/mob/living/carbon/owner
 	var/datum/brain_trauma/special/imaginary_friend/trauma
 
-/mob/abstract/mental/friend/Login()
+/mob/abstract/mental/friend/LateLogin()
 	..()
 	to_chat(src, "<span class='notice'><b>You are the imaginary friend of [owner]!</b></span>")
 	to_chat(src, "<span class='notice'>You are absolutely loyal to your friend, no matter what.</span>")

--- a/code/datums/brain_damage/schizo.dm
+++ b/code/datums/brain_damage/schizo.dm
@@ -135,7 +135,7 @@
 
 	..()
 
-/mob/living/mental/split_personality/Login()
+/mob/living/mental/split_personality/LateLogin()
 	..()
 	to_chat(src, "<span class='notice'>As a split personality, you cannot do anything but observe. However, you will eventually gain control of your body, switching places with the current personality.</span>")
 
@@ -209,7 +209,7 @@
 	var/objective
 	var/codeword
 
-/mob/living/mental/split_personality/traitor/Login()
+/mob/living/mental/split_personality/traitor/LateLogin()
 	..()
 	to_chat(src, "<span class='notice'>As a brainwashed personality, you cannot do anything yet but observe. However, you may gain control of your body if you hear the special codeword, switching places with the current personality.</span>")
 	to_chat(src, "<span class='notice'>Your activation codeword is: <b>[codeword]</b></span>")

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -75,3 +75,5 @@
 	var/obj/screen/plane_master/parallax_spacemaster/parallax_spacemaster = null
 
 	var/authed = TRUE
+
+	var/is_initialized = FALSE // Used to track whether the client has been initialized with InitClient.

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -358,9 +358,10 @@
 		return m
 		//Do auth shit
 	else
+		. = ..()
 		src.InitClient()
 		src.InitPrefs()
-		. = ..()
+		mob.LateLogin()
 
 /client/proc/InitPrefs()
 	//preferences datum - also holds some persistant data for the client (because we may as well keep these datums to a minimum)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -447,6 +447,8 @@
 
 	fetch_unacked_warning_count()
 
+	is_initialized = TRUE
+
 //////////////
 //DISCONNECT//
 //////////////

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -350,11 +350,11 @@
 			return 0
 
 	if(IsGuestKey(key) && config.external_auth)
-		//src.real_mob = ..()
 		src.authed = FALSE
 		var/mob/abstract/unauthed/m = new()
 		m.client = src
 		src.InitPrefs() //Init some default prefs
+		m.LateLogin()
 		return m
 		//Do auth shit
 	else

--- a/code/modules/mob/abstract/new_player/login.dm
+++ b/code/modules/mob/abstract/new_player/login.dm
@@ -24,7 +24,7 @@
 /mob/abstract/new_player
 	var/client/my_client // Need to keep track of this ourselves, since by the time Logout() is called the client has already been nulled
 
-/mob/abstract/new_player/Login()
+/mob/abstract/new_player/LateLogin()
 	update_Login_details()	//handles setting lastKnownIP and computer_id for use by the ban systems as well as checking for multikeying
 
 	to_chat(src, "<div class='info'>Game ID: <div class='danger'>[game_id]</div></div>")

--- a/code/modules/mob/abstract/new_player/login.dm
+++ b/code/modules/mob/abstract/new_player/login.dm
@@ -25,6 +25,8 @@
 	var/client/my_client // Need to keep track of this ourselves, since by the time Logout() is called the client has already been nulled
 
 /mob/abstract/new_player/LateLogin()
+	..()
+
 	update_Login_details()	//handles setting lastKnownIP and computer_id for use by the ban systems as well as checking for multikeying
 
 	to_chat(src, "<div class='info'>Game ID: <div class='danger'>[game_id]</div></div>")

--- a/code/modules/mob/abstract/observer/login.dm
+++ b/code/modules/mob/abstract/observer/login.dm
@@ -1,4 +1,4 @@
-/mob/abstract/observer/Login()
+/mob/abstract/observer/LateLogin()
 	..()
 	if (ghostimage)
 		ghostimage.icon_state = src.icon_state

--- a/code/modules/mob/abstract/unauthed/login.dm
+++ b/code/modules/mob/abstract/unauthed/login.dm
@@ -8,7 +8,7 @@
 /mob/abstract/unauthed/New()
 	verbs -= typesof(/mob/verb)
 
-/mob/abstract/unauthed/Login()
+/mob/abstract/unauthed/LateLogin()
 	update_Login_details()
 	to_chat(src, "<span class='danger'><b>You need to authenticate before you can continue.</b></span>")
 	token = md5("[client.ckey][client.computer_id][world.time][rand()]")
@@ -34,11 +34,12 @@
 	if(!client)
 		qdel(src)
 	deltimer(timeout_timer)
-	var/client/c = client
+	var/client/c = client // so we don't lose the client in the current mob.
+
 	show_browser(src, null, "window=auth;")
-	client.verbs += typesof(/client/verb) // Let's return regular client verbs
-	client.authed = TRUE // We declare client as authed now
-	client.prefs = null //Null them so we can load them from the db again for the correct ckey
+	c.verbs += typesof(/client/verb) // Let's return regular client verbs
+	c.authed = TRUE // We declare client as authed now
+	c.prefs = null //Null them so we can load them from the db again for the correct ckey
 	// Check for bans
 	var/list/ban_data = world.IsBanned(ckey(newkey), c.address, c.computer_id, 1, TRUE)
 	if(ban_data)
@@ -47,14 +48,19 @@
 		to_chat(c, "Description: [ban_data["desc"]]")
 		del(c)
 		return
-	directory -= client.ckey
+
+	directory -= c.ckey
 	if(newkey)
-		client.key = newkey // Try seeting ckey
+		c.key = newkey // Try seeting ckey
+		// ^^^^ THIS INVOKES mob/Login()!
+		// and also modifies the c.mob to the actual mob they disconnected out of.
+
 	directory[c.ckey] = c
 	// Init the client and give it a new_player mob.
 	// Note that modifying the key variable does not invoke client/New() or client/Login() again.
 	c.InitClient()
 	c.InitPrefs()
+	c.mob.LateLogin()
 
 	if(istype(c.mob, /mob/abstract/unauthed))
 		c.mob = new /mob/abstract/new_player()

--- a/code/modules/mob/abstract/unauthed/login.dm
+++ b/code/modules/mob/abstract/unauthed/login.dm
@@ -9,6 +9,8 @@
 	verbs -= typesof(/mob/verb)
 
 /mob/abstract/unauthed/LateLogin()
+	SHOULD_CALL_PARENT(FALSE)
+
 	update_Login_details()
 	to_chat(src, "<span class='danger'><b>You need to authenticate before you can continue.</b></span>")
 	token = md5("[client.ckey][client.computer_id][world.time][rand()]")

--- a/code/modules/mob/living/carbon/brain/login.dm
+++ b/code/modules/mob/living/carbon/brain/login.dm
@@ -1,3 +1,3 @@
-/mob/living/carbon/brain/Login()
+/mob/living/carbon/brain/LateLogin()
 	..()
 	sleeping = 0

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/Login()
+/mob/living/carbon/human/LateLogin()
 	..()
 	update_hud()
 	if(species) species.handle_login_special(src)

--- a/code/modules/mob/living/carbon/human/logout.dm
+++ b/code/modules/mob/living/carbon/human/logout.dm
@@ -1,4 +1,4 @@
 /mob/living/carbon/human/Logout()
 	..()
-	if(species) species.handle_logout_special(src)
-	return
+	if(species)
+		species.handle_logout_special(src)

--- a/code/modules/mob/living/carbon/slime/login.dm
+++ b/code/modules/mob/living/carbon/slime/login.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/slime/Login()
+/mob/living/carbon/slime/LateLogin()
 	..()
 	update_hud()
 	return

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -1,5 +1,5 @@
 
-/mob/living/Login()
+/mob/living/LateLogin()
 	..()
 	//Mind updates
 	mind_initialize()	//updates the mind (or creates and initializes one if one doesn't exist)

--- a/code/modules/mob/living/parasite/meme.dm
+++ b/code/modules/mob/living/parasite/meme.dm
@@ -23,7 +23,7 @@ var/controlling
 /mob/living/parasite
 	var/mob/living/carbon/host // the host that this parasite occupies
 
-/mob/living/parasite/Login()
+/mob/living/parasite/LateLogin()
 	..()
 	// make the client see through the host instead
 	client.eye = host

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -1,4 +1,4 @@
-/mob/living/silicon/ai/Login()	//ThisIsDumb(TM) TODO: tidy this up ¬_¬ ~Carn
+/mob/living/silicon/ai/LateLogin()	//ThisIsDumb(TM) TODO: tidy this up ¬_¬ ~Carn // It's still dumb and not really tidied up. Enjoy!
 	..()
 	regenerate_icons()
 	flash = new /obj/screen()

--- a/code/modules/mob/living/silicon/ai/logout.dm
+++ b/code/modules/mob/living/silicon/ai/logout.dm
@@ -7,4 +7,3 @@
 			client.eye = loc
 			client.perspective = EYE_PERSPECTIVE
 	src.view_core()
-	return

--- a/code/modules/mob/living/silicon/login.dm
+++ b/code/modules/mob/living/silicon/login.dm
@@ -1,3 +1,3 @@
-/mob/living/silicon/Login()
+/mob/living/silicon/LateLogin()
 	sleeping = FALSE
 	..()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -166,7 +166,7 @@
 	id_card.registered_name = ""
 
 
-/mob/living/silicon/pai/Login()
+/mob/living/silicon/pai/LateLogin()
 	greet()
 	..()
 

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -1,4 +1,4 @@
-/mob/living/silicon/robot/Login()
+/mob/living/silicon/robot/LateLogin()
 	..()
 	regenerate_icons()
 	show_laws(0)

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -38,7 +38,7 @@
 /mob/living/simple_animal/borer/roundstart
 	roundstart = TRUE
 
-/mob/living/simple_animal/borer/Login()
+/mob/living/simple_animal/borer/LateLogin()
 	..()
 	if(mind)
 		borers.add_antagonist(mind)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -148,7 +148,7 @@
 	turns_since_move = turns_per_move
 	..()
 
-/mob/living/simple_animal/Login()
+/mob/living/simple_animal/LateLogin()
 	if(src && src.client)
 		src.client.screen = null
 	..()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -29,12 +29,19 @@
  * In the case of Aurora code, mob/Login is invoked BEFORE client initialization
  * is completed, in order to permit remote authentication.
  *
+ * This also invokes mob/proc/LateLogin in cases where the client has already been
+ * initialized. This is the case when a ckey is moved around from mob to mob during
+ * gameplay.
+ *
  * Use /mob/proc/LateLogin() instead.
  */
 /mob/Login()
 	SHOULD_NOT_OVERRIDE(TRUE)
 
 	..()
+
+	if (client.is_initialized)
+		LateLogin()
 
 /**
  * \brief A function to replace most uses of mob/Login with. 99% of the time, you

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -23,7 +23,30 @@
 						message_admins("<font color='red'><B>Notice: </B></font><font color='blue'><A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as [key_name_admin(M)] (no longer logged in). </font>", 1)
 						log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).",ckey=key_name(src))
 
+/**
+ * Currently marked as SHOULD_NOT_OVERRIDE.
+ *
+ * In the case of Aurora code, mob/Login is invoked BEFORE client initialization
+ * is completed, in order to permit remote authentication.
+ *
+ * Use /mob/proc/LateLogin() instead.
+ */
 /mob/Login()
+	SHOULD_NOT_OVERRIDE(TRUE)
+
+	..()
+
+/**
+ * \brief A function to replace most uses of mob/Login with. 99% of the time, you
+ * should implement an override of this function.
+ *
+ * This function is invoked AFTER client/proc/InitClient and client/proc/InitPrefs.
+ * It can expect the client.ckey to be properly populated with the client's final
+ * ckey.
+ */
+/mob/proc/LateLogin()
+	SHOULD_CALL_PARENT(TRUE)
+
 	player_list |= src
 	update_Login_details()
 	SSfeedback.update_status()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -61,7 +61,6 @@
 	next_move = 1
 	sight |= SEE_SELF
 	disconnect_time = null
-	..()
 
 	player_age = client.player_age
 

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -1,4 +1,6 @@
 /mob/Logout()
+	SHOULD_CALL_PARENT(TRUE)
+
 	SSnanoui.user_logout(src) // this is used to clean up (remove) this user's Nano UIs
 	player_list -= src
 	disconnect_time = world.realtime
@@ -27,4 +29,3 @@
 	if (mob_thinks)
 		MOB_START_THINKING(src)
 	..()
-	return 1

--- a/code/modules/psionics/mob/mob.dm
+++ b/code/modules/psionics/mob/mob.dm
@@ -1,8 +1,8 @@
 /mob/living
 	var/datum/psi_complexus/psi
 
-/mob/living/Login()
-	. = ..()
+/mob/living/LateLogin()
+	..()
 	if(psi)
 		psi.update(TRUE)
 		if(!psi.suppressed)

--- a/code/modules/spell_system/spells/spells.dm
+++ b/code/modules/spell_system/spells/spells.dm
@@ -7,7 +7,7 @@
 		for(var/obj/screen/movable/spell_master/spell_master in spell_masters)
 			spell_master.update_spells(0, src)
 
-/mob/Login()
+/mob/LateLogin()
 	..()
 	if(spell_masters)
 		for(var/obj/screen/movable/spell_master/spell_master in spell_masters)

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -23,8 +23,8 @@ var/global/list/can_enter_vent_with = list(
 /mob/living/proc/can_ventcrawl()
 	return 0
 
-/mob/living/Login()
-	. = ..()
+/mob/living/LateLogin()
+	..()
 	//login during ventcrawl
 	if(is_ventcrawling && istype(loc, /obj/machinery/atmospherics)) //attach us back into the pipes
 		remove_ventcrawl()

--- a/html/changelogs/skull132_fix-remote-auth.yml
+++ b/html/changelogs/skull132_fix-remote-auth.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - bugfix: "A bug fixed in remote auth where the HUD setup procs would crash during a reconnect."

--- a/tools/Redirector/Redirector.dm
+++ b/tools/Redirector/Redirector.dm
@@ -29,7 +29,7 @@ world
 
 	var/link = ""
 
-mob/Login()
+/mob/LateLogin()
 	..()
 
 	var/list/weights = list()


### PR DESCRIPTION
Issue:
The call chains in normal BYOND login and remote auth login are _not_ the same, currently. And this is a major issue, resulting in #8773 and #7895.

The login procedure for BYOND auth looks like this:
* ckey/key is set on client.
* client/InitClient is called.
* client/InitPrefs is called.
* mob/Login is called.

The login for remote auth looks like this:
* ckey/key IS NOT KNOWN INITIALLY.
* ckey/key is set -> THIS INVOKES mob/Login.
* client/InitClient is called.
* client/InitPrefs is called.

The problem arises when code in mob/Login or its children needs one of the following items:
* key/ckey,
* preferences,
* database data about the client.

The proposed solution:
We implement our custom proc, `mob/proc/LateLogin` and mark `mob/Login` as SHOULD NOT OVERRIDE. This allows us to set the client's ckey in the remote auth process, without causing a data dependency issue.

So the final, consolidated process for both cases now is:
* ckey/key is known (or set).
* mob/Login is invoked. (Dud, marked as do not override.)
* client/InitClient is called.
* client/InitPrefs is called.
* mob/LateLogin is called.

Other stuff:
* Imports an updated set of SpacemanDMM macros, all of which work with 1.4.
* Fixes #8773 
* Fixes #7895 