### PR TITLE
Lung Rescue Things

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -512,11 +512,14 @@
 		data["name"] = O.name
 		var/list/wounds = list()
 		data["damage"] = get_internal_damage(O)
-		if(istype(O, /obj/item/organ/internal/lungs) && H.is_lung_ruptured())
-			if(O.is_broken())
+		if(istype(O, /obj/item/organ/internal/lungs))
+			var/obj/item/organ/internal/lungs/L = O
+			if(L.is_broken())
 				wounds += get_broken_lung_desc()
-			else
+			else if(L.is_bruised())
 				wounds += get_collapsed_lung_desc()
+			if(L.rescued)
+				wounds += "Has a small puncture wound."
 
 		if(O.status & ORGAN_DEAD)
 			wounds += "Necrotic and decaying."

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -65,11 +65,17 @@
 			)
 			owner.losebreath = round(damage/2)
 
-	if(is_bruised() && rescued)
-		if(prob(4))
-			to_chat(owner, SPAN_WARNING("It feels hard to breathe..."))
-			if (owner.losebreath < 5)
-				owner.losebreath = min(owner.losebreath + 1, 5) // it's still not good, but it's much better than an untreated collapsed lung
+	if(rescued)
+		if(is_bruised())
+			if(prob(4))
+				to_chat(owner, SPAN_WARNING("It feels hard to breathe..."))
+				if (owner.losebreath < 5)
+					owner.losebreath = min(owner.losebreath + 1, 5) // it's still not good, but it's much better than an untreated collapsed lung
+		else
+			if(prob(2))
+				to_chat(owner, SPAN_WARNING("It feels hard to breathe, and something in your chest is whistling..."))
+				if (owner.losebreath < 2)
+					owner.losebreath = min(owner.losebreath + 1, 2)
 
 /obj/item/organ/internal/lungs/proc/rupture()
 	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
@@ -328,6 +334,8 @@
 	. = list()
 	if(is_bruised())
 		. += "[pick("wheezing", "gurgling")] sounds"
+	if(rescued)
+		. += "a whistling sound"
 
 	var/list/breathtype = list()
 	if(get_oxygen_deprivation() > 50)
@@ -340,6 +348,10 @@
 	. += "[english_list(breathtype)] breathing"
 
 	return english_list(.)
+
+/obj/item/organ/internal/lungs/surgical_fix(mob/user)
+	..()
+	rescued = FALSE
 
 #undef HUMAN_MAX_OXYLOSS
 #undef HUMAN_CRIT_MAX_OXYLOSS

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1189,6 +1189,10 @@
 	H.adjustOxyLoss(removed) //Every unit heals 1 oxy damage
 	H.add_chemical_effect(CE_PNEUMOTOXIC, -removed * 1.5)
 	H.add_chemical_effect(CE_PULSE, -1)
+
+	var/obj/item/organ/internal/lungs/L = H.internal_organs_by_name[BP_LUNGS]
+	L.rescued = FALSE
+
 	. = ..()
 
 /datum/reagent/pneumalin/overdose(var/mob/living/carbon/human/H, var/alien, var/removed)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -128,7 +128,7 @@
 			if(blocked > 20)
 				user.visible_message("<b>[user]</b> jabs \the [src] into [H], but their armor blocks it!", SPAN_WARNING("You jab \the [src] into [H], but their armor blocks it!"))
 				return
-			user.visible_message("<b>[user]</b> jabs \the [src] between [P] ribs with \the [src]!", SPAN_NOTICE("You jab \the [src] between [SM] ribs!"))
+			user.visible_message("<b>[user]</b> jabs \the [src] between [P] ribs!", SPAN_NOTICE("You jab \the [src] between [SM] ribs!"))
 			H.apply_damage(3, BRUTE, BP_CHEST)
 			H.custom_pain("The pain in your chest is living hell!", 75, affecting = H.organs_by_name[BP_CHEST])
 			var/obj/item/organ/internal/lungs/L = H.internal_organs_by_name[BP_LUNGS]

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -9,6 +9,7 @@
 /obj/item/reagent_containers/syringe
 	name = "syringe"
 	desc = "A syringe."
