### PR TITLE
Synths can no longer be flushed down disposals

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -9,7 +9,7 @@
 /mob/living/proc/isSynthetic()
 	return 0
 
-/mob/living/isSynthetic()
+/mob/living/carbon/human/isSynthetic()
 	// If they are 100% robotic, they count as synthetic.
 	for(var/obj/item/organ/external/E in organs)
 		if(!(E.status & ORGAN_ROBOT))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -9,7 +9,7 @@
 /mob/living/proc/isSynthetic()
 	return 0
 
-/mob/living/carbon/human/isSynthetic()
+/mob/living/isSynthetic()
 	// If they are 100% robotic, they count as synthetic.
 	for(var/obj/item/organ/external/E in organs)
 		if(!(E.status & ORGAN_ROBOT))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -213,6 +213,7 @@
 // mouse drop another mob or self
 //
 /obj/machinery/disposal/MouseDrop_T(mob/target, mob/user)
+	var/mob/living/U = target
 	if(user.stat || !user.canmove || !istype(target))
 		return
 	if(target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1)
@@ -225,7 +226,7 @@
 	if(!check_mob_size(target))
 		to_chat(user, SPAN_NOTICE("The opening is too narrow for [target] to fit!"))
 		return
-	if(target.isSynthetic())
+	if(U.isSynthetic())
 		to_chat(user, SPAN_NOTICE("[target] is a bit too clunky to fit!"))
 		return
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -226,6 +226,7 @@
 		to_chat(user, SPAN_NOTICE("The opening is too narrow for [target] to fit!"))
 		return
 	if(target.isSynthetic())
+		to_chat(user, SPAN_NOTICE("[target] is a bit too clunky to fit!"))
 		return
 
 	src.add_fingerprint(user)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -222,8 +222,10 @@
 	if(isanimal(user) && target != user)
 		return
 
-	if(!check_mob_size(target))
+	if(!check_mob_size(target))f
 		to_chat(user, SPAN_NOTICE("The opening is too narrow for [target] to fit!"))
+		return
+	if(target.isSynthetic())
 		return
 
 	src.add_fingerprint(user)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -222,7 +222,7 @@
 	if(isanimal(user) && target != user)
 		return
 
-	if(!check_mob_size(target))f
+	if(!check_mob_size(target))
 		to_chat(user, SPAN_NOTICE("The opening is too narrow for [target] to fit!"))
 		return
 	if(target.isSynthetic())

--- a/html/changelogs/disposalsfix.yml
+++ b/html/changelogs/disposalsfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Lady Fowl
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rsctweak: "Makes it so synths cannot be put into disposals."


### PR DESCRIPTION
changes: 
  - rsctweak: "Makes it so synths cannot be put into disposals."

Flushing things down disposals is already cheesing it enough to where it makes combat unfair and ends it quickly, its essentialy a game over for IPC's and synths. This PR attempts to remedy this issue by removing the unrealistic nature of litterally flushing a machine down a garbage disposal