### PR TITLE
Crossbow Stuff

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -81,14 +81,14 @@
 				M.turf_collision(T, speed)
 
 //decided whether a movable atom being thrown can pass through the turf it is in.
-/atom/movable/proc/hit_check(var/speed)
+/atom/movable/proc/hit_check(var/speed, var/target)
 	if(throwing)
 		for(var/atom/A in get_turf(src))
 			if(A == src)
 				continue
 			if(isliving(A))
 				var/mob/living/M = A
-				if(M.lying)
+				if(M.lying && M != target)
 					continue
 				throw_impact(A, speed)
 			if(isobj(A))
@@ -158,7 +158,7 @@
 		if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
 			break
 		src.Move(step)
-		hit_check(speed)
+		hit_check(speed, target)
 		dist_travelled++
 		dist_since_sleep++
 		if(dist_since_sleep >= speed)

--- a/code/game/objects/items/weapons/RFD.dm
+++ b/code/game/objects/items/weapons/RFD.dm
@@ -54,7 +54,7 @@
 /obj/item/rfd/examine(var/mob/user)
 	..()
 	if(loc == user)
-		to_chat(usr, "It currently holds [stored_matter]/30 matter-units.")
+		to_chat(user, "It currently holds [stored_matter]/30 matter-units.")
 
 /obj/item/rfd/attack_self(mob/user)
 	//Change the mode

--- a/code/game/objects/items/weapons/RFD.dm
+++ b/code/game/objects/items/weapons/RFD.dm
@@ -66,7 +66,6 @@
 		spark(get_turf(loc), 3, alldirs)
 
 /obj/item/rfd/attackby(obj/item/W, mob/user)
-
 	if(istype(W, /obj/item/rfd_ammo))
 		if((stored_matter + 10) > 30)
 			to_chat(user, SPAN_NOTICE("The RFD can't hold any more matter-units."))
@@ -88,19 +87,30 @@
 		src.add_fingerprint(user)
 		return
 
-	if((crafting) && (istype(W,/obj/item/crossbowframe)))
-		var/obj/item/crossbowframe/F = W
-		if(F.buildstate == 5)
-			if(!user.unEquip(src))
+	if(crafting)
+		var/obj/item/crossbow // the thing we're gonna add, check what it is below
+		if(istype(W, /obj/item/crossbowframe))
+			var/obj/item/crossbowframe/F = W
+			if(F.buildstate != 5)
+				to_chat(user, SPAN_WARNING("You need to fully assemble the crossbow frame first!"))
 				return
-			qdel(F)
+			crossbow = F
+		else if(istype(W, /obj/item/gun/launcher/crossbow) && !istype(W, /obj/item/gun/launcher/crossbow/RFD))
+			var/obj/item/gun/launcher/crossbow/C = W
+			if(C.bolt)
+				to_chat(user, SPAN_WARNING("You need to remove \the [C.bolt] from \the [C] before you can attach it to \the [src]."))
+				return
+			if(C.cell)
+				to_chat(user, SPAN_WARNING("You need to remove \the [C.cell] from \the [C] before you can attach it to \the [src]."))
+				return
+			crossbow = C
+
+		if(crossbow)
+			qdel(crossbow)
 			var/obj/item/gun/launcher/crossbow/RFD/CB = new(get_turf(user)) // can be found in crossbow.dm
 			forceMove(CB)
 			CB.stored_matter = src.stored_matter
 			add_fingerprint(user)
-			return
-		else
-			to_chat(user, SPAN_NOTICE("You need to fully assemble the crossbow frame first!"))
 			return
 	..()
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -256,7 +256,8 @@
 						M.stop_pulling()
 
 		if(mob.pinned.len)
-			to_chat(src, "<span class='notice'>You're pinned to a wall by [mob.pinned[1]]!</span>")
+			to_chat(src, "<span class='warning'>You're pinned to a wall by [mob.pinned[1]]!</span>")
+			move_delay = world.time + 1 SECOND // prevent spam
 			return 0
 
 		move_delay = world.time - leftover//set move delay

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -54,17 +54,17 @@
 				var/mob/living/carbon/C = usr
 				C.toggle_throw_mode()
 			else
