### PR TITLE
Splitting obj/item/stack/.../full stacks no longer makes the new stack full

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -274,7 +274,7 @@
 
 	var/orig_amount = src.get_amount()
 	if (transfer && src.use(transfer))
-		var/obj/item/stack/newstack = new src.type(loc, transfer)
+		var/obj/item/stack/newstack = new src.stacktype(loc, transfer)
 		newstack.color = color
 		if (prob(transfer/orig_amount * 100))
 			transfer_fingerprints_to(newstack)

--- a/html/changelogs/full_steel_stacks.yml
+++ b/html/changelogs/full_steel_stacks.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Splitting stacks which are of type /obj/item/stack/.../full will no longer result in the new stack having the maximum amount in it."


### PR DESCRIPTION
Fixes #9603