### PR TITLE
Armory Split

### DIFF
--- a/html/changelogs/geeves-embiggening_armory.yml
+++ b/html/changelogs/geeves-embiggening_armory.yml
@@ -4,5 +4,5 @@ delete-after: True
 
 changes: 
   - tweak: "The armory has been split into two levels, as it's been getting cramped lately. Much of the lethal weaponry has been moved upstairs."
-  - rscadd: "In addition to the moved weapons, the upper armory received; 4 9mm signal pistols, and 4 boot knives."
-  - rscadd: "The lower armory received; 5 .45 flash rounds, 5 .45 rubber rounds, two generic storage closets (for prototype or looted weapons), 1 box of spare handcuffs (1 was moved), 2 boxes of firing pins, and a button to open and close it from the inside."
+  - rscadd: "In addition to the moved weapons, the upper armory received; 4 9mm signal pistols, 4 keypad maglocks, and 4 boot knives."
+  - rscadd: "The lower armory received; 5 .45 flash rounds, 5 .45 rubber rounds, 4 flashes, two generic storage closets (for prototype or looted weapons), 1 box of spare handcuffs (1 was moved), 2 boxes of firing pins, and a button to open and close it from the inside."

--- a/html/changelogs/geeves-embiggening_armory.yml
+++ b/html/changelogs/geeves-embiggening_armory.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "The armory has been split into two levels, as it's been getting cramped lately. Much of the lethal weaponry has been moved upstairs."
+  - rscadd: "In addition to the moved weapons, the upper armory received; 4 9mm signal pistols, and 4 boot knives."
+  - rscadd: "The lower armory received; 5 .45 flash rounds, 5 .45 rubber rounds, two generic storage closets (for prototype or looted weapons), 1 box of spare handcuffs (1 was moved), 2 boxes of firing pins, and a button to open and close it from the inside."

--- a/maps/_common/areas/station/security.dm
+++ b/maps/_common/areas/station/security.dm
@@ -53,8 +53,11 @@
 	icon_state = "Warden"
 
 /area/security/armoury
-	name = "Security - Armory"
+	name = "Security - Armory Upper"
 	icon_state = "Warden"
+
+/area/security/armoury/lower
+	name = "Security - Armory Lower"
 
 /area/security/forensics_office
 	name = "Security - Forensic Office"
@@ -85,23 +88,6 @@
 /area/security/security_office
 	name = "Security - Security Office"
 	icon_state = "security"
-
-/*
-	New()
-		..()
-
-		spawn(10) //let objects set up first
-			for(var/turf/turfToGrayscale in src)
-				if(turfToGrayscale.icon)
-					var/icon/newIcon = icon(turfToGrayscale.icon)
-					newIcon.GrayScale()
-					turfToGrayscale.icon = newIcon
-				for(var/obj/objectToGrayscale in turfToGrayscale) //1 level deep, means tables, apcs, locker, etc, but not locker contents
-					if(objectToGrayscale.icon)
-						var/icon/newIcon = icon(objectToGrayscale.icon)
-						newIcon.GrayScale()
-						objectToGrayscale.icon = newIcon
-*/
 
 /area/security/nuke_storage
 	name = "Vault"

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -492,8 +492,8 @@
 "aba" = (
 /obj/structure/flora/pottedplant/random,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/vacantoffice2)
@@ -948,7 +948,7 @@
 "abY" = (
 /obj/structure/closet/l3closet/security,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "abZ" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -1098,8 +1098,8 @@
 /area/maintenance/substation/security)
 "acp" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal{
 	dir = 1
@@ -1497,8 +1497,8 @@
 	},
 /obj/structure/flora/pottedplant/random,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/vacantoffice2)
@@ -1988,8 +1988,8 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 8
@@ -2220,12 +2220,14 @@
 /turf/simulated/floor/tiled/old,
 /area/maintenance/security_starboard)
 "aeg" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 28
+/obj/structure/table/rack,
+/obj/item/storage/box/handcuffs{
+	pixel_x = 2;
+	pixel_y = 2
 	},
+/obj/item/storage/box/handcuffs,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aeh" = (
 /obj/effect/floor_decal/corner_wide/mauve{
 	dir = 5
@@ -3058,10 +3060,10 @@
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	internal_pressure_bound_default = 4000;
-	use_power = 1;
 	pressure_checks = 2;
 	pressure_checks_default = 2;
-	pump_direction = 0
+	pump_direction = 0;
+	use_power = 1
 	},
 /turf/simulated/floor/bluegrid{
 	name = "Server Base";
@@ -3225,8 +3227,8 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled{
 	name = "cooled floor";
@@ -3426,8 +3428,8 @@
 	name = "Evidence Closet"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled{
 	name = "cooled floor";
@@ -4345,8 +4347,8 @@
 /area/maintenance/atmos_control)
 "aij" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/structure/closet/crate,
 /obj/random/loot,
@@ -4466,8 +4468,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -5056,8 +5058,8 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Master Grid";
@@ -5183,7 +5185,7 @@
 /area/engineering/atmos/storage)
 "ajR" = (
 /turf/simulated/wall/r_wall,
-/area/security/armoury)
+/area/security/armoury/lower)
 "ajS" = (
 /obj/structure/table/standard,
 /obj/item/paper,
@@ -5702,8 +5704,8 @@
 /area/engineering/atmos/storage)
 "akJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/requests_console{
 	department = "Atmospherics";
@@ -6075,10 +6077,10 @@
 /area/maintenance/atmos_control)
 "alt" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Substation - Atmospherics";
 	charge = 2e+006;
 	input_attempt = 1;
-	output_attempt = 1;
-	RCon_tag = "Substation - Atmospherics"
+	output_attempt = 1
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
@@ -6159,7 +6161,7 @@
 "alD" = (
 /obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "alE" = (
 /obj/effect/floor_decal/corner_wide/mauve{
 	dir = 6
@@ -6171,7 +6173,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/network/security{
-	c_tag = "Security - Armoury Fore";
+	c_tag = "Security - Lower Armoury Fore";
 	network = list("Security","Armoury")
 	},
 /obj/structure/table/rack,
@@ -6182,7 +6184,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "alG" = (
 /obj/structure/table/rack,
 /obj/item/device/magnetic_lock/security{
@@ -6198,34 +6200,20 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "alH" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Armory Locker (Storage)"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Riot Gear Storage";
-	req_access = list(3)
-	},
-/obj/item/clothing/shoes/leg_guard/riot,
-/obj/item/clothing/gloves/arm_guard/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/shield/riot,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "alI" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 5;
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "alJ" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 5;
@@ -6235,19 +6223,15 @@
 	dir = 1
 	},
 /obj/machinery/camera/network/security{
-	c_tag = "Armoury - Riot Storage";
+	c_tag = "Armoury - Lower Stairway";
 	network = list("Security","Armoury")
 	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "alK" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Laser Rifle)"
-	},
-/obj/item/gun/energy/rifle/laser,
-/obj/item/gun/energy/rifle/laser,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "alL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6782,8 +6766,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -6835,8 +6819,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "amO" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "amP" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
@@ -6855,13 +6842,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/nuke_storage)
-"amQ" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Ion Rifle)"
-	},
-/obj/item/gun/energy/rifle/ionrifle,
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
 "amR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
@@ -6959,8 +6939,8 @@
 	dir = 5
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -7271,14 +7251,14 @@
 /obj/item/clothing/suit/storage/vest/heavy/officer,
 /obj/item/clothing/suit/storage/vest/heavy/officer,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "anT" = (
 /obj/structure/table/rack,
 /obj/item/reagent_containers/spray/pepper,
 /obj/item/reagent_containers/spray/pepper,
 /obj/item/reagent_containers/spray/pepper,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "anU" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/evidence,
@@ -7292,44 +7272,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
-"anV" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Riot Gear Storage";
-	req_access = list(3)
-	},
-/obj/item/clothing/shoes/leg_guard/riot,
-/obj/item/clothing/gloves/arm_guard/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
-/obj/item/shield/riot,
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
 "anW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "anX" = (
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (En. Carbine)"
-	},
-/obj/item/gun/energy/gun,
-/obj/item/gun/energy/gun,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "anY" = (
 /obj/random/junk,
 /obj/structure/reagent_dispensers/extinguisher,
@@ -7715,17 +7670,17 @@
 /area/engineering/engine_room)
 "aoC" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Supermatter - Grid";
 	charge = 1e+007;
 	cur_coils = 4;
 	input_attempt = 1;
 	input_level = 500000;
 	output_attempt = 1;
