### PR TITLE
Pet Names

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -98,7 +98,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/wipe_ai,	// allow admins to force-wipe AIs
 	/client/proc/fix_player_list,
 	/client/proc/reset_openturf,
-	/client/proc/toggle_aooc
+	/client/proc/toggle_aooc,
+	/client/proc/reset_name
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,

--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -25,6 +25,17 @@
 	for(var/spell in wizardy_spells)
 		src.add_spell(new spell, "const_spell_ready")
 
+/mob/living/simple_animal/familiar/verb/rename_familiar()
+	set name = "Name Familiar"
+	set category = "IC"
+	set desc = "Name this familiar."
+	set src in view(1)
+
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this familiar? No numbers or symbols other than -", "No numbers or symbols, please.")
+
+
 /mob/living/simple_animal/familiar/carcinus
 	name = "crab"
 	desc = "A small crab said to be made of stone and starlight."

--- a/code/modules/mob/living/simple_animal/friendly/carp.dm
+++ b/code/modules/mob/living/simple_animal/friendly/carp.dm
@@ -113,6 +113,20 @@
 	set_dir(get_dir(src, friend))
 	say("Glubglub!")
 
+/mob/living/simple_animal/carp/verb/rename_carp()
+	set name = "Name Carp"
+	set category = "IC"
+	set desc = "Name this space carp."
+	set src in view(1)
+
+	if(!client)
+		to_chat(usr, span("notice", "This carp doesn't seem important enough to name.")) 
+		return
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this space carp? No numbers or symbols other than -", "No numbers or symbols, please.")
+
+
 // ENGINEERING HAS AN ACTUAL PET, WHAAAAAAAAAAAAAT? - geeves
 /mob/living/simple_animal/carp/fluff/ginny
 	name = "Ginny"
@@ -133,6 +147,10 @@
 
 	befriend_job = "Chief Engineer"
 	holder_type = /obj/item/holder/carp/baby
+
+/mob/living/simple_animal/carp/fluff/ginny/Initialize()
+	. = ..()
+	verbs -= /mob/living/simple_animal/carp/verb/rename_carp
 
 /mob/living/simple_animal/carp/fluff/ginny/death()
 	.=..()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -219,6 +219,17 @@
 	set_dir(get_dir(src, friend))
 	say("Meow!")
 
+/mob/living/simple_animal/cat/verb/rename_cat()
+	set name = "Name Cat"
+	set category = "IC"
+	set desc = "Name this cat."
+	set src in view(1)
+
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this cat? No numbers or symbols other than -", "No numbers or symbols, please.")
+
+
 //RUNTIME IS ALIVE! SQUEEEEEEEE~
 /mob/living/simple_animal/cat/fluff/Runtime
 	name = "Runtime"
@@ -232,6 +243,11 @@
 	can_nap = 1
 	befriend_job = "Chief Medical Officer"
 	holder_type = /obj/item/holder/cat/black
+	unique = TRUE
+
+/mob/living/simple_animal/cat/fluff/Runtime/Initialize()
+	. = ..()
+	verbs -= /mob/living/simple_animal/cat/verb/rename_cat
 
 /mob/living/simple_animal/cat/fluff/Runtime/death()
 	.=..()
@@ -264,10 +280,15 @@
 	can_nap = 1
 	var/friend_name = "Erstatz Vryroxes"
 	holder_type = /obj/item/holder/cat/black
+	unique = TRUE
+
+/mob/living/simple_animal/cat/fluff/bones/Initialize()
+	. = ..()
+	verbs -= /mob/living/simple_animal/cat/verb/rename_cat
 
 /mob/living/simple_animal/cat/fluff/bones/death()
 	.=..()
-	desc = "Bones is dead"
+	desc = "Bones is dead."
 
 /mob/living/simple_animal/cat/kitten/Initialize()
 	. = ..()
@@ -282,3 +303,8 @@
 	icon_dead = "penny_dead"
 	icon_rest = "penny_rest"
 	holder_type = /obj/item/holder/cat/penny
