### PR TITLE
Mecha Improvements

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1596,7 +1596,7 @@
 #include "code\modules\heavy_vehicle\equipment\mining.dm"
 #include "code\modules\heavy_vehicle\equipment\utility.dm"
 #include "code\modules\heavy_vehicle\interface\_interface.dm"
-#include "code\modules\heavy_vehicle\interface\screen_objectsa.dm"
+#include "code\modules\heavy_vehicle\interface\screen_objects.dm"
 #include "code\modules\heavy_vehicle\premade\_premade.dm"
 #include "code\modules\heavy_vehicle\premade\combat.dm"
 #include "code\modules\heavy_vehicle\premade\heavy.dm"

--- a/code/modules/heavy_vehicle/equipment/utility.dm
+++ b/code/modules/heavy_vehicle/equipment/utility.dm
@@ -100,7 +100,7 @@
 
 /obj/item/mecha_equipment/clamp/get_hardpoint_maptext()
 	if(length(carrying) == 1)
-		return carrying[1].name
+		return capitalize_first_letters(carrying[1].name)
 	else if(length(carrying) > 1)
 		return "Multiple Objects"
 	. = ..()

--- a/code/modules/heavy_vehicle/interface/_interface.dm
+++ b/code/modules/heavy_vehicle/interface/_interface.dm
@@ -62,8 +62,17 @@
 	handle_hud_icons_health()
 	var/obj/item/cell/C = get_cell()
 	if(istype(C))
-		hud_power.maptext = "[round(get_cell()?.charge)]/[round(get_cell()?.maxcharge)]"
-	else hud_power.maptext = "CHECK POWER"
+		var/power_percentage = round((get_cell()?.charge / get_cell()?.maxcharge) * 100)
+		if(power_percentage >= 100)
+			hud_power.maptext_x = 21
+		else if(power_percentage < 10)
+			hud_power.maptext_x = 25
+		else if(power_percentage < 100)
+			hud_power.maptext_x = 22
+		hud_power.maptext = "<span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 8px;\">[power_percentage]%</span>"
+	else
+		hud_power.maptext_x = 13
+		hud_power.maptext = "<span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;\">NO CELL</span>"
 	refresh_hud()
 
 

--- a/code/modules/heavy_vehicle/interface/screen_objects.dm
+++ b/code/modules/heavy_vehicle/interface/screen_objects.dm
@@ -31,7 +31,7 @@
 
 	maptext_x = 34
 	maptext_y = 3
-	maptext_width = 72
+	maptext_width = 120
 
 /obj/screen/movable/mecha/hardpoint/Destroy()
 	owner = null
@@ -43,7 +43,6 @@
 	if(holding) holding.screen_loc = screen_loc
 
 /obj/screen/movable/mecha/hardpoint/proc/update_system_info()
-
 	// No point drawing it if we have no item to use or nobody to see it.
 	if(!holding || !owner)
 		return
@@ -64,7 +63,7 @@
 		overlays.Cut()
 		return
 
-	maptext = holding.get_hardpoint_maptext()
+	maptext = "<span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;\">[holding.get_hardpoint_maptext()]</span>"
 
 	var/ui_damage = (!owner.body.diagnostics || !owner.body.diagnostics.is_functional() || ((owner.emp_damage>EMP_GUI_DISRUPT) && prob(owner.emp_damage)))
 
@@ -169,6 +168,7 @@
 	icon_state = null
 
 	maptext_width = 64
+	maptext_y = 2
 
 /obj/screen/movable/mecha/toggle
 	name = "toggle"

--- a/code/modules/heavy_vehicle/mech_interaction.dm
+++ b/code/modules/heavy_vehicle/mech_interaction.dm
@@ -164,6 +164,20 @@
 		return A.attack_generic(src, arms.melee_damage, "attacked")
 	return
 
