### PR TITLE
Flash Round Buff

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -13,6 +13,7 @@
 	var/projectile_type = /obj/item/projectile
 
 	var/def_zone = ""	//Aiming at
+	var/hit_zone		// The place that actually got hit
 	var/mob/firer = null//Who shot it
 	var/silenced = FALSE	//Attack message
 
@@ -124,7 +125,7 @@
 	return 1
 
 //called when the projectile stops flying because it collided with something
-/obj/item/projectile/proc/on_impact(var/atom/A)
+/obj/item/projectile/proc/on_impact(var/atom/A, var/affected_limb)
 	return
 
 //Checks if the projectile is eligible for embedding. Not that it necessarily will.
@@ -169,7 +170,7 @@
 
 	//roll to-hit
 	miss_modifier = max(15*(distance-1) - round(25*accuracy) + miss_modifier, 0)
-	var/hit_zone = get_zone_with_miss_chance(def_zone, target_mob, miss_modifier, ranged_attack=(distance > 1 || original != target_mob)) //if the projectile hits a target we weren't originally aiming at then retain the chance to miss
+	hit_zone = get_zone_with_miss_chance(def_zone, target_mob, miss_modifier, ranged_attack=(distance > 1 || original != target_mob)) //if the projectile hits a target we weren't originally aiming at then retain the chance to miss
 
 	var/result = PROJECTILE_FORCE_MISS
 	if(hit_zone)
@@ -266,7 +267,7 @@
 		return FALSE
 
 	//stop flying
-	on_impact(A)
+	on_impact(A, hit_zone)
 
 	qdel(src)
 	return TRUE
@@ -284,7 +285,7 @@
 	//If no angle needs to resolve it from xo/yo!
 	if(direct_target)
 		direct_target.bullet_act(src, def_zone)
-		on_impact(direct_target)
+		on_impact(direct_target, def_zone)
 		qdel(src)
 		return
 	if(isnum(angle))

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -16,15 +16,19 @@
 	var/brightness = 7
 	var/light_duration = 5
 
-/obj/item/projectile/energy/flash/on_impact(var/atom/A)
-	var/turf/T = flash_range? src.loc : get_turf(A)
-	if(!istype(T)) return
+/obj/item/projectile/energy/flash/on_impact(var/atom/A, affected_limb)
+	var/turf/T = flash_range ? src.loc : get_turf(A)
+	if(!istype(T))
+		return
 
 	//blind adjacent people
-	for (var/mob/living/carbon/M in viewers(T, flash_range))
+	for(var/mob/living/carbon/M in viewers(T, flash_range))
 		if(M.eyecheck() < FLASH_PROTECTION_MODERATE)
 			M.confused = rand(5,15)
 			flick("e_flash", M.flash)
+		else if(affected_limb && M == A)
+			M.confused = rand(2, 7)
+			flick("flash", M.flash)
 
 	//snap pop
 	playsound(src, 'sound/effects/snap.ogg', 50, 1)

--- a/html/changelogs/geeves-signal_buff.yml
+++ b/html/changelogs/geeves-signal_buff.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Flash rounds have been buffed. Scoring a headshot now ignores eye-protection, but only grants half the effects of a standard flash round effect."


### PR DESCRIPTION
* Flash rounds have been buffed. Scoring a headshot now ignores eye-protection, but only grants half the effects of a standard flash round effect.