### PR TITLE
Fix Ambition Box

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -217,7 +217,7 @@
 		memory = new_memo
 
 	else if (href_list["amb_edit"])
-		var/new_ambition = input("Enter a new ambition", "Memory",src.ambitions) as null|message
+		var/new_ambition = input("Enter a new ambition", "Memory",html_decode(src.ambitions)) as null|message
 		if(isnull(new_ambition))
 			return
 		src.ambitions = sanitize(new_ambition)

--- a/code/game/antagonist/antagonist_objectives.dm
+++ b/code/game/antagonist/antagonist_objectives.dm
@@ -42,7 +42,7 @@
 		return
 	var/new_ambitions = input(src, "Write a short sentence of what your character hopes to accomplish \
 	today as an antagonist.  Remember that this is purely optional.  It will be shown at the end of the \
-	round for everybody else.", "Ambitions", mind.ambitions) as null|message
+	round for everybody else.", "Ambitions", html_decode(mind.ambitions)) as null|message
 	if(isnull(new_ambitions))
 		return
 	new_ambitions = sanitize(new_ambitions)

--- a/html/changelogs/tehflamintaco - FixAmbitionBox.yml
+++ b/html/changelogs/tehflamintaco - FixAmbitionBox.yml
@@ -1,0 +1,4 @@
+author: Teh Flamin'Taco
+delete-after: True
+changes: 
+  - bugfix: "Set-Ambition should no-longer be filled with HTML constructs when edited."


### PR DESCRIPTION
Previously, Set-Ambition would dump the HTML-Encoded ambition into the edit box.
This decodes it first.

No more #34; spam.