### PR TITLE
Adds mixed secret to the config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -53,6 +53,7 @@ var/list/gamemode_cache = list()
 	var/list/votable_modes = list()		// votable modes
 	var/list/probabilities_secret = list()			// relative probability of each mode in secret/random
 	var/list/probabilities_mixed_secret = list()	// relative probability of each mode in heavy secret mode
+	var/mixedsecret_enabled = FALSE
 	var/ipc_timelock_active = FALSE
 	var/humans_need_surnames = 0
 	var/allow_random_events = 0			// enables random events mid-round when set to 1
@@ -329,7 +330,8 @@ var/list/gamemode_cache = list()
 				if (M.votable)
 					src.votable_modes += M.config_tag
 	src.votable_modes += ROUNDTYPE_STR_SECRET
-//	votable_modes += ROUNDTYPE_STR_MIXED_SECRET
+	if(config.mixedsecret_enabled)
+		votable_modes += ROUNDTYPE_STR_MIXED_SECRET
 
 /datum/configuration/proc/load(filename, type = "config") //the type can also be game_options, in which case it uses a different switch. not making it separate to not copypaste code - Urist
 	var/list/Lines = file2list(filename)
@@ -504,6 +506,9 @@ var/list/gamemode_cache = list()
 
 				if ("server")
 					config.server = value
+
+				if("mixed_secret_enabled")
+					config.mixedsecret_enabled = TRUE
 
 				if ("banappeals")
 					config.banappeals = value

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -330,8 +330,6 @@ var/list/gamemode_cache = list()
 				if (M.votable)
 					src.votable_modes += M.config_tag
 	src.votable_modes += ROUNDTYPE_STR_SECRET
-	if(config.mixedsecret_enabled)
-		votable_modes += ROUNDTYPE_STR_MIXED_SECRET
 
 /datum/configuration/proc/load(filename, type = "config") //the type can also be game_options, in which case it uses a different switch. not making it separate to not copypaste code - Urist
 	var/list/Lines = file2list(filename)
@@ -509,6 +507,7 @@ var/list/gamemode_cache = list()
 
 				if("mixed_secret_enabled")
 					config.mixedsecret_enabled = TRUE
+					votable_modes += ROUNDTYPE_STR_MIXED_SECRET
 
 				if ("banappeals")
 					config.banappeals = value

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -507,7 +507,7 @@ var/list/gamemode_cache = list()
 
 				if("mixed_secret_enabled")
 					config.mixedsecret_enabled = TRUE
-					votable_modes += ROUNDTYPE_STR_MIXED_SECRET
+					config.votable_modes += ROUNDTYPE_STR_MIXED_SECRET
 
 				if ("banappeals")
 					config.banappeals = value

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -245,7 +245,7 @@ var/datum/controller/subsystem/vote/SSvote
 						continue
 					AddChoice(F, capitalize(M.name), "[M.required_players]")
 				AddChoice(ROUNDTYPE_STR_SECRET, "Secret")
-				if(ROUNDTYPE_STR_MIXED_SECRET in choices)
+				if(config.mixedsecret_enabled && ROUNDTYPE_STR_MIXED_SECRET in choices)
 					AddChoice(ROUNDTYPE_STR_MIXED_SECRET, "Mixed Secret")
 			if("crew_transfer")
 				if(check_rights(R_ADMIN|R_MOD, 0))

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -245,7 +245,7 @@ var/datum/controller/subsystem/vote/SSvote
 						continue
 					AddChoice(F, capitalize(M.name), "[M.required_players]")
 				AddChoice(ROUNDTYPE_STR_SECRET, "Secret")
-				if(config.mixedsecret_enabled && ROUNDTYPE_STR_MIXED_SECRET in choices)
+				if(config.mixedsecret_enabled && (ROUNDTYPE_STR_MIXED_SECRET in choices))
 					AddChoice(ROUNDTYPE_STR_MIXED_SECRET, "Mixed Secret")
 			if("crew_transfer")
 				if(check_rights(R_ADMIN|R_MOD, 0))

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -770,13 +770,14 @@ proc/get_nt_opposed()
 				var/percentage = round(config.probabilities_secret[config_tag] / sum * 100, 0.1)
 				to_chat(src, "[config_tag] [percentage]%")
 
-		to_chat(src, "<b>Mixed Secret Mode Odds:</b>")
-		sum = 0
-		for(var/config_tag in config.probabilities_mixed_secret)
-			sum += config.probabilities_mixed_secret[config_tag]
-		for(var/config_tag in config.probabilities_mixed_secret)
-			if(config.probabilities_mixed_secret[config_tag] > 0)
-				var/percentage = round(config.probabilities_mixed_secret[config_tag] / sum * 100, 0.1)
-				to_chat(src, "[config_tag] [percentage]%")
+		if(config.mixedsecret_enabled)
+			to_chat(src, "<b>Mixed Secret Mode Odds:</b>")
+			sum = 0
+			for(var/config_tag in config.probabilities_mixed_secret)
+				sum += config.probabilities_mixed_secret[config_tag]
+			for(var/config_tag in config.probabilities_mixed_secret)
+				if(config.probabilities_mixed_secret[config_tag] > 0)
+					var/percentage = round(config.probabilities_mixed_secret[config_tag] / sum * 100, 0.1)
+					to_chat(src, "[config_tag] [percentage]%")
 	else
 		to_chat(src, "Displaying gamemode odds is disabled in the config.")

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -114,6 +114,8 @@ MOD_TEMPBAN_MAX 1440
 ## Maximum mod job tempban duration (in minutes)
 MOD_JOB_TEMPBAN_MAX 1440
 
+## If mixed secret is enabled or not
+#MIXED_SECRET_ENABLED
 
 ## Probablities for game modes chosen in "secret", "mixed secret" and "random" modes.
 ## S or MS after the PROBABILITY keyword dictates whether the probability is for mixed

--- a/html/changelogs/Printer16-MixedToConfig.yml
+++ b/html/changelogs/Printer16-MixedToConfig.yml
@@ -1,0 +1,7 @@
+
+author: Printer16
+
+delete-after: True
+
+changes:
+  - rscdel: "Mixed secret no longer shows up in the gamemode probabilities verb."


### PR DESCRIPTION
Turns mixed secret into a config option and fixes a bug of it showing up in gamemode probabilities when it's off.