### PR TITLE
Deadman implant

### DIFF
--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -20,6 +20,12 @@
 	desc = "A box containing an explosive implant and implanter. Use the implant in-hand to set the explosion size and trigger phrase."
 	path = /obj/item/storage/box/syndie_kit/imp_explosive
 
+/datum/uplink_item/item/implants/imp_deadman
+	name = "Deadman Implant (DANGER!)"
+	item_cost = 8
+	desc = "A box containing an explosive implant and implanter. The implant monitors vitals and will detonate when the subject dies."
+	path = /obj/item/storage/box/syndie_kit/imp_deadman
+
 /datum/uplink_item/item/implants/imp_uplink
 	name = "Uplink Implant"
 	path = /obj/item/storage/box/syndie_kit/imp_uplink

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -166,7 +166,7 @@ Implant Specifics:<BR>"}
 
 /obj/item/implant/explosive/deadman/implanted(mob/source)
 	START_PROCESSING(SSprocessing, src)
-	return 1
+	return TRUE
 
 /obj/item/implant/explosive/deadman/emp_act(severity)
 	if(malfunction)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -203,8 +203,8 @@ Implant Specifics:<BR>"}
 	icon_state = "implant_evil"
 
 /obj/item/implant/explosive/Initialize()
+	. = ..()
 	if(uses_codewords)
-		. = ..()
 		phrase = "You are [pick(adjectives)]"
 
 /obj/item/implant/explosive/get_data()

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -149,7 +149,7 @@ Implant Specifics:<BR>"}
 		return
 	var/mob/M = imp_in
 
-	if(M.stat == 2)
+	if(M.stat == DEAD)
 		activate("death")
 
 /obj/item/implant/explosive/deadman/activate(var/cause)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -150,13 +150,11 @@ Implant Specifics:<BR>"}
 	var/mob/M = imp_in
 
 	if(M.stat == DEAD)
-		activate("death")
+		activate()
 
 /obj/item/implant/explosive/deadman/activate(var/cause)
-	switch(cause)
-		if("death")
-			small_countdown(src)
-			STOP_PROCESSING(SSprocessing, src)
+	small_countdown(src)
+	STOP_PROCESSING(SSprocessing, src)
 
 /obj/item/implant/explosive/deadman/small_boom()
 	if(imp_in)
@@ -188,9 +186,6 @@ Implant Specifics:<BR>"}
 				small_countdown()
 			else if (prob(30))
 				meltdown()
-
-/obj/item/implant/explosive/deadman/islegal()
-	return 0
 
 //BS12 Explosive
 /obj/item/implant/explosive

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -139,13 +139,13 @@
 	return
 
 
-/obj/item/implantcase/dexplosive
+/obj/item/implantcase/explosive/deadman
 	name = "glass case - 'explosive'"
 	desc = "A case containing an explosive."
 	icon_state = "implantcase-r"
 
-/obj/item/implantcase/dexplosive/New()
-	src.imp = new /obj/item/implant/dexplosive( src )
+/obj/item/implantcase/explosive/deadman/New()
+	src.imp = new /obj/item/implant/explosive/deadman( src )
 	..()
 	return
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -97,7 +97,12 @@
 
 /obj/item/storage/box/syndie_kit/imp_explosive
 	name = "box (E)"
-	starts_with = list(/obj/item/implanter = 1, /obj/item/implant/explosive = 1)
+	starts_with = list(/obj/item/implanter = 1, /obj/item/implant/explosive/ = 1)
+
+/obj/item/storage/box/syndie_kit/imp_deadman
+	name = "box (D)"
+	starts_with = list(/obj/item/implanter = 1, /obj/item/implant/explosive/deadman = 1)
+
 
 /obj/item/storage/box/syndie_kit/imp_uplink
 	name = "boxed uplink implant (with injector)"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -97,7 +97,7 @@
 
 /obj/item/storage/box/syndie_kit/imp_explosive
 	name = "box (E)"
-	starts_with = list(/obj/item/implanter = 1, /obj/item/implant/explosive/ = 1)
+	starts_with = list(/obj/item/implanter = 1, /obj/item/implant/explosive = 1)
 
 /obj/item/storage/box/syndie_kit/imp_deadman
 	name = "box (D)"

--- a/code/modules/cargo/bounties/engineer.dm
+++ b/code/modules/cargo/bounties/engineer.dm
@@ -135,7 +135,7 @@
 	reward_high = 5700
 	wanted_types = list(/obj/machinery/pipedispenser/disposal)
 
-	/datum/bounty/item/engineer/bookcase
+/datum/bounty/item/engineer/bookcase
 	name = "Bookcases"
 	description = "We're showing some love to one of the libraries on the %DOCKSHORT. A bonus will be paid to any station who has some skilled engineers build some for us."
 	reward_low = 6000

--- a/html/changelogs/houseofsynth - deadman implant.yml
+++ b/html/changelogs/houseofsynth - deadman implant.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added the "Deadman Implant" to the uplink. The implant costs 8 TC and will detonate when the implanted individual dies."
+  - rscadd: "Added the deadman implant to the uplink. The implant costs 8 TC and will detonate when the implanted individual dies."
 

--- a/html/changelogs/houseofsynth - deadman implant.yml
+++ b/html/changelogs/houseofsynth - deadman implant.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: House_Of_Synth
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added the "Deadman Implant" to the uplink. The implant costs 8 TC and will detonate when the implanted individual dies."
+


### PR DESCRIPTION
Fixes the old and unused "dexplosive" implant. Rebranded it as the Deadman implant which will detonate when the implanted mob dies. Includes interaction with EMPs and based on severity has a small chance to detonate and a larger chance to malfunction, rendering the implant useless. The implant can be found in the uplink for 8TC

Adds a uses_codewords var to the verbal explosive implant so that this implant any future implants can adopt the codeword system. Might be worth moving the codeword system to /implants/ to make this easier but that's a story for another PR.

Fixes an indentation error with a cargo bounty. Not sure what caused it, it just flagged up on the compiler so I fixed it. 