### PR TITLE
Fixes ninjas being unable to access the rhino suit

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -87,6 +87,8 @@
 	allowed_module_types = MODULE_GENERAL | MODULE_LIGHT_COMBAT | MODULE_HEAVY_COMBAT | MODULE_SPECIAL | MODULE_MEDICAL | MODULE_UTILITY | MODULE_VAURCA
 
 /obj/item/rig/merc/distress/ninja
+	req_access = null
+
 	initial_modules = list(
 		/obj/item/rig_module/mounted,
 		/obj/item/rig_module/power_sink,

--- a/html/changelogs/Ferner-200910-bugfix_rhinoninja.yml
+++ b/html/changelogs/Ferner-200910-bugfix_rhinoninja.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Ninjas can now access the rhino suit properly if they decide to purchase it."


### PR DESCRIPTION
Ninjas could buy the rhino suit with their uplink but not access it, this fixes that.
Sets it to null access instead of syndicate, as that's in line with the other non-standard ninja suits.