### PR TITLE
Misc Bugfixes

### DIFF
--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -77,7 +77,6 @@
 
 #define isprojectile(A) istype(A, /obj/item/projectile)
 
-#define to_chat(target, message)                            target << message
 #define to_world(message)                                   world << message
 #define sound_to(target, sound)                             target << sound
 #define to_file(file_entry, file_content)                   file_entry << file_content

--- a/code/_helpers/files.dm
+++ b/code/_helpers/files.dm
@@ -27,7 +27,7 @@
 //Sends resource files to client cache
 /client/proc/getFiles()
 	for(var/file in args)
-		to_chat(src, browse_rsc(file))
+		src << browse_rsc(file)
 
 /client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm"))
 	var/path = root

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -543,3 +543,11 @@ datum/projectile_data
 		if(M.client)
 			viewing += M.client
 	flick_overlay(I, viewing, duration)
+
+/proc/to_chat(target, message)
+	if(ismech(target))
+		var/mob/living/heavy_vehicle/mech = target
+		for(var/pilot in mech.pilots)
+			pilot << message
+	else
+		target << message

--- a/code/controllers/subsystems/emergency_shuttle.dm
+++ b/code/controllers/subsystems/emergency_shuttle.dm
@@ -221,6 +221,8 @@ var/datum/controller/subsystem/emergency_shuttle/emergency_shuttle
 //returns 1 if the shuttle has gone to the station and come back at least once,
 //used for game completion checking purposes
 /datum/controller/subsystem/emergency_shuttle/proc/returned()
+	if(!shuttle)
+		return FALSE
 	return (departed && shuttle.moving_status == SHUTTLE_IDLE && shuttle.location)	//we've gone to the station at least once, no longer in transit and are idle back at centcom
 
 //returns 1 if the shuttle is not idle at centcom
@@ -235,10 +237,14 @@ var/datum/controller/subsystem/emergency_shuttle/emergency_shuttle
 
 //returns 1 if the shuttle is currently in transit (or just leaving) to the station
 /datum/controller/subsystem/emergency_shuttle/proc/going_to_station()
+	if(!shuttle)
+		return FALSE
 	return (!shuttle.direction && shuttle.moving_status != SHUTTLE_IDLE)
 
 //returns 1 if the shuttle is currently in transit (or just leaving) to centcom
 /datum/controller/subsystem/emergency_shuttle/proc/going_to_centcom()
+	if(!shuttle)
+		return FALSE
 	return (shuttle.direction && shuttle.moving_status != SHUTTLE_IDLE)
 
 

--- a/code/controllers/subsystems/virtual_reality.dm
+++ b/code/controllers/subsystems/virtual_reality.dm
@@ -148,10 +148,13 @@
 		return
 
 	var/desc = input("Please select a remote control compatible mech to take over.", "Remote Mech Selection") in mech|null
-	if(!desc)
+	if(!desc || desc == "Return")
 		return
 
 	var/mob/living/heavy_vehicle/chosen_mech = mech[desc]
+	if(!istype(chosen_mech))
+		to_chat(user, SPAN_WARNING("Something went wrong while selecting your mech. Please make an issue on Github describing what you did leading up to this."))
+		return
 	var/mob/living/remote_pilot = chosen_mech.pilots[1] // the first pilot
 	mind_transfer(user, remote_pilot)
 

--- a/code/datums/server_greeting.dm
+++ b/code/datums/server_greeting.dm
@@ -215,17 +215,17 @@
 	var/list/data = list("div" = "", "content" = "", "update" = 1, "changeHash" = null)
 
 	if (outdated_info & OUTDATED_NOTE)
-		to_chat(user, output("#note-placeholder", "greeting.browser:RemoveElement"))
+		user << output("#note-placeholder", "greeting.browser:RemoveElement")
 
 		data["div"] = "#note"
 		data["update"] = 1
 
 		for (var/datum/client_notification/a in user.prefs.notifications)
 			data["content"] = a.get_html()