+	unique = TRUE
+
+/mob/living/simple_animal/cat/penny/Initialize()
+	. = ..()
+	verbs -= /mob/living/simple_animal/cat/verb/rename_cat

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -37,16 +37,32 @@
 	. = ..()
 	nutrition = max_nutrition * 0.8	//They can start a little hungry, but let's no go crazy
 
+/mob/living/simple_animal/corgi/verb/rename_corgi()
+	set name = "Name Corgi"
+	set category = "IC"
+	set desc = "Name this corgi."
+	set src in view(1)
+
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this corgi? No numbers or symbols other than -", "No numbers or symbols, please.")
+
+
 //IAN! SQUEEEEEEEEE~
 /mob/living/simple_animal/corgi/Ian
 	name = "Ian"
 	real_name = "Ian"	//Intended to hold the name without altering it.
 	gender = MALE
-	desc = "It's a corgi."
+	desc = "It's a the famous corgi, Sir Ian McBarken."
 	//var/obj/movement_target
 	response_help  = "pets"
 	response_disarm = "bops"
 	response_harm   = "kicks"
+	unique = TRUE
+
+/mob/living/simple_animal/corgi/Ian/Initialize()
+	. = ..()
+	verbs -= /mob/living/simple_animal/corgi/verb/rename_corgi
 
 /mob/living/simple_animal/corgi/Ian/think()
 	..()
@@ -133,6 +149,7 @@
 	response_disarm = "bops"
 	response_harm   = "kicks"
 	var/puppies = 0
+	unique = TRUE
 
 //Lisa already has a cute bow!
 /mob/living/simple_animal/corgi/Lisa/Topic(href, href_list)

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -34,6 +34,17 @@
 				turns_since_move = 0
 	regenerate_icons()
 
+/mob/living/simple_animal/crab/verb/rename_crab()
+	set name = "Name Crab"
+	set category = "IC"
+	set desc = "Name this crab."
+	set src in view(1)
+
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this crab? No numbers or symbols other than -", "No numbers or symbols, please.")
+
+
 //COFFEE! SQUEEEEEEEEE!
 /mob/living/simple_animal/crab/Coffee
 	name = "Coffee"
@@ -42,3 +53,7 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "stomps"
+
+/mob/living/simple_animal/crab/Coffee/Initialize()
+	. = ..()
+	verbs -= /mob/living/simple_animal/crab/verb/rename_crab

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -116,6 +116,17 @@
 	else
 		..()
 
+/mob/living/simple_animal/cow/verb/rename_cow()
+	set name = "Name Cow"
+	set category = "IC"
+	set desc = "Name this cow."
+	set src in view(1)
+
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this cow? No numbers or symbols other than -", "No numbers or symbols, please.")
+
+
 /mob/living/simple_animal/chick
 	name = "\improper chick"
 	desc = "Adorable! They make such a racket though."
@@ -267,6 +278,17 @@
 	else
 		STOP_PROCESSING(SSprocessing, src)
 
+/mob/living/simple_animal/chicken/verb/rename_chicken()
+	set name = "Name Chicken"
+	set category = "IC"
+	set desc = "Name this chicken."
+	set src in view(1)
+
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this chicken? No numbers or symbols other than -", "No numbers or symbols, please.")
+
+
 // Penguins
 
 /mob/living/simple_animal/penguin
@@ -307,3 +329,15 @@
 	name = "emperor penguin"
 	desc = "Emperor of all he surveys."
 
+/mob/living/simple_animal/penguin/verb/rename_penguin()
+	set name = "Name Penguin"
+	set category = "IC"
+	set desc = "Name this penguin."
+	set src in view(1)
+
+	if(!client)
+		to_chat(usr, span("notice", "This penguin doesn't seem important enough to name.")) 
+		return
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this penguin? No numbers or symbols other than -", "No numbers or symbols, please.")

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -25,8 +25,28 @@
 	emote_sounds = list()
 	butchering_products = list(/obj/item/stack/material/animalhide = 3)
 
