### PR TITLE
Fixes shells and shit having 300 health instead of 200

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -116,9 +116,8 @@ var/list/gamemode_cache = list()
 
 	//game_options.txt configs
 
-	var/health_threshold_softcrit = 0
-	var/health_threshold_crit = 0
-	var/health_threshold_dead = -100
+	var/health_threshold_softcrit = 50
+	var/health_threshold_dead = 0
 
 	var/organ_health_multiplier = 1
 	var/organ_regeneration_multiplier = 1
@@ -957,8 +956,6 @@ var/list/gamemode_cache = list()
 			value = text2num(value)
 
 			switch(name)
-				if("health_threshold_crit")
-					config.health_threshold_crit = value
 				if("health_threshold_softcrit")
 					config.health_threshold_softcrit = value
 				if("health_threshold_dead")

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -82,7 +82,6 @@
 /datum/species/machine/shell/handle_death(var/mob/living/carbon/human/H)
 	return
 
-
 /datum/species/machine/shell/rogue
 	name = "Rogue Shell"
 	short_name = "roguejak"

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -1,13 +1,10 @@
 ### HEALTH ###
 
 ## level of health at which a mob goes into continual shock (soft crit)
-HEALTH_THRESHOLD_SOFTCRIT 0
-
-## level of health at which a mob becomes unconscious (crit)
-HEALTH_THRESHOLD_CRIT -50
+HEALTH_THRESHOLD_SOFTCRIT 50
 
 ## level of health at which a mob becomes dead
-HEALTH_THRESHOLD_DEAD -100
+HEALTH_THRESHOLD_DEAD 0
 
 ## Determines whether bones can be broken through excessive damage to the organ
 ## 0 means bones can't break, 1 means they can

--- a/html/changelogs/mattatlas-fuckthisshit.yml
+++ b/html/changelogs/mattatlas-fuckthisshit.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Species that do not respect brainmed, excluding dionae and things like zombies that have less, should now have 200 health again."


### PR DESCRIPTION
So what's going on?

```
/mob/living/carbon/human/proc/get_total_health()
    var/amount = maxHealth - getFireLoss() - getBruteLoss() - getOxyLoss() - getToxLoss()
    return amount

/datum/species/machine/handle_death_check(var/mob/living/carbon/human/H)
    if(H.get_total_health() <= config.health_threshold_dead)
        return TRUE
```

This means that you need -100 health to die currently, which is 200 - 300 for most species, which means you need to do 300 damage, which is bullshit.