### PR TITLE
Do You Like Fishsticks?

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2460,6 +2460,7 @@
 #include "code\modules\reagents\reagent_containers\food\drinks\drinkingglass.dm"
 #include "code\modules\reagents\reagent_containers\food\drinks\jar.dm"
 #include "code\modules\reagents\reagent_containers\food\drinks\bottle\robot.dm"
+#include "code\modules\reagents\reagent_containers\food\snacks\fish.dm"
 #include "code\modules\reagents\reagent_containers\food\snacks\meat.dm"
 #include "code\modules\reagents\reagent_containers\glass\bottle.dm"
 #include "code\modules\reagents\reagent_containers\glass\bottle\robot.dm"

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -33,7 +33,7 @@
 		"fishfillet" = list(
 			name = "Fish Fillet",
 			class = "Food",
-			object = /obj/item/reagent_containers/food/snacks/fishfillet,
+			object = /obj/item/reagent_containers/food/snacks/fish/fishfillet,
 			cost = 50,
 			amount = list(1,2,3,4,5),
 			emag = 0

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -30,6 +30,14 @@
 			amount = list(1,2,3,4,5),
 			emag = 0
 		),
+		"fishfillet" = list(
+			name = "Fish Fillet",
+			class = "Food",
+			object = /obj/item/reagent_containers/food/snacks/fishfillet,
+			cost = 50,
+			amount = list(1,2,3,4,5),
+			emag = 0
+		),
 		"soywafers" = list(
 			name = "Soy Wafers",
 			class = "Food",

--- a/code/modules/food/recipes_fryer.dm
+++ b/code/modules/food/recipes_fryer.dm
@@ -74,6 +74,23 @@
 	reagent_mix = RECIPE_REAGENT_REPLACE //Simplify end product
 	result = /obj/item/reagent_containers/food/snacks/friedmushroom
 
+//Fishy Recipes
+//==================
+/datum/recipe/fishandchips
+	appliance = FRYER
+	items = list(
+		/obj/item/reagent_containers/food/snacks/fries,
+		/obj/item/reagent_containers/food/snacks/fish
+	)
+	result = /obj/item/reagent_containers/food/snacks/fishandchips
+
+/datum/recipe/fishfingers
+	appliance = FRYER
+	items = list(
+		/obj/item/reagent_containers/food/snacks/fish
+	)
+	coating = /datum/reagent/nutriment/coating/batter
+	result = /obj/item/reagent_containers/food/snacks/fishfingers
 
 //Sweet Recipes.
 //==================

--- a/code/modules/food/recipes_fryer.dm
+++ b/code/modules/food/recipes_fryer.dm
@@ -23,6 +23,15 @@
 
 //Meaty Recipes
 //====================
+/datum/recipe/cubanfish
+	appliance = FRYER
+	fruit = list("chili" = 1)
+	items = list(
+		/obj/item/reagent_containers/food/snacks/dough,
+		/obj/item/reagent_containers/food/snacks/fishfillet
+	)
+	result = /obj/item/reagent_containers/food/snacks/cubancarp
+
 /datum/recipe/cubancarp
 	appliance = FRYER
 	fruit = list("chili" = 1)

--- a/code/modules/food/recipes_fryer.dm
+++ b/code/modules/food/recipes_fryer.dm
@@ -23,21 +23,12 @@
 
 //Meaty Recipes
 //====================
-/datum/recipe/cubanfish
-	appliance = FRYER
-	fruit = list("chili" = 1)
-	items = list(
-		/obj/item/reagent_containers/food/snacks/dough,
-		/obj/item/reagent_containers/food/snacks/fishfillet
-	)
-	result = /obj/item/reagent_containers/food/snacks/cubancarp
-
 /datum/recipe/cubancarp
 	appliance = FRYER
 	fruit = list("chili" = 1)
 	items = list(
 		/obj/item/reagent_containers/food/snacks/dough,
-		/obj/item/reagent_containers/food/snacks/carpmeat
+		/obj/item/reagent_containers/food/snacks/fish
 	)
 	result = /obj/item/reagent_containers/food/snacks/cubancarp
 

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -318,13 +318,6 @@
 	reagent_mix = RECIPE_REAGENT_REPLACE
 	result = /obj/item/reagent_containers/food/snacks/burger/bigbite
 
-/datum/recipe/fishandchips
-	items = list(
-		/obj/item/reagent_containers/food/snacks/fries,
-		/obj/item/reagent_containers/food/snacks/fish
-	)
-	result = /obj/item/reagent_containers/food/snacks/fishandchips
-
 /datum/recipe/sandwich
 	items = list(
 		/obj/item/reagent_containers/food/snacks/meatsteak,
@@ -529,22 +522,6 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/sausage
 	result_quantity = 2
-
-/datum/recipe/fishfingers
-	reagents = list(/datum/reagent/nutriment/flour = 10,/datum/reagent/nutriment/protein/egg = 3)
-	items = list(
-		/obj/item/reagent_containers/food/snacks/fish/fishfillet
-	)
-	result = /obj/item/reagent_containers/food/snacks/fishfingers
-	reagent_mix = RECIPE_REAGENT_REPLACE
-
-/datum/recipe/carpfingers
-	reagents = list(/datum/reagent/nutriment/flour = 10,/datum/reagent/nutriment/protein/egg = 3)
-	items = list(
-		/obj/item/reagent_containers/food/snacks/fish/carpmeat
-	)
-	result = /obj/item/reagent_containers/food/snacks/carpfingers
-	reagent_mix = RECIPE_REAGENT_REPLACE
 
 /datum/recipe/mysterysoup
 	reagents = list(/datum/reagent/water = 10, /datum/reagent/nutriment/protein/egg = 3)

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -68,16 +68,9 @@
 /datum/recipe/fishburger
 	items = list(
 		/obj/item/reagent_containers/food/snacks/bun,
-		/obj/item/reagent_containers/food/snacks/fishfillet
+		/obj/item/reagent_containers/food/snacks/fish
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/fish
-
-/datum/recipe/carpburger
-	items = list(
-		/obj/item/reagent_containers/food/snacks/bun,
-		/obj/item/reagent_containers/food/snacks/carpmeat
-	)
-	result = /obj/item/reagent_containers/food/snacks/burger/fish //There are two recipes that both make the same thing. The reagent carryover will make the carp version toxic. This is true for all subsequent instances of these fish/carp recipe doubleups.
 
 /datum/recipe/tofuburger
 	items = list(
@@ -325,17 +318,10 @@
 	reagent_mix = RECIPE_REAGENT_REPLACE
 	result = /obj/item/reagent_containers/food/snacks/burger/bigbite
 
-/datum/recipe/carpandchips
-	items = list(
-		/obj/item/reagent_containers/food/snacks/fries,
-		/obj/item/reagent_containers/food/snacks/carpmeat
-	)
-	result = /obj/item/reagent_containers/food/snacks/fishandchips
-
 /datum/recipe/fishandchips
 	items = list(
 		/obj/item/reagent_containers/food/snacks/fries,
-		/obj/item/reagent_containers/food/snacks/fishfillet
+		/obj/item/reagent_containers/food/snacks/fish
 	)
 	result = /obj/item/reagent_containers/food/snacks/fishandchips
 
@@ -547,7 +533,7 @@
 /datum/recipe/fishfingers
 	reagents = list(/datum/reagent/nutriment/flour = 10,/datum/reagent/nutriment/protein/egg = 3)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/fishfillet
+		/obj/item/reagent_containers/food/snacks/fish/fishfillet
 	)
 	result = /obj/item/reagent_containers/food/snacks/fishfingers
 	reagent_mix = RECIPE_REAGENT_REPLACE
@@ -555,7 +541,7 @@
 /datum/recipe/carpfingers
 	reagents = list(/datum/reagent/nutriment/flour = 10,/datum/reagent/nutriment/protein/egg = 3)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/carpmeat
+		/obj/item/reagent_containers/food/snacks/fish/carpmeat
 	)
 	result = /obj/item/reagent_containers/food/snacks/carpfingers
 	reagent_mix = RECIPE_REAGENT_REPLACE
@@ -852,15 +838,7 @@
 /datum/recipe/sashimi
 	reagents = list(/datum/reagent/nutriment/soysauce = 5)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/fishfillet
-	)
-	result = /obj/item/reagent_containers/food/snacks/sashimi
-
-
-/datum/recipe/carpsashimi
-	reagents = list(/datum/reagent/nutriment/soysauce = 5)
-	items = list(
-		/obj/item/reagent_containers/food/snacks/carpmeat
+		/obj/item/reagent_containers/food/snacks/fish
 	)
 	result = /obj/item/reagent_containers/food/snacks/sashimi
 
@@ -1046,27 +1024,14 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/egg_pancake
 
-/datum/recipe/grilled_fish
-	items = list(
-		/obj/item/reagent_containers/food/snacks/fishfillet,
-		/obj/item/reagent_containers/food/snacks/fishfillet,
-		/obj/item/reagent_containers/food/snacks/fishfillet,
-		/obj/item/reagent_containers/food/snacks/fishfillet,
-		/obj/item/reagent_containers/food/snacks/fishfillet,
-		/obj/item/reagent_containers/food/snacks/fishfillet
-	)
-	reagents = list(/datum/reagent/spacespice = 1)
-	fruit = list("cabbage" = 1, "lime" = 1)
-	result = /obj/item/reagent_containers/food/snacks/sliceable/grilled_carp
-
 /datum/recipe/grilled_carp
 	items = list(
-		/obj/item/reagent_containers/food/snacks/carpmeat,
-		/obj/item/reagent_containers/food/snacks/carpmeat,
-		/obj/item/reagent_containers/food/snacks/carpmeat,
-		/obj/item/reagent_containers/food/snacks/carpmeat,
-		/obj/item/reagent_containers/food/snacks/carpmeat,
-		/obj/item/reagent_containers/food/snacks/carpmeat
+		/obj/item/reagent_containers/food/snacks/fish,
+		/obj/item/reagent_containers/food/snacks/fish,
+		/obj/item/reagent_containers/food/snacks/fish,
+		/obj/item/reagent_containers/food/snacks/fish,
+		/obj/item/reagent_containers/food/snacks/fish,
+		/obj/item/reagent_containers/food/snacks/fish
 	)
 	reagents = list(/datum/reagent/spacespice = 1)
 	fruit = list("cabbage" = 1, "lime" = 1)
@@ -1074,15 +1039,7 @@
 
 /datum/recipe/sushi_roll
 	items = list(
-		/obj/item/reagent_containers/food/snacks/fishfillet,
-		/obj/item/reagent_containers/food/snacks/boiledrice
-	)
-	fruit = list("cabbage" = 1)
-	result = /obj/item/reagent_containers/food/snacks/sliceable/sushi_roll
-
-/datum/recipe/carp_roll
-	items = list(
-		/obj/item/reagent_containers/food/snacks/carpmeat,
+		/obj/item/reagent_containers/food/snacks/fish,
 		/obj/item/reagent_containers/food/snacks/boiledrice
 	)
 	fruit = list("cabbage" = 1)
@@ -1133,15 +1090,7 @@
 /datum/recipe/fish_taco
 	fruit = list("chili" = 1, "lemon" = 1)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/fishfillet,
-		/obj/item/reagent_containers/food/snacks/tortilla
-	)
-	result = /obj/item/reagent_containers/food/snacks/fish_taco
-
-/datum/recipe/carp_taco
-	fruit = list("chili" = 1, "lemon" = 1)
-	items = list(
-		/obj/item/reagent_containers/food/snacks/carpmeat,
+		/obj/item/reagent_containers/food/snacks/fish,
 		/obj/item/reagent_containers/food/snacks/tortilla
 	)
 	result = /obj/item/reagent_containers/food/snacks/fish_taco

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -68,9 +68,16 @@
 /datum/recipe/fishburger
 	items = list(
 		/obj/item/reagent_containers/food/snacks/bun,
-		/obj/item/reagent_containers/food/snacks/carpmeat
+		/obj/item/reagent_containers/food/snacks/fishfillet
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/fish
+
+/datum/recipe/carpburger
+	items = list(
+		/obj/item/reagent_containers/food/snacks/bun,
+		/obj/item/reagent_containers/food/snacks/carpmeat
+	)
+	result = /obj/item/reagent_containers/food/snacks/burger/fish //There are two recipes that both make the same thing. The reagent carryover will make the carp version toxic. This is true for all subsequent instances of these fish/carp recipe doubleups.
 
 /datum/recipe/tofuburger
 	items = list(
@@ -318,10 +325,17 @@
 	reagent_mix = RECIPE_REAGENT_REPLACE
 	result = /obj/item/reagent_containers/food/snacks/burger/bigbite
 
-/datum/recipe/fishandchips
+/datum/recipe/carpandchips
 	items = list(
 		/obj/item/reagent_containers/food/snacks/fries,
 		/obj/item/reagent_containers/food/snacks/carpmeat
+	)
+	result = /obj/item/reagent_containers/food/snacks/fishandchips
+
+/datum/recipe/fishandchips
+	items = list(
+		/obj/item/reagent_containers/food/snacks/fries,
+		/obj/item/reagent_containers/food/snacks/fishfillet
 	)
 	result = /obj/item/reagent_containers/food/snacks/fishandchips
 
@@ -533,9 +547,17 @@
 /datum/recipe/fishfingers
 	reagents = list(/datum/reagent/nutriment/flour = 10,/datum/reagent/nutriment/protein/egg = 3)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/carpmeat
+		/obj/item/reagent_containers/food/snacks/fishfillet
 	)
 	result = /obj/item/reagent_containers/food/snacks/fishfingers
+	reagent_mix = RECIPE_REAGENT_REPLACE
+
+/datum/recipe/carpfingers
+	reagents = list(/datum/reagent/nutriment/flour = 10,/datum/reagent/nutriment/protein/egg = 3)
+	items = list(
+		/obj/item/reagent_containers/food/snacks/carpmeat
+	)
+	result = /obj/item/reagent_containers/food/snacks/carpfingers
 	reagent_mix = RECIPE_REAGENT_REPLACE
 
 /datum/recipe/mysterysoup
@@ -830,10 +852,17 @@
 /datum/recipe/sashimi
 	reagents = list(/datum/reagent/nutriment/soysauce = 5)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/carpmeat
+		/obj/item/reagent_containers/food/snacks/fishfillet
 	)
 	result = /obj/item/reagent_containers/food/snacks/sashimi
 
