### PR TITLE
Warehouse Randomization Improvement

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -216,7 +216,7 @@
 		/obj/item/storage/fancy/cigarettes/blank = 5,
 		/obj/item/storage/fancy/cigarettes/acmeco = 2,
 		/obj/item/storage/fancy/cigarettes/dromedaryco = 10,
-		/obj/item/storage/fancy/cigar = 9,
+		/obj/item/storage/fancy/cigarettes/cigar = 9,
 		/obj/item/storage/fancy/cigarettes/nicotine = 10,
 		/obj/item/storage/fancy/cigarettes/rugged = 10,
 		/obj/item/storage/fancy/cigarettes/pra = 5,

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -97,11 +97,12 @@
 	desc = "This is a random bomb supply."
 	icon = 'icons/obj/assemblies/new_assemblies.dmi'
 	icon_state = "signaller"
-	spawnlist = list(
-		/obj/item/device/assembly/igniter,
-		/obj/item/device/assembly/prox_sensor,
-		/obj/item/device/assembly/signaler,
-		/obj/item/device/multitool
+	problist = list(
+		/obj/item/device/assembly/igniter = 2,
+		/obj/item/device/assembly/prox_sensor = 2,
+		/obj/item/device/assembly/signaler = 2,
+		/obj/item/device/multitool = 1,
+		/obj/item/device/transfer_valve = 0.5
 	)
 
 /obj/random/toolbox
@@ -203,6 +204,24 @@
 		/obj/item/clothing/mask/gas/voice = 1,
 		/obj/item/clothing/gloves/brassknuckles = 2,
 		/obj/item/reagent_containers/inhaler/space_drugs = 2
+	)
+
+/obj/random/smokable
+	name = "random smokable"
+	desc = "This is a random smoking item."
+	icon = 'icons/obj/cigs_lighters.dmi'
+	icon_state = "cigpacket"
+	problist = list(
+		/obj/item/storage/fancy/cigarettes = 30,
+		/obj/item/storage/fancy/cigarettes/blank = 5,
+		/obj/item/storage/fancy/cigarettes/acmeco = 2,
+		/obj/item/storage/fancy/cigarettes/dromedaryco = 10,
+		/obj/item/storage/fancy/cigar = 9,
+		/obj/item/storage/fancy/cigarettes/nicotine = 10,
+		/obj/item/storage/fancy/cigarettes/rugged = 10,
+		/obj/item/storage/fancy/cigarettes/pra = 5,
+		/obj/item/storage/fancy/cigarettes/dpra = 2,
+		/obj/item/storage/fancy/cigarettes/nka = 2
 	)
 
 /obj/random/energy

--- a/code/modules/cargo/random_stock/t1_common.dm
+++ b/code/modules/cargo/random_stock/t1_common.dm
@@ -1,7 +1,7 @@
 // --- Common ---
 
 STOCK_ITEM_COMMON(toolbox, 4)
-	if (prob(5))
+	if(prob(5))
 		new /obj/item/storage/toolbox/syndicate(L)
 	else
 		new /obj/random/toolbox(L)
@@ -16,7 +16,7 @@ STOCK_ITEM_COMMON(steel, 7)
 	new /obj/item/stack/material/steel(L, 50)
 
 STOCK_ITEM_COMMON(glass, 2.5)
-	if (prob(35))
+	if(prob(35))
 		new /obj/item/stack/material/glass/reinforced(L, rand(10,50))
 	else
 		new /obj/item/stack/material/glass(L, 50)
@@ -33,34 +33,33 @@ STOCK_ITEM_COMMON(cardboard, 1)
 //A lightreplacer and a kit of lights
 STOCK_ITEM_COMMON(lightreplacer, 1)
 	var/obj/item/device/lightreplacer/LR
-	if (prob(5))
+	if(prob(5))
 		LR = new /obj/item/device/lightreplacer/advanced(L)
 	else
 		LR = new /obj/item/device/lightreplacer(L)
 	LR.uses = 0
 
 	new /obj/item/storage/box/lights/mixed(L)
-	new /obj/item/storage/box/lights/mixed(L)
 
 //A bundle of bodybags or stasis bags
 STOCK_ITEM_COMMON(bodybag, 2.2)
-	if (prob(25))
+	if(prob(25))
 		new /obj/item/bodybag/cryobag(L)
 		new /obj/item/bodybag/cryobag(L)
-		new /obj/item/bodybag/cryobag(L)
-		new /obj/item/bodybag/cryobag(L)
+		if(prob(50))
+			new /obj/item/bodybag/cryobag(L)
+			new /obj/item/bodybag/cryobag(L)
 	else
 		new /obj/item/storage/box/bodybags(L)
 
 STOCK_ITEM_COMMON(lamp, 2.4)
-	for (var/i in 1 to rand(1, 3))
-		var/obj/item/device/flashlight/lamp/P
-		if (prob(50))
-			P = new /obj/item/device/flashlight/lamp/green(L)
-		else
-			P = new /obj/item/device/flashlight/lamp(L)
-		P.on = FALSE
-		P.queue_icon_update()
+	var/obj/item/device/flashlight/lamp/P
+	if(prob(50))
+		P = new /obj/item/device/flashlight/lamp/green(L)
+	else
+		P = new /obj/item/device/flashlight/lamp(L)
+	P.on = FALSE
+	P.queue_icon_update()
 
 STOCK_ITEM_COMMON(mousetrap, 2)
 	new /obj/item/storage/box/mousetraps(L)
@@ -71,11 +70,11 @@ STOCK_ITEM_COMMON(sterile, 2)
 
 STOCK_ITEM_COMMON(light, 1.8)
 	new /obj/item/storage/box/lights/mixed(L)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/storage/box/lights/mixed(L)
-	if (prob(25))
+	if(prob(25))
 		new /obj/item/storage/box/lights/coloredmixed(L)