-				to_chat(usr, "<span class='warning'>This mob type cannot throw items.</span>")
+				to_chat(usr, SPAN_WARNING("This mob type cannot throw items."))
 			return
 		if(NORTHWEST)
 			if(iscarbon(usr))
 				var/mob/living/carbon/C = usr
 				if(!C.get_active_hand())
-					to_chat(usr, "<span class='warning'>You have nothing to drop in your hand.</span>")
+					to_chat(usr, SPAN_WARNING("You have nothing to drop in your hand."))
 					return
 				drop_item()
 			else
-				to_chat(usr, "<span class='warning'>This mob type cannot drop items.</span>")
+				to_chat(usr, SPAN_WARNING("This mob type cannot drop items."))
 			return
 
 //This gets called when you press the delete button.
@@ -72,7 +72,7 @@
 	set hidden = 1
 
 	if(!usr.pulling)
-		to_chat(usr, "<span class='notice'>You are not pulling anything.</span>")
+		to_chat(usr, SPAN_NOTICE("You are not pulling anything."))
 		return
 	usr.stop_pulling()
 
@@ -250,13 +250,13 @@
 			for(var/mob/M in range(mob, 1))
 				if(M.pulling == mob)
 					if(!M.restrained() && M.stat == 0 && M.canmove && mob.Adjacent(M))
-						to_chat(src, "<span class='notice'>You're restrained! You can't move!</span>")
+						to_chat(src, SPAN_NOTICE("You're restrained! You can't move!"))
 						return 0
 					else
 						M.stop_pulling()
 
 		if(mob.pinned.len)
-			to_chat(src, "<span class='warning'>You're pinned to a wall by [mob.pinned[1]]!</span>")
+			to_chat(src, SPAN_WARNING("You're pinned to a wall by [mob.pinned[1]]!"))
 			move_delay = world.time + 1 SECOND // prevent spam
 			return 0
 
@@ -387,7 +387,7 @@
 		if(1)
 			var/turf/T = get_step(mob, direct)
 			if(mob.check_holy(T))
-				to_chat(mob, "<span class='warning'>You cannot get past holy grounds while you are in this plane of existence!</span>")
+				to_chat(mob, SPAN_WARNING("You cannot get past holy grounds while you are in this plane of existence!"))
 				return
 			else
 				mob.forceMove(get_step(mob, direct))
@@ -405,19 +405,19 @@
 			for(var/obj/structure/window/W in T)
 				if(istype(W, /obj/structure/window/phoronbasic) || istype(W, /obj/structure/window/phoronreinforced))
 					if(W.is_full_window())
-						to_chat(mob, "<span class='warning'>\The [W] obstructs your movement!</span>")
+						to_chat(mob, SPAN_WARNING("\The [W] obstructs your movement!"))
 						return
 
 					if((direct & W.dir) && W.density)
-						to_chat(mob, "<span class='warning'>\The [W] obstructs your movement!</span>")
+						to_chat(mob, SPAN_WARNING("\The [W] obstructs your movement!"))
 						return
 			if(istype(T, /turf/simulated/wall/phoron) || istype(T, /turf/simulated/wall/ironphoron))
-				to_chat(mob, "<span class='warning'>\The [T] obstructs your movement!</span>")
+				to_chat(mob, SPAN_WARNING("\The [T] obstructs your movement!"))
 				return
 
 			for(var/mob/living/L in T)
 				if(L.is_diona() == DIONA_WORKER)
-					to_chat(mob, "<span class='danger'>You struggle briefly as you are photovored into \the [L], trapped within a nymphomatic husk!</span>")
+					to_chat(mob, SPAN_DANGER("You struggle briefly as you are photovored into \the [L], trapped within a nymphomatic husk!"))
 					var/mob/living/carbon/alien/diona/D = new /mob/living/carbon/alien/diona(L)
 					var/mob/living/simple_animal/shade/bluespace/BS = mob
 					if (!(/mob/living/carbon/proc/echo_eject in L.verbs))
