### PR TITLE
Remove potential edgecases from gravity/slip code

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -473,7 +473,10 @@
 		return 1
 	else if (istype(T, /turf/space))
 		return 0
-	else if (!T.loc.has_gravity())
+
+	var/area/A = T.loc
+
+	if (!A.has_gravity())
 		return 0
 
 	return 1

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -467,12 +467,13 @@
 //If there's no gravity then there's no up or down so naturally you can't stand on anything.
 //For the same reason lattices in space don't count - those are things you grip, presumably.
 /mob/proc/check_solid_ground()
-	if(istype(loc, /turf/space))
-		return 0
+	var/turf/T = get_turf(src)
 
-	if(!lastarea)
-		lastarea = get_area(loc)
-	if(!lastarea.has_gravity())
+	if (!T) // nullspace so sure, have gravity.
+		return 1
+	else if (istype(T, /turf/space))
+		return 0
+	else if (!T.loc.has_gravity())
 		return 0
 
 	return 1

--- a/html/changelogs/skull132_gravity.yml
+++ b/html/changelogs/skull132_gravity.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - tweak: "Adjust some gravity behaviour, maybe fix a few bugs."


### PR DESCRIPTION
The old code relies on `lastarea` being up to date. This doesn't really make sense, and can lead to edge cases; we should just be checking the turf the mob is on.