### PR TITLE
Tweaks the rarity of a couple of guns

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1504,7 +1504,6 @@
 		)
 
 	var/list/Epic = list(
-		/obj/item/gun/energy/pulse/pistol = 1,
 		/obj/item/gun/energy/decloner = 0.5,
 		/obj/item/gun/energy/rifle/laser/xray = 1,
 		/obj/item/gun/energy/rifle/laser/tachyon = 1,
@@ -1517,7 +1516,6 @@
 		/obj/item/gun/projectile/automatic/rifle/w556 = 1,
 		/obj/item/gun/projectile/automatic/rifle/z8 = 1,
 		/obj/item/gun/projectile/cannon = 1,
-		/obj/item/gun/projectile/gyropistol = 0.5,
 		/obj/item/gun/projectile/plasma = 0.5,
 		/obj/item/gun/projectile/revolver = 0.5
 		)
@@ -1525,10 +1523,12 @@
 	var/list/Legendary = list(
 		/obj/item/gun/energy/lawgiver = 1,
 		/obj/item/gun/energy/pulse = 1,
+		/obj/item/gun/energy/pulse/pistol = 1,
 		/obj/item/gun/energy/rifle/pulse = 1,
 		/obj/item/gun/projectile/automatic/railgun = 1,
 		/obj/item/gun/projectile/automatic/rifle/l6_saw = 1,
 		/obj/item/gun/projectile/automatic/terminator = 1,
+		/obj/item/gun/projectile/gyropistol = 1,
 		/obj/item/gun/projectile/nuke = 1,
 		/obj/item/gun/projectile/revolver/mateba = 1
 		)

--- a/html/changelogs/Ferner-coding_weaponandammobalance_pt1.yml
+++ b/html/changelogs/Ferner-coding_weaponandammobalance_pt1.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - balance: "Bumped up the rarity of the pulse pistol and gyropistol in the random gun pool."


### PR DESCRIPTION
Bumps up the rarity of the pulse pistol and gyropistol in the random gun pool, a decision based on my experience observing some specific rounds.
When a gun is not easily distinguished in the hands of a goon and excessively powerful it can lead to problems, this increases their rarity from the epic category to legendary.