### PR TITLE
Fixes the inventory by removing planes

### DIFF
--- a/code/__defines/_layers.dm
+++ b/code/__defines/_layers.dm
@@ -38,12 +38,4 @@
 #define MECH_GEAR_LAYER             4.08
 #define MECH_ABOVE_LAYER            4.09
 
-#define HUD_PLANE           5
-
-#define FULLSCREEN_PLANE    4
 #define CLICKCATCHER_PLANE -100
-#define FULLSCREEN_LAYER    0
-#define DAMAGE_HUD_LAYER    1
-#define IMPAIRED_LAYER      2
-#define BLIND_LAYER         3
-#define CRIT_LAYER          4

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -63,8 +63,8 @@
 	icon = 'icons/mob/screen/full.dmi'
 	icon_state = "default"
 	screen_loc = "CENTER-7,CENTER-7"
-	plane = FULLSCREEN_PLANE
 	mouse_opacity = 0
+	layer = HUD_LAYER - 0.1
 	var/severity = 0
 	var/allstate = 0 //shows if it should show up for dead people too
 
@@ -74,33 +74,29 @@
 
 /obj/screen/fullscreen/brute
 	icon_state = "brutedamageoverlay"
-	layer = DAMAGE_HUD_LAYER
 
 /obj/screen/fullscreen/oxy
 	icon_state = "oxydamageoverlay"
-	layer = DAMAGE_HUD_LAYER
 
 /obj/screen/fullscreen/crit
 	icon_state = "passage"
-	layer = CRIT_LAYER
 
 /obj/screen/fullscreen/strong_pain
-	layer = DAMAGE_HUD_LAYER
 	icon_state = "strong_pain"
+	layer = OBFUSCATION_LAYER
 
 /obj/screen/fullscreen/blind
 	icon_state = "blackimageoverlay"
-	layer = BLIND_LAYER
+	layer = OBFUSCATION_LAYER
 
 /obj/screen/fullscreen/blackout
 	icon = 'icons/mob/screen/effects.dmi'
 	icon_state = "black"
 	screen_loc = ui_entire_screen
-	layer = BLIND_LAYER
+	layer = OBFUSCATION_LAYER
 
 /obj/screen/fullscreen/impaired
 	icon_state = "impairedoverlay"
-	layer = IMPAIRED_LAYER
 
 /obj/screen/fullscreen/blurry
 	icon = 'icons/mob/screen/effects.dmi'
@@ -124,14 +120,12 @@
 	icon = 'icons/effects/static.dmi'
 	icon_state = "1 light"
 	screen_loc = ui_entire_screen
-	layer = FULLSCREEN_LAYER
 	alpha = 127
 
 /obj/screen/fullscreen/fadeout
 	icon = 'icons/mob/screen/effects.dmi'
 	icon_state = "black"
 	screen_loc = ui_entire_screen
-	layer = FULLSCREEN_LAYER
 	alpha = 0
 	allstate = 1
 
@@ -144,8 +138,7 @@
 	icon_state = "scanlines"
 	screen_loc = ui_entire_screen
 	alpha = 50
-	layer = FULLSCREEN_LAYER
 
 /obj/screen/fullscreen/frenzy
 	icon_state = "frenzyoverlay"
-	layer = BLIND_LAYER
+	layer = OBFUSCATION_LAYER

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -10,7 +10,6 @@
 	name = ""
 	icon = 'icons/mob/screen/generic.dmi'
 	layer = SCREEN_LAYER
-	plane = HUD_PLANE
 	unacidable = 1
 	var/obj/master = null	//A reference to the object in the slot. Grabs or items, generally.
 	var/datum/hud/hud = null // A reference to the owner HUD, if any.


### PR DESCRIPTION
I should have foreseen this but tldr the hud was layering over inventory items because of plane differences. I removed HUD planes and only left the clickcatcher one.