### PR TITLE
Turrets create less unnecessary timers

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -496,8 +496,9 @@
 
 	if(!tryToShootAt(targets))
 		if(!tryToShootAt(secondarytargets) && !resetting) // if no valid targets, go for secondary targets
-			resetting = TRUE
-			addtimer(CALLBACK(src, .proc/reset), 6 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE) // no valid targets, close the cover
+			if(raised || raising) // we've already reset
+				resetting = TRUE
+				addtimer(CALLBACK(src, .proc/reset), 6 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE) // no valid targets, close the cover
 
 	if(targets.len || secondarytargets.len)
 		if(!fast_processing)

--- a/html/changelogs/less_turret_timers.yml
+++ b/html/changelogs/less_turret_timers.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Turrets no longer constantly try to reset themselves, even when in a dormant state."


### PR DESCRIPTION
Tested & turrets still act properly. 

This removes about 26 timers that were constantly running at all times.