### PR TITLE
Research Module Gripper Fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -231,7 +231,8 @@
 		/obj/item/material/minihoe,//Farmbots and xenoflora
 		/obj/item/computer_hardware,
 		/obj/item/slimesteroid,
-		/obj/item/slimesteroid2
+		/obj/item/slimesteroid2,
+		/obj/item/remote_mecha,
 		)
 
 /obj/item/gripper/chemistry //A gripper designed for chemistry, to allow borgs to work efficiently in the lab

--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -232,7 +232,7 @@
 		/obj/item/computer_hardware,
 		/obj/item/slimesteroid,
 		/obj/item/slimesteroid2,
-		/obj/item/remote_mecha,
+		/obj/item/remote_mecha
 		)
 
 /obj/item/gripper/chemistry //A gripper designed for chemistry, to allow borgs to work efficiently in the lab

--- a/html/changelogs/WilliamMurdoch-SciborgGripperFix.yml
+++ b/html/changelogs/WilliamMurdoch-SciborgGripperFix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: WilliamMurdoch
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Research robots can now pick up exosuit remote control chips with their gripper."


### PR DESCRIPTION
This should now let the science gripper pick up exosuit remote control chips. Fixes issue #9805 