@@ -517,7 +517,7 @@
 //return 1 if slipped, 0 otherwise
 /mob/proc/handle_spaceslipping()
 	if(prob(slip_chance(5)) && !buckled)
-		to_chat(src, "<span class='warning'>You slipped!</span>")
+		to_chat(src, SPAN_WARNING("You slipped!"))
 		src.inertia_dir = src.last_move
 		step(src, src.inertia_dir)
 		return 1

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -619,6 +619,7 @@
 		to_chat(user, "The fire selector is set to [current_mode.name].")
 	if(has_safety)
 		to_chat(user, "The safety is [safety() ? "on" : "off"].")
+	return TRUE
 
 /obj/item/gun/proc/switch_firemodes()
 	if(!firemodes.len)

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -8,8 +8,8 @@
 	item_state = "bolt"
 	throwforce = 8
 	w_class = ITEMSIZE_NORMAL
-	sharp = 1
-	edge = 0
+	sharp = TRUE
+	edge = FALSE
 	drop_sound = 'sound/items/drop/sword.ogg'
 	pickup_sound = /decl/sound_category/sword_pickup_sound
 
@@ -19,8 +19,8 @@
 /obj/item/spike
 	name = "alloy spike"
 	desc = "It's about a foot of weird silver metal with a wicked point."
-	sharp = 1
-	edge = 0
+	sharp = TRUE
+	edge = FALSE
 	throwforce = 5
 	w_class = ITEMSIZE_SMALL
 	icon = 'icons/obj/weapons.dmi'
@@ -75,7 +75,7 @@
 
 /obj/item/gun/launcher/crossbow/consume_next_projectile(mob/user)
 	if(tension <= 0)
-		to_chat(user, "<span class='warning'>\The [src] is not drawn back!</span>")
+		to_chat(user, SPAN_WARNING("\The [src] is not drawn back!"))
 		return null
 	return bolt
 
@@ -111,12 +111,12 @@
 		return
 
 	current_user = user
-	user.visible_message("<b>[user]</b> begins to draw back the string of \the [src].", "<span class='notice'>You begin to draw back the string of \the [src].</span>")
+	user.visible_message("<b>[user]</b> begins to draw back the string of \the [src].", SPAN_NOTICE("You begin to draw back the string of \the [src]."))
 	tension = 1
 
 	while(bolt && tension && loc == current_user)
 		if(!do_after(user, draw_time)) //crossbow strings don't just magically pull back on their own.
-			user.visible_message("<b>[user]</b> stops drawing and relaxes the string of \the [src].", "<span class='warning'>You stop drawing back and relax the string of \the [src].</span>")
+			user.visible_message("<b>[user]</b> stops drawing and relaxes the string of \the [src].", SPAN_WARNING("You stop drawing back and relax the string of \the [src]."))
 			playsound(loc, 'sound/weapons/holster/tactiholsterout.ogg', 50, FALSE)
 			tension = 0
 			update_icon()
@@ -135,7 +135,7 @@
 			to_chat(usr, SPAN_NOTICE("\The [src] clunks as you draw the string to its maximum tension!"))
 			return
 
-		user.visible_message("<b>[user]</b> draws back the string of \the [src]!", "<span class='notice'>You continue drawing back the string of \the [src]!</span>")
+		user.visible_message("<b>[user]</b> draws back the string of \the [src]!", SPAN_NOTICE("You continue drawing back the string of \the [src]!"))
 		playsound(loc, 'sound/weapons/reload_clip.ogg', 50, FALSE)
 
 /obj/item/gun/launcher/crossbow/attackby(obj/item/W as obj, mob/user as mob)
@@ -161,19 +161,19 @@
 		if(!cell)
 			user.drop_from_inventory(W, src)
 			cell = W
-			to_chat(user, "<span class='notice'>You jam \the [cell] into \the [src] and wire it to the firing coil.</span>")
+			to_chat(user, SPAN_NOTICE("You jam \the [cell] into \the [src] and wire it to the firing coil."))
 			superheat_rod(user)
 		else
