### PR TITLE
Fixes auto pain emotes + groan/scream spam.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -630,7 +630,7 @@
 		return
 	for(var/pain_emotes in pain_emotes_with_pain_level)
 		var/pain_level = pain_emotes_with_pain_level[pain_emotes]
-		if(pain_level >= pain_power)
+		if(pain_power >= pain_level)
 			// This assumes that if a pain-level has been defined it also has a list of emotes to go with it
 			var/decl/emote/E = decls_repository.get_decl(pick(pain_emotes))
 			return E.key

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -258,7 +258,7 @@
 	var/blunt = !!(brute && !sharp && !edge)
 
 	if(status & ORGAN_BROKEN && prob(40) && brute)
-		if(owner && (owner.can_feel_pain()) && stat == CONSCIOUS)
+		if(owner && (owner.can_feel_pain()) && owner.stat == CONSCIOUS)
 			owner.emote(pick("scream", "groan"))	//getting hit on broken hand hurts
 
 	if(used_weapon)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -258,7 +258,7 @@
 	var/blunt = !!(brute && !sharp && !edge)
 
 	if(status & ORGAN_BROKEN && prob(40) && brute)
-		if(owner && (owner.can_feel_pain()))
+		if(owner && (owner.can_feel_pain()) && stat == CONSCIOUS)
 			owner.emote(pick("scream", "groan"))	//getting hit on broken hand hurts
 
 	if(used_weapon)

--- a/html/changelogs/mattatlas-seccomplainedabouttheircharactercrying.yml
+++ b/html/changelogs/mattatlas-seccomplainedabouttheircharactercrying.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed people crying or screaming at very low levels of pain."
+  - bugfix: "Unconscious characters no longer spam groaning or screaming."


### PR DESCRIPTION
This bug made it possible for the game to pick a 70 pain strength emote at like 10 pain.

Which is no bueno.

Security machos can't cry, we all know that.