### PR TITLE
Renaming paper now adds the new name to the end of the paper's name.

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -120,8 +120,11 @@
 	var/n_name = sanitizeSafe(input(usr, "What would you like to label the paper?", "Paper Labelling", null) as text, MAX_NAME_LEN)
 
 	// We check loc one level up, so we can rename in clipboards and such. See also: /obj/item/photo/rename()
-	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0 && n_name)
-		name += " ([n_name])"
+	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0)
+		if(n_name)
+			name += " ([n_name])"
+		else
+			name = initial(name)
 		add_fingerprint(usr)
 
 /obj/item/paper/attack_self(mob/living/user as mob)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -4,7 +4,7 @@
  */
 
 /obj/item/paper
-	name = "sheet of paper"
+	name = "paper"
 	gender = NEUTER
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper"
@@ -93,7 +93,7 @@
 	if (old_name && icon_state == "paper_plane")
 		to_chat(user, span("notice", "You're going to have to unfold it before you can read it."))
 		return
-	if(name != "sheet of paper")
+	if(name != initial(name))
 		to_chat(user,"It's titled '[name]'.")
 	if(in_range(user, src) || isobserver(user))
 		show_content(usr)
@@ -117,11 +117,11 @@
 	if((usr.is_clumsy()) && prob(50))
 		to_chat(usr, span("warning", "You cut yourself on the paper."))
 		return
-	var/n_name = sanitizeSafe(input(usr, "What would you like to label the paper?", "Paper Labelling", null)  as text, MAX_NAME_LEN)
+	var/n_name = sanitizeSafe(input(usr, "What would you like to label the paper?", "Paper Labelling", null) as text, MAX_NAME_LEN)
 
 	// We check loc one level up, so we can rename in clipboards and such. See also: /obj/item/photo/rename()
 	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0 && n_name)
-		name = n_name
+		name += " ([n_name])"
 		add_fingerprint(usr)
 
 /obj/item/paper/attack_self(mob/living/user as mob)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -122,7 +122,7 @@
 	// We check loc one level up, so we can rename in clipboards and such. See also: /obj/item/photo/rename()
 	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0)
 		if(n_name)
-			name += " ([n_name])"
+			name = "[initial(name)] ([n_name])"
 		else
 			name = initial(name)
 		add_fingerprint(usr)

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -193,6 +193,8 @@
 	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0)
 		if(n_name)
 			name += " ([n_name])"
+		else
+			name = initial(name)
 	add_fingerprint(usr)
 	return
 

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -192,7 +192,7 @@
 	var/n_name = sanitizeSafe(input(usr, "What would you like to label the bundle?", "Bundle Labelling", null)  as text, MAX_NAME_LEN)
 	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0)
 		if(n_name)
-			name += " ([n_name])"
+			name = "[initial(name)] ([n_name])"
 		else
 			name = initial(name)
 	add_fingerprint(usr)

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -191,7 +191,8 @@
 
 	var/n_name = sanitizeSafe(input(usr, "What would you like to label the bundle?", "Bundle Labelling", null)  as text, MAX_NAME_LEN)
 	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0)
-		name = "[(n_name ? text("[n_name]") : "paper")]"
+		if(n_name)
+			name += " ([n_name])"
 	add_fingerprint(usr)
 	return
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -74,6 +74,8 @@ var/global/photo_count = 0
 	if(((loc == usr || (loc.loc && loc.loc == usr)) && usr.stat == 0))
 		if(n_name)
 			name += " ([n_name])"
+		else
+			name = initial(n_name)
 	add_fingerprint(usr)
 	return
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -71,8 +71,9 @@ var/global/photo_count = 0
 
 	var/n_name = sanitizeSafe(input(usr, "What would you like to label the photo?", "Photo Labelling", null)  as text, MAX_NAME_LEN)
 	//loc.loc check is for making possible renaming photos in clipboards
-	if(( (loc == usr || (loc.loc && loc.loc == usr)) && usr.stat == 0))
-		name = "[(n_name ? text("[n_name]") : "photo")]"
+	if(((loc == usr || (loc.loc && loc.loc == usr)) && usr.stat == 0))
+		if(n_name)
+			name += " ([n_name])"
 	add_fingerprint(usr)
 	return
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -73,7 +73,7 @@ var/global/photo_count = 0
 	//loc.loc check is for making possible renaming photos in clipboards
 	if(((loc == usr || (loc.loc && loc.loc == usr)) && usr.stat == 0))
 		if(n_name)
-			name += " ([n_name])"
+			name = "[initial(name)] ([n_name])"
 		else
 			name = initial(n_name)
 	add_fingerprint(usr)

--- a/html/changelogs/mattatlas-paper.yml
+++ b/html/changelogs/mattatlas-paper.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Renaming paper now adds the new name to the end of the paper name, so you get paper (fragmentation grenade), instead of just fragmentation grenade."
+  - tweak: "Renaming paper now adds the new name to the end of the paper name, so you get paper (fragmentation grenade), instead of just fragmentation grenade. To reset the name, just input a blank name."

--- a/html/changelogs/mattatlas-paper.yml
+++ b/html/changelogs/mattatlas-paper.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Renaming paper now adds the new name to the end of the paper name, so you get paper (fragmentation grenade), instead of just fragmentation grenade."


### PR DESCRIPTION
This fixes people being monkeys and renaming paper to "cryptographic sequencer" and hitting doors with it.