-			to_chat(user, "<span class='notice'>\The [src] already has a cell installed.</span>")
+			to_chat(user, SPAN_NOTICE("\The [src] already has a cell installed."))
 
 	else if(W.isscrewdriver())
 		if(cell)
 			var/obj/item/C = cell
 			C.forceMove(get_turf(user))
-			to_chat(user, "<span class='notice'>You jimmy \the [cell] out of \the [src] with \the [W].</span>")
+			to_chat(user, SPAN_NOTICE("You jimmy \the [cell] out of \the [src] with \the [W]."))
 			cell = null
 		else
-			to_chat(user, "<span class='notice'>\The [src] doesn't have a cell installed.</span>")
+			to_chat(user, SPAN_NOTICE("\The [src] doesn't have a cell installed."))
 
 	else if(istype(W, /obj/item/rfd))
 		W.attackby(src, user)
@@ -191,7 +191,7 @@
 	if(!istype(bolt,/obj/item/arrow/rod))
 		return
 
-	to_chat(user, "<span class='warning'>\The [bolt] plinks and crackles as it begins to glow red-hot.</span>")
+	to_chat(user, SPAN_WARNING("\The [bolt] plinks and crackles as it begins to glow red-hot."))
 	bolt.throwforce = 15
 	bolt.icon_state = "metal-rod-superheated"
 	cell.use(500)
@@ -230,11 +230,11 @@
 		if(buildstate == 0)
 			var/obj/item/stack/rods/R = W
 			if(R.use(3))
-				to_chat(user, "<span class='notice'>You assemble a backbone of rods around the wooden stock.</span>")
+				to_chat(user, SPAN_NOTICE("You assemble a backbone of rods around the wooden stock."))
 				buildstate++
 				update_icon()
 			else
-				to_chat(user, "<span class='notice'>You need at least three rods to complete this task.</span>")
+				to_chat(user, SPAN_NOTICE("You need at least three rods to complete this task."))
 			return
 	else if(W.iswelder())
 		if(buildstate == 1)
@@ -242,7 +242,7 @@
 			if(T.remove_fuel(0,user))
 				if(!src || !T.isOn()) return
 				playsound(src.loc, 'sound/items/welder_pry.ogg', 100, 1)
-				to_chat(user, "<span class='notice'>You weld the rods into place.</span>")
+				to_chat(user, SPAN_NOTICE("You weld the rods into place."))
 			buildstate++
 			update_icon()
 		return
@@ -250,33 +250,33 @@
 		var/obj/item/stack/cable_coil/C = W
 		if(buildstate == 2)
 			if(C.use(5))
-				to_chat(user, "<span class='notice'>You wire a crude cell mount into the top of the crossbow.</span>")
+				to_chat(user, SPAN_NOTICE("You wire a crude cell mount into the top of the crossbow."))
 				buildstate++
 				update_icon()
 			else
-				to_chat(user, "<span class='notice'>You need at least five segments of cable coil to complete this task.</span>")
+				to_chat(user, SPAN_NOTICE("You need at least five segments of cable coil to complete this task."))
 			return
 		else if(buildstate == 4)
 			if(C.use(5))
-				to_chat(user, "<span class='notice'>You string a steel cable across the crossbow's limbs.</span>")
+				to_chat(user, SPAN_NOTICE("You string a steel cable across the crossbow's limbs."))
 				buildstate++
 				update_icon()
 			else
-				to_chat(user, "<span class='notice'>You need at least five segments of cable coil to complete this task.</span>")
+				to_chat(user, SPAN_NOTICE("You need at least five segments of cable coil to complete this task."))
 			return
 	else if(istype(W,/obj/item/stack/material) && W.get_material_name() == MATERIAL_PLASTIC)
 		if(buildstate == 3)
 			var/obj/item/stack/material/P = W
 			if(P.use(3))
-				to_chat(user, "<span class='notice'>You assemble and install heavy plastic limbs onto the crossbow.</span>")
+				to_chat(user, SPAN_NOTICE("You assemble and install heavy plastic limbs onto the crossbow."))
 				buildstate++
 				update_icon()
 			else
