### PR TITLE
Soulstone Cooldown

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -3,19 +3,20 @@
 
 /obj/item/device/soulstone
 	name = "soul stone shard"
+	desc = "A fragment of the legendary treasure known simply as the 'Soul Stone'. The shard still flickers with a fraction of the full artefacts power."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "soulstone"
 	item_state = "electronic"
-	desc = "A fragment of the legendary treasure known simply as the 'Soul Stone'. The shard still flickers with a fraction of the full artefacts power."
 	w_class = 2
 	slot_flags = SLOT_BELT
 	origin_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 4)
-	var/imprinted = "empty"
 	appearance_flags = NO_CLIENT_COLOR
+	var/imprinted = "empty"
 
 //////////////////////////////Capturing////////////////////////////////////////////////////////
 
 /obj/item/device/soulstone/attack(mob/living/carbon/human/M as mob, mob/user as mob)
+	user.setClickCooldown(20)
 	if(!istype(M, /mob/living/carbon/human))//If target is not a human.
 		return ..()
 	if(istype(M, /mob/living/carbon/human/apparition))

--- a/html/changelogs/geeves-soulstone_cooldown.yml
+++ b/html/changelogs/geeves-soulstone_cooldown.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Soulstones now apply a 2 second click cooldown when used to suck up a soul, whether it was successful or not."


### PR DESCRIPTION
* Soulstones now apply a 2 second click cooldown when used to suck up a soul, whether it was successful or not.