### PR TITLE
Fix Loadout Safety Goggles

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -58,7 +58,7 @@
 /datum/gear/eyes/goggles/New()
 	..()
 	var/goggles = list()
-	goggles["goggles, safety"] = /obj/item/clothing/glasses/regular
+	goggles["goggles, safety"] = /obj/item/clothing/glasses/safety/goggles
 	goggles["goggles, scanning"] = /obj/item/clothing/glasses/regular/scanners
 	goggles["goggles, science"] = /obj/item/clothing/glasses/science
 	goggles["goggles, orange"] = /obj/item/clothing/glasses/spiffygogs

--- a/html/changelogs/goggles.yml
+++ b/html/changelogs/goggles.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - bugfix: "Selecting Safety Goggles in loadout preferecnes not gives you safety goggles, not prescription glasses."

--- a/html/changelogs/goggles.yml
+++ b/html/changelogs/goggles.yml
@@ -3,4 +3,4 @@ author: Sparky_hotdog
 delete-after: True
 
 changes:
-  - bugfix: "Selecting Safety Goggles in loadout preferecnes not gives you safety goggles, not prescription glasses."
+  - bugfix: "Selecting Safety Goggles in loadout preferences now gives you safety goggles, not prescription glasses."


### PR DESCRIPTION
Fixes issue #9956. Safety Goggles in Loadout preferences were prescription glasses. 

changes:
  - bugfix: "Selecting Safety Goggles in loadout preferences now gives you safety goggles, not prescription glasses."