### PR TITLE
Clamp Forcing

### DIFF
--- a/code/modules/heavy_vehicle/equipment/utility.dm
+++ b/code/modules/heavy_vehicle/equipment/utility.dm
@@ -53,6 +53,9 @@
 						INVOKE_ASYNC(FD, /obj/machinery/door/firedoor/.proc/close)
 			return
 		else if(istype(target, /obj/machinery/door/airlock))
+			if(istype(target, /obj/machinery/door/airlock/centcom))
+				to_chat(user, SPAN_WARNING("You can't force these airlocks!"))
+				return
 			var/obj/machinery/door/airlock/AD = target
 			if(!AD.operating)
 				if(AD.welded || AD.locked)

--- a/code/modules/heavy_vehicle/equipment/utility.dm
+++ b/code/modules/heavy_vehicle/equipment/utility.dm
@@ -8,9 +8,10 @@
 	var/carrying_capacity = 5
 	var/list/obj/carrying = list()
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
+	var/list/afterattack_types = list(/obj/structure/closet, /obj/machinery/door/airlock)
 
 /obj/item/mecha_equipment/clamp/resolve_attackby(atom/A, mob/user, click_params)
-	if(istype(A, /obj/structure/closet) && owner)
+	if(is_type_in_list(A, afterattack_types) && owner)
 		return FALSE
 	return ..()
 
@@ -29,6 +30,57 @@
 	. = ..()
 
 	if(.)
+		if(istype(target, /obj/machinery/door/firedoor))
+			var/obj/machinery/door/firedoor/FD = target
+			if(FD.blocked)
+				FD.visible_message(SPAN_WARNING("\The [owner] begins prying on \the [FD]!"))
+				if(do_after(owner, 10 SECONDS) && FD.blocked)
+					playsound(FD, 'sound/effects/meteorimpact.ogg', 100, 1)
+					playsound(FD, 'sound/machines/airlock_open_force.ogg', 100, 1)
+					FD.blocked = FALSE
+					INVOKE_ASYNC(FD, /obj/machinery/door/firedoor/.proc/open)
+					FD.visible_message(SPAN_WARNING("\The [owner] tears \the [FD] open!"))
+			else
+				FD.visible_message(SPAN_WARNING("\The [owner] begins forcing \the [FD]!"))
+				if(do_after(owner, 4 SECONDS) && !FD.blocked)
+					if(FD.density)
+						FD.visible_message(SPAN_WARNING("\The [owner] forces \the [FD] open!"))
+						playsound(FD, 'sound/machines/airlock_open_force.ogg', 100, 1)
+						INVOKE_ASYNC(FD, /obj/machinery/door/firedoor/.proc/open)
+					else
+						FD.visible_message(SPAN_WARNING("\The [owner] forces \the [FD] closed!"))
+						playsound(FD, 'sound/machines/airlock_close_force.ogg', 100, 1)
+						INVOKE_ASYNC(FD, /obj/machinery/door/firedoor/.proc/close)
+			return
+		else if(istype(target, /obj/machinery/door/airlock))
+			var/obj/machinery/door/airlock/AD = target
+			if(!AD.operating)
+				if(AD.welded || AD.locked)
+					AD.visible_message(SPAN_WARNING("\The [owner] begins prying on \the [AD]!"))
+					var/time_to_open = 15 SECONDS
+					if(AD.welded && AD.locked)
+						time_to_open = 30 SECONDS
+					if(do_after(owner, time_to_open))
+						AD.welded = FALSE
+						AD.locked = FALSE
+						AD.update_icon()
+						playsound(AD, 'sound/effects/meteorimpact.ogg', 100, 1)
+						playsound(AD, 'sound/machines/airlock_open_force.ogg', 100, 1)
+						AD.visible_message(SPAN_WARNING("\The [owner] tears \the [AD] open!"))
+						INVOKE_ASYNC(AD, /obj/machinery/door/airlock/.proc/open)
+				else
+					AD.visible_message(SPAN_WARNING("\The [owner] begins forcing \the [AD]!"))
+					if(do_after(owner, 5 SECONDS) && !(AD.operating || AD.welded || AD.locked))
+						if(AD.density)
+							INVOKE_ASYNC(AD, /obj/machinery/door/airlock/.proc/open)
+							playsound(AD, 'sound/machines/airlock_open_force.ogg', 100, 1)
+							AD.visible_message(SPAN_DANGER("\The [owner] forces \the [AD] open!"))
+						else
+							INVOKE_ASYNC(AD, /obj/machinery/door/airlock/.proc/close)
+							playsound(AD, 'sound/machines/airlock_close_force.ogg', 100, 1)
+							AD.visible_message(SPAN_DANGER("\The [owner] forces \the [AD] closed!"))
+			return
+	
 		if(length(carrying) >= carrying_capacity)
 			to_chat(user, SPAN_WARNING("\The [src] is fully loaded!"))
 			return

--- a/html/changelogs/geeves-clamp_thing.yml
+++ b/html/changelogs/geeves-clamp_thing.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Clamps can now be used to force open airlocks and firedoors. Welding and bolting affects how long it will take and how loud the action will be."

--- a/html/changelogs/geeves-clamp_thing.yml
+++ b/html/changelogs/geeves-clamp_thing.yml
@@ -3,4 +3,4 @@ author: Geeves
 delete-after: True
 
 changes: 
-  - rscadd: "Clamps can now be used to force open airlocks and firedoors. Welding and bolting affects how long it will take and how loud the action will be."
+  - rscadd: "Mech clamps can now be used to force open airlocks and firedoors. Welding and bolting affects how long it will take and how loud the action will be."


### PR DESCRIPTION
* Clamps can now be used to force open airlocks and firedoors. Welding and bolting affects how long it will take and how loud the action will be.

Ported with alterations from: https://github.com/Baystation12/Baystation12/pull/29055