### PR TITLE
Makes centcom airlocks unhackable via door hacking tools, be affected by ex_act or emps

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -190,6 +190,12 @@
 /obj/machinery/door/airlock/centcom/emag_act()
 	return NO_EMAG_ACT
 
+/obj/machinery/door/airlock/centcom/ex_act()
+	return
+
+/obj/machinery/door/airlock/centcom/emp_act()
+	return
+
 /obj/machinery/door/airlock/vault
 	name = "Vault"
 	icon = 'icons/obj/doors/vault.dmi'

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -154,19 +154,20 @@
 	panel_visible_while_open = TRUE
 	hatch_colour = "#eaeaea"
 
-/obj/machinery/door/airlock/centcom
-	name = "Airlock"
-	icon = 'icons/obj/doors/Doorele.dmi'
-	opacity = TRUE
-	hatch_colour = "#606061"
-	hashatch = FALSE
-
 /obj/machinery/door/airlock/vaurca
 	name = "Alien Biomass Airlock"
 	icon = 'icons/obj/doors/Doorvaurca.dmi'
 	opacity = TRUE
 	hatch_colour = "#606061"
 	hashatch = FALSE
+
+/obj/machinery/door/airlock/centcom
+	name = "Airlock"
+	icon = 'icons/obj/doors/Doorele.dmi'
+	opacity = TRUE
+	hatch_colour = "#606061"
+	hashatch = FALSE
+	hackProof = TRUE
 
 /obj/machinery/door/airlock/centcom/attackby(obj/item/I, mob/user)
 	if (operating)

--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -59,6 +59,11 @@
 	if(!is_type_in_list(target, supported_types))
 		to_chat(user, "\icon[src] <span class='warning'>Unable to hack this target!</span>")
 		return 0
+	if(istype(target, /obj/machinery/door/airlock))
+		var/obj/machinery/door/airlock/door = target
+		if(door.hackProof)
+			to_chat(user, SPAN_WARNING("Hacking [target] is beyond the capabilities of this device!"))
+			return 0
 	var/found = known_targets.Find(target)
 	if(found)
 		known_targets.Swap(1, found)	// Move the last hacked item first

--- a/html/changelogs/Ferner-200811-bugfix_centcomhack.yml
+++ b/html/changelogs/Ferner-200811-bugfix_centcomhack.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Centcom airlocks can no longer be tampered with via door hacking tools."

--- a/html/changelogs/Ferner-200811-bugfix_centcomhack.yml
+++ b/html/changelogs/Ferner-200811-bugfix_centcomhack.yml
@@ -1,4 +1,4 @@
 author: Ferner
 delete-after: True
 changes: 
-  - bugfix: "Centcom airlocks can no longer be tampered with via door hacking tools."
+  - bugfix: "Centcom airlocks can no longer be tampered with via door hacking tools, blown up or be affected by emp."


### PR DESCRIPTION
Title.
As they can't be opened via other nefarious means, this shouldn't be an exception.