### PR TITLE
Job datum blacklist gets reset properly if there is no blacklist

### DIFF
--- a/code/game/jobs/faction/faction.dm
+++ b/code/game/jobs/faction/faction.dm
@@ -29,6 +29,8 @@
 		var/datum/job/role = SSjobs.type_occupations[path]
 		if(LAZYACCESS(job_species_blacklist, role.title))
 			role.blacklisted_species = job_species_blacklist[role.title]
+		else
+			role.blacklisted_species = initial(role.blacklisted_species)
 		. += role
 
 /datum/faction/proc/get_selection_error(datum/preferences/prefs)

--- a/html/changelogs/bug_liaisons.yml
+++ b/html/changelogs/bug_liaisons.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Independent Liaisons no longer have species restrictions."


### PR DESCRIPTION
Was keeping a previous blacklist from processing another faction, on the job datum

Now it resets it to the default properly

Fixes #9746