### PR TITLE
Better Bounties

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1275,6 +1275,8 @@
 #include "code\modules\cargo\bounties\assistant.dm"
 #include "code\modules\cargo\bounties\bot.dm"
 #include "code\modules\cargo\bounties\chef.dm"
+#include "code\modules\cargo\bounties\engineer.dm"
+#include "code\modules\cargo\bounties\hydroponics.dm"
 #include "code\modules\cargo\bounties\item.dm"
 #include "code\modules\cargo\bounties\reagent.dm"
 #include "code\modules\cargo\bounties\science.dm"

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -163,3 +163,13 @@
 	if(S && S.reagents.get_reagent_amount(/datum/reagent/spacecleaner) >= 200)
 		return TRUE
 	return FALSE
+
+//Can't wait to see people have fun with THIS one.
+/datum/bounty/item/assistant/photograph
+	name = "Photographs"
+	description = "The %DOCKNAME is holding a morale project, and part of that is to display photographs from the various stations. Send us some for a participation bonus!"
+	reward_low = 15
+	reward_high = 25
+	required_count = 8
+	random_count = 2
+	wanted_types = list(/obj/item/photo)

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -65,11 +65,12 @@
 	random_count = 1
 	wanted_types = list(/obj/structure/reagent_dispensers/watertank)
 
-/datum/bounty/item/assistant/water_tank/applies_to(obj/O)
+/datum/bounty/item/assistant/water_tank/applies_to(var/obj/structure/reagent_dispensers/watertank/O)
 	if(!..())
 		return FALSE
-	var/obj/structure/reagent_dispensers/watertank/W = O
-	if(W && W.reagents.get_reagent_amount(/datum/reagent/water) >= 750)
+	if(!istype(O))
+		return FALSE
+	if(O.reagents.get_reagent_amount(/datum/reagent/water) >= 750)
 		return TRUE
 	return FALSE
 
@@ -122,11 +123,12 @@
 	reward_high = 28
 	wanted_types = list(/obj/structure/sculpting_block)
 
-/datum/bounty/item/assistant/statue/applies_to(obj/O)
+/datum/bounty/item/assistant/statue/applies_to(var/obj/structure/sculpting_block/O)
 	if(!..())
 		return FALSE
-	var/obj/structure/sculpting_block/S = O
-	if(S?.sculpted)
+	if(!istype(O))
+		return FALSE
+	if(O.sculpted)
 		return TRUE
 	return FALSE
 
@@ -156,11 +158,12 @@
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/spray)
 
-/datum/bounty/item/assistant/cleaner/applies_to(obj/O)
+/datum/bounty/item/assistant/cleaner/applies_to(var/obj/item/reagent_containers/spray/O)
 	if(!..())
 		return FALSE
-	var/obj/item/reagent_containers/spray/S = O
-	if(S && S.reagents.get_reagent_amount(/datum/reagent/spacecleaner) >= 200)
+	if(!istype(O))
+		return FALSE
+	if(O.reagents.get_reagent_amount(/datum/reagent/spacecleaner) >= 200)
 		return TRUE
 	return FALSE
 

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -1,8 +1,8 @@
 /datum/bounty/item/assistant/briefcase
 	name = "Briefcase"
 	description = "%BOSSNAME will be holding a business convention this year. Ship a few briefcases in support."
-	reward_low = 20
-	reward_high = 30
+	reward_low = 2000
+	reward_high = 3000
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/item/storage/briefcase)
@@ -11,29 +11,29 @@
 /datum/bounty/item/assistant/lung
 	name = "Lungs"
 	description = "A recent explosion at %BOSSNAME has left multiple staff with punctured lungs. Ship spare lungs to be rewarded- and save some lives."
-	reward_low = 25
-	reward_high = 35
+	reward_low = 2500
+	reward_high = 3500
 	wanted_types = list(/obj/item/organ/internal/lungs)
 
 /datum/bounty/item/assistant/appendix
 	name = "Appendix"
 	description = "%PERSONNAME wants our chefs to prepare a strange meal using a very special delicacy: an appendix. If you ship one, they'll pay."
-	reward_low = 25
-	reward_high = 35
+	reward_low = 2500
+	reward_high = 3500
 	wanted_types = list(/obj/item/organ/internal/appendix)
 
 /datum/bounty/item/assistant/hand_tele
 	name = "Hand Tele"
 	description = "%BOSSNAME has come up with a genius idea: Why not teleport cargo rather than ship it? Send over a hand tele, receive payment, then wait 6-8 years while they deliberate."
-	reward_low = 30
-	reward_high = 40
+	reward_low = 3000
+	reward_high = 5500
 	wanted_types = list(/obj/item/hand_tele)
 
 /datum/bounty/item/assistant/monkey_cubes
 	name = "Monkey Cubes"
 	description = "Due to a recent genetics accident, %BOSSNAME is in serious need of monkeys. Your mission is to ship monkey cubes."
-	reward_low = 18
-	reward_high = 24
+	reward_low = 1800
+	reward_high = 2400
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/monkeycube)
@@ -41,8 +41,8 @@
 /datum/bounty/item/assistant/curtains
 	name = "Curtain"
 	description = "Send us some curtains to help redecorate our offices!"
-	reward_low = 22
-	reward_high = 32
+	reward_low = 2200
+	reward_high = 3200
 	required_count = 5
 	random_count = 2
 	wanted_types = list(/obj/structure/curtain)
@@ -50,8 +50,8 @@
 /datum/bounty/item/assistant/action_figures
 	name = "Action Figures"
 	description = "%PERSONNAME wants a few action figures for their collection, and is willing to pay any station who provides."
-	reward_low = 20
-	reward_high = 30
+	reward_low = 2000
+	reward_high = 3000
 	required_count = 5
 	random_count = 3
 	wanted_types = list(/obj/item/toy/figure)
@@ -59,8 +59,8 @@
 /datum/bounty/item/assistant/water_tank
 	name = "Water Tank"
 	description = "Send us some water tanks that will be used for botany research, and definitely not for creating a slip 'n slide in %PERSONNAME's office."
-	reward_low = 15
-	reward_high = 25
+	reward_low = 1500
+	reward_high = 2500
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/structure/reagent_dispensers/watertank)
@@ -77,16 +77,16 @@
 /datum/bounty/item/assistant/wheelchair
 	name = "Wheelchairs"
 	description = "The medical bay at the %DOCKSHORT has been busier than usual; we're requesting some spare wheelchairs for patient transport."
-	reward_low = 23
-	reward_high = 40
+	reward_low = 2300
+	reward_high = 4000
 	required_count = 2
 	wanted_types = list(/obj/structure/bed/chair/wheelchair)
 
 /datum/bounty/item/assistant/film
 	name = "Camera Film"
 	description = "We received a gift from a delegate on Adhomai- a group of some sort of small, fat xenofauna. Everyone thinks they're cute and we're low on film from all the pictures!"
-	reward_low = 12
-	reward_high = 18
+	reward_low = 1200
+	reward_high = 1800
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/device/camera_film)
@@ -94,8 +94,8 @@
 /datum/bounty/item/assistant/trash
 	name = "Trash"
 	description = "It's time for the %COMPNAME cleanup initiative! Clean stations will receive a bonus; pick up the litter from around your station and send it to us as proof!"
-	reward_low = 10
-	reward_high = 20
+	reward_low = 1000
+	reward_high = 2000
 	required_count = 15
 	random_count = 5
 	wanted_types = list(/obj/item/trash)
@@ -103,8 +103,8 @@
 /datum/bounty/item/assistant/monkey_hide
 	name = "Monkey Hide"
 	description = "One of the scientists at %BOSSSHORT is interested in testing products on monkey skin. Your mission is to acquire monkey's hide and ship it."
-	reward_low = 15
-	reward_high = 25
+	reward_low = 1500
+	reward_high = 2500
 	required_count = 5
 	random_count = 1
 	wanted_types = list(/obj/item/stack/material/animalhide/monkey)
@@ -112,15 +112,15 @@
 /datum/bounty/item/assistant/heart
 	name = "Heart"
 	description = "%PERSONNAME is in critical condition after suffering a heart attack. Doctors say they need a new heart, fast. Ship one, pronto! Organic or mechanical, just hurry up!"
-	reward_low = 25
-	reward_high = 40
+	reward_low = 2500
+	reward_high = 4000
 	wanted_types = list(/obj/item/organ/internal/heart)
 
 /datum/bounty/item/assistant/statue
 	name = "Statue"
 	description = "%BOSSNAME would like to commision an artsy statue for the lobby. Ship one out, when possible."
-	reward_low = 22
-	reward_high = 28
+	reward_low = 2200
+	reward_high = 2800
 	wanted_types = list(/obj/structure/sculpting_block)
 
 /datum/bounty/item/assistant/statue/applies_to(var/obj/structure/sculpting_block/O)
@@ -135,16 +135,16 @@
 /datum/bounty/item/assistant/tajcard
 	name = "Collectable Card"
 	description = "%PERSONNAME is offering a bonus to any station that can help them expand their collection of collectable tajaran cards."
-	reward_low = 18
-	reward_high = 24
+	reward_low = 1800
+	reward_high = 2400
 	required_count = 2
 	wanted_types = list(/obj/item/tajcard)
 
 /datum/bounty/item/assistant/jetpack
 	name = "Jetpacks"
 	description = "We're engaging in an EVA training initiative for new miners. Ship us a few jetpacks for a station bonus."
-	reward_low = 30
-	reward_high = 40
+	reward_low = 3000
+	reward_high = 4000
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/tank/jetpack)
@@ -152,8 +152,8 @@
 /datum/bounty/item/assistant/cleaner
 	name = "Space Cleaner"
 	description = "The janitorial division of the ERT is requesting some actual supplies, to insist they aren't a joke. They're putting up for a bounty, so humor them if you want."
-	reward_low = 10
-	reward_high = 15
+	reward_low = 1000
+	reward_high = 1500
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/spray)
@@ -171,8 +171,8 @@
 /datum/bounty/item/assistant/photograph
 	name = "Photographs"
 	description = "The %DOCKNAME is holding a morale project, and part of that is to display photographs from the various stations. Send us some for a participation bonus!"
-	reward_low = 15
-	reward_high = 25
+	reward_low = 1500
+	reward_high = 2500
 	required_count = 8
 	random_count = 2
 	wanted_types = list(/obj/item/photo)

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -1,49 +1,165 @@
-
 /datum/bounty/item/assistant/briefcase
 	name = "Briefcase"
 	description = "%BOSSNAME will be holding a business convention this year. Ship a few briefcases in support."
-	reward = 2500
-	required_count = 5
+	reward_low = 20
+	reward_high = 30
+	required_count = 4
+	random_count = 1
 	wanted_types = list(/obj/item/storage/briefcase)
+	exclude_types = list(/obj/item/storage/briefcase/inflatable, /obj/item/storage/briefcase/crimekit)
 
 /datum/bounty/item/assistant/lung
 	name = "Lungs"
-	description = "A recent explosion at %BOSSNAME has left multiple staff with punctured lungs. Ship spare lungs to be rewarded."
-	reward = 3000
-	required_count = 1
+	description = "A recent explosion at %BOSSNAME has left multiple staff with punctured lungs. Ship spare lungs to be rewarded- and save some lives."
+	reward_low = 25
+	reward_high = 35
 	wanted_types = list(/obj/item/organ/internal/lungs)
 
 /datum/bounty/item/assistant/appendix
 	name = "Appendix"
-	description = "Chef Gibb of %BOSSNAME wants to prepare a traditional Unathi meal using a very special delicacy: an appendix. If you ship one, he'll pay."
-	reward = 3000
+	description = "%PERSONNAME wants our chefs to prepare a strange meal using a very special delicacy: an appendix. If you ship one, they'll pay."
+	reward_low = 25
+	reward_high = 35
 	wanted_types = list(/obj/item/organ/internal/appendix)
-
-/datum/bounty/item/assistant/comfy_chair
-	name = "Comfy Chairs"
-	description = "Commander Pat is unhappy with his chair. He claims it hurts his back. Ship some alternatives out to humor him. "
-	reward = 1500
-	required_count = 5
-	wanted_types = list(/obj/structure/bed/chair/comfy)
 
 /datum/bounty/item/assistant/hand_tele
 	name = "Hand Tele"
 	description = "%BOSSNAME has come up with a genius idea: Why not teleport cargo rather than ship it? Send over a hand tele, receive payment, then wait 6-8 years while they deliberate."
-	reward = 2000
+	reward_low = 30
+	reward_high = 40
 	wanted_types = list(/obj/item/hand_tele)
-
-/datum/bounty/item/assistant/handcuffs
-	name = "Handcuffs"
-	description = "A large influx of escaped convicts have arrived at %BOSSNAME. Now is the perfect time to ship out spare handcuffs."
-	reward = 1000
-	required_count = 5
-	wanted_types = list(/obj/item/handcuffs)
 
 /datum/bounty/item/assistant/monkey_cubes
 	name = "Monkey Cubes"
 	description = "Due to a recent genetics accident, %BOSSNAME is in serious need of monkeys. Your mission is to ship monkey cubes."
-	reward = 2000
-	required_count = 3
+	reward_low = 18
+	reward_high = 24
+	required_count = 4
+	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/monkeycube)
 
+/datum/bounty/item/assistant/curtains
+	name = "Curtain"
+	description = "Send us some curtains to help redecorate our offices!"
+	reward_low = 22
+	reward_high = 32
+	required_count = 5
+	random_count = 2
+	wanted_types = list(/obj/structure/curtain)
 
+/datum/bounty/item/assistant/action_figures
+	name = "Action Figures"
+	description = "%PERSONNAME wants a few action figures for their collection, and is willing to pay any station who provides."
+	reward_low = 20
+	reward_high = 30
+	required_count = 5
+	random_count = 3
+	wanted_types = list(/obj/item/toy/figure)
+
+/datum/bounty/item/assistant/water_tank
+	name = "Water Tank"
+	description = "Send us some water tanks that will be used for botany research, and definitely not for creating a slip 'n slide in %PERSONNAME's office."
+	reward_low = 15
+	reward_high = 25
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/structure/reagent_dispensers/watertank)
+
+/datum/bounty/item/assistant/water_tank/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	var/obj/structure/reagent_dispensers/watertank/W = O
+	if(W && W.reagents.get_reagent_amount(/datum/reagent/water) >= 750)
+		return TRUE
+	return FALSE
+
+/datum/bounty/item/assistant/wheelchair
+	name = "Wheelchairs"
+	description = "The medical bay at the %DOCKSHORT has been busier than usual; we're requesting some spare wheelchairs for patient transport."
+	reward_low = 23
+	reward_high = 40
+	required_count = 2
+	wanted_types = list(/obj/structure/bed/chair/wheelchair)
+
+/datum/bounty/item/assistant/film
+	name = "Camera Film"
+	description = "We received a gift from a delegate on Adhomai- a group of some sort of small, fat xenofauna. Everyone thinks they're cute and we're low on film from all the pictures!"
+	reward_low = 12
+	reward_high = 18
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/item/device/camera_film)
+
+/datum/bounty/item/assistant/trash
+	name = "Trash"
+	description = "It's time for the %COMPNAME cleanup initiative! Clean stations will receive a bonus; pick up the litter from around your station and send it to us as proof!"
+	reward_low = 10
+	reward_high = 20
+	required_count = 15
+	random_count = 5
+	wanted_types = list(/obj/item/trash)
+
+/datum/bounty/item/assistant/monkey_hide
+	name = "Monkey Hide"
+	description = "One of the scientists at %BOSSSHORT is interested in testing products on monkey skin. Your mission is to acquire monkey's hide and ship it."
+	reward_low = 15
+	reward_high = 25
+	required_count = 5
+	random_count = 1
+	wanted_types = list(/obj/item/stack/material/animalhide/monkey)
+
+/datum/bounty/item/assistant/heart
+	name = "Heart"
+	description = "%PERSONNAME is in critical condition after suffering a heart attack. Doctors say they need a new heart, fast. Ship one, pronto! Organic or mechanical, just hurry up!"
+	reward_low = 25
+	reward_high = 40
+	wanted_types = list(/obj/item/organ/internal/heart)
+
+/datum/bounty/item/assistant/statue
+	name = "Statue"
+	description = "%BOSSNAME would like to commision an artsy statue for the lobby. Ship one out, when possible."
+	reward_low = 22
+	reward_high = 28
+	wanted_types = list(/obj/structure/sculpting_block)
+
+/datum/bounty/item/assistant/statue/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	var/obj/structure/sculpting_block/S = O
+	if(S?.sculpted)
+		return TRUE
+	return FALSE
+
+/datum/bounty/item/assistant/tajcard
+	name = "Collectable Card"
+	description = "%PERSONNAME is offering a bonus to any station that can help them expand their collection of collectable tajaran cards."
+	reward_low = 18
+	reward_high = 24
+	required_count = 2
+	wanted_types = list(/obj/item/tajcard)
+
+/datum/bounty/item/assistant/jetpack
+	name = "Jetpacks"
+	description = "We're engaging in an EVA training initiative for new miners. Ship us a few jetpacks for a station bonus."
+	reward_low = 30
+	reward_high = 40
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/item/tank/jetpack)
+
+/datum/bounty/item/assistant/cleaner
+	name = "Space Cleaner"
+	description = "The janitorial division of the ERT is requesting some actual supplies, to insist they aren't a joke. They're putting up for a bounty, so humor them if you want."
+	reward_low = 10
+	reward_high = 15
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/item/reagent_containers/spray)
+
+/datum/bounty/item/assistant/cleaner/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	var/obj/item/reagent_containers/spray/S = O
+	if(S && S.reagents.get_reagent_amount(/datum/reagent/spacecleaner) >= 200)
+		return TRUE
+	return FALSE

