### PR TITLE
Chemistry Update Tweaks/Fixes (very overdue, sorry)

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -406,6 +406,7 @@
 	products = list(
 		/obj/item/reagent_containers/glass/bottle/antitoxin = 4,
 		/obj/item/reagent_containers/glass/bottle/inaprovaline = 4,
+		/obj/item/reagent_containers/glass/bottle/perconol = 3,
 		/obj/item/reagent_containers/glass/bottle/toxin = 4,
 		/obj/item/reagent_containers/glass/bottle/coughsyrup = 4,
 		/obj/item/reagent_containers/syringe = 12,

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -245,6 +245,6 @@ obj/item/storage/pill_bottle/butazoline
 	starts_with = list(/obj/item/reagent_containers/pill/minaphobin = 7)
 
 /obj/item/storage/pill_bottle/rmt
-	name = "bottle of 30u RMT pills"
-	desc = "Contains pills used to remedy the effects of prolonged zero-gravity adaptations."
-	starts_with = list(/obj/item/reagent_containers/pill/rmt = 7)
+	name = "bottle of 15u RMT pills"
+	desc = "Contains pills used to remedy the effects of prolonged zero-gravity adaptations. Do not exceed 30u dosage."
+	starts_with = list(/obj/item/reagent_containers/pill/rmt = 10) // 10x 15u RMT pills will last 4 hours.

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -176,7 +176,6 @@
 		list("antibiotics",		"thetamycin",		/datum/reagent/thetamycin,			80),
 		list("antitoxins",		"dylovene",			/datum/reagent/dylovene,			80),
 		list("nutrients",		"glucose",			/datum/reagent/nutriment/glucose,	80),
-		list("saline",			"saline",			/datum/reagent/saline,				80),
 		list("hyronalin",		"hyronalin",		/datum/reagent/hyronalin,			80),
 		list("synaptizine",		"synaptizine",		/datum/reagent/synaptizine,			80),
 		list("radium",			"radium",			/datum/reagent/radium,				80)
@@ -197,7 +196,6 @@
 		list("antibiotics",		"thetamycin",		/datum/reagent/thetamycin,			20),
 		list("antitoxins",		"dylovene",			/datum/reagent/dylovene,			20),
 		list("nutrients",		"glucose",			/datum/reagent/nutriment/glucose,	80),
-		list("saline",			"saline",			/datum/reagent/saline,				80),
 		list("hyronalin",		"hyronalin",		/datum/reagent/hyronalin,			20),
 		list("synaptizine",		"synaptizine",		/datum/reagent/synaptizine,			20),
 		list("radium",			"radium",			/datum/reagent/radium,				20)
@@ -293,8 +291,7 @@
 		list("synaptizine",		"synaptizine",		/datum/reagent/synaptizine,			30),
 		list("hyperzine",		"hyperzine",		/datum/reagent/hyperzine,			30),
 		list("oxycomorphine",	"oxycomorphine",	/datum/reagent/oxycomorphine,		30),
-		list("nutrients",		"glucose",			/datum/reagent/nutriment/glucose,	80),
-		list("saline",			"saline",			/datum/reagent/saline,				80)
+		list("nutrients",		"glucose",			/datum/reagent/nutriment/glucose,	80)
 		)
 
 	interface_name = "combat chem dispenser"
@@ -311,8 +308,7 @@
 		list("hyperzine",		"hyperzine",		/datum/reagent/hyperzine,		30),
 		list("oxycomorphine",	"oxycomorphine",	/datum/reagent/oxycomorphine,	30),
 		list("phoron",			"phoron",			/datum/reagent/toxin/phoron,	60),
-		list("kois",			"k'ois paste",		/datum/reagent/kois,			80),
-		list("saline",			"saline",			/datum/reagent/saline,			80)
+		list("kois",			"k'ois paste",		/datum/reagent/kois,			80)
 		)
 
 	interface_name = "vaurca combat chem dispenser"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -93,7 +93,7 @@
 
 /datum/reagent/copper/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if (alien & IS_SKRELL)
-		M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
+		M.add_chemical_effect(CE_BLOODRESTORE, 3 * removed)
 
 /datum/reagent/alcohol //Parent class for all alcoholic reagents, though this one shouldn't be used anywhere.
 	name = null	// This null name should prevent alcohol from being added to global lists.
