### PR TITLE
Various RMT pill tweaks + bugfix

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -529,9 +529,6 @@
 			G.prescription = TRUE
 			G.autodrobe_no_remove = TRUE
 
-	if(H.species)
-		H.species.equip_later_gear(H)
-
 	// So shoes aren't silent if people never change 'em.
 	H.update_noise_level()
 

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -245,6 +245,6 @@ obj/item/storage/pill_bottle/butazoline
 	starts_with = list(/obj/item/reagent_containers/pill/minaphobin = 7)
 
 /obj/item/storage/pill_bottle/rmt
-	name = "bottle of 15u RMT pills"
+	name = "bottle of 30u RMT pills"
 	desc = "Contains pills used to remedy the effects of prolonged zero-gravity adaptations."
 	starts_with = list(/obj/item/reagent_containers/pill/rmt = 7)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1627,8 +1627,8 @@
 	reagent_state = LIQUID
 	scannable = TRUE
 	color = "#AA8866"
-	overdose = REAGENTS_OVERDOSE
-	metabolism = 0.2 * REM
+	overdose = 40
+	metabolism = 0.1 * REM
 	taste_description = "sourness"
 	fallback_specific_heat = 1
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -226,7 +226,7 @@ obj/item/reagent_containers/pill/tranquility
 	name = "Regenerative-Muscular Tissue Supplement Pill"
 	desc = "Commonly abbreviated to RMT, it contains chemicals rampantly used by those seeking to remedy the effects of prolonged zero-gravity adaptations."
 	icon_state = "pill19"
-	reagents_to_add = list(/datum/reagent/rmt = 15)
+	reagents_to_add = list(/datum/reagent/rmt = 30)
 
 /obj/item/reagent_containers/pill/cetahydramine
 	name = "Cetahydramine Pill"

--- a/html/changelogs/hockaa-rmtpills.yml
+++ b/html/changelogs/hockaa-rmtpills.yml
@@ -1,0 +1,8 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+  - tweak: "RMT supplements are now 30 units by default (was 15)."
+  - tweak: "RMT now metabolises twice as slowly and overdoses at 40 units (was 20.)"
+  - bugfix: "Offworlders no longer get two pill bottles if they spawn on the Odin."

--- a/html/changelogs/hockaa-rmtpills.yml
+++ b/html/changelogs/hockaa-rmtpills.yml
@@ -4,5 +4,5 @@ delete-after: True
 
 changes: 
   - tweak: "RMT supplements are now 30 units by default (was 15)."
-  - tweak: "RMT now metabolises twice as slowly and overdoses at 40 units (was 20.)"
+  - tweak: "RMT now metabolises twice as slowly and overdoses at 40 units (was 20)."
   - bugfix: "Offworlders no longer get two pill bottles if they spawn on the Odin."


### PR DESCRIPTION
The equp_later_gear proc is now only called once, so offworlders spawning on the odin don't spawn with two pill bottles.
Changes the metabolism rate of RMT to be twice as long as it used to be, in order to better accomodate offworlders in long rounds, as they currently do not last even a 2 hour round.
Changes the units of RMT in a default pill to 30 instead of thirteen for same reasons as above.
Changes the overdose limit of RMT to 40 to accomodate for the increased amount in pills.

Edit: Changes the name of the RMT pill bottle to also reflect the change in units.