### PR TITLE
Spawning on the Odin now gives you your job uniform

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -327,6 +327,7 @@
 			EquipCustom(H, job, H.client.prefs, custom_equip_leftovers, spawn_in_storage, custom_equip_slots)
 
 		job.equip(H)
+		UniformReturn(H, H.client.prefs, job)
 
 		if (!megavend)
 			spawn_in_storage += EquipCustomDeferred(H, H.client.prefs, custom_equip_leftovers, custom_equip_slots)
@@ -701,7 +702,6 @@
 // H, job, and prefs MUST be supplied and not null.
 // leftovers, storage, custom_equip_slots can be passed if their return values are required (proc mutates passed list), or ignored if not required.
 /datum/controller/subsystem/jobs/proc/EquipCustom(mob/living/carbon/human/H, datum/job/job, datum/preferences/prefs, list/leftovers = null, list/storage = null, list/custom_equip_slots = list())
-	var/keepuniform = job.get_outfit(H)
 	Debug("EC/([H]): Entry.")
 	if (!istype(H) || !job)
 		Debug("EC/([H]): Abort: invalid arguments.")
@@ -716,8 +716,6 @@
 		var/datum/gear/G = gear_datums[thing]
 		if(G)
 
-			if(G.slot == slot_w_uniform)
-				UniformReturn(keepuniform, H)
 			if(G.augment) //augments are handled somewhere else
 				continue
 
@@ -936,8 +934,12 @@
 	C.screen -= T
 	qdel(T)
 
-/datum/controller/subsystem/jobs/proc/UniformReturn(uniform, mob/living/carbon/human/H)
+/datum/controller/subsystem/jobs/proc/UniformReturn(mob/living/carbon/human/H, datum/preferences/prefs, datum/job/job)
+	var/uniform = job.get_outfit(H)
 	var/datum/outfit/U = new uniform
-	var/uniformspawn = new U.uniform(H)
-	H.equip_or_collect(uniformspawn, H.back)
+	for(var/item in prefs.gear)
+		var/datum/gear/L = gear_datums[item]
+		if(L.slot == slot_w_uniform)
+			H.equip_or_collect(new U.uniform(H), H.back)
+			break
 #undef Debug

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -381,8 +381,6 @@
 			H.equip_wheelchair()
 
 	to_chat(H, "<B>You are [job.total_positions == 1 ? "the" : "a"] [alt_title ? alt_title : rank].</B>")
-	
-	UniformReturn(H, H.client.prefs, job)
 
 	if(job.supervisors)
 		to_chat(H, "<b>As [job.intro_prefix] [alt_title ? alt_title : rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
@@ -505,7 +503,6 @@
 		var/list/custom_equip_leftovers = list()
 
 		EquipCustom(H, job, H.client.prefs, custom_equip_leftovers, spawn_in_storage, custom_equip_slots)
-		UniformReturn(H, H.client.prefs, job)
 
 		Debug("EP/([H]): EC Complated, running pre_equip and late_equip.")
 
@@ -704,6 +701,7 @@
 // H, job, and prefs MUST be supplied and not null.
 // leftovers, storage, custom_equip_slots can be passed if their return values are required (proc mutates passed list), or ignored if not required.
 /datum/controller/subsystem/jobs/proc/EquipCustom(mob/living/carbon/human/H, datum/job/job, datum/preferences/prefs, list/leftovers = null, list/storage = null, list/custom_equip_slots = list())
+	var/keepuniform = job.get_outfit(H)
 	Debug("EC/([H]): Entry.")
 	if (!istype(H) || !job)
 		Debug("EC/([H]): Abort: invalid arguments.")
@@ -718,6 +716,8 @@
 		var/datum/gear/G = gear_datums[thing]
 		if(G)
 
+			if(G.slot == slot_w_uniform)
+				UniformReturn(keepuniform, H)
 			if(G.augment) //augments are handled somewhere else
 				continue
 
@@ -772,7 +772,7 @@
 // Attempts to equip custom items that failed to equip in EquipCustom.
 // Returns a list of items that failed to equip & should be put in storage if possible.
 // H and prefs must not be null.
-/datum/controller/subsystem/jobs/proc/EquipCustomDeferred(mob/living/carbon/human/H, datum/preferences/prefs, list/items, list/used_slots, datum/job/job)
+/datum/controller/subsystem/jobs/proc/EquipCustomDeferred(mob/living/carbon/human/H, datum/preferences/prefs, list/items, list/used_slots)
 	. = list()
 	Debug("ECD/([H]): Entry.")
 	for (var/thing in items)
@@ -936,13 +936,8 @@
 	C.screen -= T
 	qdel(T)
 
-/datum/controller/subsystem/jobs/proc/UniformReturn(mob/living/carbon/human/H, datum/preferences/prefs, datum/job/job)
-	var/uniform = job.get_outfit(H)
+/datum/controller/subsystem/jobs/proc/UniformReturn(uniform, mob/living/carbon/human/H)
 	var/datum/outfit/U = new uniform
 	var/uniformspawn = new U.uniform(H)
-	for(var/item in prefs.gear)
-		var/datum/gear/L = gear_datums[item]
-		if(L.slot == slot_w_uniform)
-			H.equip_or_collect(uniformspawn, H.back)
-			break
+	H.equip_or_collect(uniformspawn, H.back)
 #undef Debug

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+  - bugfix: "Spawning on the Odin now gives you your job uniform as well."

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,6 +1,0 @@
-author: Hocka
-
-delete-after: True
-
-changes: 
-  - bugfix: "Spawning on the Odin now gives you your job uniform as well."

--- a/html/changelogs/hockaa-uniformfix.yml
+++ b/html/changelogs/hockaa-uniformfix.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+  - bugfix: "Spawning on the Odin now gives you your job uniform as well."


### PR DESCRIPTION
Fixes #9693 

Makes the UniformReturn proc more independant - no longer relies on the check in EquipCustom() and does all the checking itself, so it can be called by the EquipRank proc rather than bouncing off of EquipCustom(), which allows it to be called regardless of if Megavend is false or not (which is the root of the problem.)