### PR TITLE
Makes the Ore Redemption Console more liberal about ejecting the ID to inactive hand

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -123,8 +123,7 @@
 		if(istype(inserted_id))
 			if(href_list["choice"] == "eject")
 				inserted_id.forceMove(loc)
-				if(!usr.get_active_hand())
-					usr.put_in_hands(inserted_id)
+				usr.put_in_hands(inserted_id)
 				inserted_id = null
 			if(href_list["choice"] == "claim")
 				if(access_mining_station in inserted_id.access)

--- a/html/changelogs/hockaa-oreredemption.yml
+++ b/html/changelogs/hockaa-oreredemption.yml
@@ -3,4 +3,4 @@ author: Hocka
 delete-after: True
 
 changes: 
-    tweak: "Ejecting your ID from the Ore Redemption console will now put the ID in your inactive hand if it's empty and your active hand is full."
+    - tweak: "Ejecting your ID from the Ore Redemption console will now put the ID in your inactive hand if it's empty and your active hand is full."

--- a/html/changelogs/hockaa-oreredemption.yml
+++ b/html/changelogs/hockaa-oreredemption.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+    tweak: "Ejecting your ID from the Ore Redemption console will now put the ID in your inactive hand if it's empty and your active hand is full."


### PR DESCRIPTION
Removes an if directive specifying the active hand for the target of ejecting IDs to give miners a little more quality of life.