### PR TITLE
Fix bugs from admin rank updates

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -85,7 +85,7 @@ var/list/forum_groupids_to_ranks = list()
 
 			//Split the line at every "-"
 			var/list/List = text2list(line, "-")
-			if(!List.len)
+			if(List.len != 2)
 				continue
 
 			//ckey is before the first "-"
@@ -94,12 +94,14 @@ var/list/forum_groupids_to_ranks = list()
 				continue
 
 			//rank follows the first "-"
-			var/rank = ""
-			if(List.len >= 2)
-				rank = ckeyEx(List[2])
+			var/rank = trim(List[2])
 
 			//load permissions associated with this rank
 			var/datum/admin_rank/rank_object = admin_ranks[rank]
+
+			if (!rank_object)
+				error("Unrecognized rank in admins.txt: \"[rank]\"")
+				continue
 
 			//create the admin datum and store it for later use
 			var/datum/admins/D = new /datum/admins(rank, rank_object?.rights || 0, ckey)
@@ -107,7 +109,7 @@ var/list/forum_groupids_to_ranks = list()
 			//find the client for a ckey if they are connected and associate them with the new admin datum
 			D.associate(directory[ckey])
 
-			log_debug("AdminRanks: Upaded Admins from Legacy System")
+			log_debug("AdminRanks: Updated Admins from Legacy System")
 
 	else
 		//The current admin system uses SQL

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -105,7 +105,10 @@
 	if(!check_rights(R_SERVER|R_DEV))
 		return
 
-	message_admins("[usr] manually reloaded admins")
+	if (config.use_forumuser_api)
+		update_admins_from_api(FALSE)
+
+	log_and_message_admins("manually reloaded admins.")
 	load_admins()
 	feedback_add_details("admin_verb","RLDA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/html/changelogs/skull132_admin-fixes.yml
+++ b/html/changelogs/skull132_admin-fixes.yml
@@ -1,0 +1,6 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - bugfix: "Reload Admins will now update the admins from the forumsuser API when enabled."
+  - bugfix: "admins.txt will now accommodate more complex rank names, specifically ones with spaces and other special characters."


### PR DESCRIPTION
Fixes `admins.txt` not accommodating rank names that contain special characters. The default `admin_ranks.json` will now work again, so setup for plebians is easier once more.

Fixes `reload admins` not updating admins from the API.