### PR TITLE
Reduces the amount of evolution points changelings get when absorbing dna

### DIFF
--- a/code/game/gamemodes/changeling/implements/powers/suck.dm
+++ b/code/game/gamemodes/changeling/implements/powers/suck.dm
@@ -65,7 +65,7 @@
 	playsound(get_turf(src), 'sound/effects/lingabsorbs.ogg', 50, 1)
 
 	changeling.chem_charges += 50
-	changeling.geneticpoints += 5
+	changeling.geneticpoints += 3
 
 	//Steal all of their languages!
 	for(var/language in T.languages)

--- a/html/changelogs/alberyk-lingpowercreepbegone.yml
+++ b/html/changelogs/alberyk-lingpowercreepbegone.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Changelings should now get only 3 evolution points when absorbing DNA."


### PR DESCRIPTION
They used to get five points, this pr changes it to three. Because this allowed them to get horror form and death sting by killing two people only.