### PR TITLE
Players who are assigned restricted jobs will be removed from the antag candidate list

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -185,6 +185,12 @@ var/global/list/additional_antag_types = list()
 				else
 					potential = antag.candidates
 				if(islist(potential))
+					for(var/potential_antag in potential)
+						var/datum/mind/player = potential_antag
+						if(!(antag.flags & ANTAG_OVERRIDE_JOB) && player.assigned_role in antag.restricted_jobs)
+							potential -= potential_antag
+							antag.candidates -= player
+							log_debug("GAMEMODE: Player [player.name] [player.ckey] was removed from the potential antags list due to being given the role [player.assigned_role] which is a restricted job!")
 					if(potential.len)
 						log_debug("GAMEMODE: Found [potential.len] potential antagonists for [antag.role_text].")
 						total_enemy_count += potential.len

--- a/html/changelogs/antag_role_check.yml
+++ b/html/changelogs/antag_role_check.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Players who are given roles restricted from an antag role they were selected for will now be removed from that role's candidate list - This may result in a game mode reset due to lack of antagonists, but it will prevent the mode spawning with too few antagonists."


### PR DESCRIPTION
Players who are assigned restricted jobs will be removed from the antagonist candidate list during the can_start check.

This may result in a game mode restart if this results in the candidate list being too small, however it will prevent modes spawning with too few (or no) antagonists.

---

I considered making the job selection functions check if someone is assigned an antag role, and then steer them away from restricted roles -- However I believe most people have only one occupation assigned for a character if they regularly play them in a head role, so I don't think this is worth doing.