### PR TITLE
Round End Summary Fixes

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -155,7 +155,7 @@ var/datum/controller/subsystem/ticker/SSticker
 				pregame_timeleft = 1 SECOND
 				to_world("Reattempting gamemode selection.")
 
-/datum/controller/subsystem/ticker/proc/game_tick()
+/datum/controller/subsystem/ticker/proc/game_tick(var/force_end = FALSE)
 	if(current_state != GAME_STATE_PLAYING)
 		return 0
 
@@ -163,7 +163,10 @@ var/datum/controller/subsystem/ticker/SSticker
 
 	var/game_finished = 0
 	var/mode_finished = 0
-	if (config.continous_rounds)
+	if(force_end)
+		game_finished = TRUE
+		mode_finished = TRUE
+	else if(config.continous_rounds)
 		game_finished = (emergency_shuttle.returned() || mode.station_was_nuked)
 		mode_finished = (!post_game && mode.check_finished())
 	else

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -18,6 +18,7 @@
 	greet(target)
 	if(!gag_announcement)
 		announce_antagonist_spawn()
+	LAZYDISTINCTADD(SSticker.mode.antag_templates, src)
 
 /datum/antagonist/proc/create_default(var/mob/source)
 	var/mob/living/M

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -6,6 +6,7 @@
 	var/text = "<br><br><font size = 2><b>The [current_antagonists.len == 1 ? "[role_text] was" : "[role_text_plural] were"]:</b></font>"
 	for(var/datum/mind/P in current_antagonists)
 		text += print_player_full(P)
+		text += print_special_role_report(P)
 		text += get_special_objective_text(P)
 		if(P.ambitions)
 			text += "<br><font color='purple'><b>Their goals for today were:</b></font>"
@@ -46,6 +47,17 @@
 			text += "<font color='green'><B>Success!</B></font>"
 		else
 			text += "<font color='red'>Fail.</font>"
+	return text
+
+/datum/antagonist/proc/print_special_role_report(var/datum/mind/ply)
+	var/text = ""
+	if(length(ply.learned_spells))
+		text += "<br><br><b>[ply.name]'s spells were:</b><br>"
+		for(var/s in ply.learned_spells)
+			var/spell/spell = s
+			text += "<b>[spell.name]</b> - "
+			text += "Speed: [spell.spell_levels["speed"]] Power: [spell.spell_levels["power"]]"
+			text += "<br>"
 	return text
 
 /datum/antagonist/proc/print_player_lite(var/datum/mind/ply)

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -100,24 +100,6 @@ var/datum/antagonist/wizard/wizards
 		feedback_set_details("round_end_result","loss - wizard killed")
 		to_world("<span class='danger'><font size = 3>The [(current_antagonists.len>1)?"[role_text_plural] have":"[role_text] has"] been killed by the crew! The Space Wizards Federation has been taught a lesson they will not soon forget!</font></span>")
 
-/datum/antagonist/wizard/print_player_summary()
-	..()
-	for(var/p in current_antagonists)
-		var/datum/mind/player = p
-		var/text = "<b>[player.name]'s spells were:</b>"
-		if(!player.learned_spells || !player.learned_spells.len)
-			text += "<br>None!"
-		else
-			for(var/s in player.learned_spells)
-				var/spell/spell = s
-				text += "<br><b>[spell.name]</b> - "
-				text += "Speed: [spell.spell_levels["speed"]] Power: [spell.spell_levels["power"]]"
-		if(player.ambitions)
-			text += "<br><font color='purple'><b>Their goals for today were:</b></font>"
-			text += "<br>  '[player.ambitions]'"
-		text += "<br>"
-		to_world(text)
-
 
 //To batch-remove wizard spells. Linked to mind.dm.
 /mob/proc/spellremove()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -80,6 +80,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/allow_character_respawn,    // Allows a ghost to respawn ,
 	/client/proc/allow_stationbound_reset,
+	/client/proc/end_round,
 	/client/proc/event_manager_panel,
 	/client/proc/empty_ai_core_toggle_latejoin,
 	/client/proc/aooc,
