### PR TITLE
EMP Nerf

### DIFF
--- a/code/modules/client/client_color.dm
+++ b/code/modules/client/client_color.dm
@@ -58,6 +58,9 @@
 	client_color = list(0.33,0.33,0.33, 0.33,0.33,0.33, 0.33,0.33,0.33)
 	priority = INFINITY
 
+/datum/client_color/monochrome/damage
+	// this is a client color to represent colour fading, which is why it has to be seperate
+
 /datum/client_color/deuteranopia
 	client_color = list(0.47,0.38,0.15, 0.54,0.31,0.15, 0,0.3,0.7)
 	priority = 100

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
@@ -136,7 +136,6 @@ datum/species/machine/handle_post_spawn(var/mob/living/carbon/human/H)
 			playsound(H.loc, 'sound/machines/buzz-two.ogg', 100, 0)
 		else
 			return 1
-
 	return 0
 
 /datum/species/machine/handle_death(var/mob/living/carbon/human/H)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -329,16 +329,16 @@
 
 	var/organ_fragility = 0.5
 
-	if((status & ORGAN_ROBOT))	//fully robotic organs take the normal emp damage, assited ones only suffer half of it
+	if(status & ORGAN_ROBOT)	//fully robotic organs take the normal emp damage, assited ones only suffer half of it
 		organ_fragility = 1
 
-	switch (severity)
-		if (1.0)
-			take_damage(rand(7,20) * emp_coeff * organ_fragility)
-		if (2.0)
-			take_damage(rand(3,7) * emp_coeff * organ_fragility)
+	switch(severity)
+		if(1.0)
+			take_damage(rand(4, 15) * emp_coeff * organ_fragility)
+		if(2.0)
+			take_damage(rand(3, 5) * emp_coeff * organ_fragility)
 		if(3.0)
-			take_damage(rand(3) * emp_coeff * organ_fragility)
+			take_damage(rand(2, 3) * emp_coeff * organ_fragility)
 
 /obj/item/organ/proc/removed(var/mob/living/carbon/human/target,var/mob/living/user)
 

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -75,13 +75,15 @@
 	..()
 	if(emp_counter)
 		emp_counter--
+		if(!emp_counter)
+			owner.remove_client_color(/datum/client_color/monochrome/damage)
 
 /obj/item/organ/internal/cell/emp_act(severity)
-	emp_counter += 30/severity
-	if(emp_counter >= 30)
-		owner.Paralyse(emp_counter/6)
-		to_chat(owner, "<span class='danger'>%#/ERR: Power leak detected!$%^/</span>")
-
+	emp_counter += 10 / severity
+	owner.add_client_color(/datum/client_color/monochrome/damage)
+	if(emp_counter >= 25)
+		owner.Paralyse(5)
+		to_chat(owner, SPAN_DANGER("%#/ERR: Power leak detected!$%^/"))
 
 /obj/item/organ/internal/surge
 	name = "surge preventor"

--- a/html/changelogs/geeves-nerf_emp.yml
+++ b/html/changelogs/geeves-nerf_emp.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "EMPs now do less damage against robotic and assisted organs."
+  - tweak: "EMPs now does slightly less against IPCs, flooring them for only around a second, but applies a monotone colour filter for some time."

--- a/html/changelogs/geeves-nerf_emp.yml
+++ b/html/changelogs/geeves-nerf_emp.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes: 
   - tweak: "EMPs now do less damage against robotic and assisted organs."
-  - tweak: "EMPs now does slightly less against IPCs, flooring them for only around a second, but applies a monotone colour filter for some time."
+  - tweak: "EMPs now does slightly less against IPCs, flooring them for only around a second, but applies a monochrome colour filter for some time."


### PR DESCRIPTION
* EMPs now do less damage against robotic and assisted organs.
* EMPs now does slightly less against IPCs, flooring them for only around a second, but applies a monotone colour filter for some time.