### PR TITLE
Xenobiology tweaks

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -114,7 +114,8 @@
 	spawn_things = list(
 				"/obj/item/stack/material/gold" = 2,
 				"/obj/item/stack/material/silver" = 2,
-				"/obj/item/stack/material/uranium" = 2
+				"/obj/item/stack/material/uranium" = 2,
+				"/obj/item/stack/material/diamond" = 1
 					   )
 
 /obj/effect/portal/spawner/phoron

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -400,7 +400,6 @@
 			/datum/reagent/impedrezene,
 			/datum/reagent/mercury,
 			/datum/reagent/mindbreaker,
-			/datum/reagent/slimetoxin,
 			/datum/reagent/inaprovaline,
 			/datum/reagent/peridaxon,
 			/datum/reagent/toxin/phoron,

--- a/code/modules/item_worth/reagents.dm
+++ b/code/modules/item_worth/reagents.dm
@@ -729,9 +729,6 @@
 /datum/reagent/psilocybin
 	value = 0.7
 
-/datum/reagent/slimetoxin
-	value = 2
-
 /datum/reagent/aslimetoxin
 	value = 3
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -529,20 +529,6 @@
 
 /* Transformations */
 
-/datum/reagent/slimetoxin
-	name = "Mutation Toxin"
-	description = "A transformative toxin isolated from jelly extract from green slimes. Use of the chemical has profound effects on the body's cells, converting animal cells into unique slime cells. These slime cells begin to replace the normal cells of the body, resulting in the development of ‘slime people', though eventually these degenerate into grey slimes."
-	reagent_state = LIQUID
-	color = "#13BC5E"
-	taste_description = "sludge"
-
-/datum/reagent/slimetoxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.species.name != SPECIES_SLIMEPERSON)
-			to_chat(M, SPAN_DANGER("Your flesh rapidly mutates!"))
-			H.set_species(SPECIES_SLIMEPERSON)
-
 /datum/reagent/aslimetoxin
 	name = "Advanced Mutation Toxin"
 	description = "A transformative toxin isolated from jelly extract from black slimes. The chemical is fundamentally the same as regular Mutation Toxin, however its effect is magnitudes faster, degenerating a body into a grey slime immediately."
@@ -665,7 +651,7 @@
 
 /datum/reagent/toxin/spectrocybin/affect_blood(var/mob/living/carbon/M, var/removed)
 	..()
-	if(!(volume > 5))	
+	if(!(volume > 5))
 		M.hallucination = max(M.hallucination, 20)
 		if(prob(20))
 			M.see_invisible = SEE_INVISIBLE_CULT

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1342,7 +1342,8 @@
 		/mob/living/simple_animal/hostile/hivebotbeacon/toxic,
 		/mob/living/simple_animal/hostile/hivebotbeacon/incendiary,
 		/mob/living/simple_animal/hostile/republicon,
-		/mob/living/simple_animal/hostile/republicon/ranged
+		/mob/living/simple_animal/hostile/republicon/ranged,
+		/mob/living/simple_animal/hostile/spider_queen
 	)
 	//exclusion list for things you don't want the reaction to create.
 	var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1261,13 +1261,26 @@
 	..()
 
 //Green
