### PR TITLE
Revert "Modular Computer Screens (#8646)"

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -101,17 +101,14 @@
 	cut_overlays()
 	if(damage >= broken_damage)
 		icon_state = icon_state_broken
-		var/mutable_appearance/broken_overlay = mutable_appearance(icon, "broken", layer + 0.1, plane)
-		add_overlay(broken_overlay)
+		add_overlay("broken")
 		return
 	if(!enabled)
 		if(icon_state_screensaver && working)
-			var/icon/screensaver_icon = icon(icon, icon_state_screensaver)
-			if(is_holographic)
-				var/icon/alpha_mask = new('icons/effects/effects.dmi', "scanline")
-				screensaver_icon.AddAlphaMask(alpha_mask)
-			var/mutable_appearance/screensaver_overlay = mutable_appearance(screensaver_icon, pick(screensaver_icon.IconStates()), layer + 0.1, plane)
-			add_overlay(screensaver_overlay)
+			if (is_holographic)
+				holographic_overlay(src, src.icon, icon_state_screensaver)
+			else
+				add_overlay(icon_state_screensaver)
 
 		if (screensaver_light_range && working)
 			set_light(screensaver_light_range, 1, screensaver_light_color ? screensaver_light_color : "#FFFFFF")
@@ -120,20 +117,16 @@
 		return
 	if(active_program)
 		var/state = active_program.program_icon_state ? active_program.program_icon_state : icon_state_menu
-		var/icon/state_icon = icon(icon, state)
-		if(is_holographic)
-			var/icon/alpha_mask = new('icons/effects/effects.dmi', "scanline")
-			state_icon.AddAlphaMask(alpha_mask)
-		var/mutable_appearance/state_overlay = mutable_appearance(state_icon, pick(state_icon.IconStates()), layer + 0.1, plane)
-		add_overlay(state_overlay)
+		if (is_holographic)
+			holographic_overlay(src, src.icon, state)
+		else
+			add_overlay(state)
 		set_light(light_strength, l_color = active_program.color)
 	else
-		var/icon/menu_icon = icon(icon, icon_state_menu)
-		if(is_holographic)
-			var/icon/alpha_mask = new('icons/effects/effects.dmi', "scanline")
-			menu_icon.AddAlphaMask(alpha_mask)
-		var/mutable_appearance/menu_overlay = mutable_appearance(menu_icon, pick(menu_icon.IconStates()), layer + 0.1, plane)
-		add_overlay(menu_overlay)
+		if (is_holographic)
+			holographic_overlay(src, src.icon, icon_state_menu)
+		else
+			add_overlay(icon_state_menu)
 		set_light(light_strength, l_color = menu_light_color)
 
 /obj/item/modular_computer/proc/turn_on(var/mob/user)

--- a/html/changelogs/wezzy_revert_scanline.yml
+++ b/html/changelogs/wezzy_revert_scanline.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Wowzewow (Wezzy)
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Computer screen animations are smooth again."


### PR DESCRIPTION
This reverts commit fa802a5749bc42e44631685b20f2ec53d6cffdbe.

they basically broke hologram overlays since the screen and scanline animations have different number of frames. 
this causes the animation to stutter.

we should probably use the new effects from the new BYOND update instead