### PR TITLE
Patting out fires on a target will now take priority over CPR

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -177,7 +177,23 @@
 		swap_hand()
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)
-	if (!is_asystole())
+	if (on_fire)
+		playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+		if (M.on_fire)
+			M.visible_message(span("warning", "[M] tries to pat out [src]'s flames, but to no avail!"),
+			span("warning", "You try to pat out [src]'s flames, but to no avail! Put yourself out first!"))
+		else
+			M.visible_message(span("warning", "[M] tries to pat out [src]'s flames!"),
+			span("warning", "You try to pat out [src]'s flames! Hot!"))
+			if(do_mob(M, src, 1.5 SECONDS))
+				if (M.IgniteMob(prob(10)))
+					M.visible_message(span("danger", "The fire spreads from [src] to [M]!"),
+					span("danger", "The fire spreads to you as well!"))
+				else
+					if (src.ExtinguishMob(1))
+						M.visible_message(span("warning", "[M] successfully pats out [src]'s flames."),
+						span("warning", "You successfully pat out [src]'s flames."))
+	else if (!is_asystole())
 		if(src == M && istype(src, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = src
 			src.visible_message(
@@ -226,22 +242,6 @@
 
 			if((isskeleton(H)) && (!H.w_uniform) && (!H.wear_suit))
 				H.play_xylophone()
-		else if (on_fire)
-			playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			if (M.on_fire)
-				M.visible_message(span("warning", "[M] tries to pat out [src]'s flames, but to no avail!"),
-				span("warning", "You try to pat out [src]'s flames, but to no avail! Put yourself out first!"))
-			else
-				M.visible_message(span("warning", "[M] tries to pat out [src]'s flames!"),
-				span("warning", "You try to pat out [src]'s flames! Hot!"))
-				if(do_mob(M, src, 1.5 SECONDS))
-					if (M.IgniteMob(prob(10)))
-						M.visible_message(span("danger", "The fire spreads from [src] to [M]!"),
-						span("danger", "The fire spreads to you as well!"))
-					else
-						if (src.ExtinguishMob(1))
-							M.visible_message(span("warning", "[M] successfully pats out [src]'s flames."),
-							span("warning", "You successfully pat out [src]'s flames."))
 		else
 			var/t_him = "it"
 			if (src.gender == MALE)

--- a/html/changelogs/extinguish_priority.yml
+++ b/html/changelogs/extinguish_priority.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Patting out flames on a target will now take priority over CPR, examining wounds, etc."
+  - bugfix: "Can now pat out flames on targets that are dead, have no heartbeat or no heart."


### PR DESCRIPTION
Fixes #9211

Currently CPR, checking wounds, etc. takes priority over putting out fire on a target. So you cannot pat out a fire until you've fixed their lungs or whatever. Also you cannot pat out fires on mobs that return false from `is_asystole()`.

This changes the priority so patting out fires happens before everything else.