-/datum/chemical_reaction/slime/mutate
-	name = "Mutation Toxin"
-	id = "mutationtoxin"
-	result = /datum/reagent/slimetoxin
+/datum/chemical_reaction/slime/teleportation
+	name = "Slime Teleportation"
+	id = "slimeteleportation"
 	required_reagents = list(/datum/reagent/toxin/phoron = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/teleportation/on_reaction(var/datum/reagents/holder)
+	..()
+	addtimer(CALLBACK(src, .proc/do_reaction, holder), 50)
+
+/datum/chemical_reaction/slime/teleportation/proc/do_reaction(var/datum/reagents/holder)
+	for(var/atom/movable/AM in circlerange(get_turf(holder.my_atom),20))
+		if(AM.anchored)
+			continue
+		var/area/A = random_station_area()
+		var/turf/target = A.random_space()
+		to_chat(AM, SPAN_WARNING("Bluespace energy teleports you somewhere else!"))
+		do_teleport(AM, target)
+		AM.visible_message("\The [AM] phases in!")
 
 //Metal
 /datum/chemical_reaction/slime/metal
@@ -1287,7 +1300,7 @@
 	name = "Slime Crit"
 	id = "m_tele"
 	result = null
-	required_reagents = list(/datum/reagent/water = 5)
+	required_reagents = list(/datum/reagent/toxin/phoron = 5)
 	result_amount = 1
 	required = /obj/item/slime_extract/gold
 
@@ -1346,18 +1359,6 @@
 		if(prob(50))
 			for(var/j = 1, j <= rand(1, 3), j++)
 				step(C, pick(NORTH,SOUTH,EAST,WEST))
-	..()
-
-/datum/chemical_reaction/slime/rare_metal
-	name = "Slime Rare Metal"
-	id = "rm_metal"
-	result = null
-	required_reagents = list(/datum/reagent/toxin/phoron = 1)
-	result_amount = 1
-	required = /obj/item/slime_extract/gold
-
-/datum/chemical_reaction/slime/rare_metal/on_reaction(var/datum/reagents/holder)
-	new /obj/effect/portal/spawner/rare_metal(get_turf(holder.my_atom))
 	..()
 
 //Silver
@@ -1425,7 +1426,7 @@
 	name = "Slime Frost Oil"
 	id = "m_frostoil"
 	result = /datum/reagent/frostoil
-	required_reagents = list(/datum/reagent/toxin/phoron = 1)
+	required_reagents = list(/datum/reagent/water = 1)
 	result_amount = 10
 	required = /obj/item/slime_extract/blue
 
@@ -1434,7 +1435,7 @@
 	name = "Slime Freeze"
 	id = "m_freeze"
 	result = null
-	required_reagents = list(/datum/reagent/toxin/phoron = 1)
+	required_reagents = list(/datum/reagent/water = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/darkblue
 	mix_message = "The slime extract begins to vibrate violently!"
@@ -1539,17 +1540,18 @@
 	required = /obj/item/slime_extract/purple
 
 //Dark Purple
-/datum/chemical_reaction/slime/plasma
-	name = "Slime Plasma"
-	id = "m_plasma"
+
+/datum/chemical_reaction/slime/rare_metal
+	name = "Slime Rare Metal"
+	id = "rm_metal"
 	result = null
 	required_reagents = list(/datum/reagent/toxin/phoron = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/darkpurple
 
-/datum/chemical_reaction/slime/plasma/on_reaction(var/datum/reagents/holder)
+/datum/chemical_reaction/slime/rare_metal/on_reaction(var/datum/reagents/holder)
 	..()
-	new /obj/effect/portal/spawner/phoron(get_turf(holder.my_atom))
+	new /obj/effect/portal/spawner/rare_metal(get_turf(holder.my_atom))
 
 //Red
 /datum/chemical_reaction/slime/glycerol
@@ -1579,7 +1581,7 @@
 	name = "Slime Potion"
 	id = "m_potion"
 	result = null
-	required_reagents = list(/datum/reagent/toxin/phoron = 1)
+	required_reagents = list(/datum/reagent/blood = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/pink
 
@@ -1617,7 +1619,7 @@
 	result = null
 	result_amount = 1
 	required = /obj/item/slime_extract/lightpink
-	required_reagents = list(/datum/reagent/toxin/phoron = 1)
+	required_reagents = list(/datum/reagent/blood = 1)
 
 /datum/chemical_reaction/slime/potion2/on_reaction(var/datum/reagents/holder)
 	..()
@@ -1628,7 +1630,7 @@
 	name = "Slime Golem"
 	id = "m_golem"
 	result = null
-	required_reagents = list(/datum/reagent/toxin/phoron = 1)
+	required_reagents = list(/datum/reagent/blood = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/adamantine
 	mix_message = "A soft fizzle is heard within the slime extract, and mystic runes suddenly appear on the floor beneath it!"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1273,7 +1273,7 @@
 	addtimer(CALLBACK(src, .proc/do_reaction, holder), 50)
 
 /datum/chemical_reaction/slime/teleportation/proc/do_reaction(var/datum/reagents/holder)
-	for(var/atom/movable/AM in circlerange(get_turf(holder.my_atom),20))
+	for(var/atom/movable/AM in circlerange(get_turf(holder.my_atom),7))
 		if(AM.anchored)
 			continue
 		var/area/A = random_station_area()

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1630,7 +1630,7 @@
 	name = "Slime Golem"
 	id = "m_golem"
 	result = null
-	required_reagents = list(/datum/reagent/blood = 1)
+	required_reagents = list(/datum/reagent/toxin/phoron = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/adamantine
 	mix_message = "A soft fizzle is heard within the slime extract, and mystic runes suddenly appear on the floor beneath it!"

--- a/html/changelogs/alberyk-xenobiotweaks.yml
+++ b/html/changelogs/alberyk-xenobiotweaks.yml
@@ -1,0 +1,8 @@
+author: Alberyk
+
+delete-after: True
+
+changes: 
+  - tweak: "Removed the reagent that turns people into slime people from xenobiology, it was replaced by a slime reaction that teleports all non anchored objects around."
+  - tweak: "Removed the phoron spawner slime reaction, it was replaced by the one that summons rare materials."
+  - tweak: "Changed a couple of slime reactions to use water or blood instead of phoron, phoron is now only used for more powerful reactions."


### PR DESCRIPTION
-removed the reagent that turns people into slime person, it was replaced by a slime reaction that teleports all non anchored objects around.
-removed the phoron spawner slime reaction, it was replaced by the one that summons rare materials, with the addition of one diamond on the top of the uranium, gold and silver
-changed a couple of reactions to use water or blood instead of phoron, phoron is now used for more powerful stuff only, like the golden core mob summon
