### PR TITLE
Blobs will now spawn in many more locations.

### DIFF
--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -8,7 +8,7 @@
 	level_seven_announcement()
 
 /datum/event/blob/start()
-	var/turf/T = pick_area_turf(/area/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
+	var/turf/T = pick_subarea_turf(/area/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
 	if(!T)
 		log_and_message_admins("Blob failed to find a viable turf.")
 		kill()

--- a/html/changelogs/blob_vine_random_spawn.yml
+++ b/html/changelogs/blob_vine_random_spawn.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "The blob event will now spawn in many different maintenance locations."


### PR DESCRIPTION
Fixes #8714 

`pick_area_turf` was always choosing from the same area. `pick_subarea_turf` will pick from all areas that are of the provided type that meet the conditions.