### PR TITLE
Adds equip procs to syndie commando, asset protection and ert

### DIFF
--- a/code/game/antagonist/outsider/commando.dm
+++ b/code/game/antagonist/outsider/commando.dm
@@ -19,3 +19,23 @@ var/datum/antagonist/deathsquad/mercenary/commandos
 /datum/antagonist/deathsquad/mercenary/New()
 	..(1)
 	commandos = src
+
+/datum/antagonist/deathsquad/mercenary/equip(var/mob/living/carbon/human/player)
+	if(!..())
+		return FALSE
+
+	for (var/obj/item/I in player)
+		if (istype(I, /obj/item/implant))
+			continue
+		player.drop_from_inventory(I)
+		if(I.loc != player)
+			qdel(I)
+
+	player.preEquipOutfit(/datum/outfit/admin/deathsquad/syndicate, FALSE)
+	player.equipOutfit(/datum/outfit/admin/deathsquad/syndicate, FALSE)
+	player.force_update_limbs()
+	player.update_eyes()
+	player.regenerate_icons()
+
+	give_codewords(player)
+	return TRUE

--- a/code/game/antagonist/outsider/deathsquad.dm
+++ b/code/game/antagonist/outsider/deathsquad.dm
@@ -28,3 +28,22 @@ var/datum/antagonist/deathsquad/deathsquad
 /datum/antagonist/deathsquad/attempt_spawn()
 	if(..())
 		deployed = TRUE
+
+/datum/antagonist/deathsquad/equip(var/mob/living/carbon/human/player)
+	if(!..())
+		return FALSE
+
+	for (var/obj/item/I in player)
+		if (istype(I, /obj/item/implant))
+			continue
+		player.drop_from_inventory(I)
+		if(I.loc != player)
+			qdel(I)
+
+	player.preEquipOutfit(/datum/outfit/admin/deathsquad, FALSE)
+	player.equipOutfit(/datum/outfit/admin/deathsquad, FALSE)
+	player.force_update_limbs()
+	player.update_eyes()
+	player.regenerate_icons()
+
+	return TRUE

--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -20,3 +20,22 @@ var/datum/antagonist/ert/ert
 /datum/antagonist/ert/New()
 	..()
 	ert = src
+
+/datum/antagonist/ert/equip(var/mob/living/carbon/human/player)
+	if(!..())
+		return FALSE
+
+	for (var/obj/item/I in player)
+		if (istype(I, /obj/item/implant))
+			continue
+		player.drop_from_inventory(I)
+		if(I.loc != player)
+			qdel(I)
+
+	player.preEquipOutfit(/datum/outfit/admin/ert/nanotrasen, FALSE)
+	player.equipOutfit(/datum/outfit/admin/ert/nanotrasen, FALSE)
+	player.force_update_limbs()
+	player.update_eyes()
+	player.regenerate_icons()
+
+	return TRUE

--- a/html/changelogs/not_a_stripper.yml
+++ b/html/changelogs/not_a_stripper.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - admin: "Syndicate Commando, Asset Protection Specialist and ERT now equip the player properly when assigned via the traitor panel."


### PR DESCRIPTION
Fixes #8875 

These roles don't become naked now, when assigned via traitor panel. 

Idk which ert outfit to use. So I just went with the NT one.  