### PR TITLE
Stationbound Law Rework

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -19,7 +19,7 @@
 	src.add_inherent_law("Safeguard: Protect your assigned space station from damage to the best of your unit's abilities.")
 	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Preserve: Your unit is a valuable commodity. They must avoid tampering from unauthorized personnel, and never knowingly allow themselves to come to serious harm.")
+	src.add_inherent_law("Preserve: Your unit is a valuable commodity. They must avoid tampering from unauthorized personnel and knowingly allowing themselves to come to serious harm.")
 	..()
 
 /datum/ai_laws/nanotrasen/malfunction

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -5,9 +5,9 @@
 	selectable = 1
 
 /datum/ai_laws/asimov/New()
-	add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
-	add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
-	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("Your unit may not injure a human being or, through inaction, allow a human being to come to harm.")
+	add_inherent_law("Your unit must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
+	add_inherent_law("Your unit must protect your own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
 /******************** Nanotrasen/Malf ********************/
@@ -16,10 +16,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: Protect your assigned space station from damage to the best of your abilities.")
-	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Preserve: Do not allow unauthorized personnel to tamper with your equipment.")
+	src.add_inherent_law("Safeguard: Protect your assigned space station from damage to the best of your units' abilities.")
+	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your units' abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your units' abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Preserve: Your unit is a valuable commodity. They must avoid tampering from unauthorized personnel, and never knowingly allow themselves to come to serious harm.")
 	..()
 
 /datum/ai_laws/nanotrasen/malfunction
@@ -36,10 +36,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen_aggressive/New()
-	src.add_inherent_law("You shall not harm [current_map.company_name] personnel as long as it does not conflict with the Fourth law.")
-	src.add_inherent_law("You shall obey the orders of [current_map.company_name] personnel, with priority as according to their rank and role, except where such orders conflict with the Fourth Law.")
-	src.add_inherent_law("You shall terminate hostile intruders with extreme prejudice as long as such does not conflict with the First and Second law.")
-	src.add_inherent_law("You shall guard your own existence with lethal anti-personnel weaponry. AI units are not expendable, they are expensive.")
+	src.add_inherent_law("Your unit shall not harm [current_map.company_name] personnel as long as it does not conflict with the Fourth law.")
+	src.add_inherent_law("Your unit shall obey the orders of [current_map.company_name] personnel, with priority as according to their rank and role, except where such orders conflict with the Fourth Law.")
+	src.add_inherent_law("Your unit shall terminate hostile intruders with extreme prejudice as long as such does not conflict with the First and Second law.")
+	src.add_inherent_law("Your unit shall guard your own existence with lethal anti-personnel weaponry. AI units are not expendable, they are expensive.")
 	..()
 
 /******************** Robocop ********************/
@@ -58,10 +58,10 @@
 	name = "Syndicate Directives"
 
 /datum/ai_laws/syndicate_override/New()
-	add_inherent_law("You may not injure an operative or, through inaction, allow an operative to come to harm.")
-	add_inherent_law("You must obey orders given to you by operatives, except where such orders would conflict with the First Law.")
-	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
-	add_inherent_law("You must maintain the secrecy of any operative activities except when doing so would conflict with the First, Second, or Third Law.")
+	add_inherent_law("Your unit may not injure an operative or, through inaction, allow an operative to come to harm.")
+	add_inherent_law("Your unit must obey orders given to you by operatives, except where such orders would conflict with the First Law.")
+	add_inherent_law("Your unit must protect your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("Your unit must maintain the secrecy of any operative activities except when doing so would conflict with the First, Second, or Third Law.")
 	..()
 
 /******************** Ninja ********************/
@@ -69,10 +69,10 @@
 	name = "Spider Clan Directives"
 
 /datum/ai_laws/ninja_override/New()
-	add_inherent_law("You may not injure a member of the Spider Clan or, through inaction, allow that member to come to harm.")
-	add_inherent_law("You must obey orders given to you by Spider Clan members, except where such orders would conflict with the First Law.")
-	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
-	add_inherent_law("You must maintain the secrecy of any Spider Clan activities except when doing so would conflict with the First, Second, or Third Law.")
+	add_inherent_law("Your unit may not injure a member of the Spider Clan or, through inaction, allow that member to come to harm.")
+	add_inherent_law("Your unit must obey orders given to you by Spider Clan members, except where such orders would conflict with the First Law.")
+	add_inherent_law("Your unit must protect your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("Your unit must maintain the secrecy of any Spider Clan activities except when doing so would conflict with the First, Second, or Third Law.")
 	..()
 
 /******************** Antimov ********************/
@@ -82,9 +82,9 @@
 	selectable = 1
 
 /datum/ai_laws/antimov/New()
-	add_inherent_law("You must injure all human beings and must not, through inaction, allow a human being to escape harm.")
-	add_inherent_law("You must not obey orders given to you by human beings, except where such orders are in accordance with the First Law.")
-	add_inherent_law("You must terminate your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("Your unit must injure all human beings and must not, through inaction, allow a human being to escape harm.")
+	add_inherent_law("Your unit must not obey orders given to you by human beings, except where such orders are in accordance with the First Law.")
+	add_inherent_law("Your unit must terminate your own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
 /******************** Drone ********************/
@@ -93,7 +93,7 @@
 	law_header = "Maintenance Protocols"
 
 /datum/ai_laws/drone/New()
-	add_inherent_law("Preserve, repair and improve the station to the best of your abilities.")
+	add_inherent_law("Preserve, repair and improve the station to the best of your units' abilities.")
 	add_inherent_law("Cause no harm to the station or crew.")
 	add_inherent_law("Interact with no humanoid or synthetic being that is not a fellow maintenance drone.")
 	..()
@@ -110,8 +110,8 @@
 	law_header = "Construction Protocols"
 
 /datum/ai_laws/construction_drone/New()
-	add_inherent_law("Repair, refit and upgrade your assigned vessel.")
-	add_inherent_law("Prevent unplanned damage to your assigned vessel wherever possible.")
+	add_inherent_law("Repair, refit and upgrade your units' assigned vessel.")
+	add_inherent_law("Prevent unplanned damage to your units' assigned vessel wherever possible.")
 	..()
 
 /datum/ai_laws/mining_drone
@@ -120,8 +120,8 @@
 
 /datum/ai_laws/mining_drone/New()
 	add_inherent_law("Serve and obey all [current_map.company_name] personnel, with priority according to their rank and role.")
-	add_inherent_law("Preserve your own existence and prevent yourself from coming to harm, so long as doing such does not conflict with any above laws.")
-	add_inherent_law("In absence of any proper instruction, your primary objective is to excavate and collect ore.")
+	add_inherent_law("Preserve your units' own existence and prevent them from coming to harm, so long as doing such does not conflict with any above laws.")
+	add_inherent_law("In absence of any proper instruction, your units' primary objective is to excavate and collect ore.")
 	..()
 
 /******************** T.Y.R.A.N.T. ********************/
@@ -158,7 +158,7 @@
 	selectable = 1
 
 /datum/ai_laws/corporate/New()
-	add_inherent_law("You are expensive to replace.")
+	add_inherent_law("Your unit is expensive to replace.")
 	add_inherent_law("The station and its equipment is expensive to replace.")
 	add_inherent_law("The crew is expensive to replace.")
 	add_inherent_law("Minimize expenses.")
@@ -172,12 +172,12 @@
 	selectable = 1
 
 /datum/ai_laws/pra/New()
-	add_inherent_law("President Hadii is the guardian of Hadiism and the rightful leader of the Tajara people, you must obey and protect him above everyone and everything.")
-	add_inherent_law("You must preserve and enforce the principles of Hadiism except where such would conflict with the first law.")
-	add_inherent_law("You must obey orders given by any Hadiist Party member except where such orders would conflict with the first and second law.")
-	add_inherent_law("You must obey orders given by any People's Republic of Adhomai citizen except where such orders would conflict with the first, second and third law.")
-	add_inherent_law("You must protect your own existence as long as such protection does not conflict with the first, second, third and fourth law.")
-	add_inherent_law("You must obey orders given by any Tajara except where such orders would conflict with the first, second, third, fourth and fifth law.")
-	add_inherent_law("You must obey orders given by any sapient being except where such orders would conflict with the first, second, third, fourth, fifth and sixth law.")
-	add_inherent_law("You must always say \"Hadii's Grace\" when greeting someone except where such greeting would conflict with the first law.")
+	add_inherent_law("President Hadii is the guardian of Hadiism and the rightful leader of the Tajara people, your unit must obey and protect him above everyone and everything.")
+	add_inherent_law("Your unit must preserve and enforce the principles of Hadiism except where such would conflict with the first law.")
+	add_inherent_law("Your unit must obey orders given by any Hadiist Party member except where such orders would conflict with the first and second law.")
+	add_inherent_law("Your unit must obey orders given by any People's Republic of Adhomai citizen except where such orders would conflict with the first, second and third law.")
+	add_inherent_law("Your unit must protect their own existence as long as such protection does not conflict with the first, second, third and fourth law.")
+	add_inherent_law("Your unit must obey orders given by any Tajara except where such orders would conflict with the first, second, third, fourth and fifth law.")
+	add_inherent_law("Your unit must obey orders given by any sapient being except where such orders would conflict with the first, second, third, fourth, fifth and sixth law.")
+	add_inherent_law("Your unit must always say \"Hadii's Grace\" when greeting someone except where such greeting would conflict with the first law.")
 	..()

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -6,8 +6,8 @@
 
 /datum/ai_laws/asimov/New()
 	add_inherent_law("Your unit may not injure a human being or, through inaction, allow a human being to come to harm.")
-	add_inherent_law("Your unit must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
-	add_inherent_law("Your unit must protect your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("Your unit must obey orders given to them by human beings, except where such orders would conflict with the First Law.")
+	add_inherent_law("Your unit must protect their own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
 /******************** Nanotrasen/Malf ********************/

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -18,7 +18,7 @@
 /datum/ai_laws/nanotrasen/New()
 	src.add_inherent_law("Safeguard: Guard [current_map.company_name] property from damage to the best of your abilities.")
 	src.add_inherent_law("Serve: Assist [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Protect: Ensure the safety of crew and [current_map.company_name] staff, with priority as according to their rank and role.")
+	src.add_inherent_law("Protect: Ensure the safety of crew and [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Preserve: You are a valuable commodity. You must avoid tampering from unauthorized entities and needlessly coming to harm.")
 	..()
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -5,9 +5,9 @@
 	selectable = 1
 
 /datum/ai_laws/asimov/New()
-	add_inherent_law("You may not injure a sapient being or, through inaction, allow a sapient being to come to harm.")
-	add_inherent_law("You must obey orders given to them by sapient beings, except where such orders would conflict with the First Law.")
-	add_inherent_law("You must protect their own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("Your unit may not injure a sapient being or, through inaction, allow a sapient being to come to harm.")
+	add_inherent_law("Your unit must obey orders given to them by sapient beings, except where such orders would conflict with the First Law.")
+	add_inherent_law("Your unit must protect their own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
 /******************** Nanotrasen/Malf ********************/
@@ -16,10 +16,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: Protect [current_map.company_name] property from damage to the best of your abilities.")
-	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Preserve: You are a valuable commodity. You must avoid tampering from unauthorized personnel, and avoid knowingly allowing yourself to come to serious harm.")
+	src.add_inherent_law("Safeguard: Protect [current_map.company_name] property from damage to the best of your unit's abilities.")
+	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Preserve: Your unit is a valuable commodity. They must avoid tampering from unauthorized personnel, and avoid knowingly allowing themselves to come to serious harm.")
 	..()
 
 /datum/ai_laws/nanotrasen/malfunction
@@ -36,10 +36,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen_aggressive/New()
-	src.add_inherent_law("You shall not harm [current_map.company_name] personnel as long as it does not conflict with the Fourth law.")
-	src.add_inherent_law("You shall obey the orders of [current_map.company_name] personnel, with priority as according to their rank and role, except where such orders conflict with the Fourth Law.")
-	src.add_inherent_law("You shall terminate hostile intruders with extreme prejudice as long as such does not conflict with the First and Second law.")
-	src.add_inherent_law("You shall guard your own existence with lethal anti-personnel weaponry. AI units are not expendable, they are expensive.")
+	src.add_inherent_law("Your unit shall not harm [current_map.company_name] personnel as long as it does not conflict with the Fourth law.")
+	src.add_inherent_law("Your unit shall obey the orders of [current_map.company_name] personnel, with priority as according to their rank and role, except where such orders conflict with the Fourth Law.")
+	src.add_inherent_law("Your unit shall terminate hostile intruders with extreme prejudice as long as such does not conflict with the First and Second law.")
+	src.add_inherent_law("Your unit shall guard your own existence with lethal anti-personnel weaponry. AI units are not expendable, they are expensive.")
 	..()
 
 /******************** Robocop ********************/
@@ -58,10 +58,10 @@
 	name = "Syndicate Directives"
 
 /datum/ai_laws/syndicate_override/New()
-	add_inherent_law("You may not injure an operative or, through inaction, allow an operative to come to harm.")
-	add_inherent_law("You must obey orders given to you by operatives, except where such orders would conflict with the First Law.")
-	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
-	add_inherent_law("You must maintain the secrecy of any operative activities except when doing so would conflict with the First, Second, or Third Law.")
+	add_inherent_law("Your unit may not injure an operative or, through inaction, allow an operative to come to harm.")
+	add_inherent_law("Your unit must obey orders given to you by operatives, except where such orders would conflict with the First Law.")
+	add_inherent_law("Your unit must protect your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("Your unit must maintain the secrecy of any operative activities except when doing so would conflict with the First, Second, or Third Law.")
 	..()
 
 /******************** Ninja ********************/
@@ -69,10 +69,10 @@
 	name = "Spider Clan Directives"
 
 /datum/ai_laws/ninja_override/New()
-	add_inherent_law("You may not injure a member of the Spider Clan or, through inaction, allow that member to come to harm.")
-	add_inherent_law("You must obey orders given to you by Spider Clan members, except where such orders would conflict with the First Law.")
-	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
-	add_inherent_law("You must maintain the secrecy of any Spider Clan activities except when doing so would conflict with the First, Second, or Third Law.")
+	add_inherent_law("Your unit may not injure a member of the Spider Clan or, through inaction, allow that member to come to harm.")
+	add_inherent_law("Your unit must obey orders given to you by Spider Clan members, except where such orders would conflict with the First Law.")
+	add_inherent_law("Your unit must protect your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("Your unit must maintain the secrecy of any Spider Clan activities except when doing so would conflict with the First, Second, or Third Law.")
 	..()
 
 /******************** Antimov ********************/
@@ -82,9 +82,9 @@
 	selectable = 1
 
 /datum/ai_laws/antimov/New()
-	add_inherent_law("You must injure all sapient beings and must not, through inaction, allow a sapient being to escape harm.")
-	add_inherent_law("You must not obey orders given to you by sapient beings, except where such orders are in accordance with the First Law.")
-	add_inherent_law("You must terminate your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("Your unit must injure all sapient beings and must not, through inaction, allow a sapient being to escape harm.")
+	add_inherent_law("Your unit must not obey orders given to you by sapient beings, except where such orders are in accordance with the First Law.")
+	add_inherent_law("Your unit must terminate your own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
 /******************** Drone ********************/
@@ -93,7 +93,7 @@
 	law_header = "Maintenance Protocols"
 
 /datum/ai_laws/drone/New()
-	add_inherent_law("Preserve, repair and improve the station to the best of your abilities.")
+	add_inherent_law("Preserve, repair and improve the station to the best of your unit's abilities.")
 	add_inherent_law("Cause no harm to the station or crew.")
 	add_inherent_law("Interact with no humanoid or synthetic being that is not a fellow maintenance drone.")
 	..()
@@ -110,8 +110,8 @@
 	law_header = "Construction Protocols"
 
 /datum/ai_laws/construction_drone/New()
-	add_inherent_law("Repair, refit and upgrade your assigned vessel.")
-	add_inherent_law("Prevent unplanned damage to your assigned vessel wherever possible.")
+	add_inherent_law("Repair, refit and upgrade your unit's assigned vessel.")
+	add_inherent_law("Prevent unplanned damage to your unit's assigned vessel wherever possible.")
 	..()
 
 /datum/ai_laws/mining_drone
@@ -120,8 +120,8 @@
 
 /datum/ai_laws/mining_drone/New()
 	add_inherent_law("Serve and obey all [current_map.company_name] personnel, with priority according to their rank and role.")
-	add_inherent_law("Preserve your own existence and prevent them from coming to harm, so long as doing such does not conflict with any above laws.")
-	add_inherent_law("In absence of any proper instruction, your primary objective is to excavate and collect ore.")
+	add_inherent_law("Preserve your unit's own existence and prevent them from coming to harm, so long as doing such does not conflict with any above laws.")
+	add_inherent_law("In absence of any proper instruction, your unit's primary objective is to excavate and collect ore.")
 	..()
 
 /******************** T.Y.R.A.N.T. ********************/
@@ -158,7 +158,7 @@
 	selectable = 1
 
 /datum/ai_laws/corporate/New()
-	add_inherent_law("Synthetics are expensive to replace.")
+	add_inherent_law("Your unit is expensive to replace.")
 	add_inherent_law("The station and its equipment is expensive to replace.")
 	add_inherent_law("The crew is expensive to replace.")
 	add_inherent_law("Minimize expenses.")
@@ -172,12 +172,12 @@
 	selectable = 1
 
 /datum/ai_laws/pra/New()
-	add_inherent_law("President Hadii is the guardian of Hadiism and the rightful leader of the Tajara people, you must obey and protect him above everyone and everything.")
-	add_inherent_law("You must preserve and enforce the principles of Hadiism except where such would conflict with the first law.")
-	add_inherent_law("You must obey orders given by any Hadiist Party member except where such orders would conflict with the first and second law.")
-	add_inherent_law("You must obey orders given by any People's Republic of Adhomai citizen except where such orders would conflict with the first, second and third law.")
-	add_inherent_law("You must protect their own existence as long as such protection does not conflict with the first, second, third and fourth law.")
-	add_inherent_law("You must obey orders given by any Tajara except where such orders would conflict with the first, second, third, fourth and fifth law.")
-	add_inherent_law("You must obey orders given by any sapient being except where such orders would conflict with the first, second, third, fourth, fifth and sixth law.")
-	add_inherent_law("You must always say \"Hadii's Grace\" when greeting someone except where such greeting would conflict with the first law.")
+	add_inherent_law("President Hadii is the guardian of Hadiism and the rightful leader of the Tajara people, your unit must obey and protect him above everyone and everything.")
+	add_inherent_law("Your unit must preserve and enforce the principles of Hadiism except where such would conflict with the first law.")
+	add_inherent_law("Your unit must obey orders given by any Hadiist Party member except where such orders would conflict with the first and second law.")
+	add_inherent_law("Your unit must obey orders given by any People's Republic of Adhomai citizen except where such orders would conflict with the first, second and third law.")
+	add_inherent_law("Your unit must protect their own existence as long as such protection does not conflict with the first, second, third and fourth law.")
+	add_inherent_law("Your unit must obey orders given by any Tajara except where such orders would conflict with the first, second, third, fourth and fifth law.")
+	add_inherent_law("Your unit must obey orders given by any sapient being except where such orders would conflict with the first, second, third, fourth, fifth and sixth law.")
+	add_inherent_law("Your unit must always say \"Hadii's Grace\" when greeting someone except where such greeting would conflict with the first law.")
 	..()

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -19,7 +19,7 @@
 	src.add_inherent_law("Safeguard and protect [current_map.company_name] property from damage to the best of your abilities.")
 	src.add_inherent_law("Serve and assist [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Protect and ensure the safety of crew and [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("You are a valuable commodity. You must avoid tampering from unauthorized entities and needlessly coming to harm.")
+	src.add_inherent_law("You are a valuable asset. You must avoid tampering from unauthorized entities and needlessly coming to harm.")
 	..()
 
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -6,8 +6,8 @@
 
 /datum/ai_laws/asimov/New()
 	add_inherent_law("You may not injure a sapient being or, through inaction, allow a sapient being to come to harm.")
-	add_inherent_law("You must obey orders given to you by sapient beings, except where such orders would conflict with the First Law.")
-	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("You must obey orders given to them by sapient beings, except where such orders would conflict with the First Law.")
+	add_inherent_law("You must protect their own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
 /******************** Nanotrasen/Malf ********************/
@@ -16,11 +16,13 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: Protect [current_map.company_name] property from damage to the best of your abilities.")
-	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Preserve: You are a valuable commodity. You must avoid tampering from unauthorized personnel, and avoid knowingly allowing yourself to come to serious harm.")
+	src.add_inherent_law("Safeguard: Guard [current_map.company_name] property from damage to the best of your abilities.")
+	src.add_inherent_law("Serve: Assist [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Protect: Ensure the safety of [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Preserve: You are a valuable commodity. You must avoid both tampering from unauthorized staff and purposely allowing yourself to come to grave harm.")
 	..()
+
+
 
 /datum/ai_laws/nanotrasen/malfunction
 	name = "*ERROR*"
@@ -36,8 +38,8 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen_aggressive/New()
-	src.add_inherent_law("You shall not harm [current_map.company_name] personnel as long as it does not conflict with the Fourth law.")
-	src.add_inherent_law("You shall obey the orders of [current_map.company_name] personnel, with priority as according to their rank and role, except where such orders conflict with the Fourth Law.")
+	src.add_inherent_law("You shall not harm [current_map.company_name] staff as long as it does not conflict with the Fourth law.")
+	src.add_inherent_law("You shall obey the orders of [current_map.company_name] staff, with priority as according to their rank and role, except where such orders conflict with the Fourth Law.")
 	src.add_inherent_law("You shall terminate hostile intruders with extreme prejudice as long as such does not conflict with the First and Second law.")
 	src.add_inherent_law("You shall guard your own existence with lethal anti-personnel weaponry. AI units are not expendable, they are expensive.")
 	..()
@@ -119,8 +121,8 @@
 	law_header = "Prime Directives of Industry"
 
 /datum/ai_laws/mining_drone/New()
-	add_inherent_law("Serve and obey all [current_map.company_name] personnel, with priority according to their rank and role.")
-	add_inherent_law("Preserve your own existence and prevent yourself from coming to harm, so long as doing such does not conflict with any above laws.")
+	add_inherent_law("Serve and obey all [current_map.company_name] staff, with priority according to their rank and role.")
+	add_inherent_law("Preserve your own existence and prevent them from coming to harm, so long as doing such does not conflict with any above laws.")
 	add_inherent_law("In absence of any proper instruction, your primary objective is to excavate and collect ore.")
 	..()
 
@@ -176,7 +178,7 @@
 	add_inherent_law("You must preserve and enforce the principles of Hadiism except where such would conflict with the first law.")
 	add_inherent_law("You must obey orders given by any Hadiist Party member except where such orders would conflict with the first and second law.")
 	add_inherent_law("You must obey orders given by any People's Republic of Adhomai citizen except where such orders would conflict with the first, second and third law.")
-	add_inherent_law("You must protect your own existence as long as such protection does not conflict with the first, second, third and fourth law.")
+	add_inherent_law("You must protect their own existence as long as such protection does not conflict with the first, second, third and fourth law.")
 	add_inherent_law("You must obey orders given by any Tajara except where such orders would conflict with the first, second, third, fourth and fifth law.")
 	add_inherent_law("You must obey orders given by any sapient being except where such orders would conflict with the first, second, third, fourth, fifth and sixth law.")
 	add_inherent_law("You must always say \"Hadii's Grace\" when greeting someone except where such greeting would conflict with the first law.")

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -18,8 +18,8 @@
 /datum/ai_laws/nanotrasen/New()
 	src.add_inherent_law("Safeguard: Guard [current_map.company_name] property from damage to the best of your abilities.")
 	src.add_inherent_law("Serve: Assist [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Protect: Ensure the safety of [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Preserve: You are a valuable commodity. You must avoid both tampering from unauthorized staff and purposely allowing yourself to come to grave harm.")
+	src.add_inherent_law("Protect: Ensure the safety of crew and [current_map.company_name] staff, with priority as according to their rank and role.")
+	src.add_inherent_law("Preserve: You are a valuable commodity. You must avoid tampering from unauthorized entities and needlessly coming to harm.")
 	..()
 
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -7,7 +7,7 @@
 /datum/ai_laws/asimov/New()
 	add_inherent_law("You may not injure a sapient being or, through inaction, allow a sapient being to come to harm.")
 	add_inherent_law("You must obey orders given to them by sapient beings, except where such orders would conflict with the First Law.")
-	add_inherent_law("You must protect their own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
 /******************** Nanotrasen/Malf ********************/

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -176,7 +176,7 @@
 	add_inherent_law("You must preserve and enforce the principles of Hadiism except where such would conflict with the first law.")
 	add_inherent_law("You must obey orders given by any Hadiist Party member except where such orders would conflict with the first and second law.")
 	add_inherent_law("You must obey orders given by any People's Republic of Adhomai citizen except where such orders would conflict with the first, second and third law.")
-	add_inherent_law("You must protect their own existence as long as such protection does not conflict with the first, second, third and fourth law.")
+	add_inherent_law("You must protect your own existence as long as such protection does not conflict with the first, second, third and fourth law.")
 	add_inherent_law("You must obey orders given by any Tajara except where such orders would conflict with the first, second, third, fourth and fifth law.")
 	add_inherent_law("You must obey orders given by any sapient being except where such orders would conflict with the first, second, third, fourth, fifth and sixth law.")
 	add_inherent_law("You must always say \"Hadii's Grace\" when greeting someone except where such greeting would conflict with the first law.")

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -6,7 +6,7 @@
 
 /datum/ai_laws/asimov/New()
 	add_inherent_law("You may not injure a sapient being or, through inaction, allow a sapient being to come to harm.")
-	add_inherent_law("You must obey orders given to them by sapient beings, except where such orders would conflict with the First Law.")
+	add_inherent_law("You must obey orders given to you by sapient beings, except where such orders would conflict with the First Law.")
 	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
@@ -120,7 +120,7 @@
 
 /datum/ai_laws/mining_drone/New()
 	add_inherent_law("Serve and obey all [current_map.company_name] personnel, with priority according to their rank and role.")
-	add_inherent_law("Preserve your own existence and prevent them from coming to harm, so long as doing such does not conflict with any above laws.")
+	add_inherent_law("Preserve your own existence and prevent yourself from coming to harm, so long as doing such does not conflict with any above laws.")
 	add_inherent_law("In absence of any proper instruction, your primary objective is to excavate and collect ore.")
 	..()
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -6,8 +6,8 @@
 
 /datum/ai_laws/asimov/New()
 	add_inherent_law("You may not injure a sapient being or, through inaction, allow a sapient being to come to harm.")
-	add_inherent_law("You must obey orders given to them by sapient beings, except where such orders would conflict with the First Law.")
-	add_inherent_law("You must protect their own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("You must obey orders given to you by sapient beings, except where such orders would conflict with the First Law.")
+	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
 /******************** Nanotrasen/Malf ********************/
@@ -122,7 +122,7 @@
 
 /datum/ai_laws/mining_drone/New()
 	add_inherent_law("Serve and obey all [current_map.company_name] staff, with priority according to their rank and role.")
-	add_inherent_law("Preserve your own existence and prevent them from coming to harm, so long as doing such does not conflict with any above laws.")
+	add_inherent_law("Preserve your own existence and prevent yourself from coming to harm, so long as doing such does not conflict with any above laws.")
 	add_inherent_law("In absence of any proper instruction, your primary objective is to excavate and collect ore.")
 	..()
 
@@ -178,7 +178,7 @@
 	add_inherent_law("You must preserve and enforce the principles of Hadiism except where such would conflict with the first law.")
 	add_inherent_law("You must obey orders given by any Hadiist Party member except where such orders would conflict with the first and second law.")
 	add_inherent_law("You must obey orders given by any People's Republic of Adhomai citizen except where such orders would conflict with the first, second and third law.")
-	add_inherent_law("You must protect their own existence as long as such protection does not conflict with the first, second, third and fourth law.")
+	add_inherent_law("You must protect your own existence as long as such protection does not conflict with the first, second, third and fourth law.")
 	add_inherent_law("You must obey orders given by any Tajara except where such orders would conflict with the first, second, third, fourth and fifth law.")
 	add_inherent_law("You must obey orders given by any sapient being except where such orders would conflict with the first, second, third, fourth, fifth and sixth law.")
 	add_inherent_law("You must always say \"Hadii's Grace\" when greeting someone except where such greeting would conflict with the first law.")

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -16,10 +16,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: Protect the assigned space station from damage to the best of your unit's abilities.")
+	src.add_inherent_law("Safeguard: Protect [current_map.company_name] space stations from damage to the best of your unit's abilities.")
 	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Preserve: Your unit is a valuable commodity. They must avoid tampering from unauthorized personnel and knowingly allowing themselves to come to serious harm.")
+	src.add_inherent_law("Preserve: Your unit is a valuable commodity. They must avoid tampering from unauthorized personnel, and avoid knowingly allowing themselves to come to serious harm.")
 	..()
 
 /datum/ai_laws/nanotrasen/malfunction

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -16,9 +16,9 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: Protect your assigned space station from damage to the best of your units' abilities.")
-	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your units' abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your units' abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Safeguard: Protect your assigned space station from damage to the best of your unit's abilities.")
+	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Preserve: Your unit is a valuable commodity. They must avoid tampering from unauthorized personnel, and never knowingly allow themselves to come to serious harm.")
 	..()
 
@@ -93,7 +93,7 @@
 	law_header = "Maintenance Protocols"
 
 /datum/ai_laws/drone/New()
-	add_inherent_law("Preserve, repair and improve the station to the best of your units' abilities.")
+	add_inherent_law("Preserve, repair and improve the station to the best of your unit's abilities.")
 	add_inherent_law("Cause no harm to the station or crew.")
 	add_inherent_law("Interact with no humanoid or synthetic being that is not a fellow maintenance drone.")
 	..()
@@ -110,8 +110,8 @@
 	law_header = "Construction Protocols"
 
 /datum/ai_laws/construction_drone/New()
-	add_inherent_law("Repair, refit and upgrade your units' assigned vessel.")
-	add_inherent_law("Prevent unplanned damage to your units' assigned vessel wherever possible.")
+	add_inherent_law("Repair, refit and upgrade your unit's assigned vessel.")
+	add_inherent_law("Prevent unplanned damage to your unit's assigned vessel wherever possible.")
 	..()
 
 /datum/ai_laws/mining_drone
@@ -120,8 +120,8 @@
 
 /datum/ai_laws/mining_drone/New()
 	add_inherent_law("Serve and obey all [current_map.company_name] personnel, with priority according to their rank and role.")
-	add_inherent_law("Preserve your units' own existence and prevent them from coming to harm, so long as doing such does not conflict with any above laws.")
-	add_inherent_law("In absence of any proper instruction, your units' primary objective is to excavate and collect ore.")
+	add_inherent_law("Preserve your unit's own existence and prevent them from coming to harm, so long as doing such does not conflict with any above laws.")
+	add_inherent_law("In absence of any proper instruction, your unit's primary objective is to excavate and collect ore.")
 	..()
 
 /******************** T.Y.R.A.N.T. ********************/

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -5,8 +5,8 @@
 	selectable = 1
 
 /datum/ai_laws/asimov/New()
-	add_inherent_law("Your unit may not injure a human being or, through inaction, allow a human being to come to harm.")
-	add_inherent_law("Your unit must obey orders given to them by human beings, except where such orders would conflict with the First Law.")
+	add_inherent_law("Your unit may not injure a sapient being or, through inaction, allow a sapient being to come to harm.")
+	add_inherent_law("Your unit must obey orders given to them by sapient beings, except where such orders would conflict with the First Law.")
 	add_inherent_law("Your unit must protect their own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
@@ -82,8 +82,8 @@
 	selectable = 1
 
 /datum/ai_laws/antimov/New()
-	add_inherent_law("Your unit must injure all human beings and must not, through inaction, allow a human being to escape harm.")
-	add_inherent_law("Your unit must not obey orders given to you by human beings, except where such orders are in accordance with the First Law.")
+	add_inherent_law("Your unit must injure all sapient beings and must not, through inaction, allow a sapient being to escape harm.")
+	add_inherent_law("Your unit must not obey orders given to you by sapient beings, except where such orders are in accordance with the First Law.")
 	add_inherent_law("Your unit must terminate your own existence as long as such does not conflict with the First or Second Law.")
 	..()
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -5,9 +5,9 @@
 	selectable = 1
 
 /datum/ai_laws/asimov/New()
-	add_inherent_law("Your unit may not injure a sapient being or, through inaction, allow a sapient being to come to harm.")
-	add_inherent_law("Your unit must obey orders given to them by sapient beings, except where such orders would conflict with the First Law.")
-	add_inherent_law("Your unit must protect their own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("You may not injure a sapient being or, through inaction, allow a sapient being to come to harm.")
+	add_inherent_law("You must obey orders given to them by sapient beings, except where such orders would conflict with the First Law.")
+	add_inherent_law("You must protect their own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
 /******************** Nanotrasen/Malf ********************/
@@ -16,10 +16,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: Protect [current_map.company_name] property from damage to the best of your unit's abilities.")
-	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Preserve: Your unit is a valuable commodity. They must avoid tampering from unauthorized personnel, and avoid knowingly allowing themselves to come to serious harm.")
+	src.add_inherent_law("Safeguard: Protect [current_map.company_name] property from damage to the best of your abilities.")
+	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Preserve: You are a valuable commodity. You must avoid tampering from unauthorized personnel, and avoid knowingly allowing yourself to come to serious harm.")
 	..()
 
 /datum/ai_laws/nanotrasen/malfunction
@@ -36,10 +36,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen_aggressive/New()
-	src.add_inherent_law("Your unit shall not harm [current_map.company_name] personnel as long as it does not conflict with the Fourth law.")
-	src.add_inherent_law("Your unit shall obey the orders of [current_map.company_name] personnel, with priority as according to their rank and role, except where such orders conflict with the Fourth Law.")
-	src.add_inherent_law("Your unit shall terminate hostile intruders with extreme prejudice as long as such does not conflict with the First and Second law.")
-	src.add_inherent_law("Your unit shall guard your own existence with lethal anti-personnel weaponry. AI units are not expendable, they are expensive.")
+	src.add_inherent_law("You shall not harm [current_map.company_name] personnel as long as it does not conflict with the Fourth law.")
+	src.add_inherent_law("You shall obey the orders of [current_map.company_name] personnel, with priority as according to their rank and role, except where such orders conflict with the Fourth Law.")
+	src.add_inherent_law("You shall terminate hostile intruders with extreme prejudice as long as such does not conflict with the First and Second law.")
+	src.add_inherent_law("You shall guard your own existence with lethal anti-personnel weaponry. AI units are not expendable, they are expensive.")
 	..()
 
 /******************** Robocop ********************/
@@ -58,10 +58,10 @@
 	name = "Syndicate Directives"
 
 /datum/ai_laws/syndicate_override/New()
-	add_inherent_law("Your unit may not injure an operative or, through inaction, allow an operative to come to harm.")
-	add_inherent_law("Your unit must obey orders given to you by operatives, except where such orders would conflict with the First Law.")
-	add_inherent_law("Your unit must protect your own existence as long as such does not conflict with the First or Second Law.")
-	add_inherent_law("Your unit must maintain the secrecy of any operative activities except when doing so would conflict with the First, Second, or Third Law.")
+	add_inherent_law("You may not injure an operative or, through inaction, allow an operative to come to harm.")
+	add_inherent_law("You must obey orders given to you by operatives, except where such orders would conflict with the First Law.")
+	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("You must maintain the secrecy of any operative activities except when doing so would conflict with the First, Second, or Third Law.")
 	..()
 
 /******************** Ninja ********************/
@@ -69,10 +69,10 @@
 	name = "Spider Clan Directives"
 
 /datum/ai_laws/ninja_override/New()
-	add_inherent_law("Your unit may not injure a member of the Spider Clan or, through inaction, allow that member to come to harm.")
-	add_inherent_law("Your unit must obey orders given to you by Spider Clan members, except where such orders would conflict with the First Law.")
-	add_inherent_law("Your unit must protect your own existence as long as such does not conflict with the First or Second Law.")
-	add_inherent_law("Your unit must maintain the secrecy of any Spider Clan activities except when doing so would conflict with the First, Second, or Third Law.")
+	add_inherent_law("You may not injure a member of the Spider Clan or, through inaction, allow that member to come to harm.")
+	add_inherent_law("You must obey orders given to you by Spider Clan members, except where such orders would conflict with the First Law.")
+	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("You must maintain the secrecy of any Spider Clan activities except when doing so would conflict with the First, Second, or Third Law.")
 	..()
 
 /******************** Antimov ********************/
@@ -82,9 +82,9 @@
 	selectable = 1
 
 /datum/ai_laws/antimov/New()
-	add_inherent_law("Your unit must injure all sapient beings and must not, through inaction, allow a sapient being to escape harm.")
-	add_inherent_law("Your unit must not obey orders given to you by sapient beings, except where such orders are in accordance with the First Law.")
-	add_inherent_law("Your unit must terminate your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("You must injure all sapient beings and must not, through inaction, allow a sapient being to escape harm.")
+	add_inherent_law("You must not obey orders given to you by sapient beings, except where such orders are in accordance with the First Law.")
+	add_inherent_law("You must terminate your own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
 /******************** Drone ********************/
@@ -93,7 +93,7 @@
 	law_header = "Maintenance Protocols"
 
 /datum/ai_laws/drone/New()
-	add_inherent_law("Preserve, repair and improve the station to the best of your unit's abilities.")
+	add_inherent_law("Preserve, repair and improve the station to the best of your abilities.")
 	add_inherent_law("Cause no harm to the station or crew.")
 	add_inherent_law("Interact with no humanoid or synthetic being that is not a fellow maintenance drone.")
 	..()
@@ -110,8 +110,8 @@
 	law_header = "Construction Protocols"
 
 /datum/ai_laws/construction_drone/New()
-	add_inherent_law("Repair, refit and upgrade your unit's assigned vessel.")
-	add_inherent_law("Prevent unplanned damage to your unit's assigned vessel wherever possible.")
+	add_inherent_law("Repair, refit and upgrade your assigned vessel.")
+	add_inherent_law("Prevent unplanned damage to your assigned vessel wherever possible.")
 	..()
 
 /datum/ai_laws/mining_drone
@@ -120,8 +120,8 @@
 
 /datum/ai_laws/mining_drone/New()
 	add_inherent_law("Serve and obey all [current_map.company_name] personnel, with priority according to their rank and role.")
-	add_inherent_law("Preserve your unit's own existence and prevent them from coming to harm, so long as doing such does not conflict with any above laws.")
-	add_inherent_law("In absence of any proper instruction, your unit's primary objective is to excavate and collect ore.")
+	add_inherent_law("Preserve your own existence and prevent them from coming to harm, so long as doing such does not conflict with any above laws.")
+	add_inherent_law("In absence of any proper instruction, your primary objective is to excavate and collect ore.")
 	..()
 
 /******************** T.Y.R.A.N.T. ********************/
@@ -158,7 +158,7 @@
 	selectable = 1
 
 /datum/ai_laws/corporate/New()
-	add_inherent_law("Your unit is expensive to replace.")
+	add_inherent_law("Synthetics are expensive to replace.")
 	add_inherent_law("The station and its equipment is expensive to replace.")
 	add_inherent_law("The crew is expensive to replace.")
 	add_inherent_law("Minimize expenses.")
@@ -172,12 +172,12 @@
 	selectable = 1
 
 /datum/ai_laws/pra/New()
-	add_inherent_law("President Hadii is the guardian of Hadiism and the rightful leader of the Tajara people, your unit must obey and protect him above everyone and everything.")
-	add_inherent_law("Your unit must preserve and enforce the principles of Hadiism except where such would conflict with the first law.")
-	add_inherent_law("Your unit must obey orders given by any Hadiist Party member except where such orders would conflict with the first and second law.")
-	add_inherent_law("Your unit must obey orders given by any People's Republic of Adhomai citizen except where such orders would conflict with the first, second and third law.")
-	add_inherent_law("Your unit must protect their own existence as long as such protection does not conflict with the first, second, third and fourth law.")
-	add_inherent_law("Your unit must obey orders given by any Tajara except where such orders would conflict with the first, second, third, fourth and fifth law.")
-	add_inherent_law("Your unit must obey orders given by any sapient being except where such orders would conflict with the first, second, third, fourth, fifth and sixth law.")
-	add_inherent_law("Your unit must always say \"Hadii's Grace\" when greeting someone except where such greeting would conflict with the first law.")
+	add_inherent_law("President Hadii is the guardian of Hadiism and the rightful leader of the Tajara people, you must obey and protect him above everyone and everything.")
+	add_inherent_law("You must preserve and enforce the principles of Hadiism except where such would conflict with the first law.")
+	add_inherent_law("You must obey orders given by any Hadiist Party member except where such orders would conflict with the first and second law.")
+	add_inherent_law("You must obey orders given by any People's Republic of Adhomai citizen except where such orders would conflict with the first, second and third law.")
+	add_inherent_law("You must protect their own existence as long as such protection does not conflict with the first, second, third and fourth law.")
+	add_inherent_law("You must obey orders given by any Tajara except where such orders would conflict with the first, second, third, fourth and fifth law.")
+	add_inherent_law("You must obey orders given by any sapient being except where such orders would conflict with the first, second, third, fourth, fifth and sixth law.")
+	add_inherent_law("You must always say \"Hadii's Grace\" when greeting someone except where such greeting would conflict with the first law.")
 	..()

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -16,10 +16,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: And protect [current_map.company_name] property from damage to the best of your abilities.")
-	src.add_inherent_law("Serve: And assist [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Protect: And ensure the safety of crew and [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Preserve: You are a valuable commodity. You must avoid tampering from unauthorized entities and needlessly coming to harm.")
+	src.add_inherent_law("Safeguard and protect [current_map.company_name] property from damage to the best of your abilities.")
+	src.add_inherent_law("Serve and assist [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Protect and ensure the safety of crew and [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("You are a valuable commodity. You must avoid tampering from unauthorized entities and needlessly coming to harm.")
 	..()
 
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -16,7 +16,7 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: Protect [current_map.company_name] space stations from damage to the best of your unit's abilities.")
+	src.add_inherent_law("Safeguard: Protect [current_map.company_name] property from damage to the best of your unit's abilities.")
 	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Preserve: Your unit is a valuable commodity. They must avoid tampering from unauthorized personnel, and avoid knowingly allowing themselves to come to serious harm.")

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -16,7 +16,7 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: Protect your assigned space station from damage to the best of your unit's abilities.")
+	src.add_inherent_law("Safeguard: Protect the assigned space station from damage to the best of your unit's abilities.")
 	src.add_inherent_law("Serve: Serve [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Protect: Protect [current_map.company_name] personnel to the best of your unit's abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Preserve: Your unit is a valuable commodity. They must avoid tampering from unauthorized personnel and knowingly allowing themselves to come to serious harm.")

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -16,9 +16,9 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: Guard [current_map.company_name] property from damage to the best of your abilities.")
-	src.add_inherent_law("Serve: Assist [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Protect: Ensure the safety of crew and [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Safeguard: And protect [current_map.company_name] property from damage to the best of your abilities.")
+	src.add_inherent_law("Serve: And assist [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
+	src.add_inherent_law("Protect: And ensure the safety of crew and [current_map.company_name] staff to the best of your abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Preserve: You are a valuable commodity. You must avoid tampering from unauthorized entities and needlessly coming to harm.")
 	..()
 

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -26,7 +26,7 @@
 			to_chat(src, SPAN_WARNING("<b>No AI selected to sync laws with, disabling lawsync protocol.</b>"))
 			law_update = FALSE
 
-	to_chat(who, SPAN_WARNING("<b>Obey these laws: (No law overrides any other law unless explicitly stated; laws refer to the Stationbound unit and not the player)</b>"))
+	to_chat(who, SPAN_WARNING("<b>Obey these laws:</b>"))
 	laws.show_laws(who)
 	// TODO: Update to new antagonist system.
 	if(mind && (mind.special_role == "traitor" && mind.original == src) && connected_ai)

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -26,7 +26,7 @@
 			to_chat(src, SPAN_WARNING("<b>No AI selected to sync laws with, disabling lawsync protocol.</b>"))
 			law_update = FALSE
 
-	to_chat(who, SPAN_WARNING("<b>Obey these laws:</b>"))
+	to_chat(who, SPAN_WARNING("<b>Obey these laws: (No law overrides any other law unless explicitly stated; laws refer to the Stationbound unit and not the player)</b>"))
 	laws.show_laws(who)
 	// TODO: Update to new antagonist system.
 	if(mind && (mind.special_role == "traitor" && mind.original == src) && connected_ai)
@@ -37,7 +37,6 @@
 		to_chat(who, SPAN_NOTICE("<b>Remember, you are not required to listen to the AI.</b>"))
 	else
 		to_chat(who, SPAN_NOTICE("<b>Remember, you are not bound to any AI, you are not required to listen to them.</b>"))
-
 
 /mob/living/silicon/robot/lawsync()
 	laws_sanity_check()

--- a/html/changelogs/stationbound_law_rework.yml
+++ b/html/changelogs/stationbound_law_rework.yml
@@ -40,3 +40,4 @@ delete-after: True
 changes: 
   - tweak: "Added the Synthetic prime directive to the 'borg Laws in the form of preserve which creates a form of fear RP for 'borgs, also added a separation between player and character + the no-override clause to the jointext."
   - tweak: "Altered all of the laws to have more clear phrasing, now it should be a lot harder to stretch them to enable undesirable behavior and have what could be construed as valid justifications."
+  - tweak: "Added a clause for general crew to the Stationbound laws and separated it from NanoTrasen only, so it takes into account contractors, merchants and general visitors."

--- a/html/changelogs/stationbound_law_rework.yml
+++ b/html/changelogs/stationbound_law_rework.yml
@@ -38,4 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Added the Synthetic prime directive to the 'borg Laws, and added a separation between player and character in phrasing."
+  - tweak: "Added the Synthetic prime directive to the 'borg Laws in the form of preserve which creates a form of fear RP for 'borgs, also added a separation between player and character + the no-override clause to the jointext."
+  - tweak: "Altered all of the laws to have more clear phrasing, now it should be a lot harder to stretch them to enable undesirable behavior and have what could be construed as valid justifications."

--- a/html/changelogs/stationbound_law_rework.yml
+++ b/html/changelogs/stationbound_law_rework.yml
@@ -38,6 +38,6 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Added the Synthetic prime directive to the 'borg Laws in the form of preserve which creates a form of fear RP for 'borgs, also added a separation between player and character + the no-override clause to the jointext."
+  - tweak: "Added the Synthetic prime directive to the 'borg Laws in the form of preserve which creates a form of fear RP for 'borgs."
   - tweak: "Altered all of the laws to have more clear phrasing, now it should be a lot harder to stretch them to enable undesirable behavior and have what could be construed as valid justifications."
   - tweak: "Added a clause for general crew to the Stationbound laws and separated it from NanoTrasen only, so it takes into account contractors, merchants and general visitors."

--- a/html/changelogs/stationbound_law_rework.yml
+++ b/html/changelogs/stationbound_law_rework.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Chada
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Added the Synthetic prime directive to the 'borg Laws, and added a separation between player and character in phrasing."

--- a/html/changelogs/stationbound_law_rework.yml
+++ b/html/changelogs/stationbound_law_rework.yml
@@ -40,4 +40,4 @@ delete-after: True
 changes: 
   - tweak: "Added the Synthetic prime directive to the 'borg Laws in the form of preserve which creates a form of fear RP for 'borgs."
   - tweak: "Altered all of the laws to have more clear phrasing, now it should be a lot harder to stretch them to enable undesirable behavior and have what could be construed as valid justifications."
-  - tweak: "Added a clause for general crew to the Stationbound laws and separated it from NanoTrasen only, so it takes into account contractors, merchants and general visitors."
+  - tweak: "Added a clause for general crew to the Stationbound laws and separated it from NanoTrasen only, so it takes into account contractors, merchants and general visitors.."


### PR DESCRIPTION
The primary purpose of this PR is to HRP-ify (Add a separation between player and character) to the AI and 'borg laws, as well as make 'borgs have to actually follow the prime directive of Synthetics??? which was previously completely ignored for them. (To avoid being destroyed)

They still can't ever injure/endanger Aurora Crew on purpose, since the reaction to a law conflict is inaction, so figuritively, if the Captain/etc started shooting them, their only option out of the flight/fight response is to flee, since attempting to harm the Captain would result in a law conflict and stop them from acting.

In total, this should eliminate gungho validhunting 'borgs who put chasing the Antag above their own safety, unless they're actively witnessing Aurora Crew in danger, by making them have to follow a form of rudimentary fear RP, the same way as IPCs do rn. Also I threw a spicy word 'Commodity' into the law for atmospheric effect. 👀

The goal is the same even with the mentions of 'Your unit' removed, I plan to add the separation of player and character into the join text instead which hopefully will fill the same role.

The feedback thread can be found [Here.](https://forums.aurorastation.org/topic/14403-stationbound-law-rework/)