+
+/datum/recipe/carpsashimi
+	reagents = list(/datum/reagent/nutriment/soysauce = 5)
+	items = list(
+		/obj/item/reagent_containers/food/snacks/carpmeat
+	)
+	result = /obj/item/reagent_containers/food/snacks/sashimi
 
 /datum/recipe/nugget
 	reagents = list(/datum/reagent/nutriment/flour = 5)
@@ -1017,6 +1046,19 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/egg_pancake
 
+/datum/recipe/grilled_fish
+	items = list(
+		/obj/item/reagent_containers/food/snacks/fishfillet,
+		/obj/item/reagent_containers/food/snacks/fishfillet,
+		/obj/item/reagent_containers/food/snacks/fishfillet,
+		/obj/item/reagent_containers/food/snacks/fishfillet,
+		/obj/item/reagent_containers/food/snacks/fishfillet,
+		/obj/item/reagent_containers/food/snacks/fishfillet
+	)
+	reagents = list(/datum/reagent/spacespice = 1)
+	fruit = list("cabbage" = 1, "lime" = 1)
+	result = /obj/item/reagent_containers/food/snacks/sliceable/grilled_carp
+
 /datum/recipe/grilled_carp
 	items = list(
 		/obj/item/reagent_containers/food/snacks/carpmeat,
@@ -1031,6 +1073,14 @@
 	result = /obj/item/reagent_containers/food/snacks/sliceable/grilled_carp
 
 /datum/recipe/sushi_roll
+	items = list(
+		/obj/item/reagent_containers/food/snacks/fishfillet,
+		/obj/item/reagent_containers/food/snacks/boiledrice
+	)
+	fruit = list("cabbage" = 1)
+	result = /obj/item/reagent_containers/food/snacks/sliceable/sushi_roll
+
+/datum/recipe/carp_roll
 	items = list(
 		/obj/item/reagent_containers/food/snacks/carpmeat,
 		/obj/item/reagent_containers/food/snacks/boiledrice
@@ -1081,6 +1131,14 @@
 	result = /obj/item/reagent_containers/food/snacks/nt_muffin
 
 /datum/recipe/fish_taco
+	fruit = list("chili" = 1, "lemon" = 1)
+	items = list(
+		/obj/item/reagent_containers/food/snacks/fishfillet,
+		/obj/item/reagent_containers/food/snacks/tortilla
+	)
+	result = /obj/item/reagent_containers/food/snacks/fish_taco
+
+/datum/recipe/carp_taco
 	fruit = list("chili" = 1, "lemon" = 1)
 	items = list(
 		/obj/item/reagent_containers/food/snacks/carpmeat,

--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -70,7 +70,7 @@
 	melee_damage_upper = 15
 	canbrush = TRUE
 	brush = /obj/item/reagent_containers/glass/rag
-	meat_type = /obj/item/reagent_containers/food/snacks/carpmeat
+	meat_type = /obj/item/reagent_containers/food/snacks/fish/carpmeat
 
 	min_oxy = 0
 

--- a/code/modules/mob/living/simple_animal/friendly/carp.dm
+++ b/code/modules/mob/living/simple_animal/friendly/carp.dm
@@ -16,7 +16,7 @@
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6
-	meat_type = /obj/item/reagent_containers/food/snacks/carpmeat
+	meat_type = /obj/item/reagent_containers/food/snacks/fish/carpmeat
 	response_help = "brushes"
 	response_disarm = "attempts to push"
 	response_harm = "injures"

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -10,7 +10,7 @@
 	icon_rest = "carp_rest"
 	speak_chance = 0
 	turns_per_move = 5
-	meat_type = /obj/item/reagent_containers/food/snacks/carpmeat
+	meat_type = /obj/item/reagent_containers/food/snacks/fish/carpmeat
 	response_help = "pets the"
 	response_disarm = "gently pushes aside the"
 	response_harm = "hits the"

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -9,7 +9,7 @@
 	icon_state = "crate"
 	icon_living = "crate"
 
-	meat_type = /obj/item/reagent_containers/food/snacks/carpmeat
+	meat_type = /obj/item/reagent_containers/food/snacks/fish/carpmeat
 	response_help = "touches"
 	response_disarm = "pushes"
 	response_harm = "hits"

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -8,7 +8,7 @@
 	icon_gib = "pine_1"
 	speak_chance = 0
 	turns_per_move = 5
-	meat_type = /obj/item/reagent_containers/food/snacks/carpmeat
+	meat_type = /obj/item/reagent_containers/food/snacks/fish/carpmeat
 	response_help = "brushes"
 	response_disarm = "pushes"
 	response_harm = "hits"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -825,15 +825,7 @@
 	icon_state = "fishfingers"
 	filling_color = "#FFDEFE"
 	bitesize = 3
-	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 7) //Extra reagents because we had to clear the original ingredients due to doughball reactions.
-
-/obj/item/reagent_containers/food/snacks/carpfingers
-	name = "fish fingers"
-	desc = "A finger of fish."
-	icon_state = "fishfingers"
-	filling_color = "#FFDEFE"
-	bitesize = 3
-	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 7, /datum/reagent/toxin/carpotoxin = 3) //Extra reagents because we had to clear the original ingredients due to doughball reactions.
+	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 7)
 
 /obj/item/reagent_containers/food/snacks/hugemushroomslice
 	name = "huge mushroom slice"
