### PR TITLE
Spawning as someone who needs wheelchairs on the Odin spawns you in a wheelchair

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -494,6 +494,9 @@
 	var/list/spawn_in_storage = list()
 	to_chat(H,"<span class='notice'>You have ten minutes to reach the station before you will be forced there.</span>")
 
+	if(H.needs_wheelchair())
+		H.equip_wheelchair()
+
 	if(job)
 		//Equip custom gear loadout.
 		var/list/custom_equip_slots = list() //If more than one item takes the same slot, all after the first one spawn in storage.

--- a/html/changelogs/Hockaa-wheelchairs.yml
+++ b/html/changelogs/Hockaa-wheelchairs.yml
@@ -1,0 +1,2 @@
+changes: 
+    - Bugfix: "Spawned on the Odin with amputated legs or feet now spawns you in a wheelchair."

--- a/html/changelogs/Hockaa-wheelchairs.yml
+++ b/html/changelogs/Hockaa-wheelchairs.yml
@@ -1,2 +1,6 @@
+author: Hocka
+
+delete-after: True
+
 changes: 
-    - Bugfix: "Spawned on the Odin with amputated legs or feet now spawns you in a wheelchair."
+    - bugfix: "Spawned on the Odin with amputated legs or feet now spawns you in a wheelchair."


### PR DESCRIPTION
Fixes #9608 (and #9423 by technicality, since it was because spawning on the Odin didn't trigger the H.equip_wheelchair() proc until you walked through an AutoDrobe rather than just being an issue with only one leg being amputated.)