### PR TITLE
Stops borgs from stripping people

### DIFF
--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/human/proc/handle_strip(var/slot_to_strip, var/mob/living/user)
-	if(!slot_to_strip || !istype(user) || ispAI(user) || (isanimal(user) && !istype(user, /mob/living/simple_animal/hostile) ) )
+	if(!slot_to_strip || !istype(user) || ispAI(user) || (isanimal(user) && !istype(user, /mob/living/simple_animal/hostile) ) || isrobot(user) )
 		return FALSE
 
 	if(user.incapacitated() || !user.Adjacent(src))

--- a/html/changelogs/alberyk-borgstripping.yml
+++ b/html/changelogs/alberyk-borgstripping.yml
@@ -1,4 +1,4 @@
-author: ChangeMe
+author: Alberyk
 
 delete-after: True
 

--- a/html/changelogs/alberyk-borgstripping.yml
+++ b/html/changelogs/alberyk-borgstripping.yml
@@ -1,0 +1,6 @@
+author: ChangeMe
+
+delete-after: True
+
+changes: 
+  - tweak: "Cyborgs can't remove items or clothing from human mobs anymore."


### PR DESCRIPTION
This pr makes so that borgs can't remove clothing items from human mobs. Because they have no hands.