### PR TITLE
Battlemonsters Entry

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1034,6 +1034,7 @@
 	vend_id = "battlemonsters"
 	products = list(
 		/obj/item/book/manual/wiki/battlemonsters = 10,
+		/obj/item/battle_monsters/wrapped/basic = 5,
 		/obj/item/battle_monsters/wrapped = 10,
 		/obj/item/battle_monsters/wrapped/pro = 10,
 		/obj/item/battle_monsters/wrapped/species = 4, //Human monsters

--- a/code/modules/battlemonsters/items/wrapped.dm
+++ b/code/modules/battlemonsters/items/wrapped.dm
@@ -40,6 +40,14 @@
 	generated_deck.update_icon()
 	qdel(src)
 
+/obj/item/battle_monsters/wrapped/basic
+	name = "battle monsters basic booster pack"
+	desc = "A pack of 7 basic battle monster cards, merely to prod the imagination."
+	icon_state = "pack2"
+	contained_cards = 7
+	rarity_max = BATTLE_MONSTERS_RARITY_COMMON
+	rarity_min = BATTLE_MONSTERS_RARITY_COMMON
+
 /obj/item/battle_monsters/wrapped/pro
 	name = "battle monsters booster pack"
 	desc = "A pack of 10 rare battle monster cards, with a chance of having legendary cards."

--- a/html/changelogs/geeves-battlemonsters_entrydecks.yml
+++ b/html/changelogs/geeves-battlemonsters_entrydecks.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Battlemonsters vendors now spawn with five free basic packs containing seven common cards, which can be used to show people how the game works without spending any money."


### PR DESCRIPTION
* Battlemonsters vendors now spawn with five free basic packs containing seven common cards, which can be used to show people how the game works without spending any money.