### PR TITLE
Pipe painters can be used on pipes that are not secured to the floor

### DIFF
--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -13,19 +13,23 @@
 		modes += "[C]"
 	mode = pick(modes)
 
-/obj/item/device/pipe_painter/afterattack(atom/A, mob/user as mob, proximity)
+/obj/item/device/pipe_painter/afterattack(var/atom/A, var/mob/user, proximity)
 	if(!proximity)
 		return
-
-	if(!istype(A,/obj/machinery/atmospherics/pipe) || istype(A,/obj/machinery/atmospherics/pipe/tank) || istype(A,/obj/machinery/atmospherics/pipe/vent) || istype(A,/obj/machinery/atmospherics/pipe/simple/heat_exchanging) || istype(A,/obj/machinery/atmospherics/pipe/simple/insulated) || !in_range(user, A))
+	if(!in_range(user, A))
 		return
-	var/obj/machinery/atmospherics/pipe/P = A
+	else if(is_type_in_list(A, list(/obj/machinery/atmospherics/pipe/tank, /obj/machinery/atmospherics/pipe/vent, /obj/machinery/atmospherics/pipe/simple/heat_exchanging, /obj/machinery/atmospherics/pipe/simple/insulated)))
+		return
+	else if(istype(A,/obj/machinery/atmospherics/pipe))
+		var/obj/machinery/atmospherics/pipe/P = A
+		P.change_color(pipe_colors[mode])
+	else if(istype(A, /obj/item/pipe) && pipe_color_check(pipe_colors[mode]))
+		var/obj/item/pipe/P = A
+		P.color = pipe_colors[mode]
 
-	P.change_color(pipe_colors[mode])
-
-/obj/item/device/pipe_painter/attack_self(mob/user as mob)
+/obj/item/device/pipe_painter/attack_self(var/mob/user)
 	mode = input("Which colour do you want to use?", "Pipe painter", mode) in modes
 
-/obj/item/device/pipe_painter/examine(mob/user)
+/obj/item/device/pipe_painter/examine(var/mob/user)
 	..(user)
 	to_chat(user, "It is in [mode] mode.")

--- a/html/changelogs/pipe_painter_paints_pipes.yml
+++ b/html/changelogs/pipe_painter_paints_pipes.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Pipe painters can now be used to paint regular pipes that are not secured."


### PR DESCRIPTION
In a continuing series of PRs inspired by 'stuff that annoys Myazaki while they play a maintenance drone'...

You can now recolour pipes before you secure them to the floor.