### PR TITLE
Fixes the frame of guest pass consoles being invisible

### DIFF
--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -55,9 +55,10 @@
 	icon_state = "guestw"
 
 	light_color = LIGHT_COLOR_BLUE
+	icon_state = "altcomputerw"
 	icon_screen = "guest"
 	icon_scanline = "altcomputerw-scanline"
-	density = 0
+	density = FALSE
 
 	var/obj/item/card/id/giver
 	var/list/accesses = list()

--- a/html/changelogs/Ferner-200721-bugfix_guestpass.yml
+++ b/html/changelogs/Ferner-200721-bugfix_guestpass.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Fixed the guest pass console frame being invisible."


### PR DESCRIPTION
As it had no icon state assigned, only the screen was being rendered.