### PR TITLE
Reducing overall lethality and nerfing lasers a bit.

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -336,11 +336,6 @@
 #define isContactLevel(Z) ((Z) in current_map.contact_levels)
 #define isNotContactLevel(Z) !isContactLevel(Z)
 
-//Affects the chance that armor will block an attack. Should be between 0 and 1.
-//If set to 0, then armor will always prevent the same amount of damage, always, with no randomness whatsoever.
-//Of course, this will affect code that checks for blocked < 100, as blocked will be less likely to actually be 100.
-#define ARMOR_BLOCK_CHANCE_MULT 1.0
-
 //Cargo Container Types
 #define CARGO_CONTAINER_CRATE "crate"
 #define CARGO_CONTAINER_FREEZER "freezer"

--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -32,7 +32,7 @@
 
 /decl/emote/audible/choke
 	key ="choke"
-	emote_message_3p = "USER chokes."
+	emote_message_3p = "USER chokes!"
 	conscious = 0
 
 /decl/emote/audible/gnarl

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -296,7 +296,7 @@
 				if(prob(50))
 					emote("gasp")
 				else
-					emote("chokes!")
+					emote("choke")
 
 
 			message = "[prefix][jointext(words," ")]"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -19,24 +19,16 @@
 	var/armor = getarmor(def_zone, attack_flag)
 
 	if(armor_pen >= armor)
-		return 0 //effective_armor is going to be 0, fullblock is going to be 0, blocked is going to 0, let's save ourselves the trouble
+		return 0 //effective_armor is going to be 0
 
-	var/effective_armor = (armor - armor_pen)/100
-	var/fullblock = (effective_armor*effective_armor) * ARMOR_BLOCK_CHANCE_MULT
+	var/blocked = (armor - armor_pen)
 
-	if(fullblock >= 1 || prob(fullblock*100))
+	if(blocked >= 100)
 		if(absorb_text)
 			show_message("<span class='warning'>[absorb_text]</span>")
 		else
 			show_message("<span class='warning'>Your armor absorbs the blow!</span>")
 		return 100
-
-	//this makes it so that X armor blocks X% damage, when including the chance of hard block.
-	//I double checked and this formula will also ensure that a higher effective_armor
-	//will always result in higher (non-fullblock) damage absorption too, which is also a nice property
-	//In particular, blocked will increase from 0 to 50 as effective_armor increases from 0 to 0.999 (if it is 1 then we never get here because ofc)
-	//and the average damage absorption = (blocked/100)*(1-fullblock) + 1.0*(fullblock) = effective_armor
-	var/blocked = (effective_armor - fullblock)/(1 - fullblock)*100
 
 	if(blocked > 20)
 		//Should we show this every single time?

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -134,8 +134,8 @@
 				if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
 					owner.eye_blurry = max(owner.eye_blurry,6)
 					damprob = owner.chem_effects[CE_STABLE] ? 40 : 80
-					if(!past_damage_threshold(6) && prob(damprob))
-						take_internal_damage(4)
+					if(!past_damage_threshold(4) && prob(damprob))
+						take_internal_damage(1)
 					if(!owner.paralysis && prob(10))
 						owner.Paralyse(rand(1,3))
 						to_chat(owner, "<span class='warning'>You feel extremely [pick("dizzy","woozy","faint")]...</span>")

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -122,7 +122,6 @@
 			var/damprob
 			//Effects of bloodloss
 			switch(blood_volume)
-
 				if(BLOOD_VOLUME_SAFE to INFINITY)
 					if(can_heal)
 						damage = max(damage-1, 0)
@@ -130,20 +129,20 @@
 					if(prob(1))
 						to_chat(owner, "<span class='warning'>You feel [pick("dizzy","woozy","faint")]...</span>")
 					damprob = owner.chem_effects[CE_STABLE] ? 30 : 60
-					if(!past_damage_threshold(4) && prob(damprob))
+					if(!past_damage_threshold(2) && prob(damprob))
 						take_internal_damage(1)
 				if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
 					owner.eye_blurry = max(owner.eye_blurry,6)
 					damprob = owner.chem_effects[CE_STABLE] ? 40 : 80
 					if(!past_damage_threshold(6) && prob(damprob))
-						take_internal_damage(2)
+						take_internal_damage(4)
 					if(!owner.paralysis && prob(10))
 						owner.Paralyse(rand(1,3))
 						to_chat(owner, "<span class='warning'>You feel extremely [pick("dizzy","woozy","faint")]...</span>")
 				if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
 					owner.eye_blurry = max(owner.eye_blurry,6)
 					damprob = owner.chem_effects[CE_STABLE] ? 60 : 100
-					if(!past_damage_threshold(8) && prob(damprob))
+					if(!past_damage_threshold(6) && prob(damprob))
 						take_internal_damage(1)
 					if(!owner.paralysis && prob(15))
 						owner.Paralyse(rand(3, 5))

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -174,7 +174,8 @@
 			blood_max *= 0.8
 
 		if(world.time >= next_blood_squirt && istype(owner.loc, /turf) && do_spray.len)
