### PR TITLE
Fixes drinking glasses and beakers not shattering when thrown.

### DIFF
--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -14,7 +14,7 @@
 	volume = 60
 	unacidable = 0
 	flags = OPENCONTAINER
-	no_shatter = TRUE
+	shatter = FALSE
 	var/paint_reagent = null //name of the reagent responsible for colouring the paint
 	var/paint_type = null //used for colouring detective technicolor coat and hat
 	reagents_to_add = list(/datum/reagent/water = 3/5, /datum/reagent/toxin/plasticide = 1/5)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -25,7 +25,7 @@
 	can_be_placed_into = null
 	flags = OPENCONTAINER | NOBLUDGEON
 	unacidable = 0
-	no_shatter = TRUE
+	shatter = FALSE
 
 	var/on_fire = 0
 	var/burn_time = 20 //if the rag burns for too long it turns to ashes

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -63,13 +63,22 @@
 	if((speed >= fragile) && !no_shatter)
 		shatter()
 
-/obj/item/reagent_containers/proc/shatter(var/mob/user)
+/obj/item/reagent_containers/proc/shatter(var/obj/item/W, var/mob/user)
 	if(reagents.total_volume)
 		reagents.splash(src.loc, reagents.total_volume) // splashes the mob holding it or the turf it's on
 	audible_message(SPAN_WARNING("\The [src] shatters with a resounding crash!"), SPAN_WARNING("\The [src] breaks."))
 	playsound(src, shatter_sound, 70, 1)
 	shatter_material.place_shard(loc)
 	qdel(src)
+
+/obj/item/reagent_containers/attackby(var/obj/item/W, var/mob/user)
+	if(!(W.flags & NOBLUDGEON) && (user.a_intent == I_HURT) && (W.force > fragile) && !no_shatter)
+		if(do_after(user, 10))
+			if(!QDELETED(src))
+				visible_message(SPAN_WARNING("[user] smashes [src] with \a [W]!"))
+				user.do_attack_animation(src)
+				shatter(W, user)
+	..()
 
 /obj/item/reagent_containers/attack(mob/M, mob/user, def_zone)
 	if(can_operate(M) && do_surgery(M, user, src))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -9,9 +9,9 @@
 	var/volume = 30
 	var/accuracy = 1
 	var/fragile = 2        // most glassware is super fragile. Not a boolean.
-	var/no_shatter = TRUE //does this container shatter?
+	var/shatter = FALSE //does this container shatter?
 	var/shatter_sound = /decl/sound_category/glass_break_sound
