### PR TITLE
Allows the cancellation of teleportation for wizards using teleport scroll

### DIFF
--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -66,7 +66,7 @@
 
 	var/A
 
-	A = input(user, "Area to jump to", "BOOYEA", A) in teleportlocs
+	A = input(user, "Area to jump to", "BOOYEA", A)  as null|anything in teleportlocs
 	var/area/thearea = teleportlocs[A]
 
 	if (user.stat || user.restrained())

--- a/html/changelogs/printer16-cancelbooyah.yml
+++ b/html/changelogs/printer16-cancelbooyah.yml
@@ -1,0 +1,7 @@
+
+author: Printer16
+
+delete-after: True
+
+changes:
+  - rscadd: "The wizard can now cancel their teleport when teleporting with their teleportation scroll."


### PR DESCRIPTION
Allows the wizard to cancel their teleport when teleporting via the teleportation scroll. Tested and works in-game.