### PR TITLE
Loadout Trim II: Electric Boogaloo

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -67,9 +67,9 @@
 				/obj/item/clothing/glasses/eyepatch,
 				/obj/item/clothing/glasses/regular,
 				/obj/item/clothing/glasses/regular/hipster,
-				/datum/gear/eyes/glasses/monocle,
-				/datum/gear/eyes/shades/aviator,
-				/datum/gear/eyes/glasses/fakesun
+				/obj/item/clothing/glasses/monocle,
+				/obj/item/clothing/glasses/sunglasses/aviator,
+				/obj/item/clothing/glasses/sunglasses/prescription
 			))
 			H.equip_or_collect(new path(), slot_glasses)
 

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -19,6 +19,17 @@
 	path = /obj/item/clothing/accessory/wcoat_rec
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 
+/datum/gear/accessory/chaps
+	display_name = "chaps selection"
+	path = /obj/item/clothing/accessory/chaps
+
+/datum/gear/accessory/chaps/New()
+	..()
+	var/chaps = list()
+	chaps["chaps, brown"] = /obj/item/clothing/accessory/chaps
+	chaps["chaps, black"] = /obj/item/clothing/accessory/chaps/black
+	gear_tweaks += new/datum/gear_tweak/path(chaps)
+
 /datum/gear/accessory/armband
 	display_name = "armband selection"
 	path = /obj/item/clothing/accessory/armband
@@ -154,56 +165,23 @@
 	sweater["argyle tubeneck sweater"] = /obj/item/clothing/accessory/sweaterargyletubeneck
 	gear_tweaks += new/datum/gear_tweak/path(sweater)
 
-/datum/gear/accessory/dressshirt
-	display_name = "dress shirt"
+/datum/gear/accessory/shirt
+	display_name = "shirt selection"
 	path = /obj/item/clothing/accessory/dressshirt
+	description = "A selection of shirts."
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 
-/datum/gear/accessory/dressshirt_r
-	display_name = "dress shirt, rolled up"
-	path = /obj/item/clothing/accessory/dressshirt_r
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-
-/datum/gear/accessory/dressshirt_crop
-	display_name = "cropped dress shirt"
-	path = /obj/item/clothing/accessory/dressshirt_crop
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-
-/datum/gear/accessory/dressshirt_crop_r
-	display_name = "cropped dress shirt, rolled up"
-	path = /obj/item/clothing/accessory/dressshirt_crop_r
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-
-/datum/gear/accessory/longsleeve
-	display_name = "long-sleeved shirt"
-	path = /obj/item/clothing/accessory/longsleeve
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-
-/datum/gear/accessory/blouse
-	display_name = "blouse"
-	path = /obj/item/clothing/accessory/blouse
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-
-/datum/gear/accessory/longsleeve_s
-	display_name = "long-sleeved shirt, striped"
-	path = /obj/item/clothing/accessory/longsleeve_s
-
-/datum/gear/accessory/longsleeve_s/New()
-	..()
-	var/lshirt = list()
-	lshirt["black-striped"] = /obj/item/clothing/accessory/longsleeve_s
-	lshirt["blue-striped"] = /obj/item/clothing/accessory/longsleeve_sb
-	gear_tweaks += new/datum/gear_tweak/path(lshirt)
-
-/datum/gear/accessory/tshirt
-	display_name = "t-shirt"
-	path = /obj/item/clothing/accessory/tshirt
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-
-/datum/gear/accessory/tshirt
-	display_name = "cropped t-shirt"
-	path = /obj/item/clothing/accessory/tshirt_crop
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
+var/shirt = list()
+	shirt["dress shirt"] = /obj/item/clothing/accessory/dressshirt
+	shirt["dress shirt, rolled up"] = /obj/item/clothing/accessory/dressshirt_r
+	shirt["dress shirt, cropped"] = /obj/item/clothing/accessory/dressshirt_crop
+	shirt["cropped dress shirt, rolled up"] = /obj/item/clothing/accessory/dressshirt_crop_r
+	shirt["long-sleeved shirt"] = /obj/item/clothing/accessory/longsleeve
+	shirt["long-sleeved shirt, blue striped"] = /obj/item/clothing/accessory/longsleeve_s
+	shirt["long-sleeved shirt, black striped"] = /obj/item/clothing/accessory/longsleeve_sb
+	shirt["t-shirt"] = /obj/item/clothing/accessory/tshirt
+	shirt["t-shirt, cropped"] = /obj/item/clothing/accessory/tshirt_crop
+	gear_tweaks += new/datum/gear_tweak/path(shirt)
 
 /datum/gear/accessory/silversun
 	display_name = "silversun floral shirt selection"