-	var/material/shatter_material = /material/glass
+	var/material/shatter_material = MATERIAL_GLASS //slight typecasting abuse here, gets converted to a material in initializee
 	var/can_be_placed_into = list(
 		/obj/machinery/chem_master,
 		/obj/machinery/chem_heater,
@@ -53,14 +53,14 @@
 	if(!possible_transfer_amounts)
 		src.verbs -= /obj/item/reagent_containers/verb/set_APTFT
 	create_reagents(volume)
-	shatter_material = new
+	shatter_material = SSmaterials.get_material_by_name(shatter_material)
 
 /obj/item/reagent_containers/attack_self(mob/user)
 	return
 
 /obj/item/reagent_containers/throw_impact(atom/hit_atom, var/speed)
 	. = ..()
-	if((speed >= fragile) && !no_shatter)
+	if((speed >= fragile) && shatter)
 		shatter()
 
 /obj/item/reagent_containers/proc/shatter(var/obj/item/W, var/mob/user)
@@ -72,7 +72,7 @@
 	qdel(src)
 
 /obj/item/reagent_containers/attackby(var/obj/item/W, var/mob/user)
-	if(!(W.flags & NOBLUDGEON) && (user.a_intent == I_HURT) && (W.force > fragile) && !no_shatter)
+	if(!(W.flags & NOBLUDGEON) && (user.a_intent == I_HURT) && (W.force > fragile) && shatter)
 		if(do_after(user, 10))
 			if(!QDELETED(src))
 				visible_message(SPAN_WARNING("[user] smashes [src] with \a [W]!"))

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -12,6 +12,7 @@
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	force = 5
 	hitsound = /decl/sound_category/bottle_hit_intact_sound
+	no_shatter = FALSE
 	var/smash_duration = 5 //Directly relates to the 'weaken' duration. Lowered by armor (i.e. helmets)
 	matter = list(MATERIAL_GLASS = 800)
 
@@ -397,6 +398,8 @@
 	drop_sound = 'sound/items/drop/shoes.ogg'
 	pickup_sound = 'sound/items/pickup/shoes.ogg'
 	reagents_to_add = list(/datum/reagent/drink/space_cola = 100)
+	shatter_material = /material/plastic
+	no_shatter = TRUE
 
 /obj/item/reagent_containers/food/drinks/bottle/space_up
 	name = "\improper Space-Up"
@@ -407,6 +410,8 @@
 	drop_sound = 'sound/items/drop/shoes.ogg'
 	pickup_sound = 'sound/items/pickup/shoes.ogg'
 	reagents_to_add = list(/datum/reagent/drink/spaceup = 100)
+	shatter_material = /material/plastic
+	no_shatter = TRUE
 
 /obj/item/reagent_containers/food/drinks/bottle/space_mountain_wind
 	name = "\improper Space Mountain Wind"
@@ -417,6 +422,8 @@
 	drop_sound = 'sound/items/drop/shoes.ogg'
 	pickup_sound = 'sound/items/pickup/shoes.ogg'
 	reagents_to_add = list(/datum/reagent/drink/spacemountainwind = 100)
+	shatter_material = /material/plastic
+	no_shatter = TRUE
 
 /obj/item/reagent_containers/food/drinks/bottle/pwine
 	name = "Chip Getmore's Velvet"
@@ -540,7 +547,6 @@
 	desc = "Blended flower buds from the Xuizi cactus. It smells faintly of vanilla. Bottled by the Arizi Guild for over 200 years."
 	icon_state = "xuizibottle"
 	center_of_mass = list("x"=16, "y"=8)
-
 	reagents_to_add = list(/datum/reagent/alcohol/butanol/xuizijuice = 30)
 
 /obj/item/reagent_containers/food/drinks/bottle/sarezhiwine

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -398,7 +398,7 @@
 	drop_sound = 'sound/items/drop/shoes.ogg'
 	pickup_sound = 'sound/items/pickup/shoes.ogg'
 	reagents_to_add = list(/datum/reagent/drink/space_cola = 100)
-	shatter_material = /material/plastic
+	shatter_material = MATERIAL_PLASTIC
 	shatter = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/space_up
@@ -410,7 +410,7 @@
 	drop_sound = 'sound/items/drop/shoes.ogg'
 	pickup_sound = 'sound/items/pickup/shoes.ogg'
 	reagents_to_add = list(/datum/reagent/drink/spaceup = 100)
-	shatter_material = /material/plastic
+	shatter_material = MATERIAL_PLASTIC
 	shatter = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/space_mountain_wind
@@ -422,7 +422,7 @@
 	drop_sound = 'sound/items/drop/shoes.ogg'
 	pickup_sound = 'sound/items/pickup/shoes.ogg'
 	reagents_to_add = list(/datum/reagent/drink/spacemountainwind = 100)
-	shatter_material = /material/plastic
+	shatter_material = MATERIAL_PLASTIC
 	shatter = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/pwine

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -12,7 +12,7 @@
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	force = 5
 	hitsound = /decl/sound_category/bottle_hit_intact_sound
-	no_shatter = FALSE
+	shatter = TRUE
 	var/smash_duration = 5 //Directly relates to the 'weaken' duration. Lowered by armor (i.e. helmets)
 	matter = list(MATERIAL_GLASS = 800)
 
@@ -399,7 +399,7 @@
 	pickup_sound = 'sound/items/pickup/shoes.ogg'
 	reagents_to_add = list(/datum/reagent/drink/space_cola = 100)
 	shatter_material = /material/plastic
-	no_shatter = TRUE
+	shatter = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/space_up
 	name = "\improper Space-Up"
@@ -411,7 +411,7 @@
 	pickup_sound = 'sound/items/pickup/shoes.ogg'
 	reagents_to_add = list(/datum/reagent/drink/spaceup = 100)
 	shatter_material = /material/plastic
-	no_shatter = TRUE
+	shatter = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/space_mountain_wind
 	name = "\improper Space Mountain Wind"
@@ -423,7 +423,7 @@
 	pickup_sound = 'sound/items/pickup/shoes.ogg'
 	reagents_to_add = list(/datum/reagent/drink/spacemountainwind = 100)
 	shatter_material = /material/plastic
-	no_shatter = TRUE
+	shatter = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/pwine
 	name = "Chip Getmore's Velvet"

--- a/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
@@ -12,6 +12,7 @@
 	pickup_sound = 'sound/items/pickup/drinkglass.ogg'
 	matter = list(MATERIAL_GLASS = 300)
 	drink_flags = NO_EMPTY_ICON	//This should not be removed unless a total overhaul of drink reagent sprites is done.
+	no_shatter = FALSE
 
 /obj/item/reagent_containers/food/drinks/drinkingglass/on_reagent_change()
 	if (reagents.reagent_list.len > 0)

--- a/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
@@ -12,7 +12,7 @@
 	pickup_sound = 'sound/items/pickup/drinkglass.ogg'
 	matter = list(MATERIAL_GLASS = 300)
 	drink_flags = NO_EMPTY_ICON	//This should not be removed unless a total overhaul of drink reagent sprites is done.
-	no_shatter = FALSE
+	shatter = TRUE
 
 /obj/item/reagent_containers/food/drinks/drinkingglass/on_reagent_change()
 	if (reagents.reagent_list.len > 0)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -15,11 +15,10 @@
 	accuracy = 0.1
 	w_class = ITEMSIZE_SMALL
 	flags = OPENCONTAINER
-	var/fragile = TRUE // most glassware is super fragile
-	var/no_shatter = FALSE //does this container shatter?
 	unacidable = 1 //glass doesn't dissolve in acid
 	drop_sound = 'sound/items/drop/bottle.ogg'
 	pickup_sound = 'sound/items/pickup/bottle.ogg'
+	no_shatter = FALSE
 	var/label_text = ""
 
 /obj/item/reagent_containers/glass/Initialize()
@@ -64,19 +63,6 @@
 /obj/item/reagent_containers/glass/AltClick(var/mob/user)
 	set_APTFT()
 
-/obj/item/reagent_containers/glass/throw_impact(atom/hit_atom, var/speed)
-	. = ..()
-	if(speed > fragile && !no_shatter)
-		shatter()
-
-/obj/item/reagent_containers/glass/proc/shatter(var/mob/user)
-	if(reagents.total_volume)
-		reagents.splash(src.loc, reagents.total_volume) // splashes the mob holding it or the turf it's on
-	audible_message(SPAN_WARNING("\The [src] shatters with a resounding crash!"), SPAN_WARNING("\The [src] breaks."))
-	playsound(src, /decl/sound_category/glass_break_sound, 70, 1)
-	new /obj/item/material/shard(loc, "glass")
-	qdel(src)
-
 /obj/item/reagent_containers/glass/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/storage/part_replacer))
 		if(!reagents || !reagents.total_volume)
