### PR TITLE
Teleporting Suit Cyclers Fix

### DIFF
--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -372,7 +372,8 @@
 		if(!suit)
 			return
 		suit.forceMove(get_turf(src))
-		usr.put_in_hands(suit)
+		if(Adjacent(usr))
+			usr.put_in_hands(suit)
 		suit = null
 		update_icon()
 
@@ -380,7 +381,8 @@
 		if(!helmet)
 			return
 		helmet.forceMove(get_turf(src))
-		usr.put_in_hands(helmet)
+		if(Adjacent(usr))
+			usr.put_in_hands(helmet)
 		helmet = null
 		update_icon()
 

--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -368,6 +368,10 @@
 	return
 
 /obj/machinery/suit_cycler/Topic(href, href_list)
+	if(!Adjacent(usr) && !issilicon(usr))
+		to_chat(usr, SPAN_WARNING("\The [src] is out of your reach."))
+		return
+
 	if(href_list["eject_suit"])
 		if(!suit)
 			return

--- a/html/changelogs/geeves-suit_cycler_exploit.yml
+++ b/html/changelogs/geeves-suit_cycler_exploit.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Suit Cyclers will now only put ejected contents in your hands if you're adjacent to it. No more bluespace cyclers."


### PR DESCRIPTION
* Suit Cyclers will now only put ejected contents in your hands if you're adjacent to it. No more bluespace cyclers.

Fixes https://github.com/Aurorastation/Aurora.3/issues/9309