### PR TITLE
Lowers roundstart strain on SStimers

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -41,6 +41,8 @@
 	//2: Do not pass input_pressure_min
 	//4: Do not pass output_pressure_max
 
+	var/broadcast_status_next_process = FALSE
+
 /obj/machinery/atmospherics/binary/dp_vent_pump/Initialize()
 	. = ..()
 	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP
@@ -105,6 +107,10 @@
 
 	if(stat & (NOPOWER|BROKEN) || !use_power)
 		return 0
+
+	if (broadcast_status_next_process)
+		broadcast_status()
+		broadcast_status_next_process = FALSE
 
 	var/datum/gas_mixture/environment = loc.return_air()
 
@@ -248,10 +254,10 @@
 		)
 
 	if(signal.data["status"])
-		addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
+		broadcast_status_next_process = TRUE
 		return //do not update_icon
 
-	addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
+	broadcast_status_next_process = TRUE
 	update_icon()
 
 #undef DEFAULT_PRESSURE_DELTA

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -24,6 +24,8 @@
 	var/id = null
 	var/datum/radio_frequency/radio_connection
 
+	var/broadcast_status_next_process = FALSE
+
 /obj/machinery/atmospherics/binary/passive_gate/Initialize()
 	. = ..()
 	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
@@ -46,6 +48,10 @@
 
 /obj/machinery/atmospherics/binary/passive_gate/machinery_process()
 	..()
+
+	if (broadcast_status_next_process)
+		broadcast_status()
+		broadcast_status_next_process = FALSE
 
 	last_flow_rate = 0
 
@@ -152,10 +158,10 @@
 		regulate_mode = text2num(signal.data["set_flow_rate"])
 
 	if("status" in signal.data)
-		addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
+		broadcast_status_next_process = TRUE
 		return //do not update_icon
 
-	addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
+	broadcast_status_next_process = TRUE
 	update_icon()
 	return
 

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -34,6 +34,8 @@ Thus, the two variables affect pump operation are set in New():
 	var/id = null
 	var/datum/radio_frequency/radio_connection
 
+	var/broadcast_status_next_process = FALSE
+
 /obj/machinery/atmospherics/binary/pump/Initialize()
 	. = ..()
 	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP
@@ -68,6 +70,10 @@ Thus, the two variables affect pump operation are set in New():
 
 	if((stat & (NOPOWER|BROKEN)) || !use_power)
 		return
+
+	if (broadcast_status_next_process)
+		broadcast_status()
+		broadcast_status_next_process = FALSE
 
 	var/power_draw = -1
 	var/pressure_delta = target_pressure - air2.return_pressure()
@@ -169,12 +175,11 @@ Thus, the two variables affect pump operation are set in New():
 		)
 
 	if(signal.data["status"])
-		addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
+		broadcast_status_next_process = TRUE
 		return //do not update_icon
 
-	addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
+	broadcast_status_next_process = TRUE
 	update_icon()
-	return
 
 /obj/machinery/atmospherics/binary/pump/attack_hand(user as mob)
 	if(..())

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -23,6 +23,8 @@
 	var/id = null
 	var/datum/radio_frequency/radio_connection
 
+	var/broadcast_status_next_process = FALSE
+
 	level = 1
 
 /obj/machinery/atmospherics/unary/outlet_injector/Initialize()
@@ -55,9 +57,13 @@
 	last_power_draw = 0
 	last_flow_rate = 0
 
+	if (broadcast_status_next_process)
+		broadcast_status()
+		broadcast_status_next_process = FALSE
+
 	if((stat & (NOPOWER|BROKEN)) || !use_power)
 		return
-	
+
 	var/power_draw = -1
 	var/datum/gas_mixture/environment = loc.return_air()
 	
@@ -143,10 +149,10 @@
 		volume_rate = between(0, number, air_contents.volume)
 
 	if(signal.data["status"])
-		addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
+		broadcast_status_next_process = TRUE
 		return //do not update_icon
 
-	addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
+	broadcast_status_next_process = TRUE
 	update_icon()
 
 /obj/machinery/atmospherics/unary/outlet_injector/hide(var/i)

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -49,6 +49,8 @@
 	var/radio_filter_out
 	var/radio_filter_in
 
+	var/broadcast_status_next_process = FALSE
+
 /obj/machinery/atmospherics/unary/vent_pump/on
 	use_power = 1
 	icon_state = "map_vent_out"
@@ -165,6 +167,10 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/machinery_process()
 	..()
+
+	if (broadcast_status_next_process)
+		broadcast_status()
+		broadcast_status_next_process = FALSE
 
 	if (hibernate > world.time)
 		return 1
@@ -336,14 +342,11 @@
 		return
 
 	if(signal.data["status"] != null)
-		addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
+		broadcast_status_next_process = TRUE
 		return //do not update_icon
 
