### PR TITLE
Repairing robotic organs is now of type /decl/surgery_step/internal because they can be inside meat

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -1,4 +1,4 @@
-//Procedures in this file: Gneric surgery steps
+//Procedures in this file: Robotic Surgery Steps
 //////////////////////////////////////////////////////////////////
 //						COMMON STEPS							//
 //////////////////////////////////////////////////////////////////
@@ -209,77 +209,6 @@
 	user.visible_message(SPAN_WARNING("[user] causes a short circuit in [target]'s [affected.name]!"),
 		SPAN_WARNING("You cause a short circuit in [target]'s [affected.name]!"))
 	target.apply_damage(rand(5,10), BURN, affected)
-
-/decl/surgery_step/robotics/fix_organ_robotic //For artificial organs
-	name = "Repair robotic organ"
-	allowed_tools = list(
-	/obj/item/stack/nanopaste = 100,
-	/obj/item/surgery/bonegel = 30,
-	/obj/item/screwdriver = 70
-	)
-
-	min_duration = 70
-	max_duration = 90
-
-/decl/surgery_step/robotics/fix_organ_robotic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(!..())
-		return FALSE
-
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	var/is_organ_damaged = 0
-	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I.damage > 0 && I.robotic >= 2)
-			is_organ_damaged = TRUE
-			break
-	return is_organ_damaged && IS_ORGAN_FULLY_OPEN
-
-/decl/surgery_step/robotics/fix_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(!ishuman(target))
-		return
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-
-	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I && I.damage > 0)
-			if(I.robotic >= 2)
-				user.visible_message("<b>[user]</b> starts mending the damage to [target]'s [I.name]'s mechanisms.", \
-					SPAN_NOTICE("You start mending the damage to [target]'s [I.name]'s mechanisms." ))
-
-	target.custom_pain("The pain in your [affected.name] is living hell!", 75)
-	..()
-
-/decl/surgery_step/robotics/fix_organ_robotic/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(!ishuman(target))
-		return
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-
-	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I && I.damage > 0)
-			if(I.robotic >= 2)
-				user.visible_message("<b>[user]</b> repairs [target]'s [I.name] with [tool].", \
-					SPAN_NOTICE("You repair [target]'s [I.name] with [tool].") )
-				I.damage = 0
-				var/obj/item/organ/internal/brain/sponge = target.internal_organs_by_name[BP_BRAIN]
-				if(sponge && istype(I, sponge))
-					target.cure_all_traumas()
-				if(istype(tool, /obj/item/stack/nanopaste))
-					var/obj/item/stack/nanopaste/nanopaste = tool
-					nanopaste.use(1)
-					return
-
-/decl/surgery_step/robotics/fix_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(!ishuman(target))
-		return
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, gumming up the mechanisms inside of [target]'s [affected.name] with \the [tool]!"), \
-		SPAN_WARNING("Your hand slips, gumming up the mechanisms inside of [target]'s [affected.name] with \the [tool]!"))
-
-	target.adjustToxLoss(5)
-	target.apply_damage(5, BRUTE, target_zone, 0, tool, damage_flags = tool.damage_flags())
-
-	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I)
-			I.take_damage(rand(3,5),0)
 
 /decl/surgery_step/robotics/detach_organ_robotic
 	name = "Detach robotic organ"

--- a/html/changelogs/fix_robot_organs.yml
+++ b/html/changelogs/fix_robot_organs.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Repairing augments and robotic internal organs with nanopaste will now work again."


### PR DESCRIPTION
Fixes #9022
Fixes #9203

/decl/surgery_step/robotics is for things involving robotic *external* organs, and things within them.
/decl/surgery_step/internal is for things involving meat OR robotic *external* organs, and things within them.