### PR TITLE
Can now build all types of flooring without them existing first

### DIFF
--- a/code/game/gamemodes/cult/cultify/turf.dm
+++ b/code/game/gamemodes/cult/cultify/turf.dm
@@ -44,7 +44,7 @@
 		pixel_y = 0
 		if(istype(src,/turf/simulated/floor))
 			var/turf/simulated/floor/F = src
-			F.set_flooring(get_flooring_data(/decl/flooring/reinforced/cult))
+			F.set_flooring(decls_repository.get_decl(/decl/flooring/reinforced/cult))
 
 /turf/proc/cultify_wall()
 	ChangeTurf(/turf/unsimulated/wall/cult)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -434,7 +434,7 @@ var/bomb_set
 
 /obj/machinery/nuclearbomb/station/LateInitialize()
 	for(var/turf/simulated/floor/T in RANGE_TURFS(1, src))
-		T.set_flooring(get_flooring_data(/decl/flooring/reinforced/circuit/red))
+		T.set_flooring(decls_repository.get_decl(/decl/flooring/reinforced/circuit/red))
 		flash_tiles += T
 	update_icon()
 

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -1,12 +1,3 @@
-var/list/flooring_types
-
-/proc/get_flooring_data(var/flooring_path)
-	if(!flooring_types)
-		flooring_types = list()
-	if(!flooring_types["[flooring_path]"])
-		flooring_types["[flooring_path]"] = new flooring_path
-	return flooring_types["[flooring_path]"]
-
 // State values:
 // [icon_base]: initial base icon_state without edges or corners.
 // if has_base_range is set, append 0-has_base_range ie.

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -25,7 +25,7 @@
 	if(!floortype && initial_flooring)
 		floortype = initial_flooring
 	if(floortype)
-		set_flooring(get_flooring_data(floortype), mapload)
+		set_flooring(decls_repository.get_decl(floortype), mapload)
 
 /turf/simulated/floor/proc/set_flooring(decl/flooring/newflooring, mapload)
 	if (!mapload)

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -53,8 +53,9 @@
 				return
 			var/obj/item/stack/S = C
 			var/decl/flooring/use_flooring
-			for(var/flooring_type in flooring_types)
-				var/decl/flooring/F = flooring_types[flooring_type]
+			var/list/decls = decls_repository.get_decls_of_subtype(/decl/flooring)
+			for(var/flooring_type in decls)
+				var/decl/flooring/F = decls[flooring_type]
 				if(!F.build_type)
 					continue
 				if(ispath(S.type, F.build_type) || ispath(S.build_type, F.build_type))

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -249,7 +249,7 @@
 			visible_message("<span class='notice'>[src] begins to improve the floor.</span>")
 			if(do_after(src, 50))
 				if(!F.flooring)
-					F.set_flooring(get_flooring_data(floor_build_type))
+					F.set_flooring(decls_repository.get_decl(floor_build_type))
 					addTiles(-1)
 			target = null
 			repairing = 0

--- a/html/changelogs/impossible_floors.yml
+++ b/html/changelogs/impossible_floors.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "It is now possible to build many types of flooring that were previously bugged, including diamond, some carpet styles, silver, gold and uranium."


### PR DESCRIPTION
Fixes #9541
Fixes #5734
Fixes #5498

Diamond turf lighting issue was due to turf editing without ChangeTurf() being called to preserve lighting. Idk how they managed that. Does not happen when building diamond floors using this fix.

Was only possible to construct previously existing (i.e. mapped) turfs due to caching system. Changing to use decl repository fixes this.