### PR TITLE
Drone self-destruct only gibs

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -425,6 +425,9 @@
 /mob/living/silicon/robot/drone/remove_robot_verbs()
 	src.verbs -= silicon_subsystems
 
+/mob/living/silicon/robot/drone/self_destruct()
+	gib()
+	
 /mob/living/silicon/robot/drone/examine(mob/user)
 	..()
 	var/msg

--- a/html/changelogs/doxxmedearly - dronesplode.yml
+++ b/html/changelogs/doxxmedearly - dronesplode.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes: 
+  - tweak: "Drone anti-theft now just gibs them instead of causing a small explosion."


### PR DESCRIPTION
Drone self-destruct caused a very small grenadelike explosion on death.
This is enough to ruin some pipes and things (such as in the outside SM cooling pipes, which can lead to a delamination)
This PR makes it so they just gib without the damage to outside things.

Stationbounds aren't affected by this PR. 

Fixes #9753