@@ -293,7 +293,7 @@
 
 /datum/reagent/iron/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if (!(alien & (IS_SKRELL | IS_VAURCA)))
-		M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
+		M.add_chemical_effect(CE_BLOODRESTORE, 3 * removed)
 
 /datum/reagent/lithium
 	name = "Lithium"
@@ -553,7 +553,7 @@
 
 /datum/reagent/sulfur/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if (alien & IS_VAURCA)
-		M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
+		M.add_chemical_effect(CE_BLOODRESTORE, 3 * removed)
 
 /datum/reagent/tungsten
 	name = "Tungsten"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1535,11 +1535,12 @@
 
 /datum/reagent/saline
 	name = "Saline Plus"
-	description = "Saline Plus, or Vaughan's Saline Solution, is an expensive improvement upon the various saline solutions of old. Saline Plus has wide clinical applications in the treatment of dehydration and hypovolaemia, with no more debates as to whether it is effective or not."
+	description = "Saline Plus is an expensive improvement upon the various saline solutions of old. Saline Plus has wide clinical applications in the treatment of dehydration and hypovolaemia, with no more debates as to whether it is effective or not."
 	reagent_state = LIQUID
 	scannable = TRUE
-	metabolism = REM * 4 
+	metabolism = 1.5
 	overdose = 5 // Low overdose and fast metabolism to necessitate IV drip usage
+	od_minimum_dose = 10
 	color = "#0064C877"
 	taste_description = "premium salty water"
 	unaffected_species = IS_MACHINE
@@ -1551,13 +1552,13 @@
 		M.adjustHydrationLoss(-removed*2)
 	else
 		M.adjustHydrationLoss(-removed*5)
-	if(volume < 2)
+	if(volume < 3)
 		M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
 	
 /datum/reagent/saline/overdose(var/mob/living/carbon/M, var/alien)
 	M.confused = max(M.confused, 20)
 	M.make_jittery(5)
-	if(prob(dose / 2))
+	if(prob(2))
 		M.emote("twitch")
 
 /datum/reagent/adrenaline
@@ -1627,7 +1628,7 @@
 	reagent_state = LIQUID
 	scannable = TRUE
 	color = "#AA8866"
-	overdose = 40
+	overdose = 30
 	metabolism = 0.1 * REM
 	taste_description = "sourness"
 	fallback_specific_heat = 1

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -629,7 +629,7 @@
 	name = "Saline Plus"
 	id = "saline"
 	result = /datum/reagent/saline
-	required_reagents = list(/datum/reagent/sugar = 0.4, /datum/reagent/water = 1, /datum/reagent/sodiumchloride = 0.9)
+	required_reagents = list(/datum/reagent/water = 2, /datum/reagent/sugar = 0.2, /datum/reagent/sodiumchloride = 0.4)
 	catalysts = list(/datum/reagent/toxin/phoron = 5)
 	result_amount = 1
 
@@ -3595,7 +3595,7 @@
 	name = "RMT"
 	id = "rmt"
 	result = /datum/reagent/rmt
-	result_amount = 1
+	result_amount = 2
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/inaprovaline = 1)
 
 /datum/chemical_reaction/gunpowder

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -211,3 +211,9 @@
 	desc = "A small bottle. Contains mortaphenyl - treats mild-severe pain as a result of severe, physical injury."
 	icon_state = "bottle-3"
 	reagents_to_add = list(/datum/reagent/mortaphenyl = 60)
+
+/obj/item/reagent_containers/glass/bottle/perconol
+	name = "perconol bottle"
+	desc = "A small bottle. Contains perconol - treats minor-moderate pain as a result of physical injury."
+	icon_state = "bottle-3"
+	reagents_to_add = list(/datum/reagent/perconol = 60)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -87,7 +87,7 @@
 
 //Pills
 /obj/item/reagent_containers/pill/antitox
-	name = "Anti-toxins Pill"
+	name = "10u Dylovene Pill"
 	desc = "Neutralizes many common toxins."
 	icon_state = "pill17"
 	reagents_to_add = list(/datum/reagent/dylovene = 10)