-			to_chat(user, output(JS_SANITIZE(data), "greeting.browser:AddContent"))
+			user << output(JS_SANITIZE(data), "greeting.browser:AddContent")
 
 	if (!user.holder)
-		to_chat(user, output("#memo-tab", "greeting.browser:RemoveElement"))
+		user << output("#memo-tab", "greeting.browser:RemoveElement")
 	else
 		if (outdated_info & OUTDATED_MEMO)
 			data["update"] = 1
@@ -236,7 +236,7 @@
 
 		data["div"] = "#memo"
 		data["content"] = get_memo_content(user)
-		to_chat(user, output(JS_SANITIZE(data), "greeting.browser:AddContent"))
+		user << output(JS_SANITIZE(data), "greeting.browser:AddContent")
 
 	if (outdated_info & OUTDATED_MOTD)
 		data["update"] = 1
@@ -247,7 +247,7 @@
 
 	data["div"] = "#motd"
 	data["content"] = motd
-	to_chat(user, output(JS_SANITIZE(data), "greeting.browser:AddContent"))
+	user << output(JS_SANITIZE(data), "greeting.browser:AddContent")
 
 	data["div"] = "#testmerges"
 	data["content"] = revdata.greeting_info
@@ -257,7 +257,7 @@
 	else
 		data["update"] = 0
 	data["changeHash"] = null
-	to_chat(user, output(JS_SANITIZE(data), "greeting.browser:AddContent"))
+	user << output(JS_SANITIZE(data), "greeting.browser:AddContent")
 
 /*
  * Basically the Topic proc for the greeting datum.

--- a/code/game/machinery/computer/arcade_orion.dm
+++ b/code/game/machinery/computer/arcade_orion.dm
@@ -455,7 +455,7 @@
 			to_chat(usr, "<span class='danger'><font size=3>You're never going to make it to Orion...</font></span>")
 			var/mob/living/M = usr
 			M.visible_message("\The [M] starts rapidly deteriorating.")
-			to_chat(M, browse (null,"window=arcade"))
+			M << browse (null,"window=arcade")
 			for(var/i=0;i<10;i++)
 				sleep(10)
 				M.Stun(5)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -280,7 +280,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 							i++
 							dat+="<BLOCKQUOTE style=\"padding:2px 4px;border-left:4px #797979 solid\">[MESSAGE.body] <FONT SIZE=1>\[Likes: <FONT COLOR='DarkGreen'>[MESSAGE.likes]</FONT> Dislikes: <FONT COLOR='maroon'>[MESSAGE.dislikes]</FONT>\]</FONT><BR>"
 							if(MESSAGE.img)
-								to_chat(usr, browse_rsc(MESSAGE.img, "tmp_photo[i].png"))
+								usr << browse_rsc(MESSAGE.img, "tmp_photo[i].png")
 								dat+="<img src='tmp_photo[i].png' width = '180'><BR>"
 								if(MESSAGE.caption)
 									dat+="<FONT SIZE=1><B>[MESSAGE.caption]</B></FONT><BR>"
@@ -386,7 +386,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat+="<B>Description</B>: [SSnews.wanted_issue.body]<BR>"
 				dat+="<B>Photo:</B>: "
 				if(SSnews.wanted_issue.img)
-					to_chat(usr, browse_rsc(SSnews.wanted_issue.img, "tmp_photow.png"))
+					usr << browse_rsc(SSnews.wanted_issue.img, "tmp_photow.png")
 					dat+="<BR><img src='tmp_photow.png' width = '180'>"
 				else
 					dat+="None"
@@ -868,7 +868,7 @@ obj/item/newspaper/attack_self(mob/user as mob)
 							i++
 							dat+="-[MESSAGE.body] <BR>"
 							if(MESSAGE.img)
-								to_chat(user, browse_rsc(MESSAGE.img, "tmp_photo[i].png"))
+								user << browse_rsc(MESSAGE.img, "tmp_photo[i].png")
 								dat+="<img src='tmp_photo[i].png' width = '180'><BR>"
 							dat+="<FONT SIZE=1>\[[MESSAGE.message_type] by <FONT COLOR='maroon'>[MESSAGE.author]</FONT>\]</FONT><BR><BR>"
 						dat+="</ul>"
@@ -884,7 +884,7 @@ obj/item/newspaper/attack_self(mob/user as mob)
 					dat+="<B>Description</B>: [important_message.body]<BR>"
 					dat+="<B>Photo:</B>: "
 					if(important_message.img)
-						to_chat(user, browse_rsc(important_message.img, "tmp_photow.png"))
+						user << browse_rsc(important_message.img, "tmp_photow.png")
 						dat+="<BR><img src='tmp_photow.png' width = '180'>"
 					else
 						dat+="None"

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -141,8 +141,8 @@ var/const/NO_EMAG_ACT = -50
 
 /obj/item/card/id/proc/show(mob/user as mob)
 	if(front && side)
-		to_chat(user, browse_rsc(front, "front.png"))
-		to_chat(user, browse_rsc(side, "side.png"))
+		user << browse_rsc(front, "front.png")
+		user << browse_rsc(side, "side.png")
 	var/datum/browser/popup = new(user, "idcard", name, 650, 260)
 	popup.set_content(dat())
 	popup.set_title_image(usr.browse_rsc_icon(src.icon, src.icon_state))

--- a/code/js/byjax.dm
+++ b/code/js/byjax.dm
@@ -45,6 +45,6 @@ proc/send_byjax(receiver, control_id, target_element, new_content=null, callback
 /*		if(callback_args)
 			argums += "&[list2params(callback_args)]"
 */