--- a/code/modules/cargo/bounties/bot.dm
+++ b/code/modules/cargo/bounties/bot.dm
@@ -24,7 +24,7 @@
 
 /datum/bounty/item/bot/farmbot
 	name = "Farmbot"
-	description = "After a k'ois incident multiple botanists are hospitalized. Provide a few farmbots to handle their duties while they recover."
+	description = "After a k'ois incident multiple botanists were hospitalized. Provide a few farmbots to handle their duties while they recover."
 	reward_low = 3700
 	reward_high = 4300
 	required_count = 3
@@ -47,4 +47,3 @@
 	reward_high = 6000
 	required_count = 2
 	wanted_types = list(/mob/living/bot/medbot)
-

--- a/code/modules/cargo/bounties/bot.dm
+++ b/code/modules/cargo/bounties/bot.dm
@@ -1,32 +1,32 @@
 /datum/bounty/item/bot/cleanbot
 	name = "Cleanbot"
 	description = "There has been a incident out our crusher which resulted in the tragic death of multiple cleanbots. Ship a few replacements."
-	reward_low = 27
-	reward_high = 37
+	reward_low = 2700
+	reward_high = 3700
 	required_count = 3
 	wanted_types = list(/mob/living/bot/cleanbot)
 
 /datum/bounty/item/bot/secbot
 	name = "Secbot"
 	description = "To revitalise the residential zones on the %DOCKSHORT, management has decided to increase the security presence. Ship us a few security bots."
-	reward_low = 40
-	reward_high = 45
+	reward_low = 4000
+	reward_high = 4500
 	required_count = 2
 	wanted_types = list(/mob/living/bot/secbot)
 
 /datum/bounty/item/bot/ed209
 	name = "ED 209"
 	description = "To increase the security presence at our checkpoints we need a couple of ED209s."
-	reward_low = 85
-	reward_high = 95
+	reward_low = 8500
+	reward_high = 9500
 	required_count = 2
 	wanted_types = list(/mob/living/bot/secbot/ed209)
 
 /datum/bounty/item/bot/farmbot
 	name = "Farmbot"
 	description = "After a k'ois incident multiple botanists are hospitalized. Provide a few farmbots to handle their duties while they recover."
-	reward_low = 37
-	reward_high = 43
+	reward_low = 3700
+	reward_high = 4300
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/mob/living/bot/farmbot)
@@ -34,8 +34,8 @@
 /datum/bounty/item/bot/floorbot
 	name = "Floorbot"
 	description = "We need a few floorbots to assist our engineers in expanding some offices."
-	reward_low = 40
-	reward_high = 45
+	reward_low = 4000
+	reward_high = 4500
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/mob/living/bot/floorbot)
@@ -43,8 +43,8 @@
 /datum/bounty/item/bot/medbot
 	name = "Medbot"
 	description = "We were unable to recruit a sufficient number of qualified medical professionals this month. Ship us a few medbots to fill the void."
-	reward_low = 55
-	reward_high = 60
+	reward_low = 5500
+	reward_high = 6000
 	required_count = 2
 	wanted_types = list(/mob/living/bot/medbot)
 

--- a/code/modules/cargo/bounties/bot.dm
+++ b/code/modules/cargo/bounties/bot.dm
@@ -1,45 +1,50 @@
-/datum/bounty/item/bot/mark_high_priority(scale_reward)
-	return ..(max(scale_reward * 0.7, 1.2))
-
 /datum/bounty/item/bot/cleanbot
 	name = "Cleanbot"
-	description = "There has been a incident out our crusher which resulted in the death of multiple janitors. Ship a replacement."
-	reward = 2000
+	description = "There has been a incident out our crusher which resulted in the tragic death of multiple cleanbots. Ship a few replacements."
+	reward_low = 27
+	reward_high = 37
 	required_count = 3
 	wanted_types = list(/mob/living/bot/cleanbot)
 
 /datum/bounty/item/bot/secbot
 	name = "Secbot"
-	description = "To revitalise the residential zones on the Odin management has decided to increase the security presence. Ship us a few security bots."
-	reward = 2500
+	description = "To revitalise the residential zones on the %DOCKSHORT, management has decided to increase the security presence. Ship us a few security bots."
+	reward_low = 40
+	reward_high = 45
 	required_count = 2
 	wanted_types = list(/mob/living/bot/secbot)
 
 /datum/bounty/item/bot/ed209
 	name = "ED 209"
 	description = "To increase the security presence at our checkpoints we need a couple of ED209s."
-	reward = 5000
+	reward_low = 85
+	reward_high = 95
 	required_count = 2
 	wanted_types = list(/mob/living/bot/secbot/ed209)
 
 /datum/bounty/item/bot/farmbot
 	name = "Farmbot"
-	description = "After a k'ois incident multiple botanists are hospitalized. Provide a farmbot to replace them."
-	reward = 2000
+	description = "After a k'ois incident multiple botanists are hospitalized. Provide a few farmbots to handle their duties while they recover."
+	reward_low = 37
+	reward_high = 43
 	required_count = 3
+	random_count = 1
 	wanted_types = list(/mob/living/bot/farmbot)
 
 /datum/bounty/item/bot/floorbot
 	name = "Floorbot"
-	description = "We need a few floorbots to assist our engineers in expanding a managers office."
-	reward = 5000
+	description = "We need a few floorbots to assist our engineers in expanding some offices."
+	reward_low = 40
+	reward_high = 45
 	required_count = 4
+	random_count = 1
 	wanted_types = list(/mob/living/bot/floorbot)
 	
 /datum/bounty/item/bot/medbot
 	name = "Medbot"
 	description = "We were unable to recruit a sufficient number of qualified medical professionals this month. Ship us a few medbots to fill the void."
-	reward = 4000
+	reward_low = 55
+	reward_high = 60
 	required_count = 2
 	wanted_types = list(/mob/living/bot/medbot)
 

--- a/code/modules/cargo/bounties/chef.dm
+++ b/code/modules/cargo/bounties/chef.dm
@@ -1,114 +1,265 @@
+/datum/bounty/item/chef/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	if(!istype(O, /obj/item/reagent_containers/food/snacks))
+		return FALSE
+	var/obj/item/reagent_containers/food/snacks/S = O
+	if(!S.bitecount) //They're not gonna take bitten food.
+		return TRUE
+	return FALSE
+
 /datum/bounty/item/chef/birthday_cake
 	name = "Birthday Cake"
-	description = "A birthday party is coming up! Ship a complete birthday cake to celebrate!"
-	reward = 4000
+	description = "A birthday party for %PERSONNAME is coming up! Ship a complete birthday cake to celebrate!"
+	reward_low = 30
+	reward_high = 40
 	wanted_types = list(
 		/obj/item/reagent_containers/food/snacks/variable/cake,
 		/obj/item/reagent_containers/food/snacks/sliceable/cake)
 
 /datum/bounty/item/chef/soup
 	name = "Soup"
-	description = "To quell the homeless uprising, %COMPNAME will be serving soup to all underpaid workers. Ship any type of soup."
-	reward = 3000
+	description = "%COMPNAME will be serving soup to the homeless for a PR initiative. Ship any type of soup. And make sure it's soup- not just hot water."
+	reward_low = 27
+	reward_high = 35
 	required_count = 3
+	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/soup)
+	exclude_types = list(/obj/item/reagent_containers/food/snacks/soup/wish)
 
 /datum/bounty/item/chef/popcorn
 	name = "Popcorn Bags"
-	description = "Upper management wants to host a movie night. Ship bags of popcorn for the occasion."
-	reward = 3000
-	required_count = 3
+	description = "%PERSONNAME wants to host a movie night. Ship bags of popcorn for the occasion."
+	reward_low = 23
+	reward_high = 30
+	required_count = 4
+	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/popcorn)
 
-/datum/bounty/item/chef/icecreamsandwich
-	name = "Ice Cream Sandwiches"
-	description = "The Air Conditioning System in the CCIA Offices has failed. Ship some icecream."
-	reward = 4000
-	required_count = 3
-	wanted_types = list(/obj/item/reagent_containers/food/snacks/icecreamsandwich)
+/datum/bounty/item/chef/icecream
+	name = "Ice Cream"
+	description = "The air conditioning system of some offices on %DOCKSHORT has failed. Ship some ice cream before we melt."
+	reward_low = 40
+	reward_high = 45
+	required_count = 4
+	random_count = 1
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/icecreamsandwich, /obj/item/reagent_containers/food/snacks/icecream)
+
+/datum/bounty/item/chef/icecream/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	if(istype(O, /obj/item/reagent_containers/food/snacks/icecreamsandwich))
+		return TRUE
+	var/obj/item/reagent_containers/food/snacks/icecream/I = O
+	if(I?.ice_creamed)
+		return TRUE
+	return FALSE
 
 /datum/bounty/item/chef/pie
 	name = "Pie"
 	description = "%BOSSSHORT management wants a pie! Ship one pie."
-	reward = 3000
-	wanted_types = list(/obj/item/reagent_containers/food/snacks/pie)
+	reward = 3142
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/pie,
+			/obj/item/reagent_containers/food/snacks/meatpie,
+			/obj/item/reagent_containers/food/snacks/tofupie,
+			/obj/item/reagent_containers/food/snacks/amanita_pie,
+			/obj/item/reagent_containers/food/snacks/plump_pie,
+			/obj/item/reagent_containers/food/snacks/xemeatpie,
+			/obj/item/reagent_containers/food/snacks/cherrypie)
 
 /datum/bounty/item/chef/salad
 	name = "Salad"
-	description = "%BOSSSHORT management is going on a health binge. Your order is to ship salad."
-	reward = 3000
+	description = "%BOSSSHORT management is going on a health binge. Ship some tasty salads to help keep them on track."
+	reward_low = 28
+	reward_high = 38
 	required_count = 3
+	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/salad)
 
-/datum/bounty/item/chef/carrotfries
-	name = "Carrot Fries"
-	description = "A health craze has started among management. A shipment of carrot fries is the order."
-	reward = 3500
+/datum/bounty/item/chef/fries
+	name = "Fries"
+	description = "Sometimes the whole office just gets a craving for a certain food. Today, it's fries. Ship some!"
+	reward_low = 28
+	reward_high = 38
 	required_count = 3
-	wanted_types = list(/obj/item/reagent_containers/food/snacks/carrotfries)
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/carrotfries, 
+				/obj/item/reagent_containers/food/snacks/fries,
+				/obj/item/reagent_containers/food/snacks/chilicheesefries, 
+				/obj/item/reagent_containers/food/snacks/cheesyfries)
 
 /datum/bounty/item/chef/superbite
 	name = "Super Bite Burger"
-	description = "Commander Tubbs thinks he can set a competitive eating world record. All he needs is a super bite burger shipped to him."
-	reward = 12000
+	description = "%PERSONNAME thinks they can set a competitive eating world record. All they need is a super bite burger shipped to them."
+	reward_low = 115
+	reward_high = 135
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/burger/superbite)
+
+/datum/bounty/item/chef/superbite/compatible_with(datum/other_bounty)
+	if(istype(other_bounty, /datum/bounty/item/chef/burger))
+		return FALSE
+	return ..()
 
 /datum/bounty/item/chef/poppypretzel
 	name = "Poppy Pretzel"
-	description = "%BOSSNAME needs a poppy pretzel for the drug-training of their security department."
-	reward = 3000
+	description = "%BOSSNAME needs a few poppy pretzels for the drug-training of their security department."
+	reward_low = 26
+	reward_high = 32
+	required_count = 3
+	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/poppypretzel)
 
 /datum/bounty/item/chef/cubancarp
 	name = "Cuban Carp"
-	description = "A Adhomai Representative is visiting %BOSSSHORT. Ship one cuban carp."
-	reward = 8000
+	description = "A diplomat is visiting %BOSSSHORT. Ship one cuban carp for the business luncheon."
+	reward_low = 82
+	reward_high = 92
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/cubancarp)
 
 /datum/bounty/item/chef/hotdog
 	name = "Hot Dog"
 	description = "%COMPNAME is conducting taste tests to determine the best hot dog recipe. Ship your station's version to participate."
-	reward = 8000
+	reward_low = 40
+	reward_high = 48
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/hotdog)
-
-/datum/bounty/item/chef/lemon
-	name = "Lemons"
-	description = "A commander needs fresh lemons. Ship him a few and he'll deposit the money into the station's account."
-	reward = 4000
-	required_count = 10
-	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown)
-
-/datum/bounty/item/chef/lemon/applies_to(obj/O)
-	if(!..())
-		return FALSE
-	var/obj/item/reagent_containers/food/snacks/grown/L = O
-	if(L && L.plantname == "lemon")
-		return TRUE
-	return FALSE	
 
 /datum/bounty/item/chef/eggplantparm
 	name = "Eggplant Parmigianas"
 	description = "A famous singer will be arriving at %BOSSSHORT, and their contract demands that they only be served Eggplant Parmigiana. Ship some, please!"
-	reward = 3500
+	reward_low = 40
+	reward_high = 48
 	required_count = 3
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/eggplantparm)
 
 /datum/bounty/item/chef/muffin
 	name = "Muffins"
-	description = "%BOSSSHORT needs muffins! Your order is to rectify this."
-	reward = 3000
-	required_count = 3
-	wanted_types = list(/obj/item/reagent_containers/food/snacks/muffin)
+	description = "%BOSSSHORT needs muffins for a morning meeting! Your station will get a bonus if you ship some."
+	reward_low = 35
+	reward_high = 42
+	required_count = 8
+	random_count = 3
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/muffin, 
+			/obj/item/reagent_containers/food/snacks/nt_muffin,
+			/obj/item/reagent_containers/food/snacks/berrymuffin)
 
 /datum/bounty/item/chef/chawanmush
 	name = "Chawanmushi"
-	description = "Someone from middle-management mentioned Chawanmushi. We never tried them so we need you to ship Chawanmushi immediately."
-	reward = 8000
+	description = "Someone from middle-management mentioned Chawanmushi. We never tried them so we need you to ship some immediately."
+	reward_low = 65
+	reward_high = 75
+	required_count = 2
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/chawanmushi)
 
 /datum/bounty/item/chef/kebab
 	name = "Kebabs"
-	description = "%BOSSSHORT is requesting a special order, please ship some kebabs."
-	reward = 3500
+	description = "%BOSSNAME is requesting a special order; please ship some kebabs."
+	reward_low = 35
+	reward_high = 42
 	required_count = 3
-	wanted_types = list(/obj/item/reagent_containers/food/snacks/variable/kebab)
+	random_count = 1
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/variable/kebab,
+			/obj/item/reagent_containers/food/snacks/monkeykabob,
+			/obj/item/reagent_containers/food/snacks/tofukabob,
+			/obj/item/reagent_containers/food/snacks/koiskebab3,
+			/obj/item/reagent_containers/food/snacks/donerkebab)
+
+/datum/bounty/item/chef/poppers
+	name = "Jalapeno Poppers"
+	description = "%PERSONNAME is trying to set a system record for most jalapeno poppers held in their mouth at once. Don't ask questions, just send them."
+	reward_low = 45
+	reward_high = 52
+	required_count = 8
+	random_count = 3
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/jalapeno_poppers)
+
+/datum/bounty/item/chef/burger
+	name = "Burger"
+	description = "%PERSONNAME is this month's food critic for a local newsletter and they're on a deadline. Give them some burgers to review."
+	reward_low = 12
+	reward_high = 20
+	required_count = 2
+	random_count = 1
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/burger)
+
+/datum/bounty/item/chef/burger/compatible_with(datum/other_bounty)
+	if(istype(other_bounty, /datum/bounty/item/chef/superbite))
+		return FALSE
+	return ..()
+
+/datum/bounty/item/chef/fortune
+	name = "Fortune Cookies"
+	description = "%PERSONNAME claims they can do divination based on fortune cookies. Send a batch so we can find out if it's true."
+	reward_low = 20
+	reward_high = 30
+	required_count = 7
+	random_count = 2
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/fortunecookie)
+
+/datum/bounty/item/chef/spaghetti
+	name = "Spaghetti"
+	description = "We're hosting a luncheon for some %COMPSHORT Academy computer programming students. We heard that they really enjoy spaghetti, so ship some!"
+	reward_low = 22
+	reward_high = 32
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/boiledspagetti,
+				/obj/item/reagent_containers/food/snacks/pastatomato,
+				/obj/item/reagent_containers/food/snacks/meatballspagetti)
+
+/datum/bounty/item/chef/dumplings
+	name = "Meat Buns or Momo"
+	description = "We're sick of eating vendor food; send us some meat buns or momo."
+	reward_low = 32
+	reward_high = 41
+	required_count = 4
+	random_count = 2
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/meatbun,
+			/obj/item/reagent_containers/food/snacks/chickenmomo,
+			/obj/item/reagent_containers/food/snacks/veggiemomo)
+
+/datum/bounty/item/chef/unathi
+	name = "Unathi Delicacies"
+	description = "We're holding a luncheon with some Hegemony representatives; send some traditional Unathi dishes!"
+	reward_low = 35
+	reward_high = 45
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/chilied_eggs, 
+			/obj/item/reagent_containers/food/snacks/hatchling_suprise, 
+			/obj/item/reagent_containers/food/snacks/red_sun_special, 
+			/obj/item/reagent_containers/food/snacks/riztizkzi_sea,
+			/obj/item/reagent_containers/food/snacks/sliceable/sushi_roll)
+
+/datum/bounty/item/chef/tajara
+	name = "Adhomai Delicacies"
+	description = "We're holding a luncheon with some representatives from Adhomai; send some traditional Tajaran dishes!"
+	reward_low = 35
+	reward_high = 45
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/stew/tajaran, 
+			/obj/item/reagent_containers/food/snacks/soup/earthenroot, 
+			/obj/item/reagent_containers/food/snacks/tajaran_bread, 
+			/obj/item/reagent_containers/food/snacks/spicy_clams,
+			/obj/item/reagent_containers/food/snacks/hardbread,
+			/obj/item/reagent_containers/food/snacks/tajcandy,
+			/obj/item/reagent_containers/food/snacks/lardwich)
+
+/datum/bounty/item/chef/curry
+	name = "Curry"
+	description = "I forgot that I was supposed to host lunch for an upcoming meeting. Ship me some curry and I'll make sure your station gets a bonus. - %PERSONNAME"
+	reward_low = 30
+	reward_high = 39
+	required_count = 4
+	random_count = 1
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/redcurry, 
+			/obj/item/reagent_containers/food/snacks/greencurry, 
+			/obj/item/reagent_containers/food/snacks/yellowcurry)
+
+/datum/bounty/item/chef/dip
+	name = "Dip"
+	description = "It's time for an office party, but %PERSONNAME forgot the dip! Send us some and we'll transfer part of their upcoming bonus to your station's account."
+	reward_low = 25
+	reward_high = 30
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/dip)

