### PR TITLE
Implement a dll call wrapper

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -72,6 +72,7 @@
 #include "code\_helpers\areas.dm"
 #include "code\_helpers\atmospherics.dm"
 #include "code\_helpers\data_structures.dm"
+#include "code\_helpers\dll_call.dm"
 #include "code\_helpers\files.dm"
 #include "code\_helpers\functional.dm"
 #include "code\_helpers\game.dm"

--- a/code/__defines/rust_g.dm
+++ b/code/__defines/rust_g.dm
@@ -1,12 +1,12 @@
 // rust_g.dm - DM API for rust_g extension library
 #define RUST_G "rust_g"
-#define WRITE_LOG(log, text) call(RUST_G, "log_write")(log, text) // Using Rust g dll to log faster with less CPU usage.
+#define WRITE_LOG(log, text) dll_call(RUST_G, "log_write", log, text) // Using Rust g dll to log faster with less CPU usage.
 
 #define RUSTG_JOB_NO_RESULTS_YET "NO RESULTS YET"
 #define RUSTG_JOB_NO_SUCH_JOB "NO SUCH JOB"
 #define RUSTG_JOB_ERROR "JOB PANICKED"
 
-#define rustg_udp_shipper_send(addr, text) call(RUST_G, "udp_shipper_send")(addr, text)
+#define rustg_udp_shipper_send(addr, text) dll_call(RUST_G, "udp_shipper_send", addr, text)
 
 #define RUSTG_HTTP_METHOD_GET "get"
 #define RUSTG_HTTP_METHOD_POST "post"
@@ -15,6 +15,6 @@
 #define RUSTG_HTTP_METHOD_PATCH "patch"
 #define RUSTG_HTTP_METHOD_HEAD "head"
 
-#define rustg_http_request_blocking(method, url, body, headers) call(RUST_G, "http_request_blocking")(method, url, body, headers)
-#define rustg_http_request_async(method, url, body, headers) call(RUST_G, "http_request_async")(method, url, body, headers)
-#define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)
+#define rustg_http_request_blocking(method, url, body, headers) dll_call(RUST_G, "http_request_blocking", method, url, body, headers)
+#define rustg_http_request_async(method, url, body, headers) dll_call(RUST_G, "http_request_async", method, url, body, headers)
+#define rustg_http_check_request(req_id) dll_call(RUST_G, "http_check_request", req_id)

--- a/code/_helpers/dll_call.dm
+++ b/code/_helpers/dll_call.dm
@@ -7,7 +7,6 @@
 
 	var/list/calling_arguments = length(args) > 2 ? args.Copy(3) : null
 
-	dll = "./[dll].[world.system_type == UNIX ? "so" : "dll"]"
 	. = call(dll, func)(arglist(calling_arguments))
 
 	if (world.timeofday - start > 10 SECONDS)

--- a/code/_helpers/dll_call.dm
+++ b/code/_helpers/dll_call.dm
@@ -1,0 +1,14 @@
+
+/** A function to wrap calls to DLLs for debugging purposes.
+ */
+/proc/dll_call(dll, func, ...)
+
+	var/start = world.timeofday
+
+	var/list/calling_arguments = length(args) > 2 ? args.Copy(3) : null
+
+	dll = "./[dll].[world.system_type == UNIX ? "so" : "dll"]"
+	. = call(dll, func)(arglist(calling_arguments))
+
+	if (world.timeofday - start > 10 SECONDS)
+		crash_with("DLL call took longer than 10 seconds: [func]")

--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -30,7 +30,7 @@
 	world.log <<  "## ERROR: [msg][log_end]"
 
 /proc/shutdown_logging()
-	call(RUST_G, "log_close_all")()
+	dll_call(RUST_G, "log_close_all")
 
 #define WARNING(MSG) warning("[MSG] in [__FILE__] at line [__LINE__] src: [src] usr: [usr].")
 //print a warning message to world.log


### PR DESCRIPTION
Implements a wrapper to the `call()()` function, meant to be used for calling dylibs.

This is useful for two reasons:
  - It allows us to debug the dylib calls (such as timing for the time being).