### PR TITLE
Remove Xenobotanist access to Hydroponics

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -104,8 +104,8 @@
 
 	minimum_character_age = 30
 
-	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_hydroponics)
-	minimal_access = list(access_research, access_xenobiology, access_hydroponics, access_tox_storage)
+	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology)
+	minimal_access = list(access_research, access_xenobiology, access_tox_storage)
 	alt_titles = list("Xenobotanist")
 
 	minimal_player_age = 14

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -11,7 +11,7 @@
 	icon_state = "farmbot0"
 	health = 50
 	maxHealth = 50
-	req_one_access = list(access_hydroponics, access_robotics)
+	req_one_access = list(access_hydroponics, access_robotics, access_xenobiology)
 
 	var/action = "" // Used to update icon
 	var/waters_trays = TRUE

--- a/html/changelogs/flpfs-removebotanyfrom-xenobio.yml
+++ b/html/changelogs/flpfs-removebotanyfrom-xenobio.yml
@@ -1,0 +1,6 @@
+author: Flpfs
+
+delete-after: True
+
+changes: 
+  - tweak: "Xenobotanists and Xenobiologists no longer have access to Hydroponics."


### PR DESCRIPTION
Xenobotanists/Xenobiologists shouldn't have the civillian hydroponics access. This pull requests removes it.