### PR TITLE
Diagnosing Timers Again

### DIFF
--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -331,6 +331,18 @@ var/datum/controller/subsystem/timer/SStimer
 	src.flags = flags
 	src.hash = hash
 
+	var/static/timeadded = world.time
+	var/static/count = 0
+
+	if (timeadded != world.time)
+		timeadded = world.time
+		count = 0
+	else
+		count++
+
+		if (count > 100)
+			crash_with("Timer New crash: [count] in one tick.")
+
 	if (flags & TIMER_CLIENT_TIME)
 		timeToRun = REALTIMEOFDAY + wait
 	else
@@ -358,6 +370,19 @@ var/datum/controller/subsystem/timer/SStimer
 
 /datum/timedevent/Destroy()
 	..()
+
+	var/static/timeadded = world.time
+	var/static/count = 0
+
+	if (timeadded != world.time)
+		timeadded = world.time
+		count = 0
+	else
+		count++
+
+		if (count > 100)
+			crash_with("Timer Destroy crash: [count] in one tick.")
+
 	if (flags & TIMER_UNIQUE && hash)
 		SStimer.hashes -= hash
 

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -340,7 +340,7 @@ var/datum/controller/subsystem/timer/SStimer
 	else
 		count++
 
-		if (count > 100)
+		if (count > 500)
 			crash_with("Timer New crash: [count] in one tick.")
 
 	if (flags & TIMER_CLIENT_TIME)
@@ -380,7 +380,7 @@ var/datum/controller/subsystem/timer/SStimer
 	else
 		count++
 
-		if (count > 100)
+		if (count > 500)
 			crash_with("Timer Destroy crash: [count] in one tick.")
 
 	if (flags & TIMER_UNIQUE && hash)

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -340,7 +340,7 @@ var/datum/controller/subsystem/timer/SStimer
 	else
 		count++
 
-		if (count > 500)
+		if (count > 1000)
 			crash_with("Timer New crash: [count] in one tick.")
 
 	if (flags & TIMER_CLIENT_TIME)
@@ -380,7 +380,7 @@ var/datum/controller/subsystem/timer/SStimer
 	else
 		count++
 
-		if (count > 500)
+		if (count > 1000)
 			crash_with("Timer Destroy crash: [count] in one tick.")
 
 	if (flags & TIMER_UNIQUE && hash)

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -341,7 +341,7 @@ var/datum/controller/subsystem/timer/SStimer
 		count++
 
 		if (count > 1000)
-			crash_with("Timer New crash: [count] in one tick.")
+			crash_with("Timer New crash: [count] in one tick. [name]")
 
 	if (flags & TIMER_CLIENT_TIME)
 		timeToRun = REALTIMEOFDAY + wait
@@ -381,7 +381,7 @@ var/datum/controller/subsystem/timer/SStimer
 		count++
 
 		if (count > 1000)
-			crash_with("Timer Destroy crash: [count] in one tick.")
+			crash_with("Timer Destroy crash: [count] in one tick. [name]")
 
 	if (flags & TIMER_UNIQUE && hash)
 		SStimer.hashes -= hash


### PR DESCRIPTION
Because spending 48 seconds cleaning up timers is NOT A GOOD IDEA.