### PR TITLE
Factions may now have their own specific job blacklists for species + some blacklists

### DIFF
--- a/code/game/jobs/faction/eridani.dm
+++ b/code/game/jobs/faction/eridani.dm
@@ -54,7 +54,11 @@
 		"Corporate Liaison" = list(
 			"Tajara",
 			"M'sai Tajara",
-			"Zhan-Khazan Tajara"
+			"Zhan-Khazan Tajara",
+			"Diona",
+			"Vaurca Worker", 
+			"Vaurca Warrior",
+			"Unathi"
 		)
 	)
 

--- a/code/game/jobs/faction/eridani.dm
+++ b/code/game/jobs/faction/eridani.dm
@@ -50,6 +50,14 @@
 		"Corporate Liaison" = /datum/outfit/job/representative/eridani
 	)
 
+	job_species_blacklist = list(
+		"Corporate Liaison" = list(
+			"Tajara",
+			"M'sai Tajara",
+			"Zhan-Khazan Tajara"
+		)
+	)
+
 /datum/outfit/job/officer/eridani
 	name = "Security Officer - Eridani"
 	uniform = /obj/item/clothing/under/rank/security/eridani

--- a/code/game/jobs/faction/faction.dm
+++ b/code/game/jobs/faction/faction.dm
@@ -5,6 +5,7 @@
 
 	var/list/allowed_role_types
 	var/list/allowed_species_types
+	var/list/job_species_blacklist //will override the normal job species list for a member of this faction
 
 	var/is_default = FALSE
 
@@ -25,7 +26,10 @@
 	. = list()
 
 	for (var/path in allowed_role_types)
-		. += SSjobs.type_occupations[path]
+		var/datum/job/role = SSjobs.type_occupations[path]
+		if(LAZYACCESS(job_species_blacklist, role.title))
+			role.blacklisted_species = job_species_blacklist[role.title]
+		. += role
 
 /datum/faction/proc/get_selection_error(datum/preferences/prefs)
 	if (!length(allowed_species_types))

--- a/code/game/jobs/faction/hephaestus.dm
+++ b/code/game/jobs/faction/hephaestus.dm
@@ -70,9 +70,8 @@
 
 	job_species_blacklist = list(
 		"Corporate Liaison" = list(
-			"Tajara",
-			"M'sai Tajara",
-			"Zhan-Khazan Tajara"
+			"Vaurca Worker", 
+			"Vaurca Warrior"
 		)
 	)
 

--- a/code/game/jobs/faction/hephaestus.dm
+++ b/code/game/jobs/faction/hephaestus.dm
@@ -68,6 +68,14 @@
 		"Corporate Liaison" = /datum/outfit/job/representative/hephaestus
 	)
 
+	job_species_blacklist = list(
+		"Corporate Liaison" = list(
+			"Tajara",
+			"M'sai Tajara",
+			"Zhan-Khazan Tajara"
+		)
+	)
+
 /datum/outfit/job/engineer/hephaestus
 	name = "Station Engineer - Hephaestus"
 	uniform = /obj/item/clothing/under/rank/hephaestus

--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -67,7 +67,10 @@
 		"Corporate Liaison" = list(
 			"Tajara",
 			"M'sai Tajara",
-			"Zhan-Khazan Tajara"
+			"Zhan-Khazan Tajara",
+			"Unathi",
+			"Vaurca Worker", 
+			"Vaurca Warrior"
 		)
 	)
 

--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -63,6 +63,14 @@
 		"Corporate Liaison" = /datum/outfit/job/representative/idris
 	)
 
+	job_species_blacklist = list(
+		"Corporate Liaison" = list(
+			"Tajara",
+			"M'sai Tajara",
+			"Zhan-Khazan Tajara"
+		)
+	)
+
 /datum/outfit/job/officer/idris
 	name = "Security Officer - Idris"
 	uniform = /obj/item/clothing/under/rank/security/idris

--- a/code/game/jobs/faction/nanotrasen.dm
+++ b/code/game/jobs/faction/nanotrasen.dm
@@ -5,6 +5,14 @@
 
 	is_default = TRUE
 
+	job_species_blacklist = list(
+		"Corporate Liaison" = list(
+			"Diona",
+			"Vaurca Worker", 
+			"Vaurca Warrior",
+		)
+	)
+
 /datum/faction/nano_trasen/New()
 	..()
 

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -57,7 +57,11 @@
 			"Xion Industrial Frame",
 			"Zeng-Hu Mobility Frame",
 			"Bishop Accessory Frame",
-			"Shell Frame"
+			"Shell Frame",
+			"Unathi",
+			"Tajara",
+			"M'sai Tajara",
+			"Zhan-Khazan Tajara"
 		)
 	)
 

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -9,9 +9,6 @@
 	Dominia, and are at the forefront of weapons development technology.
 	</p>
 
-	<p><font size='5' color='red'><b> DO NOT PLAY AN IPC AS A ZAVODSKOI LIAISON, THIS IS UNINTENDED. JOINING AS ONE WILL RESULT IN AN IPC/HEAD WHITELIST STRIP.</b></font>
-	</p>
-
 	<p>Some character examples are:
 	<ul>
 	<li><b>Surgical Specialist</b>: Unit to unit Zavodskoi ships the most firearms and weapons compared