@@ -1811,7 +1803,7 @@
 	icon_state = "fishandchips"
 	filling_color = "#E3D796"
 	center_of_mass = list("x"=16, "y"=16)
-	reagents_to_add = list(/datum/reagent/nutriment = 3, /datum/reagent/nutriment/protein/seafood = 3)
+	reagents_to_add = list(/datum/reagent/nutriment = 3, /datum/reagent/nutriment/protein/seafood = 7)
 	reagent_data = list(/datum/reagent/nutriment = list("salt" = 1, "chips" = 3))
 	bitesize = 3
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -811,22 +811,6 @@
 	reagent_data = list(/datum/reagent/nutriment = list("dryness" = 2, "bread" = 2))
 	bitesize = 1
 
-/obj/item/reagent_containers/food/snacks/carpmeat
-	name = "carp fillet"
-	desc = "A fillet of spess carp meat."
-	icon_state = "fishfillet"
-	filling_color = "#FFDEFE"
-	bitesize = 6
-	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 3, /datum/reagent/toxin/carpotoxin = 3)
-
-/obj/item/reagent_containers/food/snacks/fishfillet
-	name = "fish fillet"
-	desc = "A fillet of fish."
-	icon_state = "fishfillet"
-	filling_color = "#FFDEFE"
-	bitesize = 6
-	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 3)
-
 /obj/item/reagent_containers/food/snacks/dwellermeat
 	name = "worm fillet"
 	desc = "A fillet of electrifying cavern meat."

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -819,6 +819,14 @@
 	bitesize = 6
 	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 3, /datum/reagent/toxin/carpotoxin = 3)
 
