### PR TITLE
Allows air analyzers to scan pipes and also shows moles on readout

### DIFF
--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -82,6 +82,11 @@
 	if(istype(W,/obj/item/device/pipe_painter))
 		return 0
 
+	if(istype(W, /obj/item/device/analyzer) && Adjacent(user))
+		var/obj/item/device/analyzer/A = W
+		A.analyze_gases(src, user)
+		return FALSE
+
 	if (!W.iswrench() && !istype(W, /obj/item/pipewrench))
 		return ..()
 	var/turf/T = src.loc
@@ -1157,9 +1162,12 @@
 	if(istype(W, /obj/item/device/pipe_painter))
 		return
 
+	
+	
 	if(istype(W, /obj/item/device/analyzer) && in_range(user, src))
 		var/obj/item/device/analyzer/A = W
 		A.analyze_gases(src, user)
+		return 0
 
 /obj/machinery/atmospherics/pipe/tank/air
 	name = "Pressure Tank (Air)"

--- a/code/_helpers/atmospherics.dm
+++ b/code/_helpers/atmospherics.dm
@@ -5,7 +5,7 @@
 	A.add_fingerprint(user)
 	var/list/result = A.atmosanalyze(user)
 	if(result && result.len)
-		to_chat(user, "<span class='notice'>Results of the analysis[src == A ? "" : " of \the [A]"]</span>")
+		to_chat(user, "<span class='notice'>Results of the analysis[src == A ? "" : " of [A]"]</span>")
 		for(var/line in result)
 			to_chat(user, "<span class='notice'>[line]</span>")
 		return 1
@@ -20,6 +20,7 @@
 	var/list/results = list()
 	if (total_moles>0)
 		results += "<span class='notice'>Pressure: [round(pressure,0.1)] kPa</span>"
+		results += "<span class='notice'>Moles: [round(total_moles,0.1)]</span>"
 		for(var/mix in mixture.gas)
 			results += "<span class='notice'>[gas_data.name[mix]]: [round((mixture.gas[mix] / total_moles) * 100)]%</span>"
 		results += "<span class='notice'>Temperature: [round(mixture.temperature-T0C)]&deg;C</span>"

--- a/html/changelogs/hockaa-airanalyzers.yml
+++ b/html/changelogs/hockaa-airanalyzers.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
     - bugfix: "Air Analyzers now analyze pipes (like the PDA scanners.)"
-    - tweak: "Air analysis now shows the total amount of moles in the analyzed system."
+    - tweak: "Air analyzers now show the total amount of moles in the analyzed system."

--- a/html/changelogs/hockaa-airanalyzers.yml
+++ b/html/changelogs/hockaa-airanalyzers.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
     - bugfix: "Air Analyzers now analyze pipes (like the PDA scanners.)"
-    - tweak: "Air analysis now shows the total amount of moles in the analyzed system.
+    - tweak: "Air analysis now shows the total amount of moles in the analyzed system."

--- a/html/changelogs/hockaa-airanalyzers.yml
+++ b/html/changelogs/hockaa-airanalyzers.yml
@@ -1,0 +1,7 @@
+author: Hocka
+
+delete-after: True
+
+changes:
+    - bugfix: "Air Analyzers now analyze pipes (like the PDA scanners.)"
+    - tweak: "Air analysis now shows the total amount of moles in the analyzed system.


### PR DESCRIPTION
Calls analyze_gases() when a pipe is hit with an air analyzer - also adds a readout of the analyzed system's total moles, which is nifty for atmos techs to know.