### PR TITLE
Register move event when implanting GPS

### DIFF
--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -139,7 +139,7 @@
 	affected.implants += tool
 	if(istype(tool, /obj/item/device/gps))
 		var/obj/item/device/gps/gps = tool
-		moved_event.register(target, tool, /obj/item/device/gps/proc/update_position)
+		moved_event.register(target, gps, /obj/item/device/gps/proc/update_position)
 		gps.implanted_into = target
 	tool.forceMove(affected)
 	affected.cavity = 0

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -139,6 +139,7 @@
 	affected.implants += tool
 	if(istype(tool, /obj/item/device/gps))
 		moved_event.register(target, tool, /obj/item/device/gps/proc/update_position)
+		implanted_into = target
 	tool.forceMove(affected)
 	affected.cavity = 0
 
@@ -204,6 +205,7 @@
 
 			else if(istype(obj, /obj/item/device/gps))
 				moved_event.unregister(target, obj)
+				obj.implanted_into = null
 			playsound(target.loc, 'sound/effects/squelch1.ogg', 50, 1)
 		else
 			user.visible_message("<b>[user]</b> removes \the [tool] from [target]'s [affected.name].", \

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -202,6 +202,8 @@
 				worm.detach()
 				worm.leave_host()
 
+			else if(istype(obj, /obj/item/device/gps))
+				moved_event.unregister(target, obj)
 			playsound(target.loc, 'sound/effects/squelch1.ogg', 50, 1)
 		else
 			user.visible_message("<b>[user]</b> removes \the [tool] from [target]'s [affected.name].", \

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -138,8 +138,9 @@
 	user.drop_item()
 	affected.implants += tool
 	if(istype(tool, /obj/item/device/gps))
+		var/obj/item/device/gps/gps = tool
 		moved_event.register(target, tool, /obj/item/device/gps/proc/update_position)
-		implanted_into = target
+		gps.implanted_into = target
 	tool.forceMove(affected)
 	affected.cavity = 0
 
@@ -204,8 +205,9 @@
 				worm.leave_host()
 
 			else if(istype(obj, /obj/item/device/gps))
-				moved_event.unregister(target, obj)
-				obj.implanted_into = null
+				var/obj/item/device/gps/gps = obj
+				moved_event.unregister(target, gps)
+				gps.implanted_into = null
 			playsound(target.loc, 'sound/effects/squelch1.ogg', 50, 1)
 		else
 			user.visible_message("<b>[user]</b> removes \the [tool] from [target]'s [affected.name].", \

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -137,7 +137,8 @@
 		affected.owner.custom_pain("You feel something rip in your [affected.name]!", 1)
 	user.drop_item()
 	affected.implants += tool
-	tool.pickup(target)
+	if(istype(tool, /obj/item/device/gps))
+		moved_event.register(target, tool, /obj/item/device/gps/proc/update_position)
 	tool.forceMove(affected)
 	affected.cavity = 0
 

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -137,6 +137,7 @@
 		affected.owner.custom_pain("You feel something rip in your [affected.name]!", 1)
 	user.drop_item()
 	affected.implants += tool
+	tool.pickup(target)
 	tool.forceMove(affected)
 	affected.cavity = 0
 

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -12,6 +12,7 @@ var/list/GPS_list = list()
 	var/gpstag = "COM0"
 	var/emped = 0
 	var/held_by = null
+	var/implanted_into = null
 	var/turf/locked_location
 	var/list/tracking = list()
 	var/list/static/gps_count = list()
@@ -33,6 +34,9 @@ var/list/GPS_list = list()
 	if(held_by)
 		moved_event.unregister(held_by, src)
 		held_by = null
+	if(implanted_into)
+		move_event.unregister(implanted_into, src)
+		implanted_into = null
 	return ..()
 
 /obj/item/device/gps/pickup(var/mob/user)

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -35,7 +35,7 @@ var/list/GPS_list = list()
 		moved_event.unregister(held_by, src)
 		held_by = null
 	if(implanted_into)
-		move_event.unregister(implanted_into, src)
+		moved_event.unregister(implanted_into, src)
 		implanted_into = null
 	return ..()
 

--- a/html/changelogs/synystersparx-fix-gps.yml
+++ b/html/changelogs/synystersparx-fix-gps.yml
@@ -1,0 +1,4 @@
+author: SynysterSparx
+delete-after: True
+changes: 
+  - bugfix: "Have target pickup implanted items, which will allow GPS to continue working."

--- a/html/changelogs/synystersparx-fix-gps.yml
+++ b/html/changelogs/synystersparx-fix-gps.yml
@@ -1,4 +1,4 @@
 author: SynysterSparx
 delete-after: True
 changes: 
-  - bugfix: "Have target pickup implanted items, which will allow GPS to continue working."
+  - bugfix: "GPS Move Event registered to target when surgically implanted."


### PR DESCRIPTION
The intent here is to fix an issue where GPS would stop updating when implanted.

*GPS will register move event tied to target when surgically implanted. 
