### PR TITLE
Restores 'Print Logout Report' verb for R_MOD

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -427,6 +427,7 @@ var/list/admin_verbs_mod = list(
 	/datum/admins/proc/paralyze_mob,
 	/client/proc/toggleattacklogs,
 	/client/proc/cmd_admin_check_contents,
+	/client/proc/print_logout_report,
 	/client/proc/check_ai_laws,			/*shows AI and borg laws*/
 	/client/proc/aooc,
 	/client/proc/toggle_aooc

--- a/html/changelogs/restore_print_logout_report.yml
+++ b/html/changelogs/restore_print_logout_report.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - admin: "Restores the 'Print Logout Report' for anyone with the R_MOD permission."


### PR DESCRIPTION
Was accidentally removed by #8979 

Fixes #9039