+/mob/living/simple_animal/corgi/fox/Initialize()
+	. = ..()
+	verbs -= /mob/living/simple_animal/corgi/verb/rename_corgi
+
+/mob/living/simple_animal/corgi/verb/rename_fox()
+	set name = "Name Fox"
+	set category = "IC"
+	set desc = "Name this fox."
+	set src in view(1)
+
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this fox? No numbers or symbols other than -", "No numbers or symbols, please.")
+
+
 //Captain fox
 /mob/living/simple_animal/corgi/fox/Chauncey
 	name = "Chauncey"
 	real_name = "Chauncey"
 	desc = "Chauncey, the Captain's trustworthy fox. I wonder what it says?"
+	unique = TRUE
+
+/mob/living/simple_animal/corgi/fox/Chauncey/Initialize()
+	. = ..()
+	verbs -= /mob/living/simple_animal/corgi/verb/rename_fox

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -48,3 +48,16 @@
 
 /mob/living/simple_animal/lizard/dust()
 	..(remains = /obj/effect/decal/remains/lizard)
+
+/mob/living/simple_animal/carp/verb/rename_lizard()
+	set name = "Name Lizard"
+	set category = "IC"
+	set desc = "Name this lizard."
+	set src in view(1)
+
+	if(!client)
+		to_chat(usr, span("notice", "This lizard doesn't seem important enough to name.")) 
+		return
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this lizard? No numbers or symbols other than -", "No numbers or symbols, please.")

--- a/code/modules/mob/living/simple_animal/friendly/rat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/rat.dm
@@ -323,3 +323,16 @@
 
 /mob/living/simple_animal/rat/cannot_use_vents()
 	return
+
+/mob/living/simple_animal/rat/special //a special rat that has the ability to be named - mostly for admin spawn, but maybe later uses
+	desc = "A strangely non-generic rat."
+
+/mob/living/simple_animal/rat/special/verb/rename_rat()
+	set name = "Name rat"
+	set category = "IC"
+	set desc = "Name this rat."
+	set src in view(1)
+
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this rat? No numbers or symbols other than -", "No numbers or symbols, please.")

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -55,3 +55,13 @@
 	S2.icon_dead = "[src.colour] baby slime dead"
 	S2.colour = "[src.colour]"
 	qdel(src)
+
+/mob/living/simple_animal/slime/verb/rename_slime()
+	set name = "Name Slime"
+	set category = "IC"
+	set desc = "Name this slime."
+	set src in view(1)
+
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this slime? No numbers or symbols other than -", "No numbers or symbols, please.")

--- a/code/modules/mob/living/simple_animal/hostile/commanded/guard_dog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/guard_dog.dm
@@ -92,7 +92,7 @@
 
 	else
 		to_chat(usr, "<span class='notice'>[src] already has a name!</span>")
-		return
+		return 
 
 /mob/living/simple_animal/hostile/commanded/dog/amaskan
 	desc = "A dog trained to listen and obey its owner commands, this one is a Tamaskan."

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -684,6 +684,7 @@
 	name = "Poly"
 	desc = "Poly the Parrot. An expert on quantum cracker theory."
 	speak = list("Poly wanna cracker!", ":e Check the singlo, you chucklefucks!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN VOIDSUITS?",":e OH GOD ITS FREE CALL THE SHUTTLE")
+	unique = TRUE
 
 /mob/living/simple_animal/parrot/Poly/Initialize()
 	ears = new /obj/item/device/radio/headset/headset_eng(src)
@@ -760,3 +761,12 @@
 	icon_state = "parrot_fly"
 	return success
 
+/mob/living/simple_animal/carp/verb/rename_parrot()
+	set name = "Name Parrot"
+	set category = "IC"
+	set desc = "Name this parrot."
+	set src in view(1)
+
+	if(!can_change_name())
+		return
+	rename_self_helper(usr, defaultgex, "What do you want to name this parrot? No numbers or symbols other than -", "No numbers or symbols, please.")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -765,7 +765,7 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 		log_and_message_admins("changed [key_name(src)]'s name to [input].", M) //To track name changes and ooc shittery.
 	name = input
 	real_name = name
