### PR TITLE
Faithless mobs wail less, but always when they acquire a new target

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -42,8 +42,9 @@
 	return 1
 
 /mob/living/simple_animal/hostile/faithless/FindTarget()
+	var/my_target = target_mob
 	. = ..()
-	if(.)
+	if(. && (prob(30) || (. != my_target)))
 		audible_emote("wails at [.]")
 
 /mob/living/simple_animal/hostile/faithless/AttackingTarget()
@@ -52,7 +53,7 @@
 	if(istype(L))
 		if(prob(12))
 			L.Weaken(3)
-			L.visible_message("<span class='danger'>\the [src] knocks down \the [L]!</span>")
+			L.visible_message(SPAN_DANGER("\the [src] knocks down \the [L]!"))
 
 /mob/living/simple_animal/hostile/faithless/cult
 	faction = "cult"

--- a/html/changelogs/faithless_wail_spam.yml
+++ b/html/changelogs/faithless_wail_spam.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - tweak: "Faithless mobs will wail less often."


### PR DESCRIPTION
Fixes #9365

Can't reproduce the second part of the bug (which is actually the only bug part, so I'm not marking this as a bugfix). So I'm reducing the emote frequency.

It will now *always* wail when it acquires a new target, and will wail less when chasing the same target.
There's already a *lot* of chat spam due to their other emote and their attack text.