### PR TITLE
Various Tweaks and Changes

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -694,9 +694,9 @@ var/global/list/default_medbay_channels = list(
 		if(!SSradio)
 			src.name = "broken radio"
 			return
-
 		secure_radio_connections[ch_name] = SSradio.add_object(src, radiochannels[ch_name],  RADIO_CHAT)
 
+	setupRadioDescription()
 	return
 
 /obj/item/device/radio/borg/Topic(href, href_list)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -564,7 +564,7 @@
 		return
 
 	if(empty_delay)
-		visible_message("\The [usr] starts to empty the contents of \the [src].")
+		usr.visible_message("\The [usr] starts to empty the contents of \the [src]...", SPAN_NOTICE("You start emptying the contents of \the [src]..."))
 
 	if(!do_after(usr, contents.len * empty_delay, act_target=usr))
 		return
@@ -577,9 +577,7 @@
 		CHECK_TICK
 
 	post_remove_from_storage_deferred(loc, usr)
-
-	if(empty_delay)
-		visible_message("\The [usr] empties the contents of \the [src].")
+	usr.visible_message("<b>\The [usr]</b> empties the contents of \the [src].", , SPAN_NOTICE("You empty the contents of \the [src]."))
 
 // Override this to fill the storage object with stuff.
 /obj/item/storage/proc/fill()
@@ -656,6 +654,13 @@
 		if(src.verbs.Find(/obj/item/storage/verb/quick_empty))
 			src.quick_empty()
 			return 1
+
+/obj/item/storage/CtrlClick(mob/user)
+	if(user.get_active_hand() == src)
+		if(src.verbs.Find(/obj/item/storage/verb/quick_empty))
+			src.quick_empty()
+			return
+	..()
 
 /obj/item/storage/proc/make_exact_fit()
 	storage_slots = contents.len

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -198,6 +198,31 @@
 			return
 		if(default_part_replacement(user, O))
 			return
+
+	if(istype(O, /obj/item/mining_scanner))
+		if(!length(resource_field))
+			to_chat(user, SPAN_WARNING("\The [src] has no resource field to draw data from!"))
+			return
+		to_chat(user, SPAN_NOTICE("You start drawing the data from \the [src]..."))
+		if(do_after(user, 50, TRUE))
+			if(!length(resource_field))
+				to_chat(user, SPAN_WARNING("\The [src] has no resource field to draw data from!"))
+				return
+			var/list/ore_data = list()
+			for(var/ore_type in ore_types)
+				ore_data[ore_type] = 0
+			for(var/field in resource_field)
+				var/turf/T = field
+				if(!T.resources)
+					continue
+				for(var/ore in ore_types)
+					if(T.resources[ore])
+						ore_data[ore] += T.resources[ore]
+			to_chat(user, SPAN_NOTICE("\The [src] has found this ore in the vicinity, and is able to gather it:"))
+			for(var/entry in ore_data)
+				to_chat(user, SPAN_NOTICE(" | <b>[entry]</b> - <b>[ore_data[entry]]</b>"))
+		return
+
 	if(active)
 		return ..()
 

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -196,11 +196,8 @@
 	if(!active)
 		if(default_deconstruction_screwdriver(user, O))
 			return
-		if (!panel_open)
-			if(default_deconstruction_crowbar(user, O))
-				return
-			if(default_part_replacement(user, O))
-				return
+		if(default_part_replacement(user, O))
+			return
 	if(active)
 		return ..()
 
@@ -237,16 +234,37 @@
 		return
 
 	if(O.iscrowbar())
-		if (panel_open)
+		if(panel_open)
 			if(cell)
-				to_chat(user, SPAN_NOTICE("You wrench out \the [cell]."))
+				to_chat(user, SPAN_NOTICE("You shimmy out \the [cell]."))
 				cell.forceMove(get_turf(user))
 				component_parts -= cell
+				user.put_in_hands(cell)
 				cell = null
 				return
 			else
 				to_chat(user, SPAN_WARNING("There's no cell to remove!"))
 				return
+		else
+			to_chat(user, SPAN_WARNING("The hatch must be open to take out a power cell."))
+			return
+
+	if(istype(O, /obj/item/gripper/miner)) // the gripper will always be empty, because it passes its wrapped object's attack if it has one
+		var/obj/item/gripper/miner/M = O
+		if(panel_open)
+			if(cell)
+				to_chat(user, SPAN_NOTICE("You use your gripper to squeeze the cell out of its case."))
+				cell.forceMove(get_turf(user))
+				component_parts -= cell
+				M.grip_item(cell, user, FALSE)
+				cell = null
+				return
+			else
+				to_chat(user, SPAN_WARNING("There's no cell to remove!"))
+				return
+		else
+			to_chat(user, SPAN_WARNING("The hatch must be open to take out a power cell."))
+			return
 
 	if(istype(O, /obj/item/cell))
 		if(panel_open)
@@ -259,11 +277,11 @@
 				cell = O
 				component_parts += O
 				O.add_fingerprint(user)
-				visible_message(span("notice", "\The [user] inserts a power cell into \the [src]."),
-					span("notice", "You insert the power cell into \the [src]."))
+				visible_message("<b>\The [user]</b> inserts a power cell into \the [src].",
+					SPAN_NOTICE("You insert the power cell into \the [src]."))
 				power_change()
 		else
-			to_chat(user, span("notice", "The hatch must be open to insert a power cell."))
+			to_chat(user, SPAN_WARNING("The hatch must be open to insert a power cell."))
 			return
 	else
 		..()

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -59,6 +59,8 @@
 					to_chat(user, SPAN_NOTICE("You collect \the [I]."))
 				I.forceMove(src)
 				wrapped = I
+				wrapped.pixel_x = 0
+				wrapped.pixel_y = 0
 				update_icon()
 				return TRUE
 		if(feedback)
@@ -90,6 +92,12 @@
 		update_icon()
 	return ..()
 
+/obj/item/gripper/CtrlClick(mob/user)
+	if(wrapped)
+		drop(get_turf(src))
+		return
+	to_chat(user, SPAN_WARNING("\The [src] isn't gripping anything!"))
+
 /obj/item/gripper/verb/drop_item()
 	set name = "Drop Item"
 	set desc = "Release an item from your magnetic gripper."
@@ -98,8 +106,13 @@
 	drop(get_turf(src))
 
 /obj/item/gripper/proc/drop(var/atom/target)
-	if(wrapped?.loc == src)
-		wrapped.forceMove(target)
+	if(wrapped)
+		if(wrapped.loc == src)
+			if(force_holder)
+				wrapped.force = force_holder
+			wrapped.forceMove(target)
+			force_holder = null
+		to_chat(loc, SPAN_NOTICE("You release \the [wrapped].")) // loc will always be the cyborg
 	wrapped = null
 	update_icon()
 	return TRUE
@@ -153,6 +166,8 @@
 		if(!isturf(target.loc))
 			return
 		grip_item(target, user)
+	else if (istype(target, /obj/machinery/mining)) // to prevent them from activating it by accident
+		return
 	else if (!just_dropped)
 		target.attack_ai(user)
 	just_dropped = FALSE

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -685,6 +685,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/extinguisher/mini(src) // For navigating space and/or low grav, and just being useful.
 	src.modules += new /obj/item/device/flash(src) // Non-lethal tool that prevents any 'borg from going lethal on Crew so long as it's an option according to laws.
 	src.modules += new /obj/item/crowbar/robotic(src) // Base crowbar that all 'borgs should have access to.
+	src.modules += new /obj/item/storage/part_replacer(src)
 	src.emag = new /obj/item/gun/energy/plasmacutter/mounted(src)
 
 /obj/item/robot_module/research
@@ -730,6 +731,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/extinguisher(src) // For navigating space and/or low grav, and just being useful.
 	src.modules += new /obj/item/device/flash(src) // Non-lethal tool that prevents any 'borg from going lethal on Crew so long as it's an option according to laws.
 	src.modules += new /obj/item/crowbar/robotic(src) // Base crowbar that all 'borgs should have access to.
+	src.modules += new /obj/item/storage/part_replacer(src)
 	src.emag = new /obj/item/hand_tele(src)
 
 	var/datum/matter_synth/nanite = new /datum/matter_synth/nanite(10000)

--- a/html/changelogs/geeves-drill_tweaks.yml
+++ b/html/changelogs/geeves-drill_tweaks.yml
@@ -13,3 +13,4 @@ changes:
   - tweak: "Taking a cell out of a mining drill will now place it in one of your hands, if one is open."
   - bugfix: "Emptying a bag's contents onto the floor with the verb will now always display the message of you doing it."
   - rscadd: "Control-clicking a storage item in your active hand will now attempt to empty it onto the floor, if it has that verb."
+  - rscadd: "Using an ore detector on a drill will now give a detailed readout of the ore in the vicinity that it has access to and call pull out."

--- a/html/changelogs/geeves-drill_tweaks.yml
+++ b/html/changelogs/geeves-drill_tweaks.yml
@@ -1,0 +1,15 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Mining drills can now be properly upgraded by part replacers."
+  - rscadd: "Mining grippers can now remove cells from mining drills, if the panel is open."
+  - bugfix: "Cyborg radio descriptions now update when they reset modules."
+  - rscadd: "Mining and science cyborgs now get part replacers in their modules."
+  - bugfix: "Grippers now position their items correctly, spritewise."
+  - rscadd: "Control-clicking your gripper will now make it drop its held item."
+  - bugfix: "Clicking a mining drill with a gripper will no longer activate or deactivate it, which will prevent a lot of accidents."
+  - tweak: "Taking a cell out of a mining drill will now place it in one of your hands, if one is open."
+  - bugfix: "Emptying a bag's contents onto the floor with the verb will now always display the message of you doing it."
+  - rscadd: "Control-clicking a storage item in your active hand will now attempt to empty it onto the floor, if it has that verb."


### PR DESCRIPTION
* Mining drills can now be properly upgraded by part replacers.
* Mining grippers can now remove cells from mining drills, if the panel is open.
* Cyborg radio descriptions now update when they reset modules.
* Mining and science cyborgs now get part replacers in their modules.
* Grippers now position their items correctly, spritewise.
* Control-clicking your gripper will now make it drop its held item.
* Clicking a mining drill with a gripper will no longer activate or deactivate it, which will prevent a lot of accidents.
* Taking a cell out of a mining drill will now place it in one of your hands, if one is open.
* Emptying a bag's contents onto the floor with the verb will now always display the message of you doing it.
* Control-clicking a storage item in your active hand will now attempt to empty it onto the floor, if it has that verb.

Making this more atomic would've been a PITA. All in all, this PR makes it easier for Mining Cyborgs to assist Drill Technicians in their duties. It also makes it possible for Science Borgs to upgrade equipment around the station.