-	output_level = 500000;
-	RCon_tag = "Supermatter - Grid"
+	output_level = 500000
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_smes)
@@ -8016,62 +7971,63 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "apc" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/seccarts{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/storage/box/handcuffs,
 /obj/item/storage/box/flashbangs{
 	pixel_x = 3;
 	pixel_y = -3
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "apd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "ape" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Armoury Section";
-	req_access = list(3)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/c45m/flash,
+/obj/item/ammo_magazine/c45m/flash,
+/obj/item/ammo_magazine/c45m/flash,
+/obj/item/ammo_magazine/c45m/flash,
+/obj/item/ammo_magazine/c45m/flash,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
-"apf" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "apg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aph" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Shotgun)"
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 8;
+	name = "Riot Gear Storage";
+	req_access = list(3)
+	},
+/obj/item/clothing/shoes/leg_guard/riot,
+/obj/item/clothing/gloves/arm_guard/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/shield/riot,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "api" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8470,8 +8426,8 @@
 /area/engineering/engine_smes)
 "apV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Camera Corridor 4";
@@ -8691,13 +8647,13 @@
 	},
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aqq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aqr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -8705,41 +8661,17 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aqs" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Armoury Section";
-	req_access = list(3)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
-"aqt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aqu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8748,13 +8680,13 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aqv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aqw" = (
 /obj/machinery/vending/coffee,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -8874,8 +8806,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -9049,8 +8981,8 @@
 /area/bridge)
 "aqX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/engine{
 	c_tag = "Engineering - Engine Fore";
@@ -9393,80 +9325,16 @@
 /obj/machinery/deployable/barrier,
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "arC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/securearea{
-	pixel_x = 32
-	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
-"arD" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
-"arE" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Ammunition (.45 lethal)"
-	},
-/obj/effect/decal/warning_stripes,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
-"arF" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Ammunition (45. less-than-lethal)"
-	},
-/obj/effect/decal/warning_stripes,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "arG" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Ammunition (shotgun less-than-lethal)"
-	},
-/obj/effect/decal/warning_stripes,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/storage/box/stunshells,
-/obj/item/storage/box/flashshells{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beanbags{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/beanbags{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
-"arH" = (
-/obj/structure/sign/securearea{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "arI" = (
 /obj/machinery/computer/sentencing/courtroom{
 	pixel_y = 28
@@ -9682,8 +9550,8 @@
 "arZ" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/alarm{
 	pixel_y = 28
@@ -9734,7 +9602,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "ase" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9882,13 +9750,13 @@
 /area/engineering/engine_room)
 "asu" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Supermatter - Containment";
 	charge = 2e+006;
 	input_attempt = 1;
 	input_level = 100000;
 	is_critical = 1;
 	output_attempt = 1;
-	output_level = 200000;
-	RCon_tag = "Supermatter - Containment"
+	output_level = 200000
 	},
 /obj/structure/cable/orange{
 	icon_state = "0-2"
@@ -10099,32 +9967,13 @@
 "asN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
-"asO" = (
-/obj/structure/cable/green{
-	d1 = 1;
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
-"asP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "asQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -10133,7 +9982,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "asR" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -10145,7 +9994,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "asS" = (
 /obj/machinery/newscaster{
 	pixel_x = -30
@@ -10285,8 +10134,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -10887,8 +10736,8 @@
 /area/engineering/engine_room)
 "atO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -11260,12 +11109,12 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/light,
 /obj/machinery/camera/network/security{
-	c_tag = "Security - Armoury Aft";
+	c_tag = "Security - Lower Armoury Aft";
 	dir = 1;
 	network = list("Security","Armoury")
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "auw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11275,25 +11124,21 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aux" = (
 /obj/machinery/anti_bluespace,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "auy" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
-"auz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "auA" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "auB" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -11626,8 +11471,8 @@
 	pixel_x = -28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Bridge - Command Deck Port";
@@ -11698,8 +11543,8 @@
 /area/bridge)
 "avo" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/bridge)
@@ -12153,7 +11998,7 @@
 	req_access = list(3)
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "awd" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -12166,18 +12011,18 @@
 	network = list("Security","Armoury")
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "awe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "awf" = (
 /obj/machinery/flasher/portable,
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "awg" = (
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/blue{
@@ -12261,8 +12106,8 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled,
@@ -13209,7 +13054,7 @@
 /area/maintenance/engineering)
 "axN" = (
 /turf/simulated/wall,
-/area/security/armoury)
+/area/security/armoury/lower)
 "axO" = (
 /obj/machinery/computer/prisoner,
 /obj/machinery/requests_console{
@@ -13218,7 +13063,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "axP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -13235,7 +13080,7 @@
 /obj/item/storage/box/firingpins,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "axQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -13250,7 +13095,7 @@
 	pixel_x = 23
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "axR" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -13276,7 +13121,7 @@
 /obj/item/clothing/head/helmet/ablative,
 /obj/item/clothing/head/helmet/ablative,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "axS" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/light/small/emergency{
@@ -13284,7 +13129,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "axT" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -13535,8 +13380,8 @@
 /area/security/prison)
 "ayl" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/brig)
@@ -13907,8 +13752,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Corridor Camera 3";
@@ -14166,7 +14011,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "azt" = (
 /obj/machinery/door/window/brigdoor/southright{
 	dir = 4;
@@ -14174,7 +14019,7 @@
 	req_access = list(3)
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "azu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14188,7 +14033,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "azv" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -14211,7 +14056,7 @@
 /obj/item/clothing/head/helmet/ballistic,
 /obj/item/clothing/head/helmet/ballistic,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "azw" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -14701,8 +14546,8 @@
 	req_access = list(10)
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -15018,8 +14863,8 @@
 	RCon_tag = "Substation - Engineering Main"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -15067,7 +14912,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aAT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15077,7 +14922,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aAU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15090,7 +14935,7 @@
 	},
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aAV" = (
 /obj/structure/coatrack{
 	pixel_x = -9
@@ -15847,8 +15692,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
@@ -15906,7 +15751,7 @@
 	req_access = list(3)
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aCp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
@@ -15921,7 +15766,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aCq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -15936,7 +15781,7 @@
 	req_access = list(3)
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aCr" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -15946,7 +15791,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aCs" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
@@ -15956,7 +15801,7 @@
 	name = "Emergency Access"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/armoury/lower)
 "aCt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -16727,8 +16572,8 @@
 "aDA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/engine{
 	c_tag = "Engineering - Engine Aft";
@@ -17009,8 +16854,8 @@
 /area/ai_monitored/storage/eva)
 "aEd" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Camera Corridor 5";
@@ -17321,8 +17166,8 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
@@ -17618,8 +17463,8 @@
 /area/teleporter)
 "aEY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -18196,8 +18041,8 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
@@ -19112,8 +18957,8 @@
 /area/crew_quarters/captain)
 "aHp" = (
 /obj/machinery/atmospherics/valve/digital{
-	name = "Emergency Cooling Valve 2";
-	dir = 1
+	dir = 1;
+	name = "Emergency Cooling Valve 2"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -19924,8 +19769,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Corridor Camera 3";
@@ -20161,8 +20006,8 @@
 	pixel_y = 3
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -20790,8 +20635,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -21940,8 +21785,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -22360,8 +22205,8 @@
 /area/crew_quarters/heads/chief)
 "aMM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/firealarm/north,
 /obj/structure/filingcabinet/chestdrawer,
@@ -22567,8 +22412,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Head of Security's Office";
@@ -22602,7 +22447,7 @@
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "armoury";
-	name = "Armoury Shutters";
+	name = "Armory Blast Doors";
 	pixel_x = 38;
 	pixel_y = 28;
 	req_access = list(58)
@@ -22759,8 +22604,8 @@
 /area/security/prison)
 "aNx" = (
 /obj/machinery/cryopod{
-	icon_state = "body_scanner_0";
-	dir = 4
+	dir = 4;
+	icon_state = "body_scanner_0"
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/prison)
@@ -23685,8 +23530,8 @@
 	pixel_y = 5
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Communal Bathroom";
@@ -23700,8 +23545,8 @@
 /area/security/prison)
 "aPk" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/cryofeed{
 	dir = 4
@@ -24392,8 +24237,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sortjunction{
-	sortType = "CE Office";
-	name = "CE Office"
+	name = "CE Office";
+	sortType = "CE Office"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -24774,8 +24619,8 @@
 /area/journalistoffice)
 "aRe" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/journalistoffice)
@@ -24956,8 +24801,8 @@
 	dir = 6
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
@@ -25795,8 +25640,8 @@
 /area/journalistoffice)
 "aSF" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/journalistoffice)
@@ -27347,8 +27192,8 @@
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
@@ -27368,8 +27213,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
@@ -27409,8 +27254,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
@@ -27748,8 +27593,8 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/janitor)
@@ -28859,8 +28704,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Port Corridor - Camera 2";
@@ -30763,8 +30608,8 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics_cyborgification)
@@ -31325,8 +31170,8 @@
 /area/maintenance/substation/command)
 "bcv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -31876,8 +31721,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
@@ -32327,8 +32172,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/cryo)
@@ -32640,8 +32485,8 @@
 /area/hallway/primary/central_one)
 "beQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32998,8 +32843,8 @@
 /area/bridge/meeting_room)
 "bfA" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -34798,8 +34643,8 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
@@ -35288,8 +35133,8 @@
 	department = "Chief Medical Officer's Office"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -35639,8 +35484,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -36250,8 +36095,8 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -36439,8 +36284,8 @@
 /area/medical/medbay2)
 "blv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/structure/flora/pottedplant/random,
 /obj/effect/floor_decal/corner_wide/green{
@@ -36507,8 +36352,8 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -38228,8 +38073,8 @@
 "boJ" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
@@ -38301,8 +38146,8 @@
 /area/bridge)
 "boN" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -38518,8 +38363,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
