### PR TITLE
Simplifies hearing into handle_hearing()

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -314,6 +314,10 @@
 #define TASTE_DULL 0.5 //anything below 30%
 #define TASTE_NUMB 0.1 //anything below 150%
 
+//ear healing limit - past this ear_damage your ear will not recover its hearing over time
+#define HEARING_DAMAGE_LIMIT 100
+#define HEARING_DAMAGE_SLOW_HEAL 25
+
 //Used by emotes
 #define VISIBLE_MESSAGE 1
 #define AUDIBLE_MESSAGE 2

--- a/code/controllers/subsystems/explosives.dm
+++ b/code/controllers/subsystems/explosives.dm
@@ -341,7 +341,7 @@ var/datum/controller/subsystem/explosives/SSexplosives
 				continue
 
 		var/dist = get_dist(M, epicenter) || 1
-		if ((reception & EXPLFX_SOUND) && M.ear_deaf <= 0)
+		if ((reception & EXPLFX_SOUND) && !isdeaf(M))
 			if (dist <= close_dist)
 				M.playsound_simple(epicenter, explosion_sound, min(100, volume), use_random_freq = TRUE, falloff = 5)
 				//You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.

--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -57,73 +57,69 @@
 	activation_message="Your mind says 'Hello'."
 	mutation=mHallucination
 
-	New()
-		block=HALLUCINATIONBLOCK
+/datum/dna/gene/disability/hallucinate/New()
+	block=HALLUCINATIONBLOCK
 
 /datum/dna/gene/disability/epilepsy
 	name="Epilepsy"
 	activation_message="You get a headache."
 	disability=EPILEPSY
 
-	New()
-		block=HEADACHEBLOCK
+/datum/dna/gene/disability/epilepsy/New()
+	block=HEADACHEBLOCK
 
 /datum/dna/gene/disability/cough
 	name="Coughing"
 	activation_message="You start coughing."
 	disability=COUGHING
 
-	New()
-		block=COUGHBLOCK
+/datum/dna/gene/disability/cough/New()
+	block=COUGHBLOCK
 
 /datum/dna/gene/disability/clumsy
 	name="Clumsiness"
 	activation_message="You feel lightheaded."
 	mutation=CLUMSY
 
-	New()
-		block=CLUMSYBLOCK
+/datum/dna/gene/disability/clumsy/New()
+	block=CLUMSYBLOCK
 
 /datum/dna/gene/disability/tourettes
 	name="Tourettes"
 	activation_message="You twitch."
 	disability=TOURETTES
 
-	New()
-		block=TWITCHBLOCK
+/datum/dna/gene/disability/tourettes/New()
+	block=TWITCHBLOCK
 
 /datum/dna/gene/disability/stutter
 	name="Stuttering"
 	activation_message="You feel like forming words becomes increasingly difficult."
 	disability=STUTTERING
 
-	New()
-		block=STUTTERBLOCK
+/datum/dna/gene/disability/stutter/New()
+	block=STUTTERBLOCK
 
 /datum/dna/gene/disability/blindness
 	name="Blindness"
 	activation_message="You can't seem to see anything."
 	sdisability=BLIND
 
-	New()
-		block=BLINDBLOCK
+/datum/dna/gene/disability/blindness/New()
+	block=BLINDBLOCK
 
 /datum/dna/gene/disability/deaf
 	name="Deafness"
 	activation_message="It's kinda quiet."
 	sdisability=DEAF
 
-	New()
-		block=DEAFBLOCK
-
-	activate(var/mob/M, var/connected, var/flags)
-		..(M,connected,flags)
-		M.ear_deaf = 1
+/datum/dna/gene/disability/deaf/New()
+	block=DEAFBLOCK
 
 /datum/dna/gene/disability/nearsighted
 	name="Nearsightedness"
 	activation_message="Your eyes feel weird..."
 	disability=NEARSIGHTED
 
-	New()
-		block=GLASSESBLOCK
+/datum/dna/gene/disability/nearsighted/New()
+	block=GLASSESBLOCK

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -328,6 +328,6 @@
 		var/mob/M = A
 		var/turf/mobloc = get_turf(M)
 		if(mobloc && mobloc.z == T.z)
