### PR TITLE
Removes trailing whitespaces on chat messages

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -174,7 +174,7 @@ proc/get_radio_key_from_channel(var/channel)
 		else
 			message = copytext(message,3)
 
-	message = trim_left(message)
+	message = trim(message)
 
 	var/static/list/correct_punctuation = list("!" = TRUE, "." = TRUE, "?" = TRUE, "-" = TRUE, "~" = TRUE, "*" = TRUE, "/" = TRUE, ">" = TRUE, "\"" = TRUE, "'" = TRUE, "," = TRUE, ":" = TRUE, ";" = TRUE)
 	var/ending = copytext(message, length(message), (length(message) + 1))

--- a/html/changelogs/prevents_trailing_whitespace.yml
+++ b/html/changelogs/prevents_trailing_whitespace.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Trailing whitespaces on chat messages is now removed, preventing messages occuring with several whitespaces and then the automatically added period."


### PR DESCRIPTION
Fixes #9378

Prevents messages like:
`"Myazaki is awesome           "`

being printed like:
`"Myazaki is awesome           ."`

Instead:
`"Myazaki is awesome."`