### PR TITLE
Diona and Lumber Tweaks and Fixes

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -340,12 +340,12 @@
 	force_wielded = 20
 	throwforce = 5
 	w_class = ITEMSIZE_LARGE
-	sharp = 1
-	edge = 1
+	sharp = TRUE
+	edge = TRUE
 	origin_tech = list(TECH_COMBAT = 5)
 	attack_verb = list("chopped", "sliced", "shredded", "slashed", "cut", "ripped")
-	can_embed = 0
-	applies_material_colour = 0
+	can_embed = FALSE
+	applies_material_colour = FALSE
 	default_material = "steel"
 	parry_chance = 5
 	var/fuel_type = /datum/reagent/fuel
@@ -353,8 +353,8 @@
 	var/max_fuel = 300 // The maximum amount of fuel the chainsaw stores.
 	var/fuel_cost = 1 // Multiplier for fuel cost.
 
-	var/cutting = 0 //Ignore
-	var/powered = 0 //Ignore
+	var/cutting = FALSE //Ignore
+	var/powered = FALSE //Ignore
 	use_material_sound = FALSE
 	drop_sound = 'sound/items/drop/axe.ogg'
 	pickup_sound = 'sound/items/pickup/axe.ogg'
@@ -383,29 +383,34 @@
 	var/turf/T = get_turf(src)
 	T.audible_message(SPAN_NOTICE("\The [src] rumbles to life."))
 	playsound(src, "sound/weapons/chainsawstart.ogg", 25, 0, 30)
-	force = 15
 	force_unwielded = 30
+	force = force_unwielded
 	force_wielded = 60
+	if(wielded)
+		force = force_wielded
 	throwforce = 20
 	icon_state = "chainsaw_on"
 	base_icon = "chainsaw_on"
 	slot_flags = null
 	START_PROCESSING(SSfast_process, src)
-	powered = 1
+	powered = TRUE
 	update_held_icon()
 
 /obj/item/material/twohanded/chainsaw/proc/PowerDown()
 	var/turf/T = get_turf(src)
 	T.audible_message(SPAN_NOTICE("\The [src] slowly powers down."))
-	force = initial(force)
+	force_unwielded = initial(force_unwielded)
+	force = force_unwielded
 	force_wielded = initial(force_wielded)
+	if(wielded)
+		force = force_wielded
 	throwforce = initial(throwforce)
 	hitsound = initial(hitsound)
 	icon_state = initial(icon_state)
 	base_icon = initial(base_icon)
 	slot_flags = initial(slot_flags)
 	STOP_PROCESSING(SSfast_process, src)
-	powered = 0
+	powered = FALSE
 	update_held_icon()
 
 /obj/item/material/twohanded/chainsaw/shatter(var/consumed)
@@ -445,7 +450,9 @@
 
 /obj/item/material/twohanded/chainsaw/examine(mob/user)
 	if(..(user, 1))
-		to_chat(user, "A heavy-duty chainsaw meant for cutting wood. Contains [round(reagents.get_reagent_amount(fuel_type))] unit\s of fuel.")
+		to_chat(user, "A heavy-duty chainsaw meant for cutting wood. Contains <b>[round(reagents.get_reagent_amount(fuel_type))]</b> unit\s of fuel.")
+		if(powered)
+			to_chat(user, SPAN_NOTICE("It is currently powered on."))
 
 /obj/item/material/twohanded/chainsaw/attack(mob/M as mob, mob/living/user as mob)
 	. = ..()
@@ -457,21 +464,15 @@
 	if(!proximity) return
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,O) <= 1 && !powered)
 		O.reagents.trans_to_obj(src, max_fuel)
-		to_chat(user, "<span class='notice'>[src] refueled</span>")
+		to_chat(user, SPAN_NOTICE("You refuel \the [src]."))
 		playsound(loc, 'sound/effects/refill.ogg', 50, 1, -6)
 		return
 	else if(powered)
 		if(!istype(O))
-			user.visible_message(\
-				"<span class='warning'>[user] revs the chainsaw!.</span>",\
-				"<span class='warning'>You rev the chainsaw!.</span>",\
-				"<span class='warning'>You hear a machine rev.</span>"\
-			)
-
+			user.visible_message(SPAN_DANGER("[user] revs the chainsaw!"), SPAN_WARNING("You rev the chainsaw!"), SPAN_WARNING("You hear a chainsaw rev!"))
 			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			playsound(loc, "sound/weapons/saw/chainsword.ogg", 25, 0, 30)
 			RemoveFuel(3)
-
 	. = ..()
 
 /obj/item/material/twohanded/chainsaw/proc/eyecheck(var/multiplier, mob/living/carbon/human/H as mob) //Shamefully copied from the welder. Damage values multiplied by 0.1
@@ -488,34 +489,23 @@
 	if(eye_damage > 0)
 		to_chat(H, "<span class='danger'>Some stray sparks fly in your eyes!</span>")
 
-/obj/item/material/twohanded/chainsaw/AltClick(mob/user as mob)
-
+/obj/item/material/twohanded/chainsaw/AltClick(mob/user)
 	if(powered)
 		PowerDown(user)
 	else if(!wielded)
