### PR TITLE
Cryopods no longer allow you to withdraw headsets from frozen crew

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -203,7 +203,9 @@ var/global/list/frozen_crew = list()
 		/obj/item/card/id,
 		/obj/item/modular_computer,
 		/obj/item/device/pda,
-		/obj/item/cartridge
+		/obj/item/cartridge,
+		/obj/item/device/radio/headset,
+		/obj/item/device/encryptionkey
 	)
 
 	//For subtypes of the blacklist that are allowed to be kept

--- a/html/changelogs/no_headsets_in_cryo.yml
+++ b/html/changelogs/no_headsets_in_cryo.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Cryopods no longer allow you to withdraw headsets from previously frozen crew."


### PR DESCRIPTION
Fixes #9478 

Forgot to blacklist these in #9349 