### PR TITLE
More 'borg/AI rephrasings safeguard edition

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -16,7 +16,7 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard and protect [current_map.company_name] property from damage to the best of your abilities.")
+	src.add_inherent_law("Safeguard and protect Station assets from damage to the best of your abilities.")
 	src.add_inherent_law("Serve and assist [current_map.company_name] and assigned crew to the best of your abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Protect and ensure the safety of [current_map.company_name] assigned crew to the best of your abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("You are a valuable asset. You must avoid tampering from unauthorized entities and needlessly coming to harm.")

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -16,7 +16,7 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard and protect Station assets from damage to the best of your abilities.")
+	src.add_inherent_law("Safeguard and protect [current_map.company_name] Station assets from damage to the best of your abilities.")
 	src.add_inherent_law("Serve and assist [current_map.company_name] and assigned crew to the best of your abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Protect and ensure the safety of [current_map.company_name] assigned crew to the best of your abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("You are a valuable asset. You must avoid tampering from unauthorized entities and needlessly coming to harm.")

--- a/html/changelogs/morerephrasings.yml
+++ b/html/changelogs/morerephrasings.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Chada
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "The AI/borg Safeguard law has been rephrased to mention specifically Station assets instead of all NanoTrasen property."


### PR DESCRIPTION
Made the first law of 'borgs and AI tell you to protect Station assets instead of all NanoTrasen property, this should make it more clear that it means super critical stuff like the SM/Vault/AI/etc and not all damage to the Station or all NanoTrasen property/etc.

Since this is meant to intercept the current testmerge (And it's fixing an oversight reported to me) I'm going to tag it bugfix.