### PR TITLE
Adds a unit test that checks for invalid origin techs

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2794,6 +2794,7 @@
 #include "code\unit_tests\object_tests.dm"
 #include "code\unit_tests\observation_tests.dm"
 #include "code\unit_tests\overmap_tests.dm"
+#include "code\unit_tests\research_tests.dm"
 #include "code\unit_tests\spawner_tests.dm"
 #include "code\unit_tests\sql_tests.dm"
 #include "code\unit_tests\ss_test.dm"

--- a/code/__defines/research.dm
+++ b/code/__defines/research.dm
@@ -12,6 +12,8 @@
 #define TECH_ILLEGAL "syndicate"
 #define TECH_ARCANE "arcane"
 
+#define ALL_ORIGIN_TECHS list(TECH_MATERIAL, TECH_ENGINEERING, TECH_PHORON, TECH_POWER, TECH_BLUESPACE, TECH_BIO, TECH_COMBAT, TECH_MAGNET, TECH_DATA, TECH_ILLEGAL, TECH_ARCANE)
+
 #define IMPRINTER	0x1	//For circuits. Uses glass/chemicals.
 #define PROTOLATHE	0x2	//New stuff. Uses glass/metal/chemicals
 #define MECHFAB		0x4	//Mechfab

--- a/code/unit_tests/research_tests.dm
+++ b/code/unit_tests/research_tests.dm
@@ -1,0 +1,36 @@
+// SSresearch related unit tests
+/datum/unit_test/research
+	name = "RESEARCH template"
+	async = 0
+
+/datum/unit_test/research/check_origin_tech_valid
+	name = "RESEARCH: All origin techs shall be valid"
+
+/datum/unit_test/research/check_origin_tech_valid/start_test()
+	var/list/obj/objects = subtypesof(/obj)
+	var/failed_count = 0
+
+	for(var/object in objects)
+		var/obj/O = new object
+		if(isnull(O.origin_tech))
+			continue
+		if(!islist(O.origin_tech))
+			testing("[O] has a non-list origin-tech [O.origin_tech]")
+			log_unit_test("[ascii_red]--------------- [O] has a non-list origin-tech [O.origin_tech].")
+			failed_count++
+			continue
+		for(var/tech in O.origin_tech)
+			if(!(tech in ALL_ORIGIN_TECHS))
+				log_unit_test("[ascii_red]--------------- [O] has invalid origin_tech - [tech].")
+				failed_count++
+			if(!isnum(O.origin_tech[tech]))
+				log_unit_test("[ascii_red]--------------- [O] has invalid origin_tech value - [tech] = [O.origin_tech[tech]].")
+				failed_count++
+
+	testing("Checked [length(objects)] objects and found [failed_count] problems")
+	if(failed_count)
+		fail("[failed_count] invalid origin_tech\s found.")
+	else
+		pass("All objs have valid origin_tech.")
+
+	return TRUE

--- a/html/changelogs/unit_test_origin_techs.yml
+++ b/html/changelogs/unit_test_origin_techs.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Adding a Subspace Wavelength Analyzer to the Destructive Analyzer will no longer break the RnD computer. "


### PR DESCRIPTION
Fixes current problem where the subspace wavelength doodad makes the RnD computer inoperable when put in the destructive analyzer due to having TECH_MAGNETS instead of TECH_MAGNET.