### PR TITLE
Gluttony

### DIFF
--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -100,9 +100,9 @@
 /obj/item/organ/internal/stomach/proc/metabolize()
 	if(is_usable())
 		ingested.metabolize()
-	
+
 #define STOMACH_VOLUME 65
-	
+
 /obj/item/organ/internal/stomach/process()
 	..()
 	if(owner)

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -75,7 +75,9 @@
 		var/mob/living/L = food
 		if((species.gluttonous & GLUT_TINY) && (L.mob_size <= MOB_TINY) && !ishuman(food)) // Anything MOB_TINY or smaller
 			return DEVOUR_SLOW
-		else if((species.gluttonous & (GLUT_SMALLER|GLUT_MESSY)) && owner.mob_size > L.mob_size) // Anything we're larger than
+		else if((species.gluttonous & GLUT_SMALLER) && owner.mob_size > L.mob_size) // Anything we're larger than
+			return DEVOUR_SLOW
+		else if(species.gluttonous & GLUT_MESSY) // Anything we're smaller than
 			return DEVOUR_SLOW
 		else if(species.gluttonous & GLUT_ANYTHING) // Eat anything ever
 			return DEVOUR_FAST

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -75,9 +75,7 @@
 		var/mob/living/L = food
 		if((species.gluttonous & GLUT_TINY) && (L.mob_size <= MOB_TINY) && !ishuman(food)) // Anything MOB_TINY or smaller
 			return DEVOUR_SLOW
-		else if((species.gluttonous & GLUT_SMALLER) && owner.mob_size > L.mob_size) // Anything we're larger than
-			return DEVOUR_SLOW
-		else if(species.gluttonous & GLUT_MESSY) // Anything we're smaller than
+		else if((species.gluttonous & GLUT_MESSY) || ((species.gluttonous & GLUT_SMALLER) && owner.mob_size > L.mob_size)) //Whether you can eat things smaller, or bigger than you.
 			return DEVOUR_SLOW
 		else if(species.gluttonous & GLUT_ANYTHING) // Eat anything ever
 			return DEVOUR_FAST

--- a/html/changelogs/Crosarius-Gluttony.yml
+++ b/html/changelogs/Crosarius-Gluttony.yml
@@ -1,0 +1,8 @@
+# Your name.  
+author: Crosarius
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed Unathi not being able to eat mobs larger than themselves in their usual spectacularly messy fashion. Carp, cows, etc are back on the menu+."


### PR DESCRIPTION
Fixes an oversight which prevented Unathi from being able to devour big mobs such as space carp, cows, etc. This does not allow them to eat Humanoids.

Looks like carp are back on the menu boys!