### PR TITLE
Tesla Engine Emitter Cables Fix

### DIFF
--- a/html/changelogs/furrycactus - tesla emitter bugfix.yml
+++ b/html/changelogs/furrycactus - tesla emitter bugfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed the cables under the Tesla Engine emitters not working properly."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -26658,15 +26658,16 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2";
-	dir = 8;
-	d2 = 4
-	},
 /obj/machinery/power/emitter{
 	anchored = 1;
 	dir = 4;
 	state = 2
+	},
+/obj/structure/cable/yellow{
+	d1 = 0;
+	d2 = 8;
+	dir = 2;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/outpost/engineering/power)


### PR DESCRIPTION
Fixed the cables underneath the western emitters in the Tesla Engine not properly powering them.