### PR TITLE
No More As Name Spam

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,11 +1,3 @@
-/mob/living/carbon/human/say(var/message)
-	var/alt_name = ""
-	if(name != GetVoice())
-		alt_name = "(as [get_id_name("Unknown")])"
-
-	message = sanitize(message)
-	..(message, alt_name = alt_name)
-
 /mob/living/carbon/human/proc/forcesay(list/append)
 	if(stat == CONSCIOUS)
 		if(client)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -59,7 +59,6 @@
 	return ..()
 
 /mob/living/carbon/human/GetVoice()
-
 	var/voice_sub
 	if(istype(back,/obj/item/rig))
 		var/obj/item/rig/rig = back
@@ -75,7 +74,10 @@
 				voice_sub = changer.voice
 	if(voice_sub)
 		return voice_sub
-	if(mind && mind.changeling && mind.changeling.mimicing)
+	var/obj/item/organ/external/head/face = organs_by_name[BP_HEAD]
+	if(face?.disfigured) // if your face is ruined, your ability to vocalize is also ruined
+		return "Unknown" // above ling voice mimicing so they don't get caught out immediately
+	if(mind?.changeling?.mimicing)
 		return mind.changeling.mimicing
 	if(GetSpecialVoice())
 		return GetSpecialVoice()

--- a/html/changelogs/geeves-no_more_uggo_chat.yml
+++ b/html/changelogs/geeves-no_more_uggo_chat.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes: 
   - rscdel: "Speaking with an ID that doesn't match your voice no longer displays (as Unknown) or (as ID name)."
+  - tweak: "Being disfigured makes speech difficult, thus your voice will appear as Unknown."

--- a/html/changelogs/geeves-no_more_uggo_chat.yml
+++ b/html/changelogs/geeves-no_more_uggo_chat.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscdel: "Speaking with an ID that doesn't match your voice no longer displays (as Unknown) or (as ID name)."


### PR DESCRIPTION
* Speaking with an ID that doesn't match your voice no longer displays (as Unknown) or (as ID name).

The addition of the floating chat has largely obsoleted this feature, not that it was that important in the first place.