### PR TITLE
Bluespace turfs no longer emit light.

### DIFF
--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -7,9 +7,6 @@
 	use_space_appearance = FALSE
 	use_starlight = FALSE
 
-/turf/space/transit/Initialize()
-	. = ..()
-
 /turf/space/transit/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0, var/allow = 0, var/keep_air = FALSE)
 	return ..(N, tell_universe, 1, allow, keep_air)
 

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -6,14 +6,9 @@
 	plane = 0
 	use_space_appearance = FALSE
 	use_starlight = FALSE
-	light_color = COLOR_CYAN_BLUE
-	light_power = 6
-	light_range = 8
-	dynamic_lighting = TRUE
 
 /turf/space/transit/Initialize()
 	. = ..()
-	update_light()
 
 /turf/space/transit/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0, var/allow = 0, var/keep_air = FALSE)
 	return ..(N, tell_universe, 1, allow, keep_air)

--- a/html/changelogs/hockaa-bluespacelight.yml
+++ b/html/changelogs/hockaa-bluespacelight.yml
@@ -1,0 +1,6 @@
+author: ChangeMe
+
+delete-after: True
+
+changes: 
+  - tweak: "Bluespace turfs no longer emit light."

--- a/html/changelogs/hockaa-bluespacelight.yml
+++ b/html/changelogs/hockaa-bluespacelight.yml
@@ -1,4 +1,4 @@
-author: ChangeMe
+author: Hocka
 
 delete-after: True
 


### PR DESCRIPTION
Removes the light_color, light_power, light_range and dynamic_lighting vars from bluespace turfs.
Removes initialize()

Requested by Geeves.