### PR TITLE
Smokepops

### DIFF
--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -45,3 +45,9 @@
 	desc = "Designed to both hide identities and keep your face comfy and warm."
 	item_cost = 1
 	path = /obj/item/clothing/mask/balaclava/grey
+
+/datum/uplink_item/item/stealth_items/stealthpop
+	name = "Stealthpops"
+	desc = "Snap pops with a compound added which deploys a small smokescreen upon exploding."
+	item_cost = 1
+	path = /obj/item/storage/box/snappops/syndi

--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -31,6 +31,7 @@
 
 /datum/uplink_item/item/stealth_items/chameleon_projector
 	name = "Chameleon-Projector"
+	desc = "A device that can be used to mimic common items by scanning, then transforming into them."
 	item_cost = 8
 	path = /obj/item/device/chameleon
 

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -1,15 +1,16 @@
 /obj/item/device/chameleon
 	name = "chameleon projector"
+	desc_antag = "This device can let you disguise as common objects. Click on an object with this in your active hand to scan it, then activate it to use it in your hand."
 	icon_state = "shield0"
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	item_state = "electronic"
-	throwforce = 5.0
+	throwforce = 5
 	throw_speed = 1
 	throw_range = 5
-	w_class = 2.0
+	w_class = ITEMSIZE_SMALL
 	origin_tech = list(TECH_ILLEGAL = 4, TECH_MAGNET = 4)
-	var/can_use = 1
+	var/can_use = TRUE
 	var/obj/effect/dummy/chameleon/active_dummy = null
 	var/saved_item = /obj/item/trash/cigbutt
 	var/saved_icon = 'icons/obj/clothing/masks.dmi'
@@ -28,7 +29,8 @@
 	toggle()
 
 /obj/item/device/chameleon/afterattack(atom/target, mob/user , proximity)
-	if(!proximity) return
+	if(!proximity)
+		return
 	if(!active_dummy)
 		if(istype(target,/obj/item) && !istype(target, /obj/item/disk/nuclear))
 			playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
@@ -39,7 +41,8 @@
 			saved_overlays = target.overlays
 
 /obj/item/device/chameleon/proc/toggle()
-	if(!can_use || !saved_item) return
+	if(!can_use || !saved_item)
+		return
 	if(active_dummy)
 		eject_all()
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
@@ -53,7 +56,8 @@
 	else
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
 		var/obj/O = new saved_item(src)
-		if(!O) return
+		if(!O)
+			return
 		var/obj/effect/dummy/chameleon/C = new /obj/effect/dummy/chameleon(usr.loc)
 		C.activate(O, usr, saved_icon, saved_icon_state, saved_overlays, src)
 		qdel(O)
@@ -83,9 +87,9 @@
 /obj/effect/dummy/chameleon
 	name = ""
 	desc = ""
-	density = 0
-	anchored = 1
-	var/can_move = 1
+	density = FALSE
+	anchored = TRUE
+	var/can_move = TRUE
 	var/obj/item/device/chameleon/master = null
 
 /obj/effect/dummy/chameleon/proc/activate(var/obj/O, var/mob/M, new_icon, new_iconstate, new_overlays, var/obj/item/device/chameleon/C)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -327,25 +327,38 @@
 	drop_sound = 'sound/items/drop/food.ogg'
 	pickup_sound = 'sound/items/pickup/food.ogg'
 
-	throw_impact(atom/hit_atom)
-		..()
-		spark(src, 3, alldirs)
-		new /obj/effect/decal/cleanable/ash(src.loc)
-		src.visible_message("<span class='warning'>The [src.name] explodes!</span>","<span class='warning'>You hear a snap!</span>")
-		playsound(src, 'sound/effects/snap.ogg', 50, 1)
-		qdel(src)
+/obj/item/toy/snappop/attack_self(mob/user)
+	user.drop_from_inventory(src)
+	user.visible_message(SPAN_WARNING("\The [user] throws \the [src] at their feet!"), SPAN_NOTICE("You throw \the [src] at your feet."))
+	do_pop()
+
+/obj/item/toy/snappop/throw_impact(atom/hit_atom)
+	..()
+	do_pop()
 
 /obj/item/toy/snappop/Crossed(H as mob|obj)
 	if((ishuman(H))) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
 		if(M.m_intent == "run")
-			to_chat(M, "<span class='warning'>You step on the snap pop!</span>")
+			to_chat(M, SPAN_WARNING("You step on the snap pop!"))
+			do_pop()
 
-			spark(src, 2)
-			new /obj/effect/decal/cleanable/ash(src.loc)
-			src.visible_message("<span class='warning'>The [src.name] explodes!</span>","<span class='warning'>You hear a snap!</span>")
-			playsound(src, 'sound/effects/snap.ogg', 50, 1)
-			qdel(src)
+/obj/item/toy/snappop/proc/do_pop()
+	spark(src, 3, alldirs)
+	new /obj/effect/decal/cleanable/ash(get_turf(src))
+	visible_message(SPAN_WARNING("\The [src] explodes!"), SPAN_WARNING("You hear a snap!"))
+	playsound(get_turf(src), 'sound/effects/snap.ogg', 50, TRUE)
+	qdel(src)
+
+/obj/item/toy/snappop/syndi
+	desc_antag = "These snap pops have an extra compound added that will deploy a tiny smokescreen when snapped."
+
+/obj/item/toy/snappop/syndi/do_pop()
+	var/datum/effect/effect/system/smoke_spread/smoke = new /datum/effect/effect/system/smoke_spread
+	smoke.set_up(2, 0, get_turf(src))
+	smoke.attach(get_turf(src))
+	smoke.start()
+	..()
 
 /*
  * Water flower

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -486,6 +486,10 @@
 	can_hold = list(/obj/item/toy/snappop)
 	starts_with = list(/obj/item/toy/snappop = 8)
 
+/obj/item/storage/box/snappops/syndi
+	desc_antag = "These snap pops have an extra compound added that will deploy a tiny smokescreen when snapped."
+	starts_with = list(/obj/item/toy/snappop/syndi = 8)
+
 /obj/item/storage/box/matches
 	name = "matchbox"
 	desc = "A small box of 'Space-Proof' premium matches."

--- a/html/changelogs/geeves-smokepops.yml
+++ b/html/changelogs/geeves-smokepops.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added the ability to throw snap pops at your feet by simply activating them in hand, or clicking them in hand."
+  - rscadd: "Added smokepops, snap pops that deploy a small smokescreen. Added to the stealth and camouflage uplink for 1 TC."

--- a/html/changelogs/geeves-smokepops.yml
+++ b/html/changelogs/geeves-smokepops.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes: 
   - rscadd: "Added the ability to throw snap pops at your feet by simply activating them in hand, or clicking them in hand."
   - rscadd: "Added smokepops, snap pops that deploy a small smokescreen. Added to the stealth and camouflage uplink for 1 TC."
+  - bugfix: "Fixed chameleon projector description in the uplink."


### PR DESCRIPTION
* Added the ability to throw snap pops at your feet by simply activating them in hand, or clicking them in hand.
* Added smokepops, snap pops that deploy a small smokescreen. Added to the stealth and camouflage uplink for 1 TC.
* Fixed chameleon projector description in the uplink.