### PR TITLE
File Copying + Tech Support Buff

### DIFF
--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -413,6 +413,11 @@ var/const/access_journalist = 70//journalist's office access
 	desc = "Journalist Office"
 	region = ACCESS_REGION_GENERAL
 
+var/const/access_it = 71 // allows some unique interactions with devices
+/datum/access/tech_support
+	id = access_it
+	desc = "Tech Support"
+
 /******************
 * Central Command *
 ******************/

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -59,7 +59,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	return TRUE
 
 /datum/job/captain/get_access()
-		return get_all_station_access()
+	return get_all_station_access()
 
 /datum/job/captain/announce(mob/living/carbon/human/H)
 	. = ..()

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -296,6 +296,7 @@
 	minimal_access = list(access_library)
 	alt_titles = list("Curator", "Tech Support")
 	alt_outfits = list("Curator" = /datum/outfit/job/librarian/curator, "Tech Support" = /datum/outfit/job/librarian/tech_support)
+	title_accesses = list("Tech Support" = access_it)
 	outfit = /datum/outfit/job/librarian
 
 /datum/outfit/job/librarian

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -20,11 +20,11 @@
 	access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 			            access_heads, access_construction, access_sec_doors, access_research, access_medical,
-			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
+			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload, access_it)
 	minimal_access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 			            access_heads, access_construction, access_sec_doors, access_research, access_medical,
-			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
+			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload, access_it)
 	minimal_player_age = 7
 	outfit = /datum/outfit/job/chief_engineer
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -17,11 +17,13 @@
 	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue, access_eva, access_external_airlocks,
 			            access_tox_storage, access_teleporter, access_sec_doors, access_medical, access_engine, access_construction,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
-			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network, access_maint_tunnels)
+			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network,
+			            access_maint_tunnels, access_it)
 	minimal_access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue, access_eva, access_external_airlocks,
 			            access_tox_storage, access_teleporter, access_sec_doors, access_medical, access_engine, access_construction,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
-			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network, access_maint_tunnels)
+			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network,
+			            access_maint_tunnels, access_it)
 	minimal_player_age = 14
 	ideal_character_age = 50
 	outfit = /datum/outfit/job/rd

--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -27,8 +27,8 @@ var/global/file_uid = 0
 	return ..()
 
 // Returns independent copy of this file.
-/datum/computer_file/proc/clone(var/rename = FALSE)
-	var/datum/computer_file/temp = new type
+/datum/computer_file/proc/clone(var/rename = FALSE, var/computer)
+	var/datum/computer_file/temp = new type(computer)
 	temp.unsendable = unsendable
 	temp.undeletable = undeletable
 	temp.size = size

--- a/code/modules/modular_computers/file_system/programs/system/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/system/file_browser.dm
@@ -142,12 +142,20 @@
 		if(ishuman(usr))
 			var/mob/living/carbon/human/H = usr
 			var/obj/item/card/id/ID = H.GetIdCard()
-			if(ID?.assignment == "Tech Support")
+			if(access_it in ID.access)
 				is_usr_tech_support = TRUE
 		if(!is_usr_tech_support && computer.enrolled != 2 && istype(F, /datum/computer_file/program))
 			to_chat(usr, SPAN_WARNING("Work devices can't export programs to portable drives! Contact Tech Support to get them to load it."))
 			return TRUE
-		var/datum/computer_file/C = F.clone(0)
+		if(!RHDD.can_store_file(F.size))
+			to_chat(usr, SPAN_WARNING("\The [RHDD] doesn't have enough space to import the file."))
+			return
+		var/datum/computer_file/C = F.clone(0, "Compless")
+		for(var/datum/computer_file/installed_file in RHDD.stored_files)
+			if(C.filename == installed_file.filename)
+				to_chat(usr, SPAN_WARNING("A file with the same name is already installed on \the [computer]."))
+				qdel(C)
+				return
 		RHDD.store_file(C)
 	if(href_list["PRG_copyfromusb"])
 		. = TRUE
@@ -162,12 +170,20 @@
 		if(ishuman(usr))
 			var/mob/living/carbon/human/H = usr
 			var/obj/item/card/id/ID = H.GetIdCard()
-			if(ID?.assignment == "Tech Support")
+			if(access_it in ID.access)
 				is_usr_tech_support = TRUE
 		if(!is_usr_tech_support && computer.enrolled != 2 && istype(F, /datum/computer_file/program))
 			to_chat(usr, SPAN_WARNING("Work devices can't import programs from portable drives! Contact Tech Support to get them to load it."))
 			return TRUE
-		var/datum/computer_file/C = F.clone(0)
+		if(!HDD.can_store_file(F.size))
+			to_chat(usr, SPAN_WARNING("\The [computer]'s hard drive doesn't have enough space to import the file."))
+			return
+		var/datum/computer_file/C = F.clone(0, computer)
+		for(var/datum/computer_file/installed_file in HDD.stored_files)
+			if(C.filename == installed_file.filename)
+				to_chat(usr, SPAN_WARNING("A file with the same name is already installed on \the [computer]."))
+				qdel(C)
+				return
 		HDD.store_file(C)
 	if(href_list["PRG_encrypt"])
 		. = TRUE

