### PR TITLE
RFD-X Fixes

### DIFF
--- a/code/game/objects/items/weapons/RFD.dm
+++ b/code/game/objects/items/weapons/RFD.dm
@@ -110,6 +110,8 @@
 			var/obj/item/gun/launcher/crossbow/RFD/CB = new(get_turf(user)) // can be found in crossbow.dm
 			forceMove(CB)
 			CB.stored_matter = src.stored_matter
+			qdel(src)
+			user.put_in_hands(CB)
 			add_fingerprint(user)
 			return
 	..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -657,11 +657,11 @@
 	set src in usr
 	set category = "Object"
 	set name = "Toggle Gun Safety"
-	if(usr == loc)
+	if(has_safety && usr == loc)
 		toggle_safety(usr)
 
 /obj/item/gun/CtrlClick(var/mob/user)
-	if(user == loc)
+	if(has_safety && user == loc)
 		toggle_safety(user)
 		return TRUE
 	. = ..()

--- a/html/changelogs/geeves-rfdx_duplication.yml
+++ b/html/changelogs/geeves-rfdx_duplication.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Creating the RFD-X no longer duplicates the base RFD."
+  - bugfix: "You can no longer toggle the safety on guns that have no safety."


### PR DESCRIPTION
* Creating the RFD-X no longer duplicates the base RFD.
* You can no longer toggle the safety on guns that have no safety.