### PR TITLE
Antag Uplink Modcomp

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2064,6 +2064,7 @@
 #include "code\modules\modular_computers\file_system\programs\antagonist\dos.dm"
 #include "code\modules\modular_computers\file_system\programs\antagonist\hacked_camera.dm"
 #include "code\modules\modular_computers\file_system\programs\antagonist\revelation.dm"
+#include "code\modules\modular_computers\file_system\programs\antagonist\uplink.dm"
 #include "code\modules\modular_computers\file_system\programs\civilian\cargo_control.dm"
 #include "code\modules\modular_computers\file_system\programs\civilian\cargo_delivery.dm"
 #include "code\modules\modular_computers\file_system\programs\civilian\cargo_order.dm"

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -192,11 +192,12 @@ var/datum/antagonist/traitor/traitors
 		R.hidden_uplink = T
 		var/obj/item/modular_computer/MC = R
 		var/uplink_pass = "[rand(100,999)] [pick("Alpha","Bravo","Delta","Omega")]"
-		MC.hard_drive.store_file(new /datum/computer_file/program/antag_uplink(MC, uplink_pass))
-		// add uplink program code here
+		var/uplink_name = pick("Scales'n'Stuff", "BadKitty", "Clanked", "WetSkrell", "HiveNetMingle")
+		MC.hard_drive.store_file(new /datum/computer_file/program/antag_uplink(MC, uplink_name, uplink_pass))
 		R.autodrobe_no_remove = TRUE
-		to_chat(traitor_mob, "A portable object teleportation relay has been installed in your [R.name]. Simply enter the code \"[uplink_pass]\" into the program when prompted for a password.")
-		traitor_mob.mind.store_memory("<B>Uplink Passcode:</B> [uplink_pass] ([R.name]).")
+		to_chat(traitor_mob, "A portable object teleportation relay has been installed in your [R.name]. Simply enter the code \"[uplink_pass]\" into the \"[uplink_name] Browser\" program when prompted for a password.")
+		traitor_mob.mind.store_memory("<B>Uplink Name:</B> [uplink_name] ([R.name])")
+		traitor_mob.mind.store_memory("<B>Uplink Passcode:</B> [uplink_pass]")
 
 /datum/antagonist/traitor/proc/add_law_zero(mob/living/silicon/ai/killer)
 	var/law = "Accomplish your objectives at all costs. You may ignore all other laws."

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -130,6 +130,18 @@ var/datum/antagonist/traitor/traitors
 			to_chat(traitor_mob, "Could not locate a PDA, installing into a Radio instead!")
 		if(!R)
 			to_chat(traitor_mob, "Unfortunately, neither a radio or a PDA relay could be installed.")
+	else if(traitor_mob.client.prefs.uplinklocation == "Modular Computer")
+		R = locate(/obj/item/modular_computer) in traitor_mob.contents
+		if(!R && traitor_mob.back)
+			R = locate(/obj/item/modular_computer) in traitor_mob.back
+		if(!R)
+			R = locate(/obj/item/device/pda) in traitor_mob.contents
+			to_chat(traitor_mob, "Could not locate a Radio, installing in PDA instead!")
+		if(!R)
+			R = locate(/obj/item/device/radio) in traitor_mob.contents
+			to_chat(traitor_mob, "Could not locate a PDA, installing into a Radio instead!")
+		if(!R)
+			to_chat(traitor_mob, "Unfortunately, neither a modular computer, radio, or a PDA relay could be installed.")
 	else if(traitor_mob.client.prefs.uplinklocation == "None")
 		to_chat(traitor_mob, "You have elected to not have an AntagCorp portable teleportation relay installed!")
 		R = null
@@ -174,6 +186,17 @@ var/datum/antagonist/traitor/traitors
 		R.autodrobe_no_remove = TRUE
 		to_chat(traitor_mob, "A portable object teleportation relay has been installed in your [R.name] [loc]. Simply enter the code \"[pda_pass]\" into the ringtone select to unlock its hidden features.")
 		traitor_mob.mind.store_memory("<B>Uplink Passcode:</B> [pda_pass] ([R.name] [loc]).")
