### PR TITLE
Fixes falling off the station making you float in perpetuity

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -241,7 +241,11 @@
 			G.check_nuke_disks()
 
 		spawn(0)
-			if(loc) loc.Entered(src)
+			if(loc)
+				var/turf/T = loc
+				loc.Entered(src)
+				if(!T.is_hole)
+					fall_impact(text2num(pickweight(list("1" = 60, "2" = 30, "3" = 10))))
 
 //by default, transition randomly to another zlevel
 /atom/movable/proc/get_transit_zlevel()

--- a/html/changelogs/Ferner-200713-bugfix_spacefall.yml
+++ b/html/changelogs/Ferner-200713-bugfix_spacefall.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Falling off the station will no longer have you end up floating forever through space."

--- a/maps/aurora/code/aurora.dm
+++ b/maps/aurora/code/aurora.dm
@@ -16,7 +16,7 @@
 	contact_levels = list(3, 4, 5, 6, 7)
 	player_levels = list(2, 3, 4, 5, 6, 7, 8)
 	restricted_levels = list()
-	accessible_z_levels = list("7" = 15, "2" = 60)
+	accessible_z_levels = list("2" = 60, "6" = 20, "7" = 20)
 	base_turf_by_z = list(
 		"1" = /turf/space,
 		"2" = /turf/space,


### PR DESCRIPTION
With the removal of the roof z-level, z-level 7 was no longer part of the station, meaning, if you fell off the station you would never have any chance of getting back.

I've seen players float around 40+ minutes like this, eventually tiring and quitting.

This adds z-level 6 as a potential place you end up as you touch the map edge at the bottom.
To make falling off the station not concequence free, like it wasn't before, I added the fall_impact to anyone that ends up on a non-open turf, to simulate the fall they experienced before the removal of the roof level.
