### PR TITLE
Makes on-slip not interact with lack of gravity

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -123,8 +123,6 @@
 	return prob_slip
 
 /mob/living/carbon/human/Check_Shoegrip(checkSpecies = TRUE)
-	if(checkSpecies && (species.flags & NO_SLIP))
-		return 1
 	if(shoes && (shoes.item_flags & NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots))  //magboots + dense_object = no floating
 		return 1
 	return 0

--- a/html/changelogs/alberyk-nonslip.yml
+++ b/html/changelogs/alberyk-nonslip.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - rscdel: "Non-slip species flag should no longer grant immunity to lack of gravity effects."


### PR DESCRIPTION
For some reason, non-slip made so that you could ignore stuff likes flying around due to no gravity or slipping on space. That makes no sense, this pr removes that.