### PR TITLE
Removes Officer Beepsky at Roundstart

### DIFF
--- a/html/changelogs/furrycactus - beepsky is lrp.yml
+++ b/html/changelogs/furrycactus - beepsky is lrp.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - maptweak: "Officer Beepsky no longer spawns at roundstart. A toaster with an electric baton that beats people into an unconscious state for looking at it wrong is LRP."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -29558,7 +29558,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/mob/living/bot/secbot/beepsky,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "aZd" = (


### PR DESCRIPTION
This removes Beepsky's spawnpoint at roundstart. Robotics is entirely unaffected and can build him if they want to get the components from Security, but the shitcan shouldn't waddle around at roundstart.

The reasoning:
Beepsky is, at the moment anyway, extremely low-RP. It's an artifact from a bygone era of SS13 where he was good to have around with his instant stuns to thwack assistants who stole insulated gloves, or to get lucky hits and catch antags unawares. On the Aurora, he serves no purpose aside from beating people until they're unconscious because they accidentally clipped him when they were throwing a piece of trash away, or they misclicked him while trying to administer medication, or they misclicked him while trying to eat food when it decides to slide under their feet, or they misclicked him while trying to destroy some vines, or they misclicked him while trying to wack a spider... etc., etc., etc., etc...........
No other department gets any bots for themselves at roundstart, either. Medical doesn't get a medibot, engineering doesn't get a floorbot, janitors don't start with a cleanbot.

"But Beepsky is a legacy thing from SS13!"
So were the bright pink space carp sprites, which were replaced with something more fitting for our server's HRP setting.

"It's harmless, it only stuns people!"
With an electrified stun baton, the exact same kind that's issued to security officers, except Beepsky's is infinitely charged. And more concerning, security players seem to have a tendency of simply standing there and laughing at people who get repeatedly bashed by the bot and actively encourage it to beat the snot out of people, all the while berating the person who's being beaten unconscious with a "well, you shouldn't have done that, this is your own fault". If an actual officer started wailing on somebody with a stun baton for a reason as minor as the ones that set off Beepsky the most, they'd get IR'd, or at the very least suspended from duty for the shift.

Robotics can still build them if they would ever want to. The bots still exist in code. This just stops the Beepsky spawning roundstart. If somebody wants to make a separate PR to make Beepsky less bad, by all means you're free to do so.