### PR TITLE
Fixes Hand Overlays

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -464,7 +464,7 @@
 	if(!removed_hand_overlay)
 		var/state = (hud.l_hand_hud_object == src) ? "l_hand_removed" : "r_hand_removed"
 		removed_hand_overlay = image("icon" = 'icons/mob/screen_gen.dmi', "icon_state" = state)
-	overlays.Cut()
+	cut_overlays()
 	if(hud.mymob && ishuman(hud.mymob))
 		var/mob/living/carbon/human/H = hud.mymob
 		var/obj/item/organ/external/O

--- a/html/changelogs/geeves-handcuff_fix.yml
+++ b/html/changelogs/geeves-handcuff_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Hand overlays, such as handcuffs and damaged or destroyed hands, should now update correctly."


### PR DESCRIPTION
* Hand overlays, such as handcuffs and damaged or destroyed hands, should now update correctly.

Fixes https://github.com/Aurorastation/Aurora.3/issues/9457