### PR TITLE
Mechanical organ repairs and minor augment fixes

### DIFF
--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -207,6 +207,7 @@
 	cooldown = 25
 	activable = TRUE
 	organ_tag = BP_AUG_EYE_SENSORS
+	parent_organ = BP_HEAD
 	action_button_name = "Toggle Eye Sensors"
 
 	var/static/list/hud_types = list(
@@ -256,6 +257,7 @@
 	cooldown = 20
 	action_button_icon = "cyber_hair"
 	organ_tag = BP_AUG_HAIR
+	parent_organ = BP_HEAD
 	activable = TRUE
 	action_button_name = "Activate Synthetic Hair Extensions"
 	species_restricted = list("Human","Off-Worlder Human", "Tajara", "Zhan-Khazan Tajara", "M'sai Tajara", "Shell Frame")

--- a/html/changelogs/augment_fixes-aleksix.yml
+++ b/html/changelogs/augment_fixes-aleksix.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: aleksix
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Hair extenstions and eye sensors augments now reside in a person's head."
+  - rscadd: "Added a way to repair mechanical organs, including augments, using nanopaste or ghetto methods of bone gel or screwdriver."


### PR DESCRIPTION
Mechanical organs in organics, including augments, can now be repaired. The procedure is the same as with normal internal organs, but requiring nanopaste, bone gel(30%) or a screwdriver(50%) to repair.
Additionally, eye sensors and hair extensions were moved from the chest to the head region.
Fixes #9022