### PR TITLE
Making Gimmicks Affordable

### DIFF
--- a/code/datums/uplink/corporate_equipment.dm
+++ b/code/datums/uplink/corporate_equipment.dm
@@ -3,24 +3,24 @@
 
 /datum/uplink_item/item/corporate_equipment/suit/zavodskoi
 	name = "Revenant Combat Suit"
-	item_cost = 14
+	item_cost = 10
 	path = /obj/structure/closet/crate/gear_loadout/zavodskoi
 	desc = "A full spaceworthy kit of a Zavodskoi Interstellar Revenant-type combat suit. Heavily resistant against fast projectiles and backpack-portable. Only wearable by Humans and Humanoid IPCs."
 
 /datum/uplink_item/item/corporate_equipment/suit/zenghu
 	name = "Dragon Biohazard Control Suit"
-	item_cost = 12
+	item_cost = 10
 	path = /obj/structure/closet/crate/gear_loadout/zenghu
 	desc = "A full spaceworthy kit of a Zeng-Hu Pharmaceuticals Dragon-type biohazard containment suit. Entirely resistant against radiation in most circumstances. Only wearable by Humans and Humanoid IPCs."
 
 /datum/uplink_item/item/corporate_equipment/suit/hephaestus
 	name = "Caiman Drop Suit"
-	item_cost = 16
+	item_cost = 10
 	path = /obj/structure/closet/crate/gear_loadout/hephaestus
 	desc = "A full spaceworthy kit of a Hephaestus Industries Caiman-type terraforming suit. Very resistant against slow-moving blunt force, but heavy. Only wearable by Humans and Humanoid IPCs."
 
 /datum/uplink_item/item/corporate_equipment/suit/einstein
 	name = "Banshee Combat Suit"
-	item_cost = 14
+	item_cost = 10
 	path = /obj/structure/closet/crate/gear_loadout/einstein
 	desc = "A full spaceworthy kit of an Einstein Engines Banshee-type infiltration suit. Resistant against lasers, but made of paper against anything else. Only wearable by Humans and Humanoid IPCs."

--- a/code/datums/uplink/gear loadout.dm
+++ b/code/datums/uplink/gear loadout.dm
@@ -1,6 +1,6 @@
 /datum/uplink_item/item/gear_loadout
 	category = /datum/uplink_category/gear_loadout
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT*4
+	item_cost = 70
 
 /datum/uplink_item/item/gear_loadout/coalition
 	name = "Coalition of Colonies Assets (Group)"
@@ -9,7 +9,7 @@
 /datum/uplink_item/item/gear_loadout/coalition_single
 	name = "Coalition of Colonies Assets (Single)"
 	path = /obj/structure/closet/crate/secure/gear_loadout/coalition_single
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	item_cost = 15
 
 /datum/uplink_item/item/gear_loadout/eridani
 	name = "Eridani Corporate Federation Assets (Group)"
@@ -18,7 +18,7 @@
 /datum/uplink_item/item/gear_loadout/eridani_single
 	name = "Eridani Corporate Federation Assets (Single)"
 	path = /obj/structure/closet/crate/secure/gear_loadout/eridani_single
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	item_cost = 15
 
 /datum/uplink_item/item/gear_loadout/elyra
 	name = "Serene Republic of Elyra Assets (Group)"
@@ -27,7 +27,7 @@
 /datum/uplink_item/item/gear_loadout/elyra_single
 	name = "Serene Republic of Elyra Assets (Single)"
 	path = /obj/structure/closet/crate/secure/gear_loadout/elyra_single
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	item_cost = 15
 
 /datum/uplink_item/item/gear_loadout/elyra
 	name = "Serene Republic of Elyra Assets (Group)"
@@ -36,7 +36,7 @@
 /datum/uplink_item/item/gear_loadout/elyra_single
 	name = "Serene Republic of Elyra Assets (Single)"
 	path = /obj/structure/closet/crate/secure/gear_loadout/elyra_single
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	item_cost = 15
 
 /datum/uplink_item/item/gear_loadout/sol
 	name = "Sol Alliance Assets (Group)"
@@ -45,7 +45,7 @@
 /datum/uplink_item/item/gear_loadout/sol_single
 	name = "Sol Alliance Assets (Single)"
 	path = /obj/structure/closet/crate/secure/gear_loadout/sol_single
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	item_cost = 15
 
 /datum/uplink_item/item/gear_loadout/dominia
 	name = "Empire of Dominia Assets (Group)"
@@ -54,14 +54,14 @@
 /datum/uplink_item/item/gear_loadout/dominia_single
 	name = "Empire of Dominia Assets (Single)"
 	path = /obj/structure/closet/crate/secure/gear_loadout/dominia/single
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	item_cost = 15
 
 /datum/uplink_item/item/gear_loadout/cowboys
 	name = "Frontier Cowboys (Group)"
 	path = /obj/structure/closet/crate/secure/gear_loadout/ram_ranch
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT*2
+	item_cost = 50
 
 /datum/uplink_item/item/gear_loadout/cowboy_single
 	name = "Frontier Cowboy (Single)"
 	path = /obj/structure/closet/crate/secure/gear_loadout/ram_ranch/single
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT/2
+	item_cost = 10

--- a/html/changelogs/GMR25-OverpricedNoMore.yml
+++ b/html/changelogs/GMR25-OverpricedNoMore.yml
@@ -1,0 +1,6 @@
+author: GMR25
+
+delete-after: True
+
+changes: 
+  - balance: "Reduced the price of gimmick crates in the uplink (Gear Loadout/Corporate Equipment)."


### PR DESCRIPTION
Changes the price of faction kits in the uplink, with the group kits remaining more expensive due to the power of the additional equipment. Feedback thread linked shortly.

Feedback: https://forums.aurorastation.org/topic/14932-make-gimmick-kits-cheaper/