-			owner.visible_message("<span class='danger'>Blood squirts from \the [owner]'s [pick(do_spray)]!</span>", "<span class='danger'><font size=3>Blood is squirting out of your [pick(do_spray)]!</font></span>")
+			owner.visible_message("<span class='danger'>Blood squirts from \the [owner]'s [pick(do_spray)]!</span>", \
+								"<span class='danger'><font size=3>Blood sprays out of your [pick(do_spray)]!</font></span>")
 			owner.eye_blurry = 2
 			owner.Stun(1)
 			next_blood_squirt = world.time + 100

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -9,11 +9,11 @@
 	parent_organ = BP_CHEST
 	robotic_name = "gas exchange system"
 	robotic_sprite = "lungs-prosthetic"
-	min_bruised_damage = 25
+	min_bruised_damage = 30
 	min_broken_damage = 45
 	toxin_type = CE_PNEUMOTOXIC
 
-	max_damage = 70
+	max_damage = 80
 	relative_size = 60
 
 	var/breathing = 0

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -362,7 +362,6 @@
 	if(prob(organ_hit_chance))
 		var/obj/item/organ/internal/victim = pickweight(victims)
 		damage_amt = max(damage_amt*victim.damage_reduction, 0)
-		world << "Damage given to: <b>[victim]</b>: [damage_amt]"
 		victim.take_internal_damage(damage_amt)
 		return TRUE
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -323,7 +323,10 @@
 	var/laser = (damage_flags & DAM_LASER)
 	var/sharp = (damage_flags & DAM_SHARP)
 
-	if(laser || BP_IS_ROBOTIC(src))
+	if(laser)
+		return FALSE
+
+	if(BP_IS_ROBOTIC(src))
 		damage_amt += burn
 		cur_damage += burn_dam
 
@@ -358,7 +361,8 @@
 	organ_hit_chance = min(organ_hit_chance, 100)
 	if(prob(organ_hit_chance))
 		var/obj/item/organ/internal/victim = pickweight(victims)
-		damage_amt -= max(damage_amt*victim.damage_reduction, 0)
+		damage_amt = max(damage_amt*victim.damage_reduction, 0)
+		world << "Damage given to: <b>[victim]</b>: [damage_amt]"
 		victim.take_internal_damage(damage_amt)
 		return TRUE
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -336,8 +336,6 @@
 	var/organ_damage_threshold = 10
 	if(sharp)
 		organ_damage_threshold *= 0.5
-	if(laser)
-		organ_damage_threshold *= 2
 
 	if(!(cur_damage + damage_amt >= max_damage) && !(damage_amt >= organ_damage_threshold))
 		return FALSE

--- a/html/changelogs/example.yml
+++ b/html/changelogs/example.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.  
-author: ChangeMe
+author: MattAtlas, MikoMyazaki2
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -38,5 +38,7 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - experiment: "Lasers no longer do organ damage."
+  - experiment: "Armor blocking is now fully percentage based. No more random 100% blocks."
+  - tweak: "Brain damage from bloodloss is now much slower."
+  - tweak: "Lungs now have slightly more health."

--- a/html/changelogs/mattatlas-itstimeforyoutonotdie.yml
+++ b/html/changelogs/mattatlas-itstimeforyoutonotdie.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.  
-author: ChangeMe
+author: MattAtlas, MikoMyazaki2
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -38,5 +38,7 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - experiment: "Lasers no longer do organ damage."
+  - experiment: "Armor blocking is now fully percentage based. No more random 100% blocks."
+  - tweak: "Brain damage from bloodloss is now much slower."
+  - tweak: "Lungs now have slightly more health."


### PR DESCRIPTION
Based on https://github.com/Aurorastation/Aurora.3/pull/9658

What this does:

- Remove RNG from armor. This means that damage dealt is mostly predictable. Overall we end up in a better spot, because armor will be more consistent.

- Remove organ damage from lasers. This was a tough choice to make but one I believe necessary until we have a new armor system that allows us to tweak this easier. My reasoning for this is that organ damage AND blood boil together are a bit too extreme. If security still ends to do organ damage, they have .45s for that.

- Buff lung HP a bit. They should no longer get one hit fucked.

- Brain damage from bloodloss has been reverted back to what it was prior to one of my last PRs. Brain decay should now be considerably slower. Experimental, but it should cause a lot less "unintentional" deaths. Similiarly, antags and security will have to actually try to murder someone. 

My results from testing this with Geeves:
A mercenary is dropped overtime by slightly less than one laser rifle magazine (10-12 shots is the point at which they enter paincrit), but is dropped instantly upon emptying a full one into them. At this point they'll be at 68%-ish blood oxygenation, which means they'll die overtime. Two .45 magazines will drop a mercenary, along with breaking their ribs and busting their lungs with a considerable amount of bloodloss. Three .45 magazines are basically guaranteed death. Emptying a full laser rifle magazine into an authentic breacher now only does 38 burn damage.

It takes 15ish mercenary rifle bullets to get an officer into paincrit with severe organ damage. A full magazine is certain to basically maim them, and kill them if they're left with no help.