### PR TITLE
Labourer's Choice cigarette packet doesn't go invisible when opened

### DIFF
--- a/code/game/objects/items/tajara.dm
+++ b/code/game/objects/items/tajara.dm
@@ -8,6 +8,10 @@
 	cigarette_to_spawn = /obj/item/clothing/mask/smokable/cigarette/adhomai
 	can_hold = list(/obj/item/clothing/mask/smokable/cigarette, /obj/item/flame/lighter, /obj/item/trash/cigbutt, /obj/item/tajcard)
 
+/obj/item/storage/box/fancy/cigarettes/pra/update_icon()
+	var/card_count = instances_of_type_in_list(new /obj/item/tajcard, src.contents) //having cards in here doesn't count for icon
+	icon_state = "[initial(icon_state)][contents.len - card_count]"
+
 /obj/item/storage/box/fancy/cigarettes/pra/fill()
 	..()
 	new /obj/item/tajcard(src)

--- a/html/changelogs/labourers_choice.yml
+++ b/html/changelogs/labourers_choice.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Labourer's Choice cigarette packet will no longer go invisible after being opened."


### PR DESCRIPTION
Fixes #9549 

Taj card was throwing off the count to determine icon state.