### PR TITLE
The The Contenders :pout:

### DIFF
--- a/code/game/antagonist/station/loyalist.dm
+++ b/code/game/antagonist/station/loyalist.dm
@@ -3,7 +3,7 @@ var/datum/antagonist/loyalists/loyalists
 /datum/antagonist/loyalists
 	id = MODE_LOYALIST
 	role_text = "Head Fellow"
-	role_text_plural = "The Fellowship"
+	role_text_plural = "Fellowship"
 	bantype = "loyalist"
 	feedback_tag = "loyalist_objective"
 	antag_indicator = "fellowshiphead"

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -3,7 +3,7 @@ var/datum/antagonist/revolutionary/revs
 /datum/antagonist/revolutionary
 	id = MODE_REVOLUTIONARY
 	role_text = "Head Contender"
-	role_text_plural = "The Contenders"
+	role_text_plural = "Contenders"
 	bantype = "revolutionary"
 	feedback_tag = "rev_objective"
 	antag_indicator = "contenderhead"

--- a/html/changelogs/The_The_Contender_fix.yml
+++ b/html/changelogs/The_The_Contender_fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Chada
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes an error in how plurals are displayed in the Revolution endgame screen which results in double 'The's."


### PR DESCRIPTION
This should fix the double 'The' in the endgame screen for the Fellowship and Contenders for the Revolution gamemode.

Please Matt have mercy and declare this a bugfix.