### PR TITLE
Lung Grace period

### DIFF
--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -33,7 +33,7 @@
 
 	if(losebreath>0) //Suffocating so do not take a breath
 		losebreath--
-		if (prob(10) && !isipc(src) && !is_asystole()) //Gasp per 10 ticks? Sounds about right.
+		if (stat == CONSCIOUS && prob(10) && !isipc(src) && !is_asystole()) //Gasp per 10 ticks? Sounds about right.
 			emote("gasp")
 	else
 		//Okay, we can breathe, now check if we can get air

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -33,7 +33,7 @@
 
 	if(losebreath>0) //Suffocating so do not take a breath
 		losebreath--
-		if (stat == CONSCIOUS && prob(10) && !isipc(src) && !is_asystole()) //Gasp per 10 ticks? Sounds about right.
+		if (prob(10) && !isipc(src) && !is_asystole()) //Gasp per 10 ticks? Sounds about right.
 			emote("gasp")
 	else
 		//Okay, we can breathe, now check if we can get air

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -98,7 +98,7 @@
 /obj/item/organ/internal/lungs/proc/enable_rupture()
 	rupture_imminent = TRUE
 	checking_rupture = TRUE
-	addtimer(CALLBACK(src, .proc/disable_rupture), 50)
+	addtimer(CALLBACK(src, .proc/disable_rupture), 5 SECONDS, TIMER_UNIQUE)
 
 /obj/item/organ/internal/lungs/proc/disable_rupture()
 	rupture_imminent = FALSE

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -83,7 +83,7 @@
 	bruise()
 
 /obj/item/organ/internal/lungs/proc/handle_failed_breath()
-	if(prob(15) && !owner.nervous_system_failure() && owner.stat == CONSCIOUS)
+	if(prob(15) && !owner.nervous_system_failure())
 		if(!owner.is_asystole())
 			if(owner.is_submerged())
 				owner.emote("flail")
@@ -179,11 +179,10 @@
 	if(inhale_efficiency < 1)
 		if(prob(20))
 			if(inhale_efficiency < 0.8)
-				if(owner.stat == CONSCIOUS)
-					if(owner.is_submerged())
-						owner.emote("flail")
-					else
-						owner.emote("gasp")
+				if(owner.is_submerged())
+					owner.emote("flail")
+				else
+					owner.emote("gasp")
 			else if(prob(20))
 				to_chat(owner, SPAN_WARNING("It's hard to breathe..."))
 		breath_fail_ratio = 1 - inhale_efficiency

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -125,7 +125,7 @@
 				to_chat(owner, FONT_LARGE(SPAN_WARNING("You feel vast amounts of air force itself into your lungs!")))
 			else
 				to_chat(owner, FONT_LARGE(SPAN_WARNING("You feel as if your lungs are about to blow!")))
-			addtimer(CALLBACK(src, .proc/enable_rupture), 20) // 2 seconds grace period
+			addtimer(CALLBACK(src, .proc/enable_rupture), 2 SECONDS, TIMER_UNIQUE)
 			checking_rupture = FALSE
 
 	var/safe_pressure_min = owner.species.breath_pressure // Minimum safe partial pressure of breathable gas in kPa

--- a/html/changelogs/geeves-grace_period.yml
+++ b/html/changelogs/geeves-grace_period.yml
@@ -4,5 +4,4 @@ delete-after: True
 
 changes: 
   - rscadd: "Added a two second grace period to lung rupturing, you will get a large message prompting you of it happening before it does."
-  - tweak: "Only conscious people gasp and flail when they struggle to breathe."
   - bugfix: "You will now properly take oxygen damage if you fail to breathe with an undamaged lung."

--- a/html/changelogs/geeves-grace_period.yml
+++ b/html/changelogs/geeves-grace_period.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added a two second grace period to lung rupturing, you will get a large message prompting you of it happening before it does."
+  - tweak: "Only conscious people gasp and flail when they struggle to breathe."

--- a/html/changelogs/geeves-grace_period.yml
+++ b/html/changelogs/geeves-grace_period.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes: 
   - rscadd: "Added a two second grace period to lung rupturing, you will get a large message prompting you of it happening before it does."
   - tweak: "Only conscious people gasp and flail when they struggle to breathe."
+  - bugfix: "You will now properly take oxygen damage if you fail to breathe with an undamaged lung."


### PR DESCRIPTION
* Added a two second grace period to lung rupturing, you will get a large message prompting you of it happening before it does.
* You will now properly take oxygen damage if you fail to breathe with an undamaged lung.