-		to_chat(user, "<span class='notice'>You need to hold this with two hands to turn this on.</span>")
+		to_chat(user, SPAN_WARNING("You need to hold this with two hands to turn this on."))
 	else if(reagents.get_reagent_amount(/datum/reagent/fuel) <= 0)
-		user.visible_message(\
-			"<span class='notice'>[user] pulls the cord on the [src], but nothing happens.</span>",\
-			"<span class='notice'>You pull the cord on the [src], but nothing happens.</span>",\
-			"<span class='notice'>You hear a cord being pulled.</span>"\
-		)
+		user.visible_message(SPAN_WARNING("[user] pulls the cord on \the [src], but nothing happens."), SPAN_WARNING("You pull the cord on \the [src], but nothing happens."), SPAN_NOTICE("You hear a cord being pulled."))
 	else
 		var/max = rand(3,6)
 		for(var/i in 1 to max)
-			user.visible_message(\
-				"<span class='notice'>[user] pulls the cord on the [src]...</span>",\
-				"<span class='notice'>You pull the cord on the [src]...</span>",\
-				"<span class='notice'>You hear a cord being pulled and an engine sputtering...</span>"\
-			)
+			user.visible_message(SPAN_WARNING("[user] pulls the cord on \the [src]..."), SPAN_NOTICE("You pull the cord on \the [src]..."), SPAN_NOTICE("You hear a cord being pulled and an engine sputtering..."))
 			if(i == max)
 				PowerUp(user)
 			else
 				playsound(loc, 'sound/weapons/saw/chainsawpull.ogg', 50, 0, 15)
 				if(!do_after(user, 2 SECONDS, act_target = user))
 					break
-
-
 
 /obj/item/material/twohanded/chainsaw/pre_attack(var/mob/living/target, var/mob/living/user)
 	if(istype(target) && wielded && powered)

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -400,7 +400,7 @@
 	return
 
 /material/diona/place_dismantled_girder(var/turf/target)
-	target.spawn_diona_nymph(target)
+	new /obj/structure/diona/vines(target)
 
 /material/steel/holographic
 	name = "holo" + DEFAULT_WALL_MATERIAL

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -414,8 +414,8 @@ var/list/diona_banned_languages = list(
 	if(E_old)
 		qdel(E_old)
 
-	visible_message("<span class='danger'>With a shower of sticky sap, a new mass of tendrils bursts forth from [src]'s trunk, forming a new [E]</span>",
-		"<span class='danger'>With a shower of sticky sap, a new mass of tendrils bursts forth from your trunk, forming a new [E]</span>")
+	visible_message("<span class='danger'>With a shower of sticky sap, a new mass of tendrils bursts forth from [src]'s trunk, forming a new [E].</span>",
+		"<span class='danger'>With a shower of sticky sap, a new mass of tendrils bursts forth from your trunk, forming a new [E].</span>")
 	var/datum/reagents/vessel = get_vessel(0)
 	var/datum/reagent/B = vessel.get_master_reagent()
 	B.touch_turf(get_turf(src))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -366,6 +366,11 @@
 			for(var/obj/effect/overlay/wallrot/E in W)
 				qdel(E)
 			W.visible_message(SPAN_NOTICE("The fungi are completely dissolved by the solution!"))
+	if(istype(T, /turf/simulated/floor/diona))
+		T.visible_message(SPAN_WARNING("\The [T] squirms as it's hit by the solution, before dissolving."))
+		var/turf/simulated/floor/F = T
+		F.make_plating()
+		playsound(F, 'sound/species/diona/gestalt_grow.ogg', 30, TRUE)
 
 /datum/reagent/toxin/plantbgone/touch_obj(var/obj/O, var/volume)
 	if(istype(O, /obj/structure/alien/weeds))

--- a/html/changelogs/geeves-diona_bugfixes.yml
+++ b/html/changelogs/geeves-diona_bugfixes.yml
@@ -7,3 +7,4 @@ changes:
   - bugfix: "Alien vines have been renamed to biomass vines, and can now be attacked and welded to destroy them."
   - tweak: "Diona walls now spawn vines when ripped apart, instead of nymphs. It should help with lag when many are erected."
   - bugfix: "Chainsaws now have the correct damage values when powered on."
+  - rscadd: "Biomass floors can now be sprayed with plant-b-gone to remove them."

--- a/html/changelogs/geeves-diona_bugfixes.yml
+++ b/html/changelogs/geeves-diona_bugfixes.yml
@@ -1,0 +1,9 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Diona structures can now be attacked by regular weapons to damage and destroy them."
+  - bugfix: "Alien vines have been renamed to biomass vines, and can now be attacked and welded to destroy them."
+  - tweak: "Diona walls now spawn vines when ripped apart, instead of nymphs. It should help with lag when many are erected."
+  - bugfix: "Chainsaws now have the correct damage values when powered on."


### PR DESCRIPTION
* Diona structures can now be attacked by regular weapons to damage and destroy them.
* Alien vines have been renamed to biomass vines, and can now be attacked and welded to destroy them.
* Diona walls now spawn vines when ripped apart, instead of nymphs. It should help with lag when many are erected.
* Chainsaws now have the correct damage values when powered on.
* Biomass floors can now be sprayed with plant-b-gone to remove them.