### PR TITLE
Makes thermal aviators less obvious

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -613,7 +613,8 @@ BLIND     // can't see anything
 
 /obj/item/clothing/glasses/thermal/aviator
 	name = "aviators"
-	desc = "Modified aviator glasses with a toggled thermal-vision mode. Comes with bonus prescription overlay."
+	desc = "A pair of designer sunglasses. Doesn't seem like it'll block flashes. Comes with built-in prescription lenses."
+	desc_antag = "Modified aviator glasses with a toggled thermal-vision mode."
 	icon_state = "aviator_thr"
 	off_state = "aviator_off"
 	item_state_slots = list(slot_r_hand_str = "sunglasses", slot_l_hand_str = "sunglasses")

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -613,7 +613,7 @@ BLIND     // can't see anything
 
 /obj/item/clothing/glasses/thermal/aviator
 	name = "aviators"
-	desc = "A pair of designer sunglasses. Doesn't seem like it'll block flashes. Comes with built-in prescription lenses."
+	desc = "A pair of designer sunglasses. They should put HUDs in these."
 	desc_antag = "Modified aviator glasses with a toggled thermal-vision mode."
 	icon_state = "aviator_thr"
 	off_state = "aviator_off"

--- a/html/changelogs/hockaa-thermalstuffs.yml
+++ b/html/changelogs/hockaa-thermalstuffs.yml
@@ -1,0 +1,7 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+  - tweak: "The normal description of thermal aviators is now the same as standard aviators so that they aren't given away so easily."
+  - rscadd: "Thermal aviators now have an antag-specific description."

--- a/html/changelogs/hockaa-thermalstuffs.yml
+++ b/html/changelogs/hockaa-thermalstuffs.yml
@@ -3,5 +3,5 @@ author: Hocka
 delete-after: True
 
 changes: 
-  - tweak: "The normal description of thermal aviators is now the same as standard aviators so that they aren't given away so easily."
+  - bugfix: "The normal description of thermal aviators is now the same as standard aviators so that they aren't given away so easily."
   - rscadd: "Thermal aviators now have an antag-specific description."


### PR DESCRIPTION
Fixes #9894 
Makes the standard description of thermal aviators the same as the standard aviators and makes the antag description the previously standard one.