### PR TITLE
Fixes Idris armband in loadout.

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_factions.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_factions.dm
@@ -20,7 +20,7 @@
 
 /datum/gear/faction/idris_armband
 	display_name = "idris armband"
-	path = /obj/item/clothing/head/beret/sec/idris
+	path = /obj/item/clothing/accessory/armband/idris
 	faction = "Idris Incorporated"
 
 /datum/gear/faction/zavodskoi_beret

--- a/html/changelogs/stryker-moreclothesbugfix.yml
+++ b/html/changelogs/stryker-moreclothesbugfix.yml
@@ -1,4 +1,4 @@
- author: The Stryker
+author: The Stryker
 delete-after: True
 changes: 
   - bugfix: "The Idris armband in the loadout actually spawns now."

--- a/html/changelogs/stryker-moreclothesbugfix.yml
+++ b/html/changelogs/stryker-moreclothesbugfix.yml
@@ -1,0 +1,4 @@
+ author: The Stryker
+delete-after: True
+changes: 
+  - bugfix: "The Idris armband in the loadout actually spawns now."


### PR DESCRIPTION
Due to a mistake, the Idris armband in loadout was spawning the Idris beret instead. Makes the Idris armband actually spawn.