### PR TITLE
Removes tobacco damage

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -598,9 +598,6 @@
 	var/nicotine = 0.2
 
 /datum/reagent/toxin/tobacco/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_CARDIOTOXIC, removed*strength*0.5)
-	M.add_chemical_effect(CE_PNEUMOTOXIC, removed*strength)
-	M.add_chemical_effect(CE_HEPATOTOXIC, removed*strength*0.25)
 	M.reagents.add_reagent(/datum/reagent/mental/nicotine, removed * nicotine)
 
 /datum/reagent/toxin/tobacco/rich

--- a/html/changelogs/remove_tobacco_damage.yml
+++ b/html/changelogs/remove_tobacco_damage.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - tweak: "Smoking or chewing tobacco products will no longer produce pain messages."


### PR DESCRIPTION
Fixes #9265

Chewing tobacco causes pain message spam due to the organ damage. This organ damage is on the order of 1e-5 per life tick, and is therefore completely negligible and instantly healed by the player due to the low strength of the tobacco reagent.

In my opinion this damage does not need to be simulated. The tobacco organ damage will never reach a meaningful number in the length of a round even when smoking/chewing tobacco constantly. People overdoing smoking will suffer the nicotine overdose effects.