### PR TITLE
Cooking Tooltip Eyesore Fix

### DIFF
--- a/code/modules/cooking/machinery/cooking_machines/_cooker.dm
+++ b/code/modules/cooking/machinery/cooking_machines/_cooker.dm
@@ -32,7 +32,9 @@
 
 /obj/machinery/appliance/cooker/MouseEntered(location, control, params)
 	. = ..()
-	if(get_dist(usr, src) <= 2)
+	var/list/modifiers = params2list(params)
+	if(modifiers["shift"] && get_dist(usr, src) <= 2)
+		params = replacetext(params, "shift=1;", "") // tooltip doesn't appear unless this is stripped
 		var/description = ""
 		if(isemptylist(cooking_objs))
 			description = "It is empty."

--- a/code/modules/cooking/machinery/cooking_machines/container.dm
+++ b/code/modules/cooking/machinery/cooking_machines/container.dm
@@ -34,7 +34,9 @@
 
 /obj/item/reagent_containers/cooking_container/MouseEntered(location, control, params)
 	. = ..()
-	if(get_dist(usr, src) <= 2)
+	var/list/modifiers = params2list(params)
+	if(modifiers["shift"] && get_dist(usr, src) <= 2)
+		params = replacetext(params, "shift=1;", "") // tooltip doesn't appear unless this is stripped
 		var/description
 		if(length(contents))
 			description = get_content_info()

--- a/html/changelogs/geeves-shift_tooltip.yml
+++ b/html/changelogs/geeves-shift_tooltip.yml
@@ -3,4 +3,4 @@ author: Geeves
 delete-after: True
 
 changes: 
-  - bugfix: "Cooking appliance tooltips only appear when you shift hover over them, instead of popping up wildly as you hover over the kitchen."
+  - bugfix: "Cooking appliance tooltips only appear when you shift hover over them, instead of popping up wildly as you hover across the kitchen."

--- a/html/changelogs/geeves-shift_tooltip.yml
+++ b/html/changelogs/geeves-shift_tooltip.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Cooking appliance tooltips only appear when you shift hover over them, instead of popping up wildly as you hover over the kitchen."


### PR DESCRIPTION
* Cooking appliance tooltips only appear when you shift hover over them, instead of popping up wildly as you hover over the kitchen.