### PR TITLE
Fixes runtime with spawning at the arrivals location

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -39,7 +39,7 @@ datum/preferences
 	var/can_edit_ipc_tag = TRUE
 	var/gender = MALE					//gender of character (well duh)
 	var/age = 30						//age of character
-	var/spawnpoint = "Arrivals Shuttle" //where this character will spawn (0-2).
+	var/spawnpoint = /datum/spawnpoint/arrivals //where this character will spawn (0-2).
 	var/b_type = "A+"					//blood type (not-chooseable)
 	var/backbag = 2						//backpack type
 	var/backbag_style = 1

--- a/html/changelogs/arrivals_runtime.yml
+++ b/html/changelogs/arrivals_runtime.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed runtime with spawning at the arrivals location."


### PR DESCRIPTION
Runtime was at this line H.forceMove(pick(spawnpos.turfs))

Where spawnpos was equal to "Arrivals Shuttle" and therefore did not have a turfs var.