+/obj/item/reagent_containers/food/snacks/fishfillet
+	name = "fish fillet"
+	desc = "A fillet of fish."
+	icon_state = "fishfillet"
+	filling_color = "#FFDEFE"
+	bitesize = 6
+	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 3)
+
 /obj/item/reagent_containers/food/snacks/dwellermeat
 	name = "worm fillet"
 	desc = "A fillet of electrifying cavern meat."
@@ -833,7 +841,15 @@
 	icon_state = "fishfingers"
 	filling_color = "#FFDEFE"
 	bitesize = 3
-	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 4, /datum/reagent/toxin/carpotoxin = 3)
+	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 7) //Extra reagents because we had to clear the original ingredients due to doughball reactions.
+
+/obj/item/reagent_containers/food/snacks/carpfingers
+	name = "fish fingers"
+	desc = "A finger of fish."
+	icon_state = "fishfingers"
+	filling_color = "#FFDEFE"
+	bitesize = 3
+	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 7, /datum/reagent/toxin/carpotoxin = 3) //Extra reagents because we had to clear the original ingredients due to doughball reactions.
 
 /obj/item/reagent_containers/food/snacks/hugemushroomslice
 	name = "huge mushroom slice"
@@ -1006,13 +1022,13 @@
 	bitesize = 2
 
 /obj/item/reagent_containers/food/snacks/burger/fish
