### PR TITLE
Increases some robotic combat mech costs and levels

### DIFF
--- a/code/modules/research/designs/mechfab/mechs/designs_exosuits.dm
+++ b/code/modules/research/designs/mechfab/mechs/designs_exosuits.dm
@@ -65,28 +65,28 @@
 /datum/design/item/mechfab/exosuit/combat_head
 	name = "Combat Exosuit Sensors"
 	time = 30
-	materials = list(DEFAULT_WALL_MATERIAL = 10000)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, MATERIAL_GOLD = 10500, MATERIAL_SILVER = 10000)
 	build_path = /obj/item/mech_component/sensors/combat
 	req_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 3)
 
 /datum/design/item/mechfab/exosuit/combat_torso
 	name = "Combat Exosuit Chassis"
 	time = 60
-	materials = list(DEFAULT_WALL_MATERIAL = 45000)
+	materials = list(DEFAULT_WALL_MATERIAL = 45000, MATERIAL_GOLD = 10500, MATERIAL_SILVER = 10000)
 	build_path = /obj/item/mech_component/chassis/combat
 	req_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 3)
 
 /datum/design/item/mechfab/exosuit/combat_arms
 	name = "Combat Exosuit Manipulators"
 	time = 30
-	materials = list(DEFAULT_WALL_MATERIAL = 15000)
+	materials = list(DEFAULT_WALL_MATERIAL = 15000, MATERIAL_GOLD = 10500, MATERIAL_SILVER = 10000)
 	build_path = /obj/item/mech_component/manipulators/combat
 	req_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 3)
 
 /datum/design/item/mechfab/exosuit/combat_legs
 	name = "Combat Exosuit Motivators"
 	time = 30
-	materials = list(DEFAULT_WALL_MATERIAL = 15000)
+	materials = list(DEFAULT_WALL_MATERIAL = 15000, MATERIAL_GOLD = 10500, MATERIAL_SILVER = 10000)
 	build_path = /obj/item/mech_component/propulsion/combat
 	req_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 3)
 
@@ -145,27 +145,30 @@
 /datum/design/item/mechfab/exosuit/heavy_head
 	name = "Heavy Exosuit Sensors"
 	time = 35
-	materials = list(DEFAULT_WALL_MATERIAL = 12000)
+	materials = list(DEFAULT_WALL_MATERIAL = 12000, MATERIAL_PHORON = 12500, MATERIAL_SILVER = 10000, MATERIAL_GOLD = 10000)
 	build_path = /obj/item/mech_component/sensors/heavy
-	req_tech = list(TECH_COMBAT = 2)
+	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4)
 
 /datum/design/item/mechfab/exosuit/heavy_torso
 	name = "Heavy Exosuit Chassis"
 	time = 75
-	materials = list(DEFAULT_WALL_MATERIAL = 70000, MATERIAL_URANIUM = 10000)
+	materials = list(DEFAULT_WALL_MATERIAL = 70000, MATERIAL_URANIUM = 10000, MATERIAL_SILVER = 10000, MATERIAL_GOLD = 10000)
 	build_path = /obj/item/mech_component/chassis/heavy
+	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4)
 
 /datum/design/item/mechfab/exosuit/heavy_arms
 	name = "Heavy Exosuit Manipulators"
 	time = 35
-	materials = list(DEFAULT_WALL_MATERIAL = 20000)
+	materials = list(DEFAULT_WALL_MATERIAL = 20000, MATERIAL_PHORON = 12500, MATERIAL_SILVER = 10000, MATERIAL_GOLD = 10000)
 	build_path = /obj/item/mech_component/manipulators/heavy
+	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4)
 
 /datum/design/item/mechfab/exosuit/heavy_legs
 	name = "Heavy Exosuit Motivators"
 	time = 35
-	materials = list(DEFAULT_WALL_MATERIAL = 20000)
+	materials = list(DEFAULT_WALL_MATERIAL = 20000, MATERIAL_PHORON = 12500, MATERIAL_SILVER = 10000, MATERIAL_GOLD = 10000)
 	build_path = /obj/item/mech_component/propulsion/heavy
+	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4)
 
 /datum/design/item/mechfab/exosuit/spider
 	name = "Quadruped Motivators"

--- a/html/changelogs/alberyk-mechprices.yml
+++ b/html/changelogs/alberyk-mechprices.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Increased the material price for the combat and heavy exosuit parts."
+  - tweak: "Heavy exosuit parts now require more research levels to unlock."


### PR DESCRIPTION
Turns out that combat mech parts just used steel, this pr makes so that they use gold and silver. Heavy exosuits parts now costs more materials and take more levels to unlock.