### PR TITLE
Useful Fire Extinguishers

### DIFF
--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -28,6 +28,10 @@
 			if(T == get_turf(target))
 				break
 		sleep(delay)
+	if(length(reagents))
+		var/mob/M = locate() in get_turf(src)
+		if(M)
+			reagents.trans_to(M, reagents.get_reagent_amount() * 0.75)
 	sleep(lifespan)
 	qdel(src)
 

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -13,9 +13,9 @@
 	force = 8
 	matter = list(DEFAULT_WALL_MATERIAL = 90)
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
-	amount_per_transfer_from_this = 300
+	amount_per_transfer_from_this = 150
 	possible_transfer_amounts = null
-	volume = 300
+	volume = 150
 	drop_sound = 'sound/items/drop/gascan.ogg'
 	pickup_sound = 'sound/items/pickup/gascan.ogg'
 
@@ -74,10 +74,9 @@
 	desc = "A one time use extinguisher refiller that allows fire extinguishers to be refilled with an aerosol mix. This one contains monoammonium phosphate."
 
 /obj/item/reagent_containers/extinguisher_refill/filled/Initialize()
-		. =..()
-		reagents.add_reagent(/datum/reagent/toxin/fertilizer/monoammoniumphosphate, volume)
-		flags &= ~OPENCONTAINER
-		return
+	. = ..()
+	reagents.add_reagent(/datum/reagent/toxin/fertilizer/monoammoniumphosphate, volume)
+	flags &= ~OPENCONTAINER
 
 /obj/item/extinguisher
 	name = "fire extinguisher"

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -7,7 +7,7 @@
 	hitsound = 'sound/weapons/smash.ogg'
 	flags = CONDUCT | OPENCONTAINER
 	throwforce = 8
-	w_class = ITEMSIZE_LARGE // Don't want to give people free bluespace beakers.
+	w_class = ITEMSIZE_NORMAL
 	throw_speed = 2
 	throw_range = 10
 	force = 8
@@ -20,7 +20,6 @@
 	pickup_sound = 'sound/items/pickup/gascan.ogg'
 
 /obj/item/reagent_containers/extinguisher_refill/attackby(var/obj/O as obj, var/mob/user as mob)
-
 	if(istype(O,/obj/item/extinguisher))
 		var/obj/item/extinguisher/E = O
 		if(src.is_open_container())
@@ -89,7 +88,7 @@
 	hitsound = 'sound/weapons/smash.ogg'
 	flags = CONDUCT
 	throwforce = 10
-	w_class = ITEMSIZE_NORMAL
+	w_class = ITEMSIZE_HUGE
 	throw_speed = 2
 	throw_range = 10
 	force = 10.0
@@ -132,6 +131,11 @@
 		to_chat(user,"\The [src] contains [src.reagents.total_volume] units of reagents.")
 		to_chat(user,"The safety is [safety ? "on" : "off"].")
 	return
+
+/obj/item/extinguisher/attack(mob/living/M, mob/living/user, target_zone)
+	if(ismob(M) && user.a_intent != I_HURT)
+		return FALSE
+	return ..()
 
 /obj/item/extinguisher/attack_self(mob/user as mob)
 	safety = !safety
@@ -177,16 +181,15 @@
 		sleep(3)
 
 /obj/item/extinguisher/afterattack(var/atom/target, var/mob/user, var/flag)
-
-	if (!safety)
-		if (src.reagents.total_volume < 1)
-			to_chat(usr, "<span class='notice'>\The [src] is empty.</span>")
+	if(!safety)
+		if(reagents.total_volume < 1)
+			to_chat(user, SPAN_WARNING("\The [src] is empty."))
 			return
 
-		if (world.time < src.last_use + 20)
+		if(world.time < last_use + 20)
 			return
 
-		src.last_use = world.time
+		last_use = world.time
 
 		playsound(src.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
 
@@ -204,14 +207,16 @@
 
 		for(var/a = 1 to spray_particles)
 			spawn(0)
-				if(!src || !reagents.total_volume) return
+				if(!src || !reagents.total_volume)
+					return
 
-				var/obj/effect/effect/water/W = new(get_turf(src))
 				var/turf/my_target
 				if(a <= the_targets.len)
 					my_target = the_targets[a]
 				else
 					my_target = pick(the_targets)
+
+				var/obj/effect/effect/water/W = new(get_turf(src))
 				W.create_reagents(spray_amount)
 				reagents.trans_to_obj(W, spray_amount)
 				W.set_color()

--- a/html/changelogs/geeves-useful_extinguishers.yml
+++ b/html/changelogs/geeves-useful_extinguishers.yml
@@ -6,3 +6,4 @@ changes:
   - rscadd: "You can now only hit people with fire extinguishers if you are on hurt intent."
   - tweak: "Extinguisher refills now fit in your backpack, fire extinguishers now do not."
   - rscadd: "Foam from fire extinguishers now go onto mobs as well, instead of just the turfs."
+  - tweak: "Halved the amount of volume extinguisher refill canisters have."

--- a/html/changelogs/geeves-useful_extinguishers.yml
+++ b/html/changelogs/geeves-useful_extinguishers.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "You can now only hit people with fire extinguishers if you are on hurt intent."
+  - tweak: "Extinguisher refills now fit in your backpack, fire extinguishers now do not."
+  - rscadd: "Foam from fire extinguishers now go onto mobs as well, instead of just the turfs."


### PR DESCRIPTION
* You can now only hit people with fire extinguishers if you are on hurt intent.
* Extinguisher refills now fit in your backpack, fire extinguishers now do not.
* Foam from fire extinguishers now go onto mobs as well, instead of just the turfs.
* Halved the amount of volume extinguisher refill canisters have.