### PR TITLE
Removes lichdom from the necromancer spellbook

### DIFF
--- a/code/modules/spell_system/spellbook/variants/necromancer.dm
+++ b/code/modules/spell_system/spellbook/variants/necromancer.dm
@@ -15,7 +15,6 @@
 	spells = list(/spell/targeted/projectile/dumbfire/fireball =	1,
 				/spell/targeted/torment =							1,
 				/spell/targeted/subjugation =						1,
-				/spell/targeted/lichdom =							2,
 				/spell/aoe_turf/conjure/mirage =					1,
 				/spell/aoe_turf/conjure/summon/bats =				1,
 				/spell/targeted/shapeshift/corrupt_form =			1,

--- a/html/changelogs/alberyk-unfnnui.yml
+++ b/html/changelogs/alberyk-unfnnui.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - rscdel: "Removed lichdom from the necromancer spellbook."


### PR DESCRIPTION
What it says in the title. Despite being a rather unique and original spell, it is used most of the time to just murder everyone, while the lich tries to hide their phylactery at the most bullshit places possible.