### PR TITLE
Fixes a problem with weapon_and_ammo

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1537,10 +1537,6 @@
 		var/obj/item/ammo_magazine/am = spawned.magazine_type
 		new am(spawned.loc)
 		new am(spawned.loc)
-
-	if(istype(spawned, /obj/item/gun/projectile/musket))
-		new /obj/item/reagent_containers/powder_horn(spawned.loc)
-
 	else if(istype(spawned, /obj/item/gun/projectile/shotgun) && spawned.caliber == "shotgun")
 		if(istype(spawned.loc, /obj/item/storage/box))
 			spawned.loc.icon_state = "largebox"
@@ -1548,8 +1544,14 @@
 		for(var/i = 0; i < 8; i++)
 			new spawned.ammo_type(b)
 	else if(spawned.ammo_type)
+		var/list/provided_ammo = list()
 		for(var/i = 0; i < (spawned.max_shells * 2); i++)
-			new spawned.ammo_type(spawned.loc)
+			provided_ammo += new spawned.ammo_type(spawned.loc)
+		if(provided_ammo.len)
+			new /obj/item/ammo_pile(spawned.loc, provided_ammo)
+
+	if(istype(spawned, /obj/item/gun/projectile/musket))
+		new /obj/item/reagent_containers/powder_horn(spawned.loc)
 
 /obj/random/weapon_and_ammo/spawn_item()
 	var/obj/item/W = pick_gun()

--- a/html/changelogs/Ferner-200826-bugfix_weapon_and_ammo.yml
+++ b/html/changelogs/Ferner-200826-bugfix_weapon_and_ammo.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Fixed the random weapon with ammo uplink option spawning the wrong amounts/kinds of ammo occasionally."


### PR DESCRIPTION
It occasionally spawned both magazines and loose rounds.
Also made it so weapons that don't have magazines spawn with an ammo_pile containing the rounds instead of them individually.