### PR TITLE
Research can access the chem codex program

### DIFF
--- a/code/modules/modular_computers/file_system/programs/research/chemistry_codex.dm
+++ b/code/modules/modular_computers/file_system/programs/research/chemistry_codex.dm
@@ -4,8 +4,8 @@
 	program_icon_state = "generic"
 	extended_desc = "Useful program to view chemical reactions and how to make them."
 	size = 14
-	required_access_run = access_medical
-	required_access_download = access_medical
+	required_access_run = list(access_medical, access_research)
+	required_access_download = list(access_medical, access_research)
 	available_on_ntnet = TRUE
 
 /datum/computer_file/program/chemistry_codex/ui_interact(mob/user)

--- a/html/changelogs/chem-codex-research.yml
+++ b/html/changelogs/chem-codex-research.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Research can now access and download the Chemistry Codex that is installed on the Research wrist computers."


### PR DESCRIPTION
It already spawns on some of the research preset computers, idk why they don't have access. Seems like a bug.