--- a/code/modules/cargo/bounties/chef.dm
+++ b/code/modules/cargo/bounties/chef.dm
@@ -11,8 +11,8 @@
 /datum/bounty/item/chef/birthday_cake
 	name = "Birthday Cake"
 	description = "A birthday party for %PERSONNAME is coming up! Ship a complete birthday cake to celebrate!"
-	reward_low = 30
-	reward_high = 40
+	reward_low = 3000
+	reward_high = 4000
 	wanted_types = list(
 		/obj/item/reagent_containers/food/snacks/variable/cake,
 		/obj/item/reagent_containers/food/snacks/sliceable/cake)
@@ -20,8 +20,8 @@
 /datum/bounty/item/chef/soup
 	name = "Soup"
 	description = "%COMPNAME will be serving soup to the homeless for a PR initiative. Ship any type of soup. And make sure it's soup- not just hot water."
-	reward_low = 27
-	reward_high = 35
+	reward_low = 2700
+	reward_high = 3500
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/soup)
@@ -30,8 +30,8 @@
 /datum/bounty/item/chef/popcorn
 	name = "Popcorn Bags"
 	description = "%PERSONNAME wants to host a movie night. Ship bags of popcorn for the occasion."
-	reward_low = 23
-	reward_high = 30
+	reward_low = 2300
+	reward_high = 3000
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/popcorn)
@@ -39,8 +39,8 @@
 /datum/bounty/item/chef/icecream
 	name = "Ice Cream"
 	description = "The air conditioning system of some offices on %DOCKSHORT has failed. Ship some ice cream before we melt."
-	reward_low = 40
-	reward_high = 45
+	reward_low = 4000
+	reward_high = 4500
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/icecreamsandwich, /obj/item/reagent_containers/food/snacks/icecream)
@@ -70,8 +70,8 @@
 /datum/bounty/item/chef/salad
 	name = "Salad"
 	description = "%BOSSSHORT management is going on a health binge. Ship some tasty salads to help keep them on track."
-	reward_low = 28
-	reward_high = 38
+	reward_low = 2800
+	reward_high = 3800
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/salad)
@@ -79,8 +79,8 @@
 /datum/bounty/item/chef/fries
 	name = "Fries"
 	description = "Sometimes the whole office just gets a craving for a certain food. Today, it's fries. Ship some!"
-	reward_low = 28
-	reward_high = 38
+	reward_low = 2800
+	reward_high = 3800
 	required_count = 3
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/carrotfries, 
 				/obj/item/reagent_containers/food/snacks/fries,
@@ -90,8 +90,8 @@
 /datum/bounty/item/chef/superbite
 	name = "Super Bite Burger"
 	description = "%PERSONNAME thinks they can set a competitive eating world record. All they need is a super bite burger shipped to them."
-	reward_low = 115
-	reward_high = 135
+	reward_low = 11500
+	reward_high = 13500
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/burger/superbite)
 
 /datum/bounty/item/chef/superbite/compatible_with(var/datum/other_bounty)
@@ -102,8 +102,8 @@
 /datum/bounty/item/chef/poppypretzel
 	name = "Poppy Pretzel"
 	description = "%BOSSNAME needs a few poppy pretzels for the drug-training of their security department."
-	reward_low = 26
-	reward_high = 32
+	reward_low = 2600
+	reward_high = 3200
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/poppypretzel)
@@ -111,30 +111,30 @@
 /datum/bounty/item/chef/cubancarp
 	name = "Cuban Carp"
 	description = "A diplomat is visiting %BOSSSHORT. Ship one cuban carp for the business luncheon."
-	reward_low = 82
-	reward_high = 92
+	reward_low = 8200
+	reward_high = 9200
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/cubancarp)
 
 /datum/bounty/item/chef/hotdog
 	name = "Hot Dog"
 	description = "%COMPNAME is conducting taste tests to determine the best hot dog recipe. Ship your station's version to participate."
-	reward_low = 40
-	reward_high = 48
+	reward_low = 4000
+	reward_high = 4800
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/hotdog)
 
 /datum/bounty/item/chef/eggplantparm
 	name = "Eggplant Parmigianas"
 	description = "A famous singer will be arriving at %BOSSSHORT, and their contract demands that they only be served Eggplant Parmigiana. Ship some, please!"
-	reward_low = 40
-	reward_high = 48
+	reward_low = 4000
+	reward_high = 4800
 	required_count = 3
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/eggplantparm)
 
 /datum/bounty/item/chef/muffin
 	name = "Muffins"
 	description = "%BOSSSHORT needs muffins for a morning meeting! Your station will get a bonus if you ship some."
-	reward_low = 35
-	reward_high = 42
+	reward_low = 3500
+	reward_high = 4200
 	required_count = 8
 	random_count = 3
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/muffin, 
@@ -144,16 +144,16 @@
 /datum/bounty/item/chef/chawanmush
 	name = "Chawanmushi"
 	description = "Someone from middle-management mentioned Chawanmushi. We never tried them so we need you to ship some immediately."
-	reward_low = 65
-	reward_high = 75
+	reward_low = 6500
+	reward_high = 7500
 	required_count = 2
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/chawanmushi)
 
 /datum/bounty/item/chef/kebab
 	name = "Kebabs"
 	description = "%BOSSNAME is requesting a special order; please ship some kebabs."
-	reward_low = 35
-	reward_high = 42
+	reward_low = 3500
+	reward_high = 4200
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/variable/kebab,
@@ -165,8 +165,8 @@
 /datum/bounty/item/chef/poppers
 	name = "Jalapeno Poppers"
 	description = "%PERSONNAME is trying to set a system record for most jalapeno poppers held in their mouth at once. Don't ask questions, just send them."
-	reward_low = 45
-	reward_high = 52
+	reward_low = 4500
+	reward_high = 5200
 	required_count = 8
 	random_count = 3
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/jalapeno_poppers)
@@ -174,8 +174,8 @@
 /datum/bounty/item/chef/burger
 	name = "Burger"
 	description = "%PERSONNAME is this month's food critic for a local newsletter and they're on a deadline. Give them some burgers to review."
-	reward_low = 12
-	reward_high = 20
+	reward_low = 1200
+	reward_high = 2000
 	required_count = 2
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/burger)
@@ -188,8 +188,8 @@
 /datum/bounty/item/chef/fortune
 	name = "Fortune Cookies"
 	description = "%PERSONNAME claims they can do divination based on fortune cookies. Send a batch so we can find out if it's true."
-	reward_low = 20
-	reward_high = 30
+	reward_low = 2000
+	reward_high = 3000
 	required_count = 7
 	random_count = 2
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/fortunecookie)
@@ -197,8 +197,8 @@
 /datum/bounty/item/chef/spaghetti
 	name = "Spaghetti"
 	description = "We're hosting a luncheon for some %COMPSHORT Academy computer programming students. We heard that they really enjoy spaghetti, so ship some!"
-	reward_low = 22
-	reward_high = 32
+	reward_low = 2200
+	reward_high = 3200
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/boiledspagetti,
@@ -208,8 +208,8 @@
 /datum/bounty/item/chef/dumplings
 	name = "Meat Buns or Momo"
 	description = "We're sick of eating vendor food; send us some meat buns or momo."
-	reward_low = 32
-	reward_high = 41
+	reward_low = 3200
+	reward_high = 4100
 	required_count = 4
 	random_count = 2
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/meatbun,
@@ -219,8 +219,8 @@
 /datum/bounty/item/chef/unathi
 	name = "Unathi Delicacies"
 	description = "We're holding a luncheon with some Hegemony representatives; send some traditional Unathi dishes!"
-	reward_low = 35
-	reward_high = 45
+	reward_low = 3500
+	reward_high = 5500
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/chilied_eggs, 
@@ -232,8 +232,8 @@
 /datum/bounty/item/chef/tajara
 	name = "Adhomai Delicacies"
 	description = "We're holding a luncheon with some representatives from Adhomai; send some traditional Tajaran dishes!"
-	reward_low = 35
-	reward_high = 45
+	reward_low = 3500
+	reward_high = 5500
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/stew/tajaran, 
@@ -247,8 +247,8 @@
 /datum/bounty/item/chef/curry
 	name = "Curry"
 	description = "I forgot that I was supposed to host lunch for an upcoming meeting. Ship me some curry and I'll make sure your station gets a bonus. - %PERSONNAME"
-	reward_low = 30
-	reward_high = 39
+	reward_low = 3000
+	reward_high = 3900
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/redcurry, 
@@ -258,8 +258,8 @@
 /datum/bounty/item/chef/dip
 	name = "Dip"
 	description = "It's time for an office party, but %PERSONNAME forgot the dip! Send us some and we'll transfer part of their upcoming bonus to your station's account."
-	reward_low = 25
-	reward_high = 30
+	reward_low = 2500
+	reward_high = 3000
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/dip)

--- a/code/modules/cargo/bounties/chef.dm
+++ b/code/modules/cargo/bounties/chef.dm
@@ -94,7 +94,7 @@
 	reward_high = 135
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/burger/superbite)
 
-/datum/bounty/item/chef/superbite/compatible_with(datum/other_bounty)
+/datum/bounty/item/chef/superbite/compatible_with(var/datum/other_bounty)
 	if(istype(other_bounty, /datum/bounty/item/chef/burger))
 		return FALSE
 	return ..()
@@ -180,7 +180,7 @@
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/burger)
 
-/datum/bounty/item/chef/burger/compatible_with(datum/other_bounty)
+/datum/bounty/item/chef/burger/compatible_with(var/datum/other_bounty)
 	if(istype(other_bounty, /datum/bounty/item/chef/superbite))
 		return FALSE
 	return ..()

--- a/code/modules/cargo/bounties/engineer.dm
+++ b/code/modules/cargo/bounties/engineer.dm
@@ -49,11 +49,12 @@
 	random_count = 2
 	wanted_types = list(/obj/structure/reagent_dispensers/fueltank)
 
-/datum/bounty/item/engineer/fuel_tank/applies_to(obj/O)
+/datum/bounty/item/engineer/fuel_tank/applies_to(var/obj/structure/reagent_dispensers/fueltank/O)
 	if(!..())
 		return FALSE
-	var/obj/structure/reagent_dispensers/fueltank/F = O
-	if(F && F.reagents.get_reagent_amount(/datum/reagent/fuel) >= 750)
+	if(!istype(O))
+		return FALSE
+	if(O.reagents.get_reagent_amount(/datum/reagent/fuel) >= 750)
 		return TRUE
 	return FALSE
 
@@ -65,15 +66,15 @@
 	wanted_types = list(/obj/item/tank)
 	var/moles_required = 20 // A full tank is 28 moles, but we give some leeway.
 
-/datum/bounty/item/engineer/phoron_tank/applies_to(obj/O)
+/datum/bounty/item/engineer/phoron_tank/applies_to(var/obj/item/tank/O)
 	if(!..())
 		return FALSE
-	var/obj/item/tank/T = O
-	if(T)
-		if(!T.air_contents.gas["phoron"])
-			return FALSE
-		return T.air_contents.gas["phoron"] >= moles_required
-	return FALSE
+	if(!istype(O))
+		return FALSE
+	if(!O.air_contents.gas["phoron"])
+		return FALSE
+	return O.air_contents.gas["phoron"] >= moles_required
+
 
 /datum/bounty/item/engineer/vending
 	name = "Vending Machines"
@@ -101,11 +102,12 @@
 	required_count = 3
 	wanted_types = list(/obj/machinery/portable_atmospherics/powered/pump)
 
-/datum/bounty/item/engineer/pap/applies_to(obj/O)
+/datum/bounty/item/engineer/pap/applies_to(var/obj/machinery/portable_atmospherics/powered/pump/O)
 	if(!..())
 		return FALSE
-	var/obj/machinery/portable_atmospherics/powered/pump/P = O
-	if(P?.holding.air_contents.return_pressure() >= 5000)
+	if(!istype(O))
+		return FALSE
+	if(O.holding.air_contents.return_pressure() >= 5000)
 		return TRUE
 	return FALSE
 

--- a/code/modules/cargo/bounties/engineer.dm
+++ b/code/modules/cargo/bounties/engineer.dm
@@ -1,8 +1,8 @@
 /datum/bounty/item/engineer/comfy_chair
 	name = "Comfy Chairs"
 	description = "%PERSONNAME is unhappy with their chair. They claim it hurts their back. Have engineers craft some alternatives and ship them out to humor them."
-	reward_low = 24
-	reward_high = 39
+	reward_low = 2400
+	reward_high = 3900
 	required_count = 4
 	random_count = 2
 	wanted_types = list(/obj/structure/bed/chair/comfy)
@@ -10,15 +10,15 @@
 /datum/bounty/item/engineer/smes_coil
 	name = "Superconductive magnetic coil"
 	description = "A xenobotanist from the NSS Upsilon sent us a gigantic lemon. We're turning it into a battery; send us an SMES coil so we can contain its power."
-	reward_low = 40
-	reward_high = 45
+	reward_low = 4000
+	reward_high = 4500
 	wanted_types = list(/obj/item/smes_coil)
 
 /datum/bounty/item/engineer/solar
 	name = "Solar Assemblies or Trackers"
 	description = "A meteor shower ruined some backup solar arrays on the %DOCKNAME; ship us some assemblies or tracker electronics so we can expedite repairs."
-	reward_low = 75
-	reward_high = 97
+	reward_low = 6500
+	reward_high = 8700
 	required_count = 6
 	random_count = 2
 	wanted_types = list(/obj/item/solar_assembly, /obj/item/tracker_electronics)
@@ -26,16 +26,16 @@
 /datum/bounty/item/engineer/eshield
 	name = "Emergency Shields"
 	description = "Another station is requesting emergency energy shields. Apparently there was a baby carp migration and they want to set up a safe play area for them. Treat this as urgent."
-	reward_low = 75
-	reward_high = 90
+	reward_low = 7500
+	reward_high = 9000
 	required_count = 2
 	wanted_types = list(/obj/machinery/shield)
 
 /datum/bounty/item/engineer/firesuit
 	name = "Firesuits"
 	description = "I'm about to drop my mixtape in our next meeting. Send some suits to protect management from this straight FIRE. - %PERSONNAME"
-	reward_low = 20
-	reward_high = 32
+	reward_low = 2000
+	reward_high = 3200
 	required_count = 2
 	random_count = 1
 	wanted_types = list(/obj/item/clothing/suit/fire)
@@ -43,8 +43,8 @@
 /datum/bounty/item/engineer/fuel_tank
 	name = "Fuel Tank"
 	description = "After some observations of the Aurora, we think it's best if you send us a few of those fuel tanks so nobody hurts themselves."
-	reward_low = 25
-	reward_high = 35
+	reward_low = 2500
+	reward_high = 3500
 	required_count = 4
 	random_count = 2
 	wanted_types = list(/obj/structure/reagent_dispensers/fueltank)
@@ -61,8 +61,8 @@
 /datum/bounty/item/engineer/phoron_tank
 	name = "Full Tank of Phoron"
 	description = "Another station has requested supplies to test a new engine. In particular, they request a full tank of phoron. Please don't send a whole canister; they'll get... ideas."
-	reward_low = 22
-	reward_high = 32
+	reward_low = 2200
+	reward_high = 3200
 	wanted_types = list(/obj/item/tank)
 	var/moles_required = 20 // A full tank is 28 moles, but we give some leeway.
 
@@ -79,8 +79,8 @@
 /datum/bounty/item/engineer/vending
 	name = "Vending Machines"
 	description = "We're researching the cause of the widespread brand intelligence virus. Send us some vending machines of any kind from your station so we can examine them. Just get permission, first."
-	reward_low = 35
-	reward_high = 50
+	reward_low = 3500
+	reward_high = 5000
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/machinery/vending)
@@ -88,8 +88,8 @@
 /datum/bounty/item/engineer/coffin
 	name = "Coffins"
 	description = "%PERSONNAME is holding a funeral service for some brave maintenance drones. Kind of weird, but they're a nice person and willing to put up for a bounty. Ship us some urns or wooden coffins to humor them."
-	reward_low = 25
-	reward_high = 30
+	reward_low = 2500
+	reward_high = 3000
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/structure/closet/coffin, /obj/item/material/urn)
@@ -97,8 +97,8 @@
 /datum/bounty/item/engineer/pap
 	name = "Portable Air Pumps"
 	description = "After a breach, some employees have been opening emergency shutters with no regard for their safety. Send us some pumps with at least 5,000kpa of air mix to get this taken care of quickly."
-	reward_low = 72
-	reward_high = 88
+	reward_low = 7200
+	reward_high = 8800
 	required_count = 3
 	wanted_types = list(/obj/machinery/portable_atmospherics/powered/pump)
 