-		to_chat(receiver, output(argums,"[control_id]:replaceContent"))
+		receiver << output(argums,"[control_id]:replaceContent")
 	return
 

--- a/code/modules/admin/DB ban/ban_mirroring.dm
+++ b/code/modules/admin/DB ban/ban_mirroring.dm
@@ -342,7 +342,7 @@
 	data += list(list(C.ckey, C.address, C.computer_id))
 
 	var/data_str = json_encode(data)
-	to_chat(C, output(list2params(list("E-DAT", data_str, 900)), "greeting.browser:setCookie"))
+	C << output(list2params(list("E-DAT", data_str, 900)), "greeting.browser:setCookie")
 
 #undef BAD_CID
 #undef BAD_IP

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -464,7 +464,7 @@ proc/admin_notice(var/message, var/rights)
 						i++
 						dat+="<BLOCKQUOTE style=\"padding:4px;border-left:4px #797979 solid\">[MESSAGE.body] <FONT SIZE=1>\[Likes: <A href='?src=\ref[src];ac_setlikes=1;'><FONT COLOR='DarkGreen'>[MESSAGE.likes]</FONT></A> Dislikes: <A href='?src=\ref[src];ac_setdislikes=1;'><FONT COLOR='maroon'>[MESSAGE.dislikes]</FONT></A>\]</FONT><BR>"
 						if(MESSAGE.img)
-							to_chat(usr, browse_rsc(MESSAGE.img, "tmp_photo[i].png"))
+							usr << browse_rsc(MESSAGE.img, "tmp_photo[i].png")
 							dat+="<img src='tmp_photo[i].png' width = '180'><BR><BR>"
 						dat+="<FONT SIZE=1><A href='?src=\ref[src];ac_view_comments=1;ac_story=\ref[MESSAGE]'>View Comments</A> <A href='?src=\ref[src];ac_add_comment=1;ac_story=\ref[MESSAGE]'>Add Comment</A> <A href='?src=\ref[src];ac_like=1;ac_story=\ref[MESSAGE]'>Like Story</A> <A href='?src=\ref[src];ac_dislike=1;ac_story=\ref[MESSAGE]'>Dislike Story</A></FONT><BR>"
 						dat+="<FONT SIZE=1>\[Story by <FONT COLOR='maroon'>[MESSAGE.author] - [MESSAGE.time_stamp]</FONT>\]</FONT></BLOCKQUOTE><BR>"
