### PR TITLE
Baby carp hide-hair

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -423,15 +423,15 @@ var/list/holder_mob_icon_cache = list()
 	icon_state = "babycarp"
 	item_state = "babycarp"
 	slot_flags = SLOT_HEAD
-	flags_inv = HIDEEARS|BLOCKHEADHAIR // carp wings blocks stuff - geeves
+	flags_inv = HIDEEARS
 	w_class = 1
 
-/obj/item/holder/carp/baby/verb/toggle_block_hair(mob/user)
+/obj/item/holder/carp/baby/verb/toggle_block_hair()
 	set name = "Toggle Hair Coverage"
 	set category = "Object"
 
 	flags_inv ^= BLOCKHEADHAIR
-	to_chat(user, SPAN_NOTICE("[src] will now [flags_inv & BLOCKHEADHAIR ? "hide" : "show"] hair."))
+	to_chat(usr, SPAN_NOTICE("\The [src] will now [flags_inv & BLOCKHEADHAIR ? "hide" : "show"] hair."))
 
 /obj/item/holder/borer
 	name = "cortical borer"

--- a/html/changelogs/doxxmedearly - babycarp-dodododododo.yml
+++ b/html/changelogs/doxxmedearly - babycarp-dodododododo.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes: 
+  - bugfix: "Toggling hide hair coverage on baby carp will no longer bring up a menu of mobs."
+  - tweak: "Baby carp no longer hide hair by default."


### PR DESCRIPTION
Toggle hair coverage on baby carp brought up a menu of all mobs in view. No longer does that.
Doesn't do it by default anymore. 