### PR TITLE
Mech Damage

### DIFF
--- a/code/modules/heavy_vehicle/mech_damage.dm
+++ b/code/modules/heavy_vehicle/mech_damage.dm
@@ -45,10 +45,9 @@
 		var/list/components = list(body, arms, legs, head)
 		components = shuffle(components)
 		for(var/obj/item/mech_component/MC in components)
-			if(MC)
-				MC.take_burn_damage(amount)
-				MC.update_health()
-				break
+			MC.take_burn_damage(amount)
+			MC.update_health()
+			break
 
 /mob/living/heavy_vehicle/adjustBruteLoss(var/amount, var/obj/item/mech_component/C)
 	if(C)
@@ -58,10 +57,9 @@
 		var/list/components = list(body, arms, legs, head)
 		components = shuffle(components)
 		for(var/obj/item/mech_component/MC in components)
-			if(MC)
-				MC.take_burn_damage(amount)
-				MC.update_health()
-				break
+			MC.take_burn_damage(amount)
+			MC.update_health()
+			break
 
 /mob/living/heavy_vehicle/proc/zoneToComponent(var/zone)
 	switch(zone)

--- a/code/modules/heavy_vehicle/mech_damage.dm
+++ b/code/modules/heavy_vehicle/mech_damage.dm
@@ -118,7 +118,7 @@
 /mob/living/heavy_vehicle/fall_impact(levels_fallen, stopped_early = FALSE, var/damage_mod = 1)
 	// No gravity, stop falling into spess!
 	var/area/area = get_area(src)
-	if(istype(loc, /turf/space) || (area && !area.has_gravity()))
+	if(isspace(loc) || (area && !area.has_gravity()))
 		return FALSE
 
 	visible_message(SPAN_DANGER("\The [src] falls and lands on \the [loc]!"), "", SPAN_DANGER("You hear a thud!"))

--- a/code/modules/heavy_vehicle/mech_damage.dm
+++ b/code/modules/heavy_vehicle/mech_damage.dm
@@ -124,7 +124,7 @@
 	visible_message(SPAN_DANGER("\The [src] falls and lands on \the [loc]!"), "", SPAN_DANGER("You hear a thud!"))
 
 	var/z_velocity = 5 * (levels_fallen**2) // 1z - 5, 2z - 20, 3z - 45
-	var/damage = (z_velocity + rand(-10, 10)) * damage_mod
+	var/damage = max((z_velocity + rand(-10, 10)) * damage_mod, 0)
 
 	apply_damage(damage, BRUTE, BP_L_LEG) // can target any leg, it will be changed to the proper component
 

--- a/code/modules/heavy_vehicle/mech_damage.dm
+++ b/code/modules/heavy_vehicle/mech_damage.dm
@@ -37,17 +37,31 @@
 	maxHealth = body.mech_health
 	health = maxHealth-(getFireLoss()+getBruteLoss())
 
-/mob/living/heavy_vehicle/adjustFireLoss(var/amount)
-	var/obj/item/mech_component/MC = pick(list(arms, legs, body, head))
-	if(MC)
-		MC.take_burn_damage(amount)
-		MC.update_health()
+/mob/living/heavy_vehicle/adjustFireLoss(var/amount, var/obj/item/mech_component/C)
+	if(C)
+		C.take_brute_damage(amount)
+		C.update_health()
+	else
+		var/list/components = list(body, arms, legs, head)
+		components = shuffle(components)
+		for(var/obj/item/mech_component/MC in components)
+			if(MC)
+				MC.take_burn_damage(amount)
+				MC.update_health()
+				break
 
-/mob/living/heavy_vehicle/adjustBruteLoss(var/amount)
-	var/obj/item/mech_component/MC = pick(list(arms, legs, body, head))
-	if(MC)
-		MC.take_brute_damage(amount)
-		MC.update_health()
+/mob/living/heavy_vehicle/adjustBruteLoss(var/amount, var/obj/item/mech_component/C)
+	if(C)
+		C.take_brute_damage(amount)
+		C.update_health()
+	else
+		var/list/components = list(body, arms, legs, head)
+		components = shuffle(components)
+		for(var/obj/item/mech_component/MC in components)
+			if(MC)
+				MC.take_burn_damage(amount)
+				MC.update_health()
+				break
 
 /mob/living/heavy_vehicle/proc/zoneToComponent(var/zone)
 	switch(zone)
@@ -100,3 +114,20 @@
 			for(var/thing in pilots)
 				var/mob/pilot = thing
 				pilot.emp_act(severity)
+
+/mob/living/heavy_vehicle/fall_impact(levels_fallen, stopped_early = FALSE, var/damage_mod = 1)
+	// No gravity, stop falling into spess!
+	var/area/area = get_area(src)
+	if(istype(loc, /turf/space) || (area && !area.has_gravity()))
+		return FALSE
+
+	visible_message(SPAN_DANGER("\The [src] falls and lands on \the [loc]!"), "", SPAN_DANGER("You hear a thud!"))
+
+	var/z_velocity = 5 * (levels_fallen**2) // 1z - 5, 2z - 20, 3z - 45
+	var/damage = (z_velocity + rand(-10, 10)) * damage_mod
+
+	apply_damage(damage, BRUTE, BP_L_LEG) // can target any leg, it will be changed to the proper component
+
+	playsound(loc, "sound/effects/bang.ogg", 100, 1)
+	playsound(loc, "sound/effects/bamf.ogg", 100, 1)
+	return TRUE

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -646,19 +646,6 @@
 /mob/living/carbon/human/bst/fall_impact(var/damage_mod)
 	return FALSE
 
-/mob/living/heavy_vehicle/fall_impact(levels_fallen, stopped_early = FALSE, var/damage_mod = 1)
-	. = ..()
-	if (!.)
-		return
-
-	var/z_velocity = 5*(levels_fallen**2)
-	var/damage = ((60 + z_velocity) + rand(-20,20)) * damage_mod
-
-	apply_damage(damage)
-
-	playsound(loc, "sound/effects/bang.ogg", 100, 1)
-	playsound(loc, "sound/effects/bamf.ogg", 100, 1)
-
 /obj/vehicle/fall_impact(levels_fallen, stopped_early = FALSE, var/damage_mod = 1)
 	. = ..()
 	if (!.)

--- a/html/changelogs/geeves-mech_damage.yml
+++ b/html/changelogs/geeves-mech_damage.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Mechs now take MUCH less damage when dropping down z-levels, and the damage is now properly applied to only the legs."
+  - bugfix: "Fixed mech damage being applied randomly instead of to the targetted component."


### PR DESCRIPTION
* Mechs now take MUCH less damage when dropping down z-levels, and the damage is now properly applied to only the legs.
* Fixed mech damage being applied randomly instead of to the targetted component.