### PR TITLE
Allows One-Handed Cuffing

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -47,7 +47,7 @@
 		if(fast_place)
 			place_handcuffs(C, user)
 		else
-			if(c.stat == DEAD) // gotta make sure those corpses don't run off...
+			if(C.stat == DEAD) // gotta make sure those corpses don't run off...
 				restrain()
 				return
 			if(C.stat == UNCONSCIOUS)
@@ -61,15 +61,15 @@
 
 /obj/item/handcuffs/proc/restrain(var/mob/living/carbon/C, var/mob/user)
 	if(is_restraining)
-				return
-		is_restraining = TRUE
-		to_chat(user, "<span class='danger'>You begin to restrain [C] with \the [src]. This would be faster if you had a firm grip on them!!</span>")
-		visible_message("<span class='danger'>\The [user] is attempting to restrain \the [C]!</span>")
-		if(!do_mob(user, C, 70))
+		return
+	is_restraining = TRUE
+	to_chat(user, "<span class='danger'>You begin to restrain [C] with \the [src]. This would be faster if you had a firm grip on them!!</span>")
+	visible_message("<span class='danger'>\The [user] is attempting to restrain \the [C]!</span>")
+	if(!do_mob(user, C, 70))
 		is_restraining = FALSE
-			return	
-		is_restraining = FALSE
-		place_handcuffs(C, user)
+		return	
+	is_restraining = FALSE
+	place_handcuffs(C, user)
 
 /obj/item/handcuffs/proc/place_handcuffs(var/mob/living/carbon/target, var/mob/user)
 	playsound(src.loc, cuff_sound, 30, 1, -2)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -54,7 +54,7 @@
 				restrain()
 				return
 			if(C.a_intent == I_HELP)
-				restrain() 
+				restrain(C, user)
 			else
 				to_chat(user, "<span class='danger'>\the [C] is not unconscious or cooperative! Try getting a good grip on them first, or suggest they cooperate!</span>")
 				to_chat(C, "<span class='danger'>\the [user] is trying to restrain you, but you resist them! Try being more helpful if you meant to cooperate.</span>")

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -56,7 +56,7 @@
 			if(C.a_intent == I_HELP)
 				restrain() 
 			else
-				to_chat(user, "<span class='danger'>\the [C] is not unconcious or cooperative! Try getting a good grip on them first, or suggest they cooperate!</span>")
+				to_chat(user, "<span class='danger'>\the [C] is not unconscious or cooperative! Try getting a good grip on them first, or suggest they cooperate!</span>")
 				to_chat(C, "<span class='danger'>\the [user] is trying to restrain you, but you resist them! Try being more helpful if you meant to cooperate.</span>")
 
 /obj/item/handcuffs/proc/restrain(var/mob/living/carbon/C, var/mob/user)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -47,17 +47,26 @@
 		if(fast_place)
 			place_handcuffs(C, user)
 		else
-			if(is_restraining)
+			if(C.stat == UNCONSCIOUS)
+				restrain()
 				return
-			is_restraining = TRUE
-			to_chat(user, "<span class='danger'>You begin to restrain [C] with \the [src]. This would be faster if you had a firm grip on them!!</span>")
-			visible_message("<span class='danger'>\The [user] is attempting to restrain \the [C]!</span>")
-			if(!do_mob(user, C, 70))
-				is_restraining = FALSE
-				return	
-			is_restraining = FALSE
-			place_handcuffs(C, user)
+			if(C.a_intent == I_HELP)
+				restrain() 
+			else
+				to_chat(user, "<span class='danger'>\the [C] is not unconcious or cooperative! Try getting a good grip on them first, or suggest they cooperate!</span>")
+				to_chat(C, "<span class='danger'>\the [user] is trying to restrain you, but you resist them! Try being more helpful if you meant to cooperate.</span>")
 
+/obj/item/handcuffs/proc/restrain(var/mob/living/carbon/C, var/mob/user)
+	if(is_restraining)
+				return
+		is_restraining = TRUE
+		to_chat(user, "<span class='danger'>You begin to restrain [C] with \the [src]. This would be faster if you had a firm grip on them!!</span>")
+		visible_message("<span class='danger'>\The [user] is attempting to restrain \the [C]!</span>")
+		if(!do_mob(user, C, 70))
+		is_restraining = FALSE
+			return	
+		is_restraining = FALSE
+		place_handcuffs(C, user)
 
 /obj/item/handcuffs/proc/place_handcuffs(var/mob/living/carbon/target, var/mob/user)
 	playsound(src.loc, cuff_sound, 30, 1, -2)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -63,7 +63,7 @@
 	if(is_restraining)
 		return
 	is_restraining = TRUE
