### PR TITLE
PDA message alerts don't appear for unconscious players

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1182,7 +1182,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	else
 		L = get(src, /mob/living/silicon)
 
-	if(L)
+	if(L && L.stat == CONSCIOUS)
 		if(reception_message)
 			to_chat(L, reception_message)
 		SSnanoui.update_user_uis(L, src) // Update the receiving user's PDA UI so that they can see the new message

--- a/html/changelogs/pda_message_alert_fix.yml
+++ b/html/changelogs/pda_message_alert_fix.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "PDA message alerts no longer appear for unconscious players."


### PR DESCRIPTION
Fixes #8826