-	name = "fillet -o- carp sandwich"
-	desc = "Almost like a carp is yelling somewhere... Give me back that fillet -o- carp, give me that carp."
+	name = "fillet -o- fish sandwich"
+	desc = "Almost like a fish is yelling somewhere... Give me back that fillet -o- fish, give me that fish."
 	icon_state = "fishburger"
 	filling_color = "#FFDEFE"
 	center_of_mass = list("x"=16, "y"=10)
 	bitesize = 3
-	reagents_to_add = list(/datum/reagent/nutriment = 3, /datum/reagent/nutriment/protein/seafood = 6, /datum/reagent/toxin/carpotoxin = 3)
+	reagents_to_add = list(/datum/reagent/nutriment = 3, /datum/reagent/nutriment/protein/seafood = 6)
 
 /obj/item/reagent_containers/food/snacks/burger/tofu
 	name = "tofu burger"
@@ -1277,14 +1293,14 @@
 	reagents_to_add = list(/datum/reagent/nutriment/protein/tofu = 8)
 
 /obj/item/reagent_containers/food/snacks/cubancarp
-	name = "cuban carp"
+	name = "cuban fish sandwich"
 	desc = "A sandwich that burns your tongue and then leaves it numb!"
 	icon_state = "cubancarp"
 	trash = /obj/item/trash/plate
 	filling_color = "#E9ADFF"
 	center_of_mass = list("x"=12, "y"=5)
 	bitesize = 3
