### PR TITLE
Petting a pAI toggles the pAI's flashlight program properly

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -120,7 +120,7 @@
 	switch(M.a_intent)
 		if(I_HELP)
 			M.visible_message(span("notice","[M] [response_help] \the [src]"))
-			toggle_flashlight()
+			computer.toggle_service("flashlight", src)
 
 		if(I_DISARM)
 			M.visible_message(span("notice","[M] [response_disarm] \the [src]"))

--- a/html/changelogs/pet_the_pais.yml
+++ b/html/changelogs/pet_the_pais.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - bugfix: "Petting a pAI and toggling its flashlight now properly updates the pAIs flashlight program state."


### PR DESCRIPTION
Fixes #9191

Now instead of toggling the pAI's flashlight directly, it toggles the flashlight program which itself toggles the flashlight.