### PR TITLE
Fixes offworlders not getting a bottle of RMT pills when spawning on the Odin

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -25,6 +25,8 @@
 	var/safe_to_sanitize = FALSE
 	var/list/deferred_preference_sanitizations = list()
 
+	var/laterequipped
+
 /datum/controller/subsystem/jobs/New()
 	NEW_SS_GLOBAL(SSjobs)
 
@@ -393,8 +395,9 @@
 			var/obj/item/clothing/glasses/G = H.glasses
 			G.prescription = TRUE
 
-	if(H.species)
+	if(H.species && !laterequipped)
 		H.species.equip_later_gear(H)
+		laterequipped = TRUE
 
 	BITSET(H.hud_updateflag, ID_HUD)
 	BITSET(H.hud_updateflag, IMPLOYAL_HUD)
@@ -528,6 +531,10 @@
 			var/obj/item/clothing/glasses/G = H.glasses
 			G.prescription = TRUE
 			G.autodrobe_no_remove = TRUE
+	
+	if(H.species && !laterequipped)
+		H.species.equip_later_gear(H)
+		laterequipped = TRUE
 
 	// So shoes aren't silent if people never change 'em.
 	H.update_noise_level()

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -25,8 +25,6 @@
 	var/safe_to_sanitize = FALSE
 	var/list/deferred_preference_sanitizations = list()
 
-	var/laterequipped
-
 /datum/controller/subsystem/jobs/New()
 	NEW_SS_GLOBAL(SSjobs)
 
@@ -395,9 +393,9 @@
 			var/obj/item/clothing/glasses/G = H.glasses
 			G.prescription = TRUE
 
-	if(H.species && !laterequipped)
+	if(H.species && !H.species_items_equipped)
 		H.species.equip_later_gear(H)
-		laterequipped = TRUE
+		H.species_items_equipped = TRUE
 
 	BITSET(H.hud_updateflag, ID_HUD)
 	BITSET(H.hud_updateflag, IMPLOYAL_HUD)
@@ -532,9 +530,9 @@
 			G.prescription = TRUE
 			G.autodrobe_no_remove = TRUE
 	
-	if(H.species && !laterequipped)
+	if(H.species && !H.species_items_equipped)
 		H.species.equip_later_gear(H)
-		laterequipped = TRUE
+		H.species_items_equipped = TRUE
 
 	// So shoes aren't silent if people never change 'em.
 	H.update_noise_level()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -5,6 +5,8 @@
 	icon = 'icons/mob/human.dmi'
 	icon_state = "body_m_s"
 
+	var/species_items_equipped // used so species that need special items (autoinhalers for vaurca/RMT for offworlders) don't get them twice when they shouldn't.
+
 	var/list/hud_list[10]
 	var/embedded_flag	  //To check if we've need to roll for damage on movement while an item is imbedded in us.
 	var/obj/item/rig/wearing_rig // This is very not good, but it's much much better than calling get_rig() every update_canmove() call.

--- a/html/changelogs/hockaa-rmtpills.yml
+++ b/html/changelogs/hockaa-rmtpills.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+  - bugfix: "Offworlders no longer spawn with no RMT on the Odin."

--- a/html/changelogs/hockaa-rmtpills.yml
+++ b/html/changelogs/hockaa-rmtpills.yml
@@ -3,4 +3,4 @@ author: Hocka
 delete-after: True
 
 changes: 
-  - bugfix: "Offworlders no longer spawn with no RMT on the Odin."
+  - bugfix: "Offworlders and Vaurca no longer spawn without their essentials on the Odin."


### PR DESCRIPTION
Re-adds the equip_gear_later proc to the equippersonal proc, but now also checks if the proc was already called via a TRUE/FALSE check on the human and stops it if it's TRUE.