### PR TITLE
Preloading RSC from external URLs

### DIFF
--- a/code/__defines/_compile_options.dm
+++ b/code/__defines/_compile_options.dm
@@ -3,3 +3,11 @@
 
 // If defined, the sunlight system is enabled. Caution: this uses a LOT of memory.
 //#define ENABLE_SUNLIGHT
+
+// We want to use external resources. Kthx.
+#define PRELOAD_RSC 0
+
+#ifndef PRELOAD_RSC             //set to:
+#define PRELOAD_RSC 2           //  0 to allow using external resources or on-demand behaviour;
+#endif                          //  1 to use the default behaviour;
+                                //  2 for preloading absolutely everything;

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -316,6 +316,8 @@ var/list/gamemode_cache = list()
 	var/profiler_restart_period = 120 SECONDS
 	var/profiler_timeout_threshold = 5 SECONDS
 
+	var/list/external_rsc_urls = list()
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -956,6 +958,9 @@ var/list/gamemode_cache = list()
 					use_forumuser_api = TRUE
 				if ("forumuser_api_key")
 					global.forumuser_api_key = value
+
+				if ("external_rsc_urls")
+					external_rsc_urls = splittext(value, ",")
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -60,7 +60,7 @@
 	var/account_join_date = null					// Date of the BYOND account creation in ISO 8601 format.
 	var/unacked_warning_count = 0
 
-	preload_rsc = 1
+	preload_rsc = PRELOAD_RSC
 
 		////////////
 		//PARALLAX//
@@ -77,8 +77,6 @@
 	var/authed = TRUE
 
 	var/is_initialized = FALSE // Used to track whether the client has been initialized with InitClient.
-
-	preload_rsc = 0
 
 	///goonchat chatoutput of the client
 	var/datum/chatOutput/chatOutput

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -19,6 +19,7 @@
 		- If so, is there any protection against somebody spam-clicking a link?
 	If you have any  questions about this stuff feel free to ask. ~Carn
 	*/
+
 /client/Topic(href, href_list, hsrc)
 	if(!usr || usr != mob)	//stops us calling Topic for somebody else's client. Also helps prevent usr=null
 		return
@@ -555,6 +556,14 @@
 
 //send resources to the client. It's here in its own proc so we can move it around easiliy if need be
 /client/proc/send_resources()
+#if (PRELOAD_RSC == 0)
+	var/static/next_external_rsc = 0
+	var/list/external_rsc_urls = config.external_rsc_urls
+	if(length(external_rsc_urls))
+		next_external_rsc = Wrap(next_external_rsc+1, 1, external_rsc_urls.len+1)
+		preload_rsc = external_rsc_urls[next_external_rsc]
+#endif
+
 	SSassets.handle_connect(src)
 
 /mob/proc/MayRespawn()
@@ -740,3 +749,5 @@
 				M.set_dir(get_dir(M, over_object))
 				gun.Fire(get_turf(over_object), mob, params, (get_dist(over_object, mob) <= 1), FALSE)
 	CHECK_TICK
+
+

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -603,3 +603,9 @@ FAIL2TOPIC_ENABLED 0
 #FORUMUSER_API_URL
 ## The API key of the system.
 #FORUMUSER_API_KEY
+
+## External resource URL
+## Set the PRELOAD_RSC in code/__defines/_compile_options.dm to 0 to use this.
+## Must contain a .zip of the server's .rsc file. Must use HTTP (not secured).
+## Can contain multiple URLs which are then cycled through. Delimit them with a COMMA.
+#EXTERNAL_RSC_URLS http://one.tld/rsc.zip

--- a/html/changelogs/skull132_preload-rsc.yml
+++ b/html/changelogs/skull132_preload-rsc.yml
@@ -1,0 +1,5 @@
+author: Skull132
+delete-after: True
+
+changes:
+  - backend: "Allow the game to load resources from external websites, which should speed things up."


### PR DESCRIPTION
Ports the external URL preloading from tg-station. This allows us to point the config to an external URL, from which the .rsc file will be downloaded. This will be way faster than using the BYOND system, as we don't have to deal with BYOND's netcode.