### PR TITLE
Borg Drill Fix

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -338,8 +338,10 @@
 
 /obj/item/pickaxe/borgdrill
 	name = "cyborg mining drill"
+	icon = 'icons/obj/contained_items/tools/drills.dmi'
 	icon_state = "diamonddrill"
 	item_state = "jackhammer"
+	contained_sprite = TRUE
 	digspeed = 10
 	digspeed_unwielded = 10
 	force_unwielded = 25.0

--- a/html/changelogs/geeves-borg_drill_fix.yml
+++ b/html/changelogs/geeves-borg_drill_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Borg drills no longer have an invisible sprite."


### PR DESCRIPTION
* Borg drills no longer have an invisible sprite.

Fixes https://github.com/Aurorastation/Aurora.3/issues/9962