### PR TITLE
Lit update

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -846,3 +846,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if(user)
 		attack_self(user)
 	return TRUE
+
+//Override this for items that can be flame sources.
+/obj/item/proc/isFlameSource()
+	return FALSE

--- a/code/game/objects/items/weapons/candle.dm
+++ b/code/game/objects/items/weapons/candle.dm
@@ -31,7 +31,7 @@
 		if(WT.isOn()) //Badasses dont get blinded by lighting their candle with a welding tool
 			light()
 			to_chat(user, span("notice", "\The [user] casually lights \the [name] with [W]."))
-	else if(isflamesource(W))
+	else if(W.isFlameSource())
 		light()
 		to_chat(user, span("notice", "\The [user] lights \the [name]."))
 	else if(istype(W, /obj/item/flame/candle))

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -16,20 +16,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/flame
 	var/lit = 0
 
-/proc/isflamesource(A)
-	var/obj/item/I = A
-	if(I.iswelder())
-		var/obj/item/weldingtool/WT = A
-		return (WT.isOn())
-	else if(istype(I, /obj/item/flame))
-		var/obj/item/flame/F = I
-		return (F.lit)
-	else if(istype(I, /obj/item/device/assembly/igniter))
-		return 1
-	else if(istype(I, /obj/item/clothing/gloves/fluff/lunea_gloves))
-		var/obj/item/clothing/gloves/fluff/lunea_gloves/F = I
-		return (F.lit)
-	return 0
+/obj/item/flame/isFlameSource()
+	return lit
 
 ///////////
 //MATCHES//
@@ -103,6 +91,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/icon_off
 	var/type_butt = null
 	var/chem_volume = 15 //Size of a syringe
+	var/genericmes = "USER lights NAME with FLAME"
 	var/matchmes = "USER lights NAME with FLAME"
 	var/lightermes = "USER lights NAME with FLAME"
 	var/zippomes = "USER lights NAME with FLAME"
@@ -206,7 +195,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/smokable/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if(isflamesource(W))
+	if(W.isFlameSource())
 		var/text = matchmes
 		if(istype(W, /obj/item/flame/match))
 			text = matchmes
@@ -218,10 +207,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			text = weldermes
 		else if(istype(W, /obj/item/device/assembly/igniter))
 			text = ignitermes
-		text = replacetext(text, "USER", "[user]")
-		text = replacetext(text, "NAME", "[name]")
-		text = replacetext(text, "FLAME", "[W.name]")
+		else
+			text = genericmes
+		text = replacetext(text, "USER", "\the [user]")
+		text = replacetext(text, "NAME", "\the [name]")
+		text = replacetext(text, "FLAME", "\the [W.name]")
 		light(text)
+
+/obj/item/clothing/mask/smokable/isFlameSource()
+	return lit
 
 /obj/item/clothing/mask/smokable/cigarette
 	name = "cigarette"

--- a/code/game/objects/items/weapons/grenades/dynamite.dm
+++ b/code/game/objects/items/weapons/grenades/dynamite.dm
@@ -18,7 +18,7 @@
 		if(WT.isOn())
 			activate(user)
 
-	else if(isflamesource(W))
+	else if(W.isFlameSource())
 		activate(user)
 
 	else if(istype(W, /obj/item/flame/candle))

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -486,6 +486,9 @@
 /obj/item/weldingtool/proc/isOn()
 	return src.welding
 
+/obj/item/weldingtool/isFlameSource()
+	return isOn()
+
 //Sets the welding state of the welding tool. If you see W.welding = 1 anywhere, please change it to W.setWelding(1)
 //so that the welding tool updates accordingly
 /obj/item/weldingtool/proc/setWelding(var/set_welding, var/mob/M)

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -33,3 +33,6 @@
 	activate()
 	add_fingerprint(user)
 	return
+
+/obj/item/device/assembly/igniter/isFlameSource()
+	return TRUE

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -197,7 +197,7 @@
 		if(WT.isOn()) //Badasses dont get blinded by lighting their candle with a welding tool
 			light()
 			to_chat(user, span("notice", "\The [user] casually lights \the [name] with [W]."))
-	else if(isflamesource(W))
+	else if(W.isFlameSource())
 		light()
 		to_chat(user, span("notice", "\The [user] lights \the [name]."))
 	else if(istype(W, /obj/item/flame/candle))

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -1065,6 +1065,9 @@ All custom items with worn sprites must follow the contained sprite system: http
 		item_state = initial(item_state)
 		set_light(0)
 
+/obj/item/clothing/gloves/fluff/lunea_gloves/isFlameSource()
+	return lit
+
 
 /obj/item/fluff/fernando_knittingneedles //Kitting Needles - Fernando Gonzales - resilynn
 	name = "knitting needles"

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -56,9 +56,9 @@
 	if(!on_fire && W.isFlameSource())
 		ignite()
 		if(on_fire)
-			visible_message(span("warning", "\The [user] lights \the [src] with \the [W]."))
+			visible_message(SPAN_WARNING("\The [user] lights \the [src] with \the [W]."))
 		else
-			to_chat(user, span("warning", "You manage to singe \the [src], but fail to light it."))
+			to_chat(user, SPAN_WARNING("You manage to singe \the [src], but fail to light it."))
 
 	. = ..()
 	update_name()

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -53,14 +53,12 @@
 		remove_contents(user)
 
 /obj/item/reagent_containers/glass/rag/attackby(obj/item/W, mob/user)
