### PR TITLE
Fixes #8821

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -231,12 +231,14 @@
 		if (!AM.loc)
 			continue
 
+		var/turf/AM_turf = get_turf(AM)
+
 		if(ismob(AM))
 			mobs[AM] = TRUE
-			hearturfs[AM.locs[1]] = TRUE
+			hearturfs[AM_turf] = TRUE
 		else if(isobj(AM))
 			objs[AM] = TRUE
-			hearturfs[AM.locs[1]] = TRUE
+			hearturfs[AM_turf] = TRUE
 
 	for(var/m in player_list)
 		var/mob/M = m
@@ -248,13 +250,16 @@
 			if (!mobs[M])
 				mobs[M] = TRUE
 			continue
-		if(M.loc && hearturfs[M.locs[1]])
+
+		var/turf/M_turf = get_turf(M)
+		if(M.loc && hearturfs[M_turf])
 			if (!mobs[M])
 				mobs[M] = TRUE
 
 	for(var/o in listening_objects)
 		var/obj/O = o
-		if(O && O.loc && hearturfs[O.locs[1]])
+		var/turf/O_turf = get_turf(O)
+		if(O && O.loc && hearturfs[O_turf])
 			if (!objs[O])
 				objs[O] = TRUE
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -107,12 +107,12 @@
 				if(istype(I, /mob))
 					var/mob/M = I
 					listening += M
-					hearturfs += M.locs[1]
+					hearturfs += get_turf(M)
 					for(var/obj/O in M.contents)
 						listening_obj |= O
 				else if(istype(I, /obj))
 					var/obj/O = I
-					hearturfs += O.locs[1]
+					hearturfs += get_turf(O)
 					listening_obj |= O
 
 
@@ -120,7 +120,7 @@
 				if(M.stat == DEAD && M.client?.prefs.toggles & CHAT_GHOSTEARS)
 					M.hear_say(message, verb, speaking, null, null, src)
 					continue
-				if(M.loc && (M.locs[1] in hearturfs))
+				if(M.loc && (get_turf(M) in hearturfs))
 					M.hear_say(message, verb, speaking, null, null, src)
 	else
 		to_chat(src, SPAN_WARNING("No holopad connected."))

--- a/html/changelogs/skull132_8821.yml
+++ b/html/changelogs/skull132_8821.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - bugfix: "Fixed recorders and pAIs and other things not hearing anything while being held in hands. (Bug only affected the server if it was using BYOND > 513.1512.)"


### PR DESCRIPTION
Problem: pAIs and other held objects weren't hearing anything when the server was running newer BYOND.

Cause: Our get objects and mobs in view range fast system was relying on unspecified behaviour. Said behaviour was removed from 513.1512 and higher: http://www.byond.com/forum/post/2410404

Solution: use `get_turf` over `locs[1]` to get the turf of the object.