### PR TITLE
Particle Accelerators are easier to hack + PA wire tidying

### DIFF
--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -5,7 +5,6 @@
 var/const/PARTICLE_TOGGLE_WIRE = 1 // Toggles whether the PA is on or not.
 var/const/PARTICLE_STRENGTH_WIRE = 2 // Determines the strength of the PA.
 var/const/PARTICLE_LIMIT_POWER_WIRE = 4 // Determines how strong the PA can be.
-//var/const/PARTICLE_NOTHING_WIRE = 8 // Blank wire
 
 /datum/wires/particle_acc/control_box/GetInteractWindow()
 	var/obj/machinery/particle_accelerator/control_box/C = holder

--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -1,12 +1,19 @@
 /datum/wires/particle_acc/control_box
-	wire_count = 5
+	wire_count = 4
 	holder_type = /obj/machinery/particle_accelerator/control_box
 
 var/const/PARTICLE_TOGGLE_WIRE = 1 // Toggles whether the PA is on or not.
 var/const/PARTICLE_STRENGTH_WIRE = 2 // Determines the strength of the PA.
-var/const/PARTICLE_INTERFACE_WIRE = 4 // Determines the interface showing up.
-var/const/PARTICLE_LIMIT_POWER_WIRE = 8 // Determines how strong the PA can be.
-//var/const/PARTICLE_NOTHING_WIRE = 16 // Blank wire
+var/const/PARTICLE_LIMIT_POWER_WIRE = 4 // Determines how strong the PA can be.
+//var/const/PARTICLE_NOTHING_WIRE = 8 // Blank wire
+
+/datum/wires/particle_acc/control_box/GetInteractWindow()
+	var/obj/machinery/particle_accelerator/control_box/C = holder
+	. += ..()
+	. += text("<br>\n[]<br>\n[]<br>\n[]",
+	((C.active && C.assembled) ? "The firing light is on." : "The firing light is off."),
+	(C.strength ? "The strength light is blinking." : "The strength light is off."),
+	(C.strength_upper_limit == 2 ? "The strength limiter light is on." : "The strength limiter light is off."))
 
 /datum/wires/particle_acc/control_box/CanUse(var/mob/living/L)
 	var/obj/machinery/particle_accelerator/control_box/C = holder
@@ -24,9 +31,6 @@ var/const/PARTICLE_LIMIT_POWER_WIRE = 8 // Determines how strong the PA can be.
 		if(PARTICLE_STRENGTH_WIRE)
 			C.add_strength()
 
-		if(PARTICLE_INTERFACE_WIRE)
-			C.interface_control = !C.interface_control
-
 		if(PARTICLE_LIMIT_POWER_WIRE)
 			C.visible_message("\icon[C]<b>[C]</b> makes a large whirring noise.")
 
@@ -37,14 +41,6 @@ var/const/PARTICLE_LIMIT_POWER_WIRE = 8 // Determines how strong the PA can be.
 		if(PARTICLE_TOGGLE_WIRE)
 			if(C.active == !mended)
 				C.toggle_power(usr)
-
-		if(PARTICLE_STRENGTH_WIRE)
-
-			for(var/i = 1; i < 3; i++)
-				C.remove_strength()
-
-		if(PARTICLE_INTERFACE_WIRE)
-			C.interface_control = mended
 
 		if(PARTICLE_LIMIT_POWER_WIRE)
 			C.strength_upper_limit = (mended ? 2 : 3)

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -15,7 +15,6 @@
 	active = FALSE
 	dir = NORTH
 	var/strength_upper_limit = 2
-	var/interface_control = TRUE
 	var/list/obj/structure/particle_accelerator/connected_parts
 	var/assembled = 0
 	var/parts

--- a/html/changelogs/hockaa-PAtweak.yml
+++ b/html/changelogs/hockaa-PAtweak.yml
@@ -1,0 +1,8 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+  - rscadd: "The Particle Accelerator's controller now has some text when viewing the wires to make tampering a bit more obvious."
+  - tweak: "Removes the interface wire from the Particle Accelerator's controller as it was functionally just a second blank wire."
+  - tweak: "Cutting and mending the Particle Accelerator controller's strength wire no longer decreases the strength and just prevents you from changing the strength of the accelerator."


### PR DESCRIPTION
Adds text to the PA controller wire window so that what the wires are doing is more obvious. Removes the interaction where both cutting AND mending the strength wire would take away 1 from the strength. Completely removes the interface wire and the interface_control var as they did absolutely nothing other than act as a second blank wire.

The PA being on or off is signified by the firing light being on or off, the strength light will blink if there is a number assigned and is off if there is no blink - and the limiter light will be on or off depending on if the PA strength is limited or not.