### PR TITLE
Kataphract K'lax Augments

### DIFF
--- a/code/datums/outfits/ert/kataphract.dm
+++ b/code/datums/outfits/ert/kataphract.dm
@@ -71,6 +71,11 @@
 		var/obj/item/clothing/shoes/magboots/hegemony/boots = new(H)
 		H.equip_to_slot_if_possible(boots, slot_shoes)
 
+	var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/klax(H)
+	var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+	A.replaced(H, affected)
+	H.update_body()
+
 /datum/outfit/admin/ert/kataphract/specialist
 	name = "Kataphract-Hopeful Spec."
 

--- a/code/modules/ghostroles/spawner/human/kataphract.dm
+++ b/code/modules/ghostroles/spawner/human/kataphract.dm
@@ -133,6 +133,11 @@
 	if(H?.shoes)
 		H.shoes.color = uniform_colour
 
+	var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/klax(H)
+	var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+	A.replaced(H, affected)
+	H.update_body()
+
 /datum/outfit/admin/kataphract/knight
 	name = "Kataphract Knight"
 

--- a/html/changelogs/geeves-hopeful_speaks.yml
+++ b/html/changelogs/geeves-hopeful_speaks.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Kataphract K'lax now spawn in with the Sinta'Unathi augment, allowing them to speak with their teammates."


### PR DESCRIPTION
* Kataphract K'lax now spawn in with the Sinta'Unathi augment, allowing them to speak with their teammates.