### PR TITLE
Are ya feelin' the scarcity now, supply?

### DIFF
--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -30,14 +30,6 @@
 	random_count = 1
 	wanted_types = list(/obj/item/reagent_containers/glass/beaker/noreact)
 
-/datum/bounty/item/science/posibrain
-	name = "Posibrain"
-	description = "Due to a sudden spike in accidents management has decided to replace some of the staff with borgs. Ship us 2 posibrains."
-	reward_low = 8000
-	reward_high = 8500
-	required_count = 2
-	wanted_types = list(/obj/item/device/mmi/digital/posibrain)
-
 /datum/bounty/item/science/borgbody
 	name = "Robot Endoskeleton"
 	description = "The %DOCKSHORT has decided to rely more on cyborgs for dangerous tasks. Ship us a fully assembled robot endoskeletons without a mmi/posibrain inside of it."

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -18,3 +18,44 @@
 		claimed = TRUE
 		for(var/i = 0; i < reward; ++i)
 			SScargo.try_add_bounty(SScargo.random_bounty())
+
+//during phoron scarcity lore arc. remove when lore permits. 
+//reward_low and reward_high are set to half of the target amount since they will always be marked high priority.
+
+/datum/bounty/item/phoron_sheet
+	name = "Phoron Sheets"
+	description = "Always prioritize this bounty. Failure to meet this quota may result in adverse impact upon your status in the NanoTrasen Corporation."
+	reward_low = 8000
+	reward_high = 9000
+	required_count = 150
+	random_count = 25
+	wanted_types = list(/obj/item/stack/material/phoron)
+	high_priority = TRUE
+
+/datum/bounty/item/phoron_sheet/New()
+	..()
+	required_count = round(required_count, 10)
+
+/datum/bounty/item/phoron_canister
+	name = "Phoron Canisters"
+	description = "Always prioritize this bounty. Failure to meet this quota may result in adverse impact upon your status in the NanoTrasen Corporation. Tanks must be filled to at least standard stock amounts."
+	reward_low = 7500
+	reward_high = 8500
+	required_count = 4
+	random_count = 1 // 3 to 5
+	wanted_types = list(/obj/machinery/portable_atmospherics/canister)
+	high_priority = TRUE	
+	var/moles_required = 1800 //Roundstart total_moles is about 1871 per tank. This is a small leeway.
+
+/datum/bounty/item/phoron_canister/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	if(!istype(O, /obj/machinery/portable_atmospherics/canister))
+		return FALSE
+
+	var/obj/machinery/portable_atmospherics/canister/C = O
+	var/datum/gas_mixture/environment = C.return_air()
+	if(!environment || !C.air_contents.gas["phoron"])
+		return FALSE
+
+	return C.air_contents.gas["phoron"] >= moles_required

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -26,7 +26,7 @@
 	description = "Always prioritize this bounty. Failure to meet this quota may result in adverse impact upon your status in the NanoTrasen Corporation."
 	reward_low = 14000
 	reward_high = 18000
-	required_count = 150
+	required_count = 125
 	random_count = 25
 	wanted_types = list(/obj/item/stack/material/phoron)
 	high_priority = TRUE

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -20,13 +20,12 @@
 			SScargo.try_add_bounty(SScargo.random_bounty())
 
 //during phoron scarcity lore arc. remove when lore permits. 
-//reward_low and reward_high are set to half of the target amount since they will always be marked high priority.
 
 /datum/bounty/item/phoron_sheet
 	name = "Phoron Sheets"
 	description = "Always prioritize this bounty. Failure to meet this quota may result in adverse impact upon your status in the NanoTrasen Corporation."
-	reward_low = 8000
-	reward_high = 9000
+	reward_low = 14000
+	reward_high = 18000
 	required_count = 150
 	random_count = 25
 	wanted_types = list(/obj/item/stack/material/phoron)
@@ -35,27 +34,33 @@
 /datum/bounty/item/phoron_sheet/New()
 	..()
 	required_count = round(required_count, 10)
+	//Temporarily overwrite the normal price randomization because the random_count is so high. There would be absolutely nuts price fluctuation. It's a temporary bounty anyway.
+	reward = round(rand(reward_low, reward_high), 100)
+
+/datum/bounty/item/phoron_sheet/ship(var/obj/item/stack/material/phoron/O)
+	if(!applies_to(O))
+		return
+	shipped_count += O.amount
 
 /datum/bounty/item/phoron_canister
 	name = "Phoron Canisters"
