### PR TITLE
Makes antagonist candidate searching work better for multi-modes

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -723,6 +723,11 @@
 
 	values += value
 
+/proc/list_keys(var/list/L) // Return a list of keys in a list
+	. = list()
+	for(var/e in L)
+		. += e
+
 // Return a list of the values in an assoc list (including null)
 /proc/list_values(var/list/L)
 	. = list()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -240,11 +240,14 @@ var/global/list/additional_antag_types = list()
 		for(var/datum/antagonist/antag in antag_templates)
 			antag.candidates = list_keys(valid_templates_per_candidate) & antag.candidates // orders antag.candidates by valid_templates_per_candidate
 		
+		var/datum/antagonist/last_template = antag_templates[antag_templates.len]
+		last_template.candidates = shuffle(last_template.candidates)
 
 	for(var/datum/antagonist/antag in antag_templates)
 		//antag roles that replace jobs need to be assigned before the job controller hands out jobs.
 		if(antag.flags & ANTAG_OVERRIDE_JOB)
 			antag.attempt_spawn() //select antags to be spawned
+		antag.candidates = shuffle(antag.candidates) // makes selection past initial_spawn_req fairer
 
 ///post_setup()
 /datum/game_mode/proc/post_setup()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -218,6 +218,30 @@ var/global/list/additional_antag_types = list()
 		antag.update_initial_spawn_target()
 		antag.build_candidate_list() //compile a list of all eligible candidates
 
+	if(length(antag_templates) > 1) // If we have multiple templates to satisfy, we must pick candidates who satisfy fewer templates first, and fill the template with fewest candidates first
+		var/list/template_candidates = list()
+		var/list/all_candidates = list() // All candidates for every template, may contain duplicates
+		var/list/antag_templates_by_initial_spawn_req = list()
+
+		for(var/datum/antagonist/antag in antag_templates)
+			template_candidates[antag.id] = length(antag.candidates)
+			all_candidates += antag.candidates
+			antag_templates_by_initial_spawn_req[antag] = antag.initial_spawn_req
+
+		sortTim(antag_templates_by_initial_spawn_req, /proc/cmp_numeric_asc, TRUE)
+		antag_templates = list_keys(antag_templates_by_initial_spawn_req)
+
+		var/list/valid_templates_per_candidate = list() // number of roles each candidate can satisfy
+		for(var/candidate in all_candidates)
+			valid_templates_per_candidate[candidate]++
+
+		sortTim(valid_templates_per_candidate, /proc/cmp_numeric_asc, TRUE)
+
+		for(var/datum/antagonist/antag in antag_templates)
+			antag.candidates = list_keys(valid_templates_per_candidate) & antag.candidates // orders antag.candidates by valid_templates_per_candidate
+		
+
+	for(var/datum/antagonist/antag in antag_templates)
 		//antag roles that replace jobs need to be assigned before the job controller hands out jobs.
 		if(antag.flags & ANTAG_OVERRIDE_JOB)
 			antag.attempt_spawn() //select antags to be spawned

--- a/html/changelogs/sorts_antag_candidates.yml
+++ b/html/changelogs/sorts_antag_candidates.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Antagonist candidate selection is now more intelligent when there are multiple types of antagonist in the round to prepare for."


### PR DESCRIPTION
Will help avoid situations like this by:
- Assigning candidates to the mode that needs fewest people first
- Assigning the candidate who can fill the fewest modes first

![candidates](https://user-images.githubusercontent.com/47489928/89134660-92643f80-d51e-11ea-8a3d-ed056bf01b81.png)
