### PR TITLE
Remote Chair Fix

### DIFF
--- a/code/game/objects/structures/vr/_remote_chair.dm
+++ b/code/game/objects/structures/vr/_remote_chair.dm
@@ -2,31 +2,31 @@
 	name = "virtual reality centre"
 	desc = "A comfortable chair with full audio-visual transposition centres."
 	icon_state = "shuttlechair_down"
-	var/portable = FALSE // can it be moved around 'n shit
 	var/portable_type
 	can_dismantle = FALSE
-	var/list/remote_network // Which network does this remote control belong to?
+	var/remote_network // Which network does this remote control belong to?
 
 /obj/structure/bed/chair/remote/Initialize()
 	. = ..()
-	if(portable && portable_type)
+	if(portable_type)
 		name = "portable [name]"
 
 /obj/structure/bed/chair/remote/examine(mob/user)
 	..()
-	if(portable && portable_type)
+	if(portable_type)
 		to_chat(user, FONT_SMALL(SPAN_NOTICE("Can be packed up by using a wrench on it.")))
 
 /obj/structure/bed/chair/remote/update_icon()
 	return
 
 /obj/structure/bed/chair/remote/attackby(obj/item/W, mob/user)
-	if(portable && portable_type && W.iswrench())
+	if(portable_type && W.iswrench())
 		user.visible_message(SPAN_NOTICE("\The [user] starts dismantling \the [src]..."), SPAN_NOTICE("You start dismantling \the [src]..."))
 		if(do_after(user, 20 SECONDS, TRUE, src))
 			user.visible_message(SPAN_NOTICE("\The [user] dismantles \the [src]."), SPAN_NOTICE("You dismantle \the [src]."))
 			var/obj/kit = new portable_type(get_turf(src))
 			user.put_in_hands(kit)
+			qdel(src)
 		return
 	..()
 

--- a/code/game/objects/structures/vr/mech_chair.dm
+++ b/code/game/objects/structures/vr/mech_chair.dm
@@ -10,7 +10,6 @@
 		SSvirtualreality.mech_selection(H, remote_network)
 
 /obj/structure/bed/chair/remote/mech/portable
-	portable = TRUE
 	portable_type = /obj/item/deployable_kit/remote_mech
 
 /obj/structure/bed/chair/remote/mech/prison
@@ -19,5 +18,4 @@
 	remote_network = "prisonmechs"
 
 /obj/structure/bed/chair/remote/mech/prison/portable
-	portable = TRUE
 	portable_type = /obj/item/deployable_kit/remote_mech/brig

--- a/html/changelogs/geeves-remote_chair_fix.yml
+++ b/html/changelogs/geeves-remote_chair_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Remote control chairs can no longer be duplicated via dismantlement."


### PR DESCRIPTION
* Remote control chairs can no longer be duplicated via dismantlement.