### PR TITLE
Species inherent spells now get properly removed when changing species

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -395,7 +395,9 @@
 
 	if(inherent_spells)
 		for(var/spell_path in inherent_spells)
-			H.remove_spell(spell_path)
+			for(var/spell/spell in H.spell_list)
+				if(istype(spell, spell_path))
+					H.remove_spell(spell)
 	return
 
 /datum/species/proc/add_inherent_verbs(var/mob/living/carbon/human/H)

--- a/html/changelogs/remove_inherent_spells.yml
+++ b/html/changelogs/remove_inherent_spells.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - bugfix: "Inherent spells are now properly removed when you change species away from that species, e.g. when Golems would change using a plastic surgery machine."


### PR DESCRIPTION
Fixes #9811

Inherent spells was a list of paths, not a list of initialized datums. The logic was supposed to be targeting the mob's spells list instead.