### PR TITLE
Disruptor Nerf

### DIFF
--- a/code/modules/projectiles/guns/energy/disrupter.dm
+++ b/code/modules/projectiles/guns/energy/disrupter.dm
@@ -17,6 +17,7 @@
 	secondary_projectile_type = /obj/item/projectile/energy/blaster
 	max_shots = 12 //12 shots stun, 8 shots lethal.
 	charge_cost = 150
+	fire_delay = 8
 	accuracy = 1
 	has_item_ratio = FALSE
 	modifystate = "disruptorpistolstun"

--- a/html/changelogs/geeves-disruptor_nerf_two.yml
+++ b/html/changelogs/geeves-disruptor_nerf_two.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Disruptors now have a firing delay of 0.8s, up from the intended 0.6s, up from 0.4s with the previously buggy code."

--- a/html/changelogs/geeves-disruptor_nerf_two.yml
+++ b/html/changelogs/geeves-disruptor_nerf_two.yml
@@ -3,4 +3,4 @@ author: Geeves
 delete-after: True
 
 changes: 
-  - tweak: "Disruptors now have a firing delay of 0.8s, up from the intended 0.6s, up from 0.4s with the previously buggy code."
+  - tweak: "Disruptors now have a firing delay of 0.8s."


### PR DESCRIPTION
* Disruptors now have a firing delay of 0.8s.