-			if(M.ear_deaf <= 0 || !M.ear_deaf)
+			if(!isdeaf(M))
 				M.playsound_simple(T, 'sound/effects/meteorimpact.ogg', range, use_random_freq = TRUE, use_pressure = FALSE)
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -31,14 +31,9 @@
 //This is a central proc that all emotes are run through. This handles sending the messages to living mobs
 /mob/proc/send_emote(var/message, var/type)
 	var/list/messageturfs = list()//List of turfs we broadcast to.
-	var/list/messagemobs = list() 
+	var/list/messagemobs = list()
 	var/list/ghosts = list()
 	var/list/ghosts_nearby = list()
-
-	var/hearing_aid = FALSE
-	if(type == 2 && ishuman(src))
-		var/mob/living/carbon/human/H = src
-		hearing_aid = H.has_hearing_aid()
 
 	for (var/turf in view(world.view, get_turf(src)))
 		messageturfs += turf
@@ -50,7 +45,7 @@
 			if (isobserver(M))
 				ghosts_nearby += M
 				continue
-			else if (isliving(M) && !(type == 2 && ((sdisabilities & DEAF) && !hearing_aid) || ear_deaf > 1))
+			else if (isliving(M) && !(type == 2 && isdeaf(M)))
 				messagemobs += M
 		else if(src.client)
 			if (M.stat == DEAD && (M.client.prefs.toggles & CHAT_GHOSTSIGHT))
@@ -62,6 +57,6 @@
 
 	for(var/mob/O in ghosts)
 		O.show_message("[ghost_follow_link(src, O)] [message]", type)
-	
+
 	for(var/mob/GN in ghosts_nearby)
 		GN.show_message("[ghost_follow_link(src, GN)] <b>[message]</b>", type)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -63,12 +63,7 @@
 		if((client.prefs.toggles & CHAT_GHOSTEARS) && (speaker in view(src)))
 			message = "<b>[message]</b>"
 
-	var/hearing_aid = FALSE
-	if(ishuman(src))
-		var/mob/living/carbon/human/H = src
-		hearing_aid = H.has_hearing_aid()
-
-	if(((sdisabilities & DEAF) && !hearing_aid) || ear_deaf > 1)
+	if(isdeaf(src))
 		if(!language || !(language.flags & INNATE)) // INNATE is the flag for audible-emote-language, so we don't want to show an "x talks but you cannot hear them" message if it's set
 			if(speaker == src)
 				to_chat(src, "<span class='warning'>You cannot hear yourself speak!</span>")
@@ -205,7 +200,7 @@
 		formatted = language.format_message_radio(message, verb)
 	else
 		formatted = "[verb], <span class=\"body\">\"[message]\"</span>"
-	if(sdisabilities & DEAF || ear_deaf)
+	if(isdeaf(src))
 		if(prob(20))
 			to_chat(src, "<span class='warning'>You feel your headset vibrate but can hear nothing from it!</span>")
 	else

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -773,17 +773,6 @@
 			if(!embedded_needs_process())
 				embedded_flag = 0
 
-		//Ears
-		if(sdisabilities & DEAF)	//disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
-		else if(ear_deaf)			//deafness, heals slowly over time
-			ear_deaf = max(ear_deaf-1, 0)
-		else if(istype(l_ear, /obj/item/clothing/ears/earmuffs) || istype(r_ear, /obj/item/clothing/ears/earmuffs))	//resting your ears with earmuffs heals ear damage faster
-			ear_damage = max(ear_damage-0.15, 0)
-			ear_deaf = max(ear_deaf, 1)
-		else if(ear_damage < 25)	//ear damage heals slowly under this threshold. otherwise you'll need earmuffs
-			ear_damage = max(ear_damage-0.05, 0)
-
 		//Resting
 		if(resting)
 			dizziness = max(0, dizziness - 15)
@@ -1293,6 +1282,20 @@
 
 	update_equipment_vision()
 	species.handle_vision(src)
+
+/mob/living/carbon/human/handle_hearing()
+	..()
+
+	if(ear_damage < HEARING_DAMAGE_LIMIT)
+		//Hearing aids allow our ear_deaf to reach zero, if we have a hearing disability
+		if(ear_deaf <= 1 && (sdisabilities & DEAF) && has_hearing_aid())
+			setEarDamage(-1, max(ear_deaf-1, 0))
+
+		if(istype(l_ear, /obj/item/clothing/ears/earmuffs) || istype(r_ear, /obj/item/clothing/ears/earmuffs))	//resting your ears with earmuffs heals ear damage faster
+			adjustEarDamage(-0.15, 0)
+			setEarDamage(-1, max(ear_deaf, 1))
+		else if(ear_damage < HEARING_DAMAGE_SLOW_HEAL)	//ear damage heals slowly under this threshold. otherwise you'll need earmuffs
+			adjustEarDamage(-0.05, 0)
 
 /mob/living/carbon/human/update_sight()
 	..()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -121,12 +121,8 @@
 		eye_blurry = max(eye_blurry-1, 0)
 
 	//Ears
