### PR TITLE
Fixes firemodes being a footgun

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -8,6 +8,7 @@
 /datum/firemode
 	var/name = "default"
 	var/list/settings = list()
+	var/list/original_settings
 
 /datum/firemode/New(obj/item/gun/gun, list/properties = null)
 	..()
@@ -24,8 +25,19 @@
 			settings[propname] = propvalue
 
 /datum/firemode/proc/apply_to(obj/item/gun/gun)
+	LAZYINITLIST(original_settings)
+
 	for(var/propname in settings)
+		original_settings[propname] = gun.vars[propname]
 		gun.vars[propname] = settings[propname]
+
+/datum/firemode/proc/unapply_to(obj/item/gun/gun)
+	if (LAZYLEN(original_settings))
+		for (var/propname in settings)
+			gun.vars[propname] = original_settings[propname]
+
+		LAZYCLEARLIST(original_settings)
+		original_settings = null
 
 //Parent gun type. Guns are weapons that can be aimed at mobs and act over a distance
 /obj/item/gun
@@ -583,6 +595,9 @@
 /obj/item/gun/proc/switch_firemodes()
 	if(!firemodes.len)
 		return null
+
+	var/datum/firemode/old_mode = firemodes[sel_mode]
+	old_mode.unapply_to(src)
 
 	sel_mode++
 	if(sel_mode > firemodes.len)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -33,7 +33,7 @@
 
 /datum/firemode/proc/unapply_to(obj/item/gun/gun)
 	if (LAZYLEN(original_settings))
-		for (var/propname in settings)
+		for (var/propname in original_settings)
 			gun.vars[propname] = original_settings[propname]
 
 		LAZYCLEARLIST(original_settings)

--- a/code/modules/projectiles/guns/energy/lawgiver.dm
+++ b/code/modules/projectiles/guns/energy/lawgiver.dm
@@ -23,10 +23,7 @@
 			charge_cost = 50,
 			fire_delay = 3,
 			recoil = 1,
-			burst = null,
-			move_delay = null,
 			accuracy = 1,
-			dispersion = null,
 			projectile_type = /obj/item/projectile/bullet/pistol,
 			fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 		),
@@ -47,10 +44,7 @@
 			charge_cost = 400,
 			fire_delay = 6,
 			recoil = 3,
-			burst = null,
-			move_delay = null,
 			accuracy = 0,
-			dispersion = null,
 			projectile_type = /obj/item/projectile/bullet/gyro/law,
 			fire_sound = 'sound/effects/Explosion1.ogg'
 		),
@@ -59,10 +53,7 @@
 			charge_cost = 50,
 			fire_delay = 4,
 			recoil = 0,
-			burst = null,
-			move_delay = null,
 			accuracy = 1,
-			dispersion = null,
 			projectile_type = /obj/item/projectile/energy/electrode,
 			fire_sound = 'sound/weapons/Taser.ogg'
 		),
@@ -71,10 +62,7 @@
 			charge_cost = 250,
 			fire_delay = 4,
 			recoil = 3,
-			burst = null,
-			move_delay = null,
 			accuracy = 1,
-			dispersion = null,
 			projectile_type = /obj/item/projectile/bullet/shotgun/incendiary,
 			fire_sound = 'sound/weapons/gunshot/gunshot1.ogg'
 		),
@@ -83,10 +71,7 @@
 			charge_cost = 130,
 			fire_delay = 6,
 			recoil = 3,
-			burst = null,
-			move_delay = null,
 			accuracy = 1,
-			dispersion = null,
 			projectile_type = /obj/item/projectile/bullet/rifle/a556,
 			fire_sound = 'sound/weapons/gunshot/gunshot1.ogg'
 		),
@@ -95,10 +80,7 @@
 			charge_cost = 250,
 			fire_delay = 6,
 			recoil = 3,
-			burst = null,
-			move_delay = null,
 			accuracy = 0,
-			dispersion = null,
 			projectile_type = /obj/item/projectile/bullet/pellet/shotgun,
 			fire_sound = 'sound/weapons/gunshot/gunshot1.ogg'
 		)

--- a/code/modules/projectiles/guns/energy/lawgiver.dm
+++ b/code/modules/projectiles/guns/energy/lawgiver.dm
@@ -175,6 +175,8 @@
 	return
 
 /obj/item/gun/energy/lawgiver/proc/hear(var/msg)
+	var/datum/firemode/old_mode = firemodes[sel_mode]
+
 	var/list/replacechars = list("'" = "","\"" = "",">" = "","<" = "","(" = "",")" = ""," " = "")
 	msg = sanitize_old(msg, replacechars)
 	/* Firing Modes*/
@@ -218,6 +220,7 @@
 		play_message()
 
 	if(mode_check != sel_mode)