@@ -114,8 +114,8 @@
 /datum/bounty/item/engineer/spaceac
 	name = "Space A/C"
 	description = "The A/C is out in our offices, and everyone's talking about ice cream. I'm authorizing a bounty for some actual A/C units, since that will actually solve the issue. - %PERSONNAME"
-	reward_low = 50
-	reward_high = 65
+	reward_low = 5000
+	reward_high = 6500
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/machinery/space_heater)
@@ -123,23 +123,23 @@
 /datum/bounty/item/engineer/pipe
 	name = "Atmospheric Pipe Dispenser"
 	description = "We need another pipe dispenser to help expedite an atmospherics project. The station will get a bonus if you send us a pipe dispenser."
-	reward_low = 50
-	reward_high = 57
+	reward_low = 5000
+	reward_high = 5700
 	wanted_types = list(/obj/machinery/pipedispenser)
 	exclude_types = list(/obj/machinery/pipedispenser/disposal)
 
 /datum/bounty/item/engineer/disposal
 	name = "Disposal Pipe Dispenser"
 	description = "The %DOCKSHORT is undergoing an overhaul of its mail delivery chutes. Lend us a dispenser to help expedite it for a bonus."
-	reward_low = 50
-	reward_high = 57
+	reward_low = 5000
+	reward_high = 5700
 	wanted_types = list(/obj/machinery/pipedispenser/disposal)
 
 	/datum/bounty/item/engineer/bookcase
 	name = "Bookcases"
 	description = "We're showing some love to one of the libraries on the %DOCKSHORT. A bonus will be paid to any station who has some skilled engineers build some for us."
-	reward_low = 60
-	reward_high = 70
+	reward_low = 6000
+	reward_high = 7000
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/structure/bookcase)
@@ -147,8 +147,8 @@
 /datum/bounty/item/engineer/generator
 	name = "Portable Generators"
 	description = "Another station reported some engine troubles, and needs a few portable generators to maintain critical operations. Ship any type of P.A.C.M.A.N. generators to receive a bonus."
-	reward_low = 50
-	reward_high = 62
+	reward_low = 5000
+	reward_high = 6200
 	required_count = 2
 	random_count = 1
 	wanted_types = list(/obj/machinery/power/port_gen/pacman)

--- a/code/modules/cargo/bounties/engineer.dm
+++ b/code/modules/cargo/bounties/engineer.dm
@@ -1,0 +1,143 @@
+/datum/bounty/item/engineer/comfy_chair
+	name = "Comfy Chairs"
+	description = "%PERSONNAME is unhappy with their chair. They claim it hurts their back. Have engineers craft some alternatives and ship them out to humor them."
+	reward_low = 24
+	reward_high = 39
+	required_count = 4
+	random_count = 2
+	wanted_types = list(/obj/structure/bed/chair/comfy)
+
+/datum/bounty/item/engineer/smes_coil
+	name = "Superconductive magnetic coil"
+	description = "A xenobotanist from the NSS Upsilon sent us a gigantic lemon. We're turning it into a battery; send us an SMES coil so we can contain its power."
+	reward_low = 40
+	reward_high = 45
+	wanted_types = list(/obj/item/smes_coil)
+
+/datum/bounty/item/engineer/solar
+	name = "Solar Assemblies or Trackers"
+	description = "A meteor shower ruined some backup solar arrays on the %DOCKNAME; ship us some assemblies or tracker electronics so we can expedite repairs."
+	reward_low = 75
+	reward_high = 97
+	required_count = 6
+	random_count = 2
+	wanted_types = list(/obj/item/solar_assembly, /obj/item/tracker_electronics)
+
+/datum/bounty/item/engineer/eshield
+	name = "Emergency Shields"
+	description = "Another station is requesting emergency energy shields. Apparently there was a baby carp migration and they want to set up a safe play area for them. Treat this as urgent."
+	reward_low = 75
+	reward_high = 90
+	required_count = 2
+	wanted_types = list(/obj/machinery/shield)
+
+/datum/bounty/item/engineer/firesuit
+	name = "Firesuits"
+	description = "I'm about to drop my mixtape in our next meeting. Send some suits to protect management from this straight FIRE. - %PERSONNAME"
+	reward_low = 20
+	reward_high = 32
+	required_count = 2
+	random_count = 1
+	wanted_types = list(/obj/item/clothing/suit/fire)
+
+/datum/bounty/item/engineer/fuel_tank
+	name = "Fuel Tank"
+	description = "After some observations of the Aurora, we think it's best if you send us a few of those fuel tanks so nobody hurts themselves."
+	reward_low = 25
+	reward_high = 35
+	required_count = 4
+	random_count = 2
+	wanted_types = list(/obj/structure/reagent_dispensers/fueltank)
+
+/datum/bounty/item/engineer/fuel_tank/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	var/obj/structure/reagent_dispensers/fueltank/F = O
+	if(F && F.reagents.get_reagent_amount(/datum/reagent/fuel) >= 750)
+		return TRUE
+	return FALSE
+
+/datum/bounty/item/engineer/phoron_tank/
+	name = "Full Tank of Phoron"
+	description = "Another station has requested supplies to test a new engine. In particular, they request a full tank of phoron. Please don't send a whole canister; they'll get... ideas."
+	reward_low = 22
+	reward_high = 32
+	wanted_types = list(/obj/item/tank)
+	var/moles_required = 20 // A full tank is 28 moles, but we give some leeway.
+
+/datum/bounty/item/engineer/phoron_tank/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	var/obj/item/tank/T = O
+	if(T)
+		if(!T.air_contents.gas["phoron"])
+			return FALSE
+		return T.air_contents.gas["phoron"] >= moles_required
+	return FALSE
+
+/datum/bounty/item/engineer/vending
+	name = "Vending Machines"
+	description = "We're researching the cause of the widespread brand intelligence virus. Send us some vending machines of any kind from your station so we can examine them. Just get permission, first."
+	reward_low = 35
+	reward_high = 50
+	required_count = 4
+	random_count = 1
+	wanted_types = list(/obj/machinery/vending)
+
+/datum/bounty/item/engineer/coffin
+	name = "Coffins"
+	description = "%PERSONNAME is holding a funeral service for some brave maintenance drones. Kind of weird, but they're a nice person and willing to put up for a bounty. Ship us some urns or wooden coffins to humor them."
+	reward_low = 25
+	reward_high = 30
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/structure/closet/coffin, /obj/item/material/urn)
+
+/datum/bounty/item/engineer/pap
+	name = "Portable Air Pumps"
+	description = "After a breach, some employees have been opening emergency shutters with no regard for their safety. Send us some pumps with at least 5,000kpa of air mix to get this taken care of quickly."
+	reward_low = 72
+	reward_high = 88
+	required_count = 3
+	wanted_types = list(/obj/machinery/portable_atmospherics/powered/pump)
+
+/datum/bounty/item/engineer/pap/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	var/obj/machinery/portable_atmospherics/powered/pump/P = O
+	if(P?.holding.air_contents.return_pressure() >= 5000)
+		return TRUE
+	return FALSE
+
+/datum/bounty/item/engineer/spaceac
+	name = "Space A/C"
+	description = "The A/C is out in our offices, and everyone's talking about ice cream. I'm authorizing a bounty for some actual A/C units, since that will actually solve the issue. - %PERSONNAME"
+	reward_low = 50
+	reward_high = 65
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/machinery/space_heater)
+
+/datum/bounty/item/engineer/pipe
+	name = "Atmospheric Pipe Dispenser"
+	description = "We need another pipe dispenser to help expedite an atmospherics project. The station will get a bonus if you send us a pipe dispenser."
+	reward_low = 50
+	reward_high = 57
+	wanted_types = list(/obj/machinery/pipedispenser)
+	exclude_types = list(/obj/machinery/pipedispenser/disposal)
+
+/datum/bounty/item/engineer/disposal
+	name = "Disposal Pipe Dispenser"
+	description = "The %DOCKSHORT is undergoing an overhaul of its mail delivery chutes. Lend us a dispenser to help expedite it for a bonus."
+	reward_low = 50
+	reward_high = 57
+	wanted_types = list(/obj/machinery/pipedispenser/disposal)
+
+	/datum/bounty/item/engineer/bookcase
+	name = "Bookcases"
+	description = "We're showing some love to one of the libraries on the %DOCKSHORT. A bonus will be paid to any station who has some skilled engineers build some for us."
+	reward_low = 65
+	reward_high = 75
+	required_count = 4
+	random_count = 1
+	wanted_types = list(/obj/structure/bookcase)

--- a/code/modules/cargo/bounties/engineer.dm
+++ b/code/modules/cargo/bounties/engineer.dm
@@ -57,7 +57,7 @@
 		return TRUE
 	return FALSE
 
-/datum/bounty/item/engineer/phoron_tank/
+/datum/bounty/item/engineer/phoron_tank
 	name = "Full Tank of Phoron"
 	description = "Another station has requested supplies to test a new engine. In particular, they request a full tank of phoron. Please don't send a whole canister; they'll get... ideas."
 	reward_low = 22
@@ -136,8 +136,17 @@
 	/datum/bounty/item/engineer/bookcase
 	name = "Bookcases"
 	description = "We're showing some love to one of the libraries on the %DOCKSHORT. A bonus will be paid to any station who has some skilled engineers build some for us."
-	reward_low = 65
-	reward_high = 75
+	reward_low = 60
+	reward_high = 70
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/structure/bookcase)
+
+/datum/bounty/item/engineer/generator
+	name = "Portable Generators"
+	description = "Another station reported some engine troubles, and needs a few portable generators to maintain critical operations. Ship any type of P.A.C.M.A.N. generators to receive a bonus."
+	reward_low = 50
+	reward_high = 62
+	required_count = 2
+	random_count = 1
+	wanted_types = list(/obj/machinery/power/port_gen/pacman)

--- a/code/modules/cargo/bounties/hydroponics.dm
+++ b/code/modules/cargo/bounties/hydroponics.dm
@@ -10,12 +10,12 @@
 
 /datum/bounty/item/hydroponicist/ert
 	name = "Rations"
-	description = "%BOSSSHORT is sending ERT out on a long mission. We need something for them to eat!"
+	description = "%BOSSSHORT is sending ERT out on a long mission. We need some long-lasting rations for them to eat!"
 	reward_low = 22
 	reward_high = 28
 	required_count = 6
 	random_count = 2
-	wanted_types = list(/obj/item/reagent_containers/food/snacks/liquidfood, /obj/item/pen/crayon, /obj/item/storage/field_ration)
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/liquidfood, /obj/item/pen/crayon)
 
 /datum/bounty/item/hydroponicist/towels
 	name = "Towels"
@@ -56,50 +56,54 @@
 				/obj/item/reagent_containers/food/snacks/monkeycube/wrapped/neaeracube,
 				/obj/item/reagent_containers/food/snacks/monkeycube/wrapped/vkrexicube)
 
-/datum/bounty/item/hydroponicist/random_produce
-	name = "Produce"
-	description = "%BOSSNAME is in need of a bundle of fresh produce for an upcoming luncheon. Send your best!"
+/datum/bounty/item/hydroponicist/produce
+	name = "Produce - Any"
+	description = "%BOSSNAME is in need of a bundle of fresh produce. Send your best!"
 	reward_low = 30
-	reward_high = 37
-	required_count = 12 
+	reward_high = 35
+	required_count = 18
 	random_count = 5
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown)
-	var/datum/seed/wanted_produce 
+	var/list/produce_picks = list(/datum/seed)
 
-/datum/bounty/item/hydroponicist/random_produce/New()
-	..()
-	var/list/produce_picks = list()
-	var/list/forbidden = list(/datum/seed/berry/poison, 
-				/datum/seed/nettle, 
-				/datum/seed/tomato, 
-				/datum/seed/realeggplant, 
-				/datum/seed/tomato, 
-				/datum/seed/koisspore,
-				/datum/seed/koisspore/black,
-				/datum/seed/mushroom/mold,
-				/datum/seed/mushroom/poison,
-				/datum/seed/mushroom/ghost,
-				/datum/seed/weeds,
-				/datum/seed/kudzu,
-				/datum/seed/diona,
-				/datum/seed/tobacco,
-				/datum/seed/flower)
-	for(var/datum/seed/S in subtypesof(/datum/seed))
-		if(locate(S) in forbidden)
-			continue
-		produce_picks += S
-	var/chosen = pick(produce_picks)
-	wanted_produce = new chosen
-	name = wanted_produce.seed_name
-
-/datum/bounty/item/hydroponicist/random_produce/applies_to(obj/O)
+/datum/bounty/item/hydroponicist/produce/applies_to(obj/O)
 	if(!istype(O, /obj/item/reagent_containers/food/snacks/grown))
 		return FALSE
 	var/obj/item/reagent_containers/food/snacks/grown/G = O
-	if(G.bitecount > 0)
+	if(G.bitecount > 0) //still not accepting partially-eaten food
 		return FALSE
-	if(G.seed == wanted_produce)
+	if(is_type_in_list(G.seed, produce_picks)) //check if it's a type we want.
 		return TRUE
-	else
-		world << "Unequal wants. produce seed is [G.seed] and wanted_produce is [wanted_produce]"
 	return FALSE
+
+/datum/bounty/item/hydroponicist/produce/fruit
+	name = "Produce - Fruit"
+	description = "%BOSSNAME is in need of a bundle of fresh fruit. Send your best!"
+	required_count = 12
+	random_count = 3
+	produce_picks = list(/datum/seed/tomato, 
+				/datum/seed/berry, 
+				/datum/seed/apple, 
+				/datum/seed/grapes,
+				/datum/seed/banana,
+				/datum/seed/watermelon,
+				/datum/seed/citrus,
+				/datum/seed/cherries,
+				/datum/seed/nifberries,
+				/datum/seed/dyn,
+				/datum/seed/wulumunusha,
+				/datum/seed/sugartree)
+
+/datum/bounty/item/hydroponicist/produce/mushroom
+	name = "Produce - Mushrooms"
+	description = "%BOSSNAME is in need of some fresh mushrooms. Send your best!"
+	required_count = 15
+	random_count = 3
+	produce_picks = list(/datum/seed/mushroom)
+
+/datum/bounty/item/hydroponicist/produce/tobacco
+	name = "Produce - Tobacco"
+	description = "%BOSSNAME is in need of some fresh tobacco leaves. Send your best!"
+	required_count = 10
+	random_count = 2
+	produce_picks = list(/datum/seed/tobacco)

--- a/code/modules/cargo/bounties/hydroponics.dm
+++ b/code/modules/cargo/bounties/hydroponics.dm
@@ -2,8 +2,8 @@
 /datum/bounty/item/hydroponicist/potato_cells
 	name = "Potato Batteries"
 	description = "%BOSSNAME is researching an environmentally-friendly power source on another station. Send us some potato batteries."
-	reward_low = 20
-	reward_high = 30
+	reward_low = 2000
+	reward_high = 3000
 	required_count = 6
 	random_count = 3
 	wanted_types = list(/obj/item/cell/potato)
@@ -11,8 +11,8 @@
 /datum/bounty/item/hydroponicist/ert
 	name = "Rations"
 	description = "%BOSSSHORT is sending ERT out on a long mission. We need some long-lasting rations for them to eat!"
-	reward_low = 22
-	reward_high = 28
+	reward_low = 2200
+	reward_high = 2800
 	required_count = 6
 	random_count = 2
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/liquidfood, /obj/item/pen/crayon)
@@ -20,8 +20,8 @@
 /datum/bounty/item/hydroponicist/towels
 	name = "Towels"
 	description = "%BOSSSHORT is having the sickest pool party ever. Send us some towels for a reward, and maybe an invitation!"
-	reward_low = 30
-	reward_high = 35
+	reward_low = 3000
+	reward_high = 3500
 	required_count = 8
 	random_count = 3
 	wanted_types = list(/obj/item/towel, /obj/item/towel_flat)
@@ -29,8 +29,8 @@
 /datum/bounty/item/hydroponicist/gloves
 	name = "Botanical Gloves"
 	description = "%BOSSNAME is participating in a massive tree-planting initiative on Biesel. Help us help the company's image by sending our volunteers some gardening gloves!"
-	reward_low = 22
-	reward_high = 30
+	reward_low = 2200
+	reward_high = 3000
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/item/clothing/gloves/botanic_leather)
@@ -38,8 +38,8 @@
 /datum/bounty/item/hydroponicist/flower_crown
 	name = "Flower Crowns"
 	description = "It's time for the monthly %COMPNAME company dance. This month's theme is floral in nature, so send us some flower crowns to give to attendees."
-	reward_low = 36
-	reward_high = 44
+	reward_low = 3600
+	reward_high = 4400
 	required_count = 6
 	random_count = 2
 	wanted_types = list(/obj/item/clothing/head/sunflower_crown, /obj/item/clothing/head/lavender_crown, /obj/item/clothing/head/poppy_crown)
@@ -47,8 +47,8 @@
 /datum/bounty/item/assistant/animal_cubes
 	name = "Xeno Cubes"
 	description = "Monkeys are very limiting for xenostudies research. Please ship some alternative cubes (wrapped) to alleviate a shortage experienced by our other labs."
-	reward_low = 20
-	reward_high = 26
+	reward_low = 2000
+	reward_high = 2600
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped/farwacube,
@@ -59,8 +59,8 @@
 /datum/bounty/item/hydroponicist/produce
 	name = "Produce - Any"
 	description = "%BOSSNAME is in need of a bundle of fresh produce. Send your best!"
-	reward_low = 30
-	reward_high = 35
+	reward_low = 3000
+	reward_high = 3500
 	required_count = 18
 	random_count = 5
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown)