@@ -580,7 +580,7 @@ proc/admin_notice(var/message, var/rights)
 				<B>Photo:</B>:
 			"}
 			if(SSnews.wanted_issue.img)
-				to_chat(usr, browse_rsc(SSnews.wanted_issue.img, "tmp_photow.png"))
+				usr << browse_rsc(SSnews.wanted_issue.img, "tmp_photow.png")
 				dat+="<BR><img src='tmp_photow.png' width = '180'>"
 			else
 				dat+="None"

--- a/code/modules/admin/map_capture.dm
+++ b/code/modules/admin/map_capture.dm
@@ -24,7 +24,7 @@
 		var/cap = generate_image(tx ,ty ,tz ,range, CAPTURE_MODE_PARTIAL, null, ligths, 1)
 		var/file_name = "map_capture_x[tx]_y[ty]_z[tz]_r[range].png"
 		to_chat(usr, "Saved capture in cache as [file_name].")
-		to_chat(usr, browse_rsc(cap, file_name))
+		usr << browse_rsc(cap, file_name)
 	else
 		to_chat(usr, "Target coordinates are incorrect.")
 
@@ -33,7 +33,7 @@
 		var/cap = generate_image(currentx ,currenty ,currentz ,16, CAPTURE_MODE_PARTIAL, null, ligths, 1)
 		var/file_name = "map_capture_x[currentx]_y[currenty]_z[currentz]_r16.png"
 		to_chat(usr, "Saved capture in cache as [file_name].")
-		to_chat(usr, browse_rsc(cap, file_name))
+		usr << browse_rsc(cap, file_name)
 		currentx = currentx + 16
 		spawn (6)
 			del(cap)
@@ -45,7 +45,7 @@
 			var/cap = generate_image(currentx ,currenty ,currentz ,16, CAPTURE_MODE_PARTIAL, null, ligths, 1)
 			var/file_name = "map_capture_x[currentx]_y[currenty]_z[currentz]_r16.png"
 			to_chat(usr, "Saved capture in cache as [file_name].")
-			to_chat(usr, browse_rsc(cap, file_name))
+			usr << browse_rsc(cap, file_name)
 			currentx = currentx + 16
 			spawn (6)
 				del(cap)

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -24,9 +24,9 @@
 		var/atom/A = D
 		if(A.icon && A.icon_state)
 			sprite = icon(A.icon, A.icon_state)
-			to_chat(usr, browse_rsc(sprite, "view_vars_sprite.png"))
+			usr << browse_rsc(sprite, "view_vars_sprite.png")
 