@@ -229,14 +207,6 @@
 	scarfs["plain scarf"] = /obj/item/clothing/accessory/scarf
 	scarfs["zebra scarf"] = /obj/item/clothing/accessory/scarf/zebra
 	gear_tweaks += new/datum/gear_tweak/path(scarfs)
-
-/datum/gear/accessory/chaps
-	display_name = "chaps, brown"
-	path = /obj/item/clothing/accessory/chaps
-
-/datum/gear/accessory/chaps/black
-	display_name = "chaps, black"
-	path = /obj/item/clothing/accessory/chaps/black
 
 /datum/gear/accessory/dogtags
 	display_name = "dogtags"
@@ -269,17 +239,17 @@
 	path = /obj/item/clothing/accessory/badge/dia
 	allowed_roles = list("Detective")
 
-/datum/gear/accessory/idbadge
-	display_name = "badge, identification"
+/datum/gear/accessory/badge
+	display_name = "badge selection"
 	path = /obj/item/clothing/accessory/badge/idbadge
 
-/datum/gear/accessory/nt_idbadge
-	display_name = "badge, NanoTrasen ID"
-	path = /obj/item/clothing/accessory/badge/idbadge/nt
-
-/datum/gear/accessory/electronic_idbadge
-	display_name = "badge, electronic"
-	path = /obj/item/clothing/accessory/badge/idbadge/intel
+/datum/gear/accessory/badge/New()
+	..()
+	var/badge = list()
+	badge["badge, identification"] = /obj/item/clothing/accessory/badge/idbadge
+	badge["badge, NanoTrasen ID"] = /obj/item/clothing/accessory/badge/idbadge/nt
+	badge["badge, electronic"] = /obj/item/clothing/accessory/badge/idbadge/intel
+	gear_tweaks += new/datum/gear_tweak/path(badge)
 
 /datum/gear/accessory/namepin
 	display_name = "pin tag (colourable)"

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -171,6 +171,8 @@
 	description = "A selection of shirts."
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 
+/datum/gear/accessory/shirt/New()
+	..()
 	var/shirt = list()
 	shirt["dress shirt"] = /obj/item/clothing/accessory/dressshirt
 	shirt["dress shirt, rolled up"] = /obj/item/clothing/accessory/dressshirt_r

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -171,7 +171,7 @@
 	description = "A selection of shirts."
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 
-var/shirt = list()
+	var/shirt = list()
 	shirt["dress shirt"] = /obj/item/clothing/accessory/dressshirt
 	shirt["dress shirt, rolled up"] = /obj/item/clothing/accessory/dressshirt_r
 	shirt["dress shirt, cropped"] = /obj/item/clothing/accessory/dressshirt_crop

--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -6,114 +6,74 @@
 	sort_category = "Glasses and Eyewear"
 
 /datum/gear/eyes/glasses
-	display_name = "glasses, prescription"
+	display_name = "glasses selection"
+	description = "A selection of eyewear, tinted and tintedn't
 	path = /obj/item/clothing/glasses/regular
 
