### PR TITLE
Fix mounted (sub)machine gun using safeties

### DIFF
--- a/code/modules/mob/living/silicon/robot/syndicate_robot.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate_robot.dm
@@ -93,6 +93,7 @@
 		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4,    burst_accuracy=list(0,-1,-1),       dispersion=list(0, 15, 15)),
 		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=4,    burst_accuracy=list(0,-1,-1,-2,-2), dispersion=list(0, 15, 15, 18, 18, 20))
 		)
+	has_safety = FALSE
 
 /obj/item/gun/energy/crossbow/cyborg
 	name = "mounted energy-crossbow"

--- a/html/changelogs/skull132-safety_fix.yml
+++ b/html/changelogs/skull132-safety_fix.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - bugfix: "Mounted (sub)machinegun for mechs now works again. It had its safety enabled otherwise."


### PR DESCRIPTION
The mounted machine guns had a safety, which started as set to 1. This caused it being unable to function when mounted. This is fixed by removing the safety from the weapon class used.