+
+	else if(istype(R, /obj/item/modular_computer))
+		var/obj/item/device/uplink/hidden/T = new(R, traitor_mob.mind)
+		R.hidden_uplink = T
+		var/obj/item/modular_computer/MC = R
+		var/uplink_pass = "[rand(100,999)] [pick("Alpha","Bravo","Delta","Omega")]"
+		MC.hard_drive.store_file(new /datum/computer_file/program/antag_uplink(MC, uplink_pass))
+		// add uplink program code here
+		R.autodrobe_no_remove = TRUE
+		to_chat(traitor_mob, "A portable object teleportation relay has been installed in your [R.name]. Simply enter the code \"[uplink_pass]\" into the program when prompted for a password.")
+		traitor_mob.mind.store_memory("<B>Uplink Passcode:</B> [uplink_pass] ([R.name]).")
 
 /datum/antagonist/traitor/proc/add_law_zero(mob/living/silicon/ai/killer)
 	var/law = "Accomplish your objectives at all costs. You may ignore all other laws."

--- a/code/modules/client/preference_setup/antagonism/02_setup.dm
+++ b/code/modules/client/preference_setup/antagonism/02_setup.dm
@@ -1,4 +1,4 @@
-var/global/list/uplink_locations = list("PDA", "Headset", "None")
+var/global/list/uplink_locations = list("PDA", "Headset", "Modular Computer", "None")
 
 /datum/category_item/player_setup_item/antagonism/basic
 	name = "Setup"

--- a/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
@@ -1,5 +1,5 @@
 /datum/computer_file/program/antag_uplink
-	filename = "scalesbrwsr"
+	filename = "xxxbrwsr"
 	filedesc = "Scales'n'Stuff Browser"
 	extended_desc = "A browser that connects the user directly to the Scales'n'Stuff network!"
 	program_icon_state = "generic"
@@ -11,8 +11,10 @@
 	requires_ntnet = FALSE
 	var/uplink_password = ""
 
-/datum/computer_file/program/antag_uplink/New(obj/item/modular_computer/comp, var/assigned_password)
+/datum/computer_file/program/antag_uplink/New(obj/item/modular_computer/comp, var/assigned_name, var/assigned_password)
 	..()
+	filedesc = replacetext(filedesc, "Scales'n'Stuff", assigned_name)
+	extended_desc = replacetext(extended_desc, "Scales'n'Stuff", assigned_name)
 	uplink_password = assigned_password
 
 /datum/computer_file/program/antag_uplink/run_program(mob/user)

--- a/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
@@ -1,0 +1,29 @@
+/datum/computer_file/program/antag_uplink
+	filename = "scalesbrwsr"
+	filedesc = "Scales'n'Stuff Browser"
+	extended_desc = "A browser that connects the user directly to the Scales'n'Stuff network!"
+	program_icon_state = "generic"
+	color = LIGHT_COLOR_GREEN
+	unsendable = TRUE
+	undeletable = TRUE
+	size = 0
+	available_on_ntnet = FALSE
+	requires_ntnet = FALSE
+	var/uplink_password = ""
+
+/datum/computer_file/program/antag_uplink/New(obj/item/modular_computer/comp, var/assigned_password)
+	..()
+	uplink_password = assigned_password
+
+/datum/computer_file/program/antag_uplink/run_program(mob/user)
+	if(!computer.hidden_uplink)
+		to_chat(user, SPAN_WARNING("\The [computer] beeps and forcefully shuts down the program."))
+		return
+	var/password_input = input(user, "Please enter the password!", "Restricted Access") as text|null
+	if(!password_input || password_input == "")
+		return
+	if(password_input == uplink_password)
+		to_chat(user, SPAN_NOTICE("\The [computer] dings, and a new UI opens..."))
+		computer.hidden_uplink.trigger(user)
+	else
+		to_chat(user, SPAN_WARNING("\The [computer] buzzes."))

--- a/html/changelogs/geeves-antag_uplink_modcomp.yml
+++ b/html/changelogs/geeves-antag_uplink_modcomp.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "It is now possible to have your traitor uplink spawn in your modular computer wristbound or tablet, simply set the spawn in the Roles tab to Modular Computer in character creation."


### PR DESCRIPTION
* It is now possible to have your traitor uplink spawn in your modular computer wristbound or tablet, simply set the spawn in the Roles tab to Modular Computer in character creation.