### PR TITLE
Airlock safety first

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -987,7 +987,10 @@ About the new airlock wires panel:
 			else if(!activate && !density)
 				close()
 		if("safeties")
-			set_safeties(!activate, 1)
+			if(safe && issilicon(usr) && !player_is_antag(usr.mind))
+				to_chat(usr, SPAN_WARNING("Your programming prevents you from disabling the door safeties."))
+			else
+				set_safeties(!activate, 1)
 		if("timing")
 			// Door speed control
 			if(src.isWireCut(AIRLOCK_WIRE_SPEED))

--- a/html/changelogs/doxxmedearly - synth_safety.yml
+++ b/html/changelogs/doxxmedearly - synth_safety.yml
@@ -1,6 +1,6 @@
-author: ChangeMe
+author: Doxxmedearly
 
 delete-after: True
 
 changes: 
-  - tweak: "AI and stationbounds can no longer disable airlock safeties. They can re-enable them if they are off and the wire isn't cut."
+  - tweak: "Non-traitor AI and stationbounds can no longer disable airlock safeties. They can re-enable them if they are off and the wire isn't cut."

--- a/html/changelogs/doxxmedearly - synth_safety.yml
+++ b/html/changelogs/doxxmedearly - synth_safety.yml
@@ -1,0 +1,6 @@
+author: ChangeMe
+
+delete-after: True
+
+changes: 
+  - tweak: "AI and stationbounds can no longer disable airlock safeties. They can re-enable them if they are off and the wire isn't cut."

--- a/vueui/src/components/view/misc/doors.vue
+++ b/vueui/src/components/view/misc/doors.vue
@@ -76,7 +76,8 @@ export default {
           n: 'Safeties',
           et: 'Nominal',
           dt: 'Overridden',
-          d: true
+          d: true,
+          a: true
         },
         timing: {
           n: 'Timing',


### PR DESCRIPTION
Non-traitor stationbounds and AIs can no longer disable airlock safeties. They can re-enable them. 
-They have no reason to make a door less safe.
-We already removed door bolts to prevent them from validing antags. This prevents them from force-closing doors on them. 