@@ -50,6 +47,18 @@
 		/datum/species/unathi,
 		/datum/species/diona,
 		/datum/species/machine
+	)
+
+	job_species_blacklist = list(
+		"Corporate Liaison" = list(
+			"Baseline Frame",
+			"Hephaestus G1 Industrial Frame",
+			"Hephaestus G2 Industrial Frame",
+			"Xion Industrial Frame",
+			"Zeng-Hu Mobility Frame",
+			"Bishop Accessory Frame",
+			"Shell Frame"
+		)
 	)
 
 	titles_to_loadout = list(

--- a/code/game/jobs/faction/zeng_hu.dm
+++ b/code/game/jobs/faction/zeng_hu.dm
@@ -68,6 +68,17 @@
 		"Corporate Liaison" = /datum/outfit/job/representative/zeng_hu
 	)
 
+	job_species_blacklist = list(
+		"Corporate Liaison" = list(
+			"Unathi",
+			"Tajara",
+			"M'sai Tajara",
+			"Zhan-Khazan Tajara",
+			"Vaurca Worker", 
+			"Vaurca Warrior"
+		)
+	)
+
 /datum/outfit/job/doctor/zeng_hu
 	name = "Physician - Zeng-Hu"
 	uniform = /obj/item/clothing/under/rank/zeng

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -18,8 +18,6 @@
 	outfit = /datum/outfit/job/representative
 	alt_titles = list("Consular Officer")
 
-	blacklisted_species = list("M'sai Tajara", "Zhan-Khazan Tajara")
-
 /datum/job/representative/get_outfit(mob/living/carbon/human/H, alt_title = null)
 	if(H.mind?.role_alt_title == "Consular Officer" || alt_title == "Consular Officer")
 		var/datum/citizenship/citizenship = SSrecords.citizenships[H.citizenship]

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -1,4 +1,4 @@
-
+var/const/NUM_JOB_DEPTS     = 3 //ENGSEC, MEDSCI and CIVILIAN
 var/const/ENGSEC			=(1<<0)
 
 var/const/CAPTAIN			=(1<<0)

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -283,10 +283,20 @@
 /datum/category_item/player_setup_item/occupation/proc/sanitize_faction()
 	if (!SSjobs.name_factions[pref.faction])
 		pref.faction = SSjobs.default_faction.name
-
-		to_client_chat("<span class='danger'>Your faction selection has been reset to [pref.faction].</span>")
-		to_client_chat("<span class='danger'>Your jobs have been reset due to this!</span>")
+		to_client_chat(SPAN_DANGER("Your faction selection has been reset to [pref.faction]."))
+		to_client_chat(SPAN_DANGER("Your jobs have been reset due to this!"))
 		ResetJobs()
+		return TOPIC_REFRESH_UPDATE_PREVIEW
+
+	var/datum/faction/faction = SSjobs.name_factions[pref.faction]
+	for(var/datum/job/job in faction.get_occupations())
+		for(var/department = 1 to NUM_JOB_DEPTS)
+			if(pref.GetJobDepartment(job, department) & job.flag)
+				if(pref.species in job.blacklisted_species)
+					to_client_chat(SPAN_DANGER("Your faction selection does not permit this species-occupation combination, [pref.species] as [job.title]."))
+					to_client_chat(SPAN_DANGER("Your jobs have been reset due to this!"))
+					ResetJobs()
+					return TOPIC_REFRESH_UPDATE_PREVIEW
 
 /datum/category_item/player_setup_item/occupation/proc/SetPlayerAltTitle(datum/job/job, new_title)
 	// remove existing entry

--- a/html/changelogs/paradoxspace-t1000.yml
+++ b/html/changelogs/paradoxspace-t1000.yml
@@ -3,5 +3,4 @@ author: ParadoxSpace & mikomyazaki
 delete-after: True
 
 changes: 
-  - rscadd: "IPCs can now be Zavodskoi Interstellar contractors. However, they cannot be corp reps."
-  - rscadd: "Tajara can only be NT/Independent corp reps."
+  - tweak: "Corp. Liason species blacklists have been updated for NT, EPMC, Hephaestus, Idris, Zavodskoi, Zeng-Hu."

--- a/html/changelogs/paradoxspace-t1000.yml
+++ b/html/changelogs/paradoxspace-t1000.yml
@@ -1,0 +1,7 @@
+author: ParadoxSpace & mikomyazaki
+
+delete-after: True
+
+changes: 
+  - rscadd: "IPCs can now be Zavodskoi Interstellar contractors. However, they cannot be corp reps."
+  - rscadd: "Tajara can only be NT/Independent corp reps."


### PR DESCRIPTION
Resubmitting #8334 which was reverted, with corrections.

Need to get someone to check if the blacklists I took from that PR are still correct.

Issue with previous PR was that it was resetting player jobs if ANY job was banned from that species. And so since all xenos are banned from Captain, when the player would try to be NanoTransen it would reset their jobs.