-	if (prob(15))
+	if(prob(15))
 		var/type = pick( \
 			/obj/item/storage/box/lights/colored/red, \
 			/obj/item/storage/box/lights/colored/green, \
@@ -92,56 +91,40 @@ STOCK_ITEM_COMMON(aid, 4)
 STOCK_ITEM_COMMON(flame, 2)
 	new /obj/item/storage/box/matches(L)
 	new /obj/item/flame/lighter/random(L)
+
+STOCK_ITEM_COMMON(candles, 1.5)
 	new /obj/item/storage/fancy/candle_box(L)
-	new /obj/item/storage/fancy/candle_box(L)
+	if(prob(75))
+		new /obj/item/storage/fancy/candle_box(L)
 
 STOCK_ITEM_COMMON(crayons, 1.5)
 	new /obj/item/storage/fancy/crayons(L)
 
 STOCK_ITEM_COMMON(figure, 1)
+	new /obj/random/action_figure(L)
 
 STOCK_ITEM_COMMON(bombsupply, 4.5)
-	new /obj/random/bomb_supply(L)
-	new /obj/random/bomb_supply(L)
-	new /obj/random/bomb_supply(L)
-	new /obj/random/bomb_supply(L)
+	for(var/i, i < rand(1, 3), i++)
+		new /obj/random/bomb_supply(L)
 
 STOCK_ITEM_COMMON(tech, 5)
-	new /obj/random/tech_supply(L)
-	new /obj/random/tech_supply(L)
-	new /obj/random/tech_supply(L)
-	new /obj/random/tech_supply(L)
+	for(var/i, i < rand(1, 3), i++)
+		new /obj/random/tech_supply(L)
 
-STOCK_ITEM_COMMON(smokes, 2)
-	new /obj/item/flame/lighter/random(L)
-	if (prob(20))
-		new /obj/item/storage/fancy/cigarettes/cigar(L)
-		new /obj/item/storage/fancy/cigarettes/cigar(L)
-	else
-		new /obj/item/storage/fancy/cigarettes/blank(L)
-		new /obj/item/storage/fancy/cigarettes/blank(L)
-		if (prob(50))
-			new /obj/item/storage/fancy/cigarettes/dromedaryco(L)
-			new /obj/item/storage/fancy/cigarettes/dromedaryco(L)
-			new /obj/item/storage/fancy/cigarettes/dromedaryco(L)
-			new /obj/item/storage/fancy/cigarettes/dromedaryco(L)
-		else
-			new /obj/item/storage/fancy/cigarettes(L)
-			new /obj/item/storage/fancy/cigarettes(L)
-			new /obj/item/storage/fancy/cigarettes(L)
-			new /obj/item/storage/fancy/cigarettes(L)
-
-	if (prob(30))
-		new /obj/item/clothing/mask/smokable/pipe(L)
+STOCK_ITEM_COMMON(smokable, 2)
+	if(prob(50))
+		new /obj/item/flame/lighter/random(L)
+	for(var/i, i < rand(2, 5), i++)
+		new /obj/random/smokable(L)
 
 STOCK_ITEM_COMMON(vials, 2)
-	if (prob(20))
+	if(prob(20))
 		new /obj/item/storage/lockbox/vials(L)
 	else
 		new /obj/item/storage/fancy/vials(L)
 
 STOCK_ITEM_COMMON(smallcell, 4)
-	for (var/i in 1 to rand(1, 4))
+	for(var/i in 1 to rand(1, 2))
 		var/type = pick( \
 			/obj/item/cell, \
 			/obj/item/cell/device, \
@@ -164,10 +147,14 @@ STOCK_ITEM_COMMON(circuitboard, 2)
 	var/type = pick(allboards)
 	new type(L)
 
-STOCK_ITEM_COMMON(smalloxy, 3.2)
+STOCK_ITEM_COMMON(oxy, 3.2)
 	new /obj/random/smalltank(L)
-	new /obj/random/smalltank(L)
-	new /obj/random/smalltank(L)
+	new /obj/item/tank/oxygen(L)
+	if(prob(25))
+		new /obj/random/smalltank(L)
+		new /obj/random/smalltank(L)
+	if(prob(10))
+		new /obj/item/tank/oxygen(L)
 
 STOCK_ITEM_COMMON(belts, 2)
 	new /obj/random/belt(L)
@@ -178,11 +165,11 @@ STOCK_ITEM_COMMON(backpack, 4.5)
 	new /obj/random/backpack(L)
 
 STOCK_ITEM_COMMON(weldgear, 2)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/clothing/glasses/welding(L)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/clothing/head/welding(L)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/weldpack(L)
 
 STOCK_ITEM_COMMON(inflatable, 3)
@@ -194,7 +181,7 @@ STOCK_ITEM_COMMON(wheelchair, 1)
 	//We'll put it ontop of a crate if we need to though, its not essential to find clear space
 	//In any case, we always spawn it on a turf and never in a container
 	var/turf/T = get_turf(L)
-	if (!turf_clear(T))
+	if(!turf_clear(T))
 		for (var/turf/U in range(T,1))
 			if (turf_clear(U))
 				T = U
@@ -204,25 +191,26 @@ STOCK_ITEM_COMMON(wheelchair, 1)
 
 STOCK_ITEM_COMMON(meson, 1.5)
 	new /obj/item/clothing/glasses/meson(L)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/clothing/glasses/meson(L)
 
 STOCK_ITEM_COMMON(trap, 2)
 	new /obj/item/trap(L)
-	if (prob(50))
+	if(prob(30))
 		new /obj/item/trap(L)
 
 STOCK_ITEM_COMMON(trays, 1.8)
-	for (var/i in 1 to rand(1, 7))
-		new /obj/item/tray(L)
+	new /obj/item/tray(L)
 
 STOCK_ITEM_COMMON(utensil, 2)
 	new /obj/item/storage/box/kitchen(L)
 
-STOCK_ITEM_COMMON(metalfoam, 1.5)
-	new /obj/item/grenade/chem_grenade/metalfoam(L)
-	new /obj/item/grenade/chem_grenade/metalfoam(L)
-	new /obj/item/grenade/chem_grenade/metalfoam(L)
+STOCK_ITEM_COMMON(utilitygrenades, 1.5)
+	for(var/i, i < rand(1, 4), i++)
+		if(prob(50))
+			new /obj/item/grenade/chem_grenade/metalfoam(L)
+		else
+			new /obj/item/grenade/chem_grenade/cleaner(L)
 
 STOCK_ITEM_COMMON(nanopaste, 2)
 	new /obj/item/stack/nanopaste(L)
@@ -244,13 +232,14 @@ STOCK_ITEM_COMMON(gloves, 3.3)
 	exclusion += typesof(/obj/item/clothing/gloves/ballistic)
 	allgloves -= exclusion
 
-	for (var/i in 1 to rand(1, 5))
+	for (var/i in 1 to rand(1, 3))
 		var/gtype = pick(allgloves)
 		new gtype(L)
 
 STOCK_ITEM_COMMON(insulated, 1.8)
 	new /obj/item/clothing/gloves/yellow(L)
-	new /obj/item/clothing/gloves/yellow(L)
+	if(prob(50))
+		new /obj/item/clothing/gloves/yellow(L)
 
 STOCK_ITEM_COMMON(scanners, 3.2)
 	//A random scanning device, most are useless
@@ -269,48 +258,48 @@ STOCK_ITEM_COMMON(scanners, 3.2)
 		/obj/item/barcodescanner = 1,
 		/obj/item/device/depth_scanner = 1
 	)
-	for (var/i in 1 to rand(1, 3))
+	for(var/i in 1 to rand(1, 3))
 		var/stype = pickweight(possible)
 		new stype(L)
 
 STOCK_ITEM_COMMON(binoculars, 1.5)
 	new /obj/item/device/binoculars(L)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/device/binoculars(L)
 
 STOCK_ITEM_COMMON(flash, 1)
 	new /obj/item/device/flash(L)
 
 STOCK_ITEM_COMMON(maglock, 2)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/device/magnetic_lock/engineering(L)
 	else
 		new /obj/item/device/magnetic_lock/security(L)
 
-STOCK_ITEM_COMMON(luminol, 2)
-	new /obj/item/reagent_containers/spray/luminol(L)
+STOCK_ITEM_COMMON(forensic, 1)
+	if(prob(50))
+		new /obj/item/reagent_containers/spray/luminol(L)
+	else
+		new /obj/item/device/uv_light(L)
+	if(prob(25))
+		new /obj/item/storage/box/slides(L)
 
 STOCK_ITEM_COMMON(cleaning, 3.5)
-	if (prob(80))
+	if(prob(80))
 		new /obj/item/reagent_containers/glass/rag(L)
-	if (prob(80))
-		var/list/soaps = list(
-			/obj/item/soap,
-			/obj/item/soap/nanotrasen,
-			/obj/item/soap/deluxe,
-			/obj/item/soap/syndie
-		)
-		var/soaptype = pick(soaps)
-		new soaptype(L)
-	if (prob(80))
+	if(prob(80))
+		new /obj/random/soap(L)
+	if(prob(80))
 		new /obj/item/mop(L)
+	else if(prob(5))
+		new /obj/item/mop/advanced(L)
 
-STOCK_ITEM_COMMON(bsdm, 2)
-	if (prob(50))
+STOCK_ITEM_COMMON(bsdm, 1.5)
+	if(prob(50))
 		new /obj/item/clothing/glasses/sunglasses/blindfold(L)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/clothing/mask/muzzle(L)
-	if (prob(30))
+	if(prob(30))
 		new /obj/item/clothing/suit/straight_jacket(L)
 
 STOCK_ITEM_COMMON(charger, 2)
@@ -331,9 +320,6 @@ STOCK_ITEM_COMMON(smokebombs, 1.1)
 STOCK_ITEM_COMMON(jar, 2)
 	new /obj/item/glass_jar(L)
 
-STOCK_ITEM_COMMON(uvlight, 1.2)
-	new /obj/item/device/uv_light(L)
-
 STOCK_ITEM_COMMON(glasses, 1.2)
 	new /obj/item/storage/box/rxglasses(L)
 
@@ -353,7 +339,7 @@ STOCK_ITEM_COMMON(pills, 1.2)
 	new newtype(L)
 
 STOCK_ITEM_COMMON(cosmetic, 2.2)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/lipstick/random(L)
 	else
 		new /obj/item/haircomb(L)
@@ -361,9 +347,20 @@ STOCK_ITEM_COMMON(cosmetic, 2.2)
 STOCK_ITEM_COMMON(suitcooler, 1.2)
 	new /obj/item/device/suit_cooling_unit(L)
 
+STOCK_ITEM_COMMON(paperwork, 1.2)
+	if(prob(50))
+		new /obj/item/hand_labeler(L)
+	else
+		new /obj/item/clipboard(L)
+	if(prob(15))
+		var/obj/item/pen/fountain/F = pick(typesof(/obj/item/pen/fountain))
+		new F(L)
+	else if(prob(15))
+		new /obj/item/pen/multi(L)
+
 STOCK_ITEM_COMMON(officechair, 1.2)
 	var/turf/T = get_turf(L)
-	if (!turf_clear(T))
+	if(!turf_clear(T))
 		for (var/turf/U in range(T,1))
 			if (turf_clear(U))
 				T = U
@@ -371,7 +368,7 @@ STOCK_ITEM_COMMON(officechair, 1.2)
 	new /obj/structure/bed/chair/office/dark(T)
 
 STOCK_ITEM_COMMON(booze, 3.7)
-	if (prob(8))//Spare keg of beer or xuizi juice
+	if(prob(8))//Spare keg of beer or xuizi juice
 		var/turf/T = get_turf(L)
 		if (!turf_clear(T))
 			for (var/turf/U in range(T,1))
@@ -391,7 +388,7 @@ STOCK_ITEM_COMMON(booze, 3.7)
 
 STOCK_ITEM_COMMON(plant, 3.5)
 	var/turf/T = get_turf(L)
-	if (!turf_clear(T))
+	if(!turf_clear(T))
 		for (var/turf/U in range(T,1))
 			if (turf_clear(U))
 				T = U
@@ -409,11 +406,11 @@ STOCK_ITEM_COMMON(bag, 3.5)
 		/obj/item/storage/bag/books \
 	)
 	new type(L)
