### PR TITLE
Adds a generic photo item to the custom loadout

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -35,7 +35,8 @@
 		/obj/item/stamp,
 		/obj/item/device/paicard,
 		/obj/item/device/encryptionkey,
-		/obj/item/fluff)
+		/obj/item/fluff,
+		/obj/item/generic_photo)
 	slot_flags = SLOT_ID
 
 	var/obj/item/card/id/front_id = null

--- a/code/modules/client/preference_setup/loadout/loadout_general.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_general.dm
@@ -158,3 +158,7 @@
 	toothpaste["toothpaste and green toothbrush"] = /obj/item/storage/box/toothpaste/green
 	toothpaste["toothpaste and red toothbrush"] = /obj/item/storage/box/toothpaste/red
 	gear_tweaks += new/datum/gear_tweak/path(toothpaste)
+
+/datum/gear/photo
+	display_name = "photo"
+	path =  /obj/item/generic_photo

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -280,7 +280,7 @@ var/global/photo_count = 0
 
 /obj/item/generic_photo //this is just meant for the custom loadout, so people can rename and change the desc this to whatever they want
 	name = "photo"
-	desc = "A photo of some mudane situation."
+	desc = "A photo of some mundane situation."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "photo"
 	item_state = "paper"

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -15,7 +15,7 @@
 	desc = "A camera film cartridge. Insert it into a camera to reload it."
 	icon_state = "film"
 	item_state = "electropack"
-	w_class = 1.0
+	w_class = ITEMSIZE_SMALL
 
 
 /********
@@ -28,7 +28,7 @@ var/global/photo_count = 0
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "photo"
 	item_state = "paper"
-	w_class = 2.0
+	w_class = ITEMSIZE_SMALL
 	var/id
 	var/icon/img	//Big photo image
 	var/scribble	//Scribble on the back.
@@ -123,7 +123,7 @@ var/global/photo_count = 0
 	desc = "A polaroid camera."
 	icon_state = "camera"
 	item_state = "electropack"
-	w_class = 2.0
+	w_class = ITEMSIZE_SMALL
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
@@ -277,3 +277,13 @@ var/global/photo_count = 0
 		p.id = id
 
 	return p
+
+/obj/item/generic_photo //this is just meant for the custom loadout, so people can rename and change the desc this to whatever they want
+	name = "photo"
+	desc = "A photo of some mudane situation."
+	icon = 'icons/obj/bureaucracy.dmi'
+	icon_state = "photo"
+	item_state = "paper"
+	w_class = ITEMSIZE_SMALL
+	drop_sound = 'sound/items/drop/paper.ogg'
+	pickup_sound = 'sound/items/pickup/paper.ogg'

--- a/html/changelogs/alberyk-photo.yml
+++ b/html/changelogs/alberyk-photo.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added a generic photo item to the custom loadout."


### PR DESCRIPTION
So people can change the name and description and carry the picture of their family/pets/that fish they caught when fishing in their wallets.