-	to_chat(usr, browse_rsc('code/js/view_variables.js', "view_variables.js"))
+	usr << browse_rsc('code/js/view_variables.js', "view_variables.js")
 
 	var/html = {"
 		<html>

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -185,7 +185,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	pref.update_preview_icon()
 	if(!pref.preview_icon)
 		pref.update_preview_icon()
-	to_chat(user, browse_rsc(pref.preview_icon, "previewicon.png"))
+	user << browse_rsc(pref.preview_icon, "previewicon.png")
 
 	var/datum/species/mob_species = all_species[pref.species]
 	out += "<table><tr style='vertical-align:top'><td><b>Body</b> "
@@ -691,7 +691,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	if(current_species.preview_icon)
 		var/icon/preview = icon(current_species.preview_icon, "")
 		preview.Scale(64, 64)	// Scale it here to stop it blurring.
-		to_chat(usr, browse_rsc(icon(icon = preview, icon_state = ""), "species_preview_[current_species.short_name].png"))
+		usr << browse_rsc(icon(icon = preview, icon_state = ""), "species_preview_[current_species.short_name].png")
 		dat += "<img src='species_preview_[current_species.short_name].png' width='64px' height='64px'><br/><br/>"
 	dat += "<b>Language:</b> [current_species.language]<br/>"
 	dat += "<small>"

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -111,7 +111,7 @@
 
 		if(board["[i]"])
 			var/obj/item/I = board["[i]"]
-			to_chat(user, browse_rsc(board_icons["[I.icon] [I.icon_state]"],"[I.icon_state].png"))
+			user << browse_rsc(board_icons["[I.icon] [I.icon_state]"],"[I.icon_state].png")
 			dat += " style='background-image:url([I.icon_state].png)'>"
 		else
 			dat+= ">"

--- a/code/modules/mob/abstract/freelook/chunk.dm
+++ b/code/modules/mob/abstract/freelook/chunk.dm
@@ -63,9 +63,10 @@
 
 	var/turf/center = locate(x + 8, y + 8, z)
 
-	for(var/turf/t in RANGE_TURFS(10, center))
-		if(t.x >= x && t.y >= y && t.x < x + 16 && t.y < y + 16)
-			turfs[t] = t
+	if(center)
+		for(var/turf/t in RANGE_TURFS(10, center))
+			if(t.x >= x && t.y >= y && t.x < x + 16 && t.y < y + 16)
+				turfs[t] = t
 
 	add_sources(visualnet.sources)
 	acquire_visible_turfs(visibleTurfs)

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -469,7 +469,7 @@ nanoui is used to open and update nano browser uis
 	var/list/send_data = get_send_data(data)
 
 	//to_chat(user, list2json(data) // used for debugging)
-	to_chat(user, output(list2params(list(json_encode(send_data))),"[window_id].browser:receiveUpdateData"))
+	user << output(list2params(list(json_encode(send_data))),"[window_id].browser:receiveUpdateData")
 
  /**
   * This Topic() proc is called whenever a user clicks on a link within a Nano UI

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -126,7 +126,7 @@
 		user << browse(dat, "window=[name]")
 	else if(istype(pages[page], /obj/item/photo))
 		var/obj/item/photo/P = W
-		to_chat(user, browse_rsc(P.img, "tmp_photo.png"))
+		user << browse_rsc(P.img, "tmp_photo.png")
 		user << browse(dat + "<html><head><title>[P.name]</title></head>" + "<body style='overflow:hidden'>" + "<div> <img src='tmp_photo.png' width = '180'" + "[P.scribble ? "<div> Written on the back:<br><i>[P.scribble]</i>" : null]" + "</body></html>", "window=[name]")
 
 /obj/item/paper_bundle/attack_self(mob/user as mob)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -59,7 +59,7 @@ var/global/photo_count = 0
 		to_chat(user, "<span class='notice'>It is too far away.</span>")
 
 /obj/item/photo/proc/show(mob/user as mob)
-	to_chat(user, browse_rsc(img, "tmp_photo_[id].png"))
+	user << browse_rsc(img, "tmp_photo_[id].png")
 	user << browse("<html><head><title>[name]</title></head>" + "<body style='overflow:hidden;margin:0;text-align:center'>" + "<img src='tmp_photo_[id].png' width='[64*photo_size]' style='-ms-interpolation-mode:nearest-neighbor' />" + "[scribble ? "<br>Written on the back:<br><i>[scribble]</i>" : ""]" + "</body></html>", "window=book;size=[64*photo_size]x[scribble ? 400 : 64*photo_size]")
 	onclose(user, "[name]")
 	return

--- a/code/modules/scripting/IDE.dm
+++ b/code/modules/scripting/IDE.dm
@@ -13,16 +13,16 @@ client/verb/tcssave()
 				log_misc(msg)
 				message_admins("[mob.name] has uploaded a NTLS script to [Machine.SelectedServer] ([mob.x],[mob.y],[mob.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[mob.x];Y=[mob.y];Z=[mob.z]'>JMP</a>)",0,1)
 				Server.setcode( tcscode ) // this actually saves the code from input to the server
-				to_chat(src, output(null, "tcserror")) // clear the errors)
+				src << output(null, "tcserror") // clear the errors
 			else
-				to_chat(src, output(null, "tcserror"))
-				to_chat(src, output("<font color = red>Failed to save: Unable to locate server machine. (Back up your code before exiting the window!)</font>", "tcserror"))
+				src << output(null, "tcserror")
+				src << output("<font color = red>Failed to save: Unable to locate server machine. (Back up your code before exiting the window!)</font>", "tcserror")
 		else
-			to_chat(src, output(null, "tcserror"))
-			to_chat(src, output("<font color = red>Failed to save: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror"))
+			src << output(null, "tcserror")
+			src << output("<font color = red>Failed to save: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror")
 	else
-		to_chat(src, output(null, "tcserror"))
-		to_chat(src, output("<font color = red>Failed to save: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror"))
+		src << output(null, "tcserror")
+		src << output("<font color = red>Failed to save: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror")
 
 
 client/verb/tcscompile()
@@ -39,42 +39,42 @@ client/verb/tcscompile()
 				var/list/compileerrors = Server.compile() // then compile the code!
 
 				// Output all the compile-time errors
-				to_chat(src, output(null, "tcserror"))
+				src << output(null, "tcserror")
 
 				if(compileerrors.len)
-					to_chat(src, output("<b>Compile Errors</b>", "tcserror"))
+					src << output("<b>Compile Errors</b>", "tcserror")
 					for(var/scriptError/e in compileerrors)
-						to_chat(src, output("<font color = red>\t>[e.message]</font>", "tcserror"))
-					to_chat(src, output("([compileerrors.len] errors)", "tcserror"))
+						src << output("<font color = red>\t>[e.message]</font>", "tcserror")
+					src << output("([compileerrors.len] errors)", "tcserror")
 
 					// Output compile errors to all other people viewing the code too
 					for(var/mob/M in Machine.viewingcode)
 						if(M.client)
-							to_chat(M, output(null, "tcserror"))
-							to_chat(M, output("<b>Compile Errors</b>", "tcserror"))
+							M << output(null, "tcserror")
+							M << output("<b>Compile Errors</b>", "tcserror")
 							for(var/scriptError/e in compileerrors)
-								to_chat(M, output("<font color = red>\t>[e.message]</font>", "tcserror"))
-							to_chat(M, output("([compileerrors.len] errors)", "tcserror"))
+								M << output("<font color = red>\t>[e.message]</font>", "tcserror")
+							M << output("([compileerrors.len] errors)", "tcserror")
 
 
 				else
-					to_chat(src, output("<font color = blue>TCS compilation successful!</font>", "tcserror"))
-					to_chat(src, output("(0 errors)", "tcserror"))
+					src << output("<font color = blue>TCS compilation successful!</font>", "tcserror")
+					src << output("(0 errors)", "tcserror")
 
 					for(var/mob/M in Machine.viewingcode)
 						if(M.client)
-							to_chat(M, output("<font color = blue>TCS compilation successful!</font>", "tcserror"))
-							to_chat(M, output("(0 errors)", "tcserror"))
+							M << output("<font color = blue>TCS compilation successful!</font>", "tcserror")
+							M << output("(0 errors)", "tcserror")
 
 			else
-				to_chat(src, output(null, "tcserror"))
-				to_chat(src, output("<font color = red>Failed to compile: Unable to locate server machine. (Back up your code before exiting the window!)</font>", "tcserror"))
+				src << output(null, "tcserror")
+				src << output("<font color = red>Failed to compile: Unable to locate server machine. (Back up your code before exiting the window!)</font>", "tcserror")
 		else
-			to_chat(src, output(null, "tcserror"))
-			to_chat(src, output("<font color = red>Failed to compile: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror"))
+			src << output(null, "tcserror")
+			src << output("<font color = red>Failed to compile: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror")
 	else
-		to_chat(src, output(null, "tcserror"))
-		to_chat(src, output("<font color = red>Failed to compile: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror"))
+		src << output(null, "tcserror")
+		src << output("<font color = red>Failed to compile: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror")
 
 client/verb/tcsrun()
 	set hidden = 1
@@ -90,32 +90,32 @@ client/verb/tcsrun()
 				var/list/compileerrors = Server.compile() // then compile the code!
 
 				// Output all the compile-time errors
-				to_chat(src, output(null, "tcserror"))
+				src << output(null, "tcserror")
 
 				if(compileerrors.len)
-					to_chat(src, output("<b>Compile Errors</b>", "tcserror"))
+					src << output("<b>Compile Errors</b>", "tcserror")
 					for(var/scriptError/e in compileerrors)
-						to_chat(src, output("<font color = red>\t>[e.message]</font>", "tcserror"))
-					to_chat(src, output("([compileerrors.len] errors)", "tcserror"))
+						src << output("<font color = red>\t>[e.message]</font>", "tcserror")
+					src << output("([compileerrors.len] errors)", "tcserror")
 
 					// Output compile errors to all other people viewing the code too
 					for(var/mob/M in Machine.viewingcode)
 						if(M.client)
-							to_chat(M, output(null, "tcserror"))
-							to_chat(M, output("<b>Compile Errors</b>", "tcserror"))
+							M << output(null, "tcserror")
+							M << output("<b>Compile Errors</b>", "tcserror")
 							for(var/scriptError/e in compileerrors)
-								to_chat(M, output("<font color = red>\t>[e.message]</font>", "tcserror"))
-							to_chat(M, output("([compileerrors.len] errors)", "tcserror"))
+								M << output("<font color = red>\t>[e.message]</font>", "tcserror")
+							M << output("([compileerrors.len] errors)", "tcserror")
 
 				else
 					// Finally, we run the code!
-					to_chat(src, output("<font color = blue>TCS compilation successful! Code executed.</font>", "tcserror"))
-					to_chat(src, output("(0 errors)", "tcserror"))
+					src << output("<font color = blue>TCS compilation successful! Code executed.</font>", "tcserror")
+					src << output("(0 errors)", "tcserror")
 
 					for(var/mob/M in Machine.viewingcode)
 						if(M.client)
-							to_chat(M, output("<font color = blue>TCS compilation successful!</font>", "tcserror"))
-							to_chat(M, output("(0 errors)", "tcserror"))
+							M << output("<font color = blue>TCS compilation successful!</font>", "tcserror")
+							M << output("(0 errors)", "tcserror")
 
 					var/datum/signal/signal = new()
 					signal.data["message"] = ""
@@ -132,14 +132,14 @@ client/verb/tcsrun()
 
 
 			else
-				to_chat(src, output(null, "tcserror"))
-				to_chat(src, output("<font color = red>Failed to run: Unable to locate server machine. (Back up your code before exiting the window!)</font>", "tcserror"))
+				src << output(null, "tcserror")
+				src << output("<font color = red>Failed to run: Unable to locate server machine. (Back up your code before exiting the window!)</font>", "tcserror")
 		else
-			to_chat(src, output(null, "tcserror"))
-			to_chat(src, output("<font color = red>Failed to run: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror"))
+			src << output(null, "tcserror")
+			src << output("<font color = red>Failed to run: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror")
 	else
-		to_chat(src, output(null, "tcserror"))
-		to_chat(src, output("<font color = red>Failed to run: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror"))
+		src << output(null, "tcserror")
+		src << output("<font color = red>Failed to run: Unable to locate machine. (Back up your code before exiting the window!)</font>", "tcserror")
 
 
 client/verb/exittcs()
@@ -171,16 +171,16 @@ client/verb/tcsrevert()
 
 				winset(mob, "tcscode", "text=\"[showcode]\"")
 
-				to_chat(src, output(null, "tcserror")) // clear the errors)
+				src << output(null, "tcserror") // clear the errors
 			else
-				to_chat(src, output(null, "tcserror"))
-				to_chat(src, output("<font color = red>Failed to revert: Unable to locate server machine.</font>", "tcserror"))
+				src << output(null, "tcserror")
+				src << output("<font color = red>Failed to revert: Unable to locate server machine.</font>", "tcserror")
 		else
-			to_chat(src, output(null, "tcserror"))
-			to_chat(src, output("<font color = red>Failed to revert: Unable to locate machine.</font>", "tcserror"))
+			src << output(null, "tcserror")
+			src << output("<font color = red>Failed to revert: Unable to locate machine.</font>", "tcserror")
 	else
-		to_chat(src, output(null, "tcserror"))
-		to_chat(src, output("<font color = red>Failed to revert: Unable to locate machine.</font>", "tcserror"))
+		src << output(null, "tcserror")
+		src << output("<font color = red>Failed to revert: Unable to locate machine.</font>", "tcserror")
 
 
 client/verb/tcsclearmem()
@@ -195,17 +195,17 @@ client/verb/tcsclearmem()
 				var/obj/machinery/telecomms/server/Server = Machine.SelectedServer
 				Server.memory = list() // clear the memory
 				// Show results
-				to_chat(src, output(null, "tcserror"))
-				to_chat(src, output("<font color = blue>Server memory cleared!</font>", "tcserror"))
+				src << output(null, "tcserror")
+				src << output("<font color = blue>Server memory cleared!</font>", "tcserror")
 				for(var/mob/M in Machine.viewingcode)
 					if(M.client)
-						to_chat(M, output("<font color = blue>Server memory cleared!</font>", "tcserror"))
+						M << output("<font color = blue>Server memory cleared!</font>", "tcserror")
 			else
-				to_chat(src, output(null, "tcserror"))
-				to_chat(src, output("<font color = red>Failed to clear memory: Unable to locate server machine.</font>", "tcserror"))
+				src << output(null, "tcserror")
+				src << output("<font color = red>Failed to clear memory: Unable to locate server machine.</font>", "tcserror")
 		else
-			to_chat(src, output(null, "tcserror"))
-			to_chat(src, output("<font color = red>Failed to clear memory: Unable to locate machine.</font>", "tcserror"))
+			src << output(null, "tcserror")
+			src << output("<font color = red>Failed to clear memory: Unable to locate machine.</font>", "tcserror")
 	else
-		to_chat(src, output(null, "tcserror"))
-		to_chat(src, output("<font color = red>Failed to clear memory: Unable to locate machine.</font>", "tcserror"))
+		src << output(null, "tcserror")
+		src << output("<font color = red>Failed to clear memory: Unable to locate machine.</font>", "tcserror")

--- a/code/modules/vueui/ui.dm
+++ b/code/modules/vueui/ui.dm
@@ -281,7 +281,7 @@ main ui datum.
 /datum/vueui/proc/push_change(var/list/ndata)
 	if(ndata && status > STATUS_DISABLED)
 		src.data = ndata
-	to_chat(user, output(list2params(list(generate_data_json())),"[windowid].browser:receiveUIState"))
+	user << output(list2params(list(generate_data_json())),"[windowid].browser:receiveUIState")
 
 /**
   * Check for change and push that change of data

--- a/html/changelogs/geeves-misc_bugfixes.yml
+++ b/html/changelogs/geeves-misc_bugfixes.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Mech pilots now properly get messages from their mech actions."


### PR DESCRIPTION
* Mech pilots now properly get messages from their mech actions.

This also gets rid of to_chat as a macro and replaces it as a proc, gets rid of a few emergency shuttle subsystem runtimes, mech subsystem runtimes, and gets rid of an AI spawn runtime, at the cost of being blind for a second or so after spawning in, which is fine.


Most importantly, it get rids of to_chats that aren't even to_chats.