-/datum/gear/eyes/glasses/hipster
-	display_name = "glasses, hipster"
-	path = /obj/item/clothing/glasses/regular/hipster
+/datum/gear/eyes/glasses/New()
+	..()
+	var/glasses = list()
+	glasses["glasses, regular"] = /obj/item/clothing/glasses/regular
+	glasses["glasses, hipster"] = /obj/item/clothing/glasses/regular/hipster
+	glasses["glasses, circle"] = /obj/item/clothing/glasses/regular/circle
+	glasses["glasses, jamjar"] = /obj/item/clothing/glasses/regular/jamjar
+	glasses["glasses, monocle"] = /obj/item/clothing/glasses/monocle
+	glasses["glasses, safety"] = /obj/item/clothing/glasses/safety
+	glasses["sunglasses, fat"] = /obj/item/clothing/glasses/sunglasses/big
+	glasses["sunglasses, prescription"] = /obj/item/clothing/glasses/sunglasses/prescription
+	glasses["sunglasses, aviator"] = /obj/item/clothing/glasses/sunglasses/aviator
+	gear_tweaks += new/datum/gear_tweak/path(glasses)
 
-/datum/gear/eyes/glasses/circle
-	display_name = "glasses, circle"
-	path = /obj/item/clothing/glasses/regular/circle
-
-/datum/gear/eyes/glasses/jamjar
-	display_name = "glasses, jamjar"
-	path = /obj/item/clothing/glasses/regular/jamjar
-
-/datum/gear/eyes/glasses/monocle
-	display_name = "monocle"
-	path = /obj/item/clothing/glasses/monocle
-
-/datum/gear/eyes/glasses/safety
-	display_name = "safety glasses"
-	path = /obj/item/clothing/glasses/safety
-
-/datum/gear/eyes/glasses/safety/goggles
-	display_name = "safety goggles"
+/datum/gear/eyes/goggles
+	display_name = "goggles selection"
+	description = "A selection of safer eyewear."
 	path = /obj/item/clothing/glasses/safety/goggles
 
-/datum/gear/eyes/scanning_goggles
-	display_name = "scanning goggles"
-	path = /obj/item/clothing/glasses/regular/scanners
+/datum/gear/eyes/goggles/New()
+	..()
+	var/goggles = list()
+	goggles["goggles, safety"] = /obj/item/clothing/glasses/regular
+	goggles["goggles, scanning"] = /obj/item/clothing/glasses/regular/hipster
+	goggles["goggles, science"] = /obj/item/clothing/glasses/regular/circle
+	goggles["goggles, orange"] = /obj/item/clothing/glasses/regular/jamjar
+	gear_tweaks += new/datum/gear_tweak/path(goggles)
 
-/datum/gear/eyes/sciencegoggles
-	display_name = "science Goggles"
-	path = /obj/item/clothing/glasses/science
-
-/datum/gear/eyes/security
-	display_name = "security HUD"
-	path = /obj/item/clothing/glasses/hud/security
-	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Security Cadet", "Detective", "Forensic Technician")
-
-/datum/gear/eyes/security/aviator
-	display_name = "aviators, security"
-	path = /obj/item/clothing/glasses/sunglasses/sechud/aviator
-
-/datum/gear/eyes/medical
-	display_name = "medical HUD"
-	path = /obj/item/clothing/glasses/hud/health
+/datum/gear/eyes/medhuds
+	display_name = "medical HUD selection"
+	description = "A selection of medical HUDs."
+	path = /obj/item/clothing/glasses/hud/health/aviator
 	allowed_roles = list("Physician", "Surgeon", "Chief Medical Officer", "Pharmacist", "Emergency Medical Technician", "Psychiatrist", "Medical Resident")
 
-/datum/gear/eyes/medical/aviator
-	display_name = "aviators, medical"
-	path = /obj/item/clothing/glasses/hud/health/aviator
+/datum/gear/eyes/medhuds/New()
+	..()
+	var/medhud = list()
+	medhud["aviators, medical"] = /obj/item/clothing/glasses/hud/health/aviator
+	medhud["HUD, medical"] = /obj/item/clothing/glasses/hud/health
+	medhud["HUDpatch, medical"] = /obj/item/clothing/glasses/eyepatch/hud/medical
+	gear_tweaks += new/datum/gear_tweak/path(medhud)
 
-/datum/gear/eyes/shades
-	display_name = "sunglasses, fat (Security/Command)"
-	path = /obj/item/clothing/glasses/sunglasses/big
-	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Captain", "Head of Personnel", "Quartermaster", "Internal Affairs Agent", "Detective", "Forensic Technician")
+/datum/gear/eyes/sechuds
+	display_name = "security HUD selection"
+	description = "A selection of security HUDs."
+	path = /obj/item/clothing/glasses/sunglasses/sechud/aviator
+	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Security Cadet", "Detective", "Forensic Technician")
 
