### PR TITLE
Fixes closing APCs.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -506,7 +506,7 @@
 						new /obj/item/module/power_control(loc)
 		else if (opened < COVER_REMOVED)
 			panel_open = FALSE
-			opened = COVER_OPENED
+			opened = COVER_CLOSED
 			update_icon()
 	else if (W.iscrowbar() && !((stat & BROKEN) || hacker) )
 		if(coverlocked && !(stat & MAINT))

--- a/html/changelogs/fixes_closing_apcs.yml
+++ b/html/changelogs/fixes_closing_apcs.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "APCs can be closed with a crowbar, again."


### PR DESCRIPTION
APCs can be closed with a crowbar again, when open and they have their cell present.