### PR TITLE
Fix SQL Error in AdminRanks

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -208,6 +208,9 @@ var/list/forum_groupids_to_ranks = list()
 	return TRUE
 
 /proc/insert_user_to_admins_table(datum/forum_user/user)
+	if(isnull(user.ckey))
+		log_debug("AdminRanks: [user.forum_name] does not have a ckey linked - Ignoring")
+		return
 	var/rights = 0
 
 	for (var/group_id in (user.forum_secondary_groups + user.forum_primary_group))


### PR DESCRIPTION
Fix `SQL Error: 'Column 'ckey' cannot be null'` in AdminRanks