-/datum/gear/eyes/shades/prescriptionsun
-	display_name = "sunglasses, presciption (Security/Command)"
-	path = /obj/item/clothing/glasses/sunglasses/prescription
-
-/datum/gear/eyes/shades/aviator
-	display_name = "sunglasses, aviator (Security/Command)"
-	path = /obj/item/clothing/glasses/sunglasses/aviator
-
-/datum/gear/eyes/glasses/fakesun
-	display_name = "sunglasses, stylish"
-	path = /obj/item/clothing/glasses/fakesunglasses
-
-/datum/gear/eyes/glasses/fakesun/prescription
-	display_name = "prescription sunglasses, stylish"
-	path = /obj/item/clothing/glasses/fakesunglasses/prescription
-
-/datum/gear/eyes/glasses/fakesun/aviator
-	display_name = "aviators, stylish"
-	path = /obj/item/clothing/glasses/fakesunglasses/aviator
+/datum/gear/eyes/medhuds/New()
+	..()
+	var/sechud = list()
+	sechud["aviators, security"] = /obj/item/clothing/glasses/sunglasses/sechud/aviator
+	sechud["HUD, security"] = /obj/item/clothing/glasses/hud/security
+	sechud["HUDpatch, security"] = /obj/item/clothing/glasses/eyepatch/hud/security
+	gear_tweaks += new/datum/gear_tweak/path(sechud)
 
 /datum/gear/eyes/hudpatch
 	display_name = "iPatch"
 	path = /obj/item/clothing/glasses/eyepatch/hud
 
-/datum/gear/eyes/secpatch
-	display_name = "HUDpatch, Security"
-	path= /obj/item/clothing/glasses/eyepatch/hud/security
-	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Security Cadet", "Detective", "Forensic Technician")
-	cost = 2 //snowflake tax
-
-/datum/gear/eyes/medpatch
-	display_name = "HUDpatch, Medical"
-	path = /obj/item/clothing/glasses/eyepatch/hud/medical
-	allowed_roles = list("Physician", "Surgeon", "Chief Medical Officer", "Pharmacist", "Emergency Medical Technician", "Psychiatrist", "Medical Resident")
-	cost = 2
-
 /datum/gear/eyes/scipatch
 	display_name = "HUDpatch, Science"
 	path = /obj/item/clothing/glasses/eyepatch/hud/science
-	cost = 2
-
-/datum/gear/eyes/weldpatch
-	display_name = "HUDpatch, Welding"
-	path = /obj/item/clothing/glasses/eyepatch/hud/welder
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Engineering Apprentice","Research Director","Roboticist")
-	cost = 2
-
-/datum/gear/eyes/spiffygogs
-	display_name = "orange goggles"
-	path = /obj/item/clothing/glasses/spiffygogs
+	cost = 1
 
 /datum/gear/eyes/circuitry
 	display_name = "goggles, circuitry (empty)"

--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -7,7 +7,7 @@
 
 /datum/gear/eyes/glasses
 	display_name = "glasses selection"
-	description = "A selection of eyewear, tinted and tintedn't
+	description = "A selection of eyewear, tinted and tintedn't"
 	path = /obj/item/clothing/glasses/regular
 
 /datum/gear/eyes/glasses/New()

--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -39,21 +39,12 @@
 	caps["grey cap"] = /obj/item/clothing/head/soft/grey
 	caps["white cap"] = /obj/item/clothing/head/soft/white
 	caps["flat cap"] = /obj/item/clothing/head/flatcap
-	caps["mailman cap"] = /obj/item/clothing/head/mailman
 	gear_tweaks += new/datum/gear_tweak/path(caps)
-
-/datum/gear/head/beret
-	display_name = "beret, red"
-	path = /obj/item/clothing/head/beret
 
 /datum/gear/head/beret/eng
 	display_name = "beret, engie-orange"
 	path = /obj/item/clothing/head/beret/engineering
 	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Engineering Apprentice")
