### PR TITLE
Ammo Pile Fixes

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_pile.dm
+++ b/code/modules/projectiles/ammunition/ammo_pile.dm
@@ -103,6 +103,7 @@
 		var/obj/item/ammo_casing/first_round = ammo[1]
 		name = "[first_round.caliber] pile"
 		desc = "A pile of [first_round.caliber] rounds."
+		ammo_type = first_round.type
 		max_ammo = first_round.max_stack
 
 /obj/item/ammo_pile/proc/get_next_ammo() //Returns the next shell to be used.
@@ -139,6 +140,9 @@
 	if(ismob(bullet.loc))
 		var/mob/gunman = bullet.loc
 		gunman.drop_from_inventory(bullet, src)
+	if(istype(bullet.loc, /obj/item/storage))
+		var/obj/item/storage/S = bullet.loc
+		S.remove_from_storage(bullet, src)
 	bullet.forceMove(src)
 	ammo += bullet
 	var/image/ammo_picture = image(bullet.icon, bullet.icon_state, dir = pick(alldirs))

--- a/html/changelogs/geeves-ammo_stack_fix.yml
+++ b/html/changelogs/geeves-ammo_stack_fix.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes ammo 'duplication' when stacking ammo from a storage container."
+  - bugfix: "Fixes ammo piles not taking the correct ammo types."


### PR DESCRIPTION
* Fixes ammo 'duplication' when stacking ammo from a storage container.
* Fixes ammo piles not taking the correct ammo types.

Fixes https://github.com/Aurorastation/Aurora.3/issues/9347