@@ -38559,8 +38404,8 @@
 /area/assembly/robotics)
 "bpj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled,
@@ -38597,8 +38442,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/bed/chair/plastic{
 	dir = 4
@@ -38665,8 +38510,8 @@
 /area/medical/reception)
 "bpx" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 1
@@ -39927,8 +39772,8 @@
 	req_access = list(5)
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40225,8 +40070,8 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/table/rack,
 /obj/random/loot,
@@ -42598,8 +42443,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -42965,8 +42810,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
@@ -43396,8 +43241,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -43472,8 +43317,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner_wide/lime{
@@ -44166,8 +44011,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet/blue,
 /area/rnd/rdoffice)
@@ -44442,8 +44287,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/bed/roller,
 /obj/effect/floor_decal/corner_wide/lime{
@@ -45020,12 +44865,12 @@
 "bCu" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/requests_console{
-	name = "Research Director RC";
-	pixel_x = -2;
-	pixel_y = -30;
+	announcementConsole = 1;
 	department = "Research Director's Desk";
 	departmentType = 5;
-	announcementConsole = 1
+	name = "Research Director RC";
+	pixel_x = -2;
+	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/rdoffice)
@@ -45287,8 +45132,8 @@
 	},
 /obj/structure/cable/green,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgerywing)
@@ -46025,8 +45870,8 @@
 	pixel_x = -25
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/corner_wide/lime{
@@ -46491,8 +46336,8 @@
 /area/medical/surgeryobs)
 "bFL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/structure/bed/chair/plastic{
 	dir = 4
@@ -48828,8 +48673,8 @@
 /area/library)
 "bLu" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Aft Corridor - Camera 4";
@@ -50267,8 +50112,8 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/item/stool/padded,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/primary/aft)
@@ -50333,8 +50178,8 @@
 /obj/structure/table/stone/marble,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -51368,8 +51213,8 @@
 /area/chapel/main)
 "bSj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
@@ -51608,8 +51453,8 @@
 /area/chapel/main)
 "bSG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52154,8 +51999,8 @@
 	dir = 5
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -52578,8 +52423,8 @@
 /area/crew_quarters/locker/locker_toilet)
 "bUO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/requests_console{
 	department = "Chapel";
@@ -52684,8 +52529,8 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/wood,
@@ -53354,8 +53199,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled,
@@ -53436,8 +53281,8 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -55494,8 +55339,8 @@
 /area/maintenance/disposal)
 "cbk" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -55879,8 +55724,8 @@
 /area/maintenance/bar)
 "ccm" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
@@ -56710,8 +56555,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
@@ -57412,8 +57257,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
@@ -58200,8 +58045,8 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
@@ -58276,12 +58121,12 @@
 /area/outpost/mining_main/eva)
 "cgT" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "mining_east_pump";
-	tag_exterior_door = "mining_east_outer";
 	id_tag = "mining_east_airlock";
-	tag_interior_door = "mining_east_inner";
 	pixel_y = -25;
-	tag_chamber_sensor = "mining_east_sensor"
+	tag_airpump = "mining_east_pump";
+	tag_chamber_sensor = "mining_east_sensor";
+	tag_exterior_door = "mining_east_outer";
+	tag_interior_door = "mining_east_inner"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -58643,8 +58488,8 @@
 	},
 /obj/machinery/disposal,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
@@ -58977,8 +58822,8 @@
 /area/outpost/mining_main/refinery)
 "cin" = (
 /obj/effect/floor_decal/industrial/warning/dust{
-	tag = "icon-warning_dust (SOUTHWEST)";
-	dir = 10
+	dir = 10;
+	tag = "icon-warning_dust (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/asteroid/airless,
 /area/outpost/mining_main/eva)
@@ -59041,8 +58886,8 @@
 "ciI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	icon_state = "conveyor-broken";
-	dir = 10
+	dir = 10;
+	icon_state = "conveyor-broken"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -59829,8 +59674,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -59968,8 +59813,8 @@
 	id = "qm_warehouse";
 	name = "Warehouse Door Control";
 	pixel_x = 24;
-	req_access = list(31);
-	pixel_y = 4
+	pixel_y = 4;
+	req_access = list(31)
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
@@ -61771,8 +61616,8 @@
 /area/rnd/chemistry)
 "iPS" = (
 /obj/machinery/conveyor{
-	icon_state = "conveyor-broken";
-	dir = 8
+	dir = 8;
+	icon_state = "conveyor-broken"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -62453,6 +62298,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
+"kWL" = (
+/obj/structure/banner,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury/lower)
 "kYd" = (
 /obj/item/stack/tile/floor_white{
 	pixel_x = -3;
@@ -63160,6 +63009,12 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/old_white,
 /area/maintenance/medbay)
+"myT" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury/lower)
 "mzO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -63228,8 +63083,8 @@
 	},
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
@@ -63851,6 +63706,14 @@
 	},
 /turf/simulated/floor/tiled/old_white,
 /area/maintenance/medbay)
+"ofY" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury/lower)
 "ohn" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -64496,6 +64359,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/maintenance/bar)
+"prJ" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 8;
+	name = "Riot Gear Storage";
+	req_access = list(3)
+	},
+/obj/item/clothing/shoes/leg_guard/riot,
+/obj/item/clothing/gloves/arm_guard/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/shield/riot,
+/obj/structure/sign/securearea{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury/lower)
 "prS" = (
 /obj/structure/table/wood,
 /obj/random/loot,
@@ -64521,6 +64408,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
+"ptm" = (
+/obj/machinery/button/remote/blast_door{
+	id = "armoury";
+	name = "Armory Blast Doors";
+	pixel_x = -28;
+	pixel_y = -26;
+	req_access = null;
+	req_one_access = list(3, 58)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury/lower)
 "pvB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -64556,8 +64454,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 5
@@ -65047,8 +64945,8 @@
 /area/rnd/research)
 "qOq" = (
 /obj/machinery/conveyor{
-	icon_state = "conveyor-broken";
-	dir = 8
+	dir = 8;
+	icon_state = "conveyor-broken"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/barricade/steel,
@@ -65141,8 +65039,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
@@ -65393,6 +65291,15 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/eva)
+"rCA" = (
+/obj/structure/table/rack,
+/obj/item/storage/box/firingpins{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/firingpins,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury/lower)
 "rDW" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 1;
@@ -65498,6 +65405,10 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/old_white,
 /area/maintenance/medbay)
+"rPu" = (
+/obj/structure/stairs/north,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury/lower)
 "rPZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -66330,8 +66241,8 @@
 "tCT" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -66497,8 +66408,8 @@
 /area/assembly/robotics_cyborgification)
 "tQm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
@@ -66657,8 +66568,8 @@
 /area/medical/cryo)
 "udn" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating,