-
-/datum/gear/head/beret/purp
-	display_name = "beret, purple"
-	path = /obj/item/clothing/head/beret/purple
 
 /datum/gear/head/beret/color
 	display_name = "beret (colorable)"

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -47,6 +47,8 @@
 	jackets["black vest"] = /obj/item/clothing/suit/storage/toggle/leather_vest
 	jackets["brown vest"] = /obj/item/clothing/suit/storage/toggle/brown_jacket/sleeveless
 	jackets["leather coat"] = /obj/item/clothing/suit/storage/leathercoat
+	jackets["puffer jacket"] = /obj/item/clothing/suit/jacket/puffer
+	jackets["puffer vest"] = /obj/item/clothing/suit/jacket/puffer/vest
 
 	gear_tweaks += new/datum/gear_tweak/path(jackets)
 
@@ -172,63 +174,28 @@
 	description = "A worn out, curiously comfortable t-shirt with a picture of Ian."
 	path = /obj/item/clothing/suit/ianshirt
 
+
 /datum/gear/suit/winter
-	display_name = "winter coat"
+	display_name = "winter coat selection"
+	description = "A selection of coats for the thermally challenged."
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat
 
-/datum/gear/suit/winter/red
-	display_name = "winter coat, red"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/red
-
-/datum/gear/suit/winter/captain
-	display_name = "winter coat, captain"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/captain
-	allowed_roles = list("Captain")
-
-/datum/gear/suit/winter/security
-	display_name = "winter coat, security"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/security
-	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Security Cadet", "Detective", "Forensic Technician")
-
-/datum/gear/suit/winter/science
-	display_name = "winter coat, science"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/science
-	allowed_roles = list("Research Director", "Scientist", "Xenobiologist", "Roboticist", "Lab Assistant", "Geneticist")
-
-/datum/gear/suit/winter/medical
-	display_name = "winter coat, medical"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical
-	allowed_roles = list("Chief Medical Officer", "Physician", "Surgeon", "Emergency Medical Technician", "Medical Resident", "Psychiatrist", "Pharmacist")
-
-/datum/gear/suit/winter/iac
-	display_name = "winter coat, IAC"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/iac
-	allowed_roles = list("Chief Medical Officer", "Physician", "Surgeon", "Emergency Medical Technician", "Medical Resident", "Psychiatrist", "Pharmacist")
-
-/datum/gear/suit/winter/engineering
-	display_name = "winter coat, engineering"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering
-	allowed_roles = list("Station Engineer", "Chief Engineer", "Engineering Apprentice")
-
-/datum/gear/suit/winter/atmos
-	display_name = "winter coat, atmospherics"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering/atmos
-	allowed_roles = list("Atmospheric Technician", "Chief Engineer")
-
-/datum/gear/suit/winter/hydro
-	display_name = "winter coat, hydroponics"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/hydro
-	allowed_roles = list("Head of Personnel", "Gardener")
-
-/datum/gear/suit/winter/cargo
-	display_name = "winter coat, cargo"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/cargo
-	allowed_roles = list("Cargo Technician", "Quartermaster", "Head of Personnel")
-
-/datum/gear/suit/winter/mining
-	display_name = "winter coat, mining"
-	path = /obj/item/clothing/suit/storage/hooded/wintercoat/miner
-	allowed_roles = list("Quartermaster", "Head of Personnel", "Shaft Miner")
+/datum/gear/suit/winter/New()
+	..()
+	var/wintercoat = list()
+	wintercoat["winter coat"] = /obj/item/clothing/suit/storage/hooded/wintercoat
+	wintercoat["winter coat, red"] = /obj/item/clothing/suit/storage/hooded/wintercoat/red
+	wintercoat["winter coat, captain"] = /obj/item/clothing/suit/storage/hooded/wintercoat/captain
+	wintercoat["winter coat, security"] = /obj/item/clothing/suit/storage/hooded/wintercoat/security
+	wintercoat["winter coat, science"] = /obj/item/clothing/suit/storage/hooded/wintercoat/science
+	wintercoat["winter coat, IAC"] = /obj/item/clothing/suit/storage/hooded/wintercoat/iac
+	wintercoat["winter coat, medical"] = /obj/item/clothing/suit/storage/hooded/wintercoat/medical
+	wintercoat["winter coat, engineering"] = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering
+	wintercoat["winter coat, atmospherics"] = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering/atmos
+	wintercoat["winter coat, hydroponics"] = /obj/item/clothing/suit/storage/hooded/wintercoat/hydro
+	wintercoat["winter coat, cargo"] = /obj/item/clothing/suit/storage/hooded/wintercoat/cargo
+	wintercoat["winter coat, mining"] = /obj/item/clothing/suit/storage/hooded/wintercoat/miner
+	gear_tweaks += new/datum/gear_tweak/path(wintercoat)
 
 /datum/gear/suit/secjacket
 	display_name = "navy security jacket (Security Officer)"
