### PR TITLE
Mech Weapon Safeties

### DIFF
--- a/code/modules/heavy_vehicle/equipment/_equipment.dm
+++ b/code/modules/heavy_vehicle/equipment/_equipment.dm
@@ -88,6 +88,10 @@
 		if(!icon_state)
 			icon = holding.icon
 			icon_state = holding.icon_state
+		if(istype(holding, /obj/item/gun))
+			var/obj/item/gun/G = holding
+			G.has_safety = FALSE
+			G.safety_state = FALSE
 		desc = "[holding.desc] This one is suitable for installation on an exosuit."
 
 /obj/item/mecha_equipment/mounted_system/Destroy()

--- a/html/changelogs/geeves-mech_safeties.yml
+++ b/html/changelogs/geeves-mech_safeties.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Mech Weaponry no longer have safeties, and can be used as normal."


### PR DESCRIPTION
* Mech Weaponry no longer have safeties, and can be used as normal.