### PR TITLE
Capitalizes item names for cargo programs for consistency

### DIFF
--- a/html/changelogs/example - Copy.yml
+++ b/html/changelogs/example - Copy.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - tweak: "Item names in the Cargo-related computer programs will now be consistently capitalized."

--- a/nano/templates/cargo_control.tmpl
+++ b/nano/templates/cargo_control.tmpl
@@ -280,7 +280,7 @@
     {{props data.bounties}}
         {{if value.high_priority}}
             <tr style={{:value.background}}>
-                <td><b>{{:value.name}}</b></td>
+                <td style="text-transform:capitalize;"><b>{{:value.name}}</b></td>
                 <td><b>High Priority: {{:value.description}}</b></td>
                 <td><b>{{:value.reward_string}}</b></td>
                 <td>{{:value.completion_string}}</td>
@@ -294,7 +294,7 @@
             </tr>
         {{else}}
             <tr style={{:value.background}}>
-                <td>{{:value.name}}</td>
+                <td style="text-transform:capitalize;">{{:value.name}}</td>
                 <td>{{:value.description}}</td>
                 <td>{{:value.reward_string}}</td>
                 <td>{{:value.completion_string}}</td>
@@ -397,7 +397,7 @@
         </tr>
     {{props data.order_details.items}}
 		<tr>
-			<td>{{:value.name}}</td>
+			<td style="text-transform:capitalize;">{{:value.name}}</td>
             <td>{{:value.supplier_name}}</td>
             <td>{{:value.price}}</td>
 		</tr>

--- a/nano/templates/cargo_delivery.tmpl
+++ b/nano/templates/cargo_delivery.tmpl
@@ -102,7 +102,7 @@
         </tr>
     {{props data.order_details.items}}
 		<tr>
-			<td>{{:value.name}}</td>
+			<td style="text-transform:capitalize;">{{:value.name}}</td>
             <td>{{:value.supplier_name}}</td>
             <td>{{:value.price}}</td>
 		</tr>
@@ -159,7 +159,7 @@
         </tr>
     {{props data.order_details.items}}
 		<tr>
-			<td>{{:value.name}}</td>
+			<td style="text-transform:capitalize;">{{:value.name}}</td>
             <td>{{:value.supplier_name}}</td>
             <td>{{:value.price}}</td>
 		</tr>

--- a/nano/templates/cargo_order.tmpl
+++ b/nano/templates/cargo_order.tmpl
@@ -51,7 +51,7 @@
 		<table>
 		{{for data.category_items}}
 			<tr>
-				<td><b>{{:value.name}}</b></td>
+				<td style="text-transform:capitalize;"><b>{{:value.name}}</b></td>
 			</tr>
 			<tr>
 				<td><i>{{:value.description}}</i></td>
@@ -83,7 +83,7 @@
         </tr>
     {{props data.order_items}}
 		<tr>
-			<td>{{:value.name}}</td>
+			<td style="text-transform:capitalize;">{{:value.name}}</td>
             <td>{{:value.supplier_name}}</td>
             <td>{{:value.price}}</td>
 			<td>{{:helper.link('Delete', 'close', {'remove_item' : value.item_id}, null)}}</td>


### PR DESCRIPTION
Scrolling through the cargo orders list looks kind of messy due to capitalization inconsistency. Items now have their first letter in each word capitalized.