@@ -323,14 +290,6 @@
 		var/obj/item/clothing/suit/storage/toggle/track/track = track_style
 		tracks[initial(track.name)] = track
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(tracks))
-
-/datum/gear/suit/puffer_coat
-	display_name = "puffer coat"
-	path = /obj/item/clothing/suit/jacket/puffer
-
-/datum/gear/suit/puffer_vest
-	display_name = "puffer vest"
-	path = /obj/item/clothing/suit/jacket/puffer/vest
 
 /datum/gear/suit/cardigan
 	display_name = "cardigan selection"

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -229,6 +229,11 @@
 	suit["elyran holographic suit, masculine"] = /obj/item/clothing/under/elyra_holo/masc
 	gear_tweaks += new/datum/gear_tweak/path(suit)
 
+/datum/gear/uniform/miscellaneous/kimono
+	display_name = "kimono"
+	path = /obj/item/clothing/under/kimono
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
+
 /datum/gear/uniform/officer
 	display_name = "uniforms, (Security Officer)"
 	description = "A selection of officer uniforms."

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -229,11 +229,6 @@
 	suit["elyran holographic suit, masculine"] = /obj/item/clothing/under/elyra_holo/masc
 	gear_tweaks += new/datum/gear_tweak/path(suit)
 
-/datum/gear/uniform/miscellaneous/kimono
-	display_name = "kimono"
-	path = /obj/item/clothing/under/kimono
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-
 /datum/gear/uniform/officer
 	display_name = "uniforms, (Security Officer)"
 	description = "A selection of officer uniforms."
@@ -277,7 +272,6 @@
 	uniform["warden uniform, dark blue"] = /obj/item/clothing/under/rank/warden/dark_blue
 	gear_tweaks += new/datum/gear_tweak/path(uniform)
 
-
 /datum/gear/uniform/hos
 	display_name = "uniform, corporate (Head of Security)"
 	path = /obj/item/clothing/under/rank/head_of_security/corp
@@ -311,7 +305,7 @@
 
 /datum/gear/uniform/miscellaneous/hanbok
 	display_name = "hanbok selection"
-	description = "A selection of Koynanger formalwear."
+	description = "A selection of Konyanger formalwear."
 	path = /obj/item/clothing/under/konyang
 
 /datum/gear/uniform/miscellaneous/hanbok/New()

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -68,35 +68,16 @@
 	path = /obj/item/device/paicard
 
 /datum/gear/utility/wallet
-	display_name = "wallet, orange"
+	display_name = "wallet, selection"
 	path = /obj/item/storage/wallet
 