--- a/code/modules/cargo/bounties/hydroponics.dm
+++ b/code/modules/cargo/bounties/hydroponics.dm
@@ -1,0 +1,105 @@
+//Hydro bounties. Things that can be biogenerated and stuff
+/datum/bounty/item/hydroponicist/potato_cells
+	name = "Potato Batteries"
+	description = "%BOSSNAME is researching an environmentally-friendly power source on another station. Send us some potato batteries."
+	reward_low = 20
+	reward_high = 30
+	required_count = 6
+	random_count = 3
+	wanted_types = list(/obj/item/cell/potato)
+
+/datum/bounty/item/hydroponicist/ert
+	name = "Rations"
+	description = "%BOSSSHORT is sending ERT out on a long mission. We need something for them to eat!"
+	reward_low = 22
+	reward_high = 28
+	required_count = 6
+	random_count = 2
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/liquidfood, /obj/item/pen/crayon, /obj/item/storage/field_ration)
+
+/datum/bounty/item/hydroponicist/towels
+	name = "Towels"
+	description = "%BOSSSHORT is having the sickest pool party ever. Send us some towels for a reward, and maybe an invitation!"
+	reward_low = 30
+	reward_high = 35
+	required_count = 8
+	random_count = 3
+	wanted_types = list(/obj/item/towel, /obj/item/towel_flat)
+
+/datum/bounty/item/hydroponicist/gloves
+	name = "Botanical Gloves"
+	description = "%BOSSNAME is participating in a massive tree-planting initiative on Biesel. Help us help the company's image by sending our volunteers some gardening gloves!"
+	reward_low = 22
+	reward_high = 30
+	required_count = 4
+	random_count = 1
+	wanted_types = list(/obj/item/clothing/gloves/botanic_leather)
+
+/datum/bounty/item/hydroponicist/flower_crown
+	name = "Flower Crowns"
+	description = "It's time for the monthly %COMPNAME company dance. This month's theme is floral in nature, so send us some flower crowns to give to attendees."
+	reward_low = 36
+	reward_high = 44
+	required_count = 6
+	random_count = 2
+	wanted_types = list(/obj/item/clothing/head/sunflower_crown, /obj/item/clothing/head/lavender_crown, /obj/item/clothing/head/poppy_crown)
+
+/datum/bounty/item/assistant/animal_cubes
+	name = "Xeno Cubes"
+	description = "Monkeys are very limiting for xenostudies research. Please ship some alternative cubes (wrapped) to alleviate a shortage experienced by our other labs."
+	reward_low = 20
+	reward_high = 26
+	required_count = 4
+	random_count = 1
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped/farwacube,
+				/obj/item/reagent_containers/food/snacks/monkeycube/wrapped/stokcube,
+				/obj/item/reagent_containers/food/snacks/monkeycube/wrapped/neaeracube,
+				/obj/item/reagent_containers/food/snacks/monkeycube/wrapped/vkrexicube)
+
+/datum/bounty/item/hydroponicist/random_produce
+	name = "Produce"
+	description = "%BOSSNAME is in need of a bundle of fresh produce for an upcoming luncheon. Send your best!"
+	reward_low = 30
+	reward_high = 37
+	required_count = 12 
+	random_count = 5
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown)
+	var/datum/seed/wanted_produce 
+
+/datum/bounty/item/hydroponicist/random_produce/New()
+	..()
+	var/list/produce_picks = list()
+	var/list/forbidden = list(/datum/seed/berry/poison, 
+				/datum/seed/nettle, 
+				/datum/seed/tomato, 
+				/datum/seed/realeggplant, 
+				/datum/seed/tomato, 
+				/datum/seed/koisspore,
+				/datum/seed/koisspore/black,
+				/datum/seed/mushroom/mold,
+				/datum/seed/mushroom/poison,
+				/datum/seed/mushroom/ghost,
+				/datum/seed/weeds,
+				/datum/seed/kudzu,
+				/datum/seed/diona,
+				/datum/seed/tobacco,
+				/datum/seed/flower)
+	for(var/datum/seed/S in subtypesof(/datum/seed))
+		if(locate(S) in forbidden)
+			continue
+		produce_picks += S
+	var/chosen = pick(produce_picks)
+	wanted_produce = new chosen
+	name = wanted_produce.seed_name
+
+/datum/bounty/item/hydroponicist/random_produce/applies_to(obj/O)
+	if(!istype(O, /obj/item/reagent_containers/food/snacks/grown))
+		return FALSE
+	var/obj/item/reagent_containers/food/snacks/grown/G = O
+	if(G.bitecount > 0)
+		return FALSE
+	if(G.seed == wanted_produce)
+		return TRUE
+	else
+		world << "Unequal wants. produce seed is [G.seed] and wanted_produce is [wanted_produce]"
+	return FALSE

--- a/code/modules/cargo/bounties/hydroponics.dm
+++ b/code/modules/cargo/bounties/hydroponics.dm
@@ -66,13 +66,12 @@
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown)
 	var/list/produce_picks = list(/datum/seed)
 
-/datum/bounty/item/hydroponicist/produce/applies_to(obj/O)
-	if(!istype(O, /obj/item/reagent_containers/food/snacks/grown))
+/datum/bounty/item/hydroponicist/produce/applies_to(var/obj/item/reagent_containers/food/snacks/grown/O)
+	if(!istype(O))
 		return FALSE
-	var/obj/item/reagent_containers/food/snacks/grown/G = O
-	if(G.bitecount > 0) //still not accepting partially-eaten food
+	if(O.bitecount > 0) //still not accepting partially-eaten food
 		return FALSE
-	if(is_type_in_list(G.seed, produce_picks)) //check if it's a type we want.
+	if(is_type_in_list(O.seed, produce_picks)) //check if it's a type we want.
 		return TRUE
 	return FALSE
 

--- a/code/modules/cargo/bounties/item.dm
+++ b/code/modules/cargo/bounties/item.dm
@@ -35,6 +35,6 @@
 		return
 	shipped_count += 1
 
-/datum/bounty/item/compatible_with(datum/other_bounty)
+/datum/bounty/item/compatible_with(var/datum/other_bounty)
 	return type != other_bounty.type
 

--- a/code/modules/cargo/bounties/item.dm
+++ b/code/modules/cargo/bounties/item.dm
@@ -11,7 +11,7 @@
 	..()
 	wanted_types = typecacheof(wanted_types)
 	exclude_types = typecacheof(exclude_types)
-	if(random_count)
+	if(random_count > 0)
 		required_count = rand(max(1, required_count - random_count), required_count + random_count)
 		//adjust the reward. If more than standard required_count, increase reward. If less, decrease.
 		//Will make the reward more/less depending if it was randomized to require more/less, by 5% of the item's reward per difference. Not huge.

--- a/code/modules/cargo/bounties/item.dm
+++ b/code/modules/cargo/bounties/item.dm
@@ -1,14 +1,21 @@
 /datum/bounty/item
 	var/required_count = 1
 	var/shipped_count = 0
-	var/list/wanted_types  // Types accepted for the bounty.
+	var/list/wanted_types = list() // Types accepted for the bounty.
 	var/include_subtypes = TRUE     // Set to FALSE to make the datum apply only to a strict type.
-	var/list/exclude_types // Types excluded.
+	var/list/exclude_types = list() // Types excluded.
+	var/random_count = 0 //number. This will randomize required_count when initialized by picking a random amount of required_count + and - this number. at least 1 will always be required count. Leave at 0 to not randomize.
+
 
 /datum/bounty/item/New()
 	..()
 	wanted_types = typecacheof(wanted_types)
 	exclude_types = typecacheof(exclude_types)
+	if(random_count)
+		required_count = rand(max(1, required_count - random_count), required_count + random_count)
+		//adjust the reward. If more than standard required_count, increase reward. If less, decrease.
+		//Will make the reward more/less depending if it was randomized to require more/less, by 5% of the item's reward per difference. Not huge.
+		reward += (required_count - initial(required_count)) * round(reward * 0.05, 10)
 
 /datum/bounty/item/completion_string()
 	return {"[shipped_count]/[required_count]"}

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -6,7 +6,7 @@
 	"We're holding an office party and need some drink variety.",
 	"We're holding a mixing competition, and you'll receive a bonus for competing.",
 	"One of our agents has had a hard day and need to unwind so badly they're willing to put up for a bounty.",
-	"We're doing a public taste test for a PR campaign.",
+	"We need some drinks for a PR campaign setup.",
 	"One of our bartenders is having trouble getting inspired, and wants to see a different drink.")
 
 /datum/bounty/reagent/completion_string()
@@ -49,8 +49,8 @@
 		/datum/reagent/alcohol/ethanol/coffee/b52,
 		/datum/reagent/alcohol/ethanol/bananahonk,
 		/datum/reagent/alcohol/ethanol/bilk,
-		/datum/reagent/alcohol/ethanol/black_russian,
-		/datum/reagent/alcohol/ethanol/bloody_mary,
+		/datum/reagent/alcohol/ethanol/blackrussian,
+		/datum/reagent/alcohol/ethanol/bloodymary,
 		/datum/reagent/alcohol/ethanol/martini,
 		/datum/reagent/alcohol/ethanol/cubalibre,
 		/datum/reagent/alcohol/ethanol/erikasurprise,
@@ -61,7 +61,7 @@
 		/datum/reagent/alcohol/ethanol/irishcarbomb,
 		/datum/reagent/alcohol/ethanol/manhattan,
 		/datum/reagent/alcohol/ethanol/margarita,
-		/datum/reagent/alcohol/ethanol/gargle_blaster,
+		/datum/reagent/alcohol/ethanol/gargleblaster,
 		/datum/reagent/alcohol/ethanol/screwdrivercocktail,
 		/datum/reagent/alcohol/ethanol/cobaltvelvet,
 		/datum/reagent/alcohol/ethanol/snowwhite,
@@ -101,11 +101,12 @@
 /datum/bounty/reagent/complex_drink/New()
 	..()
 	// Don't worry about making this comprehensive. It doesn't matter if some drinks are skipped.