-	if(sdisabilities & DEAF)		//disabled-deaf, doesn't get better on its own
-		setEarDamage(-1, max(ear_deaf, 1))
-	else
-		// deafness heals slowly over time, unless ear_damage is over 100
-		if(ear_damage < 100)
-			adjustEarDamage(-0.05,-1)
+	handle_hearing()
+
 	if((is_pacified()) && a_intent == I_HURT)
 		to_chat(src, "<span class='notice'>You don't feel like harming anybody.</span>")
 		a_intent_change(I_HELP)
@@ -174,6 +170,13 @@
 			reset_view(null)
 	else if(!client.adminobs)
 		reset_view(null)
+
+/mob/living/proc/handle_hearing()
+	// deafness heals slowly over time, unless ear_damage is over HEARING_DAMAGE_LIMIT
+	if(ear_damage < HEARING_DAMAGE_LIMIT)
+		adjustEarDamage(-0.05, -1)
+	if(sdisabilities & DEAF) //disabled-deaf, doesn't get better on its own
+		setEarDamage(-1, max(ear_deaf, 1))
 
 /mob/living/proc/update_sight()
 	if(stat == DEAD || eyeobj)

--- a/code/modules/mob/living/parasite/meme.dm
+++ b/code/modules/mob/living/parasite/meme.dm
@@ -390,7 +390,7 @@ var/controlling
 		M.show_message("<B>[host]</B> whispers something incoherent.",2) // 2 stands for hearable message
 
 	// Find out whether the target can hear
-	if(target.disabilities & 32 || target.ear_deaf)
+	if(target.disabilities & 32 || isdeaf(target))
 		to_chat(src, "<span class='warning'>Your target doesn't seem to hear you.</span>")
 		return
 
@@ -434,7 +434,7 @@ var/controlling
 		M.show_message("<B>[host]</B> screams something incoherent!",2) // 2 stands for hearable message
 
 	// Find out whether the target can hear
-	if(target.disabilities & 32 || target.ear_deaf)
+	if(target.disabilities & 32 || isdeaf(target))
 		to_chat(src, "<span class='warning'>Your target doesn't seem to hear you.</span>")
 		return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -89,7 +89,7 @@
 			else
 				msg = alt
 				type = alt_type
-		if (type & 2 && (sdisabilities & DEAF || ear_deaf))//Hearing related
+		if (type & 2 && isdeaf(src))//Hearing related
 			if (!( alt ))
 				return
 			else

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -155,7 +155,7 @@
 proc/isdeaf(A)
 	if(istype(A, /mob))
 		var/mob/M = A
-		return (M.sdisabilities & DEAF) || M.ear_deaf
+		return M.ear_deaf
 	return 0
 
 proc/iscuffed(A)

--- a/code/modules/psionics/events/mini_spasm.dm
+++ b/code/modules/psionics/events/mini_spasm.dm
@@ -25,7 +25,7 @@
 	for(var/obj/item/device/radio/radio in listening_objects)
 		if(radio.on)
 			for(var/mob/living/victim in range(radio.canhear_range, radio.loc))
-				if(isnull(victims[victim]) && victim.stat == CONSCIOUS && !victim.ear_deaf)
+				if(isnull(victims[victim]) && victim.stat == CONSCIOUS && !isdeaf(victim))
 					victims[victim] = radio
 	for(var/thing in victims)
 		var/mob/living/victim = thing

--- a/html/changelogs/hearing_aids.yml
+++ b/html/changelogs/hearing_aids.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Hearing aids should now allow deaf characters to hear holocomms, radios, etc."


### PR DESCRIPTION
Currently, hearing related stuff is handled in at least three places throughout Life(), and whether a mob is deaf or not is complicated - Handled by an `sdisabilities` flag, `has_hearing_aid()` and `ear_deaf`.

This change consolidates everything into `handle_hearing()`; whether a mob is deaf or not can be determined just by the value of `ear_deaf` using `isdeaf()`

Fixes #9310
Fixes #8490