-	to_chat(user, "<span class='danger'>You begin to restrain [C] with \the [src]. This would be faster if you had a firm grip on them!!</span>")
+	to_chat(user, "<span class='danger'>You begin to restrain [C] with \the [src]. This would be faster if you had a firm grip on them!</span>")
 	visible_message("<span class='danger'>\The [user] is attempting to restrain \the [C]!</span>")
 	if(!do_mob(user, C, 70))
 		is_restraining = FALSE

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -47,6 +47,9 @@
 		if(fast_place)
 			place_handcuffs(C, user)
 		else
+			if(c.stat == DEAD) // gotta make sure those corpses don't run off...
+				restrain()
+				return
 			if(C.stat == UNCONSCIOUS)
 				restrain()
 				return

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -48,7 +48,7 @@
 			place_handcuffs(C, user)
 		else
 			if(C.stat == DEAD) // gotta make sure those corpses don't run off...
-				restrain()
+				restrain(C, user)
 				return
 			if(C.stat == UNCONSCIOUS)
 				restrain()

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -14,6 +14,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 500)
 	var/elastic
 	var/dispenser = 0
+	var/is_restraining = FALSE
 	var/breakouttime = 1200 //Deciseconds = 120s = 2 minutes
 	var/cuff_sound = 'sound/weapons/handcuffs.ogg'
 	var/cuff_type = "handcuffs"
@@ -34,19 +35,29 @@
 			place_handcuffs(user, user)
 			return
 
-		var/can_place
+		var/fast_place
 		if(istype(user, /mob/living/silicon/robot))
-			can_place = TRUE
+			fast_place = TRUE
 		else
 			for (var/obj/item/grab/G in C.grabbed_by)
 				if (G.loc == user && G.state >= GRAB_AGGRESSIVE)
-					can_place = TRUE
+					fast_place = TRUE
 					break
 
-		if(can_place)
+		if(fast_place)
 			place_handcuffs(C, user)
 		else
-			to_chat(user, "<span class='danger'>You need to have a firm grip on [C] before you can put \the [src] on!</span>")
+			if(is_restraining)
+				return
+			is_restraining = TRUE
+			to_chat(user, "<span class='danger'>You begin to restrain [C] with \the [src]. This would be faster if you had a firm grip on them!!</span>")
+			visible_message("<span class='danger'>\The [user] is attempting to restrain \the [C]!</span>")
+			if(!do_mob(user, C, 70))
+				is_restraining = FALSE
+				return	
+			is_restraining = FALSE
+			place_handcuffs(C, user)
+
 
 /obj/item/handcuffs/proc/place_handcuffs(var/mob/living/carbon/target, var/mob/user)
 	playsound(src.loc, cuff_sound, 30, 1, -2)

--- a/html/changelogs/Kaedwuff - Handicuffs.yml
+++ b/html/changelogs/Kaedwuff - Handicuffs.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "You can now handcuff people one-handed, but it takes about 3 times as long as handcuffing while gripping."

--- a/html/changelogs/Kaedwuff - Handicuffs.yml
+++ b/html/changelogs/Kaedwuff - Handicuffs.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "You can now handcuff people one-handed, but it takes about 3 times as long as handcuffing while gripping."
+  - tweak: "You can now handcuff people one-handed, but it takes about 3 times as long as handcuffing while gripping. They must be in help intent or unconscious for this to work."


### PR DESCRIPTION
The decision to restrict handcuffing to an aggressive grab was a decent nerf to people that used the toxic meta that was stuncuffing, but it is too binary and restrictive, and does not take into account a lot of other things.

Like that people who have one arm get to just eat shit.  
Or people who want to hold a hostage at weaponpoint while cuffing them can't cuff someone who isn't trying to fight back or escape without putting the weapon away and changing the power dynamic.

So I changed it - you can now cuff people without being in a grab, but it takes a full 10 seconds to complete, instead of the normal 3 for when you have someone aggressive grabbed.