### PR TITLE
Adds an option for a green vision tint disability

### DIFF
--- a/code/modules/client/client_color.dm
+++ b/code/modules/client/client_color.dm
@@ -111,3 +111,7 @@
 
 /datum/client_color/oversaturated/New()
 	client_color = color_saturation(40)
+
+/datum/client_color/color_tint/green
+	client_color = list(0, 0.3, 0, 0, 0.3, 0, 0, 0.3, 0)
+	priority = 100

--- a/code/modules/mob/abstract/new_player/character_traits.dm
+++ b/code/modules/mob/abstract/new_player/character_traits.dm
@@ -49,6 +49,13 @@
 /datum/character_disabilities/total_colorblind/apply_self(var/mob/living/carbon/human/H)
 	H.add_client_color(/datum/client_color/monochrome)
 
+/datum/character_disabilities/color_tint
+	name = "Color Tint (Green)"
+	desc = "You have a permanent green color tint over your vision."
+
+/datum/character_disabilities/color_tint/apply_self(var/mob/living/carbon/human/H)
+	H.add_client_color(/datum/client_color/color_tint/green)
+
 /datum/character_disabilities/mute
 	name = "Muteness"
 	desc = "You are unable to form coherent speech."

--- a/html/changelogs/color-tints.yml
+++ b/html/changelogs/color-tints.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added some vision color tints under the disabilities list."


### PR DESCRIPTION
[This is to address the problem discussed in this thread](https://forums.aurorastation.org/topic/14796-mesons-please-reconsider-a-solution/page/2/?tab=comments#comment-139980) about a player who finds the game difficult to see without the meson vision's color filter.

WIP while I get them to tell me exactly what type of green works best.

Alternative to their custom item application, because someone could steal it / break it.