### PR TITLE
Raider random vendors will spawn without their scan_id lights on 

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -508,7 +508,8 @@
 
 /obj/random/vendor
 	name = "random vendor"
-	var/depleted = 0
+	var/depleted = FALSE
+	var/scan_id = TRUE // Should the spawned vendor check IDs
 	problist = list(
 		/obj/machinery/vending/boozeomat = 1,
 		/obj/machinery/vending/coffee = 1,
@@ -556,6 +557,8 @@
 
 			// Clamp to an integer so we don't get 0.78 of a screwdriver.
 			V.products[content] = round(V.products[content])
+
+	V.scan_id &= scan_id
 
 /obj/random/pda_cart/item_to_spawn()
 	var/list/options = typesof(/obj/item/cartridge)

--- a/html/changelogs/raider-base-vendors.yml
+++ b/html/changelogs/raider-base-vendors.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "The randomized vending machines in the Raider base will now be always accessible by the raiders."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -29280,7 +29280,9 @@
 /turf/simulated/floor/carpet/blue,
 /area/shuttle/merchant)
 "nEc" = (
-/obj/random/vendor,
+/obj/random/vendor{
+	scan_id = 0
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/unsimulated/floor{
 	icon_state = "steel_dirty"


### PR DESCRIPTION
Allows them to access their own starting equipment.

Fixes #9772