-	var/list/possible_reagents = list(/datum/reagent/alcohol/ethanol/hooch,
+	var/list/possible_reagents = list(
+		/datum/reagent/alcohol/ethanol/hooch,
 		/datum/reagent/alcohol/ethanol/atomicbomb,
 		/datum/reagent/alcohol/ethanol/beepsky_smash,
 		/datum/reagent/alcohol/ethanol/booger,
-		/datum/reagent/alcohol/ethanol/hippies_delight,
+		/datum/reagent/alcohol/ethanol/hippiesdelight,
 		/datum/reagent/alcohol/ethanol/goldschlager,
 		/datum/reagent/alcohol/ethanol/manhattan_proj,
 		/datum/reagent/alcohol/ethanol/neurotoxin,
@@ -137,7 +138,7 @@
 /datum/bounty/reagent/chemical/New()
 	..()
 	// Don't worry about making this comprehensive. It doesn't matter if some chems are skipped.
-	var/list/possible_reagents = list(/datum/reagent/nutriment/honey,
+	var/list/possible_reagents = list(
 		/datum/reagent/leporazine,
 		/datum/reagent/clonexadone,
 		/datum/reagent/space_drugs,
@@ -148,11 +149,11 @@
 		/datum/reagent/mental/escitalopram,
 		/datum/reagent/mental/risperidone,
 		/datum/reagent/rmt,
-		/datum/reagent/frostoil,
-		/datum/reagent/slimejelly,
+		/datum/reagent/tramadol,
 		/datum/reagent/oxycodone,
 		/datum/reagent/imidazoline,
 		/datum/reagent/peridaxon,
+		/datum/reagent/mannitol,
 		/datum/reagent/ipecac,
 		/datum/reagent/hyperzine,
 		/datum/reagent/calomel,

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -37,8 +37,8 @@
 
 /datum/bounty/reagent/simple_drink
 	name = "Simple Drink"
-	reward_low = 10
-	reward_high = 15
+	reward_low = 1000
+	reward_high = 1800
 
 /datum/bounty/reagent/simple_drink/New()
 	..()
@@ -95,8 +95,8 @@
 //Complex drinks. Requires coordination with other departments for ingredients
 /datum/bounty/reagent/complex_drink
 	name = "Complex Drink"
-	reward_low = 20
-	reward_high = 30
+	reward_low = 2000
+	reward_high = 3200
 
 /datum/bounty/reagent/complex_drink/New()
 	..()
@@ -132,8 +132,8 @@
 //Medicines, toxins, and drugs
 /datum/bounty/reagent/chemical
 	name = "Chemical"
-	reward_low = 20
-	reward_high = 30
+	reward_low = 2000
+	reward_high = 3200
 
 /datum/bounty/reagent/chemical/New()
 	..()

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -5,7 +5,7 @@
 	var/list/possible_descriptions = list("We're interested in testing the quality of our stations' bartenders!",
 	"We're holding an office party and need some drink variety.",
 	"We're holding a mixing competition, and you'll receive a bonus for competing.",
-	"One of our agents has had a hard day and need to unwind so badly they're willing to put up for a bounty.",
+	"One of our agents has had a hard day and needs to unwind so badly they're willing to put up for a bounty.",
 	"We need some drinks for a PR campaign setup.",
 	"One of our bartenders is having trouble getting inspired, and wants to see a different drink.")
 

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -65,7 +65,7 @@
 		/datum/reagent/alcohol/ethanol/screwdrivercocktail,
 		/datum/reagent/alcohol/ethanol/cobaltvelvet,
 		/datum/reagent/alcohol/ethanol/snowwhite,
-		/datum/reagent/alcohol/ethanol/syndicatebomb,
+		/datum/reagent/alcohol/ethanol/gibsonhooch,
 		/datum/reagent/alcohol/ethanol/manly_dorf,
 		/datum/reagent/alcohol/ethanol/thirteenloko,
 		/datum/reagent/alcohol/ethanol/vodkamartini,

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -2,6 +2,12 @@
 	var/required_volume = 10
 	var/shipped_volume = 0
 	var/datum/reagent/wanted_reagent
+	var/list/possible_descriptions = list("We're interested in testing the quality of our stations' bartenders!",
+	"We're holding an office party and need some drink variety.",
+	"We're holding a mixing competition, and you'll receive a bonus for competing.",
+	"One of our agents has had a hard day and need to unwind so badly they're willing to put up for a bounty.",
+	"We're doing a public taste test for a PR campaign.",
+	"One of our bartenders is having trouble getting inspired, and wants to see a different drink.")
 
 /datum/bounty/reagent/completion_string()
 	return {"[round(shipped_volume)]/[required_volume] Units"}
@@ -31,94 +37,140 @@
 
 /datum/bounty/reagent/simple_drink
 	name = "Simple Drink"
-	reward = 1500
+	reward_low = 10
+	reward_high = 15
 
 /datum/bounty/reagent/simple_drink/New()
+	..()
 	// Don't worry about making this comprehensive. It doesn't matter if some drinks are skipped.
-	var/static/list/possible_reagents = list(\
-		/datum/reagent/alcohol/ethanol/antifreeze,\
-		/datum/reagent/alcohol/ethanol/andalusia,\
-		/datum/reagent/alcohol/ethanol/coffee/b52,\
-		/datum/reagent/alcohol/ethanol/bananahonk,\
-		/datum/reagent/alcohol/ethanol/beepsky_smash,\
-		/datum/reagent/alcohol/ethanol/bilk,\
-		/datum/reagent/alcohol/ethanol/black_russian,\
-		/datum/reagent/alcohol/ethanol/bloody_mary,\
-		/datum/reagent/alcohol/ethanol/martini,\
-		/datum/reagent/alcohol/ethanol/cubalibre,\
-		/datum/reagent/alcohol/ethanol/erikasurprise,\
-		/datum/reagent/alcohol/ethanol/ginfizz,\
-		/datum/reagent/alcohol/ethanol/gintonic,\
-		/datum/reagent/alcohol/ethanol/grog,\
-		/datum/reagent/alcohol/ethanol/hooch,\
-		/datum/reagent/alcohol/ethanol/iced_beer,\
-		/datum/reagent/alcohol/ethanol/irishcarbomb,\
-		/datum/reagent/alcohol/ethanol/manhattan,\
-		/datum/reagent/alcohol/ethanol/margarita,\
-		/datum/reagent/alcohol/ethanol/gargle_blaster,\
-		/datum/reagent/alcohol/ethanol/screwdrivercocktail,\
-		/datum/reagent/alcohol/ethanol/snowwhite,\
-		/datum/reagent/drink/coffee/soy_latte,\
-		/datum/reagent/drink/coffee/cafe_latte,\
-		/datum/reagent/alcohol/ethanol/gibsonhooch,\
-		/datum/reagent/alcohol/ethanol/manly_dorf,\
-		/datum/reagent/alcohol/ethanol/thirteenloko,\
-		/datum/reagent/alcohol/ethanol/vodkamartini,\
-		/datum/reagent/alcohol/ethanol/whiskeysoda,\
-		/datum/reagent/alcohol/ethanol/demonsblood,\
-		/datum/reagent/alcohol/ethanol/singulo)
+	var/list/possible_reagents = list(
+		/datum/reagent/alcohol/ethanol/antifreeze,
+		/datum/reagent/alcohol/ethanol/andalusia,
+		/datum/reagent/alcohol/ethanol/coffee/b52,
+		/datum/reagent/alcohol/ethanol/bananahonk,
+		/datum/reagent/alcohol/ethanol/bilk,
+		/datum/reagent/alcohol/ethanol/black_russian,
+		/datum/reagent/alcohol/ethanol/bloody_mary,
+		/datum/reagent/alcohol/ethanol/martini,
+		/datum/reagent/alcohol/ethanol/cubalibre,
+		/datum/reagent/alcohol/ethanol/erikasurprise,
+		/datum/reagent/alcohol/ethanol/ginfizz,
+		/datum/reagent/alcohol/ethanol/gintonic,
+		/datum/reagent/alcohol/ethanol/grog,
+		/datum/reagent/alcohol/ethanol/iced_beer,
+		/datum/reagent/alcohol/ethanol/irishcarbomb,
+		/datum/reagent/alcohol/ethanol/manhattan,
+		/datum/reagent/alcohol/ethanol/margarita,
+		/datum/reagent/alcohol/ethanol/gargle_blaster,
+		/datum/reagent/alcohol/ethanol/screwdrivercocktail,
+		/datum/reagent/alcohol/ethanol/cobaltvelvet,
+		/datum/reagent/alcohol/ethanol/snowwhite,
+		/datum/reagent/alcohol/ethanol/syndicatebomb,
+		/datum/reagent/alcohol/ethanol/manly_dorf,
+		/datum/reagent/alcohol/ethanol/thirteenloko,
+		/datum/reagent/alcohol/ethanol/vodkamartini,
+		/datum/reagent/alcohol/ethanol/whiskeysoda,
+		/datum/reagent/alcohol/ethanol/demonsblood,
+		/datum/reagent/alcohol/ethanol/cinnamonapplewhiskey,
+		/datum/reagent/drink/coffee/soy_latte,
+		/datum/reagent/drink/coffee/cafe_latte,
+		/datum/reagent/drink/tea/coco_chaitea,
+		/datum/reagent/drink/tea/chaitealatte,
+		/datum/reagent/drink/tea/bureacratea,
+		/datum/reagent/drink/tea/desert_tea,
+		/datum/reagent/drink/tea/hakhma_tea,
+		/datum/reagent/drink/tea/portsvilleminttea,
+		/datum/reagent/drink/meatshake,
+		/datum/reagent/alcohol/butanol/sandgria,
+		/datum/reagent/alcohol/butanol/cactuscola,
+		/datum/reagent/alcohol/butanol/trizkizki_tea)
 
-	var/reagent_type = pick(possible_reagents)
+	var/datum/reagent/reagent_type = pick(possible_reagents)
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
-	description = "%BOSSSHORT is thirsty! Send a shipment of [name] to %DOCKNAME to quench the company's thirst."
-	reward += rand(0, 2) * 500
-	..()
+	description = "[pick(possible_descriptions)] Send a shipment of [name]." //punctuation is already in pick()
+	required_volume = rand(2, 12) * 10
+	reward += required_volume * 20		//range from +400(20u) to +2400(120u)
 
+//Complex drinks. Requires coordination with other departments for ingredients
 /datum/bounty/reagent/complex_drink
 	name = "Complex Drink"
-	reward = 4000
+	reward_low = 20
+	reward_high = 30
 
 /datum/bounty/reagent/complex_drink/New()
+	..()
 	// Don't worry about making this comprehensive. It doesn't matter if some drinks are skipped.
-	var/static/list/possible_reagents = list(\
-		/datum/reagent/alcohol/ethanol/atomicbomb,\
-		/datum/reagent/alcohol/ethanol/booger,\
-		/datum/reagent/alcohol/ethanol/hippies_delight,\
-		/datum/reagent/alcohol/ethanol/goldschlager,\
-		/datum/reagent/alcohol/ethanol/manhattan_proj,\
-		/datum/reagent/alcohol/ethanol/neurotoxin,\
-		/datum/reagent/alcohol/ethanol/patron,\
-		/datum/reagent/alcohol/ethanol/silencer)
+	var/list/possible_reagents = list(/datum/reagent/alcohol/ethanol/hooch,
+		/datum/reagent/alcohol/ethanol/atomicbomb,
+		/datum/reagent/alcohol/ethanol/beepsky_smash,
+		/datum/reagent/alcohol/ethanol/booger,
+		/datum/reagent/alcohol/ethanol/hippies_delight,
+		/datum/reagent/alcohol/ethanol/goldschlager,
+		/datum/reagent/alcohol/ethanol/manhattan_proj,
+		/datum/reagent/alcohol/ethanol/neurotoxin,
+		/datum/reagent/alcohol/ethanol/singulo,
+		/datum/reagent/alcohol/ethanol/patron,
+		/datum/reagent/alcohol/ethanol/silencer,
+		/datum/reagent/alcohol/ethanol/cbsc,
+		/datum/reagent/alcohol/ethanol/rixulin_sundae,
+		/datum/reagent/drink/xrim,
+		/datum/reagent/drink/tea/securitea,
+		/datum/reagent/drink/toothpaste/sedantian_firestorm,
+		/datum/reagent/alcohol/butanol/wastelandheat,
+		/datum/reagent/alcohol/butanol/contactwine,
+		/datum/reagent/alcohol/butanol/crocodile_booze)
 		
 	var/reagent_type = pick(possible_reagents)
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
-	description = "%BOSSSHORT is offering a reward for talented bartenders. Ship a container of [name] to claim the prize."
-	reward += rand(0, 4) * 500
-	..()
+	description = "[pick(possible_descriptions)] Send a shipment of [name]." //punctuation is already in pick()
+	required_volume = rand(2, 12) * 10
+	reward += required_volume * 30		//range from +600(20u) to +3600(120u)
 
+//Medicines, toxins, and drugs
 /datum/bounty/reagent/chemical
 	name = "Chemical"
-	reward = 4000
-	required_volume = 30
+	reward_low = 20
+	reward_high = 30
 
 /datum/bounty/reagent/chemical/New()
+	..()
 	// Don't worry about making this comprehensive. It doesn't matter if some chems are skipped.
-	var/static/list/possible_reagents = list(\
-		/datum/reagent/leporazine,\
-		/datum/reagent/clonexadone,\
-		/datum/reagent/rezadone,\
-		/datum/reagent/space_drugs,\
-		/datum/reagent/thermite,\
-		/datum/reagent/nutriment/honey,\
-		/datum/reagent/frostoil,\
-		/datum/reagent/slimejelly,\
-		/datum/reagent/toxin/cyanide)
+	var/list/possible_reagents = list(/datum/reagent/nutriment/honey,
+		/datum/reagent/leporazine,
+		/datum/reagent/clonexadone,
+		/datum/reagent/space_drugs,
+		/datum/reagent/thermite,
+		/datum/reagent/antihistamine,
+		/datum/reagent/sterilizine,
+		/datum/reagent/mental/duloxetine,
+		/datum/reagent/mental/escitalopram,
+		/datum/reagent/mental/risperidone,
+		/datum/reagent/rmt,
+		/datum/reagent/frostoil,
+		/datum/reagent/slimejelly,
+		/datum/reagent/oxycodone,
+		/datum/reagent/imidazoline,
+		/datum/reagent/peridaxon,
+		/datum/reagent/ipecac,
+		/datum/reagent/hyperzine,
+		/datum/reagent/calomel,
+		/datum/reagent/pacifier,
+		/datum/reagent/dexalin/plus,
+		/datum/reagent/ryetalyn,
+		/datum/reagent/pneumalin,
+		/datum/reagent/acid/polyacid,
+		/datum/reagent/mutagen,
+		/datum/reagent/impedrezene,
+		/datum/reagent/night_juice,
+		/datum/reagent/toxin/cardox,
+		/datum/reagent/toxin/lean,
+		/datum/reagent/toxin/stimm)
 
 	var/reagent_type = pick(possible_reagents)
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
-	description = "%BOSSSHORT is in desperate need of the chemical [name]. Ship a container of it to be rewarded."
-	reward += rand(0, 4) * 500
-	..()
+	description = "One of our labs is in desperate need of [name]. Ship a container of it to be rewarded."
+	required_volume = rand(2, 12) * 10
+	reward += required_volume * 40		//range from +800(20u) to +4800(120u)

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -1,22 +1,22 @@
 /datum/bounty/item/science/boh
 	name = "Bag of Holding"
 	description = "%COMPNAME would make good use of a high-capacity backpack. If you have any, please ship them."
-	reward_low = 60
-	reward_high = 72
+	reward_low = 6000
+	reward_high = 7200
 	wanted_types = list(/obj/item/storage/backpack/holding)
 
 /datum/bounty/item/science/nightvision_goggles
 	name = "Night Vision Goggles"
 	description = "An electrical storm has busted all the lights at %BOSSSHORT. While management is waiting for replacements, perhaps some night vision goggles can be shipped?"
-	reward_low = 52
-	reward_high = 60
+	reward_low = 5200
+	reward_high = 6000
 	wanted_types = list(/obj/item/clothing/glasses/night)
 
 /datum/bounty/item/science/experimental_welding_tool
 	name = "Experimental Welding Tool"
 	description = "A recent accident has left most of %BOSSSHORT's welding tools exploded. Ship replacements to be rewarded."
-	reward_low = 52
-	reward_high = 60
+	reward_low = 5200
+	reward_high = 6000
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/weldingtool/experimental)
@@ -24,8 +24,8 @@
 /datum/bounty/item/science/cryostasis_beaker
 	name = "Cryostasis Beaker"
 	description = "Chemists at %BOSSNAME have discovered a new chemical that can only be held in cryostasis beakers. The only problem is they don't have any! Rectify this to receive a station bonus."
-	reward_low = 52
-	reward_high = 60
+	reward_low = 5200
+	reward_high = 6000
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/glass/beaker/noreact)
@@ -33,23 +33,23 @@
 /datum/bounty/item/science/advanced_egun
 	name = "Advanced Energy Gun"
 	description = "With the price of rechargers on the rise, upper management is interested in purchasing guns that are self-powered. If you ship one, they'll pay."
-	reward_low = 60
-	reward_high = 72
+	reward_low = 6000
+	reward_high = 7200
 	wanted_types = list(/obj/item/gun/energy/gun/nuclear)
 
 /datum/bounty/item/science/posibrain
 	name = "Posibrain"
 	description = "Due to a sudden spike in accidents management has decided to replace some of the staff with borgs. Ship us 2 posibrains."
-	reward_low = 80
-	reward_high = 85
+	reward_low = 8000
+	reward_high = 8500
 	required_count = 2
 	wanted_types = list(/obj/item/device/mmi/digital/posibrain)
 
 /datum/bounty/item/science/borgbody
 	name = "Robot Endoskeleton"
 	description = "The %DOCKSHORT has decided to rely more on cyborgs for dangerous tasks. Ship us a fully assembled robot endoskeletons without a mmi/posibrain inside of it."
-	reward_low = 50
-	reward_high = 65
+	reward_low = 5000
+	reward_high = 6500
 	required_count = 1
 	wanted_types = list(/obj/item/robot_parts/robot_suit)
 
@@ -65,15 +65,15 @@
 /datum/bounty/item/science/forcegloves
 	name = "Force Gloves"
 	description = "%PERSONNAME has been challenged to a sparring duel in the holodeck. Ship them a pair of forcegloves so there can be a fair fight."
-	reward_low = 25
-	reward_high = 35
+	reward_low = 2500
+	reward_high = 3500
 	wanted_types = list(/obj/item/clothing/gloves/force)
 
 /datum/bounty/item/science/fossil
 	name = "Fossil"
 	description = "We want to set up a display in one of the libraries on the %DOCKSHORT. Ship us a unique discovery when you are done displaying it on-station."
-	reward_low = 75
-	reward_high = 85
+	reward_low = 7500
+	reward_high = 8500
 	required_count = 1
 	random_count = 1 //wants one or two
 	wanted_types = list(/obj/item/fossil, /obj/skeleton)
@@ -81,8 +81,8 @@
 /datum/bounty/item/science/circuitboard
 	name = "Telecomms Monitor Circuitboard"
 	description = "Due to a hardware failure, %COMPNAME requires a new circuit board to replace the spare that was used to fix the problem."
-	reward_low = 35
-	reward_high = 45
+	reward_low = 3500
+	reward_high = 4500
 	required_count = 1
 	wanted_types = list(/obj/item/circuitboard/comm_monitor)
 
@@ -121,8 +121,8 @@
 /datum/bounty/item/science/battery
 	name = "Heavy-Duty Power Cell"
 	description = "%COMPNAME has requested some power cells to fill their supply closet. Please fully charge them first."
-	reward_low = 35
-	reward_high = 45
+	reward_low = 3500
+	reward_high = 4500
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/item/cell/apc)
@@ -138,20 +138,20 @@
 
 /datum/bounty/item/science/battery/high
 	name = "High-Capacity power Cell"
-	reward_low = 45
-	reward_high = 50
+	reward_low = 4500
+	reward_high = 5000
 	wanted_types = list(/obj/item/cell/high)
 
 /datum/bounty/item/science/battery/super
 	name = "Super-Capacity power Cell"
-	reward_low = 45
-	reward_high = 50
+	reward_low = 4500
+	reward_high = 5000
 	required_count = 3
 	wanted_types = list(/obj/item/cell/super)
 
 /datum/bounty/item/science/battery/hyper
 	name = "Hyper-Capacity power Cell"
-	reward_low = 50
-	reward_high = 60
+	reward_low = 5000
+	reward_high = 6000
 	required_count = 3
 	wanted_types = list(/obj/item/cell/hyper)

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -47,18 +47,37 @@
 
 /datum/bounty/item/science/borgbody
 	name = "Robot Endoskeleton"
-	description = "Due to a sudden spike accidents, management has decided to rely more on cyborgs. Ship us a fully assembled robot endoskeletons without a mmi/posibrain inside of it."
-	reward_low = 65
-	reward_high = 75
-	required_count = 2
+	description = "The %DOCKSHORT has decided to rely more on cyborgs for dangerous tasks. Ship us a fully assembled robot endoskeletons without a mmi/posibrain inside of it."
+	reward_low = 50
+	reward_high = 65
+	required_count = 1
 	wanted_types = list(/obj/item/robot_parts/robot_suit)
 
+/datum/bounty/item/science/borgbody/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	if(!istype(O, /obj/item/robot_parts/robot_suit))
+		return FALSE
+	var/obj/item/robot_parts/robot_suit/RS = O
+	if(RS.check_completion())
+		return TRUE
+	return FALSE
+	
 /datum/bounty/item/science/forcegloves
 	name = "Force Gloves"
 	description = "%PERSONNAME has been challenged to a sparring duel in the holodeck. Ship them a pair of forcegloves so there can be a fair fight."
 	reward_low = 25
 	reward_high = 35
 	wanted_types = list(/obj/item/clothing/gloves/force)
+
+/datum/bounty/item/science/fossil
+	name = "Fossil"
+	description = "We want to set up a display in one of the libraries on the %DOCKSHORT. Ship us a unique discovery when you are done displaying it on-station."
+	reward_low = 75
+	reward_high = 85
+	required_count = 1
+	random_count = 1 //wants one or two
+	wanted_types = list(/obj/item/fossil, /obj/skeleton)
 
 /datum/bounty/item/science/circuitboard
 	name = "Telecomms Monitor Circuitboard"
@@ -102,9 +121,9 @@
 
 /datum/bounty/item/science/battery
 	name = "Heavy-Duty Power Cell"
-	description = "%COMPNAME has requested some power cells to fill their supply closet. Please charge them first."
-	reward_low = 20
-	reward_high = 25
+	description = "%COMPNAME has requested some power cells to fill their supply closet. Please fully charge them first."
+	reward_low = 35
+	reward_high = 45
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/item/cell/apc)
@@ -121,20 +140,20 @@
 
 /datum/bounty/item/science/battery/high
 	name = "High-Capacity power Cell"
-	reward_low = 30
-	reward_high = 35
+	reward_low = 45
+	reward_high = 50
 	wanted_types = list(/obj/item/cell/high)
 
 /datum/bounty/item/science/battery/super
 	name = "Super-Capacity power Cell"
-	reward_low = 40
-	reward_high = 45
+	reward_low = 45
+	reward_high = 50
 	required_count = 3
 	wanted_types = list(/obj/item/cell/super)
 
 /datum/bounty/item/science/battery/hyper
 	name = "Hyper-Capacity power Cell"
-	reward_low = 45
-	reward_high = 50
+	reward_low = 50
+	reward_high = 60
 	required_count = 3
 	wanted_types = list(/obj/item/cell/hyper)

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -53,13 +53,12 @@
 	required_count = 1
 	wanted_types = list(/obj/item/robot_parts/robot_suit)
 
-/datum/bounty/item/science/borgbody/applies_to(obj/O)
+/datum/bounty/item/science/borgbody/applies_to(var/obj/item/robot_parts/robot_suit/O)
 	if(!..())
 		return FALSE
-	if(!istype(O, /obj/item/robot_parts/robot_suit))
+	if(!istype(O))
 		return FALSE
-	var/obj/item/robot_parts/robot_suit/RS = O
-	if(RS.check_completion())
+	if(O.check_completion())
 		return TRUE
 	return FALSE
 	
@@ -128,13 +127,12 @@
 	random_count = 1
 	wanted_types = list(/obj/item/cell/apc)
 
-/datum/bounty/item/science/battery/applies_to(obj/O)
+/datum/bounty/item/science/battery/applies_to(var/obj/item/cell/O)
 	if(!..())
 		return FALSE
-	if(!istype(O, /obj/item/cell))
+	if(!istype(O))
 		return FALSE
-	var/obj/item/cell/C = O
-	if(C.charge == C.maxcharge)
+	if(O.charge == O.maxcharge)
 		return TRUE
 	return FALSE
 

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -1,52 +1,70 @@
 /datum/bounty/item/science/boh
 	name = "Bag of Holding"
-	description = "%COMPNAME would make good use of high-capacity backpacks. If you have any, please ship them."
-	reward = 10000
+	description = "%COMPNAME would make good use of a high-capacity backpack. If you have any, please ship them."
+	reward_low = 60
+	reward_high = 72
 	wanted_types = list(/obj/item/storage/backpack/holding)
 
 /datum/bounty/item/science/nightvision_goggles
 	name = "Night Vision Goggles"
 	description = "An electrical storm has busted all the lights at %BOSSSHORT. While management is waiting for replacements, perhaps some night vision goggles can be shipped?"
