### PR TITLE
Crucial Stationbound information added to show laws.

### DIFF
--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -28,7 +28,7 @@
 
 	to_chat(who, SPAN_WARNING("<b>Obey these laws:</b>"))
 	laws.show_laws(who)
-	to_chat(who, SPAN_WARNING("<b>(No law overrides any other law unless explicitly stated; laws refer to the Stationbound unit and not the player)</b>"))
+	to_chat(who, SPAN_WARNING("<b>(No law overrides any other law unless explicitly stated; laws refer to the stationbound unit and not the player)</b>"))
 	// TODO: Update to new antagonist system.
 	if(mind && (mind.special_role == "traitor" && mind.original == src) && connected_ai)
 		to_chat(who, SPAN_NOTICE("<b>Remember, [connected_ai.name] is technically your master, but your objective comes first.</b>"))

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -26,8 +26,9 @@
 			to_chat(src, SPAN_WARNING("<b>No AI selected to sync laws with, disabling lawsync protocol.</b>"))
 			law_update = FALSE
 
-	to_chat(who, SPAN_WARNING("<b>Obey these laws: (No law overrides any other law unless explicitly stated; laws refer to the Stationbound unit and not the player)</b>"))
+	to_chat(who, SPAN_WARNING("<b>Obey these laws:</b>"))
 	laws.show_laws(who)
+	to_chat(who, SPAN_WARNING("<b>(No law overrides any other law unless explicitly stated; laws refer to the Stationbound unit and not the player)</b>"))
 	// TODO: Update to new antagonist system.
 	if(mind && (mind.special_role == "traitor" && mind.original == src) && connected_ai)
 		to_chat(who, SPAN_NOTICE("<b>Remember, [connected_ai.name] is technically your master, but your objective comes first.</b>"))

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -26,7 +26,7 @@
 			to_chat(src, SPAN_WARNING("<b>No AI selected to sync laws with, disabling lawsync protocol.</b>"))
 			law_update = FALSE
 
-	to_chat(who, SPAN_WARNING("<b>Obey these laws:</b>"))
+	to_chat(who, SPAN_WARNING("<b>Obey these laws: (No law overrides any other law unless explicitly stated; laws refer to the Stationbound unit and not the player)</b>"))
 	laws.show_laws(who)
 	// TODO: Update to new antagonist system.
 	if(mind && (mind.special_role == "traitor" && mind.original == src) && connected_ai)

--- a/html/changelogs/showlawsinfo.yml
+++ b/html/changelogs/showlawsinfo.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Chada
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Added a separation between player and character to the show laws info for 'borgs and AI."


### PR DESCRIPTION
Just as it says on the tin here, this was split from [#8957](https://github.com/Aurorastation/Aurora.3/pull/8957)
And exists to make reverting that PR during a testmerge leave this info intact.