### PR TITLE
Fixes burglars spawning with raider items

### DIFF
--- a/code/datums/outfits/outfit_antag.dm
+++ b/code/datums/outfits/outfit_antag.dm
@@ -359,8 +359,9 @@
 	if(W)
 		W.handle_item_insertion(passport)
 
-/datum/outfit/admin/syndicate/raider/burglar
+/datum/outfit/admin/syndicate/burglar
 	name = "Burglar"
+	allow_backbag_choice = FALSE
 
 	uniform = list(
 		/obj/item/clothing/under/suit_jacket/really_black,
@@ -369,6 +370,7 @@
 		/obj/item/clothing/under/suit_jacket/burgundy
 		)
 
+	belt = null
 	suit = /obj/item/clothing/suit/armor/bulletproof
 
 	shoes = list(
@@ -399,7 +401,7 @@
 
 	backpack_contents = list()
 
-/datum/outfit/admin/syndicate/raider/burglar/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/admin/syndicate/burglar/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(visualsOnly)
 		return
@@ -448,6 +450,12 @@
 			uniform.attackby(holster, H)
 		else
 			H.put_in_any_hand_if_possible(holster)
+
+	var/obj/item/storage/wallet/W = H.wear_id
+	var/obj/item/card/id/syndicate/raider/passport = new(H.loc)
+	passport.name = "[H.real_name]'s Passport"
+	if(W)
+		W.handle_item_insertion(passport)
 
 // Non-syndicate antag outfits
 

--- a/code/game/antagonist/outsider/burglar.dm
+++ b/code/game/antagonist/outsider/burglar.dm
@@ -46,8 +46,8 @@ var/datum/antagonist/burglar/burglars
 		if(I.loc != player)
 			qdel(I)
 
-	player.preEquipOutfit(/datum/outfit/admin/syndicate/raider/burglar, FALSE)
-	player.equipOutfit(/datum/outfit/admin/syndicate/raider/burglar, FALSE)
+	player.preEquipOutfit(/datum/outfit/admin/syndicate/burglar, FALSE)
+	player.equipOutfit(/datum/outfit/admin/syndicate/burglar, FALSE)
 	player.force_update_limbs()
 	player.update_eyes()
 	player.regenerate_icons()

--- a/html/changelogs/Ferner-200914-bugfix_burglaroutfit.yml
+++ b/html/changelogs/Ferner-200914-bugfix_burglaroutfit.yml
@@ -1,0 +1,4 @@
+ author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Fixed burglars spawning with raider stuff."

--- a/html/changelogs/Ferner-200914-bugfix_burglaroutfit.yml
+++ b/html/changelogs/Ferner-200914-bugfix_burglaroutfit.yml
@@ -1,4 +1,4 @@
- author: Ferner
+author: Ferner
 delete-after: True
 changes: 
   - bugfix: "Fixed burglars spawning with raider stuff."


### PR DESCRIPTION
The burglar outfit was a child of the raider one, this fixes that as it lead to burglars getting stuff they're not supposed to at roundstart.