### PR TITLE
Disruptor Nerf

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -344,9 +344,7 @@
 
 	update_held_icon()
 
-	//update timing
-	var/delay = max(burst_delay+1, fire_delay)
-	user.setClickCooldown(min(delay, DEFAULT_QUICK_COOLDOWN))
+	user.setClickCooldown(fire_delay)
 	user.setMoveCooldown(move_delay)
 
 // Similar to the above proc, but does not require a user, which is ideal for things like turrets.

--- a/code/modules/projectiles/guns/energy/disrupter.dm
+++ b/code/modules/projectiles/guns/energy/disrupter.dm
@@ -17,6 +17,7 @@
 	secondary_projectile_type = /obj/item/projectile/energy/blaster
 	max_shots = 12 //12 shots stun, 8 shots lethal.
 	charge_cost = 150
+	fire_delay = 8
 	accuracy = 1
 	has_item_ratio = FALSE
 	modifystate = "disruptorpistolstun"

--- a/code/modules/projectiles/guns/energy/disrupter.dm
+++ b/code/modules/projectiles/guns/energy/disrupter.dm
@@ -17,7 +17,6 @@
 	secondary_projectile_type = /obj/item/projectile/energy/blaster
 	max_shots = 12 //12 shots stun, 8 shots lethal.
 	charge_cost = 150
-	fire_delay = 8
 	accuracy = 1
 	has_item_ratio = FALSE
 	modifystate = "disruptorpistolstun"

--- a/html/changelogs/geeves-disruptor_nerf.yml
+++ b/html/changelogs/geeves-disruptor_nerf.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed guns not having their fire delays properly applied."
+  - tweak: "Disruptors now have a firing delay of 0.8s, up from the intended 0.6s, up from 0.4s with the previously buggy code."

--- a/html/changelogs/geeves-disruptor_nerf.yml
+++ b/html/changelogs/geeves-disruptor_nerf.yml
@@ -2,6 +2,5 @@ author: Geeves
 
 delete-after: True
 
-changes: 
-  - bugfix: "Fixed guns not having their fire delays properly applied."
+changes:
   - tweak: "Disruptors now have a firing delay of 0.8s, up from the intended 0.6s, up from 0.4s with the previously buggy code."


### PR DESCRIPTION
* Disruptors now have a firing delay of 0.8s, up from the intended 0.6s, up from 0.4s with the previously buggy code.