### PR TITLE
Fixes compressed matter implants + allows items to be retrieved from them.

### DIFF
--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -11,6 +11,7 @@
 
 /datum/uplink_item/item/implants/imp_compress
 	name = "Compressed Matter Implant"
+	desc = "A box containing a single implanter and matter cartridge. To remove an unintended target, use the implanter in-hand then open the cartridge with a screwdriver."
 	item_cost = 8
 	path = /obj/item/storage/box/syndie_kit/imp_compress
 

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -594,6 +594,27 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	var/activation_emote = "sigh"
 	var/obj/item/scanned = null
 
+/obj/item/implant/compressed/attackby(var/obj/item/T, mob/user)
+	if(T.isscrewdriver())
+		if(!scanned)
+			to_chat(user, SPAN_NOTICE("There is nothing to remove from the implant."))
+		else
+			to_chat(user, SPAN_NOTICE("You remove \the [scanned] from the implant."))
+			user.put_in_hands(scanned)
+			scanned = null
+	if(istype(T, /obj/item/implanter))
+		var/obj/item/implanter/implanter = T
+		if(implanter.imp)
+			to_chat(user, SPAN_NOTICE("\The [implanter] already has an implant loaded."))
+			return
+		user.drop_from_inventory(src)
+		forceMove(implanter)
+		implanter.imp = src
+		implanter.update()
+	else
+		..()
+
+
 /obj/item/implant/compressed/get_data()
 	. = {"
 <b>Implant Specifications:</b><BR>

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -127,8 +127,11 @@
 		return
 	if(istype(A,/obj/item) && imp)
 		var/obj/item/implant/compressed/c = imp
+		if(istype(A,/obj/item/implant/compressed))
+			to_chat(user, SPAN_NOTICE("The implant is loaded into the implanter."))
+			return
 		if (c.scanned)
-			to_chat(user, "<span class='warning'>Something is already scanned inside the implant!</span>")
+			to_chat(user, SPAN_WARNING("Something is already scanned inside the implant!</span>"))
 			return
 		c.scanned = A
 		if(istype(A.loc,/mob/living/carbon/human))

--- a/html/changelogs/hockaa-matterimplant.yml
+++ b/html/changelogs/hockaa-matterimplant.yml
@@ -1,0 +1,8 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed the compressed matter implanter trying to scan it's own implant when trying to put it back in."
+  - tweak: "Items that were canned by a compressed matter implanter can now be returned by activating the implanter in hand and using a screwdriver on the implant."
+  - tweak: "The compressed matter implant listing on the uplink now has a more accurate description for retrieving scanned items."


### PR DESCRIPTION
Fixes #9812 

Adds a check so that the implanter, without a loaded implant, doesn't try to load it's own implant which made the implanter unusable.
Lets you remove the scanned item of a compressed matter implant by removing the implanter from the implanter (use implanter in-hand) and then using a screwdriver on the implant.
Updates the uplink description text of compressed matter implants to instruct on how to remove items, saving antags from getting into a fuss.