+	desc_info = "This tool can be used to reinflate a collapsed lung. To do this, activate grab intent, select the patient's chest, then click on them. It will hurt a lot, but it will buy time until surgery can be performed."
 	icon = 'icons/obj/syringe.dmi'
 	item_icons = list(
 		slot_l_hand_str = 'icons/mob/items/lefthand_medical.dmi',
@@ -120,17 +121,20 @@
 		if (check_zone(user.zone_sel.selecting) == BP_CHEST) // impromptu needle thoracostomy, re-inflate a collapsed lung
 			var/P = (user == target) ? "their" : (target.name + "\'s")
 			var/SM = (user == target) ? "your" : (target.name + "\'s")
-			user.visible_message(SPAN_DANGER("[user] aims \the [src] between [P] ribs!"), SPAN_DANGER("You aim \the [src] between [SM] ribs!"))
+			user.visible_message("<b>[user]</b> aims \the [src] between [P] ribs!", SPAN_NOTICE("You aim \the [src] between [SM] ribs!"))
 			if(!do_mob(user, target, 1.5 SECONDS))
 				return
-			user.visible_message(SPAN_WARNING("[user] jabs \the [src] between [P] ribs with \the [src]!"), SPAN_WARNING("You jab \the [src] between [SM] ribs!"))
-			if(H.is_lung_ruptured())
-				var/obj/item/organ/internal/lungs/L = H.internal_organs_by_name[BP_LUNGS]
-				if(!L.rescued)
-					L.rescued = TRUE
-				else
-					L.rescued = FALSE
-					L.take_damage(3)
+			var/blocked = H.getarmor_organ(H.organs_by_name[BP_CHEST], "melee")
+			if(blocked > 20)
+				user.visible_message("<b>[user]</b> jabs \the [src] into [H], but their armor blocks it!", SPAN_WARNING("You jab \the [src] into [H], but their armor blocks it!"))
+				return
+			user.visible_message("<b>[user]</b> jabs \the [src] between [P] ribs with \the [src]!", SPAN_NOTICE("You jab \the [src] between [SM] ribs!"))
+			H.apply_damage(3, BRUTE, BP_CHEST)
+			H.custom_pain("The pain in your chest is living hell!", 75, affecting = H.organs_by_name[BP_CHEST])
+			var/obj/item/organ/internal/lungs/L = H.internal_organs_by_name[BP_LUNGS]
+			if(!L)
+				return
+			L.rescued = TRUE
 			return
 
 	if(user.a_intent == I_HURT && ishuman(user))

--- a/html/changelogs/geeves-syringe_stuff.yml
+++ b/html/changelogs/geeves-syringe_stuff.yml
@@ -8,3 +8,4 @@ changes:
   - rscadd: "You can no longer rescue lungs through armor."
   - rscadd: "Rescuing someone's lung without giving them painkillers first will be very painful for them."
   - rscadd: "Added instructions on how to rescue lungs to the syringe extra info."
+  - tweak: "Rescued lungs can only be fixed by doing surgery on them."

--- a/html/changelogs/geeves-syringe_stuff.yml
+++ b/html/changelogs/geeves-syringe_stuff.yml
@@ -1,0 +1,10 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Having an uninjured but rescued (jabbed with a syringe to reinflate) lung will still suffocate you slowly, and give a unique message."
+  - rscadd: "Rescued lungs can now be diagnosed by stethoscopes and advanced bodyscanners."
+  - rscadd: "You can no longer rescue lungs through armor."
+  - rscadd: "Rescuing someone's lung without giving them painkillers first will be very painful for them."
+  - rscadd: "Added instructions on how to rescue lungs to the syringe extra info."


### PR DESCRIPTION
* Having an uninjured but rescued (jabbed with a syringe to reinflate) lung will still suffocate you slowly, and give a unique message.
* Rescued lungs can now be diagnosed by stethoscopes and advanced bodyscanners.
* You can no longer rescue lungs through armor.
* Rescuing someone's lung without giving them painkillers first will be very painful for them.
* Added instructions on how to rescue lungs to the syringe extra info.
* Rescued lungs can only be fixed by doing surgery on them, or using inhaling Pneumalin.