### PR TITLE
Fixes a runtime during roundstart

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -147,7 +147,8 @@
 
 	if (client)
 		var/turf/B = GetAbove(T)
-		up_hint.icon_state = "uphint[(B ? !!B.is_hole : 0)]"
+		if(up_hint)
+			up_hint.icon_state = "uphint[(B ? !!B.is_hole : 0)]"
 
 	if (is_noisy && !stat && !lying)
 		if ((x == last_x && y == last_y) || !footsound)


### PR DESCRIPTION
When mobs spawn for the first time, they call Move()
Move then changes the icon state of the up_hint, however, up_hint is at this point not initialized, so it runtimes instead