### PR TITLE
Closets and chairs will not produce a slowdown when they do not have a mob

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -213,7 +213,8 @@
 	. = 0
 	if(istype(pulling, /obj/structure))
 		var/obj/structure/P = pulling
-		. += P.slowdown
+		if(P.buckled_mob || locate(/mob) in P.contents)
+			. += P.slowdown
 
 /mob/proc/Life()
 	return

--- a/html/changelogs/buckled_mob_slowdown.yml
+++ b/html/changelogs/buckled_mob_slowdown.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - tweak: "Closets, chairs, etc. without a mob inside/buckled will not cause a slowdown when being dragged."


### PR DESCRIPTION
Changed my mind about this being necessary. I think "realism" can take a backseat here, also I guess most mobs are relatively heavy compared to a chair.