-		//log_debug("DEBUG \[[world.timeofday]\]: vent_pump/receive_signal: unknown command \"[signal.data["command"]]\"\n[signal.debug_print()]")
-	addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
-
+	broadcast_status_next_process = TRUE
 	update_icon()
-	return
 
 /obj/machinery/atmospherics/unary/vent_pump/attackby(obj/item/W, mob/user)
 	if(W.iswelder())

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -31,6 +31,8 @@
 
 	var/welded = 0
 
+	var/broadcast_status_next_process = FALSE
+
 /obj/machinery/atmospherics/unary/vent_scrubber/on
 	use_power = 1
 	icon_state = "map_scrubber_on"
@@ -138,7 +140,11 @@
 
 	if (!node)
 		use_power = 0
-	//broadcast_status()
+
+	if (broadcast_status_next_process)
+		broadcast_status()
+		broadcast_status_next_process = FALSE
+
 	if(!use_power || (stat & (NOPOWER|BROKEN)))
 		return 0
 	if(welded)
@@ -244,11 +250,10 @@
 		return
 
 	if(signal.data["status"] != null)
-		addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
+		broadcast_status_next_process = TRUE
 		return //do not update_icon
 
-//			log_debug("DEBUG \[[world.timeofday]\]: vent_scrubber/receive_signal: unknown command \"[signal.data["command"]]\"\n[signal.debug_print()]")
-	addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
+	broadcast_status_next_process = TRUE
 	update_icon()
 	return
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -992,7 +992,7 @@ obj/item/newspaper/attackby(obj/item/W as obj, mob/user as mob)
 		if (!alert)
 			alert = 1
 			update_icon()
-			addtimer(CALLBACK(src, .proc/clearAlert), 300)
+			addtimer(CALLBACK(src, .proc/clearAlert), 300, TIMER_UNIQUE)
 
 		playsound(src.loc, 'sound/machines/twobeep.ogg', 75, 1)
 	else

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -983,25 +983,24 @@ obj/item/newspaper/attackby(obj/item/W as obj, mob/user as mob)
 	src.paper_remaining--
 	return
 
-//Removed for now so these aren't even checked every tick. Left this here in-case Agouri needs it later.
-///obj/machinery/newscaster/process()       //Was thinking of doing the icon update through process, but multiple iterations per second does not
-//	return                                  //bode well with a newscaster network of 10+ machines. Let's just return it, as it's added in the machines list.
-
-/obj/machinery/newscaster/proc/newsAlert(var/news_call)   //This isn't Agouri's work, for it is ugly and vile.
-	var/turf/T = get_turf(src)                      //Who the fuck uses spawn(600) anyway, jesus christ
+/obj/machinery/newscaster/proc/newsAlert(var/news_call)
+	var/turf/T = get_turf(src)
 	if(news_call)
 		for(var/mob/O in hearers(world.view-1, T))
 			O.show_message("<span class='newscaster'><EM>[src.name]</EM> beeps, \"[news_call]\"</span>",2)
-		src.alert = 1
-		src.update_icon()
-		addtimer(CALLBACK(src, .proc/clearAlert), 300)
+		
+		if (!alert)
+			alert = 1
+			update_icon()
+			addtimer(CALLBACK(src, .proc/clearAlert), 300)
+
 		playsound(src.loc, 'sound/machines/twobeep.ogg', 75, 1)
 	else
 		for(var/mob/O in hearers(world.view-1, T))
 			O.show_message("<span class='newscaster'><EM>[src.name]</EM> beeps, \"Attention! Wanted issue distributed!\"</span>",2)
-		playsound(src.loc, 'sound/machines/warning-buzzer.ogg', 75, 1)
+		playsound(loc, 'sound/machines/warning-buzzer.ogg', 75, 1)
 	return
 
 /obj/machinery/newscaster/proc/clearAlert()
-	src.alert = 0
-	src.update_icon()
+	alert = 0
+	update_icon()

--- a/html/changelogs/skull132-less_timers.yml
+++ b/html/changelogs/skull132-less_timers.yml
@@ -1,0 +1,6 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - bugfix: "Newscasters should no longer attempt to kill the server with timers."
+  - tweak: "Remote control of vents and scrubbers may be a bit less responsive."


### PR DESCRIPTION
We have about 7k timers at round start, 5k of those were from news, 2k from pumps.

Newscasters created 1 timer per caster per news story added. This is a mega-oof and is an issue during round load. It's now fixed by having the casters only create 1 timer per alert event per instance.

Scrubbers and vents and such also created a lot of singleshot timers, purely due to how many of them there are. This was for broadcasting UI info to remote control interfaces. I shunted that over to the machinery_process proc. It's less determenistic and might be less-responsive, but hopefully this won't prove an issue.