-	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 3, /datum/reagent/nutriment = 3, /datum/reagent/toxin/carpotoxin = 3, /datum/reagent/capsaicin = 3)
+	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 3, /datum/reagent/nutriment = 3, /datum/reagent/capsaicin = 3)
 
 /obj/item/reagent_containers/food/snacks/chickenkatsu
 	name = "chicken katsu"
@@ -1811,7 +1827,7 @@
 	icon_state = "fishandchips"
 	filling_color = "#E3D796"
 	center_of_mass = list("x"=16, "y"=16)
-	reagents_to_add = list(/datum/reagent/nutriment = 3, /datum/reagent/nutriment/protein/seafood = 3, /datum/reagent/toxin/carpotoxin = 3)
+	reagents_to_add = list(/datum/reagent/nutriment = 3, /datum/reagent/nutriment/protein/seafood = 3)
 	reagent_data = list(/datum/reagent/nutriment = list("salt" = 1, "chips" = 3))
 	bitesize = 3
 
@@ -3767,15 +3783,15 @@
 	bitesize = 3
 
 /obj/item/reagent_containers/food/snacks/sashimi
-	name = "carp sashimi"
-	desc = "A traditional human dish, recreated using space carp."
+	name = "sashimi"
+	desc = "A traditional human dish."
 	icon_state = "sashimi"
 	trash = /obj/item/trash/grease
 	drop_sound = 'sound/items/trayhit1.ogg'
 	filling_color = "#FFDEFE"
 	center_of_mass = list("x"=17, "y"=13)
 	bitesize = 4
