### PR TITLE
Department Radio Colours

### DIFF
--- a/code/controllers/subsystems/radio.dm
+++ b/code/controllers/subsystems/radio.dm
@@ -188,3 +188,20 @@ var/datum/controller/subsystem/radio/SSradio
 		else
 			if(DEPT_FREQS_ASSOC[fstr])
 				. = "deptradio"
+
+/proc/get_job_span_class(var/job)
+	if(job in command_positions)
+		return "comradio"
+	if(job in engineering_positions)
+		return "engradio"
+	if(job in medical_positions)
+		return "medradio"
+	if(job in science_positions)
+		return "sciradio"
+	if(job in cargo_positions)
+		return "supradio"
+	if(job in civilian_positions)
+		return "srvradio"
+	if(job in security_positions)
+		return "secradio"
+	return "radio"

--- a/code/datums/uplink/announcements.dm
+++ b/code/datums/uplink/announcements.dm
@@ -31,11 +31,7 @@
 /datum/uplink_item/abstract/announcements/fake_crew_arrival
 	name = "Crew Arrival Announcement/Records"
 	desc = "Creates a fake crew arrival announcement as well as fake crew records, using your current appearance (including held items!) and worn id card. Trigger with care!"
-	item_cost = 8
-
-/datum/uplink_item/abstract/announcements/fake_crew_arrival/New()
-	..()
-	antag_roles = list(MODE_MERCENARY)
+	item_cost = 4
 
 /datum/uplink_item/abstract/announcements/fake_crew_arrival/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/user, var/list/args)
 	if(!user)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -172,7 +172,7 @@
 				jobname = H.get_assignment()
 
 		else if (iscarbon(speaker)) // Nonhuman carbon mob
-			jobname = "No id"
+			jobname = "Unknown"
 		else if (isAI(speaker))
 			jobname = "AI"
 		else if (isrobot(speaker))
@@ -201,6 +201,11 @@
 		formatted = language.format_message_radio(message, verb)
 	else
 		formatted = "[verb], <span class=\"body\">\"[message]\"</span>"
+
+	var/datum/record/general/R = SSrecords.find_record("name", speaker_name)
+	if(R)
+		speaker_name = "<span class='[get_job_span_class(R.rank)]'><font size='1'>\[[R.rank]\]</font> [speaker_name]</span>"
+
 	if(sdisabilities & DEAF || ear_deaf)
 		if(prob(20))
 			to_chat(src, "<span class='warning'>You feel your headset vibrate but can hear nothing from it!</span>")

--- a/html/changelogs/geeves-department_coloured_radio_name.yml
+++ b/html/changelogs/geeves-department_coloured_radio_name.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes: 
   - rscadd: "Speaking on the radio now cross-references the records database. If the name of the voice is in the records database, their name and role is shown, and coloured in their department's colour."
+  - tweak: "The antag buyable in the Announcements uplink that makes a fake arrivals announcement and generates a fake record for the buyer is no longer restricted to Mercenaries, and costs 4 TC instead of 8 TC now."

--- a/html/changelogs/geeves-department_coloured_radio_name.yml
+++ b/html/changelogs/geeves-department_coloured_radio_name.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Speaking on the radio now cross-references the records database. If the name of the voice is in the records database, their name and role is shown, and coloured in their department's colour."


### PR DESCRIPTION
* Speaking on the radio now cross-references the records database. If the name of the voice is in the records database, their name and role is shown, and coloured in their department's colour.
* The antag buyable in the Announcements uplink that makes a fake arrivals announcement and generates a fake record for the buyer is no longer restricted to Mercenaries, and costs 4 TC instead of 8 TC now.

A screenshot of how it looks. The role is `[role]` instead of just `role`, but this is just an example.
![image](https://user-images.githubusercontent.com/22774890/85956760-4c98e200-b988-11ea-9282-7341821f43d5.png)

This is probably a pretty divisive PR, but I made it cuz it was pretty fun to make. If people dislike it a lot, closing it is A-okay.