### PR TITLE
Ghostspawner Spawn Atom UI Fix

### DIFF
--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -127,10 +127,7 @@
 		VUEUI_SET_CHECK(data["spawners"][G.short_name]["can_edit"], G.can_edit(user), ., data)
 		VUEUI_SET_CHECK(data["spawners"][G.short_name]["enabled"], G.enabled, ., data)
 		VUEUI_SET_CHECK(data["spawners"][G.short_name]["count"], G.count, ., data)
-		data["spawners"][G.short_name]["spawnatoms"] = 0
-		var/num_of_atoms = length(G.spawn_atoms)
-		if(num_of_atoms)
-			data["spawners"][G.short_name]["spawnatoms"] = num_of_atoms
+		VUEUI_SET_CHECK(data["spawners"][G.short_name]["spawnatoms"], length(G.spawn_atoms), ., data)
 		VUEUI_SET_CHECK(data["spawners"][G.short_name]["max_count"], G.max_count, ., data)
 		VUEUI_SET_CHECK_LIST(data["spawners"][G.short_name]["tags"], G.tags, ., data)
 		VUEUI_SET_CHECK_LIST(data["spawners"][G.short_name]["spawnpoints"], G.spawnpoints, ., data)

--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -127,6 +127,10 @@
 		VUEUI_SET_CHECK(data["spawners"][G.short_name]["can_edit"], G.can_edit(user), ., data)
 		VUEUI_SET_CHECK(data["spawners"][G.short_name]["enabled"], G.enabled, ., data)
 		VUEUI_SET_CHECK(data["spawners"][G.short_name]["count"], G.count, ., data)
+		data["spawners"][G.short_name]["spawnatoms"] = 0
+		var/num_of_atoms = length(G.spawn_atoms)
+		if(num_of_atoms)
+			data["spawners"][G.short_name]["spawnatoms"] = num_of_atoms
 		VUEUI_SET_CHECK(data["spawners"][G.short_name]["max_count"], G.max_count, ., data)
 		VUEUI_SET_CHECK_LIST(data["spawners"][G.short_name]["tags"], G.tags, ., data)
 		VUEUI_SET_CHECK_LIST(data["spawners"][G.short_name]["spawnpoints"], G.spawnpoints, ., data)

--- a/html/changelogs/geeves-ghostspawner_ui.yml
+++ b/html/changelogs/geeves-ghostspawner_ui.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Ghostroles with finite slots no longer display an infinity symbol, instead showing the number of remaining spawn objects."

--- a/vueui/src/components/view/misc/ghostspawner.vue
+++ b/vueui/src/components/view/misc/ghostspawner.vue
@@ -15,6 +15,7 @@
         <td>{{data.name}}</td>
         <td>{{data.desc}}</td>
         <td v-if="data.max_count > 0">{{data.max_count - data.count}} / {{data.max_count}}</td>
+        <td v-else-if="data.spawnatoms > 0">{{data.spawnatoms}}</td>
         <td v-else>&infin;</td>
         <td class="action">
           <vui-button :disabled="(data.cant_spawn !== 0)" :params="{spawn: index, spawnpoint: spawnpoint}" icon="star">Spawn</vui-button> 


### PR DESCRIPTION
* Ghostroles with finite slots no longer display an infinity symbol, instead showing the number of remaining spawn objects.