### PR TITLE
Role blacklists will no longer become null sometimes

### DIFF
--- a/code/game/jobs/faction/faction.dm
+++ b/code/game/jobs/faction/faction.dm
@@ -30,7 +30,8 @@
 		if(LAZYACCESS(job_species_blacklist, role.title))
 			role.blacklisted_species = job_species_blacklist[role.title]
 		else
-			role.blacklisted_species = initial(role.blacklisted_species)
+			var/datum/job/J = new role.type
+			role.blacklisted_species = J.blacklisted_species
 		. += role
 
 /datum/faction/proc/get_selection_error(datum/preferences/prefs)

--- a/html/changelogs/species_blacklist_fix.yml
+++ b/html/changelogs/species_blacklist_fix.yml
@@ -1,0 +1,7 @@
+
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - bugfix: "Faction job-species blacklists will no longer be nulled under some circumstances, allowing invalid job-species combinations."


### PR DESCRIPTION
Using initial() on lists is bad, oops. 

Wonder if I should make some stuff to copy datums / retrieve vars from re-initialized datums more neatly...?