-	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 3, /datum/reagent/toxin/carpotoxin = 3)
+	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 3)
 
 /obj/item/reagent_containers/food/snacks/nugget
 	name = "chicken nugget"
@@ -4144,7 +4160,7 @@
 
 /obj/item/reagent_containers/food/snacks/sliceable/grilled_carp
 	name = "korlaaskak"
-	desc = "A well-dressed carp, seared to perfection and adorned with herbs and spices. Can be sliced into proper serving sizes."
+	desc = "A well-dressed fish, seared to perfection and adorned with herbs and spices. Can be sliced into proper serving sizes."
 	icon_state = "grilled_carp"
 	slice_path = /obj/item/reagent_containers/food/snacks/grilled_carp_slice
 	slices_num = 6
@@ -4154,13 +4170,13 @@
 
 /obj/item/reagent_containers/food/snacks/grilled_carp_slice
 	name = "korlaaskak slice"
-	desc = "A well-dressed fillet of carp, seared to perfection and adorned with herbs and spices."
+	desc = "A well-dressed fillet of fish, seared to perfection and adorned with herbs and spices."
 	icon_state = "grilled_carp_slice"
 	trash = /obj/item/trash/plate
 
 /obj/item/reagent_containers/food/snacks/sliceable/sushi_roll
-	name = "ouerean carp log"
-	desc = "A giant carp roll wrapped in special grass that combines unathi and human cooking techniques. Can be sliced into proper serving sizes."
+	name = "ouerean fish log"
+	desc = "A giant fish roll wrapped in special grass that combines unathi and human cooking techniques. Can be sliced into proper serving sizes."
 	icon_state = "sushi_roll"
 	slice_path = /obj/item/reagent_containers/food/snacks/sushi_serve
 	slices_num = 3
@@ -4168,8 +4184,8 @@
 	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 6)
 
 /obj/item/reagent_containers/food/snacks/sushi_serve
-	name = "ouerean carp cake"
-	desc = "A serving of carp roll wrapped in special grass that combines unathi and human cooking techniques."
+	name = "ouerean fish cake"
+	desc = "A serving of fish roll wrapped in special grass that combines unathi and human cooking techniques."
 	icon_state = "sushi_serve"
 
 /obj/item/reagent_containers/food/snacks/spreads
@@ -4256,7 +4272,7 @@
 	reagent_data = list(/datum/reagent/nutriment = list("flatbread" = 3))
 
 /obj/item/reagent_containers/food/snacks/fish_taco
-	name = "carp taco"
+	name = "fish taco"
 	desc = "A questionably cooked fish taco decorated with herbs, spices, and special sauce."
 	icon_state = "fish_taco"
 	reagents_to_add = list(/datum/reagent/nutriment = 3, /datum/reagent/nutriment/protein/seafood = 3)

