### PR TITLE
The Lethality Fix To End All Lethality Fixes

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -9,8 +9,9 @@
 	Returns
 	a blocked amount between 0 - 100, representing the success of the armor check.
 */
-#define MOB_FIRE_LIGHT_RANGE  3  //These control the intensity and range of light given off by a mob which is on fire
-#define MOB_FIRE_LIGHT_POWER  2
+#define MOB_FIRE_LIGHT_RANGE    3  //These control the intensity and range of light given off by a mob which is on fire
+#define MOB_FIRE_LIGHT_POWER    2
+#define ARMOR_SOFTEN_THRESHOLD  20
 
 /mob/living/proc/run_armor_check(var/def_zone = null, var/attack_flag = "melee", var/armour_pen = 0, var/absorb_text = null, var/soften_text = null)
 	if(armour_pen >= 100)
@@ -38,7 +39,7 @@
 	//and the average damage absorption = (blocked/100)*(1-fullblock) + 1.0*(fullblock) = effective_armor
 	var/blocked = (effective_armor - fullblock)/(1 - fullblock)*100
 
-	if(blocked > 20)
+	if(blocked > ARMOR_SOFTEN_THRESHOLD)
 		//Should we show this every single time?
 		if(soften_text)
 			show_message("<span class='warning'>[soften_text]</span>")
@@ -90,7 +91,7 @@
 	//Armor
 	var/absorb = run_armor_check(def_zone, P.check_armour, P.armor_penetration)
 	var/damaged
-	if(absorb > 20)
+	if(absorb > ARMOR_SOFTEN_THRESHOLD)
 		if(P.damage_flags & DAM_SHARP || P.damage_flags & DAM_SHARP || P.damage_flags & DAM_LASER)
 			P.damage_flags &= ~DAM_SHARP
 			P.damage_flags &= ~DAM_EDGE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -90,7 +90,7 @@
 	//Armor
 	var/absorb = run_armor_check(def_zone, P.check_armour, P.armor_penetration)
 	var/damaged
-	if(prob(absorb))
+	if(absorb > 20)
 		if(P.damage_flags & DAM_SHARP || P.damage_flags & DAM_SHARP || P.damage_flags & DAM_LASER)
 			P.damage_flags &= ~DAM_SHARP
 			P.damage_flags &= ~DAM_EDGE

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -125,7 +125,7 @@
 			if(!do_mob(user, target, 1.5 SECONDS))
 				return
 			var/blocked = H.getarmor_organ(H.organs_by_name[BP_CHEST], "melee")
-			if(blocked > 20)
+			if(blocked > ARMOR_SOFTEN_THRESHOLD)
 				user.visible_message("<b>[user]</b> jabs \the [src] into [H], but their armor blocks it!", SPAN_WARNING("You jab \the [src] into [H], but their armor blocks it!"))
 				return
 			user.visible_message("<b>[user]</b> jabs \the [src] between [P] ribs!", SPAN_NOTICE("You jab \the [src] between [SM] ribs!"))

--- a/html/changelogs/mattatlas-thewartoendallwars.yml
+++ b/html/changelogs/mattatlas-thewartoendallwars.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - experiment: "Softened hits now always remove laser or sharp properties from a bullet instead of it being a chance."


### PR DESCRIPTION
It turns out that removing laser flags and such was a chance instead of a proper check. This is no bueno because it means this shit never happens. Now, we just check for softens and above. If you soften a laser hit, for example, your blood no longer gets boiled.