-				to_chat(user, "<span class='notice'>You need at least three plastic sheets to complete this task.</span>")
+				to_chat(user, SPAN_NOTICE("You need at least three plastic sheets to complete this task."))
 			return
 	else if(W.isscrewdriver())
 		if(buildstate == 5)
-			to_chat(user, "<span class='notice'>You secure the crossbow's various parts.</span>")
+			to_chat(user, SPAN_NOTICE("You secure the crossbow's various parts."))
 			new /obj/item/gun/launcher/crossbow(get_turf(src))
 			qdel(src)
 		return
@@ -308,11 +308,11 @@
 	if(stored_matter >= boltcost && !bolt)
 		bolt = new/obj/item/arrow/RFD(src)
 		stored_matter -= boltcost
-		to_chat(user, "<span class='notice'>The RFD flashforges a new bolt!</span>")
+		to_chat(user, SPAN_NOTICE("The RFD flashforges a new bolt!"))
 		playsound(loc, 'sound/weapons/kinetic_reload.ogg', 50, FALSE)
 		update_icon()
 	else
-		to_chat(user, "<span class='warning'>The \'Low Ammo\' light on the device blinks yellow.</span>")
+		to_chat(user, SPAN_WARNING("The \'Low Ammo\' light on the device blinks yellow."))
 		playsound(loc, 'sound/items/rfd_empty.ogg', 50, FALSE)
 		flick("[icon_state]-empty", src)
 
@@ -329,23 +329,23 @@
 /obj/item/gun/launcher/crossbow/RFD/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/rfd_ammo))
 		if((stored_matter + 10) > max_stored_matter)
-			to_chat(user, "<span class='notice'>The RFD can't hold that many additional matter-units.</span>")
+			to_chat(user, SPAN_NOTICE("The RFD can't hold that many additional matter-units."))
 			return
 		stored_matter += 10
 		qdel(W)
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-		to_chat(user, "<span class='notice'>The RFD now holds <b>[stored_matter]/[max_stored_matter]</b> matter-units.</span>")
+		to_chat(user, SPAN_NOTICE("The RFD now holds <b>[stored_matter]/[max_stored_matter]</b> matter-units."))
 		update_icon()
 		return
 	if(istype(W, /obj/item/arrow/RFD))
 		var/obj/item/arrow/RFD/A = W
 		if((stored_matter + 5) > max_stored_matter)
-			to_chat(user, "<span class='notice'>Unable to reclaim flashforged bolt. The RFD can't hold that many additional matter-units.</span>")
+			to_chat(user, SPAN_NOTICE("Unable to reclaim flashforged bolt. The RFD can't hold that many additional matter-units."))
 			return
 		stored_matter += 5
 		qdel(A)
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-		to_chat(user, "<span class='notice'>Flashforged bolt reclaimed. The RXD now holds <b>[stored_matter]/[max_stored_matter]</b> matter-units.</span>")
+		to_chat(user, SPAN_NOTICE("Flashforged bolt reclaimed. The RXD now holds <b>[stored_matter]/[max_stored_matter]</b> matter-units."))
 		update_icon()
 		return
 

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -38,9 +38,9 @@
 	if(next)
 		grenades -= next //Remove grenade from loaded list.
 		chambered = next
-		to_chat(M, "<span class='warning'>You pump [src], loading \a [next] into the chamber.</span>")
+		to_chat(M, SPAN_WARNING("You pump [src], loading \a [next] into the chamber."))
 	else
-		to_chat(M, "<span class='warning'>You pump [src], but the magazine is empty.</span>")
+		to_chat(M, SPAN_WARNING("You pump [src], but the magazine is empty."))
 	update_icon()
 
 /obj/item/gun/launcher/grenade/examine(mob/user)
@@ -54,12 +54,12 @@
 	if(!can_load_grenade_type(G, user))
 		return
 	if(grenades.len >= max_grenades)
