### PR TITLE
Fixes Discord Button Not Working

### DIFF
--- a/code/datums/discord/bot.dm
+++ b/code/datums/discord/bot.dm
@@ -407,7 +407,7 @@ var/datum/discord_bot/discord_bot = null
 		log_debug("BOREALIS: HTTP error while fetching invite: [res.status_code].")
 		return
 	else
-		var/list/A = res.body
+		var/list/A = json_decode(res.body)
 
 		// No length to return data, but a valid 200 return header.
 		// So we simply have no invites active. Make one!

--- a/html/changelogs/skull132_discord-button.yml
+++ b/html/changelogs/skull132_discord-button.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: true
+
+changes:
+  - bugfix: "The Discord button works again."


### PR DESCRIPTION
Issue: Discord button up top right doesn't work.

Cause: I forgot to `json_decode` the message body.

Fix: We do as above.

I checked all of the other calls in this file and they seem fine, so only this one was sour.