### PR TITLE
Robodoc Alt Title Removal

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -138,7 +138,6 @@
 
 	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
-	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer")
 
 	minimal_player_age = 7
 

--- a/html/changelogs/geeves-robodoc_alt_titles.yml
+++ b/html/changelogs/geeves-robodoc_alt_titles.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscdel: "Roboticist alt-titles have been removed. This doesn't affect their education or speciality, but they will be expected to be able to do a bit of everything."


### PR DESCRIPTION
* Roboticist alt-titles have been removed. This doesn't affect their education or speciality, but they will be expected to be able to do a bit of everything.

Roboticists don't have enough gameplay to have half of it removed when you pick an alt-title, so by removing it, we also remove the expectation of having to not know the other half of your job description.