### PR TITLE
Apostrophes and hyphens no longer automatically capitalize the letter after in sanitization

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -62,6 +62,7 @@
 #define SYMBOLS_DETECTED 2
 #define NUMBERS_DETECTED 3
 #define LETTERS_DETECTED 4
+#define SYMBOLS_DETECTED_NEW_WORD 5 // symbols that we will interpret as the start of a new word
 
 /**
   * Filters out undesirable characters from names.
@@ -96,7 +97,7 @@
 
 			// a  .. z
 			if(97 to 122)   //Lowercase Letters
-				if(last_char_group == NO_CHARS_DETECTED || last_char_group == SPACES_DETECTED || last_char_group == SYMBOLS_DETECTED) //start of a word
+				if(last_char_group == NO_CHARS_DETECTED || last_char_group == SPACES_DETECTED || last_char_group == SYMBOLS_DETECTED_NEW_WORD) //start of a word
 					char = uppertext(char)
 				number_of_alphanumeric++
 				last_char_group = LETTERS_DETECTED
@@ -108,17 +109,17 @@
 				number_of_alphanumeric++
 				last_char_group = NUMBERS_DETECTED
 
-			// '  -  .
-			if(39,45,46)   //Common name punctuation
+			// '  -
+			if(39,45)   //Common name punctuation
 				if(last_char_group == NO_CHARS_DETECTED)
 					continue
 				last_char_group = SYMBOLS_DETECTED
 
-			// ~   |   @  :  #  $  %  &  *  +
-			if(126,124,64,58,35,36,37,38,42,43)			//Other symbols that we'll allow (mainly for AI)
+			// ~   |   @  :  #  $  %  &  *  + .
+			if(126,124,64,58,35,36,37,38,42,43,46)			//Other symbols that we'll allow (mainly for AI)
 				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers) //suppress at start of string
 					continue
-				last_char_group = SYMBOLS_DETECTED
+				last_char_group = SYMBOLS_DETECTED_NEW_WORD
 
 			//Space
 			if(32)
@@ -153,6 +154,7 @@
 #undef SYMBOLS_DETECTED
 #undef NUMBERS_DETECTED
 #undef LETTERS_DETECTED
+#undef SYMBOLS_DETECTED_NEW_WORD
 
 //Returns null if there is any bad text in the string
 /proc/reject_bad_text(text, max_length=512)

--- a/html/changelogs/name_symbols_capitalization.yml
+++ b/html/changelogs/name_symbols_capitalization.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Special symbols ' and - will no longer automatically capitalize the following character, this was affecting names mostly."


### PR DESCRIPTION
Fixes #9721

I guess . is not used in names that aren't robot/AI names so I kept it automatically capitalizing stuff after it.