### PR TITLE
Bumps rust_g version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     MACRO_COUNT=77
     FLYWAY_BUILD="5.2.4"
     NODE_VERSION=10
-    RUST_G_VERSION="0.4.1"
+    RUST_G_VERSION="0.4.2a"
     PATH=/opt/python/3.7.1/bin:$PATH
     SPACEMAN_DMM_VERSION="suite-1.4"
   matrix:


### PR DESCRIPTION
The `a` at the end denotes an aurora specific build number, as to not be confused with the upstream's versions.