### PR TITLE
Prevents unintentional player kills with conversion

### DIFF
--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -85,6 +85,12 @@ var/datum/antagonist/cultist/cult
 		to_chat(player, "You catch a glimpse of the Realm of Nar-Sie, the Geometer of Blood. You now see how flimsy the world is, you see that it should be open to the knowledge of That Which Waits. Assist your new compatriots in their dark dealings. Their goals are yours, and yours are theirs. You serve the Dark One above all else. Bring It back.")
 		if(player.current && !istype(player.current, /mob/living/simple_animal/construct))
 			player.current.add_language(LANGUAGE_CULT)
+			player.current.verbs |= /datum/antagonist/cultist/proc/appraise_offering
+
+/datum/antagonist/cultist/remove_antagonist(var/datum/mind/player)
+	. = ..()
+
+	player.current.verbs -= /datum/antagonist/cultist/proc/appraise_offering
 
 /datum/antagonist/cultist/can_become_antag(var/datum/mind/player, ignore_role = 1)
 	if(!..())
@@ -93,3 +99,21 @@ var/datum/antagonist/cultist/cult
 		if(L?.imp_in == player.current)
 			return FALSE
 	return TRUE
+
+/datum/antagonist/cultist/proc/appraise_offering()
+	set name = "Appraise Offering"
+	set category = "IC"
+
+	var/list/targets = list()
+	for(var/mob/living/carbon/target in view(5, usr))
+		targets |= target
+	targets -= usr
+
+	var/mob/living/carbon/target = input(usr,"Who do you believe may be a worthy offering?") as null|anything in targets
+	if(!istype(target))
+		return
+
+	if(!cult.can_become_antag(target.mind) || jobban_isbanned(target, "cultist") || player_is_antag(target.mind))
+		to_chat(usr, SPAN_CULT("You get the sense that [target] would be an unworthy offering."))
+	else
+		to_chat(usr, SPAN_CULT("You get the sense that your master would be pleased to welcome [target] into the cult."))

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -102,6 +102,7 @@ var/datum/antagonist/cultist/cult
 
 /datum/antagonist/cultist/proc/appraise_offering()
 	set name = "Appraise Offering"
+	set desc = "Find out if someone close-by can be converted to join the cult, or not."
 	set category = "IC"
 
 	var/list/targets = list()

--- a/code/game/gamemodes/cult/runes/convert.dm
+++ b/code/game/gamemodes/cult/runes/convert.dm
@@ -74,13 +74,7 @@
 				//waiting_for_input ensures this is only shown once, so they basically auto-resist from here on out. They still need to find a way to get off the freaking rune if they don't want to burn to death, though.
 				to_chat(target, SPAN_CULT("Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind, something sinister takes root."))
 				to_chat(target, SPAN_CULT("And you were able to force it out of your mind. Though the memory of that dark, horrible vision will surely haunt you for decades to come."))
-				var/has_implant // we don't want people with loy implants to just get gibbed
-				for(var/obj/item/implant/mindshield/L in target)
-					if(L?.imp_in == target)
-						has_implant = TRUE
-				if(!has_implant)
-					to_chat(target, SPAN_CULT("..or will it?"))
-					target.gib() // people who can't be cultists get gibbed to preserve cult anonymity
+				target.visible_message(SPAN_WARNING("The markings below [target] lose their glow, this unworthy offering has been rejected!"))
 			else
 				var/choice = alert(target,"Do you want to join the cult?", "Submit to Nar'Sie", "Resist", "Submit")
 				waiting_for_input[target] = FALSE

--- a/html/changelogs/appraise_offering.yml
+++ b/html/changelogs/appraise_offering.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - tweak: "Characters that cannot be converted by the Cult will no longer be gibbed if this is attempted."
+  - rscadd: "Cultists have a new verb, 'Appraise Offering' in the IC tab which allows them to see if a nearby mob can be converted or not."


### PR DESCRIPTION
Apparently unintentionally gibbing people seriously messes up some cult rounds. This removes the gibbing and adds a verb to check if someone can be cult'd.

Am sure cultists can find another way to kill people, if they want to, after a conversion fails.