-	reward = 10000
+	reward_low = 52
+	reward_high = 60
 	wanted_types = list(/obj/item/clothing/glasses/night)
 
 /datum/bounty/item/science/experimental_welding_tool
 	name = "Experimental Welding Tool"
 	description = "A recent accident has left most of %BOSSSHORT's welding tools exploded. Ship replacements to be rewarded."
-	reward = 10000
+	reward_low = 52
+	reward_high = 60
 	required_count = 3
+	random_count = 1
 	wanted_types = list(/obj/item/weldingtool/experimental)
 
 /datum/bounty/item/science/cryostasis_beaker
 	name = "Cryostasis Beaker"
-	description = "Chemists at %BOSSNAME have discovered a new chemical that can only be held in cryostasis beakers. The only problem is they don't have any! Rectify this to receive payment."
-	reward = 10000
+	description = "Chemists at %BOSSNAME have discovered a new chemical that can only be held in cryostasis beakers. The only problem is they don't have any! Rectify this to receive a station bonus."
+	reward_low = 52
+	reward_high = 60
+	required_count = 3
+	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/glass/beaker/noreact)
 
 /datum/bounty/item/science/advanced_egun
 	name = "Advanced Energy Gun"
 	description = "With the price of rechargers on the rise, upper management is interested in purchasing guns that are self-powered. If you ship one, they'll pay."
-	reward = 10000
+	reward_low = 60
+	reward_high = 72
 	wanted_types = list(/obj/item/gun/energy/gun/nuclear)
 
 /datum/bounty/item/science/posibrain
 	name = "Posibrain"
 	description = "Due to a sudden spike in accidents management has decided to replace some of the staff with borgs. Ship us 2 posibrains."
-	reward = 10000
+	reward_low = 80
+	reward_high = 85
 	required_count = 2
 	wanted_types = list(/obj/item/device/mmi/digital/posibrain)
 
 /datum/bounty/item/science/borgbody
 	name = "Robot Endoskeleton"
-	description = "Due to a sudden spike in assistants-related accidents management has decided to replace some of them with borgs. Ship us fully assembled robot endoskeletons without a mmi/posibrain inside of it."
-	reward = 10000
+	description = "Due to a sudden spike accidents, management has decided to rely more on cyborgs. Ship us a fully assembled robot endoskeletons without a mmi/posibrain inside of it."
+	reward_low = 65
+	reward_high = 75
 	required_count = 2
 	wanted_types = list(/obj/item/robot_parts/robot_suit)
+
+/datum/bounty/item/science/forcegloves
+	name = "Force Gloves"
+	description = "%PERSONNAME has been challenged to a sparring duel in the holodeck. Ship them a pair of forcegloves so there can be a fair fight."
+	reward_low = 25
+	reward_high = 35
+	wanted_types = list(/obj/item/clothing/gloves/force)
 
 /datum/bounty/item/science/circuitboard
 	name = "Telecomms Monitor Circuitboard"
 	description = "Due to a hardware failure, %COMPNAME requires a new circuit board to replace the spare that was used to fix the problem."
-	reward = 4000
+	reward_low = 35
+	reward_high = 45
 	required_count = 1
 	wanted_types = list(/obj/item/circuitboard/comm_monitor)
 
@@ -57,14 +75,6 @@
 /datum/bounty/item/science/circuitboard/commtraffic
 	name = "Telecomms Traffic Control Circuitboard"
 	wanted_types = list(/obj/item/circuitboard/comm_traffic)
-
-/datum/bounty/item/science/circuitboard/seccamera
-	name = "Security Camera Monitor Circuitboard"
-	wanted_types = list(/obj/item/circuitboard/security)
-
-/datum/bounty/item/science/circuitboard/engcamera
-	name = "Engineering Camera Monitor Circuitboard"
-	wanted_types = list(/obj/item/circuitboard/security/engineering)
 
 /datum/bounty/item/science/circuitboard/messagemonitor
 	name = "Message Monitor Circuitboard"
@@ -78,10 +88,6 @@
 	name = "Borg Upload Circuitboard"
 	wanted_types = list(/obj/item/circuitboard/borgupload)
 
-/datum/bounty/item/science/circuitboard/airalert
-	name = "Atmos Alert Circuitboard"
-	wanted_types = list(/obj/item/circuitboard/atmos_alert)
-
 /datum/bounty/item/science/circuitboard/robotics
 	name = "Robotics Control Circuitboard"
 	wanted_types = list(/obj/item/circuitboard/robotics)
@@ -90,10 +96,6 @@
 	name = "Drone Control Circuitboard"
 	wanted_types = list(/obj/item/circuitboard/drone_control)
 
-/datum/bounty/item/science/circuitboard/cloning
-	name = "Cloning Control Circuitboard"
-	wanted_types = list(/obj/item/circuitboard/cloning)
-
 /datum/bounty/item/science/circuitboard/powermonitor
 	name = "Power Monitor Circuitboard"
 	wanted_types = list(/obj/item/circuitboard/powermonitor)
@@ -101,45 +103,38 @@
 /datum/bounty/item/science/battery
 	name = "Heavy-Duty Power Cell"
 	description = "%COMPNAME has requested some power cells to fill their supply closet. Please charge them first."
-	reward = 3000
-	required_count = 5
+	reward_low = 20
+	reward_high = 25
+	required_count = 4
+	random_count = 1
 	wanted_types = list(/obj/item/cell/apc)
+
+/datum/bounty/item/science/battery/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	if(!istype(O, /obj/item/cell))
+		return FALSE
+	var/obj/item/cell/C = O
+	if(C.charge == C.maxcharge)
+		return TRUE
+	return FALSE
 
 /datum/bounty/item/science/battery/high
 	name = "High-Capacity power Cell"
-	reward = 3500
-	required_count = 4
+	reward_low = 30
+	reward_high = 35
 	wanted_types = list(/obj/item/cell/high)
 
 /datum/bounty/item/science/battery/super
 	name = "Super-Capacity power Cell"
-	reward = 4000
+	reward_low = 40
+	reward_high = 45
 	required_count = 3
 	wanted_types = list(/obj/item/cell/super)
 
 /datum/bounty/item/science/battery/hyper
 	name = "Hyper-Capacity power Cell"
-	reward = 5000
-	required_count = 2
+	reward_low = 45
+	reward_high = 50
+	required_count = 3
 	wanted_types = list(/obj/item/cell/hyper)
-
-/datum/bounty/item/science/borgbody/halstre
-	description = "We require you to ship us one fully assembled cyborg endoskeleton without a mmi/posibrain inside of it"
-	required_count = 1
-
-/datum/bounty/item/science/borgbody/applies_to(obj/O)
-	if(!..())
-		return FALSE
-	var/obj/item/robot_parts/robot_suit/S = O
-	if(S && S.l_leg && S.r_leg && S.l_arm && S.r_arm && S.chest && S.head)
-		return TRUE
-	return FALSE
-
-/datum/bounty/item/science/borgbody/compatible_with(datum/other_bounty)
-	if(!..())
-		return FALSE
-	var/datum/bounty/item/other_item_bounty = other_bounty
-	if(other_bounty && (/obj/item/robot_parts/robot_suit in other_item_bounty.wanted_types))
-		return FALSE
-	return TRUE
-

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -1,29 +1,108 @@
 /datum/bounty/item/security/headset
 	name = "Security Headset"
 	description = "%COMPNAME wants to ensure that their encryption is working correctly. Ship them a security headset so that they can check."
-	reward = 800
+	reward_low = 7
+	reward_high = 12
+	random_count = 1
 	wanted_types = list(/obj/item/device/radio/headset/headset_sec , /obj/item/device/radio/headset/heads/hos)
 
 /datum/bounty/item/security/securitybelt
 	name = "Security Belt"
-	description = "%BOSSSHORT is having difficulties with their security belts. Ship one from the station to receive compensation."
-	reward = 800
+	description = "%BOSSNAME is having difficulties with their security belts. Ship one from the station to receive compensation."
+	reward_low = 7
+	reward_high = 12
+	random_count = 1
 	wanted_types = list(/obj/item/storage/belt/security)
 
 /datum/bounty/item/security/sechuds
 	name = "Security HUDSunglasses"
-	description = "%BOSSSHORT screwed up and ordered the wrong type of security sunglasses. They request the station ship some of theirs."
-	reward = 800
+	description = "%BOSSNAME screwed up and ordered the wrong type of security sunglasses. They request the station ship some of theirs."
+	reward_low = 7
+	reward_high = 12
 	wanted_types = list(/obj/item/clothing/glasses/sunglasses/sechud)
 
-/datum/bounty/item/security/hardsuit
-	name = "Security Hardsuit"
-	description = "Pirates have engaged the NMV Icarus! Quick! Ship a security hardsuit to aid the fight!"
-	reward = 2000
+/datum/bounty/item/security/voidsuit
+	name = "Security Voidsuit"
+	description = "The %DOCKSHORT has misplaced one of its security voidsuits, and a training exercise is about to begin. Ship a spare for a station bonus. Don't forget the helmet."
+	reward_low = 25
+	reward_high = 35
 	wanted_types = list(/obj/item/clothing/suit/space/void/security)
 
-/datum/bounty/item/security/forcegloves
-	name = "Force Gloves"
-	description = "Captain Francis of Station 8 has been challenged to a sparring duel in the holodeck. Ship him a pair of forcegloves so there can be a fair fight."
-	reward = 2000
-	wanted_types = list(/obj/item/clothing/gloves/force)
+/datum/bounty/item/security/voidsuit/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	var/obj/item/clothing/suit/space/void/security/S = O
+	if(S && S.helmet)
+		return TRUE
+	return FALSE
+
+/datum/bounty/item/security/maglight
+	name = "Maglights"
+	description = "Some civil protection agents lost their flashlights, and think the plastic ones are too lame. Send some maglights to appease their picky tastes."
+	reward_low = 22
+	reward_high = 30
+	required_count = 2
+	random_count = 1
+	wanted_types = list(/obj/item/device/flashlight/maglight)
+
+/datum/bounty/item/security/handcuffs
+	name = "Handcuffs"
+	description = "A large influx of criminals have arrived at %BOSSNAME for processing and transfer. Now is the perfect time to ship out spare handcuffs."
+	reward_low = 12
+	reward_high = 19
+	required_count = 4
+	random_count = 2
+	wanted_types = list(/obj/item/handcuffs)
+
+/datum/bounty/item/security/teargas
+	name = "Teargas Grenades"
+	description = "We're training some new civil protection officers, but our order for tear gas is running behind. Ship some for a bonus to your station's account."
+	reward_low = 20
+	reward_high = 30
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/item/grenade/chem_grenade/teargas)
+
+/datum/bounty/item/security/smoke
+	name = "Smoke Grenades"
+	description = "We need a few extra smoke grenades to restock the ERT. Any station that ships spares will be compensated."
+	reward_low = 22
+	reward_high = 32
+	required_count = 3
+	random_count = 1
+	wanted_types = list(/obj/item/grenade/chem_grenade/gas)
+
+/datum/bounty/item/security/pepper
+	name = "Pepper Spray"
+	description = "Time to help some civil protection troopers toughen their response to being pepper sprayed. Any station that helps will be compensated. I love this job. -%PERSONNAME"
+	reward_low = 12
+	reward_high = 22
+	required_count = 4
+	random_count = 1
+	wanted_types = list(/obj/item/reagent_containers/spray/pepper)
+
+/datum/bounty/item/security/pepper/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	var/obj/item/reagent_containers/spray/pepper/P = O
+	if(P && P.reagents.get_reagent_amount(/datum/reagent/capsaicin/condensed) >= 25)
+		return TRUE
+	return FALSE
+
+/datum/bounty/item/security/flash
+	name = "Flashes"
+	description = "The %DOCKSHORT has a few more new recruits than expected; we'll compensate any station that helps us provide some basic equipment. Right now, we need flashes."
+	reward_low = 12
+	reward_high = 22
+	required_count = 4
+	random_count = 1
+	wanted_types = list(/obj/item/device/flash)
+	include_subtypes = FALSE
+
+/datum/bounty/item/security/flash/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	var/obj/item/device/flash/F = O
+	if(F && !F.broken)
+		return TRUE
+	return FALSE

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -28,11 +28,12 @@
 	reward_high = 35
 	wanted_types = list(/obj/item/clothing/suit/space/void/security)
 
-/datum/bounty/item/security/voidsuit/applies_to(obj/O)
+/datum/bounty/item/security/voidsuit/applies_to(var/obj/item/clothing/suit/space/void/security/O)
 	if(!..())
 		return FALSE
-	var/obj/item/clothing/suit/space/void/security/S = O
-	if(S && S.helmet)
+	if(!istype(O))
+		return FALSE
+	if(O.helmet)
 		return TRUE
 	return FALSE
 
@@ -81,11 +82,12 @@
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/spray/pepper)
 
-/datum/bounty/item/security/pepper/applies_to(obj/O)
+/datum/bounty/item/security/pepper/applies_to(var/obj/item/reagent_containers/spray/pepper/O)
 	if(!..())
 		return FALSE
-	var/obj/item/reagent_containers/spray/pepper/P = O
-	if(P && P.reagents.get_reagent_amount(/datum/reagent/capsaicin/condensed) >= 25)
+	if(!istype(O))
+		return FALSE
+	if(O.reagents.get_reagent_amount(/datum/reagent/capsaicin/condensed) >= 25)
 		return TRUE
 	return FALSE
 
@@ -99,10 +101,11 @@
 	wanted_types = list(/obj/item/device/flash)
 	include_subtypes = FALSE
 
-/datum/bounty/item/security/flash/applies_to(obj/O)
+/datum/bounty/item/security/flash/applies_to(var/obj/item/device/flash/O)
 	if(!..())
 		return FALSE
-	var/obj/item/device/flash/F = O
-	if(F && !F.broken)
+	if(!istype(O))
+		return FALSE
+	if(!O.broken)
 		return TRUE
 	return FALSE

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -1,31 +1,31 @@
 /datum/bounty/item/security/headset
 	name = "Security Headset"
 	description = "%COMPNAME wants to ensure that their encryption is working correctly. Ship them a security headset so that they can check."
-	reward_low = 7
-	reward_high = 12
+	reward_low = 700
+	reward_high = 1200
 	random_count = 1
 	wanted_types = list(/obj/item/device/radio/headset/headset_sec , /obj/item/device/radio/headset/heads/hos)
 
 /datum/bounty/item/security/securitybelt
 	name = "Security Belt"
 	description = "%BOSSNAME is having difficulties with their security belts. Ship one from the station to receive compensation."
-	reward_low = 7
-	reward_high = 12
+	reward_low = 700
+	reward_high = 1200
 	random_count = 1
 	wanted_types = list(/obj/item/storage/belt/security)
 
 /datum/bounty/item/security/sechuds
 	name = "Security HUDSunglasses"
 	description = "%BOSSNAME screwed up and ordered the wrong type of security sunglasses. They request the station ship some of theirs."
-	reward_low = 7
-	reward_high = 12
+	reward_low = 700
+	reward_high = 1200
 	wanted_types = list(/obj/item/clothing/glasses/sunglasses/sechud)
 
 /datum/bounty/item/security/voidsuit
 	name = "Security Voidsuit"
 	description = "The %DOCKSHORT has misplaced one of its security voidsuits, and a training exercise is about to begin. Ship a spare for a station bonus. Don't forget the helmet."
-	reward_low = 25
-	reward_high = 35
+	reward_low = 2500
+	reward_high = 4500
 	wanted_types = list(/obj/item/clothing/suit/space/void/security)
 
 /datum/bounty/item/security/voidsuit/applies_to(var/obj/item/clothing/suit/space/void/security/O)
@@ -40,8 +40,8 @@
 /datum/bounty/item/security/maglight
 	name = "Maglights"
 	description = "Some civil protection agents lost their flashlights, and think the plastic ones are too lame. Send some maglights to appease their picky tastes."
-	reward_low = 22
-	reward_high = 30
+	reward_low = 2200
+	reward_high = 3000
 	required_count = 2
 	random_count = 1
 	wanted_types = list(/obj/item/device/flashlight/maglight)
@@ -49,8 +49,8 @@
 /datum/bounty/item/security/handcuffs
 	name = "Handcuffs"
 	description = "A large influx of criminals have arrived at %BOSSNAME for processing and transfer. Now is the perfect time to ship out spare handcuffs."
-	reward_low = 12
-	reward_high = 19
+	reward_low = 1200
+	reward_high = 1900
 	required_count = 4
 	random_count = 2
 	wanted_types = list(/obj/item/handcuffs)
@@ -58,8 +58,8 @@
 /datum/bounty/item/security/teargas
 	name = "Teargas Grenades"
 	description = "We're training some new civil protection officers, but our order for tear gas is running behind. Ship some for a bonus to your station's account."
-	reward_low = 20
-	reward_high = 30
+	reward_low = 2000
+	reward_high = 3000
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/grenade/chem_grenade/teargas)
@@ -67,8 +67,8 @@
 /datum/bounty/item/security/smoke
 	name = "Smoke Grenades"
 	description = "We need a few extra smoke grenades to restock the ERT. Any station that ships spares will be compensated."
-	reward_low = 22
-	reward_high = 32
+	reward_low = 2200
+	reward_high = 3200
 	required_count = 3
 	random_count = 1
 	wanted_types = list(/obj/item/grenade/chem_grenade/gas)
@@ -76,8 +76,8 @@
 /datum/bounty/item/security/pepper
 	name = "Pepper Spray"
 	description = "Time to help some civil protection troopers toughen their response to being pepper sprayed. Any station that helps will be compensated. I love this job. -%PERSONNAME"
-	reward_low = 12
-	reward_high = 22
+	reward_low = 1200
+	reward_high = 2200
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/spray/pepper)
@@ -94,8 +94,8 @@
 /datum/bounty/item/security/flash
 	name = "Flashes"
 	description = "The %DOCKSHORT has a few more new recruits than expected; we'll compensate any station that helps us provide some basic equipment. Right now, we need flashes."
