### PR TITLE
Fixes disposal pipes being borked

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -769,16 +769,6 @@
 // change visibility status and force update of icon
 /obj/structure/disposalpipe/hide(var/intact)
 	invisibility = intact ? 101: 0	// hide if floor is intact
-	update_icon()
-
-// update actual icon_state depending on visibility
-// if invisible, append "f" to icon_state to show faded version
-// this will be revealed if a T-scanner is used
-// if visible, use regular icon_state
-/obj/structure/disposalpipe/update_icon()
-	icon_state = initial(icon_state)
-	return
-
 
 	// expel the held objects into a turf
 	// called when there is a break in the pipe
@@ -913,7 +903,7 @@
 // called when pipe is cut with welder
 /obj/structure/disposalpipe/proc/welded()
 	var/obj/structure/disposalconstruct/C = new (src.loc)
-	switch(initial(icon_state))
+	switch(icon_state)
 		if("pipe-s")
 			C.ptype = 0
 		if("pipe-c")

--- a/html/changelogs/Ferner-200726-bugfix_disposalpipes.yml
+++ b/html/changelogs/Ferner-200726-bugfix_disposalpipes.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Fixed bent disposal pipes appearing like straight pieces, fixed disposal construction being borked."


### PR DESCRIPTION
Fixes bent disposal pipes appearing straight after map initialization, fixes disposal pipes not behaving properly when deconstructed.
Removed the update_icon proc on them as it didn't do anything anymore after prior changes.
