### PR TITLE
Fixes mechs constructed from the ground up using the incorrect layers

### DIFF
--- a/code/modules/heavy_vehicle/components/frame.dm
+++ b/code/modules/heavy_vehicle/components/frame.dm
@@ -62,14 +62,16 @@
 
 
 /obj/structure/heavy_vehicle_frame/update_icon()
-	var/list/new_overlays = get_mech_icon(list(body, head), MECH_BASE_LAYER)
+	//As mech icons uses a caching system, any changes here, particularly to layers, must be reflected in /mob/living/heavy_vehicle/update_icon().
+	var/list/new_overlays = get_mech_icon(list(body), MECH_BASE_LAYER)
 	if(body)
 		density = TRUE
-		overlays += get_mech_image("[body.icon_state]_cockpit", body.icon, body.color)
-		if(body.pilot_coverage < 100 || body.transparent_cabin)
-			new_overlays += get_mech_image("[body.icon_state]_open_overlay", body.icon, body.color)
+		new_overlays += get_mech_image("[body.icon_state]_cockpit", body.on_mech_icon, MECH_BASE_LAYER)
 	else
 		density = FALSE
+	if(head)
+		new_overlays += get_mech_image("[head.icon_state]", head.on_mech_icon, head.color, MECH_HEAD_LAYER)
+		new_overlays += get_mech_image("[head.icon_state]_eyes", head.on_mech_icon, null, MECH_EYES_LAYER)
 	if(arms)
 		new_overlays += get_mech_image(arms.icon_state, arms.on_mech_icon, arms.color, MECH_ARM_LAYER)
 	if(legs)

--- a/code/modules/heavy_vehicle/mech_icon.dm
+++ b/code/modules/heavy_vehicle/mech_icon.dm
@@ -20,6 +20,7 @@ proc/get_mech_icon(var/list/components = list(), var/overlay_layer = FLOAT_LAYER
 	return all_images
 
 /mob/living/heavy_vehicle/update_icon()
+	//As mech icons uses a caching system, any changes here, particularly to layers, must be reflected in /obj/structure/heavy_vehicle_frame/update_icon().
 	var/list/new_overlays = get_mech_icon(list(body), MECH_BASE_LAYER)
 	if(body && !hatch_closed)
 		new_overlays += get_mech_image("[body.icon_state]_cockpit", body.on_mech_icon, MECH_BASE_LAYER)

--- a/html/changelogs/Ferner-200915-bugfix_mechconstructionicons.yml
+++ b/html/changelogs/Ferner-200915-bugfix_mechconstructionicons.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Mechs constructed from the ground up now layer its parts correctly."


### PR DESCRIPTION
An oversight when I tweaked the layers, as mechs use a cache system for its icons, icons generated during manual construction will still be used even after the mech is finished, leading to incorrect layering in some instances.