### PR TITLE
Ablative energy armor value increase

### DIFF
--- a/code/modules/clothing/gloves/arm_guard.dm
+++ b/code/modules/clothing/gloves/arm_guard.dm
@@ -23,7 +23,7 @@
 	desc = "These arm guards will protect your hands and arms from energy weapons."
 	icon_state = "arm_guards_laser"
 	siemens_coefficient = 0
-	armor = list(melee = 25, bullet = 25, laser = 80, energy = 10, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 25, bullet = 25, laser = 80, energy = 40, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/gloves/arm_guard/bulletproof
 	name = "ballistic arm guards"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -81,7 +81,7 @@
 	name = "ablative helmet"
 	desc = "A helmet made from advanced materials which protects against concentrated energy weapons."
 	icon_state = "helmet_reflect"
-	armor = list(melee = 25, bullet = 25, laser = 80, energy = 10, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 25, bullet = 25, laser = 80, energy = 40, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0
 
 /obj/item/clothing/head/helmet/ballistic

--- a/code/modules/clothing/shoes/leg_guard.dm
+++ b/code/modules/clothing/shoes/leg_guard.dm
@@ -24,7 +24,7 @@
 	desc = "These will protect your legs and feet from energy weapons."
 	icon_state = "leg_guards_laser"
 	siemens_coefficient = 0
-	armor = list(melee = 25, bullet = 25, laser = 80, energy = 10, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 25, bullet = 25, laser = 80, energy = 40, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/shoes/leg_guard/bulletproof
 	name = "ballistic leg guards"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -142,7 +142,7 @@
 	icon_state = "armor_reflec"
 	item_state = "armor_reflec"
 	blood_overlay_type = "armor"
-	armor = list(melee = 25, bullet = 25, laser = 80, energy = 10, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 25, bullet = 25, laser = 80, energy = 40, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0
 	pocket_slots = 4
 

--- a/html/changelogs/Aboshehab - AblativeEnergyIncease.yml
+++ b/html/changelogs/Aboshehab - AblativeEnergyIncease.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Aboshehab
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Ablative armor Energy protection raised from 10 to 40."


### PR DESCRIPTION
With added weaponry that utilize energy type of projectiles, some of the older armor were left untouched when they would reasonable provide decent protection to them. This is the ablative vest description as well.

"A vest that excels in protecting the wearer against energy projectiles."


So they do decent protection to it now by raising the energy armor values from 10 to 40. I reasoned that for every 10 laser protection the armor could do, it should at least do 5 energy, so the value is deliberate as opposed to random.

