### PR TITLE
Fixes ghost emote spam

### DIFF
--- a/code/datums/records.dm
+++ b/code/datums/records.dm
@@ -132,7 +132,7 @@
 /datum/record/general/New(var/mob/living/carbon/human/H, var/nid)
 	..()
 	if (!H)
-		var/mob/living/carbon/human/dummy = SSmob.get_mannequin("New record")
+		var/mob/living/carbon/human/dummy/mannequin/dummy = SSmob.get_mannequin("New record")
 		photo_front = getFlatIcon(dummy, SOUTH, always_use_defdir = TRUE)
 		photo_side = getFlatIcon(dummy, WEST, always_use_defdir = TRUE)
 	else

--- a/code/modules/mob/abstract/new_player/menu.dm
+++ b/code/modules/mob/abstract/new_player/menu.dm
@@ -239,7 +239,7 @@
 		observer.timeofdeath = world.time // Set the time of death so that the respawn timer works correctly.
 
 		announce_ghost_joinleave(src)
-		var/mob/living/carbon/human/dummy/mannequin = new
+		var/mob/living/carbon/human/dummy/mannequin/mannequin = new
 		client.prefs.dress_preview_mob(mannequin)
 		observer.appearance = mannequin
 		observer.alpha = 127


### PR DESCRIPTION
Mobs created to use for ghost appearance were dummies instead of mannequins, which made them process. Epic.