@@ -67861,6 +67772,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/assembly/chargebay)
+"wJk" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Armory Locker (Storage)"
+	},
+/obj/structure/sign/securearea{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury/lower)
 "wJm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -93538,7 +93458,7 @@ aab
 ajR
 ajR
 alD
-amO
+alK
 anS
 apb
 aqp
@@ -93795,7 +93715,7 @@ aab
 ajR
 ajR
 abY
-amO
+alK
 anT
 apc
 aqq
@@ -94052,12 +93972,12 @@ aab
 ajR
 ajR
 alF
-amO
-amO
-amO
+alK
+alK
+alK
 aqq
-amO
-amO
+alK
+alK
 auv
 ajR
 axP
@@ -94309,7 +94229,7 @@ aab
 ajR
 ajR
 alG
-amO
+alK
 aeg
 apd
 aqr
@@ -94565,14 +94485,14 @@ agN
 aab
 ajR
 ajR
-ajR
-ajR
-ajR
+wJk
+alK
+rCA
 ape
 aqs
-ajR
-ajR
-ajR
+alK
+ofY
+kWL
 ajR
 ajR
 ajR
@@ -94823,12 +94743,12 @@ aab
 ajR
 ajR
 alH
-alH
-anV
-apf
-aqt
-arD
-asO
+alK
+alK
+alK
+aqs
+alK
+ofY
 aux
 awd
 axR
@@ -95084,13 +95004,13 @@ amO
 anW
 apg
 aqu
-arE
-asP
-amO
-amO
-amO
-amO
-amO
+alK
+ofY
+alK
+alK
+alK
+alK
+ptm
 aCr
 aEe
 aGe
@@ -95337,17 +95257,17 @@ aab
 ajR
 ajR
 alJ
-amO
-amO
-amO
+rPu
+alK
+alK
 aqq
-arF
-asP
+alK
+ofY
 auy
-amO
-amO
-amO
-amO
+alK
+alK
+alK
+alK
 aCs
 aEh
 aGf
@@ -95594,17 +95514,17 @@ aab
 ajR
 ajR
 alI
-amO
-amO
-amO
+myT
+myT
+alK
 aqv
 arG
 asQ
-auz
+arG
 awe
-amO
-amO
-amO
+alK
+alK
+alK
 aCs
 aEe
 aGe
@@ -95851,11 +95771,11 @@ aab
 ajR
 ajR
 alK
-amQ
+alK
 anX
 aph
-aeg
-arH
+prJ
+aph
 asR
 auA
 awf

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -6208,25 +6208,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury/lower)
 "alI" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 5;
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury/lower)
-"alJ" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 5;
-	pixel_y = 22
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Armoury - Lower Stairway";
 	network = list("Security","Armoury")
 	},
-/obj/structure/window/reinforced,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury/lower)
+"alJ" = (
+/obj/structure/stairs/north,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury/lower)
 "alK" = (
@@ -7246,10 +7241,10 @@
 /area/maintenance/engineering)
 "anS" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/storage/vest/heavy/officer,
-/obj/item/clothing/suit/storage/vest/heavy/officer,
-/obj/item/clothing/suit/storage/vest/heavy/officer,
-/obj/item/clothing/suit/storage/vest/heavy/officer,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/device/flash,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury/lower)
 "anT" = (
@@ -7274,14 +7269,14 @@
 /area/security/brig)
 "anW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury/lower)
 "anX" = (
 /obj/machinery/light/small/emergency{
 	dir = 4
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 36
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury/lower)
@@ -11137,6 +11132,11 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
+/obj/structure/table/rack,
+/obj/item/clothing/suit/storage/vest/heavy/officer,
+/obj/item/clothing/suit/storage/vest/heavy/officer,
+/obj/item/clothing/suit/storage/vest/heavy/officer,
+/obj/item/clothing/suit/storage/vest/heavy/officer,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury/lower)
 "auB" = (
@@ -65406,7 +65406,9 @@
 /turf/simulated/floor/tiled/old_white,
 /area/maintenance/medbay)
 "rPu" = (
-/obj/structure/stairs/north,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 36
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury/lower)
 "rPZ" = (
@@ -95257,7 +95259,7 @@ aab
 ajR
 ajR
 alJ
-rPu
+alK
 alK
 alK
 aqq
@@ -95513,9 +95515,9 @@ afo
 aab
 ajR
 ajR
-alI
 myT
 myT
+alK
 alK
 aqv
 arG
@@ -95770,8 +95772,8 @@ afo
 aab
 ajR
 ajR
-alK
-alK
+rPu
+rPu
 anX
 aph
 prJ

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -3668,11 +3668,15 @@
 /area/security/forensics_office)
 "hE" = (
 /obj/structure/grille,
-/obj/structure/cable,
+/obj/structure/grille,
 /obj/structure/cable{
-	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/unsimulated/chasm_mask,
 /area/security/armoury)
@@ -6101,10 +6105,14 @@
 /area/medical/upperlevel)
 "mA" = (
 /obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/unsimulated/chasm_mask,
 /area/security/armoury)
@@ -6450,10 +6458,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/stairs)
 "oC" = (
-/obj/machinery/anti_bluespace,
-/obj/machinery/camera/network/security{
-	c_tag = "Armoury - Upper Storage";
-	network = list("Security","Armoury")
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -6698,16 +6704,17 @@
 /turf/simulated/wall,
 /area/medical/upperlevel)
 "pX" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/grille,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/sign/securearea{
-	pixel_y = 32
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/sign/flag/nanotrasen{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/unsimulated/chasm_mask,
 /area/security/armoury)
 "pZ" = (
 /turf/simulated/open/airless,
@@ -7068,12 +7075,18 @@
 	},
 /area/mine/unexplored)
 "rN" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Shotgun)"
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/unsimulated/chasm_mask,
 /area/security/armoury)
 "sd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7110,20 +7123,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"sj" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/unsimulated/chasm_mask,
-/area/security/armoury)
 "sk" = (
 /obj/structure/track{
 	icon_state = "track5"
@@ -7521,15 +7520,12 @@
 	},
 /area/mine/unexplored)
 "uv" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Ammunition (45. less-than-lethal)"
+/obj/structure/table/rack,
+/obj/item/material/kitchen/utensil/knife/boot{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/effect/decal/warning_stripes,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/material/kitchen/utensil/knife/boot,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "uw" = (
@@ -7655,9 +7651,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/abandoned)
 "vf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Ammunition (9mm)"
 	},
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/effect/decal/warning_stripes,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "vh" = (
@@ -7696,9 +7699,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_interstitial)
 "vr" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Armoury Section";
-	req_access = list(3)
+/obj/structure/table/rack,
+/obj/item/material/kitchen/utensil/knife/boot{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/material/kitchen/utensil/knife/boot,
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -7911,11 +7919,17 @@
 /turf/simulated/wall,
 /area/maintenance/interstitial_cargo)
 "wI" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Laser Rifle)"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/item/gun/energy/rifle/laser,
-/obj/item/gun/energy/rifle/laser,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "wJ" = (
@@ -8008,9 +8022,15 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_cargo)
 "xt" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Weaponry (Signal Pistol)"
