### PR TITLE
Added the FT role as permitted roles for the idris sec sleeve patch 

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_factions.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_factions.dm
@@ -105,7 +105,7 @@
 	display_name = "idris security sleeve patch"
 	path = /obj/item/clothing/accessory/sleevepatch/idrissec
 	faction = "Idris Incorporated"
-	allowed_roles = list("Security Officer","Detective")
+	allowed_roles = list("Security Officer","Detective", "Forensic Technician")
 
 /datum/gear/faction/heph_labcoat
 	display_name = "hephaestus labcoat"

--- a/html/changelogs/Aboshehab - idrisSleevePatch.yml
+++ b/html/changelogs/Aboshehab - idrisSleevePatch.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Aboshehab
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Idris contractors working as Forensic Technicians can now select the idris security sleeve patch from the loadout."
+


### PR DESCRIPTION
Idris contractors can be Forensic Technician yet cannot pick out the idris security sleeve patch as they should be.

This PR fixes it.