+		old_mode.unapply_to(src)
 		var/datum/firemode/new_mode = firemodes[sel_mode]
 		new_mode.apply_to(src)
 		mode_check = sel_mode

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -19,8 +19,8 @@
 	turret_is_lethal = 1
 
 	firemodes = list(
-		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, fire_sound='sound/weapons/Taser.ogg', fire_delay=null, charge_cost=null),
-		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam, fire_sound='sound/weapons/Laser.ogg', fire_delay=null, charge_cost=null),
+		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, fire_sound='sound/weapons/Taser.ogg'),
+		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam, fire_sound='sound/weapons/Laser.ogg'),
 		list(mode_name="DESTROY", projectile_type=/obj/item/projectile/beam/pulse, fire_sound='sound/weapons/pulse.ogg', fire_delay=25)
 		)
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -456,10 +456,10 @@
 	is_wieldable = TRUE
 
 	firemodes = list(
-		list(mode_name="2 second burst", can_autofire = FALSE, burst=10, burst_delay = 1, fire_delay = 20, burst_accuracy = null, dispersion = null),
-		list(mode_name="4 second burst", can_autofire = FALSE, burst=20, burst_delay = 1, fire_delay = 40, burst_accuracy = null, dispersion = null),
-		list(mode_name="6 second burst", can_autofire = FALSE, burst=30, burst_delay = 1, fire_delay = 60, burst_accuracy = null, dispersion = null),
-		list(mode_name="point-burst auto", can_autofire = TRUE, burst = 1, burst_delay = null, fire_delay = 1, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(1.0, 1.0, 1.0, 1.0, 1.2))
+		list(mode_name="2 second burst", burst=10, burst_delay = 1, fire_delay = 20),
+		list(mode_name="4 second burst", burst=20, burst_delay = 1, fire_delay = 40),
+		list(mode_name="6 second burst", burst=30, burst_delay = 1, fire_delay = 60),
+		list(mode_name="point-burst auto", can_autofire = TRUE, burst = 1, fire_delay = 1, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(1.0, 1.0, 1.0, 1.0, 1.2))
 		)
 
 	action_button_name = "Wield thermal drill"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -17,9 +17,9 @@
 	sel_mode = 1
 
 	firemodes = list(
-		list(mode_name="semiauto",       can_autofire=0, burst=1, fire_delay=null, move_delay=null,     burst_accuracy=null,            dispersion=null),
-		list(mode_name="3-round bursts", can_autofire=0, burst=3, fire_delay=null, move_delay=null,    burst_accuracy=list(1,0,0),      dispersion=list(0, 10, 15)),
-		list(mode_name="short bursts",   can_autofire=0, burst=5, fire_delay=null, move_delay=null,    burst_accuracy=list(1,0,,-1,-1), dispersion=list(5, 10, 15, 20)),
+		list(mode_name="semiauto",       can_autofire=0, burst=1),
+		list(mode_name="3-round bursts", can_autofire=0, burst=3, burst_accuracy=list(1,0,0), dispersion=list(0, 10, 15)),
+		list(mode_name="short bursts",   can_autofire=0, burst=5, burst_accuracy=list(1,0,,-1,-1), dispersion=list(5, 10, 15, 20)),
 		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=1, one_hand_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(1.0, 1.0, 1.0, 1.0, 1.2))
 		)
 
@@ -118,9 +118,9 @@
 	is_wieldable = TRUE
 
 	firemodes = list(
-		list(mode_name="semiauto",       burst=1, fire_delay=10,   move_delay=null, burst_accuracy=null, dispersion=null),
-		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=null,    burst_accuracy=list(1,0,0),       dispersion=list(0, 5, 10)),
-		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=null,    burst_accuracy=list(1,0,0,-1,-1), dispersion=list(5, 5, 15)),
+		list(mode_name="semiauto",       burst=1, fire_delay=10),
+		list(mode_name="3-round bursts", burst=3, burst_accuracy=list(1,0,0),       dispersion=list(0, 5, 10)),
+		list(mode_name="short bursts",   burst=5, burst_accuracy=list(1,0,0,-1,-1), dispersion=list(5, 5, 15)),
 		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=1, one_hand_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(1.0, 1.0, 1.0, 1.0, 1.2)),
 		)
 
@@ -202,9 +202,9 @@
 
 	burst_delay = 4
 	firemodes = list(
-		list(mode_name="semiauto",       burst=1,    fire_delay=10,   move_delay=null, use_launcher=null, burst_accuracy=null, dispersion=null),
-		list(mode_name="3-round bursts", burst=3,    fire_delay=null, move_delay=null,    use_launcher=null, burst_accuracy=list(2,1,1), dispersion=list(0, 7.5)),
-		list(mode_name="fire grenades",  burst=null, fire_delay=null, move_delay=null, use_launcher=1,    burst_accuracy=null, dispersion=null)
+		list(mode_name="semiauto", burst=1, fire_delay=10),
+		list(mode_name="3-round bursts", burst=3, burst_accuracy=list(2,1,1), dispersion=list(0, 7.5)),
+		list(mode_name="fire grenades", use_launcher=1)
 		)
 
 	var/use_launcher = 0