-	reward_low = 12
-	reward_high = 22
+	reward_low = 1200
+	reward_high = 2200
 	required_count = 4
 	random_count = 1
 	wanted_types = list(/obj/item/device/flash)

--- a/code/modules/cargo/bounties/slime.dm
+++ b/code/modules/cargo/bounties/slime.dm
@@ -1,6 +1,6 @@
 /datum/bounty/item/slime
-	reward_low = 40
-	reward_high = 60
+	reward_low = 4000
+	reward_high = 6000
 
 /datum/bounty/item/slime/New()
 	..()

--- a/code/modules/cargo/bounties/slime.dm
+++ b/code/modules/cargo/bounties/slime.dm
@@ -1,9 +1,10 @@
 /datum/bounty/item/slime
-	reward = 3000
+	reward_low = 40
+	reward_high = 60
 
 /datum/bounty/item/slime/New()
 	..()
-	description = "%COMPNAME's science lead is hunting for the rare and exotic [name]. A bounty has been offered for finding it."
+	description = "One of our science leads is hunting for a sample of [name]. A bounty has been offered for finding it."
 	reward += rand(0, 4) * 500
 
 /datum/bounty/item/slime/green

--- a/code/modules/cargo/bounties/weapon_prototype.dm
+++ b/code/modules/cargo/bounties/weapon_prototype.dm
@@ -17,10 +17,10 @@
 /datum/bounty/weapon_prototype/can_claim()
 	return ..() && shipped
 
-/datum/bounty/weapon_prototype/applies_to(obj/O)
+/datum/bounty/weapon_prototype/applies_to(var/obj/item/gun/energy/laser/prototype/O)
 	if(shipped)
 		return FALSE
-	if(!istype(O, /obj/item/gun/energy/laser/prototype))
+	if(!istype(O))
 		return FALSE
 	if(accepts_weapon(O))
 		return TRUE
@@ -31,7 +31,7 @@
 		return
 	shipped = TRUE
 
-/datum/bounty/weapon_prototype/compatible_with(datum/other_bounty)
+/datum/bounty/weapon_prototype/compatible_with(var/datum/other_bounty)
 	if(!istype(other_bounty, /datum/bounty/weapon_prototype))
 		return TRUE
 	var/datum/bounty/weapon_prototype/W = other_bounty

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -47,7 +47,7 @@
 
 // When randomly generating the bounty list, duplicate bounties must be avoided.
 // This proc is used to determine if two bounties are duplicates, or incompatible in general.
-/datum/bounty/proc/compatible_with(other_bounty)
+/datum/bounty/proc/compatible_with(var/datum/other_bounty)
 	return TRUE
 
 /datum/bounty/proc/mark_high_priority(scale_reward = 2)
@@ -99,12 +99,10 @@
 // Returns FALSE if the bounty is incompatible with the current bounties.
 /datum/controller/subsystem/cargo/proc/try_add_bounty(datum/bounty/new_bounty)
 	if(!new_bounty || !new_bounty.name || !new_bounty.description)
-		log_debug("Unable to add due to lack of new_bounty, name, or description")
 		return FALSE
 	for(var/i in bounties_list)
 		var/datum/bounty/B = i
 		if(!B.compatible_with(new_bounty) || !new_bounty.compatible_with(B))
-			log_debug("[B.name] is not compatible with [new_bounty.name] or other way around")
 			return FALSE
 	bounties_list += new_bounty
 	return TRUE
@@ -118,7 +116,7 @@
 			var/subtype = pick(subtypesof(/datum/bounty/item/assistant))
 			return new subtype
 		if(2)
-			var/subtype = pick(subtypesof(/datum/bounty/item/assistant))
+			var/subtype = pick(subtypesof(/datum/bounty/item/engineer))
 			return new subtype
 		if(3)
 			var/subtype = pick(subtypesof(/datum/bounty/item/chef))
@@ -136,7 +134,7 @@
 			var/subtype = pick(subtypesof(/datum/bounty/item/science))
 			return new subtype
 		if(8)
-			var/subtype = pick(subtypesof(/datum/bounty/item/slime))
+			var/subtype = pick(subtypesof(/datum/bounty/item/hydroponicist))
 			return new subtype
 		if(9)
 			var/subtype = pick(subtypesof(/datum/bounty/item/bot))

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -1,7 +1,14 @@
+#define BOUNTY_MIN 1000
+#define BOUNTY_MAX 15000
+
+#define BOUNTY_NUM_LOW 1
+#define BOUNTY_NUM_MED 2
+#define BOUNTY_NUM_HIGH 3
+
 /datum/bounty
 	var/name
 	var/description
-	var/reward = 1000 // In credits. Mostly a fallback
+	var/reward = BOUNTY_MIN // In credits. Mostly a fallback
 	var/reward_low = 0	//x100 in credits. Minimum paid out. If 0, uses reward value instead
 	var/reward_high = 0	//x100 in credits. Maximum paid out. If 0, uses reward value instead
 	var/claimed = FALSE
@@ -54,7 +61,7 @@
 	if(high_priority)
 		return
 	high_priority = TRUE
-	reward = min(round(reward * scale_reward), 15000)	//15k limit
+	reward = min(round(reward * scale_reward), BOUNTY_MAX)	//15k limit
 
 //Generates a list of available bounties to be displayed
 /datum/controller/subsystem/cargo/proc/get_bounty_list()
@@ -159,36 +166,36 @@
 
 // Called lazily at startup to populate bounties_list with random bounties.
 /datum/controller/subsystem/cargo/proc/setupBounties()
-	for(var/i = 0; i < 3; i++)
+	for(var/i = 0; i < BOUNTY_NUM_HIGH; i++)
 		CHECK_TICK
 		var/datum/bounty/subtype = pick(subtypesof(/datum/bounty/item/assistant))
 		try_add_bounty(new subtype)
 
-	for(var/i = 0; i < 3; i++)
+	for(var/i = 0; i < BOUNTY_NUM_HIGH; i++)
 		CHECK_TICK
 		var/list/subtypes = subtypesof(/datum/bounty/item/bot)
 		subtypes += subtypesof(/datum/bounty/item/science)
 		var/datum/bounty/subtype = pick(subtypes)
 		try_add_bounty(new subtype)
 
-	for(var/i = 0; i < 2; i++)
+	for(var/i = 0; i < BOUNTY_NUM_MED; i++)
 		CHECK_TICK
 		var/datum/bounty/subtype = pick(subtypesof(/datum/bounty/item/chef))
 		try_add_bounty(new subtype)
 
-	for(var/i = 0; i < 2; i++)
+	for(var/i = 0; i <  BOUNTY_NUM_MED; i++)
 		CHECK_TICK
 		var/datum/bounty/subtype = pick(subtypesof(/datum/bounty/item/hydroponicist))
 		try_add_bounty(new subtype)
 
-	for(var/i = 0; i < 3; i++)
+	for(var/i = 0; i < BOUNTY_NUM_HIGH; i++)
 		CHECK_TICK
 		var/list/subtypes = subtypesof(/datum/bounty/item/security)
 		subtypes += subtypesof(/datum/bounty/item/engineer)
 		var/datum/bounty/subtype = pick(subtypes)
 		try_add_bounty(new subtype)
 
-	for(var/i = 0; i < 1; i++)
+	for(var/i = 0; i < BOUNTY_NUM_LOW; i++)
 		CHECK_TICK
 		var/list/subtypes = subtypesof(/datum/bounty/weapon_prototype)
 		subtypes += subtypesof(/datum/bounty/item/slime)

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -9,14 +9,14 @@
 	var/name
 	var/description
 	var/reward = BOUNTY_MIN // In credits. Mostly a fallback
-	var/reward_low = 0	//x100 in credits. Minimum paid out. If 0, uses reward value instead
-	var/reward_high = 0	//x100 in credits. Maximum paid out. If 0, uses reward value instead
+	var/reward_low = 0	//If 0, uses reward value instead
+	var/reward_high = 0	//If 0, uses reward value instead. Must be higher than reward_low
 	var/claimed = FALSE
 	var/high_priority = FALSE
 
 /datum/bounty/New()
-	if(reward_low && reward_high)
-		reward = rand(reward_low, reward_high) * 100	//Keeps it tidy like 1200, 4500, instead of getting like 1457 credits
+	if(reward_low > 0 && reward_high > reward_low)
+		reward = round(rand(reward_low, reward_high), 100)	
 	description = replacetext(description, "%DOCKNAME",current_map.dock_name)
 	description = replacetext(description, "%DOCKSHORT",current_map.dock_short)
 	description = replacetext(description, "%BOSSNAME",current_map.boss_name)

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -37,7 +37,9 @@
 
 /datum/export/large/reagent_dispenser/get_cost(obj/O)
 	var/obj/structure/reagent_dispensers/D = O
-	var/ratio = D.reagents.total_volume / D.reagents.maximum_volume
+	var/ratio
+	if(D?.reagents)
+		ratio = D.reagents.total_volume / D.reagents.maximum_volume
 
 	return ..() + round(contents_cost * ratio)
 

--- a/code/modules/cargo/random_stock/t1_common.dm
+++ b/code/modules/cargo/random_stock/t1_common.dm
@@ -528,9 +528,9 @@ STOCK_ITEM_COMMON(gasmask, 2)
 	new type(L)
 
 STOCK_ITEM_COMMON(mining, 2)
-	var/list/mine_items = list(/obj/item/shovel, /obj/item/pickaxe, /obj/item/clothing/glasses/material,
+	var/list/mine_items = list(/obj/item/shovel, /obj/item/clothing/glasses/material,
 				/obj/item/device/flashlight/lantern, /obj/item/mining_scanner, /obj/item/storage/box/excavation)
-	for(var/i in 1 to rand(1, 3))
+	for(var/i in 1 to rand(1, 2))
 		var/to_spawn = pick(mine_items)
 		new to_spawn(L)
 

--- a/code/modules/cargo/random_stock/t1_common.dm
+++ b/code/modules/cargo/random_stock/t1_common.dm
@@ -410,7 +410,7 @@ STOCK_ITEM_COMMON(bag, 3.5)
 		new type(L)
 
 STOCK_ITEM_COMMON(extinguish, 2.2)
-	for(var/i in 1 to rand(1, 3))
+	for(var/i in 1 to rand(1, 2))
 		var/type = pick( \
 			/obj/item/extinguisher, \
 			/obj/item/extinguisher/mini \
@@ -545,6 +545,11 @@ STOCK_ITEM_COMMON(custom_ka, 1)
 
 STOCK_ITEM_COMMON(towel, 1)
 	new /obj/item/towel(L)
+
+STOCK_ITEM_COMMON(camera, 1)
+	new /obj/item/device/camera(L)
+	if(prob(60))
+		new /obj/item/device/camera_film(L)
 
 STOCK_ITEM_COMMON(nothing, 0)
 	// do nothing

--- a/code/modules/cargo/random_stock/t2_uncommon.dm
+++ b/code/modules/cargo/random_stock/t2_uncommon.dm
@@ -330,7 +330,7 @@ STOCK_ITEM_UNCOMMON(randomhide, 0.5)
 	var/obj/item/stack/material/animalhide/spawn_hide = pick(typesof(/obj/item/stack/material/animalhide))
 	new spawn_hide(L, rand(5, 50))
 
-STOCK_ITEM_UNCOMMON(hoodie, 0.5)
+STOCK_ITEM_UNCOMMON(hoodie, 1)
 	new /obj/random/hoodie(L)
 
 STOCK_ITEM_UNCOMMON(bang, 0.5)
@@ -377,7 +377,21 @@ STOCK_ITEM_UNCOMMON(pops, 0.5)
 		new /obj/item/storage/box/snappops/syndi(L)
 
 STOCK_ITEM_UNCOMMON(collectable_headwear, 0.5)
-	var/type = pick(subtypesof(/obj/item/clothing/head/collectable/))
+	var/type = pick(subtypesof(/obj/item/clothing/head/collectable))
+	new type(L)
+
+STOCK_ITEM_UNCOMMON(pickaxes, 1)
+	var/list/pickaxe_type = list(
+		/obj/item/pickaxe = 10,
+		/obj/item/pickaxe/hammer = 1,
+		/obj/item/pickaxe/silver = 2,
+		/obj/item/pickaxe/drill = 5,
+		/obj/item/pickaxe/gold = 0.5,
+		/obj/item/pickaxe/diamond = 0.25,
+		/obj/item/pickaxe/brush = 1,
+		/obj/item/pickaxe/hand = 2
+		)
+	var/type = pickweight(pickaxe_type)
 	new type(L)
 
 STOCK_ITEM_UNCOMMON(alt_glasses, 1)

--- a/code/modules/cargo/random_stock/t2_uncommon.dm
+++ b/code/modules/cargo/random_stock/t2_uncommon.dm
@@ -171,9 +171,6 @@ STOCK_ITEM_UNCOMMON(MMI, 1.5)
 STOCK_ITEM_UNCOMMON(voidsuit, 2)
 	new /obj/random/voidsuit(L,1)
 
-STOCK_ITEM_UNCOMMON(nightvision, 2)
-	new /obj/item/clothing/glasses/night(L)
-
 STOCK_ITEM_UNCOMMON(violin, 2)
 	new /obj/item/device/violin(L)
 
@@ -274,8 +271,11 @@ STOCK_ITEM_UNCOMMON(manual, 2)
 	var/type = pick(booklist)
 	new type(L)
 
-STOCK_ITEM_UNCOMMON(jammer, 2)
-	new /obj/item/device/radiojammer(L)
+STOCK_ITEM_UNCOMMON(spystuff, 1)
+	if(prob(40))
+		new /obj/item/device/radiojammer(L)
+	else
+		new /obj/item/clothing/glasses/night(L)
 
 STOCK_ITEM_UNCOMMON(seeds, 1)
 	for(var/i in 1 to rand(1, 3))

--- a/code/modules/item_worth/reagents.dm
+++ b/code/modules/item_worth/reagents.dm
@@ -243,10 +243,10 @@
 /datum/reagent/alcohol/ethanol/bilk
 	value = 0.12
 
-/datum/reagent/alcohol/ethanol/black_russian
+/datum/reagent/alcohol/ethanol/blackrussian
 	value = 0.14
 
-/datum/reagent/alcohol/ethanol/bloody_mary
+/datum/reagent/alcohol/ethanol/bloodymary
 	value = 0.14
 
 /datum/reagent/alcohol/ethanol/booger
@@ -294,7 +294,7 @@
 /datum/reagent/alcohol/ethanol/erikasurprise
 	value = 0.16
 
-/datum/reagent/alcohol/ethanol/gargle_blaster
+/datum/reagent/alcohol/ethanol/gargleblaster
 	value = 0.21
 
 /datum/reagent/alcohol/ethanol/gintonic
@@ -303,7 +303,7 @@
 /datum/reagent/alcohol/ethanol/goldschlager
 	value = 0.2
 
-/datum/reagent/alcohol/ethanol/hippies_delight
+/datum/reagent/alcohol/ethanol/hippiesdelight
 	value = 0.12
 
 /datum/reagent/alcohol/ethanol/hooch

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -86,7 +86,7 @@ var/list/lunchables_alcohol_reagents_ = list(
 	/datum/reagent/alcohol/ethanol/atomicbomb,
 	/datum/reagent/alcohol/ethanol/beepsky_smash,
 	/datum/reagent/alcohol/ethanol/coffee,
-	/datum/reagent/alcohol/ethanol/hippies_delight,
+	/datum/reagent/alcohol/ethanol/hippiesdelight,
 	/datum/reagent/alcohol/ethanol/hooch,
 	/datum/reagent/alcohol/ethanol/thirteenloko,
 	/datum/reagent/alcohol/ethanol/manhattan_proj,

--- a/html/changelogs/doxxmedearly - bounties_rework.yml
+++ b/html/changelogs/doxxmedearly - bounties_rework.yml
@@ -1,0 +1,12 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added new cargo bounties."
+  - rscadd: "Adjusted cargo bounties. Reward amounts are semi-randomized, as is the number of required items for some bounties. The types of bounties that appear are more randomized."
+  - tweak: "Altered some bounty descriptions."
+  - tweak: "Any food that has bites taken out of it will no longer count for the related bounty."
+  - tweak: "More types of pies, muffins, and kabobs should now count for their respective bounties."
+  - tweak: "Further adjusted cargo warehouse spawns."
+  


### PR DESCRIPTION
  - rscadd: "Added new cargo bounties."
  - rscadd: "Adjusted cargo bounties. Reward amounts are semi-randomized, as is the number of required items for some bounties. The types of bounties that appear are more randomized."
  - tweak: "Altered some bounty descriptions."
  - tweak: "Any food that has bites taken out of it will no longer count for the related bounty."
  - tweak: "More types of pies, muffins, and kabobs should now count for their respective bounties."
  - tweak: "Further adjusted cargo warehouse spawns."

Alright there's a bit going on here.

New bounties- self explanatory. We need more variety, especially since the PR that (rightfully) weeded out most of the meme ones. This includes wholly new bounties, new reagent types, and even a few different sections- engineering in particular was left out by bounties.

Semi-randomization: Just to add a bit of variety, there's some randomization. Reward amounts are picked from a range, so it's not always just one flat amount. If a bounty requires multiple items (ie, 6 toolboxes), there's some randomization, too. Rewards will be adjusted by this; if you need to collect more than the required_count, the reward will increase. 

Also it was kind of super predictable that you'd ALWAYS have x types of bounties. I've only very slightly adjusted this to provide a bit more variety.

descriptions: self explanatory. 

food bounty stuff: self explanatory. i fucking hate food typepaths.

warehouse spawns: just some further adjustments after some in-round testing. NVGs and jammers were appearing far too frequently. fire extinguishers were spammed, and I added just a bit more variety.