### PR TITLE
Removes armor RNG

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -336,11 +336,6 @@
 #define isContactLevel(Z) ((Z) in current_map.contact_levels)
 #define isNotContactLevel(Z) !isContactLevel(Z)
 
-//Affects the chance that armor will block an attack. Should be between 0 and 1.
-//If set to 0, then armor will always prevent the same amount of damage, always, with no randomness whatsoever.
-//Of course, this will affect code that checks for blocked < 100, as blocked will be less likely to actually be 100.
-#define ARMOR_BLOCK_CHANCE_MULT 1.0
-
 //Cargo Container Types
 #define CARGO_CONTAINER_CRATE "crate"
 #define CARGO_CONTAINER_FREEZER "freezer"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -19,24 +19,16 @@
 	var/armor = getarmor(def_zone, attack_flag)
 
 	if(armor_pen >= armor)
-		return 0 //effective_armor is going to be 0, fullblock is going to be 0, blocked is going to 0, let's save ourselves the trouble
+		return 0 //effective_armor is going to be 0
 
-	var/effective_armor = (armor - armor_pen)/100
-	var/fullblock = (effective_armor*effective_armor) * ARMOR_BLOCK_CHANCE_MULT
+	var/blocked = (armor - armor_pen)/100
 
-	if(fullblock >= 1 || prob(fullblock*100))
+	if(blocked >= 1)
 		if(absorb_text)
 			show_message("<span class='warning'>[absorb_text]</span>")
 		else
 			show_message("<span class='warning'>Your armor absorbs the blow!</span>")
 		return 100
-
-	//this makes it so that X armor blocks X% damage, when including the chance of hard block.
-	//I double checked and this formula will also ensure that a higher effective_armor
-	//will always result in higher (non-fullblock) damage absorption too, which is also a nice property
-	//In particular, blocked will increase from 0 to 50 as effective_armor increases from 0 to 0.999 (if it is 1 then we never get here because ofc)
-	//and the average damage absorption = (blocked/100)*(1-fullblock) + 1.0*(fullblock) = effective_armor
-	var/blocked = (effective_armor - fullblock)/(1 - fullblock)*100
 
 	if(blocked > 20)
 		//Should we show this every single time?

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -13,6 +13,7 @@
 #define MOB_FIRE_LIGHT_POWER  2
 
 /mob/living/proc/run_armor_check(var/def_zone = null, var/attack_flag = "melee", var/armor_pen = 0, var/absorb_text = null, var/soften_text = null)
+	testing("Running armor check")
 	if(armor_pen >= 100)
 		return 0 //might as well just skip the processing
 
@@ -21,9 +22,9 @@
 	if(armor_pen >= armor)
 		return 0 //effective_armor is going to be 0
 
-	var/blocked = (armor - armor_pen)/100
+	var/blocked = (armor - armor_pen)
 
-	if(blocked >= 1)
+	if(blocked >= 100)
 		if(absorb_text)
 			show_message("<span class='warning'>[absorb_text]</span>")
 		else
@@ -37,6 +38,7 @@
 		else
 			show_message("<span class='warning'>Your armor softens the blow!</span>")
 
+	testing("Blocked is [blocked]")
 	return round(blocked, 1)
 
 //Adds two armor values together.

--- a/html/changelogs/no_armor_rng.yml
+++ b/html/changelogs/no_armor_rng.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - tweak: "Armor no longer has a random chance to fully block attacks."


### PR DESCRIPTION
Done at the request of @NonQueueingMatt so we can balance armor a bit easier.

This removes the chance for armour to fully nullify a hit, keeping the normal % damage reduction.

This also effectively reduces all armour by (100-armor) * (armor/100)^2 which we may need to tweak.