-	if (prob(30))
+	if(prob(30))
 		new type(L)
 
 STOCK_ITEM_COMMON(extinguish, 2.2)
-	for (var/i in 1 to rand(1, 3))
+	for(var/i in 1 to rand(1, 3))
 		var/type = pick( \
 			/obj/item/extinguisher, \
 			/obj/item/extinguisher/mini \
@@ -421,7 +418,7 @@ STOCK_ITEM_COMMON(extinguish, 2.2)
 		new type(L)
 
 STOCK_ITEM_COMMON(hailer, 1.1)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/device/megaphone(L)
 	else
 		new /obj/item/device/hailer(L)
@@ -430,12 +427,12 @@ STOCK_ITEM_COMMON(hailer, 1.1)
 //Take em up to science for gun testing
 STOCK_ITEM_COMMON(target, 2)
 	var/turf/T = get_turf(L)
-	if (!turf_clear(T))
-		for (var/turf/U in range(T,1))
-			if (turf_clear(U))
+	if(!turf_clear(T))
+		for(var/turf/U in range(T,1))
+			if(turf_clear(U))
 				T = U
 				break
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/target(T)
 	else
 		new /obj/structure/target_stake(T)
@@ -445,8 +442,8 @@ STOCK_ITEM_COMMON(snacks, 4)
 	//This ensures the cargo bay will have a supply of food in an obtainable place for animals
 	//allows nymphs and rats to raid it for nutrients, and thus gives player rats more
 	//reason to infest the warehouse
-	if (CS && prob(65))
-		if (!isturf(L))
+	if(CS && prob(65))
+		if(!isturf(L))
 			L = get_turf(pick(CS.tables))
 
 	var/list/snacks = list(
@@ -461,32 +458,14 @@ STOCK_ITEM_COMMON(snacks, 4)
 	var/type = pickweight(snacks)
 	new type(L)
 
-STOCK_ITEM_COMMON(oxytank, 2.5)
-	new /obj/item/tank/oxygen(L)
-	new /obj/item/tank/oxygen(L)
-
-STOCK_ITEM_COMMON(signs, 4)
-	var/list/allsigns = subtypesof(/obj/structure/sign)
-	allsigns -= typesof(/obj/structure/sign/double)
-	allsigns -= typesof(/obj/structure/sign/poster)
-	allsigns -= /obj/structure/sign/directions
-	allsigns -= typesof(/obj/structure/sign/christmas)
-	allsigns -= typesof(/obj/structure/sign/flag)
-
-	for (var/i in 1 to rand(1, 5))
-		var/newsign = pick(allsigns)
-		if (newsign != /obj/structure/sign)//Dont want to spawn the generic parent class
-			var/obj/structure/sign/S = new newsign(L)
-			S.unfasten()
-
 STOCK_ITEM_COMMON(posters, 3)
 	new /obj/item/contraband/poster(L)
-	if (prob(50))
+	if(prob(40))
 		new /obj/item/contraband/poster(L)
-	if (prob(50))
+	if(prob(20))
 		new /obj/item/contraband/poster(L)
 
-STOCK_ITEM_COMMON(parts, 6)
+STOCK_ITEM_COMMON(parts, 5)
 	var/list/parts = list(
 		/obj/item/stock_parts/console_screen = 3, //Low ranking parts, common
 		/obj/item/stock_parts/capacitor = 3,
@@ -513,20 +492,20 @@ STOCK_ITEM_COMMON(parts, 6)
 		/obj/item/stock_parts/subspace/transmitter = 0.5
 	)
 
-	for (var/i in 1 to rand(2, 5))
+	for(var/i in 1 to rand(2, 3))
 		var/part = pickweight(parts)
 		new part(L)
 
 STOCK_ITEM_COMMON(cane, 2)
-	if (prob(5))
+	if(prob(5))
 		new /obj/item/cane/concealed(L)
-	else if (prob(20))
-		new /obj/item/staff/broom(L)
+	else if(prob(40))
+		new /obj/item/cane/crutch(L)
 	else
 		new /obj/item/cane(L)
 
 STOCK_ITEM_COMMON(warning, 2.2)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/clothing/suit/caution(L)
 	else
 		new /obj/item/clothing/head/cone(L)
@@ -548,38 +527,24 @@ STOCK_ITEM_COMMON(gasmask, 2)
 	var/type = pickweight(masks)
 	new type(L)
 
-STOCK_ITEM_COMMON(cleanernades, 1.5)
-	new /obj/item/grenade/chem_grenade/cleaner(L)
-	new /obj/item/grenade/chem_grenade/cleaner(L)
-	if (prob(50))
-		new /obj/item/grenade/chem_grenade/cleaner(L)
-		new /obj/item/grenade/chem_grenade/cleaner(L)
-
 STOCK_ITEM_COMMON(mining, 2)
-	if (prob(50))
-		new /obj/item/shovel(L)
-	if (prob(50))
-		new /obj/item/pickaxe(L)
-	if (prob(50))
-		new /obj/item/clothing/glasses/material(L)
-	if (prob(50))
-		new /obj/item/device/flashlight/lantern(L)
-	if (prob(50))
-		new /obj/item/mining_scanner(L)
-	if (prob(25))
-		new /obj/item/storage/box/excavation(L)
+	var/list/mine_items = list(/obj/item/shovel, /obj/item/pickaxe, /obj/item/clothing/glasses/material,
+				/obj/item/device/flashlight/lantern, /obj/item/mining_scanner, /obj/item/storage/box/excavation)
+	for(var/i, i < rand(1, 3), i++)
+		var/to_spawn = pick(mine_items)
+		new to_spawn(L)
 
 STOCK_ITEM_COMMON(paicard, 2)
 	new /obj/item/device/paicard(L)
-
-STOCK_ITEM_COMMON(phoronsheets, 2)
-	new /obj/item/stack/material/phoron(L, rand(5,50))
 
 STOCK_ITEM_COMMON(hide, 1)
 	new /obj/item/stack/material/animalhide(L, rand(5,50))
 
 STOCK_ITEM_COMMON(custom_ka, 1)
 	new /obj/random/custom_ka(L)
+
+STOCK_ITEM_COMMON(towel, 1)
+	new /obj/item/towel(L)
 
 STOCK_ITEM_COMMON(nothing, 0)
 	// do nothing

--- a/code/modules/cargo/random_stock/t1_common.dm
+++ b/code/modules/cargo/random_stock/t1_common.dm
@@ -104,17 +104,17 @@ STOCK_ITEM_COMMON(figure, 1)
 	new /obj/random/action_figure(L)
 
 STOCK_ITEM_COMMON(bombsupply, 4.5)
-	for(var/i, i < rand(1, 3), i++)
+	for(var/i in 1 to rand(1, 3))
 		new /obj/random/bomb_supply(L)
 
 STOCK_ITEM_COMMON(tech, 5)
-	for(var/i, i < rand(1, 3), i++)
+	for(var/i in 1 to rand(1, 3))
 		new /obj/random/tech_supply(L)
 
 STOCK_ITEM_COMMON(smokable, 2)
 	if(prob(50))
 		new /obj/item/flame/lighter/random(L)
-	for(var/i, i < rand(2, 5), i++)
+	for(var/i in 1 to rand(2, 4))
 		new /obj/random/smokable(L)
 
 STOCK_ITEM_COMMON(vials, 2)
@@ -206,7 +206,7 @@ STOCK_ITEM_COMMON(utensil, 2)
 	new /obj/item/storage/box/kitchen(L)
 
 STOCK_ITEM_COMMON(utilitygrenades, 1.5)
-	for(var/i, i < rand(1, 4), i++)
+	for(var/i in 1 to rand(1, 4))
 		if(prob(50))
 			new /obj/item/grenade/chem_grenade/metalfoam(L)
 		else
@@ -530,7 +530,7 @@ STOCK_ITEM_COMMON(gasmask, 2)
 STOCK_ITEM_COMMON(mining, 2)
 	var/list/mine_items = list(/obj/item/shovel, /obj/item/pickaxe, /obj/item/clothing/glasses/material,
 				/obj/item/device/flashlight/lantern, /obj/item/mining_scanner, /obj/item/storage/box/excavation)
-	for(var/i, i < rand(1, 3), i++)
+	for(var/i in 1 to rand(1, 3))
 		var/to_spawn = pick(mine_items)
 		new to_spawn(L)
 

--- a/code/modules/cargo/random_stock/t2_uncommon.dm
+++ b/code/modules/cargo/random_stock/t2_uncommon.dm
@@ -278,7 +278,7 @@ STOCK_ITEM_UNCOMMON(jammer, 2)
 	new /obj/item/device/radiojammer(L)
 
 STOCK_ITEM_UNCOMMON(seeds, 1)
-	for(var/i, i < rand(1, 3), i++)
+	for(var/i in 1 to rand(1, 3))
 		var/obj/item/seeds/SP = pick(subtypesof(/obj/item/seeds))
 		new SP(L)
 
@@ -386,7 +386,7 @@ STOCK_ITEM_UNCOMMON(alt_glasses, 1)
 			/obj/item/clothing/glasses/threedglasses,
 			/obj/item/clothing/glasses/regular/hipster,
 			/obj/item/clothing/glasses/regular/scanners)
-	for(var/i, i < rand(1, 2), i++)
+	for(var/i in 1 to rand(1, 2))
 		var/type = pick(glasses)
 		new type(L)
 

--- a/code/modules/cargo/random_stock/t2_uncommon.dm
+++ b/code/modules/cargo/random_stock/t2_uncommon.dm
@@ -3,9 +3,9 @@
 STOCK_ITEM_UNCOMMON(shrooms, 2)
 	if(prob(65))
 		new /obj/item/seeds/glowshroom(L)
-	if(prob(25))
+	if(prob(5))
 		new /obj/item/seeds/ghostmushroomseed(L)
-	if(prob(50))
+	if(prob(30))
 		new /obj/item/seeds/amanitamycelium(L)
 
 STOCK_ITEM_UNCOMMON(plasteel, 3)
@@ -104,7 +104,7 @@ STOCK_ITEM_UNCOMMON(chempack, 5)
 		C.setLabel(R.name)
 
 STOCK_ITEM_UNCOMMON(robolimbs, 3)
-	for(var/i in 1 to rand(1, 3))
+	for(var/i in 1 to rand(1, 2))
 		var/manuf = pick(fabricator_robolimbs)
 		var/type = pick( \
 			/obj/item/robot_parts/l_arm, \
@@ -141,7 +141,10 @@ STOCK_ITEM_UNCOMMON(inhaler, 1)
 	new I(L)
 
 STOCK_ITEM_UNCOMMON(advwelder, 2)
-	new /obj/item/weldingtool/hugetank(L)
+	if(prob(5))
+		new /obj/item/weldingtool/experimental(L)
+	else
+		new /obj/item/weldingtool/hugetank(L)
 
 STOCK_ITEM_UNCOMMON(sord, 1)
 	new /obj/item/sord(L)
@@ -264,13 +267,11 @@ STOCK_ITEM_UNCOMMON(scythe, 0.75)
 STOCK_ITEM_UNCOMMON(laserpoint, 0.75)
 	new /obj/item/device/laser_pointer(L)
 
-
 STOCK_ITEM_UNCOMMON(manual, 2)
-	var/list/booklist = list(subtypesof(/obj/item/book/manual))
+	var/list/booklist = subtypesof(/obj/item/book/manual)
 	booklist -= /obj/item/book/manual/wiki //just this one. we want to keep the subtypes.
 	booklist -= /obj/item/book/manual/nuclear //yeah no
 	var/type = pick(booklist)
-
 	new type(L)
 
 STOCK_ITEM_UNCOMMON(jammer, 2)
@@ -288,7 +289,8 @@ STOCK_ITEM_UNCOMMON(briefcase, 2)
 	if(prob(20))
 		new /obj/item/storage/secure/briefcase(L)
 	else
-		new /obj/item/storage/briefcase(L)
+		var/obj/item/storage/briefcase/B = pick(typesof(/obj/item/storage/briefcase))
+		new B(L)
 
 STOCK_ITEM_UNCOMMON(blade, 1.2)
 	var/list/blades = list(
@@ -299,7 +301,8 @@ STOCK_ITEM_UNCOMMON(blade, 1.2)
 		/obj/item/material/hatchet/butch = 1,
 		/obj/item/material/hatchet = 1.5,
 		/obj/item/material/hatchet/unathiknife = 0.75,
-		/obj/item/material/knife/tacknife = 1
+		/obj/item/material/knife/tacknife = 1,
+		/obj/item/material/knife/bayonet = 0.5
 	)
 
 	var/type = pickweight(blades)
@@ -372,6 +375,20 @@ STOCK_ITEM_UNCOMMON(pops, 0.5)
 		new /obj/item/storage/box/snappops(L)
 	else
 		new /obj/item/storage/box/snappops/syndi(L)
+
+STOCK_ITEM_UNCOMMON(collectable_headwear, 0.5)
+	var/type = pick(subtypesof(/obj/item/clothing/head/collectable/))
+	new type(L)
+
+STOCK_ITEM_UNCOMMON(alt_glasses, 1)
+	var/list/glasses = list(/obj/item/clothing/glasses/regular/circle, 
+			/obj/item/clothing/glasses/regular/jamjar,
+			/obj/item/clothing/glasses/threedglasses,
+			/obj/item/clothing/glasses/regular/hipster,
+			/obj/item/clothing/glasses/regular/scanners)
+	for(var/i, i < rand(1, 2), i++)
+		var/type = pick(glasses)
+		new type(L)
 
 STOCK_ITEM_UNCOMMON(nothing, 0)
 	// no-op

--- a/code/modules/cargo/random_stock/t2_uncommon.dm
+++ b/code/modules/cargo/random_stock/t2_uncommon.dm
@@ -1,15 +1,21 @@
 // --- Uncommon ---
 
-STOCK_ITEM_UNCOMMON(glowshrooms, 2)
-	new /obj/item/seeds/glowshroom(L)
-	new /obj/item/seeds/glowshroom(L)
-	new /obj/item/seeds/glowshroom(L)
+STOCK_ITEM_UNCOMMON(shrooms, 2)
+	if(prob(65))
+		new /obj/item/seeds/glowshroom(L)
+	if(prob(25))
+		new /obj/item/seeds/ghostmushroomseed(L)
+	if(prob(50))
+		new /obj/item/seeds/amanitamycelium(L)
 
 STOCK_ITEM_UNCOMMON(plasteel, 3)
 	new /obj/item/stack/material/plasteel(L, rand(1,30))
 
 STOCK_ITEM_UNCOMMON(silver, 2)
 	new /obj/item/stack/material/silver(L, rand(5,30))
+
+STOCK_ITEM_UNCOMMON(phoronsheets, 2)
+	new /obj/item/stack/material/phoron(L, rand(5,50))
 
 STOCK_ITEM_UNCOMMON(phoronglass, 2)
 	new /obj/item/stack/material/glass/phoronglass(L, 50)
@@ -23,26 +29,33 @@ STOCK_ITEM_UNCOMMON(marble, 2)
 STOCK_ITEM_UNCOMMON(iron, 2)
 	new /obj/item/stack/material/iron(L, 50)
 
+STOCK_ITEM_UNCOMMON(other_mat, 0.5)
+	var/obj/item/stack/material/M = pick(/obj/item/stack/material/osmium, /obj/item/stack/material/mhydrogen, /obj/item/stack/material/tritium, /obj/item/stack/material/bronze)
+	new M(L, rand(1, 10))
+
 STOCK_ITEM_UNCOMMON(flare, 2)
 	new /obj/item/device/flashlight/flare(L)
 	new /obj/item/device/flashlight/flare(L)
 	if (prob(50))
 		new /obj/random/glowstick(L)
 
-STOCK_ITEM_UNCOMMON(deathalarm, 2)
-	new /obj/item/storage/box/cdeathalarm_kit(L)
-
-STOCK_ITEM_UNCOMMON(trackimp, 1)
-	new /obj/item/storage/box/trackimp(L)
+STOCK_ITEM_UNCOMMON(implants, 1)
+	if(prob(50))
+		new /obj/item/storage/box/cdeathalarm_kit(L)
+	else 
+		new /obj/item/storage/box/trackimp(L)
 
 STOCK_ITEM_UNCOMMON(flashbang, 0.75)
 	new /obj/item/storage/box/flashbangs(L)
 
-STOCK_ITEM_UNCOMMON(cuffs, 1)
-	new /obj/item/storage/box/handcuffs(L)
+STOCK_ITEM_UNCOMMON(arrest, 1)
+	if(prob(60))
+		new /obj/item/storage/box/handcuffs(L)
+	else
+		new /obj/item/device/holowarrant(L)
 
 STOCK_ITEM_UNCOMMON(monkey, 2)
-	if (prob(40))
+	if(prob(40))
 		var/type = pick( \
 			/obj/item/storage/box/monkeycubes/farwacubes, \
 			/obj/item/storage/box/monkeycubes/stokcubes, \
@@ -53,17 +66,17 @@ STOCK_ITEM_UNCOMMON(monkey, 2)
 		new /obj/item/storage/box/monkeycubes(L)
 
 STOCK_ITEM_UNCOMMON(specialcrayon, 1.5)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/pen/crayon/mime(L)
 	else
 		new /obj/item/pen/crayon/rainbow(L)
 
 STOCK_ITEM_UNCOMMON(contraband, 2)
-	for (var/i in 1 to rand(1,8))
+	for(var/i in 1 to rand(1, 4))
 		new /obj/random/contraband(L)
 
 STOCK_ITEM_UNCOMMON(mediumcell, 3)
-	for (var/i in 1 to rand(1,2))
+	for(var/i in 1 to rand(1,2))
 		var/type = pick( \
 			/obj/item/cell/super, \
 			/obj/item/cell/potato, \
@@ -77,7 +90,7 @@ STOCK_ITEM_UNCOMMON(chempack, 5)
 		/datum/reagent/liquid_fire, /datum/reagent/philosopher_stone, /datum/reagent/toxin/undead, /datum/reagent/love_potion, /datum/reagent/shapesand, /datum/reagent/usolve,\
 		/datum/reagent/sglue, /datum/reagent/black_matter, /datum/reagent/bottle_lightning, /datum/reagent/toxin/trioxin, /datum/reagent/toxin/phoron_salt, /datum/reagent/toxin/nanites, /datum/reagent/nitroglycerin)
 	chems -= exclusion
-	for (var/i in 1 to rand(2, 6))
+	for (var/i in 1 to rand(2, 4))
 		var/obj/item/reagent_containers/chem_disp_cartridge/C = new /obj/item/reagent_containers/chem_disp_cartridge(L)
 		var/rname = pick(chems)
 		var/datum/reagent/R = SSchemistry.chemical_reagents[rname]
@@ -91,7 +104,7 @@ STOCK_ITEM_UNCOMMON(chempack, 5)
 		C.setLabel(R.name)
 
 STOCK_ITEM_UNCOMMON(robolimbs, 3)
-	for (var/i in 1 to rand(2, 5))
+	for(var/i in 1 to rand(1, 3))
 		var/manuf = pick(fabricator_robolimbs)
 		var/type = pick( \
 			/obj/item/robot_parts/l_arm, \
@@ -110,20 +123,22 @@ STOCK_ITEM_UNCOMMON(circuitboards, 3)
 	exclusion += typesof(/obj/item/circuitboard/mecha)
 
 	allboards -= exclusion
-	for (var/i in 1 to rand(2, 5))
+	for(var/i in 1 to rand(2, 3))
 		var/type = pick(allboards)
 		new type(L)
 
 STOCK_ITEM_UNCOMMON(jetpack, 3)
 	new /obj/item/tank/jetpack/void(L)
-	new /obj/item/tank/emergency_oxygen/double(L)
+	if(prob(40))
+		new /obj/item/tank/emergency_oxygen/double(L)
 
 STOCK_ITEM_UNCOMMON(xenocostume, 1)
 	new /obj/item/clothing/suit/xenos(L)
 	new /obj/item/clothing/head/xenos(L)
 
 STOCK_ITEM_UNCOMMON(inhaler, 1)
-	log_debug("Unimplemented item inhaler.")
+	var/obj/item/reagent_containers/inhaler/I = pick(subtypesof(/obj/item/reagent_containers/inhaler))
+	new I(L)
 
 STOCK_ITEM_UNCOMMON(advwelder, 2)
 	new /obj/item/weldingtool/hugetank(L)
@@ -136,7 +151,7 @@ STOCK_ITEM_UNCOMMON(policebaton, 1.5)
 
 STOCK_ITEM_UNCOMMON(stunbaton, 0.75) //batons spawn with no powercell
 	var/obj/item/melee/baton/B = new /obj/item/melee/baton(L)
-	if (B.bcell)
+	if(B.bcell)
 		QDEL_NULL(B.bcell)
 
 	B.queue_icon_update()
@@ -144,10 +159,8 @@ STOCK_ITEM_UNCOMMON(stunbaton, 0.75) //batons spawn with no powercell
 STOCK_ITEM_UNCOMMON(firingpin, 3)
 	new /obj/item/storage/box/firingpins(L)
 
-STOCK_ITEM_UNCOMMON(watches, 3)
-	new /obj/item/clothing/gloves/watch(L)
-	new /obj/item/clothing/gloves/watch(L)
-	new /obj/item/clothing/gloves/watch(L)
+STOCK_ITEM_UNCOMMON(watch, 3)
+	new /obj/random/watches(L)
 
 STOCK_ITEM_UNCOMMON(MMI, 1.5)
 	new /obj/item/device/mmi(L)
@@ -166,11 +179,11 @@ STOCK_ITEM_UNCOMMON(atmosfiresuit, 2)
 	new /obj/item/clothing/suit/fire/atmos(L)
 
 STOCK_ITEM_UNCOMMON(pdacart, 3)
-	for (var/i in 1 to rand(1, 4))
+	for(var/i in 1 to rand(1, 3))
 		new /obj/random/pda_cart(L)
 
 STOCK_ITEM_UNCOMMON(debugger, 2)
-	new /obj/item/device/debugger(L)//No idea what this thing does, or if it works at all
+	new /obj/item/device/debugger(L)
 
 STOCK_ITEM_UNCOMMON(surgerykit, 2.5)
 	new /obj/item/storage/firstaid/surgery(L)
@@ -186,7 +199,7 @@ STOCK_ITEM_UNCOMMON(gift, 4)
 
 STOCK_ITEM_UNCOMMON(coatrack, 1)
 	var/turf/T = get_turf(L)
-	if (!turf_clear(T))
+	if(!turf_clear(T))
 		for (var/turf/U in range(T,1))
 			if (turf_clear(U))
 				T = U
@@ -195,7 +208,7 @@ STOCK_ITEM_UNCOMMON(coatrack, 1)
 
 STOCK_ITEM_UNCOMMON(riotshield, 2)
 	new /obj/item/shield/riot(L)
-	if (prob(60))
+	if(prob(40))
 		new /obj/item/shield/riot(L)
 
 STOCK_ITEM_UNCOMMON(fireaxe, 1)
@@ -215,21 +228,18 @@ STOCK_ITEM_UNCOMMON(robot, 2)
 	)
 
 	var/type = pickweight(bots)
-	if (type == /mob/living/bot/secbot/ed209)//ED is large and should spawn on the floor
+	if(type == /mob/living/bot/secbot/ed209)//ED is large and should spawn on the floor
 		L = get_turf(L)
-		if (!turf_clear(L))
-			for (var/turf/U in range(L,1))
-				if (turf_clear(U))
+		if(!turf_clear(L))
+			for(var/turf/U in range(L,1))
+				if(turf_clear(U))
 					L = U
 					break
 
 	var/mob/living/bot/newbot = new type(L)
 	newbot.on = FALSE	//Deactivated
-	if (prob(10))
+	if(prob(10))
 		newbot.emag_act(9999, null)
-
-STOCK_ITEM_UNCOMMON(taperoll, 1)
-	// ???
 
 STOCK_ITEM_UNCOMMON(headset, 2)
 	var/list/sets = list(
@@ -251,39 +261,31 @@ STOCK_ITEM_UNCOMMON(bat, 1.2)
 STOCK_ITEM_UNCOMMON(scythe, 0.75)
 	new /obj/item/material/scythe(L)
 
+STOCK_ITEM_UNCOMMON(laserpoint, 0.75)
+	new /obj/item/device/laser_pointer(L)
+
+
 STOCK_ITEM_UNCOMMON(manual, 2)
-	var/type = pick( \
-		/obj/item/book/manual/excavation, \
-		/obj/item/book/manual/mass_spectrometry, \
-		/obj/item/book/manual/anomaly_spectroscopy, \
-		/obj/item/book/manual/materials_chemistry_analysis, \
-		/obj/item/book/manual/anomaly_testing, \
-		/obj/item/book/manual/stasis, \
-		/obj/item/book/manual/engineering_particle_accelerator, \
-		/obj/item/book/manual/supermatter_engine, \
-		/obj/item/book/manual/engineering_singularity_safety, \
-		/obj/item/book/manual/medical_cloning, \
-		/obj/item/book/manual/ripley_build_and_repair, \
-		/obj/item/book/manual/research_and_development, \
-		/obj/item/book/manual/robotics_cyborgs, \
-		/obj/item/book/manual/medical_diagnostics_manual, \
-		/obj/item/book/manual/chef_recipes, \
-		/obj/item/book/manual/barman_recipes, \
-		/obj/item/book/manual/detective, \
-		/obj/item/book/manual/atmospipes, \
-		/obj/item/book/manual/evaguide \
-	)
+	var/list/booklist = list(subtypesof(/obj/item/book/manual))
+	booklist -= /obj/item/book/manual/wiki //just this one. we want to keep the subtypes.
+	booklist -= /obj/item/book/manual/nuclear //yeah no
+	var/type = pick(booklist)
 
 	new type(L)
 
 STOCK_ITEM_UNCOMMON(jammer, 2)
 	new /obj/item/device/radiojammer(L)
 
+STOCK_ITEM_UNCOMMON(seeds, 1)
+	for(var/i, i < rand(1, 3), i++)
+		var/obj/item/seeds/SP = pick(subtypesof(/obj/item/seeds))
+		new SP(L)
+
 STOCK_ITEM_UNCOMMON(rped, 2)
 	new /obj/item/storage/part_replacer(L)
 
 STOCK_ITEM_UNCOMMON(briefcase, 2)
-	if (prob(20))
+	if(prob(20))
 		new /obj/item/storage/secure/briefcase(L)
 	else
 		new /obj/item/storage/briefcase(L)
@@ -315,38 +317,61 @@ STOCK_ITEM_UNCOMMON(laserscalpel, 1.3)
 STOCK_ITEM_UNCOMMON(electropack, 1)
 	new /obj/item/device/radio/electropack(L)
 
-	if (istype(L, /obj/structure/closet/crate) && prob(40))
+	if(istype(L, /obj/structure/closet/crate) && prob(40))
 		var/obj/structure/closet/crate/cr = L
 		cr.rigged = TRUE
 		//Boobytrapped crate, will electrocute when you attempt to open it
 		//Can be disarmed with wirecutters or ignored with insulated gloves
 
-STOCK_ITEM_UNCOMMON(monkeyhide, 0.5)
-	new /obj/item/stack/material/animalhide/monkey(L, 50)
-
-STOCK_ITEM_UNCOMMON(cathide, 0.5)
-	new /obj/item/stack/material/animalhide/cat(L, 50)
-
-STOCK_ITEM_UNCOMMON(corgihide, 0.5)
-	new /obj/item/stack/material/animalhide/corgi(L, 50)
-
-STOCK_ITEM_UNCOMMON(lizardhide, 0.5)
-	new /obj/item/stack/material/animalhide/lizard(L, 50)
+STOCK_ITEM_UNCOMMON(randomhide, 0.5)
+	var/obj/item/stack/material/animalhide/spawn_hide = pick(typesof(/obj/item/stack/material/animalhide))
+	new spawn_hide(L, rand(5, 50))
 
 STOCK_ITEM_UNCOMMON(hoodie, 0.5)
 	new /obj/random/hoodie(L)
 
+STOCK_ITEM_UNCOMMON(bang, 0.5)
+	var/obj/item/gun/bang/B = pick(subtypesof(/obj/item/gun/bang))
+	new B(L)
+
 STOCK_ITEM_UNCOMMON(cookingoil, 1)
 	var/turf/T = get_turf(L)
-	if (!turf_clear(T))
-		for (var/turf/U in range(T,1))
-			if (turf_clear(U))
+	if(!turf_clear(T))
+		for(var/turf/U in range(T,1))
+			if(turf_clear(U))
 				T = U
 				break
 	new /obj/structure/reagent_dispensers/cookingoil(T)
 
 STOCK_ITEM_UNCOMMON(coin, 1.3)
 	new /obj/random/coin(L)
+	if(prob(20))
+		new /obj/random/coin(L)
+
+STOCK_ITEM_UNCOMMON(plushie, 1)
+	new /obj/random/plushie(L)
+
+STOCK_ITEM_UNCOMMON(flag, 1)
+	new /obj/random/random_flag(L)
+
+STOCK_ITEM_UNCOMMON(apiary, 1)
+	new /obj/item/bee_pack(L)
+	if(prob(75))
+		new /obj/item/bee_net(L)
+	if(prob(60))
+		new /obj/item/bee_smoker(L)
+	if(prob(30))
+		new /obj/item/honey_frame(L)
+
+STOCK_ITEM_UNCOMMON(wristbound, 0.5)
+	var/obj/item/modular_computer/wristbound/preset/P = pick(subtypesof(/obj/item/modular_computer/wristbound/preset))
+	new P(L)
+
+STOCK_ITEM_UNCOMMON(pops, 0.5)
+	if(prob(85))
+		new /obj/item/storage/box/snappops(L)
+	else
+		new /obj/item/storage/box/snappops/syndi(L)
 
 STOCK_ITEM_UNCOMMON(nothing, 0)
 	// no-op

--- a/code/modules/cargo/random_stock/t3_rare.dm
+++ b/code/modules/cargo/random_stock/t3_rare.dm
@@ -26,8 +26,10 @@ STOCK_ITEM_RARE(posibrain, 3)
 
 STOCK_ITEM_RARE(bsbeaker, 3)
 	new /obj/item/reagent_containers/glass/beaker/bluespace(L)
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/reagent_containers/glass/beaker/bluespace(L)
+	else if(prob(40))
+		new /obj/item/reagent_containers/glass/beaker/noreact(L)
 
 STOCK_ITEM_RARE(energyshield, 2)
 	new /obj/item/shield/energy(L)
@@ -89,7 +91,7 @@ STOCK_ITEM_RARE(exogear, 1.5)
 		/obj/item/mecha_equipment/sleeper = 0.9
 	)
 
-	for (var/i in 1 to rand(2,5))
+	for(var/i in 1 to rand(1,3))
 		var/type = pickweight(equips)
 		new type(L)
 
@@ -99,16 +101,57 @@ STOCK_ITEM_RARE(teleporter, 1)
 STOCK_ITEM_RARE(voice, 1.5)
 	new /obj/item/clothing/mask/gas/voice(L)
 
-STOCK_ITEM_RARE(xenohide, 0.5)
-	new /obj/item/stack/material/animalhide/xeno(L, rand(2,15))
-
-STOCK_ITEM_RARE(humanhide, 0.5)
-	new /obj/item/stack/material/animalhide/human(L, rand(2,15))
-
-STOCK_ITEM_RARE(contraband, 0.8)
-	new /obj/random/contraband(L)
-
 STOCK_ITEM_RARE(prebuilt_ka, 0.5)
 	new /obj/random/prebuilt_ka(L)
+
+STOCK_ITEM_RARE(ipctags, 0.5)
+	if(prob(50))
+		new /obj/item/ipc_tag_scanner(L)
+	else
+		new /obj/item/implanter/ipc_tag(L)
+
+STOCK_ITEM_RARE(rfd, 0.5)
+	var/obj/item/rfd/rfd_spawn = pick(/obj/item/rfd/construction, /obj/item/rfd/mining, /obj/item/rfd/piping)
+	new rfd_spawn(L)
+
+STOCK_ITEM_RARE(xbow, 0.5)
+	if(prob(95))
+		new /obj/item/toy/crossbow(L)
+	else
+		new /obj/item/gun/energy/crossbow(L)
+
+STOCK_ITEM_RARE(watertank, 1)
+	if(prob(25))
+		new /obj/item/watertank/janitor(L)
+	else
+		new /obj/item/watertank(L)
+
+STOCK_ITEM_RARE(bmonster, 0.5)
+	var/obj/item/battle_monsters/wrapped/W = pick(subtypesof(/obj/item/battle_monsters/wrapped))
+	new W(L)
+	if(prob(15))
+		W = pick(subtypesof(/obj/item/battle_monsters/wrapped))
+		new W(L)
+
+STOCK_ITEM_RARE(rare_clothing, 1)
+	var/list/clothing_picks = list(
+		/obj/item/clothing/under/elyra_holo,
+		/obj/item/clothing/suit/acapjacket,
+		/obj/item/clothing/head/acapcap,
+		/obj/item/clothing/suit/storage/toggle/himeo,
+		/obj/item/clothing/suit/storage/vysoka_f,
+		/obj/item/clothing/suit/storage/vysoka_m,
+		/obj/item/clothing/under/rank/iacjumpsuit,
+		/obj/item/clothing/under/rank/fatigues/marine,
+		/obj/item/clothing/under/rank/dress/subofficer,
+		/obj/item/clothing/under/dominia/lyodsuit/hoodie,
+		/obj/item/clothing/under/rank/head_of_security/corp,
+		/obj/item/clothing/shoes/sandal/clogs,
+		/obj/item/clothing/under/lance,
+		/obj/item/clothing/under/dress/lance_dress/male,
+		/obj/item/clothing/under/kilt)
+	for(var/i, i < rand(1, 2), i++)
+		var/obj/item/clothing/C = pick(clothing_picks)
+		new C(L)
 
 STOCK_ITEM_RARE(nothing, 0)

--- a/code/modules/cargo/random_stock/t3_rare.dm
+++ b/code/modules/cargo/random_stock/t3_rare.dm
@@ -150,7 +150,7 @@ STOCK_ITEM_RARE(rare_clothing, 1)
 		/obj/item/clothing/under/lance,
 		/obj/item/clothing/under/dress/lance_dress/male,
 		/obj/item/clothing/under/kilt)
-	for(var/i, i < rand(1, 2), i++)
+	for(var/i in 1 to rand(1, 2))
 		var/obj/item/clothing/C = pick(clothing_picks)
 		new C(L)
 

--- a/html/changelogs/doxxmedearly - warehouse_randoms.yml
+++ b/html/changelogs/doxxmedearly - warehouse_randoms.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes: 
+  - tweak: "Adjusted cargo warehouse spawns. Added items, made some patterns less predictable, and removed some filler junk (Such as signs and huge stacks of trays)."


### PR DESCRIPTION
The patterns of warehouse spawns right now are predictable and it's both tiring and laughable. This PR attempts to breathe some fresh life into sorting the warehouse.

Tried to space out the commits for easier reviewing. 

-Broke up some groups of things. For example, you can right now look at a pile and go "Yes there will be exactly four groups of X brand cigs". So some groups got rearranged and some that spawned more than one item will not always spawn the same amount.

-Removed excess. Signs are annoying. There's no reason to fill crates with 7 trays. Of course we want plenty of "junk" to sort through but this was a poor way to do it. Some items that spawn in groups have their numbers reduced, such as machinery components, robotic limbs, etc.

-Added new items. Most just to get some variety in and get people to see the items we don't normally see around. Nothing too crazy; just some new things to see and sort. Some of it is also "junk" to make up for the removals. 

Tested about half a dozen times with decent randomization, going to do a few more just to make sure there's nothing weird going on but for now it should be good. 