### PR TITLE
Having something in the uniform slot in your loadout now puts your job uniform into your backpack when you spawn

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -718,7 +718,6 @@
 
 			if(G.slot == slot_w_uniform)
 				UniformReturn(keepuniform, H)
-
 			if(G.augment) //augments are handled somewhere else
 				continue
 
@@ -763,7 +762,6 @@
 				else if (leftovers)
 					leftovers += thing
 					Debug("EC/([H]): Unable to equip [thing]; sending to overflow.")
-
 			else if (storage)
 				storage += thing
 				Debug("EC/([H]): Unable to equip [thing]; sending to storage.")
@@ -775,7 +773,6 @@
 // Returns a list of items that failed to equip & should be put in storage if possible.
 // H and prefs must not be null.
 /datum/controller/subsystem/jobs/proc/EquipCustomDeferred(mob/living/carbon/human/H, datum/preferences/prefs, list/items, list/used_slots)
-
 	. = list()
 	Debug("ECD/([H]): Entry.")
 	for (var/thing in items)
@@ -943,5 +940,4 @@
 	var/datum/outfit/U = new uniform
 	var/uniformspawn = new U.uniform(H)
 	H.equip_or_collect(uniformspawn, H.back)
-
 #undef Debug

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -701,6 +701,7 @@
 // H, job, and prefs MUST be supplied and not null.
 // leftovers, storage, custom_equip_slots can be passed if their return values are required (proc mutates passed list), or ignored if not required.
 /datum/controller/subsystem/jobs/proc/EquipCustom(mob/living/carbon/human/H, datum/job/job, datum/preferences/prefs, list/leftovers = null, list/storage = null, list/custom_equip_slots = list())
+	var/keepuniform = job.get_outfit(H)
 	Debug("EC/([H]): Entry.")
 	if (!istype(H) || !job)
 		Debug("EC/([H]): Abort: invalid arguments.")
@@ -714,6 +715,9 @@
 	for(var/thing in prefs.gear)
 		var/datum/gear/G = gear_datums[thing]
 		if(G)
+
+			if(G.slot == slot_w_uniform)
+				UniformReturn(keepuniform, H)
 
 			if(G.augment) //augments are handled somewhere else
 				continue
@@ -747,7 +751,7 @@
 				else
 					metadata = list()
 				var/obj/item/CI = G.spawn_item(null,metadata)
-				if (G.slot == slot_wear_mask || G.slot == slot_wear_suit || G.slot == slot_head || G.slot == slot_w_uniform)
+				if (G.slot == slot_wear_mask || G.slot == slot_wear_suit || G.slot == slot_head)
 					if (leftovers)
 						leftovers += thing
 					Debug("EC/([H]): [thing] failed mask/suit/head check; leftovers=[!!leftovers]")
@@ -759,6 +763,7 @@
 				else if (leftovers)
 					leftovers += thing
 					Debug("EC/([H]): Unable to equip [thing]; sending to overflow.")
+
 			else if (storage)
 				storage += thing
 				Debug("EC/([H]): Unable to equip [thing]; sending to storage.")
@@ -770,6 +775,7 @@
 // Returns a list of items that failed to equip & should be put in storage if possible.
 // H and prefs must not be null.
 /datum/controller/subsystem/jobs/proc/EquipCustomDeferred(mob/living/carbon/human/H, datum/preferences/prefs, list/items, list/used_slots)
+
 	. = list()
 	Debug("ECD/([H]): Entry.")
 	for (var/thing in items)
@@ -932,5 +938,10 @@
 	sleep(5)
 	C.screen -= T
 	qdel(T)
+
+/datum/controller/subsystem/jobs/proc/UniformReturn(uniform, mob/living/carbon/human/H)
+	var/datum/outfit/U = new uniform
+	var/uniformspawn = new U.uniform(H)
+	H.equip_or_collect(uniformspawn, H.back)
 
 #undef Debug

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -747,7 +747,7 @@
 				else
 					metadata = list()
 				var/obj/item/CI = G.spawn_item(null,metadata)
-				if (G.slot == slot_wear_mask || G.slot == slot_wear_suit || G.slot == slot_head)
+				if (G.slot == slot_wear_mask || G.slot == slot_wear_suit || G.slot == slot_head || G.slot == slot_w_uniform)
 					if (leftovers)
 						leftovers += thing
 					Debug("EC/([H]): [thing] failed mask/suit/head check; leftovers=[!!leftovers]")

--- a/code/modules/clothing/factions/dominia.dm
+++ b/code/modules/clothing/factions/dominia.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/clothing/masks/lyodsuit.dmi'
 	icon_state = "dom_thermal_mask"
 	item_state = "dom_thermal_mask"
+	flags_inv = BLOCKHAIR
 	contained_sprite = TRUE
 	canremove = FALSE
 

--- a/html/changelogs/hockaa-uniforms.yml
+++ b/html/changelogs/hockaa-uniforms.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes: 
   - bugfix: "If you have something else from the loadout equipped to your uniform slot your job's uniform will now be put in your backpack."
+  - bugfix: "Lyodsuit masks no longer show hair."

--- a/html/changelogs/hockaa-uniforms.yml
+++ b/html/changelogs/hockaa-uniforms.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+  - bugfix: "If you have something else from the loadout equipped to your uniform slot your job's uniform will now be put in your backpack."


### PR DESCRIPTION
Adds the uniform slot to the custom equip check for items to be but into the backpack (as it was with things like hard hats etc)

Edit: After having the PR up for like 7 hours I just realised I made a typing error in the title - your loadout items go into the backpack, your job uniform gets equipped.

Also gives the BLOCKHAIR flag to lyodsuit masks at the request of Geeves.