@@ -312,6 +313,7 @@ var/list/admin_verbs_hideable = list(
 	/datum/admins/proc/toggleaban,
 	/client/proc/create_poll,
 	/client/proc/allow_stationbound_reset,
+	/client/proc/end_round,
 	/client/proc/toggle_log_hrefs,
 	/datum/admins/proc/immreboot,
 	/client/proc/cmd_dev_bst,
@@ -1165,6 +1167,20 @@ var/list/admin_verbs_cciaa = list(
 
 	log_and_message_admins("admin-wiped [key_name_admin(target)]'s core.")
 	target.do_wipe_core()
+
+/client/proc/end_round()
+	set name = "zEnd Roundz"
+	set desc = "This button will end the round."
+	set category = "Server"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(alert("Are you sure you want to end the round?", "Confirm Round End", "No", "No", "Yes") != "Yes")
+		return
+
+	log_and_message_admins("has ended the round with the End Round button.")
+	SSticker.game_tick(TRUE)
 
 /client/proc/restart_sql()
 	set category = "Debug"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1169,14 +1169,14 @@ var/list/admin_verbs_cciaa = list(
 	target.do_wipe_core()
 
 /client/proc/end_round()
-	set name = "zEnd Roundz"
+	set name = "End Round"
 	set desc = "This button will end the round."
 	set category = "Server"
 
 	if(!check_rights(R_ADMIN))
 		return
 
-	if(alert("Are you sure you want to end the round?", "Confirm Round End", "No", "No", "Yes") != "Yes")
+	if(alert(usr, "Are you sure you want to end the round?", "Confirm Round End", "No", "Yes") != "Yes")
 		return
 
 	log_and_message_admins("has ended the round with the End Round button.")

--- a/code/modules/spell_system/artifacts/items/apprentice_pebble.dm
+++ b/code/modules/spell_system/artifacts/items/apprentice_pebble.dm
@@ -13,7 +13,7 @@
 	SSghostroles.add_spawn_atom("apprentice", src)
 	var/area/A = get_area(src)
 	if(A)
-		say_dead_direct("An artificer pebble has been created in [A.name]! Spawn at it by using the ghost spawner menu in the ghost tab.")
+		say_dead_direct("A wizard apprentice pebble has been created in [A.name]! Spawn at it by using the ghost spawner menu in the ghost tab.")
 	
 /obj/item/apprentice_pebble/Destroy()
 	if(contract)

--- a/code/modules/spell_system/spells/spells.dm
+++ b/code/modules/spell_system/spells/spells.dm
@@ -44,7 +44,9 @@
 			if(spell_master.type == master_type)
 				LAZYADD(spell_list, spell_to_add)
 				spell_master.add_spell(spell_to_add)
-				return 1
+				if(mind)
+					LAZYDISTINCTADD(mind.learned_spells, spell_to_add)
+				return TRUE
 
 	var/obj/screen/movable/spell_master/new_spell_master = new master_type //we're here because either we didn't find our type, or we have no spell masters to attach to
 	if(client)
@@ -56,11 +58,8 @@
 	spell_masters.Add(new_spell_master)
 	LAZYADD(spell_list, spell_to_add)
 	if(mind)
-		if(!mind.learned_spells)
-			mind.learned_spells = list()
-		mind.learned_spells += spell_to_add
-
-	return 1
+		LAZYDISTINCTADD(mind.learned_spells, spell_to_add)
+	return TRUE
 
 /mob/proc/remove_spell(var/spell/spell_to_remove)
 	if(!spell_to_remove || !istype(spell_to_remove))

--- a/html/changelogs/geeves-wizard_roundend_report.yml
+++ b/html/changelogs/geeves-wizard_roundend_report.yml
@@ -1,0 +1,9 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - admin: "Added an admin verb that ends the round smoothly, displaying the end round card."
+  - bugfix: "Wizard learned spells are now properly displayed at round."
+  - bugfix: "Antags added to gamemodes they don't belong in, now properly update the gamemode's antag template, allowing their things to be displayed at round end."
+  - bugfix: "Fixed a typo in the apprentice pebble spawn-in calling it an 'artificer pebble' in deadchat."


### PR DESCRIPTION
* Added an admin verb that ends the round smoothly, displaying the end round card.
* Wizard learned spells are now properly displayed at round.
* Antags added to gamemodes they don't belong in, now properly update the gamemode's antag template, allowing their things to be displayed at round end.
* Fixed a typo in the apprentice pebble spawn-in calling it an 'artificer pebble' in deadchat.