### PR TITLE
Fixes a runtime in windowdoor.dm

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -76,7 +76,7 @@
 		return
 	if (src.operating)
 		return
-	if (src.density && (!issmall(AM) || ishuman(AM) || isrobot(AM)) && src.allowed(AM))
+	if (src.density && (ishuman(AM) || isrobot(AM)) && src.allowed(AM))
 		open()
 		//secure doors close faster
 		var/time = check_access(null) ? 50 : 20


### PR DESCRIPTION
`src.allowed()` assumes the argument is mob. The way the if-chain worked is that ANYTHING that's NOT small would get a valid pass in the eager-evaluation and then be fed into allowed. This results in no difference in behaviour, but runtimes.