### PR TITLE
Yet more brainmed tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -114,6 +114,6 @@
 	return "grue"
 
 /datum/species/shadow/handle_death_check(var/mob/living/carbon/human/H)
-	if(H.get_total_health() <= 0)
+	if(H.get_total_health() <= config.health_threshold_dead)
 		return TRUE
 	return FALSE

--- a/code/modules/mob/living/carbon/human/species/outsider/undead.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/undead.dm
@@ -92,7 +92,7 @@
 	hud_type = /datum/hud_data/construct
 
 /datum/species/skeleton/handle_death_check(var/mob/living/carbon/human/H)
-	if(H.get_total_health() <= 0)
+	if(H.get_total_health() <= config.health_threshold_dead)
 		return TRUE
 	return FALSE
 
@@ -146,7 +146,7 @@
 	qdel(H)
 
 /datum/species/apparition/handle_death_check(var/mob/living/carbon/human/H)
-	if(H.get_total_health() <= 0)
+	if(H.get_total_health() <= config.health_threshold_dead)
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -184,7 +184,7 @@
 	return current_flags
 
 /datum/species/diona/handle_death_check(var/mob/living/carbon/human/H)
-	if(H.get_total_health() <= 0)
+	if(H.get_total_health() <= config.health_threshold_dead)
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -119,7 +119,7 @@ var/global/list/golem_types = list("Coal Golem",
 		qdel(H)
 
 /datum/species/golem/handle_death_check(var/mob/living/carbon/human/H)
-	if(H.get_total_health() <= 0)
+	if(H.get_total_health() <= config.health_threshold_dead)
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
@@ -298,7 +298,7 @@ datum/species/machine/handle_post_spawn(var/mob/living/carbon/human/H)
 	check_tag(H, H.client)
 
 /datum/species/machine/handle_death_check(var/mob/living/carbon/human/H)
-	if(H.get_total_health() <= 0)
+	if(H.get_total_health() <= config.health_threshold_dead)
 		return TRUE
 	return FALSE
 

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -96,7 +96,7 @@
 
 /obj/item/organ/internal/brain/process()
 	if(owner)
-		if(damage > max_damage / 2 && healed_threshold)
+		if(damage > (max_damage * 0.75) && healed_threshold)
 			handle_severe_brain_damage()
 
 		if(damage < (max_damage / 4))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -254,15 +254,16 @@
 
 	var/laser = (damage_flags & DAM_LASER)
 	var/sharp = (damage_flags & DAM_SHARP)
+	var/edge = (damage_flags & DAM_EDGE)
 	var/blunt = !!(brute && !sharp && !edge)
 
 	if(status & ORGAN_BROKEN && prob(40) && brute)
 		if(owner && (owner.can_feel_pain()))
 			owner.emote(pick("scream", "groan"))	//getting hit on broken hand hurts
+
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)
 
-	var/can_cut = (prob(brute*2) || sharp) && !(status & ORGAN_ROBOT)
 	var/spillover = 0
 	if(!is_damageable(brute + burn))
 		spillover = brute_dam + burn_dam + brute - max_damage
@@ -278,6 +279,13 @@
 	if(brute_dam + brute > min_broken_damage && prob(brute_dam + brute * (1 + blunt)))
 		fracture()
 
+	// High brute damage or sharp objects may damage internal organs
+	if(length(internal_organs))
+		if(damage_internal_organs(brute, burn, damage_flags))
+			brute /= 2
+			burn /= 2
+
+	var/can_cut = !BP_IS_ROBOTIC(src) && (sharp || prob(brute))
 	if(brute)
 		var/to_create = BRUISE
 		if(can_cut)
@@ -293,24 +301,14 @@
 		else
 			createwound(BURN, burn)
 
-	add_pain(0.8 * burn + 0.6 * brute)
+	add_pain(0.6 * burn + 0.4 * brute)
 
 	//If there are still hurties to dispense
 	if (spillover)
 		owner.shock_stage += spillover * config.organ_damage_spillover_multiplier
 
-	// High brute damage or sharp objects may damage internal organs
-	if(length(internal_organs))
-		if(damage_internal_organs(brute, burn, damage_flags))
-			var/brute_div = 2 //We want melee weapons to not be affected by this.
-			if(damage_flags & DAM_BULLET)
-				brute_div = 1.25
-			brute /= brute_div
-			burn /= 2
-
 	// sync the organ's damage with its wounds
 	update_damages()
-
 	if(owner)
 		owner.updatehealth() //droplimb will call updatehealth() again if it does end up being called
 
@@ -352,7 +350,7 @@
 	if(!length(victims))
 		return FALSE
 
-	organ_hit_chance += 5 * damage_amt/organ_damage_threshold
+	organ_hit_chance += 5 * damage_amt / organ_damage_threshold
 
 	if(encased && !(status & ORGAN_BROKEN)) //ribs protect
 		organ_hit_chance *= 0.6

--- a/html/changelogs/mattatlas-outofcontrol.yml
+++ b/html/changelogs/mattatlas-outofcontrol.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Melee weapons are now on par with bullets for internal organ wounding."
+  - tweak: "When internal organs are damaged, the pain felt is now less."
+  - tweak: "The severe brain damage event now happens at 150 brain damage instead of 100."
+  - tweak: "Things that aren't sharp now have an overall less chance of cutting."
+  - tweak: "Brute and burn damage now apply less pain overall."

--- a/html/changelogs/mattatlas-outofcontrol.yml
+++ b/html/changelogs/mattatlas-outofcontrol.yml
@@ -43,3 +43,4 @@ changes:
   - tweak: "The severe brain damage event now happens at 150 brain damage instead of 100."
   - tweak: "Things that aren't sharp now have an overall less chance of cutting."
   - tweak: "Brute and burn damage now apply less pain overall."
+  - bugfix: "IPCs, Dionae and so on now once again die at -100 damage."


### PR DESCRIPTION
- Melee weapons are now on par with bullets for internal organ wounding.
- When internal organs are damaged, the pain felt is now less. -> I moved the code that handles internal organ damage (e.g, the one that lowers damage if it penetrates) to before the pain is added to the organ.
- The severe brain damage event now happens at 150 brain damage instead of 100. -> It happens too often and too early.
- Things that aren't sharp now have an overall less chance of cutting. -> Self explainatory.
- Brute and burn damage now apply less pain overall. -> Lasers and bullets just do too much pain currently, downing you extremely quickly.
- IPCs, Dionae and so on now once again die at -100 damage. -> I didn't actually think this was true, but, here we are.