@@ -111,79 +111,79 @@
 	reagents_to_add = list(/datum/reagent/adminordrazine = 50)
 
 /obj/item/reagent_containers/pill/stox
-	name = "Sleeping Pill"
+	name = "15u Soporific Pill"
 	desc = "Commonly used to treat insomnia."
 	icon_state = "pill8"
 	reagents_to_add = list(/datum/reagent/soporific = 15)
 
 /obj/item/reagent_containers/pill/kelotane
-	name = "Kelotane Pill"
+	name = "10u Kelotane Pill"
 	desc = "Used to treat minor burns."
 	icon_state = "pill11"
 	reagents_to_add = list(/datum/reagent/kelotane = 10)
 
 /obj/item/reagent_containers/pill/perconol
-	name = "Perconol Pill"
+	name = "10u Perconol Pill"
 	desc = "A light painkiller available over-the-counter."
 	icon_state = "pill8"
 	reagents_to_add = list(/datum/reagent/perconol = 10)
 
 /obj/item/reagent_containers/pill/mortaphenyl
-	name = "Mortaphenyl Pill"
+	name = "10u Mortaphenyl Pill"
 	desc = "A mortaphenyl pill, it's a potent painkiller."
 	icon_state = "pill8"
 	reagents_to_add = list(/datum/reagent/mortaphenyl = 10)
 
 /obj/item/reagent_containers/pill/corophenidate
-	name = "Corophenidate Pill"
+	name = "5u Corophenidate Pill"
 	desc = "Improves the ability to concentrate."
 	icon_state = "pill8"
 	reagents_to_add = list(/datum/reagent/mental/corophenidate = 5)
   
 /obj/item/reagent_containers/pill/minaphobin
-	name = "Minaphobin Pill"
+	name = "5u Minaphobin Pill"
 	desc = "Used to treat anxiety disorders and depression."
 	icon_state = "pill8"
 	reagents_to_add = list(/datum/reagent/mental/minaphobin = 5)
 
 /obj/item/reagent_containers/pill/inaprovaline
-	name = "Inaprovaline Pill"
+	name = "10u Inaprovaline Pill"
 	desc = "Used to stabilize heart activity."
 	icon_state = "pill20"
 	reagents_to_add = list(/datum/reagent/inaprovaline = 10)
 
 /obj/item/reagent_containers/pill/dexalin
-	name = "Dexalin Pill"
+	name = "15u Dexalin Pill"
 	desc = "Used to treat oxygen deprivation."
 	icon_state = "pill16"
 	reagents_to_add = list(/datum/reagent/dexalin = 15)
 
 /obj/item/reagent_containers/pill/dexalin_plus
-	name = "Dexalin Plus Pill"
+	name = "15u Dexalin Plus Pill"
 	desc = "Used to treat extreme oxygen deprivation."
 	icon_state = "pill8"
 	reagents_to_add = list(/datum/reagent/dexalin/plus = 15)
 
 /obj/item/reagent_containers/pill/dermaline
-	name = "Dermaline Pill"
+	name = "10u Dermaline Pill"
 	desc = "Used to treat severe burn wounds."
 	icon_state = "pill12"
 	reagents_to_add = list(/datum/reagent/dermaline = 10)
 
 /obj/item/reagent_containers/pill/dylovene
-	name = "Dylovene Pill"
+	name = "15u Dylovene Pill"
 	desc = "A broad-spectrum anti-toxin."
 	icon_state = "pill13"
 	reagents_to_add = list(/datum/reagent/dylovene = 15)
 
 /obj/item/reagent_containers/pill/butazoline
-	name = "Butazoline Pill"
+	name = "10u Butazoline Pill"
 	desc = "Used to treat major injuries and bleeding."
 	icon_state = "pill18"
 	reagents_to_add = list(/datum/reagent/butazoline = 10)
 
 /obj/item/reagent_containers/pill/bicaridine
-	name = "Bicaridine Pill"
+	name = "10u Bicaridine Pill"
 	desc = "Used to treat minor injuries and bleeding."
 	icon_state = "pill18"
 	reagents_to_add = list(/datum/reagent/bicaridine = 10)