+	},
+/obj/item/gun/projectile/pistol/flash,
+/obj/item/gun/projectile/pistol/flash,
+/obj/item/gun/projectile/pistol/flash,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "xv" = (
@@ -8058,11 +8078,14 @@
 /turf/simulated/floor/plating,
 /area/janitor/stairs)
 "xM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/table/rack,
+/obj/item/device/magnetic_lock/keypad{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/item/device/magnetic_lock/keypad{
+	pixel_x = 2;
+	pixel_y = 2
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -8390,8 +8413,8 @@
 	},
 /area/security/forensics_office)
 "zV" = (
-/obj/machinery/alarm{
-	pixel_y = 28
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -8487,11 +8510,12 @@
 /area/quartermaster/storage)
 "AI" = (
 /obj/structure/grille,
+/obj/structure/grille,
 /obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/unsimulated/chasm_mask,
 /area/security/armoury)
@@ -8759,25 +8783,17 @@
 /turf/simulated/open,
 /area/medical/abandoned)
 "Cu" = (
-/obj/structure/table/rack,
-/obj/item/material/kitchen/utensil/knife/boot{
-	pixel_x = -2;
-	pixel_y = 2
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/item/material/kitchen/utensil/knife/boot,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "CA" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Ammunition (.45 lethal)"
+/obj/machinery/anti_bluespace,
+/obj/machinery/camera/network/security{
+	c_tag = "Armoury - Upper Storage";
+	network = list("Security","Armoury")
 	},
-/obj/effect/decal/warning_stripes,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "CC" = (
@@ -9304,19 +9320,6 @@
 "Fs" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"Ft" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/unsimulated/chasm_mask,
-/area/security/armoury)
 "Fv" = (
 /obj/structure/lattice,
 /obj/structure/girder,
@@ -9776,15 +9779,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_interstitial)
 "HZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Signal Pistol)"
-	},
-/obj/item/gun/projectile/pistol/flash,
-/obj/item/gun/projectile/pistol/flash,
-/obj/item/gun/projectile/pistol/flash,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "Ic" = (
@@ -10901,15 +10898,27 @@
 /area/mine/unexplored)
 "LV" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	name = "Ammunition (9mm)"
+	name = "Ammunition (shotgun)"
 	},
-/obj/item/ammo_magazine/mc9mm/flash,
-/obj/item/ammo_magazine/mc9mm/flash,
-/obj/item/ammo_magazine/mc9mm/flash,
-/obj/item/ammo_magazine/mc9mm/flash,
-/obj/item/ammo_magazine/mc9mm/flash,
-/obj/item/ammo_magazine/mc9mm/flash,
 /obj/effect/decal/warning_stripes,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/storage/box/stunshells,
+/obj/item/storage/box/flashshells{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/beanbags{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/beanbags{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/incendiaryshells,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "LY" = (
@@ -11081,15 +11090,14 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/stairs)
 "MF" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Weaponry (Ion Rifle)"
 	},
-/turf/unsimulated/chasm_mask,
+/obj/item/gun/energy/rifle/ionrifle,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "MH" = (
 /obj/machinery/light{
@@ -11191,12 +11199,14 @@
 /area/maintenance/interstitial_construction_site/zone_2)
 "Ne" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Ion Rifle)"
+	name = "Ammunition (45. less-than-lethal)"
 	},
-/obj/item/gun/energy/rifle/ionrifle,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "Nf" = (
@@ -11251,14 +11261,25 @@
 /turf/simulated/wall,
 /area/maintenance/interstitial_construction_site/zone_2)
 "NG" = (
+/obj/structure/grille,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall/r_wall,
+/turf/unsimulated/chasm_mask,
 /area/security/armoury)
 "NH" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -11757,6 +11778,15 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_construction_site/office)
+"Qv" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "Qz" = (
 /turf/simulated/wall,
 /area/maintenance/elevator)
@@ -11968,20 +11998,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"RI" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/unsimulated/chasm_mask,
-/area/security/armoury)
 "RJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -12710,23 +12726,20 @@
 /turf/simulated/floor/plating,
 /area/medical/abandoned)
 "Vk" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "Vn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Weaponry (En. Carbine)"
 	},
+/obj/item/gun/energy/gun,
+/obj/item/gun/energy/gun,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "Vp" = (
@@ -12783,18 +12796,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_interstitial)
 "VF" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Ammunition (.45 lethal)"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/unsimulated/chasm_mask,
+/obj/effect/decal/warning_stripes,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "VH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12862,6 +12874,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/maintenance/interstitial_construction_site)
+"VW" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "Wa" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12937,14 +12966,11 @@
 /area/mine/unexplored)
 "WD" = (
 /obj/structure/grille,
+/obj/structure/cable,
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/unsimulated/chasm_mask,
 /area/security/armoury)
@@ -13072,6 +13098,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
+"Xq" = (
+/obj/structure/grille,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "Xu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -13127,27 +13163,10 @@
 /area/maintenance/elevator)
 "XC" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	name = "Ammunition (shotgun)"
+	name = "Weaponry (Shotgun)"
 	},
