### PR TITLE
More intoxication adjustments

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -94,9 +94,9 @@
 #define INTOX_DEATH      0.45
 
 //How many units of intoxication to remove per second
-#define INTOX_FILTER_HEALTHY 0.35
-#define INTOX_FILTER_BRUISED 0.2
-#define INTOX_FILTER_DAMAGED 0.10
+#define INTOX_FILTER_HEALTHY 0.15
+#define INTOX_FILTER_BRUISED 0.10
+#define INTOX_FILTER_DAMAGED 0.05
 
 #define	BASE_DIZZY 50 //Base dizziness from getting drunk.
 #define DIZZY_ADD_SCALE 15 //Amount added for every 0.01 percent over the JUDGEIMP limit

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -147,7 +147,7 @@
 /datum/reagent/alcohol/affect_ingest(mob/living/carbon/M, alien, removed)
 
 	if(alien != IS_DIONA)
-		M.intoxication += (strength / 100) * removed * 3.15
+		M.intoxication += (strength / 100) * removed * 3.5
 
 		if (druggy != 0)
 			M.druggy = max(M.druggy, druggy)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -2591,7 +2591,7 @@
 	name = "Cork Popper"
 	description = "A fancy cocktail with a hint of lemon."
 	color = "#766818"
-	strength = "30"
+	strength = 30
 	taste_description = "sour and smokey"
 
 	glass_icon_state = "corkpopper"

--- a/html/changelogs/doxxmedearly - intoxic.yml
+++ b/html/changelogs/doxxmedearly - intoxic.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes: 
+  - tweak: "The liver is less effective as filtering alcohol, and drinks hit a little harder."


### PR DESCRIPTION
Liver's still too good at its job. It processes alcohol out far too quickly, even for our slightly sped up game pace. Low strength drinks will never get a person drunk.

INTOX_FILTER defines are only for booze processing. This has no bearing on toxins filtering. It ONLY affects the speed at which a mob loses intoxication.

The effects will be that a person stays drunk longer, and allows easier intoxication buildup so even low-strength drinks have a chance to intoxicate a person with enough booze.

Drink strength multiplier moved back to its original 3.5 (which I had lowered to 3.15 in a previous PR). 