### PR TITLE
Fixes augment spawning and tweaks names of language processors slightly

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -901,7 +901,13 @@
 				to_chat(H, SPAN_WARNING("Your current job or whitelist status does not permit you to spawn with [thing]!"))
 				continue
 
-			var/obj/item/organ/A = new G.path(H)
+			var/metadata
+			var/list/gear_test = prefs.gear[G.display_name]
+			if(gear_test?.len)
+				metadata = gear_test
+			else
+				metadata = list()
+			var/obj/item/organ/A = G.spawn_item(H, metadata)
 			var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
 			A.replaced(H, affected)
 			H.update_body()

--- a/code/modules/client/preference_setup/loadout/loadout_xeno/vaurca.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/vaurca.dm
@@ -123,7 +123,7 @@
 
 /datum/gear/augment/language_processor/New()
 	..()
-	var/language_processor = list()
-	language_processor["klaxan sinta unathi language processor"] = /obj/item/organ/internal/augment/language/klax
-	language_processor["cthur nral malic language processor"] = /obj/item/organ/internal/augment/language/cthur
-	gear_tweaks += new /datum/gear_tweak/path(language_processor)
+	var/language_processors = list()
+	language_processors["K'laxan [LANGUAGE_UNATHI] language processor"] = /obj/item/organ/internal/augment/language/klax
+	language_processors["C'thur [LANGUAGE_SKRELLIAN] language processor"] = /obj/item/organ/internal/augment/language/cthur
+	gear_tweaks += new /datum/gear_tweak/path(language_processors)

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -328,9 +328,9 @@
 	owner.set_default_language(pick(owner.languages))
 
 /obj/item/organ/internal/augment/language/klax
-	name = "klaxan language processor"
+	name = "K'laxan language processor"
 	augment_languages = list(LANGUAGE_UNATHI)
 
 /obj/item/organ/internal/augment/language/cthur
-	name = "cthur language processor"
+	name = "C'thur language processor"
 	augment_languages = list(LANGUAGE_SKRELLIAN)

--- a/html/changelogs/MDP-fixes_bug_bugs.yml
+++ b/html/changelogs/MDP-fixes_bug_bugs.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MoondancerPony
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changes the capitalisation of the language processors slightly."
+  - bugfix: "You can now actually spawn with the implant you have selected."


### PR DESCRIPTION
* Augments now apply metadata.
* Language processors now use the proper language macros (if the name is changed in the future) and are capitalised, as hives are technically cultures and should be capitalised.