### PR TITLE
Drill Fix

### DIFF
--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -98,6 +98,10 @@
 					attached_satchel.insert_into_storage(ore)
 	else if(istype(get_turf(src), /turf/simulated/floor))
 		var/turf/simulated/floor/T = get_turf(src)
+		var/turf/below_turf = GetBelow(T)
+		if(!istype(below_turf.loc, /area/mine))
+			system_error("Potential station breach below.")
+			return
 		T.ex_act(2.0)
 
 	//Dig out the tasty ores.

--- a/html/changelogs/geeves-drill_fix.yml
+++ b/html/changelogs/geeves-drill_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Mining drills will no longer breach station areas if placed and activated above them."


### PR DESCRIPTION
* Mining drills will no longer breach station areas if placed and activated above them.