### PR TITLE
Scorched Skeletron Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -14,6 +14,8 @@
 		var/fire_dmg = getFireLoss()
 		if(fire_dmg > maxHealth * 3)
 			ChangeToSkeleton()
+			real_name = "Unknown"
+			name = real_name
 		else if(fire_dmg > maxHealth * 1.5)
 			ChangeToHusk()
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -261,7 +261,7 @@ There are several things that need to be remembered:
 	if (!base_icon)	// Icon ain't in the cache, so generate it.
 		//BEGIN CACHED ICON GENERATION.
 		var/obj/item/organ/external/chest = get_organ(BP_CHEST)
-		base_icon = chest.get_icon()
+		base_icon = chest.get_icon(skeleton)
 
 		for(var/obj/item/organ/external/part in organs)
 			if(isnull(part) || part.is_stump())

--- a/html/changelogs/geeves-skeletron_fix.yml
+++ b/html/changelogs/geeves-skeletron_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Burning into a skeleton now properly makes you unidentifiable, and no longer keeps your species torso."


### PR DESCRIPTION
* Burning into a skeleton now properly makes you unidentifiable, and no longer keeps your species torso.