### PR TITLE
Adds the chemistry codex to medical and research computers

### DIFF
--- a/code/modules/modular_computers/file_system/programs/app_presets.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets.dm
@@ -84,7 +84,8 @@
 		new /datum/computer_file/program/civilian/cargoorder(comp),
 		new /datum/computer_file/program/suit_sensors(comp),
 		new /datum/computer_file/program/records/medical(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/ntsl2_interpreter(comp),
+		new /datum/computer_file/program/chemistry_codex(comp)
 	)
 	return _prg_list
 
@@ -105,7 +106,8 @@
 		new /datum/computer_file/program/suit_sensors(comp),
 		new /datum/computer_file/program/records/employment(comp),
 		new /datum/computer_file/program/records/medical(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/ntsl2_interpreter(comp),
+		new /datum/computer_file/program/chemistry_codex(comp)
 	)
 	return _prg_list
 
@@ -125,7 +127,8 @@
 		new /datum/computer_file/program/civilian/cargoorder(comp),
 		new /datum/computer_file/program/ntnetmonitor(comp),
 		new /datum/computer_file/program/aidiag(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/ntsl2_interpreter(comp),
+		new /datum/computer_file/program/chemistry_codex(comp)
 	)
 	return _prg_list
 
@@ -146,7 +149,8 @@
 		new /datum/computer_file/program/ntnetmonitor(comp),
 		new /datum/computer_file/program/aidiag(comp),
 		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/ntsl2_interpreter(comp),
+		new /datum/computer_file/program/chemistry_codex(comp)
 	)
 	return _prg_list
 

--- a/html/changelogs/skull132-missing_codex.yml
+++ b/html/changelogs/skull132-missing_codex.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - tweak: "Added chemistry codex to the medical and research computer presets."


### PR DESCRIPTION
Labelled as bugfix because this not being done is an oversight of the original PR: the original PR is largely worthless without this.