--- a/code/modules/modular_computers/file_system/programs/system/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/system/file_browser.dm
@@ -136,7 +136,16 @@
 		if(!HDD || !RHDD)
 			return TRUE
 		var/datum/computer_file/F = HDD.find_file_by_name(href_list["PRG_copytousb"])
-		if(!F || !istype(F) || (computer.enrolled != 2 && istype(F, /datum/computer_file/program)))
+		if(!F || !istype(F))
+			return TRUE
+		var/is_usr_tech_support = FALSE
+		if(ishuman(usr))
+			var/mob/living/carbon/human/H = usr
+			var/obj/item/card/id/ID = H.GetIdCard()
+			if(ID?.assignment == "Tech Support")
+				is_usr_tech_support = TRUE
+		if(!is_usr_tech_support && computer.enrolled != 2 && istype(F, /datum/computer_file/program))
+			to_chat(usr, SPAN_WARNING("Work devices can't export programs to portable drives! Contact Tech Support to get them to load it."))
 			return TRUE
 		var/datum/computer_file/C = F.clone(0)
 		RHDD.store_file(C)
@@ -147,7 +156,16 @@
 		if(!HDD || !RHDD)
 			return TRUE
 		var/datum/computer_file/F = RHDD.find_file_by_name(href_list["PRG_copyfromusb"])
-		if(!F || !istype(F) || (computer.enrolled != 2 && istype(F, /datum/computer_file/program)))
+		if(!F || !istype(F))
+			return TRUE
+		var/is_usr_tech_support = FALSE
+		if(ishuman(usr))
+			var/mob/living/carbon/human/H = usr
+			var/obj/item/card/id/ID = H.GetIdCard()
+			if(ID?.assignment == "Tech Support")
+				is_usr_tech_support = TRUE
+		if(!is_usr_tech_support && computer.enrolled != 2 && istype(F, /datum/computer_file/program))
+			to_chat(usr, SPAN_WARNING("Work devices can't import programs from portable drives! Contact Tech Support to get them to load it."))
 			return TRUE
 		var/datum/computer_file/C = F.clone(0)
 		HDD.store_file(C)

--- a/code/modules/modular_computers/file_system/programs/system/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/system/file_browser.dm
@@ -133,10 +133,10 @@
 		. = TRUE
 		var/obj/item/computer_hardware/hard_drive/HDD = computer.hard_drive
 		var/obj/item/computer_hardware/hard_drive/portable/RHDD = computer.portable_drive
-		if(!HDD || !RHDD || computer.enrolled != 2)
+		if(!HDD || !RHDD)
 			return TRUE
 		var/datum/computer_file/F = HDD.find_file_by_name(href_list["PRG_copytousb"])
-		if(!F || !istype(F))
+		if(!F || !istype(F) || (computer.enrolled != 2 && istype(F, /datum/computer_file/program)))
 			return TRUE
 		var/datum/computer_file/C = F.clone(0)
 		RHDD.store_file(C)
@@ -144,10 +144,10 @@
 		. = TRUE
 		var/obj/item/computer_hardware/hard_drive/HDD = computer.hard_drive
 		var/obj/item/computer_hardware/hard_drive/portable/RHDD = computer.portable_drive
-		if(!HDD || !RHDD || computer.enrolled != 2)
+		if(!HDD || !RHDD)
 			return TRUE
 		var/datum/computer_file/F = RHDD.find_file_by_name(href_list["PRG_copyfromusb"])
-		if(!F || !istype(F))
+		if(!F || !istype(F) || (computer.enrolled != 2 && istype(F, /datum/computer_file/program)))
 			return TRUE
 		var/datum/computer_file/C = F.clone(0)
 		HDD.store_file(C)

--- a/html/changelogs/geeves-file_copying.yml
+++ b/html/changelogs/geeves-file_copying.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed tape recorder drive files being unable to be copied to work devices, by allowing work devices to copy text files to and from portable drives."

--- a/html/changelogs/geeves-file_copying.yml
+++ b/html/changelogs/geeves-file_copying.yml
@@ -4,4 +4,5 @@ delete-after: True
 
 changes: 
   - bugfix: "Fixed tape recorder drive files being unable to be copied to work devices, by allowing work devices to copy text files to and from portable drives."
-  - tweak: "Tech Support can now install computer programs onto work devices."
+  - tweak: "Tech Support, Captains, CEs, and RDs can now install computer programs onto work devices."
+  - rscadd: "Importing or exporting programs will now tell you if there isn't enough space or if the same file is already on the target hard drive."

--- a/html/changelogs/geeves-file_copying.yml
+++ b/html/changelogs/geeves-file_copying.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes: 
   - bugfix: "Fixed tape recorder drive files being unable to be copied to work devices, by allowing work devices to copy text files to and from portable drives."
+  - tweak: "Tech Support can now install computer programs onto work devices."


### PR DESCRIPTION
* Fixed tape recorder drive files being unable to be copied to work devices, by allowing work devices to copy text files to and from portable drives.
* Tech Support can now install computer programs onto work devices.