+/mob/living/heavy_vehicle/setClickCooldown(var/timeout)
+	next_move = max(world.time + timeout, next_move)
+	for(var/hardpoint in hardpoint_hud_elements)
+		var/obj/screen/movable/mecha/hardpoint/H = hardpoint_hud_elements[hardpoint]
+		if(H)
+			H.color = "#FF0000"
+	addtimer(CALLBACK(src, .proc/reset_hardpoint_color), timeout)
+
+/mob/living/heavy_vehicle/proc/reset_hardpoint_color()
+	for(var/hardpoint in hardpoint_hud_elements)
+		var/obj/screen/movable/mecha/hardpoint/H = hardpoint_hud_elements[hardpoint]
+		if(H)
+			H.color = null
+
 /mob/living/heavy_vehicle/proc/set_hardpoint(var/hardpoint_tag)
 	clear_selected_hardpoint()
 	if(hardpoints[hardpoint_tag])
@@ -265,8 +279,7 @@
 	return
 
 /mob/living/heavy_vehicle/relaymove(var/mob/living/user, var/direction)
-
-	if(world.time < next_move)
+	if(world.time < next_mecha_move)
 		return 0
 
 	if(!user || incapacitated() || user.incapacitated() || lockdown)
@@ -274,15 +287,15 @@
 
 	if(!legs)
 		to_chat(user, "<span class='warning'>\The [src] has no means of propulsion!</span>")
-		next_move = world.time + 3 // Just to stop them from getting spammed with messages.
+		next_mecha_move = world.time + 3 // Just to stop them from getting spammed with messages.
 		return
 
 	if(!legs.motivator || legs.total_damage > 45)
 		to_chat(user, "<span class='warning'>Your motivators are damaged! You can't move!</span>")
-		next_move = world.time + 15
+		next_mecha_move = world.time + 15
 		return
 
-	next_move = world.time + legs.move_delay
+	next_mecha_move = world.time + legs.move_delay
 
 	if(maintenance_protocols)
 		to_chat(user, "<span class='warning'>Maintenance protocols are in effect.</span>")
@@ -305,7 +318,7 @@
 		get_cell()?.use(legs.power_use * CELLRATE)
 		if(legs && legs.mech_turn_sound)
 			playsound(src.loc,legs.mech_turn_sound,40,1)
-		next_move = world.time + legs.turn_delay
+		next_mecha_move = world.time + legs.turn_delay
 		set_dir(direction)
 		if(istype(hardpoints[HARDPOINT_BACK], /obj/item/mecha_equipment/shield))
 			var/obj/item/mecha_equipment/shield/S = hardpoints[HARDPOINT_BACK]

--- a/code/modules/heavy_vehicle/mecha.dm
+++ b/code/modules/heavy_vehicle/mecha.dm
@@ -67,6 +67,7 @@
 	var/use_air      = FALSE
 
 	// Interface stuff.
+	var/next_mecha_move = 0
 	var/list/hud_elements = list()
 	var/list/hardpoint_hud_elements = list()
 	var/obj/screen/movable/mecha/health/hud_health

--- a/html/changelogs/geeves-mecha_improvements.yml
+++ b/html/changelogs/geeves-mecha_improvements.yml
@@ -1,0 +1,9 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Mecha movement and equipment usage cooldowns have been decoupled. You can now move directly after using your equipment, which makes them MUCH less clunky to use."
+  - rscadd: "Mecha hardpoint UI elements will now get tinted red during their cooldowns, which will turn back to normal once the equipment can be used again."
+  - tweak: "Mecha UI text have been overhauled to look much prettier."
+  - tweak: "The charge level for mechs is now displayed as a percentage value, and actually fits on the screen."


### PR DESCRIPTION
* Mecha movement and equipment usage cooldowns have been decoupled. You can now move directly after using your equipment, which makes them MUCH less clunky to use.
* Mecha hardpoint UI elements will now get tinted red during their cooldowns, which will turn back to normal once the equipment can be used again.
* Mecha UI text have been overhauled to look much prettier.
* The charge level for mechs is now displayed as a percentage value, and actually fits on the screen.