### PR TITLE
Pulsing/mending the Particle Accelerator activation wire now shows currect user information.

### DIFF
--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -19,7 +19,7 @@ var/const/PARTICLE_LIMIT_POWER_WIRE = 8 // Determines how strong the PA can be.
 	switch(index)
 
 		if(PARTICLE_TOGGLE_WIRE)
-			C.toggle_power()
+			C.toggle_power(usr)
 
 		if(PARTICLE_STRENGTH_WIRE)
 			C.add_strength()
@@ -36,7 +36,7 @@ var/const/PARTICLE_LIMIT_POWER_WIRE = 8 // Determines how strong the PA can be.
 
 		if(PARTICLE_TOGGLE_WIRE)
 			if(C.active == !mended)
-				C.toggle_power()
+				C.toggle_power(usr)
 
 		if(PARTICLE_STRENGTH_WIRE)
 

--- a/html/changelogs/hockaa-PAfix.yml
+++ b/html/changelogs/hockaa-PAfix.yml
@@ -1,0 +1,6 @@
+author: ChangeMe
+
+delete-after: True
+
+changes: 
+  - bugfix: "Admin logs now state accurate user information when Particle Accelerators are activated via wire pulsing/mending."

--- a/html/changelogs/hockaa-PAfix.yml
+++ b/html/changelogs/hockaa-PAfix.yml
@@ -1,4 +1,4 @@
-author: ChangeMe
+author: Hocka
 
 delete-after: True
 


### PR DESCRIPTION
Changers the toggle_power() proc calls during wire tampering code blocks to also send user information, otherwise the logs would show up with "PA activated by *null*" when activated in such a way.