-/obj/effect/decal/warning_stripes,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/storage/box/stunshells,
-/obj/item/storage/box/flashshells{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beanbags{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/beanbags{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/incendiaryshells,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/gun/projectile/shotgun/pump,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "XG" = (
@@ -13183,11 +13202,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/upperlevel)
 "XR" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (En. Carbine)"
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Armoury Section";
+	req_access = list(3)
 	},
-/obj/item/gun/energy/gun,
-/obj/item/gun/energy/gun,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "XT" = (
@@ -13241,9 +13259,11 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "Yb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Weaponry (Laser Rifle)"
 	},
+/obj/item/gun/energy/rifle/laser,
+/obj/item/gun/energy/rifle/laser,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "Yd" = (
@@ -13315,18 +13335,15 @@
 /area/mine/unexplored)
 "Yy" = (
 /obj/structure/grille,
+/obj/structure/grille,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/unsimulated/chasm_mask,
 /area/security/armoury)
@@ -13387,8 +13404,13 @@
 /turf/simulated/open,
 /area/maintenance/medbay_interstitial)
 "YO" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 6;
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/securearea{
+	pixel_y = 32
+	},
+/obj/structure/sign/flag/nanotrasen{
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -13488,25 +13510,14 @@
 /turf/simulated/open,
 /area/turbolift/medical_interstitial)
 "ZA" = (
-/obj/structure/grille,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/unsimulated/chasm_mask,
+/turf/simulated/wall/r_wall,
 /area/security/armoury)
 "ZE" = (
 /obj/structure/cable/green{
@@ -38873,18 +38884,18 @@ ab
 qc
 ab
 aa
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -39129,19 +39140,19 @@ ab
 ab
 qc
 ab
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
 aa
-Dh
-RI
-AI
-AI
-AI
-AI
-AI
-AI
-AI
-AI
-MF
-Dh
 aa
 aa
 aa
@@ -39386,21 +39397,21 @@ aa
 ab
 qc
 ab
-aa
 Dh
-Ft
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
+hE
 WD
+WD
+WD
+WD
+WD
+WD
+WD
+WD
+AI
 Dh
 Dh
 Dh
+aa
 aa
 aa
 aa
@@ -39643,23 +39654,23 @@ aa
 ab
 qc
 ab
-aa
 Dh
-Ft
+mA
 Dh
-Cu
-Vn
-LV
-XC
-uv
-CA
 Dh
-sj
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Yy
+WD
 AI
-MF
 Dh
 Dh
 Dh
+aa
 aa
 aa
 aa
@@ -39900,23 +39911,23 @@ aa
 ab
 qc
 ab
-aa
 Dh
-Ft
+mA
 Dh
+uv
 Cu
 vf
-uw
-uw
-uw
-YO
+LV
+Ne
+VF
 Dh
 Dh
 Dh
-sj
-AI
-hE
+Yy
+WD
+Xq
 Dh
+aa
 aa
 aa
 aa
@@ -40157,23 +40168,23 @@ aa
 ab
 qc
 ab
-ab
 Dh
-Ft
+mA
 Dh
+vr
 zV
-vf
 uw
 uw
 uw
 uw
+Dh
+YO
+Dh
+Dh
 Dh
 pX
 Dh
-Dh
-Dh
-WD
-Dh
+aa
 aa
 aa
 aa
@@ -40414,23 +40425,23 @@ aa
 ab
 JR
 Mw
-Mw
-NG
 ZA
 NG
+ZA
+wI
 Vk
+xM
 xM
 uw
 uw
-uw
-uw
-vr
+XR
 uw
 Qi
 Qi
 Dh
-Yy
+VW
 Dh
+aa
 aa
 aa
 aa
@@ -40671,23 +40682,23 @@ aa
 ab
 ab
 ab
-ab
-Dh
-WD
-Dh
-oC
-Yb
-uw
-uw
-uw
-uw
 Dh
 pX
 Dh
+CA
+oC
+uw
+uw
+uw
+uw
+Dh
+YO
 Dh
 Dh
-Ft
 Dh
+mA
+Dh
+aa
 aa
 aa
 aa
@@ -40928,23 +40939,23 @@ aa
 aa
 aa
 aa
-aa
 Dh
-WD
+pX
 Dh
+HZ
 xt
 Yb
-uw
-uw
-uw
-YO
+MF
+Vn
+XC
 Dh
 Dh
 Dh
-RI
-AI
-mA
+hE
+WD
+Qv
 Dh
+aa
 aa
 aa
 aa
@@ -41185,23 +41196,23 @@ aa
 aa
 aa
 aa
-aa
 Dh
+pX
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+hE
 WD
-Dh
-uw
-HZ
-wI
-Ne
-XR
-rN
-Dh
-RI
-AI
-mA
+Qv
 Dh
 Dh
 Dh
+aa
 aa
 aa
 aa
@@ -41442,21 +41453,21 @@ aa
 aa
 aa
 aa
-aa
 Dh
+rN
 WD
+WD
+WD
+WD
+WD
+WD
+WD
+WD
+Qv
 Dh
 Dh
 Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Ft
-Dh
-Dh
-Dh
+aa
 aa
 aa
 aa
@@ -41699,19 +41710,19 @@ aa
 aa
 aa
 aa
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
 aa
-Dh
-VF
-AI
-AI
-AI
-AI
-AI
-AI
-AI
-AI
-mA
-Dh
 aa
 aa
 aa
@@ -41957,18 +41968,18 @@ aa
 aa
 aa
 aa
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
-Dh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -196,8 +196,8 @@
 /area/maintenance/interstitial_main)
 "ax" = (
 /obj/effect/floor_decal/corner/yellow/full{
-	icon_state = "corner_white_full";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_full"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -267,8 +267,8 @@
 	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -281,8 +281,8 @@
 "aK" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -293,8 +293,8 @@
 /area/maintenance/interstitial_main)
 "aL" = (
 /obj/effect/floor_decal/corner/yellow/full{
-	icon_state = "corner_white_full";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_full"
 	},
 /obj/structure/sign/vacuum{
 	pixel_x = -32
@@ -303,8 +303,8 @@
 /area/maintenance/interstitial_main)
 "aM" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
@@ -315,8 +315,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
@@ -375,8 +375,8 @@
 /area/maintenance/interstitial_main)
 "aW" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
@@ -551,15 +551,15 @@
 	},
 /obj/machinery/door/window/eastright,
 /obj/effect/floor_decal/corner/yellow/full{
-	icon_state = "corner_white_full";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_full"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/bridge_elevator)
 "bm" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -595,8 +595,8 @@
 /area/maintenance/bridge_elevator)
 "bq" = (
 /obj/effect/floor_decal/corner/yellow/full{
-	icon_state = "corner_white_full";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_full"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -660,8 +660,8 @@
 	},
 /obj/machinery/door/window/eastright,
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/bridge_elevator)
@@ -689,8 +689,8 @@
 /area/maintenance/bridge_elevator)
 "bA" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -817,8 +817,8 @@
 /area/maintenance/bridge_elevator)
 "bJ" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -833,8 +833,8 @@
 /area/maintenance/bridge_elevator)
 "bL" = (
 /obj/effect/floor_decal/corner/yellow/full{
-	icon_state = "corner_white_full";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_full"
 	},
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -1548,8 +1548,8 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/training)
@@ -1717,8 +1717,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled,
 /area/security/training)
@@ -2203,8 +2203,8 @@
 	},
 /obj/machinery/firealarm/west,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/training)
@@ -2363,8 +2363,8 @@
 "fr" = (
 /obj/machinery/photocopier,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/lino/grey,
 /area/security/detectives_office)
@@ -2513,8 +2513,8 @@
 /area/security/detectives_office)
 "fH" = (
 /turf/simulated/floor/tiled/ramp/bottom{
-	tag = "icon-rampbot (NORTH)";
-	dir = 1
+	dir = 1;
+	tag = "icon-rampbot (NORTH)"
 	},
 /area/security/detectives_office)
 "fI" = (
@@ -2525,8 +2525,8 @@
 /obj/structure/table/wood,
 /obj/item/device/camera_film,
 /obj/item/device/camera{
-	name = "detectives camera";
 	desc = "A one use - polaroid camera. 30 photos left.";
+	name = "detectives camera";
 	pictures_left = 30
 	},
 /turf/simulated/floor/lino/grey,
@@ -2600,8 +2600,8 @@
 /area/security/forensics_office)
 "fQ" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "conpipe-c";
-	dir = 4
+	dir = 4;
+	icon_state = "conpipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -2651,8 +2651,8 @@
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/security/training)
@@ -2898,8 +2898,8 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3097,8 +3097,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/training)
@@ -3145,8 +3145,8 @@
 /area/maintenance/security_interstitial)
 "gN" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "conpipe-c";
-	dir = 4
+	dir = 4;
+	icon_state = "conpipe-c"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -3385,8 +3385,8 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "conpipe-c";
-	dir = 4
+	dir = 4;
+	icon_state = "conpipe-c"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3542,8 +3542,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/training)
@@ -3609,8 +3609,8 @@
 	desc = "Avery Bennett Memorial Hall<br>The 5th and final victim of the Odin Killer. He was slain by the Odin Killer for his brave, personal investigation on the killings. Studying to become a detective at the time of his death, he was posthumously granted the title.<br>November 2428 - June 2460"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled,
 /area/security/training)
@@ -3666,6 +3666,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/ramp/bottom,
 /area/security/forensics_office)
+"hE" = (
+/obj/structure/grille,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "hF" = (
 /obj/structure/morgue{
 	dir = 2
@@ -3700,8 +3710,8 @@
 /obj/structure/table/steel,
 /obj/structure/metronome,
 /obj/machinery/light/small/red{
-	tag = "icon-bulb1 (NORTH)";
-	dir = 1
+	dir = 1;
+	tag = "icon-bulb1 (NORTH)"
 	},
 /turf/simulated/floor/reinforced,
 /area/medical/psych)
@@ -4141,8 +4151,8 @@
 	},
 /obj/machinery/porta_turret/stationary,
 /obj/machinery/light/colored/blue{
-	tag = "icon-tube_empty (WEST)";
-	dir = 8
+	dir = 8;
+	tag = "icon-tube_empty (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/bridge/selfdestruct)
@@ -4152,8 +4162,8 @@
 	},
 /obj/machinery/porta_turret/stationary,
 /obj/machinery/light/colored/blue{
-	tag = "icon-tube_empty (EAST)";
-	dir = 4
+	dir = 4;
+	tag = "icon-tube_empty (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/bridge/selfdestruct)
@@ -4552,8 +4562,8 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/security/range)
@@ -4604,8 +4614,8 @@
 /area/security/investigations)
 "jF" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/open,
 /area/security/training)
@@ -4863,9 +4873,9 @@
 /area/medical/psych)
 "kb" = (
 /obj/machinery/chakraconsole{
-	tag = "icon-body_scannerconsole (EAST)";
+	dir = 4;
 	icon_state = "body_scannerconsole";
-	dir = 4
+	tag = "icon-body_scannerconsole (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/green/diagonal,
@@ -5063,8 +5073,8 @@
 /area/medical/psych)
 "ks" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 9
@@ -5242,8 +5252,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -5388,8 +5398,8 @@
 /area/medical/psych)
 "kZ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/firealarm/west,
 /obj/machinery/ringer{
@@ -5782,8 +5792,8 @@
 /area/medical/psych)
 "lL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner_wide/green/full,
 /turf/simulated/floor/tiled/white,