-	recentlynamed = world.time
+	recentlynamed = world.time 
 
 var/regex/defaultgex = regex(@"^[A-z \-]+$")
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -104,6 +104,7 @@
 
 	var/tameable = TRUE //if you can tame it, used by the dociler for now
 	var/unique = FALSE
+	var/recentlynamed = 0
 	var/was_named = FALSE
 
 	var/flying = FALSE //if they can fly, which stops them from falling down and allows z-space travel
@@ -764,11 +765,13 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 		log_and_message_admins("changed [key_name(src)]'s name to [input].", M) //To track name changes and ooc shittery.
 	name = input
 	real_name = name
-	was_named = TRUE
+	recentlynamed = world.time
 
 var/regex/defaultgex = regex(@"^[A-z \-]+$")
 
 /mob/living/simple_animal/proc/can_change_name(usr)
+	if(src.recentlynamed + 60 SECONDS > world.time)
+		src.was_named = TRUE
 	if (src.unique)
 		to_chat(usr, span("notice", "[src.real_name] is to precious to rename!"))
 		return FALSE

--- a/html/changelogs/Kaedwuff- Named Animals.yml
+++ b/html/changelogs/Kaedwuff- Named Animals.yml
@@ -39,7 +39,7 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - backend: "Implemented a modifiable function for calling a name change prompt."
-  - rscadd: "Most simple animals can be now renamed via a special verb. Pest or hostile simple mobs can only be renamed if they have a player in them. Normal rats and hakhma cannot be renamed. You can only change a name once, then you're locked into it."
+  - rscadd: "Most simple animals can be now renamed via a special verb. Pest or hostile simple mobs can only be renamed if they have a player in them. Normal rats, non-tamed slimes, and hakhma cannot be renamed. You can only change a name once, then you're locked into it."
   - rscdel: "Station pets and similar pre-named mobs cannot be renamed."
   - admin: "Added an admin verb that resets the locked name variable, allowing the mob's name to be changed again."
   

--- a/html/changelogs/Kaedwuff- Named Animals.yml
+++ b/html/changelogs/Kaedwuff- Named Animals.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - backend: "Implemented a modifiable function for calling a name change prompt."
+  - rscadd: "Most simple animals can be now renamed via a special verb. Pest or hostile simple mobs can only be renamed if they have a player in them. Normal rats and hakhma cannot be renamed. You can only change a name once, then you're locked into it."
+  - rscdel: "Station pets and similar pre-named mobs cannot be renamed."
+  - admin: "Added an admin verb that resets the locked name variable, allowing the mob's name to be changed again."
+  

--- a/html/changelogs/Kaedwuff- Named Animals.yml
+++ b/html/changelogs/Kaedwuff- Named Animals.yml
@@ -39,7 +39,7 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - backend: "Implemented a modifiable function for calling a name change prompt."
-  - rscadd: "Most simple animals can be now renamed via a special verb. Pest or hostile simple mobs can only be renamed if they have a player in them. Normal rats, non-tamed slimes, and hakhma cannot be renamed. You can only change a name once, then you're locked into it."
+  - rscadd: "Most simple animals can be now renamed via a special verb. Pest or hostile simple mobs can only be renamed if they have a player in them. Normal rats, non-tamed slimes, and hakhma cannot be renamed. Name changes are locked in 60 seconds after you pick them."
   - rscdel: "Station pets and similar pre-named mobs cannot be renamed."
   - admin: "Added an admin verb that resets the locked name variable, allowing the mob's name to be changed again."
   


### PR DESCRIPTION
-Implemented a modifiable function for calling a name change prompt.
-Most simple animals can be now renamed via a special verb. Pest or hostile simple mobs can only be renamed if they have a player in them. Normal rats, non-tamed slimes, and hakhma cannot be renamed. You can only change a name once, then you're locked into it.
-Station pets and similar pre-named mobs cannot be renamed.
-Added an admin verb that resets the locked name variable, allowing the mob's name to be changed again.
-Non-corgi dogs already have a name change system that is tied into their mechanics, so I'm not touching that.