### PR TITLE
Funky Containers Fix

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -154,7 +154,7 @@
 		to_chat(user, "You can't place that item inside the disposal unit.")
 		return
 
-	if(istype(I, /obj/item/storage) && user.a_intent != I_HURT)
+	if(istype(I, /obj/item/storage) && length(I.contents) && user.a_intent != I_HURT)
 		var/obj/item/storage/S = I
 		user.visible_message("<b>[user]</b> empties \the [S] into \the [src].", SPAN_NOTICE("You empty \the [S] into \the [src]."), range = 3)
 		for(var/obj/item/O in S.contents)

--- a/html/changelogs/geeves-funky_containers.yml
+++ b/html/changelogs/geeves-funky_containers.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "You will now place a storage item into a disposal bin even without harm intent, if the container is empty."


### PR DESCRIPTION
* You will now place a storage item into a disposal bin even without harm intent, if the container is empty.

While not explicitly a bug, it's strange and unintended behaviour.

Fixes https://github.com/Aurorastation/Aurora.3/issues/10143