### PR TITLE
Adds a warning to antag shuttle consoles

### DIFF
--- a/code/modules/shuttles/shuttle_console_multi.dm
+++ b/code/modules/shuttles/shuttle_console_multi.dm
@@ -34,3 +34,16 @@
 	if(href_list["toggle_cloaked"])
 		shuttle.cloaked = !shuttle.cloaked
 		return TOPIC_REFRESH
+
+/obj/machinery/computer/shuttle_control/multi/can_move(var/datum/shuttle/autodock/shuttle, var/user)
+	if(istype(shuttle, /datum/shuttle/autodock/multi/antag))
+		var/datum/shuttle/autodock/multi/antag/our_shuttle = shuttle
+		if(our_shuttle.returned)
+			to_chat(user, SPAN_WARNING("You don't have enough fuel for another trip!"))
+			return FALSE
+		else if(our_shuttle.next_location == our_shuttle.home_waypoint)
+			if(our_shuttle.return_warning_cooldown < world.time)
+				our_shuttle.return_warning_cooldown = world.time + 60 SECONDS
+				alert(user, "If you return to base, you won't be able to return to [current_map.station_short]. Launch again if you're sure about this.","Shuttle Control","Acknowledged.")
+				return FALSE
+	return ..()

--- a/code/modules/shuttles/shuttles_multi.dm
+++ b/code/modules/shuttles/shuttles_multi.dm
@@ -30,6 +30,7 @@
 
 	var/cloaked = TRUE
 	var/returned = FALSE
+	var/return_warning_cooldown
 	var/announcer
 	var/arrival_message
 	var/departure_message

--- a/html/changelogs/Ferner-200908-coding_antagshuttlewarning.yml
+++ b/html/changelogs/Ferner-200908-coding_antagshuttlewarning.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - tweak: "Antag shuttles now warn the pilot that they cannot return to Aurora if they go back to base."


### PR DESCRIPTION
 - Adds a warning that antag shuttles (raider/merc/burglar) cannot go back to Aurora after they've returned to their base, as this has led to confusion on multiple occasions.