### PR TITLE
Drill Bracing Fix

### DIFF
--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -351,15 +351,13 @@
 /obj/machinery/mining/drill/proc/check_supports()
 	supported = FALSE
 
-	if((!supports || !supports.len) && initial(anchored) == 0)
-		icon_state = "mining_drill"
-		anchored = FALSE
-		active = FALSE
-	else
-		anchored = TRUE
-
 	if(supports && length(supports) >= braces_needed)
 		supported = TRUE
+		anchored = TRUE
+	else
+		icon_state = "mining_drill"
+		active = FALSE
+		anchored = FALSE
 
 	update_icon()
 
@@ -490,6 +488,10 @@
 			connect()
 		else
 			disconnect()
+
+/obj/machinery/mining/brace/Destroy()
+	disconnect()
+	return ..()
 
 /obj/machinery/mining/brace/proc/connect()
 	var/turf/T = get_step(get_turf(src), src.dir)

--- a/html/changelogs/geeves-drill_deletion.yml
+++ b/html/changelogs/geeves-drill_deletion.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Drills are no longer permanently rooted in place if one of their braces explodes or gets deleted."


### PR DESCRIPTION
* Drills are no longer permanently rooted in place if one of their braces explodes or gets deleted.

Fixes https://github.com/Aurorastation/Aurora.3/issues/8982