### PR TITLE
Away Site Pin Fix

### DIFF
--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -224,7 +224,7 @@ Pins Below.
 	fail_message = "<span class='warning'>USER ON STATION LEVEL.</span>"
 
 /obj/item/device/firing_pin/access/pin_auth(mob/living/user)
-	if(!isStationLevel(src.z))
+	if(!isStationLevel(gun.z) && !istype(get_area(), /area/centcom))
 		return TRUE
 	else
 		return FALSE

--- a/html/changelogs/geeves-awaysite_pin_fix.yml
+++ b/html/changelogs/geeves-awaysite_pin_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Away site pins should only allow the gun to fire at away sites now."


### PR DESCRIPTION
* Away site pins should only allow the gun to fire at away sites now.