### PR TITLE
Borg Unbuckle

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -152,6 +152,11 @@
 						"<span class='notice'>You hear metal clanking.</span>")
 			qdel(W)
 
+	else if(istype(W, /obj/item/gripper) && buckled_mob)
+		var/obj/item/gripper/G = W
+		if(!G.wrapped)
+			user_unbuckle_mob(user)
+
 	else if(!istype(W, /obj/item/bedsheet))
 		..()
 

--- a/html/changelogs/geeves-gripper_unbuckle.yml
+++ b/html/changelogs/geeves-gripper_unbuckle.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Borgs can now unbuckle people from rollerbeds and chairs by using an empty gripper on the chair or bed."

--- a/html/changelogs/geeves-gripper_unbuckle.yml
+++ b/html/changelogs/geeves-gripper_unbuckle.yml
@@ -3,4 +3,4 @@ author: Geeves
 delete-after: True
 
 changes: 
-  - rscadd: "Borgs can now unbuckle people from rollerbeds and chairs by using an empty gripper on the chair or bed."
+  - rscadd: "Borgs can now unbuckle people from beds and chairs by using an empty gripper on the chair or bed."


### PR DESCRIPTION
* Borgs can now unbuckle people from beds and chairs by using an empty gripper on the chair or bed.