@@ -5948,8 +5958,8 @@
 /area/mine/unexplored)
 "mh" = (
 /obj/effect/floor_decal/industrial/warning/dust{
-	tag = "icon-warning_dust (SOUTHWEST)";
-	dir = 10
+	dir = 10;
+	tag = "icon-warning_dust (SOUTHWEST)"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "asteroidplating"
@@ -6089,6 +6099,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/upperlevel)
+"mA" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "mB" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/machinery/light/small/emergency{
@@ -6430,6 +6449,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/stairs)
+"oC" = (
+/obj/machinery/anti_bluespace,
+/obj/machinery/camera/network/security{
+	c_tag = "Armoury - Upper Storage";
+	network = list("Security","Armoury")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "oD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -6670,6 +6697,18 @@
 "pT" = (
 /turf/simulated/wall,
 /area/medical/upperlevel)
+"pX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/securearea{
+	pixel_y = 32
+	},
+/obj/structure/sign/flag/nanotrasen{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "pZ" = (
 /turf/simulated/open/airless,
 /area/mine/unexplored)
@@ -7028,6 +7067,14 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
+"rN" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Weaponry (Shotgun)"
+	},
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/gun/projectile/shotgun/pump,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "sd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/pipedispenser/disposal,
@@ -7063,6 +7110,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"sj" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "sk" = (
 /obj/structure/track{
 	icon_state = "track5"
@@ -7276,8 +7337,8 @@
 /area/maintenance/elevator)
 "tm" = (
 /obj/effect/floor_decal/industrial/warning/dust{
-	tag = "icon-warning_dust (SOUTHWEST)";
-	dir = 10
+	dir = 10;
+	tag = "icon-warning_dust (SOUTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 4
@@ -7459,6 +7520,21 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
+"uv" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Ammunition (45. less-than-lethal)"
+	},
+/obj/effect/decal/warning_stripes,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
+"uw" = (
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "uD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -7578,6 +7654,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/abandoned)
+"vf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "vh" = (
 /obj/machinery/vending/coffee,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -7613,6 +7695,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_interstitial)
+"vr" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Armoury Section";
+	req_access = list(3)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "vs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7622,8 +7711,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
@@ -7821,6 +7910,14 @@
 /obj/structure/sign/vacuum,
 /turf/simulated/wall,
 /area/maintenance/interstitial_cargo)
+"wI" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Weaponry (Laser Rifle)"
+	},
+/obj/item/gun/energy/rifle/laser,
+/obj/item/gun/energy/rifle/laser,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "wJ" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 9
@@ -7910,6 +8007,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_cargo)
+"xt" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "xv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/reinforced,
@@ -7954,6 +8057,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/janitor/stairs)
+"xM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "xP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -8003,8 +8115,8 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -8277,6 +8389,12 @@
 	temperature = 278
 	},
 /area/security/forensics_office)
+"zV" = (
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "zW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8347,8 +8465,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
@@ -8367,6 +8485,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"AI" = (
+/obj/structure/grille,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "AL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced,
@@ -8630,6 +8758,28 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/open,
 /area/medical/abandoned)
+"Cu" = (
+/obj/structure/table/rack,
+/obj/item/material/kitchen/utensil/knife/boot{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/material/kitchen/utensil/knife/boot,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
+"CA" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Ammunition (.45 lethal)"
+	},
+/obj/effect/decal/warning_stripes,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "CC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -8745,6 +8895,9 @@
 	},
 /turf/simulated/open,
 /area/maintenance/interstitial_cargo)
+"Dh" = (
+/turf/simulated/wall/r_wall,
+/area/security/armoury)
 "Dj" = (
 /obj/machinery/camera/network/supply{
 	c_tag = "Cargo - Upper Warehouse";
@@ -8926,8 +9079,8 @@
 /area/quartermaster/storage)
 "En" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -9151,6 +9304,19 @@
 "Fs" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"Ft" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "Fv" = (
 /obj/structure/lattice,
 /obj/structure/girder,
@@ -9202,8 +9368,8 @@
 /area/mine/unexplored)
 "FP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 9
@@ -9298,8 +9464,8 @@
 /area/mine/unexplored)
 "Gv" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -9312,8 +9478,8 @@
 /area/maintenance/interstitial_construction_site/office)
 "Gz" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9587,8 +9753,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "conpipe-c";
-	dir = 4
+	dir = 4;
+	icon_state = "conpipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_interstitial)
@@ -9609,6 +9775,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_interstitial)
+"HZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Weaponry (Signal Pistol)"
+	},
+/obj/item/gun/projectile/pistol/flash,
+/obj/item/gun/projectile/pistol/flash,
+/obj/item/gun/projectile/pistol/flash,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "Ic" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9763,8 +9941,8 @@
 /area/quartermaster/storage)
 "IP" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/sign/vacuum{
 	pixel_x = -32
@@ -9794,8 +9972,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
@@ -9920,8 +10098,8 @@
 	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
@@ -9962,8 +10140,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow/full{
-	icon_state = "corner_white_full";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_full"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
@@ -10188,6 +10366,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/abandoned)
+"JR" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/airless{
+	icon_state = "asteroidplating"
+	},
+/area/mine/unexplored)
 "JU" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 4
@@ -10297,8 +10491,8 @@
 /area/maintenance/interstitial_cargo)
 "Kj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled,
@@ -10498,8 +10692,8 @@
 /area/medical/upperlevel)
 "Lr" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -10603,8 +10797,8 @@
 	icon_state = "12-0"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating{
 	roof_type = null
@@ -10618,8 +10812,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/interstitial_cargo)
@@ -10705,6 +10899,19 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
+"LV" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Ammunition (9mm)"
+	},
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/item/ammo_magazine/mc9mm/flash,
+/obj/effect/decal/warning_stripes,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "LY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10798,8 +11005,8 @@
 /area/maintenance/engineering_ladder)
 "Mv" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -10873,6 +11080,17 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/stairs)
+"MF" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "MH" = (
 /obj/machinery/light{
 	dir = 4;
@@ -10971,6 +11189,16 @@
 	},
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/maintenance/interstitial_construction_site/zone_2)
+"Ne" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Weaponry (Ion Rifle)"
+	},
+/obj/item/gun/energy/rifle/ionrifle,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "Nf" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -11022,6 +11250,16 @@
 "NB" = (
 /turf/simulated/wall,
 /area/maintenance/interstitial_construction_site/zone_2)
