### PR TITLE
AI no longer call atom/proc/AltClick twice on AltClicks

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -108,7 +108,6 @@
 /mob/living/silicon/ai/AltClickOn(var/atom/A)
 	if(!control_disabled && A.AIAltClick(src))
 		return
-	..()
 
 /mob/living/silicon/ai/MiddleClickOn(var/atom/A)
 	if(!control_disabled && A.AIMiddleClick(src))

--- a/html/changelogs/ai_alt_click.yml
+++ b/html/changelogs/ai_alt_click.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "AI can now properly alt-click on objects to open the stat panel list of things on that turf without it immediately closing."


### PR DESCRIPTION
AI no longer call atom/proc/AltClick twice on AltClicks, instantly closing the stat panel turf objects list they just opened. This made it appear as if they could not open the turf examine stat panel thingy.

Fixes #8907