### PR TITLE
Gibber Quality of Life

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -233,6 +233,6 @@
 				qdel(thing)
 				continue
 			thing.forceMove(get_turf(thing)) // Drop it onto the turf for throwing.
-			thing.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(0,3),emagged ? 100 : 50) // Being pelted with bits of meat and bone would hurt.
+			thing.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(1,3),emagged ? 100 : 50) // Being pelted with bits of meat and bone would hurt.
 
 		update_icon()

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -233,6 +233,6 @@
 				qdel(thing)
 				continue
 			thing.forceMove(get_turf(thing)) // Drop it onto the turf for throwing.
-			thing.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(1,3),emagged ? 100 : 50) // Being pelted with bits of meat and bone would hurt.
+			thing.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(1,3),emagged ? 50 : 10) // Being pelted with bits of meat and bone would hurt.
 
 		update_icon()

--- a/html/changelogs/Crosarius-GibberQOL.yml
+++ b/html/changelogs/Crosarius-GibberQOL.yml
@@ -1,0 +1,11 @@
+# Your name.  
+author: Crosarius
+
+delete-after: True
+
+changes: 
+  - maptweak: "Moved the gibber to a more convenient position and added in safety windows, as well as floor markings to make it more obvious that you shouldn't stand infront of it."
+  - maptweak: "Re-arranged the kitchen slightly. Removed one of the redundant meat spikes."
+  - tweak: "Gibber no longer throws meat with force comparable to being hit by a train. It will still seriously injure you though, and when emagged will mortally wound you."
+  - tweak: "Gibber no longer throws meat onto itself."
+

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -59965,12 +59965,11 @@
 "eqx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/material/ashtray/bronze,
+/obj/item/trash/cigbutt,
+/obj/item/trash/cigbutt,
+/obj/structure/table/steel,
+/obj/item/material/ashtray,
 /obj/random/loot,
-/obj/structure/table/standard,
-/obj/item/trash/cigbutt,
-/obj/item/trash/cigbutt,
-/obj/item/trash/cigbutt,
 /turf/simulated/floor/tiled/old_white,
 /area/maintenance/bar)
 "erq" = (

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -50380,23 +50380,23 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bPe" = (
-/obj/structure/table/stone/marble,
-/obj/item/material/hook,
-/obj/item/material/hatchet/butch,
 /obj/machinery/firealarm/west,
+/obj/structure/table/stone/marble,
+/obj/item/material/hatchet/butch,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
 	},
 /area/crew_quarters/kitchen/freezer)
 "bPf" = (
-/obj/structure/table/stone/marble,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1";
 	name = "adjusted light fixture";
 	pixel_x = -16
 	},
+/obj/structure/table/stone/marble,
+/obj/item/material/hook,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -50916,13 +50916,14 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bQA" = (
-/obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable/green,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/door/window/southleft,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -51139,7 +51140,12 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bRg" = (
-/obj/structure/kitchenspike,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'STAND CLEAR'.";
+	name = "\improper CAUTION: STAND CLEAR";
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -59525,8 +59531,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "dgV" = (
-/obj/structure/bed/chair,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/kitchenspike,
 /turf/simulated/floor/tiled/old_white,
 /area/maintenance/bar)
 "dhL" = (
@@ -59699,7 +59705,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "dBV" = (
-/obj/structure/closet/crate/freezer,
+/obj/structure/window/reinforced{
+	layer = 5;
+	name = "adjusted reinforced window"
+	},
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -59953,13 +59962,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
 "eqx" = (
-/obj/structure/table/steel,
-/obj/item/trash/cigbutt,
-/obj/item/trash/cigbutt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/material/ashtray,
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/random/loot,
+/obj/structure/kitchenspike,
 /turf/simulated/floor/tiled/old_white,
 /area/maintenance/bar)
 "erq" = (
@@ -60443,9 +60448,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "fBZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -61407,7 +61413,9 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "hND" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -61735,7 +61743,7 @@
 /turf/simulated/floor/tiled/old_white,
 /area/maintenance/medbay)
 "iCN" = (
-/obj/machinery/gibber,
+/obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -66517,6 +66525,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/atmos_control)
+"tLL" = (
+/obj/machinery/gibber,
+/obj/machinery/door/window/eastleft,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer{
+	name = "cold storage tiles";
+	temperature = 278
+	},
+/area/crew_quarters/kitchen/freezer)
 "tPt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced/polarized{
@@ -66562,6 +66581,7 @@
 	pixel_x = 26;
 	req_access = list(28)
 	},
+/obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -101880,7 +101900,7 @@ bPf
 kgr
 meJ
 dBV
-bRg
+tLL
 jPX
 yfB
 bSx

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -59532,7 +59532,7 @@
 /area/maintenance/cargo)
 "dgV" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/kitchenspike,
+/obj/structure/bed/chair,
 /turf/simulated/floor/tiled/old_white,
 /area/maintenance/bar)
 "dhL" = (
@@ -59709,6 +59709,7 @@
 	layer = 5;
 	name = "adjusted reinforced window"
 	},
+/obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -59964,7 +59965,12 @@
 "eqx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/kitchenspike,
+/obj/item/material/ashtray/bronze,
+/obj/random/loot,
+/obj/structure/table/standard,
+/obj/item/trash/cigbutt,
+/obj/item/trash/cigbutt,
+/obj/item/trash/cigbutt,
 /turf/simulated/floor/tiled/old_white,
 /area/maintenance/bar)
 "erq" = (
@@ -61743,7 +61749,7 @@
 /turf/simulated/floor/tiled/old_white,
 /area/maintenance/medbay)
 "iCN" = (
-/obj/structure/closet/crate/freezer,
+/obj/structure/kitchenspike,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278


### PR DESCRIPTION
Moved the gibber to a more convenient position and added in safety windows, as well as floor markings to make it more obvious that you shouldn't stand in-front of it. The kitchen was re-arranged slightly to accommodate, and one of the redundant meat spikes was removed.

Before
![image](https://user-images.githubusercontent.com/30341877/89116233-f235f880-d4d4-11ea-901e-85a4a4c84e8c.png)

After
![image](https://user-images.githubusercontent.com/30341877/89116224-d3cffd00-d4d4-11ea-87a3-11e32c210867.png)


Changes have been made to the gibber's throw-range so that it won't throw meat onto itself. Furthermore, I have reduced the speed at which the gibber throws its meat by a factor of five, as it was massively overtuned.

Previously a non-emagged gibber would do this if you stood in-front of it: 
![image](https://user-images.githubusercontent.com/30341877/89116150-3248ab80-d4d4-11ea-8937-de91376e7ec0.png)
![image](https://user-images.githubusercontent.com/30341877/89116155-3aa0e680-d4d4-11ea-8f4c-57a3da3e317d.png)

An e-magged gibber was twice as much, and when I tested it it threw meat so hard that it severed my internal thoracic artery.
![image](https://user-images.githubusercontent.com/30341877/89116169-5f955980-d4d4-11ea-9a60-240c0c3c1377.png)
![image](https://user-images.githubusercontent.com/30341877/89116191-90758e80-d4d4-11ea-9efa-e518536517aa.png)


The values that it has tuned down to will deal roughly 80 brute to you and mess you up pretty bad normally, and when emagged will do as much damage as the non-emagged version **used** to do.