-	description = "Always prioritize this bounty. Failure to meet this quota may result in adverse impact upon your status in the NanoTrasen Corporation. Tanks must be filled to at least standard stock amounts."
-	reward_low = 7500
-	reward_high = 8500
+	description = "Always prioritize this bounty. Failure to meet this quota may result in adverse impact upon your status in the NanoTrasen Corporation. Canisters must be filled to at least standard stock amounts."
+	reward_low = 15000
+	reward_high = 18000
 	required_count = 4
 	random_count = 1 // 3 to 5
 	wanted_types = list(/obj/machinery/portable_atmospherics/canister)
 	high_priority = TRUE	
 	var/moles_required = 1800 //Roundstart total_moles is about 1871 per tank. This is a small leeway.
 
-/datum/bounty/item/phoron_canister/applies_to(obj/O)
+/datum/bounty/item/phoron_canister/applies_to(var/obj/machinery/portable_atmospherics/canister/O)
 	if(!..())
 		return FALSE
-	if(!istype(O, /obj/machinery/portable_atmospherics/canister))
+	if(!istype(O))
 		return FALSE
 
-	var/obj/machinery/portable_atmospherics/canister/C = O
-	var/datum/gas_mixture/environment = C.return_air()
-	if(!environment || !C.air_contents.gas["phoron"])
+	var/datum/gas_mixture/environment = O.return_air()
+	if(!environment || !O.air_contents.gas["phoron"])
 		return FALSE
 
-	return C.air_contents.gas["phoron"] >= moles_required
+	return O.air_contents.gas["phoron"] >= moles_required

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -166,6 +166,7 @@
 
 // Called lazily at startup to populate bounties_list with random bounties.
 /datum/controller/subsystem/cargo/proc/setupBounties()
+
 	for(var/i = 0; i < BOUNTY_NUM_HIGH; i++)
 		CHECK_TICK
 		var/datum/bounty/subtype = pick(subtypesof(/datum/bounty/item/assistant))
@@ -209,12 +210,15 @@
 	var/datum/bounty/r_subtype = pick(subtypesof(/datum/bounty/reagent))
 	try_add_bounty(new r_subtype)
 
-	var/datum/bounty/B = pick(bounties_list)
-	B.mark_high_priority()
+	//phoron arc bounties. remove when arc is done.
+	var/datum/bounty/item/phoron_bounty = pick(/datum/bounty/item/phoron_sheet, /datum/bounty/item/phoron_canister)
+	try_add_bounty(new phoron_bounty)
+
+	//uncomment the below two lines when phoron scarcity arc is done
+	//var/datum/bounty/B = pick(bounties_list)
+	//B.mark_high_priority()
 
 	// Generate these last so they can't be high priority.
-	//try_add_bounty(new /datum/bounty/item/alien_organs)
-	//try_add_bounty(new /datum/bounty/item/syndicate_documents)
 	try_add_bounty(new /datum/bounty/more_bounties)
 
 /datum/controller/subsystem/cargo/proc/completed_bounty_count()

--- a/code/modules/cargo/random_stock/t2_uncommon.dm
+++ b/code/modules/cargo/random_stock/t2_uncommon.dm
@@ -14,8 +14,8 @@ STOCK_ITEM_UNCOMMON(plasteel, 3)
 STOCK_ITEM_UNCOMMON(silver, 2)
 	new /obj/item/stack/material/silver(L, rand(5,30))
 
-STOCK_ITEM_UNCOMMON(phoronsheets, 2)
-	new /obj/item/stack/material/phoron(L, rand(5,50))
+STOCK_ITEM_UNCOMMON(phoronsheets, 1.5)
+	new /obj/item/stack/material/phoron(L, rand(5,40))
 
 STOCK_ITEM_UNCOMMON(phoronglass, 2)
 	new /obj/item/stack/material/glass/phoronglass(L, 50)

--- a/html/changelogs/doxxmedearly - phoron_arc.yml
+++ b/html/changelogs/doxxmedearly - phoron_arc.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added phoron bounties. These will always be marked as the high priority bounties."
+  - rscdel: "Removed the positronic brain bounty."


### PR DESCRIPTION
Adds two bounties for phoron: sheets and canisters. These will always be the high priority marked bounties. 
Also lowers phoron sheet spawn rate and amount in warehouse (intentionally undocumented).
The bounties and spawn rates are pretty minor for now. Will probably amp both up as the arc continues.

Removed posibrain bounty since it was causing issues shipping the shuttle and with it being a thing ghosts can inhabit, it's probably best to just scrap this one. 