### PR TITLE
Hydrogen ore processing fix

### DIFF
--- a/code/modules/mining/ore_datum.dm
+++ b/code/modules/mining/ore_datum.dm
@@ -135,7 +135,7 @@ var/global/list/ore_data = list()
 	worth = 15
 
 /ore/hydrogen
-	name = "hydrogen"
+	name = ORE_HYDROGEN
 	display_name = "metallic hydrogen"
 	smelts_to = "tritium"
 	compresses_to = "mhydrogen"

--- a/html/changelogs/hydrogen_processing-aleksix.yml
+++ b/html/changelogs/hydrogen_processing-aleksix.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - bugfix: "Hyrogen ore is now processed properly."
+  - bugfix: "Hydrogen ore is now processed properly."

--- a/html/changelogs/hydrogen_processing-aleksix.yml
+++ b/html/changelogs/hydrogen_processing-aleksix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: aleksix
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Hyrogen ore is now processed properly."


### PR DESCRIPTION
Hydrogen ore is now properly processed in the mining furnace. Will most likely contribute to the Drill Technician powercreep, as they generate a lot of hydrogen and hydrogen costs were unaffected by the fix.

Fixes #8980 