@@ -115,7 +101,7 @@
 	matter = list(MATERIAL_GLASS = 500)
 	drop_sound = 'sound/items/drop/drinkglass.ogg'
 	pickup_sound = 'sound/items/pickup/drinkglass.ogg'
-	fragile = 4
+	fragile = 1
 
 /obj/item/reagent_containers/glass/beaker/Initialize()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -77,9 +77,6 @@
 			update_name_label()
 		return
 	. = ..() // in the case of nitroglycerin, explode BEFORE it shatters
-	if(!(W.flags & NOBLUDGEON) && fragile && (W.force > fragile) && !no_shatter)
-		shatter()
-		return
 
 /obj/item/reagent_containers/glass/proc/update_name_label()
 	if(label_text == "")

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -18,7 +18,7 @@
 	unacidable = 1 //glass doesn't dissolve in acid
 	drop_sound = 'sound/items/drop/bottle.ogg'
 	pickup_sound = 'sound/items/pickup/bottle.ogg'
-	no_shatter = FALSE
+	shatter = TRUE
 	var/label_text = ""
 
 /obj/item/reagent_containers/glass/Initialize()
@@ -217,7 +217,7 @@
 	drop_sound = 'sound/items/drop/helm.ogg'
 	pickup_sound = 'sound/items/pickup/helm.ogg'
 	var/helmet_type = /obj/item/clothing/head/helmet/bucket
-	no_shatter = TRUE
+	shatter = FALSE
 	fragile = 0
 
 /obj/item/reagent_containers/glass/bucket/attackby(var/obj/D, mob/user as mob)

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -15,7 +15,7 @@
 	possible_transfer_amounts = list(5,10,15,25,30,60)
 	flags = 0
 	volume = 60
-	fragile = 4
+	fragile = 2
 
 /obj/item/reagent_containers/glass/bottle/on_reagent_change()
 	update_icon()

--- a/html/changelogs/mattatlas-shatter.yml
+++ b/html/changelogs/mattatlas-shatter.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Drinking glasses, wine bottles and such now shatter when thrown."
+  - bugfix: "Beakers now properly shatter when thrown as well."

--- a/html/changelogs/mattatlas-shatter.yml
+++ b/html/changelogs/mattatlas-shatter.yml
@@ -40,3 +40,4 @@ delete-after: True
 changes: 
   - bugfix: "Drinking glasses, wine bottles and such now shatter when thrown."
   - bugfix: "Beakers now properly shatter when thrown as well."
+  - bugfix: "Reagent containers should break properly when hit. Be careful when pouring drinks, don't use harm intent."


### PR DESCRIPTION
Reagent container shattering/impact have been brought down to the base level instead of being on the glass level. Funnily enough drinking glasses are not actually glass reagent containers.

Fixes #9874 