-	if(!on_fire && istype(W, /obj/item/flame))
-		var/obj/item/flame/F = W
-		if(F.lit)
-			ignite()
-			if(on_fire)
-				visible_message(span("warning", "\The [user] lights \the [src] with \the [W]."))
-			else
-				to_chat(user, span("warning", "You manage to singe \the [src], but fail to light it."))
+	if(!on_fire && W.isFlameSource())
+		ignite()
+		if(on_fire)
+			visible_message(span("warning", "\The [user] lights \the [src] with \the [W]."))
+		else
+			to_chat(user, span("warning", "You manage to singe \the [src], but fail to light it."))
 
 	. = ..()
 	update_name()

--- a/code/modules/makeshift/makeshift_reagents.dm
+++ b/code/modules/makeshift/makeshift_reagents.dm
@@ -138,7 +138,7 @@
 	if(!istype(W, /obj/item/reagent_containers/food/snacks) && W.is_open_container())
 		trans_item(W, user)
 		return
-	if(isflamesource(W))
+	if(W.isFlameSource())
 		heat_item(W, user)
 		return
 	if(istype(W) && W.force >= 5 && !has_edge(W) && LAZYLEN(contents - analyzer))
@@ -243,7 +243,7 @@
 		transfer_out = !transfer_out
 		to_chat(user, span("notice", "You [transfer_out ? "open" : "close"] the spigot on the keg, ready to [transfer_out ? "remove" : "add"] reagents."))
 		return
-	if(isflamesource(W) && istype(welder))
+	if(W.isFlameSource() && istype(welder))
 		to_chat(user, span("notice", "You light \the [src] and begin the distillation process."))
 		addtimer(CALLBACK(src, .proc/distill), 60 SECONDS)
 		src.icon_state = "distillery-active"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -311,25 +311,12 @@
 	return t
 
 
-/obj/item/paper/proc/burnpaper(obj/item/flame/P, mob/user)
+/obj/item/paper/proc/burnpaper(obj/item/P, mob/user)
 	var/class = "warning"
-
-	if (!user.restrained())
-		if (istype(P, /obj/item/flame))
-			var/obj/item/flame/F = P
-			if (!F.lit)
-				return
-		else if (P.iswelder())
-			var/obj/item/weldingtool/F = P
-			if (!F.welding)//welding tools are 0 when off
-				return
-		else
-			//If we got here somehow, the item is incompatible and can't burn things
-			return
-
+	if(!use_check_and_message(user))
 		if(istype(P, /obj/item/flame/lighter/zippo))
 			class = "rose"
-
+			
 		user.visible_message("<span class='[class]'>[user] holds \the [P] up to \the [src], it looks like \he's trying to burn it!</span>", \
 		"<span class='[class]'>You hold \the [P] up to \the [src], burning it slowly.</span>")
 		playsound(src.loc, 'sound/bureaucracy/paperburn.ogg', 50, 1)
@@ -429,11 +416,8 @@
 			c.update_icon()
 
 
-/obj/item/paper/attackby(obj/item/P as obj, mob/user as mob)
+/obj/item/paper/attackby(var/obj/item/P, mob/user)
 	..()
-	var/clown = 0
-	if(user.mind && (user.mind.assigned_role == "Clown"))
-		clown = 1
 
 	if(istype(P, /obj/item/tape_roll))
 		var/obj/item/tape_roll/tape = P
@@ -521,11 +505,6 @@
 		stampoverlay.pixel_x = x
 		stampoverlay.pixel_y = y
 
-		if(istype(P, /obj/item/stamp/clown))
-			if(!clown)
-				to_chat(user, span("notice", "You are totally unable to use the stamp. HONK!"))
-				return
-
 		if(!ico)
 			ico = new
 		ico += "paper_[P.icon_state]"
@@ -539,7 +518,7 @@
 		playsound(src, 'sound/bureaucracy/stamp.ogg', 50, 1)
 		to_chat(user, span("notice", "You stamp the paper with \the [P]."))
 
-	else if(istype(P, /obj/item/flame) || P.iswelder())
+	else if(P.isFlameSource())
 		burnpaper(P, user)
 
 	update_icon()

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -78,7 +78,7 @@
 	if(!rag && istype(W, /obj/item/reagent_containers/glass/rag))
 		insert_rag(W, user)
 		return
-	if(rag && istype(W, /obj/item/flame))
+	if(rag && W.isFlameSource())
 		rag.attackby(W, user)
 		return
 	..()

--- a/code/modules/spell_system/artifacts/items/poppet.dm
+++ b/code/modules/spell_system/artifacts/items/poppet.dm
@@ -78,7 +78,7 @@
 	if(H && cooldown < world.time)
 		var/target_zone = user.zone_sel.selecting
 
-		if(isflamesource(W))
+		if(W.isFlameSource())
 			fire_act()
 
 		if(istype(W, /obj/item/melee/baton))

--- a/html/changelogs/doxxmedearly - better_flames.yml
+++ b/html/changelogs/doxxmedearly - better_flames.yml
@@ -1,0 +1,8 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes: 
+  - rscadd: "Cigarettes now count as flame sources for igniting things like candles, other cigarettes, etc."
+  - rscadd: "Added more ways to ignite certain objects, as some were hardcoded just to respond to lighters or welders."
+  - rscdel: "Removed more remnants of clowns from code."


### PR DESCRIPTION
Lit cigarettes now count as flame sources.
Changed the isflamesource proc from a general proc to an obj/item proc. It is tidier and will be easier to add future flame sources this way. 
Removed some hardcoded flame stuff (Such as igniting rags and paper), which depending on an item being a type instead of just being something that could produce a flame. They now check to see if an item counts as a flame source.
Found leftover clown BS while updating paper burning code and killed it off. 