### PR TITLE
Makes passing arguments to elements work

### DIFF
--- a/code/__defines/dcs/signals.dm
+++ b/code/__defines/dcs/signals.dm
@@ -17,6 +17,11 @@
 /// just before a datum's Destroy() is called: (force), at this point none of the other components chose to interrupt qdel and Destroy will be called
 #define COMSIG_PARENT_QDELETING "parent_qdeleting"
 
+/// fires on the target datum when an element is attached to it (/datum/element)
+#define COMSIG_ELEMENT_ATTACH "element_attach"
+/// fires on the target datum when an element is attached to it  (/datum/element)
+#define COMSIG_ELEMENT_DETACH "element_detach"
+
 // /atom signals
 
 // /area signals

--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -21,11 +21,13 @@
 	SHOULD_CALL_PARENT(1)
 	if(type == /datum/element)
 		return ELEMENT_INCOMPATIBLE
+	SEND_SIGNAL(target, COMSIG_ELEMENT_ATTACH, src)
 	if(element_flags & ELEMENT_DETACH)
 		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/Detach, override = TRUE)
 
 /// Deactivates the functionality defines by the element on the given datum
 /datum/element/proc/Detach(datum/source, force)
+	SEND_SIGNAL(source, COMSIG_ELEMENT_DETACH, src)
 	SHOULD_CALL_PARENT(1)
 	UnregisterSignal(source, COMSIG_PARENT_QDELETING)
 
@@ -38,13 +40,16 @@
 //DATUM PROCS
 
 /// Finds the singleton for the element type given and attaches it to src
-/datum/proc/_AddElement(eletype, ...)
-	var/datum/element/ele = SSdcs.GetElement(eletype)
-	args[1] = src
-	if(ele.Attach(arglist(args)) == ELEMENT_INCOMPATIBLE)
-		CRASH("Incompatible [eletype] assigned to a [type]! args: [json_encode(args)]")
+/datum/proc/_AddElement(list/arguments)
+	var/datum/element/ele = SSdcs.GetElement(arguments)
+	arguments[1] = src
+	if(ele.Attach(arglist(arguments)) == ELEMENT_INCOMPATIBLE)
+		CRASH("Incompatible [arguments[1]] assigned to a [type]! args: [json_encode(args)]")
 
-/// Finds the singleton for the element type given and detaches it from src
-/datum/proc/_RemoveElement(eletype)
-	var/datum/element/ele = SSdcs.GetElement(eletype)
+/**
+  * Finds the singleton for the element type given and detaches it from src
+  * You only need additional arguments beyond the type if you're using [ELEMENT_BESPOKE]
+  */
+/datum/proc/_RemoveElement(list/arguments)
+	var/datum/element/ele = SSdcs.GetElement(arguments)
 	ele.Detach(src)

--- a/html/changelogs/makes_element_arguments_work.yml
+++ b/html/changelogs/makes_element_arguments_work.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - backend: "Passing arguments to elements will now work."


### PR DESCRIPTION
The components port #8890 only partially implemented a later tg PR [#49098](https://github.com/tgstation/tgstation/pull/49098) suggested by ninjanomnom [here](https://github.com/Aurorastation/Aurora.3/pull/8327#discussion_r382769261). Missing an important part that affected elements. The result of that was that it wasn't possible to pass any arguments other than the element datum to AddElement(). 

This PR adds the missing bit, which are the changes in the linked PR [here](https://github.com/tgstation/tgstation/pull/49098/files#diff-94d1e77e32e2c42fc25c57181b14e4e7) and makes passing arguments to elements work properly.

And another unrelated missing bit that doesn't affect anything (yet)