--- a/code/modules/reagents/reagent_containers/food/snacks/fish.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/fish.dm
@@ -1,0 +1,14 @@
+/obj/item/reagent_containers/food/snacks/fish
+	icon_state = "fishfillet"
+	filling_color = "#FFDEFE"
+	reagents_to_add = list(/datum/reagent/nutriment/protein/seafood = 3)
+	bitesize = 6
+
+/obj/item/reagent_containers/food/snacks/fish/carpmeat
+	name = "carp fillet"
+	desc = "A fillet of spess carp meat."
+	reagents_to_add = list(/datum/reagent/toxin/carpotoxin = 3, /datum/reagent/nutriment/protein/seafood = 3)
+
+/obj/item/reagent_containers/food/snacks/fish/fishfillet
+	name = "fish fillet"
+	desc = "A fillet of fish."

--- a/html/changelogs/Crosarius-Fishsticks.yml
+++ b/html/changelogs/Crosarius-Fishsticks.yml
@@ -6,5 +6,7 @@ delete-after: True
 
 changes: 
   - rscadd: "Added non-toxic fish fillets compatible with all current carp fillet recipes."
+  - rscadd: "Added fish fillets to the biogenerator."
+  - tweak: "Changed fish & chips and fish fingers to be made in the deep fryer rather than the microwave. Fish fingers require a battered fish fillet instead of flour, egg, etc."
   - tweak: "Tweaked the names and descriptions of the current seafood recipes to use 'fish' instead of 'carp'."
   - maptweak: "Added 7 fish fillets to the freezerbox in the kitchen freezer."

--- a/html/changelogs/Crosarius-Fishsticks.yml
+++ b/html/changelogs/Crosarius-Fishsticks.yml
@@ -1,0 +1,10 @@
+# Your name.  
+author: Crosarius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - rscadd: "Added non-toxic fish fillets compatible with all current carp fillet recipes."
+  - tweak: "Tweaked the names and descriptions of the current seafood recipes to use 'fish' instead of 'carp'."
+  - maptweak: "Added 7 fish fillets to the freezerbox in the kitchen freezer."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -59700,6 +59700,13 @@
 /area/maintenance/research_port)
 "dBV" = (
 /obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/snacks/fishfillet,
+/obj/item/reagent_containers/food/snacks/fishfillet,
+/obj/item/reagent_containers/food/snacks/fishfillet,
+/obj/item/reagent_containers/food/snacks/fishfillet,
+/obj/item/reagent_containers/food/snacks/fishfillet,
+/obj/item/reagent_containers/food/snacks/fishfillet,
+/obj/item/reagent_containers/food/snacks/fishfillet,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -59700,13 +59700,13 @@
 /area/maintenance/research_port)
 "dBV" = (
 /obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/fishfillet,
-/obj/item/reagent_containers/food/snacks/fishfillet,
-/obj/item/reagent_containers/food/snacks/fishfillet,
-/obj/item/reagent_containers/food/snacks/fishfillet,
-/obj/item/reagent_containers/food/snacks/fishfillet,
-/obj/item/reagent_containers/food/snacks/fishfillet,
-/obj/item/reagent_containers/food/snacks/fishfillet,
+/obj/item/reagent_containers/food/snacks/fish/fishfillet,
+/obj/item/reagent_containers/food/snacks/fish/fishfillet,
+/obj/item/reagent_containers/food/snacks/fish/fishfillet,
+/obj/item/reagent_containers/food/snacks/fish/fishfillet,
+/obj/item/reagent_containers/food/snacks/fish/fishfillet,
+/obj/item/reagent_containers/food/snacks/fish/fishfillet,
+/obj/item/reagent_containers/food/snacks/fish/fishfillet,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278


### PR DESCRIPTION
I added non-toxic fish fillets so that races other than Unathi can eat seafood. Recipes are compatible with both carp fillets and fish fillets. Bear in mind that you can still use carp fillets to cook those same dishes, and ones using carp will still be poisonous!

There is no visible distinction between fish dishes that have been made with fish fillets, and those made with carp fillets, so watch out!

I also added 7 fish fillets to the freezer box in the kitchen freezer. I would also like to add a fish-fillet crate to the cargo ordering database, but from my understanding that isn't something that I have the power to do.

Fish fingers and fish and chips are now made in the deep fryer. The recipe for fish and chips has not been changed, however fish fingers now requires just a single battered fish piece, instead of egg and flour etc.

**Update**
Codewise, what I've done is I have added a snack type called fish, which contains both carpmeat and fish fillets, and modified all fish related recipes to require "fish," accepting either one of these recipes.