### PR TITLE
Armband Fix

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -89,7 +89,8 @@
 	if(flippable)
 		if(!flipped)
 			if(!overlay_state)
-				icon_state = "[icon_state]_flip"
+				icon_state = "[initial(icon_state)]_flip"
+				item_state = "[initial(item_state)]_flip"
 				flipped = 1
 			else
 				overlay_state = "[overlay_state]_flip"
@@ -97,6 +98,7 @@
 		else
 			if(!overlay_state)
 				icon_state = initial(icon_state)
+				item_state = initial(item_state)
 				flipped = 0
 			else
 				overlay_state = initial(overlay_state)

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -1947,7 +1947,6 @@ All custom items with worn sprites must follow the contained sprite system: http
 	item_state = "djikstra_robe"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	contained_sprite = TRUE
-	valid_accessory_slots = list("decor")
 
 /obj/item/clothing/accessory/fluff/djikstra_blade //Symbolic Khanjbiya - Msizi Djikstra - happyfox
 	name = "symbolic khanjbiya"

--- a/html/changelogs/geeves-armband_fixes.yml
+++ b/html/changelogs/geeves-armband_fixes.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed some armbands not flipping correctly on the mob sprite."


### PR DESCRIPTION
* Fixed some armbands not flipping correctly on the mob sprite.

This also includes a requested change to Happy Fox's custom item that allows them to add more accessories to their suit, specifically /obj/item/clothing/accessory/armband/offworlder which has `slot = "over"`.