+"NG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall/r_wall,
+/area/security/armoury)
 "NH" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -11034,8 +11272,8 @@
 /area/maintenance/interstitial_cargo)
 "NJ" = (
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
@@ -11161,8 +11399,8 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
@@ -11254,8 +11492,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -11451,6 +11689,9 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"Qi" = (
+/turf/simulated/open,
+/area/security/armoury)
 "Qk" = (
 /obj/effect/floor_decal/corner/beige/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11613,8 +11854,8 @@
 /area/medical/upperlevel)
 "QN" = (
 /obj/effect/floor_decal/corner/yellow/full{
-	icon_state = "corner_white_full";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_full"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -11727,6 +11968,20 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
+"RI" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "RJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -12055,8 +12310,8 @@
 /area/security/forensics_office)
 "Ts" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/pink/full{
@@ -12122,6 +12377,22 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/stairs)
+"TE" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/airless{
+	icon_state = "asteroidplating"
+	},
+/area/mine/unexplored)
 "TH" = (
 /obj/structure/table/standard,
 /obj/item/stack/packageWrap,
@@ -12153,11 +12424,16 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/airless{
 	icon_state = "asteroidplating"
@@ -12270,8 +12546,8 @@
 /area/quartermaster/storage)
 "UA" = (
 /obj/effect/floor_decal/industrial/warning/dust{
-	tag = "icon-warning_dust (SOUTHWEST)";
-	dir = 10
+	dir = 10;
+	tag = "icon-warning_dust (SOUTHWEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless{
@@ -12433,12 +12709,32 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/abandoned)
+"Vk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
+"Vn" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "Vp" = (
 /obj/machinery/ringer{
 	department = "Cargo";
 	id = "cargo_ringer";
-	req_access = list(31);
-	pixel_x = 30
+	pixel_x = 30;
+	req_access = list(31)
 	},
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open,
@@ -12486,6 +12782,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_interstitial)
+"VF" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "VH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12574,8 +12884,8 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
@@ -12625,6 +12935,19 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
+"WD" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "WF" = (
 /obj/structure/flora/pottedplant/random,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -12739,8 +13062,8 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/corner/yellow/full{
-	icon_state = "corner_white_full";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_full"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12802,6 +13125,31 @@
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating,
 /area/maintenance/elevator)
+"XC" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Ammunition (shotgun)"
+	},
+/obj/effect/decal/warning_stripes,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/storage/box/stunshells,
+/obj/item/storage/box/flashshells{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/beanbags{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/beanbags{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/incendiaryshells,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "XG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/frame/fire_alarm,
@@ -12834,6 +13182,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/upperlevel)
+"XR" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Weaponry (En. Carbine)"
+	},
+/obj/item/gun/energy/gun,
+/obj/item/gun/energy/gun,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "XT" = (
 /obj/structure/table/standard,
 /obj/item/folder/sec,
@@ -12847,8 +13203,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/interstitial_main)
@@ -12884,6 +13240,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"Yb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "Yd" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/corner/pink/full,
@@ -12951,6 +13313,23 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
+"Yy" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "Yz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13007,6 +13386,13 @@
 	},
 /turf/simulated/open,
 /area/maintenance/medbay_interstitial)
+"YO" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 6;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "YQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13101,6 +13487,27 @@
 "Zz" = (
 /turf/simulated/open,
 /area/turbolift/medical_interstitial)
+"ZA" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/unsimulated/chasm_mask,
+/area/security/armoury)
 "ZE" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -34874,8 +35281,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+ab
+ab
 aa
 aa
 aa
@@ -35123,6 +35530,18 @@ aa
 aa
 aa
 aa
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
 aa
 aa
 aa
@@ -35135,21 +35554,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
 ab
 ab
 ab
@@ -35376,37 +35783,37 @@ aa
 aa
 aa
 aa
+ab
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -35633,40 +36040,40 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
+TE
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
+Mw
 Ua
 Mw
 Mw
@@ -35890,41 +36297,41 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
-aa
+ab
+qc
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
@@ -36149,6 +36556,10 @@ aa
 aa
 aa
 aa
+ab
+qc
+ab
+ab
 aa
 aa
 aa
@@ -36163,25 +36574,21 @@ aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
 aa
 aa
 aa
+ab
+ab
+ab
+ab
+ab
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
 aa
 aa
 aa
@@ -36406,6 +36813,9 @@ aa
 aa
 aa
 aa
+ab
+qc
+ab
 aa
 aa
 aa
@@ -36421,21 +36831,18 @@ aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
@@ -36663,6 +37070,9 @@ aa
 aa
 aa
 aa
+ab
+qc
+ab
 aa
 aa
 aa
@@ -36679,17 +37089,14 @@ aa
 aa
 aa
 aa
+ab
+ab
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
 aa
 aa
 aa
@@ -36920,9 +37327,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+ab
+qc
+ab
 aa
 aa
 aa
@@ -37177,9 +37584,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+ab
+qc
+ab
 aa
 aa
 aa
@@ -37434,11 +37841,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+ab
+qc
+ab
+ab
+ab
 aa
 aa
 aa
@@ -37691,11 +38098,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+ab
+qc
+ab
+ab
+ab
 aa
 aa
 aa
@@ -37947,12 +38354,12 @@ aa
 aa
 aa
 aa
+ab
+ab
+qc
+ab
 aa
-aa
-aa
-aa
-aa
-aa
+ab
 aa
 aa
 aa
@@ -38204,10 +38611,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+ab
+ab
+qc
+ab
 aa
 aa
 aa
@@ -38461,23 +38868,23 @@ aa
 aa
 aa
 aa
+ab
+ab
+qc
+ab
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
 aa
 aa
 aa
@@ -38718,23 +39125,23 @@ aa
 aa
 aa
 aa
+ab
+ab
+qc
+ab
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dh
+RI
+AI
+AI
+AI
+AI
+AI
+AI
+AI
+AI
+MF
+Dh
 aa
 aa
 aa
@@ -38976,24 +39383,24 @@ aa
 aa
 aa
 aa
+ab
+qc
+ab
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dh
+Ft
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+WD
+Dh
+Dh
+Dh
 aa
 aa
 aa
@@ -39233,26 +39640,26 @@ aa
 aa
 aa
 aa
+ab
+qc
+ab
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dh
+Ft
+Dh
+Cu
+Vn
+LV
+XC
+uv
+CA
+Dh
+sj
+AI
+MF
+Dh
+Dh
+Dh
 aa
 aa
 aa
@@ -39490,26 +39897,26 @@ aa
 aa
 aa
 aa
+ab
+qc
+ab
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dh
+Ft
+Dh
+Cu
+vf
+uw
+uw
+uw
+YO
+Dh
+Dh
+Dh
+sj
+AI
+hE
+Dh
 aa
 aa
 aa
@@ -39747,26 +40154,26 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+qc
+ab
+ab
+Dh
+Ft
+Dh
+zV
+vf
+uw
+uw
+uw
+uw
+Dh
+pX
+Dh
+Dh
+Dh
+WD
+Dh
 aa
 aa
 aa
@@ -40004,26 +40411,26 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+JR
+Mw
+Mw
+NG
+ZA
+NG
+Vk
+xM
+uw
+uw
+uw
+uw
+vr
+uw
+Qi
+Qi
+Dh
+Yy
+Dh
 aa
 aa
 aa
@@ -40261,26 +40668,26 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
+ab
+Dh
+WD
+Dh
+oC
+Yb
+uw
+uw
+uw
+uw
+Dh
+pX
+Dh
+Dh
+Dh
+Ft
+Dh
 aa
 aa
 aa
@@ -40522,22 +40929,22 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dh
+WD
+Dh
+xt
+Yb
+uw
+uw
+uw
+YO
+Dh
+Dh
+Dh
+RI
+AI
+mA
+Dh
 aa
 aa
 aa
@@ -40779,22 +41186,22 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dh
+WD
+Dh
+uw
+HZ
+wI
+Ne
+XR
+rN
+Dh
+RI
+AI
+mA
+Dh
+Dh
+Dh
 aa
 aa
 aa
@@ -41036,20 +41443,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dh
+WD
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Ft
+Dh
+Dh
+Dh
 aa
 aa
 aa
@@ -41293,18 +41700,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dh
+VF
+AI
+AI
+AI
+AI
+AI
+AI
+AI
+AI
+mA
+Dh
 aa
 aa
 aa
@@ -41550,18 +41957,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
+Dh
 aa
 aa
 aa


### PR DESCRIPTION
* The armory has been split into two levels, as it's been getting cramped lately. Much of the lethal weaponry has been moved upstairs.
* In addition to the moved weapons, the upper armory received; 4 9mm signal pistols, and 4 boot knives.
* The lower armory received; 5 .45 flash rounds, 5 .45 rubber rounds, two generic storage closets (for prototype or looted weapons), 1 box of spare handcuffs (1 was moved), 2 boxes of firing pins, and a button to open and close it from the inside.

Screenshots:
Lower Armory (button to open pictured at bottom, the two blue lockers at the top are the generic storage lockers)
![image](https://user-images.githubusercontent.com/22774890/86464092-13b59000-bd2f-11ea-93a1-71e0bfb991e2.png)

Upper Armory (note the missing hazard stripes has been fixed)
![image](https://user-images.githubusercontent.com/22774890/86464151-35167c00-bd2f-11ea-8025-ef61dddd1c40.png)

A Bad Warden (don't be this guy)
![image](https://user-images.githubusercontent.com/22774890/86464191-42336b00-bd2f-11ea-9709-50033b7ff2ed.png)
