### PR TITLE
Newscaster ID Grabbing

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -955,33 +955,19 @@ obj/item/newspaper/attackby(obj/item/W as obj, mob/user as mob)
 
 ////////////////////////////////////helper procs
 
-
-/obj/machinery/newscaster/proc/scan_user(mob/living/user as mob)
-	if(istype(user,/mob/living/carbon/human))                       //User is a human
-		var/mob/living/carbon/human/human_user = user
-		if(human_user.wear_id)                                      //Newscaster scans you
-			if(istype(human_user.wear_id, /obj/item/device/pda) )	//autorecognition, woo!
-				var/obj/item/device/pda/P = human_user.wear_id
-				if(P.id)
-					src.scanned_user = GetNameAndAssignmentFromId(P.id)
-				else
-					src.scanned_user = "Unknown"
-			else if(istype(human_user.wear_id, /obj/item/card/id) )
-				var/obj/item/card/id/ID = human_user.wear_id
-				src.scanned_user = GetNameAndAssignmentFromId(ID)
-			else if(istype(human_user.wear_id, /obj/item/storage/wallet))
-				var/obj/item/storage/wallet/W = human_user.wear_id
-				if(W.GetID())
-					src.scanned_user = GetNameAndAssignmentFromId(W.GetID())
-				else
-					src.scanned_user = "Unknown"
-			else
-				src.scanned_user ="Unknown"
+// Newscaster scans you
+// autorecognition, woo!
+/obj/machinery/newscaster/proc/scan_user(mob/living/user)
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = user
+		var/obj/item/card/id/ID = H.GetIdCard()
+		if(ID)
+			scanned_user = GetNameAndAssignmentFromId(ID)
 		else
-			src.scanned_user ="Unknown"
+			scanned_user = "Unknown"
 	else
 		var/mob/living/silicon/ai_user = user
-		src.scanned_user = "[ai_user.name] ([ai_user.job])"
+		scanned_user = "[ai_user.name] ([ai_user.job])"
 
 
 /obj/machinery/newscaster/proc/print_paper()

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -958,7 +958,7 @@ obj/item/newspaper/attackby(obj/item/W as obj, mob/user as mob)
 // Newscaster scans you
 // autorecognition, woo!
 /obj/machinery/newscaster/proc/scan_user(mob/living/user)
-	if(istype(user, /mob/living/carbon/human))
+	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/card/id/ID = H.GetIdCard()
 		if(ID)

--- a/html/changelogs/geeves-newscaster_wristbound.yml
+++ b/html/changelogs/geeves-newscaster_wristbound.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Newscasters now tend to always get your ID if it's in your ID slot, hand, or glove slot."


### PR DESCRIPTION
* Newscasters now tend to always get your ID if it's in your ID slot, hand, or glove slot.

Fixes https://github.com/Aurorastation/Aurora.3/issues/9006