-		to_chat(user, "<span class='warning'>[src] is full.</span>")
+		to_chat(user, SPAN_WARNING("[src] is full."))
 		return
 	user.remove_from_mob(G)
 	G.forceMove(src)
 	grenades.Insert(1, G) //add to the head of the list, so that it is loaded on the next pump
-	user.visible_message("[user] inserts \a [G] into [src].", "<span class='notice'>You insert \a [G] into [src].</span>")
+	user.visible_message("[user] inserts \a [G] into [src].", SPAN_NOTICE("You insert \a [G] into [src]."))
 	update_maptext()
 
 /obj/item/gun/launcher/grenade/proc/unload(mob/user)
@@ -67,14 +67,14 @@
 		var/obj/item/grenade/G = grenades[grenades.len]
 		grenades.len--
 		user.put_in_hands(G)
-		user.visible_message("[user] removes \a [G] from [src].", "<span class='notice'>You remove \a [G] from [src].</span>")
+		user.visible_message("[user] removes \a [G] from [src].", SPAN_NOTICE("You remove \a [G] from [src]."))
 	else
-		to_chat(user, "<span class='warning'>[src] is empty.</span>")
+		to_chat(user, SPAN_WARNING("[src] is empty."))
 	update_maptext()
 
 /obj/item/gun/launcher/grenade/proc/can_load_grenade_type(obj/item/grenade/G, mob/user)
 	if(is_type_in_list(G, blacklisted_grenades))
-		to_chat(user, "<span class='warning'>\The [G] doesn't seem to fit in \the [src]!</span>")
+		to_chat(user, SPAN_WARNING("\The [G] doesn't seem to fit in \the [src]!"))
 		return FALSE
 	return TRUE
 
@@ -122,17 +122,17 @@
 //load and unload directly into chambered
 /obj/item/gun/launcher/grenade/underslung/load(obj/item/grenade/G, mob/user)
 	if(chambered)
-		to_chat(user, "<span class='warning'>[src] is already loaded.</span>")
+		to_chat(user, SPAN_WARNING("[src] is already loaded."))
 		return
 	user.remove_from_mob(G)
 	G.forceMove(src)
 	chambered = G
-	user.visible_message("[user] load \a [G] into [src].", "<span class='notice'>You load \a [G] into [src].</span>")
+	user.visible_message("[user] load \a [G] into [src].", SPAN_NOTICE("You load \a [G] into [src]."))
 
 /obj/item/gun/launcher/grenade/underslung/unload(mob/user)
 	if(chambered)
 		user.put_in_hands(chambered)
-		user.visible_message("[user] removes \a [chambered] from [src].", "<span class='notice'>You remove \a [chambered] from [src].</span>")
+		user.visible_message("[user] removes \a [chambered] from [src].", SPAN_NOTICE("You remove \a [chambered] from [src]."))
 		chambered = null
 	else
-		to_chat(user, "<span class='warning'>[src] is empty.</span>")
+		to_chat(user, SPAN_WARNING("[src] is empty."))

--- a/html/changelogs/geeves-crossbow_stuff.yml
+++ b/html/changelogs/geeves-crossbow_stuff.yml
@@ -1,0 +1,10 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Improved the code for making the RFD-Crossbow. You no longer have to keep the RFD-C in your hand, and it can be done with a finished crossbow, as long as it's unloaded."
+  - tweak: "Being pinned to a wall no longer spams your chat when you try to move."
+  - bugfix: "Crafted crossbows no longer have a safety, and the RFD-Crossbow now properly shows its ammo when examined."
+  - rscadd: "Added sounds to a lot of crossbow actions."
+  - rscadd: "Thrown and launched objects can now hit mobs that are lying down, if you clicked on them directly."


### PR DESCRIPTION
* Improved the code for making the RFD-Crossbow. You no longer have to keep the RFD-C in your hand, and it can be done with a finished crossbow, as long as it's unloaded.
* Being pinned to a wall no longer spams your chat when you try to move.
* Crafted crossbows no longer have a safety, and the RFD-Crossbow now properly shows its ammo when examined.
* Added sounds to a lot of crossbow actions.
* Thrown and launched objects can now hit mobs that are lying down, if you clicked on them directly.