### PR TITLE
Species Gear Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
@@ -24,10 +24,10 @@
 	allowed_accents = list(ACCENT_SCARAB, ACCENT_CETI, ACCENT_GIBSON, ACCENT_SOL, ACCENT_MARTIAN, ACCENT_JUPITER, ACCENT_COC, ACCENT_ELYRA, ACCENT_ERIDANI, ACCENT_HIMEO, ACCENT_ERIDANIDREG, ACCENT_DOMINIA, ACCENT_DEEPFRONTIER)
 
 /datum/species/human/offworlder/equip_later_gear(var/mob/living/carbon/human/H)
-	if(istype(H.get_equipped_item(slot_back), /obj/item/storage/backpack))
-		H.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/rmt(H.back), slot_in_backpack)
-	else
-		H.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/rmt(H), slot_r_hand)
+	if(istype(H.get_equipped_item(slot_back), /obj/item/storage/backpack) && H.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/rmt(H.back), slot_in_backpack))
+		return
+	var/obj/item/storage/pill_bottle/rmt/PB = new /obj/item/storage/pill_bottle/rmt(get_turf(H))
+	H.put_in_hands(PB)
 
 /datum/species/human/offworlder/get_species_tally(var/mob/living/carbon/human/H)
 

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -145,10 +145,10 @@
 		S.autodrobe_no_remove = 1
 
 /datum/species/bug/equip_later_gear(var/mob/living/carbon/human/H)
-	if(istype(H.get_equipped_item(slot_back), /obj/item/storage/backpack))
-		H.equip_to_slot_or_del(new /obj/item/reagent_containers/inhaler/phoron_special(H.back), slot_in_backpack)
-	else
-		H.equip_to_slot_or_del(new /obj/item/reagent_containers/inhaler/phoron_special(H), slot_r_hand)
+	if(istype(H.get_equipped_item(slot_back), /obj/item/storage/backpack) && H.equip_to_slot_or_del(new /obj/item/reagent_containers/inhaler/phoron_special(H.back), slot_in_backpack))
+		return
+	var/obj/item/reagent_containers/inhaler/phoron_special/I = new /obj/item/reagent_containers/inhaler/phoron_special(get_turf(H))
+	H.put_in_hands(I)
 
 /datum/species/bug/handle_post_spawn(var/mob/living/carbon/human/H)
 	H.gender = NEUTER

--- a/html/changelogs/geeves-species_gear_fix.yml
+++ b/html/changelogs/geeves-species_gear_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Vaurca and offworlders now spawn with their inhalers and pills even if their backpacks are full of loadout gear."


### PR DESCRIPTION
* Vaurca and offworlders now spawn with their inhalers and pills even if their backpacks are full of loadout gear.