@@ -207,7 +207,7 @@ obj/item/reagent_containers/pill/tranquility
 	reagents_to_add = list(/datum/reagent/mental/neurapan = 15, /datum/reagent/impedrezene = 10)
 
 /obj/item/reagent_containers/pill/thetamycin
-	name = "Thetamycin Pill"
+	name = "15u Thetamycin Pill"
 	desc = "Used to treat infections and septicaemia."
 	icon_state = "pill19"
 	reagents_to_add = list(/datum/reagent/thetamycin = 15)
@@ -223,13 +223,13 @@ obj/item/reagent_containers/pill/tranquility
 	. = ..()
 
 /obj/item/reagent_containers/pill/rmt
-	name = "Regenerative-Muscular Tissue Supplement Pill"
+	name = "15u Regenerative-Muscular Tissue Supplement Pill"
 	desc = "Commonly abbreviated to RMT, it contains chemicals rampantly used by those seeking to remedy the effects of prolonged zero-gravity adaptations."
 	icon_state = "pill19"
-	reagents_to_add = list(/datum/reagent/rmt = 30)
+	reagents_to_add = list(/datum/reagent/rmt = 15)
 
 /obj/item/reagent_containers/pill/cetahydramine
-	name = "Cetahydramine Pill"
+	name = "5u Cetahydramine Pill"
 	desc = "Used to treat coughing, sneezing and itching."
 	icon_state = "pill19"
 	reagents_to_add = list(/datum/reagent/cetahydramine = 5)

--- a/html/changelogs/chemistry_changes.yml
+++ b/html/changelogs/chemistry_changes.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Kermit
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Pill labels now have doses listed on them. Vague pill names such as 'sleeping pill' and 'anti-toxin' have been replaced with the proper names; 'soporific', 'dylovene'."
+  - tweak: "RMT has been tweaked to avoid throwing up due to pills going over the stomach capacity. 1 pill now contains 15u, as opposed to 30u; 10 pills per bottle, instead of 7 - should last 4 hours."
+  - balance: "Saline Plus has been nerfed and is no longer equivalanet to 3 blood bags. The metabolisation rate has been increased to achieve this, so drips should be set to ~1.5u/t instead of ~0.8u/t."
+  - tweak: "Saline Plus' recipe has been simplified a tad following feedback, but remains expensive and a degree difficult to make. It is now 2 parts Water, 0.2 parts Sugar, 0.4 parts Salt."
+  - tweak: "Perconol bottles will now appear in NanoMed Venders for use treating minor pain. Mortaphenyl is more suited for treating severe pain due to the side-effects that come with it."


### PR DESCRIPTION
Fixes, tweaks and balances various things related to my chemistry changes and a recent RMT change. Real life events stopped me from getting this out earlier, fortunately none of the issues related to the chemistry update required immediate attention.

**Things Changed:**

- Pills now have units labelled on them to allow for better dose management. Vague names such as 'sleeping pill' and 'anti-toxin' have been replaced with what they actually are; 'Soporific', 'Dylovene'.

- After discussing RMT with Hocka, it has been re-balanced a bit. The metabolisation remains at Hocka's value, though instead of 30u to a pill, there is now 15u to a pill, with 10 pills per bottle instead of 7. This should keep the desired effect of Hocka's change (1 bottle of RMT lasting 4 hours), without the risk of ODing people taking RMT or making them throw up due to stomach capacity.

- Saline Plus has been rebalanced/fixed. Due to poor testing on my side, 1 bottle of Saline _was_ equivalent to 3 blood bags. Now, 1 bottle of Saline is equivalent to 1 blood bag. The recipe for Saline Plus has also been simplified, but still remains expensive. The recipe is now **2 parts Water, 0.2 parts Sugar, 0.4 parts Salt** and is best made in batches of 30u, where 30 units of Saline Plus will be enough to treat 1 patient with severe blood loss.

- Saline was removed from the various RIG injectors, given it requires IV administration.

- 3 bottles of Perconol spawn per NanoMed vender. This is due to mortaphenyl being used for minor cases due to the lack of perconol, where the side-effects of mortaphenyl would actually be worse than the issue it's treating. By making perconol more available, it should end up in perconol being used for minor cases as opposed to mortaphenyl.

- Iron/Copper/Sulphur reduced in their effectiveness a slight bit more to avoid stacking saline and iron and blood.