### PR TITLE
Fixes drop airlock bolts button state for traitor borgs.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -726,6 +726,8 @@ About the new airlock wires panel:
 	VUEUI_SET_CHECK(data["elea"], electrified_at, ., data)
 	var/isAI = issilicon(user) && !player_is_antag(user.mind)
 	VUEUI_SET_CHECK(data["isai"], isAI, ., data)
+	var/isAdmin = check_rights(R_ADMIN)
+	VUEUI_SET_CHECK(data["isadmin"], isAdmin, ., data)
 
 	VUEUI_SET_CHECK(data["idscan"], !aiDisabledIdScanner, ., data)
 	VUEUI_SET_CHECK(data["bolts"], !locked, ., data)

--- a/html/changelogs/disabled_button_fix.yml
+++ b/html/changelogs/disabled_button_fix.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - bugfix: "A traitor AI/cyborg accessing an airlock UI will see the proper button state for dropping door bolts."

--- a/vueui/src/components/view/misc/doors.vue
+++ b/vueui/src/components/view/misc/doors.vue
@@ -43,7 +43,7 @@
       </vui-group-item>
       <vui-group-item v-for="(c, k) in commands" :key="k" :label="c.n + ':'">
         <vui-button style="min-width: 6em" :class="{on: s[k]}" :params="{ command: k, activate: c.i ? 1 : 0 }">{{ c.et || 'Enabled' }}</vui-button>
-        <vui-button :disabled="!!(c.a && s.isai)" style="min-width: 6em" :class="{on: !s[k] && !c.d, danger: !s[k] && c.d}" :params="{ command: k, activate: c.i ? 0 : 1 }">{{ c.dt || 'Disabled' }}</vui-button>
+        <vui-button :disabled="!!((c.a && s.isai) || isAdmin)" style="min-width: 6em" :class="{on: !s[k] && !c.d, danger: !s[k] && c.d}" :params="{ command: k, activate: c.i ? 0 : 1 }">{{ c.dt || 'Disabled' }}</vui-button>
       </vui-group-item>
     </vui-group>
   </div>

--- a/vueui/src/components/view/misc/doors.vue
+++ b/vueui/src/components/view/misc/doors.vue
@@ -43,7 +43,7 @@
       </vui-group-item>
       <vui-group-item v-for="(c, k) in commands" :key="k" :label="c.n + ':'">
         <vui-button style="min-width: 6em" :class="{on: s[k]}" :params="{ command: k, activate: c.i ? 1 : 0 }">{{ c.et || 'Enabled' }}</vui-button>
-        <vui-button :disabled="c.a && s.isai" style="min-width: 6em" :class="{on: !s[k] && !c.d, danger: !s[k] && c.d}" :params="{ command: k, activate: c.i ? 0 : 1 }">{{ c.dt || 'Disabled' }}</vui-button>
+        <vui-button :disabled="!!(c.a && s.isai)" style="min-width: 6em" :class="{on: !s[k] && !c.d, danger: !s[k] && c.d}" :params="{ command: k, activate: c.i ? 0 : 1 }">{{ c.dt || 'Disabled' }}</vui-button>
       </vui-group-item>
     </vui-group>
   </div>


### PR DESCRIPTION
Fixes #9325

Traitor borgs could toggle state through the UI, but the greyed out button made it appear they could not.

Button now properly changes to blue/green instead of grey, if your borg character is an antag.