### PR TITLE
Removes the multitool option from the augment combitool

### DIFF
--- a/code/modules/organs/subtypes/autakh.dm
+++ b/code/modules/organs/subtypes/autakh.dm
@@ -335,6 +335,12 @@
 	icon_state = "digitool"
 	item_state = "digitool"
 	w_class = ITEMSIZE_LARGE
+	tools = list(
+		"crowbar",
+		"screwdriver",
+		"wrench",
+		"wirecutters"
+		)
 
 /obj/item/combitool/robotic/throw_at()
 	usr.drop_from_inventory(src)

--- a/html/changelogs/alberyk-nerfaug.yml
+++ b/html/changelogs/alberyk-nerfaug.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - rscdel: "Removed the multitool option from the augment combitool."


### PR DESCRIPTION
What it says in the title. Mostly because there is no job restriction on the augment.