### PR TITLE
Tweaks carp/dweller behavior and some events

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -51,13 +51,15 @@
 	while (i <= num_groups)
 		var/group_size = rand(group_size_min, group_size_max)
 		for (var/j = 1, j <= group_size, j++)
-			if(prob(99))
+			if(prob(95))
 				var/mob/living/simple_animal/hostile/carp/carp = new(spawn_locations[i])
+				spawned_carp += WEAKREF(carp)
+			else if(prob(80))
+				var/mob/living/simple_animal/carp/baby/carp = new(spawn_locations[i])
 				spawned_carp += WEAKREF(carp)
 			else
 				var/mob/living/simple_animal/hostile/carp/shark/carp = new(spawn_locations[i])
 				spawned_carp += WEAKREF(carp)
-
 			CHECK_TICK
 		i++
 

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -171,12 +171,12 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 	severity = EVENT_LEVEL_MAJOR
 	available_events = list(
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",						/datum/event/nothing,				135),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",						/datum/event/blob, 					40,	list(ASSIGNMENT_ENGINEER = 5,ASSIGNMENT_SECURITY =  5), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",						/datum/event/blob, 					40,	list(ASSIGNMENT_ENGINEER = 5), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",				/datum/event/carp_migration,		50,	list(ASSIGNMENT_SECURITY =  10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",					/datum/event/meteor_wave,			40,	list(ASSIGNMENT_ENGINEER =  10),1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",					/datum/event/spacevine, 			75,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_GARDENER = 20), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Spider Infestation",			/datum/event/spider_infestation,	25, list(ASSIGNMENT_SECURITY = 10, ASSIGNMENT_MEDICAL = 5), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Major Vermin Infestation",	/datum/event/infestation/major, 	15,	list(ASSIGNMENT_SECURITY = 15, ASSIGNMENT_MEDICAL = 10))
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Major Vermin Infestation",	/datum/event/infestation/major, 	15,	list(ASSIGNMENT_SECURITY = 15, ASSIGNMENT_MEDICAL = 5))
 	)
 
 #undef ASSIGNMENT_ANY

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -26,11 +26,22 @@
 		INFESTATION_SPACE_BATS = 1,
 		INFESTATION_SPIDERLINGS = 1
 	)
-/datum/event/infestation/major
-	possible_mobs = list(
-		INFESTATION_HIVEBOTS = 1,
-		INFESTATION_SLIMES = 1
-	)
+
+/datum/event/infestation/major/setup()
+	var/player_count = 0
+	for(var/mob/living/carbon/human/H in living_mob_list)
+		if(H.stat == CONSCIOUS && H.client)
+			player_count++
+	if(player_count >= 15)
+		possible_mobs = list(
+			INFESTATION_HIVEBOTS = 1,
+			INFESTATION_SLIMES = 1
+		)
+	else
+		possible_mobs = list(
+			INFESTATION_SLIMES = 1
+		)
+	..()
 
 /datum/event/infestation/setup()
 	choose_area()

--- a/code/modules/mob/living/simple_animal/friendly/carp.dm
+++ b/code/modules/mob/living/simple_animal/friendly/carp.dm
@@ -21,6 +21,8 @@
 	response_disarm = "attempts to push"
 	response_harm = "injures"
 	gender = NEUTER
+	faction = "carp"
+	flying = TRUE
 
 	//Space carp aren't affected by atmos.
 	min_oxy = 0

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -74,10 +74,12 @@
 		return e
 
 /mob/living/simple_animal/hostile/carp/DestroySurroundings(var/bypass_prob = FALSE)
+	if(stance != HOSTILE_STANCE_ATTACKING)
+		return 0
 	if(prob(break_stuff_probability) || bypass_prob)
 		for(var/dir in cardinal) // North, South, East, West
 			var/obj/effect/energy_field/e = locate(/obj/effect/energy_field, get_step(src, dir))
-			if(e)
+			if(e && e.strength >= 1)
 				e.Stress(rand(1,2))
 				visible_message("<span class='danger'>\the [src] bites \the [e]!</span>")
 				src.do_attack_animation(e)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
@@ -60,6 +60,12 @@
 	tracer_type = /obj/effect/projectile/tracer/stun
 	impact_type = /obj/effect/projectile/impact/stun
 
+/mob/living/simple_animal/hostile/retaliate/cavern_dweller/DestroySurroundings(var/bypass_prob = FALSE)
+	if(stance != HOSTILE_STANCE_ATTACKING)
+		return 0
+	else
+		..()
+
 /obj/item/projectile/beam/cavern/on_hit(var/atom/target, var/blocked = 0)
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target

--- a/html/changelogs/Ferner-200918-coding_eventtweaks.yml
+++ b/html/changelogs/Ferner-200918-coding_eventtweaks.yml
@@ -1,0 +1,6 @@
+author: Ferner
+delete-after: True
+changes: 
+  - tweak: "Tweaked the behavior of carp/cavern dwellers to only destroy things like windows when they see a target."
+  - tweak: "Tweaked the chances a couple of major events."
+  - bugfix: "Carp no longer attack invisible shields that are depleted of strength."


### PR DESCRIPTION
 - Tweaked carp behavior to only destroy things like windows or shields if there's actually a target behind them. 
Carp idly destroying exterior windows lead to needless busywork, and also made sudden appearances of carp less scary, as you can surmize where they are ahead of time when those air alarms appear instead of having a swarm of them charge from the dark if you approached a window during the migration. Also made it so dwellers don't idly break windows either.
 - Made carp migrations have a chance to spawn the baby variants occasionally too.
 - Made active security members no longer increase the chance of blobs spawning the same way engineers do.
 - Made hivebots only have a chance of appearing if there's 15 or more players ingame, as they can be a bane of low-pop hours if they go unchecked.