@@ -274,9 +274,9 @@
 	magazine_type = /obj/item/ammo_magazine/a762
 
 	firemodes = list(
-		list(mode_name="short bursts",	burst=5, move_delay=null, burst_accuracy = list(1,0,0,-1,-1),          dispersion = list(3, 6, 9)),
-		list(mode_name="long bursts",	burst=8, move_delay=null, burst_accuracy = list(1,0,0,-1,-1,-1,-2,-2), dispersion = list(8)),
-		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=1, one_hand_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(1.0, 1.0, 1.0, 1.0, 1.2))
+		list(mode_name="short bursts",	burst=5, burst_accuracy = list(1,0,0,-1,-1), dispersion = list(3, 6, 9)),
+		list(mode_name="long bursts",	burst=8, burst_accuracy = list(1,0,0,-1,-1,-1,-2,-2), dispersion = list(8)),
+		list(mode_name="full auto", can_autofire=1, burst=1, fire_delay=1, one_hand_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(1.0, 1.0, 1.0, 1.0, 1.2))
 		)
 
 	var/cover_open = 0
@@ -367,8 +367,8 @@
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 
 	firemodes = list(
-		list(mode_name="single coil", burst = 1, fire_delay = null,  move_delay = null, burst_accuracy = null, dispersion = null),
-		list(mode_name="dual coil",	  burst = 2, move_delay = 1, accuracy = list(-2,-3), dispersion = list(20))
+		list(mode_name="single coil", burst = 1),
+		list(mode_name="dual coil", burst = 2, move_delay = 1, accuracy = list(-2,-3), dispersion = list(20))
 		)
 
 
@@ -392,9 +392,9 @@
 	is_wieldable = TRUE
 
 	firemodes = list(
-		list(mode_name="semiauto",       burst=1, move_delay=null, burst_accuracy=null, dispersion=null),
-		list(mode_name="3-round bursts", burst=3, move_delay=null,    burst_accuracy=list(2,1,1),       dispersion=list(0, 10, 15)),
-		list(mode_name="short bursts",   burst=5, move_delay=null,    burst_accuracy=list(2,1,1,0,0), dispersion=list(5, 10, 15))
+		list(mode_name="semiauto", burst=1),
+		list(mode_name="3-round bursts", burst=3, burst_accuracy=list(2,1,1), dispersion=list(0, 10, 15)),
+		list(mode_name="short bursts", burst=5, burst_accuracy=list(2,1,1,0,0), dispersion=list(5, 10, 15))
 		)
 
 
@@ -443,8 +443,8 @@
 	accuracy_wielded = 0
 
 	firemodes = list(
-		list(mode_name="semiauto",       burst=1, fire_delay= 10,  move_delay=null, burst_accuracy=null, dispersion=null),
-		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=null,    burst_accuracy=list(0,-1,-1),       dispersion=list(0, 10, 15))
+		list(mode_name="semiauto", burst=1, fire_delay= 10),
+		list(mode_name="3-round bursts", burst=3, burst_accuracy=list(0,-1,-1), dispersion=list(0, 10, 15))
 		)
 
 /obj/item/gun/projectile/automatic/rifle/shotgun/update_icon()

--- a/code/modules/projectiles/guns/projectile/improvised.dm
+++ b/code/modules/projectiles/guns/projectile/improvised.dm
@@ -228,4 +228,4 @@
 
 	needspin = FALSE
 
-	firemodes = null
+	firemodes = list()

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -120,8 +120,8 @@
 	sel_mode = 1
 
 	firemodes = list(
-		list(mode_name="semiauto",       burst=1, fire_delay=0,    move_delay=null, burst_accuracy=null, dispersion=null),
-		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=null,    burst_accuracy=list(1,0,0),       dispersion=list(0, 10))
+		list(mode_name="semiauto", burst=1, fire_delay=0),
+		list(mode_name="3-round bursts", burst=3, burst_accuracy=list(1,0,0), dispersion=list(0, 10))
 		)
 
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -199,8 +199,8 @@
 	multi_aim = 0 //Definitely a fuck no. Being able to target one person at this range is plenty.
 
 	firemodes = list(
-		list(mode_name="semiauto",       burst=1, fire_delay=0,    move_delay=null, burst_accuracy=null, dispersion=null),
-		list(mode_name="2-round bursts", burst=2, fire_delay=null, move_delay=null,    burst_accuracy=list(0,-1,-1), dispersion=list(0, 8))
+		list(mode_name="semiauto", burst=1, fire_delay=0),
+		list(mode_name="2-round bursts", burst=2, burst_accuracy=list(0,-1,-1), dispersion=list(0, 8))
 		)
 
 /obj/item/gun/projectile/automatic/rifle/w556/verb/scope()


### PR DESCRIPTION
Issue: firemodes work by dynamically declaring a list of variables to change. But they do not restore the variables to original contents if you go off the firemode. So for example, if you have 1 firemode with `list(a = 2)` and a second with `list(b = 3)`, then upon cycling ONCE through BOTH, you end up with a gun with `a = 2` AND `b = 3` at the same time. This is because the firemodes do not restore the original state they had, and instead rely on the coder remembering to use default or null values _for the same keys_ on other firemodes to make sure they get reset. Because fuck.

Solution: we save the gun's state and apply it whenever we're done with a specific firemode, before applying a new firemode.