### PR TITLE
Cargo Fluff

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -340,6 +340,7 @@
 #define CARGO_CONTAINER_CRATE "crate"
 #define CARGO_CONTAINER_FREEZER "freezer"
 #define CARGO_CONTAINER_BOX "box"
+#define CARGO_CONTAINER_BODYBAG "bodybag"
 
 // We should start using these.
 #define ITEMSIZE_TINY   1

--- a/code/controllers/subsystems/cargo.dm
+++ b/code/controllers/subsystems/cargo.dm
@@ -296,7 +296,7 @@ var/datum/controller/subsystem/cargo/SScargo
 		return path_error
 
 	//Check if a valid container is specified
-	if(!(ci.container_type == CARGO_CONTAINER_CRATE || ci.container_type == CARGO_CONTAINER_FREEZER || ci.container_type == CARGO_CONTAINER_BOX))
+	if(!(ci.container_type in list(CARGO_CONTAINER_CRATE, CARGO_CONTAINER_FREEZER, CARGO_CONTAINER_BOX, CARGO_CONTAINER_BODYBAG)))
 		log_debug("SScargo: Invalid container type specified for item [name] - [id]: Aborting")
 		qdel(ci)
 		return "Invalid container type specified for item [name] - [id]"
@@ -676,8 +676,9 @@ var/datum/controller/subsystem/cargo/SScargo
 		var/obj/A = new containertype(pickedloc)
 
 		//Label the crate
-		//TODO-CARGO: Look into wrapping it in a the suppliers paper
-		A.name = "[co.order_id] - [co.ordered_by]"
+		A.name_unlabel = A.name
+		A.name = "[A.name] ([co.order_id] - [co.ordered_by])"
+		A.verbs += /atom/proc/remove_label
 
 		//Set the access requirement
 		if(co.required_access.len > 0)

--- a/code/datums/cargo.dm
+++ b/code/datums/cargo.dm
@@ -265,6 +265,8 @@
 				return /obj/structure/largecrate
 		if(CARGO_CONTAINER_FREEZER)
 			return /obj/structure/closet/crate/freezer
+		if(CARGO_CONTAINER_BODYBAG)
+			return /obj/structure/closet/body_bag
 		else
 			log_debug("Cargo: Tried to get container type for invalid container [container_type]")
 			return /obj/structure/largecrate

--- a/html/changelogs/geeves-cargo_stuff.yml
+++ b/html/changelogs/geeves-cargo_stuff.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Certain cargo items, such as protohumans, now arrive in bodybags instead of crates."
+  - rscadd: "Cargo containers now arrive labeled, which allows you to take the label off. The paper inside the container will still hold the owner's info."


### PR DESCRIPTION
* Certain cargo items, such as protohumans, now arrive in bodybags instead of crates."
* Cargo containers now arrive labeled, which allows you to take the label off. The paper inside the container will still hold the owner's info.

Note to maintainers: I was unable to test this, because database stuff. The code is simple enough to not easily break, though. Hopefully. This PR needs some modifications to the cargo database as well. Protohumans and all their assorted variants (Proto-Skrell, Proto-Unathi, Proto-Tajara, Blank Vaurca Drone) should have their container type changed from "box" to "bodybag".