### PR TITLE
Sparky's Bugfix Trilogy

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -379,10 +379,11 @@ BREATH ANALYZER
 				break
 		var/dat = "Trace Chemicals Found: "
 		for(var/R in blood_traces)
+			var/datum/reagent/C = new R()
 			if(details)
-				dat += "[R] ([blood_traces[R]] units) "
+				dat += "[C] ([blood_traces[R]] units) "
 			else
-				dat += "[R] "
+				dat += "[C] "
 		to_chat(user, "[dat]")
 		reagents.clear_reagents()
 	return

--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -12,6 +12,7 @@
 	composition_reagent = /datum/reagent/nutriment //Dionae are plants, so eating them doesn't give animal protein
 	name = "diona nymph"
 	voice_name = "diona nymph"
+	accent = ACCENT_DIONA
 	adult_form = /mob/living/carbon/human
 	speak_emote = list("chirrups")
 	icon = 'icons/mob/diona.dmi'

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -27,13 +27,18 @@
 		playsound(user.loc, 'sound/items/eatfood.ogg', rand(10, 50), 1)
 
 /obj/item/reagent_containers/food/proc/on_consume(var/mob/user, var/mob/target)
+	var/slot = target.get_inventory_slot(src)
 	if(!reagents.total_volume)
 		if(bitecount==1)
 			target.visible_message("<b>[target]</b> [is_liquid ? "drinks" : "eats"] \the [src].", SPAN_NOTICE("You [is_liquid ? "drink" : "eat"] \the [src]."))
 		else
 			target.visible_message("<b>[target]</b> finishes [is_liquid ? "drinking" : "eating"] \the [src].", SPAN_NOTICE("You finish [is_liquid ? "drinking" : "eating"] \the [src]."))
 		if(trash)
-			user.drop_from_inventory(src)	//so trash actually stays in the active hand.
-			var/obj/item/TrashItem = new trash(user)
-			user.put_in_hands(TrashItem)
+			if(slot)
+				user.drop_from_inventory(src)	//so trash actually stays in the active hand.
+				var/obj/item/TrashItem = new trash(user)
+				user.put_in_hands(TrashItem)
+			else
+				var/obj/item/TrashItem = new trash(user)
+				TrashItem.forceMove(get_turf(src))
 		qdel(src)

--- a/html/changelogs/annoiances_fix.yml
+++ b/html/changelogs/annoiances_fix.yml
@@ -1,0 +1,8 @@
+author: Sparky_Hotdog
+
+delete-after: True
+
+changes: 
+  - bugfix: "You no longer pick up or drop plates and bowls when you finish them with cutlery."
+  - bugfix: "Mass spectrometers now show the IC name for any reagents, not their object path."
+  - bugfix: "Diona nymphs now have the default diona accent."


### PR DESCRIPTION
Fixes a bunch of minor problems I'd noticed in-game.

**Changes:** 
  - bugfix: "You no longer pick up or drop plates and bowls when you finish them with cutlery."
  - bugfix: "Mass spectrometers now show the IC name for any reagents, not their object path."
  - bugfix: "Diona nymphs now have the default diona accent."