### PR TITLE
General and Diona Pain Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -108,8 +108,8 @@ var/list/diona_banned_languages = list(
 
 //This proc handles when diona take damage from being in darkness
 /mob/living/carbon/proc/diona_darkness_damage(var/severity, var/datum/dionastats/DS)
-	adjustBruteLoss(severity*DS.trauma_factor)
-	adjustHalLoss(severity*DS.pain_factor, 1)
+	adjustBruteLoss(severity * DS.trauma_factor)
+	adjustHalLoss((severity * species.pain_mod) * DS.pain_factor) // pain mod here is to give a bit of padding to the amount of pain diona get, to make it less overbearing
 	DS.stored_energy = 0 //We reset the energy back to zero after calculating the damage. dont want it to go negative
 
 /mob/living/carbon/proc/diona_handle_temperature(var/datum/dionastats/DS)
@@ -508,15 +508,13 @@ var/list/diona_banned_languages = list(
 		return health+(maxHealth*0.5)
 
 /mob/living/carbon/proc/get_dionastats()
-	if (istype(src, /mob/living/carbon/alien/diona))
-		var/mob/living/carbon/alien/diona/T = src
-		return T.DS
+	return
 
-	if (istype(src, /mob/living/carbon/human))
-		var/mob/living/carbon/human/T = src
-		if (istype(T.species, /datum/species/diona))
-			return T.DS
-	return null
+/mob/living/carbon/alien/diona/get_dionastats()
+	return DS
+
+/mob/living/carbon/human/get_dionastats()
+	return DS
 
 //Called on a nymph when it merges with a gestalt
 //The nymph and gestalt get the combined total of both of their languages

--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -58,7 +58,7 @@
 	pain_messages = list("We're in pain", "We hurt so much", "We can't stand the pain")
 	pain_item_drop_cry = list("creaks loudly and ", "rustles erratically and ", "twitches for a moment and ")
 
-	pain_mod = 0.7
+	pain_mod = 0.5
 	grab_mod = 0.6 // Viney Tentacles and shit to cling onto
 	resist_mod = 1.5 // Reasonably stronk, not moreso than an Unathi or robot.
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -105,15 +105,15 @@
 	return 0
 
 /mob/proc/is_diona()
-	//returns which type of diona we are, or zero
-	if (istype(src, /mob/living/carbon/human))
-		var/mob/living/carbon/human/T = src
-		if (istype(T.species, /datum/species/diona) || istype(src, /mob/living/carbon/human/diona))
-			return DIONA_WORKER
+	return FALSE
 
-	if (istype(src, /mob/living/carbon/alien/diona))
-		return DIONA_NYMPH
-	return 0
+/mob/living/carbon/human/is_diona()
+	if(istype(species, /datum/species/diona))
+		return DIONA_WORKER
+	return FALSE
+
+/mob/living/carbon/alien/diona/is_diona()
+	return DIONA_NYMPH
 
 /proc/isskeleton(A)
 	if(istype(A, /mob/living/carbon/human) && (A:get_species() == SPECIES_SKELETON))

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -4,6 +4,7 @@
 /obj/item/organ/internal
 	var/dead_icon // Icon to use when the organ has died.
 	var/damage_reduction = 0.5     //modifier for internal organ injury
+	var/unknown_pain_location = TRUE // if TRUE, pain messages will point to the parent organ, otherwise it will print the organ name
 	var/toxin_type = "undefined"
 	var/relative_size = 25 //Used for size calcs
 	var/on_mob_icon

--- a/code/modules/organs/internal/species/diona.dm
+++ b/code/modules/organs/internal/species/diona.dm
@@ -1,3 +1,6 @@
+/obj/item/organ/internal/diona
+	unknown_pain_location = FALSE
+
 /obj/item/organ/internal/diona/process()
 	return
 

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -49,7 +49,7 @@ mob/var/next_pain_time = 0
 			if(!(use_emote.message_type == AUDIBLE_MESSAGE && silent))
 				emote(force_emote)
 
-	next_pain_time = world.time + (100-power)
+	next_pain_time = world.time + 5 SECONDS
 
 /mob/living/carbon/human/proc/handle_pain()
 	if(!can_feel_pain())
@@ -94,13 +94,13 @@ mob/var/next_pain_time = 0
 		if(prob(1) && !((I.status & ORGAN_DEAD) || BP_IS_ROBOTIC(I)) && I.damage > 5)
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)
 			var/pain = 10
-			var/message = "You feel a dull pain in your [parent.name]..."
+			var/message = I.unknown_pain_location ? "You feel a dull pain in your [parent.name]..." : "You feel a dull pain radiating from your [I.name]..."
 			if(I.is_bruised())
 				pain = 25
-				message = "You feel a stinging pain in your [parent.name]."
+				message = I.unknown_pain_location ? "You feel a stinging pain in your [parent.name]." : "You feel a stinging pain radiating from your [I.name]."
 			if(I.is_broken())
 				pain = 50
-				message = "You feel a sharp pain in your [parent.name]!"
+				message = I.unknown_pain_location ? "You feel a sharp pain in your [parent.name]!" : "You feel a sharp pain radiating from your [I.name]!"
 			src.custom_pain(message, pain, affecting = parent)
 
 	if(prob(1))

--- a/html/changelogs/geeves-diona_pain_buff.yml
+++ b/html/changelogs/geeves-diona_pain_buff.yml
@@ -4,6 +4,6 @@ delete-after: True
 
 changes: 
   - tweak: "Diona take less pain damage from lack of light."
-  - tweak: "Diona now take 50% the usual damage, down from 70%."
+  - tweak: "Diona now take 50% the usual pain damage, down from 70%."
   - tweak: "General pain messages now have a 5 second delay between them to prevent spam."
   - tweak: "Diona can now feel which organ of theirs are damaged, instead of pointing to the parent organ."

--- a/html/changelogs/geeves-diona_pain_buff.yml
+++ b/html/changelogs/geeves-diona_pain_buff.yml
@@ -1,0 +1,9 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Diona take less pain damage from lack of light."
+  - tweak: "Diona now take 50% the usual damage, down from 70%."
+  - tweak: "General pain messages now have a 5 second delay between them to prevent spam."
+  - tweak: "Diona can now feel which organ of theirs are damaged, instead of pointing to the parent organ."


### PR DESCRIPTION
* Diona take less pain damage from lack of light.
* Diona now take 50% the usual pain damage, down from 70%.
* General pain messages now have a 5 second delay between them to prevent spam.
* Diona can now feel which organ of theirs are damaged, instead of pointing to the parent organ.

I did some light playtesting of my own, stabbing myself as a diona and such, waltzing around in low light, and felt these values to be fair.