-/datum/gear/utility/wallet_colourable
-	display_name = "wallet, colourable"
-	path = /obj/item/storage/wallet/colourable
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-
-/datum/gear/utility/wallet_purse
-	display_name = "wallet, purse"
-	path = /obj/item/storage/wallet/purse
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-
-/datum/gear/utility/lanyard
-	display_name = "lanyard"
-	path = /obj/item/storage/wallet/lanyard
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-
-/*
-/datum/gear/utility/cheaptablet
-	display_name = "cheap tablet computer"
-	path = /obj/item/modular_computer/tablet/preset/custom_loadout/cheap
-	cost = 3
-
-/datum/gear/utility/normaltablet
-	display_name = "tablet computer"
-	path = /obj/item/modular_computer/tablet/preset/custom_loadout/advanced
-	cost = 4
-*/
+/datum/gear/utility/wallet/New()
+	..()
+	var/wallet = list()
+	wallet["wallet, colourable"] = /obj/item/storage/wallet/colourable
+	wallet["wallet, purse"] = /obj/item/storage/wallet/purse
+	wallet["wallet, lanyard"] = /obj/item/storage/wallet/lanyard
+	gear_tweaks += new/datum/gear_tweak/path(wallet)
 
 /datum/gear/utility/recorder
 	display_name = "universal recorder"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -451,23 +451,6 @@ BLIND     // can't see anything
 	icon_state = "bigsunglasses"
 	item_state = "sun"
 
-/obj/item/clothing/glasses/fakesunglasses //Sunglasses without flash immunity
-	name = "stylish sunglasses"
-	desc = "A pair of designer sunglasses. Doesn't seem like it'll block flashes."
-	icon_state = "sun"
-	item_state = "sun"
-	item_state_slots = list(slot_r_hand_str = "sunglasses", slot_l_hand_str = "sunglasses")
-
-/obj/item/clothing/glasses/fakesunglasses/prescription
-	name = "stylish prescription sunglasses"
-	prescription = 1
-
-/obj/item/clothing/glasses/fakesunglasses/aviator
-	desc = "A pair of designer sunglasses. Doesn't seem like it'll block flashes. Comes with built-in prescription lenses."
-	icon_state = "aviator"
-	item_state = "aviator"
-	prescription = 1
-
 /obj/item/clothing/glasses/sunglasses/sechud
 	name = "HUDsunglasses"
 	desc = "Sunglasses with a HUD."

--- a/code/modules/clothing/suits/hoodies.dm
+++ b/code/modules/clothing/suits/hoodies.dm
@@ -121,31 +121,26 @@
 	name = "security winter coat"
 	icon_state = "coatsecurity"
 	item_state = "coatsecurity"
-	armor = list(melee = 25, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/medical
 	name = "medical winter coat"
 	icon_state = "coatmedical"
 	item_state = "coatmedical"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 50, rad = 0)
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/iac
 	name = "IAC winter coat"
 	icon_state = "coatIAC"
 	item_state = "coatIAC"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 50, rad = 0)
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/science
 	name = "science winter coat"
 	icon_state = "coatscience"
 	item_state = "coatscience"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/engineering
 	name = "engineering winter coat"
 	icon_state = "coatengineer"
 	item_state = "coatengineer"
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 20)
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/engineering/atmos
 	name = "atmospherics winter coat"
@@ -220,7 +215,7 @@
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/hoodie/grey //legacy item. for raiders, shuttle spawn
 	color = "#777777"
-	
+
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/hoodie/random/Initialize()
 	. = ..()
@@ -233,7 +228,7 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/hoodie/crop
 	icon_state = "hoodie_crop"
 	item_state = "hoodie_crop"
-	
+
 /obj/item/clothing/suit/storage/hooded/wintercoat/hoodie/sleeveless
 	icon_state = "hoodie_sleeveless"
 	item_state = "hoodie_sleeveless"

--- a/html/changelogs/snakebittenn-loadouttrim.yml
+++ b/html/changelogs/snakebittenn-loadouttrim.yml
@@ -1,0 +1,46 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Snakebittenn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Rolls a lot of loadout items under selections."
+  - rscdel: "Removes fake sunglasses from the loadout."
+  - rscdel: "Removes red/purple berets from the loadout."
+  - rscdel: "Removes kimono from the loadout."
+  - rscdel: "Removes armor values from winter coats."
+  - rscdel: "Removes mailman hat from the loadout."


### PR DESCRIPTION
  - tweak: "Rolls a lot of loadout items under selections."
  - rscdel: "Removes fake sunglasses from the loadout."
  - rscdel: "Removes red/purple berets from the loadout."
  - rscdel: "Removes kimono from the loadout."
  - rscdel: "Removes armor values from winter coats."
  - rscdel: "Removes mailman hat from the loadout."