### PR TITLE
Droppod Fixes

### DIFF
--- a/code/modules/vehicles/droppod.dm
+++ b/code/modules/vehicles/droppod.dm
@@ -184,11 +184,6 @@
 					/area/sconference_room = 2
 					)
 				A = pickweight(cargo_destination_list)
-			if("tcoms")
-				var/tcoms_destination_list = list(
-					/area/tcommsat/lounge = 1
-					)
-				A = pickweight(tcoms_destination_list)
 			if("commandescape")
 				var/commandescape_destination_list = list(
 					/area/bridge/levela = 2,
@@ -198,8 +193,11 @@
 					)
 				A = pickweight(commandescape_destination_list)
 		if(A)
-			status = LAUNCHING
 			var/mob/user = usr
+			if(!(user in src))
+				if(alert(user, "WARNING: You are not in the droppod! Are you sure you wish to launch?", "Launch Confirmation", "Yes", "No") == "No")
+					return
+			status = LAUNCHING
 			var/datum/nanoui/ui = SSnanoui.get_open_ui(user, src, "main")
 			if(ui)
 				ui.close()

--- a/html/changelogs/geeves-droppod_launching.yml
+++ b/html/changelogs/geeves-droppod_launching.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "The Telecomms Lounge has been removed from the droppod target list, as it no longer exists."
+  - bugfix: "A warning now pops up if you attempt to launch a droppod while not inside it."

--- a/nano/templates/droppod.tmpl
+++ b/nano/templates/droppod.tmpl
@@ -7,7 +7,6 @@
     Pod Status: <span class="good">Operational</span></H2>
     {{:helper.link('Departures', 'gear', {'fire' : 'arrivals'})}}<br><br>
     {{:helper.link('Cargo Surface', 'gear', {'fire' : 'cargo'})}}<br><br>
-    {{:helper.link('Telecomms Lounge', 'gear', {'fire' : 'tcoms'})}}<br><br>
     {{:helper.link('Command Surface', 'gear', {'fire' : 'commandescape'})}}<br><br>
 {{/if}}
 


### PR DESCRIPTION
* The Telecomms Lounge has been removed from the droppod target list, as it no longer exists.
* A warning now pops up if you attempt to launch a droppod while not inside it.