### PR TITLE
Hoodies stay unzipped/zipped

### DIFF
--- a/code/modules/clothing/suits/hoodies.dm
+++ b/code/modules/clothing/suits/hoodies.dm
@@ -28,8 +28,8 @@
 	if(!lasticonstate)
 		suittoggled = FALSE
 	else
-		icon_state = "[lasticonstate]"
-		item_state = "[lasticonstate]"
+		icon_state = lasticonstate
+		item_state = lasticonstate
 		suittoggled = FALSE
 	
 	

--- a/code/modules/clothing/suits/hoodies.dm
+++ b/code/modules/clothing/suits/hoodies.dm
@@ -3,10 +3,9 @@
 /obj/item/clothing/suit/storage/hooded
 	var/obj/item/clothing/head/winterhood/hood
 	var/hoodtype = null
-	var/suittoggled = 0
+	var/suittoggled = FALSE
 	var/hooded = 0
-	var/lasticonstate = null
-	var/lastitemstate = null
+	var/lasticonstate
 
 /obj/item/clothing/suit/storage/hooded/Initialize()
 	. = ..()
@@ -26,12 +25,12 @@
 	..()
 
 /obj/item/clothing/suit/storage/hooded/proc/RemoveHood()
-	if(!lasticonstate && !lastitemstate)
-		suittoggled = 0
+	if(!lasticonstate)
+		suittoggled = FALSE
 	else
 		icon_state = "[lasticonstate]"
-		item_state = "[lastitemstate]"
-		suittoggled = 0
+		item_state = "[lasticonstate]"
+		suittoggled = FALSE
 	
 	
 	// Hood got nuked. Probably because of RIGs or the like.
@@ -71,9 +70,8 @@
 				return
 			else
 				lasticonstate = icon_state
-				lastitemstate = item_state
 				H.equip_to_slot_if_possible(hood,slot_head,0,0,1)
-				suittoggled = 1
+				suittoggled = TRUE
 				icon_state = "[initial(icon_state)]_t"
 				item_state = "[initial(item_state)]_t"
 				H.update_inv_wear_suit()
@@ -248,13 +246,12 @@
 				return
 			else
 				lasticonstate = icon_state
-				lastitemstate = item_state
 				H.equip_to_slot_if_possible(hood,slot_head,0,0,1)
-				suittoggled = 1
+				suittoggled = TRUE
 				icon_open = "[initial(icon_open)]_t" // this is where the change is.
 				icon_closed = "[initial(icon_closed)]_t"
-				icon_state = "[initial(icon_state)]_t"
-				item_state = "[initial(item_state)]_t"
+				icon_state = "[icon_state]_t"
+				item_state = "[item_state]_t"
 				H.update_inv_wear_suit()
 	else
 		RemoveHood()

--- a/code/modules/clothing/suits/hoodies.dm
+++ b/code/modules/clothing/suits/hoodies.dm
@@ -5,6 +5,8 @@
 	var/hoodtype = null
 	var/suittoggled = 0
 	var/hooded = 0
+	var/lasticonstate = null
+	var/lastitemstate = null
 
 /obj/item/clothing/suit/storage/hooded/Initialize()
 	. = ..()
@@ -24,10 +26,14 @@
 	..()
 
 /obj/item/clothing/suit/storage/hooded/proc/RemoveHood()
-	icon_state = initial(icon_state)
-	item_state = initial(item_state)
-	suittoggled = 0
-
+	if(!lasticonstate && !lastitemstate)
+		suittoggled = 0
+	else
+		icon_state = "[lasticonstate]"
+		item_state = "[lastitemstate]"
+		suittoggled = 0
+	
+	
 	// Hood got nuked. Probably because of RIGs or the like.
 	if (!hood)
 		MakeHood()
@@ -64,6 +70,8 @@
 				to_chat(H, "<span class='warning'>You're already wearing something on your head!</span>")
 				return
 			else
+				lasticonstate = icon_state
+				lastitemstate = item_state
 				H.equip_to_slot_if_possible(hood,slot_head,0,0,1)
 				suittoggled = 1
 				icon_state = "[initial(icon_state)]_t"
@@ -239,6 +247,8 @@
 				to_chat(H, "<span class='warning'>You're already wearing something on your head!</span>")
 				return
 			else
+				lasticonstate = icon_state
+				lastitemstate = item_state
 				H.equip_to_slot_if_possible(hood,slot_head,0,0,1)
 				suittoggled = 1
 				icon_open = "[initial(icon_open)]_t" // this is where the change is.

--- a/html/changelogs/Hockaa-MoreAurora.yml
+++ b/html/changelogs/Hockaa-MoreAurora.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes:
+    - bugfix: "Hoodies will now stay unzipped when you unequip them or drop them."


### PR DESCRIPTION
Adds 2 vars to the togglehood verbs that allows the removehood proc to keep the hoodies unzipped whenever they're unequipped or dropped, as the hazard vests do.