### PR TITLE
Mortaphenyl bugfix

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -131,9 +131,9 @@
 
 /obj/item/reagent_containers/pill/mortaphenyl
 	name = "mortaphenyl pill"
-
-/obj/item/reagent_containers/pill/tramadol
-	name = "tramadol pill"
+	desc = "A mortaphenyl pill, it's a potent painkiller."
+	icon_state = "pill8"
+	reagents_to_add = list(/datum/reagent/mortaphenyl = 15)
 
 /obj/item/reagent_containers/pill/corophenidate
 	name = "corophenidate pill"

--- a/html/changelogs/mortaphenylbugfix.yml
+++ b/html/changelogs/mortaphenylbugfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Chada
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed a bug with mortaphenyl pills not having the mortaphenyl regent. Or any regent for that matter"


### PR DESCRIPTION
Just fixed a problem with mortaphenyl pills (The new tramadol) not having their regent in them. I wouldn't put it above NanoTrasen to supply placebos to medical tho.