### PR TITLE
KA Leftovers Fix

### DIFF
--- a/code/modules/custom_ka/core.dm
+++ b/code/modules/custom_ka/core.dm
@@ -247,7 +247,7 @@
 		var/obj/item/projectile/kinetic/shot_projectile = new installed_barrel.projectile_type(get_turf(src))
 		shot_projectile.damage = damage_increase
 		shot_projectile.range = range_increase
-		shot_projectile.aoe = aoe_increase
+		shot_projectile.aoe = max(1, aoe_increase)
 		shot_projectile.base_damage = damage_increase
 		return shot_projectile
 	if(ispath(installed_barrel.projectile_type, /obj/item/projectile/beam))
@@ -374,7 +374,7 @@
 	firedelay_increase = max(firedelay_increase,0.125 SECONDS)
 
 	aoe_increase += round(damage_increase/30)
-	aoe_increase = max(0,aoe_increase)
+	aoe_increase = max(1, aoe_increase)
 
 	//Gun stats
 	recoil = recoil_increase*0.25

--- a/code/modules/custom_ka/projectiles.dm
+++ b/code/modules/custom_ka/projectiles.dm
@@ -22,50 +22,35 @@
 	var/turf/target_turf = get_turf(A)
 	if(!target_turf)
 		target_turf = get_turf(src)
-	if(istype(target_turf) && !aoe_shot)
-		aoe_shot = TRUE
-		strike_thing(A)
-	else if(aoe_shot)
-		do_damage(A)
-
-/obj/item/projectile/kinetic/proc/do_damage(var/atom/A)
-	var/turf/target_turf = get_turf(A)
-	if(!target_turf)
-		target_turf = get_turf(src)
 	if(istype(target_turf))
-		var/datum/gas_mixture/environment = target_turf.return_air()
-		damage *= max(1 - (environment.return_pressure() / 100) * 0.75, 0)
-		if(isliving(A)) //Never do more than 50 damage to a living being per shot.
-			damage = min(damage, 50)
-	if(istype(target_turf, /turf/simulated/mineral))
-		var/turf/simulated/mineral/M = target_turf
-		M.kinetic_hit(base_damage, dir)
+		strike_thing(target_turf)
 
-/obj/item/projectile/kinetic/proc/strike_thing(atom/target)
+/obj/item/projectile/kinetic/proc/do_damage(var/turf/T)
+	var/datum/gas_mixture/environment = T.return_air()
+	damage *= max(1 - (environment.return_pressure() / 100) * 0.75, 0)
+	for(var/mob/living/L in T)
+		damage = min(damage, 50) //Never do more than 50 damage to a living being per shot.
+	if(istype(T, /turf/simulated/mineral))
+		var/turf/simulated/mineral/M = T
+		M.kinetic_hit(base_damage)
 
-	var/turf/target_turf = get_turf(target)
-	if(istype(target_turf, /turf/simulated/mineral))
-		var/turf/simulated/mineral/M = target_turf
-		M.kinetic_hit(base_damage, dir)
+/obj/item/projectile/kinetic/proc/strike_thing(var/turf/target_turf)
+	for(var/new_target in RANGE_TURFS(aoe, target_turf))
+		var/turf/aoe_turf = new_target
+		new /obj/item/projectile/kinetic/aoe_shot(aoe_turf, src, get_dist(aoe_turf, target_turf))
+	if(!QDELETED(src))
+		qdel(src)
 
-	new /obj/effect/overlay/temp/kinetic_blast(target_turf)
+/obj/item/projectile/kinetic/aoe_shot
+	aoe_shot = TRUE
 
-	for(var/new_target in orange(aoe, target_turf))
-		new /obj/effect/overlay/temp/kinetic_blast(get_turf(new_target))
-		var/obj/item/projectile/kinetic/spread = new /obj/item/projectile/kinetic
-		if(istype(get_turf(new_target), /turf/simulated/mineral))
-			spread.aoe_shot = TRUE
-			spread.damage = max(base_damage - base_damage * get_dist(new_target, target_turf) * 0.25, 0)
-			spread.base_damage = base_damage
-			var/turf/simulated/mineral/M = new_target
-			M.kinetic_hit(spread.base_damage, dir)
-			qdel(spread)
-			CHECK_TICK
-			continue
-		else
-			spread.aoe_shot = TRUE
-			spread.damage = max(base_damage - base_damage * get_dist(new_target, target_turf) * 0.25, 0)
-			spread.base_damage = base_damage
-			spread.do_damage(new_target)
-			spread.Collide(new_target)
-			CHECK_TICK
+/obj/item/projectile/kinetic/aoe_shot/Initialize(mapload, var/obj/item/projectile/kinetic/master_shot, var/distance_from_master)
+	..()
+	var/turf/spawn_turf = mapload
+	if(!istype(spawn_turf))
+		spawn_turf = get_turf(src)
+	new /obj/effect/overlay/temp/kinetic_blast(spawn_turf)
+	damage = max(master_shot.base_damage - master_shot.base_damage * distance_from_master * 0.25, 0)
+	base_damage = master_shot.base_damage
+	do_damage(spawn_turf)
+	return INITIALIZE_HINT_QDEL

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -57,16 +57,10 @@ var/list/mineral_can_smooth_with = list(
 
 	has_resources = TRUE
 
-/turf/simulated/mineral/proc/kinetic_hit(var/damage,var/direction)
-
+/turf/simulated/mineral/proc/kinetic_hit(var/damage)
 	rock_health -= damage
-
 	if(rock_health <= 0)
-		var/turf/simulated/mineral/next_rock = get_step(src,direction)
-		if(istype(next_rock))
-			new /obj/effect/overlay/temp/kinetic_blast(next_rock)
-			next_rock.kinetic_hit(-rock_health,direction)
-		GetDrilled(1)
+		GetDrilled(TRUE)
 
 // Copypaste parent call for performance.
 /turf/simulated/mineral/Initialize(mapload)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -862,7 +862,7 @@
 		update_icon()
 		return
 
-	if(pin?.attackby(I, user)) //Allows users to use their ID on a gun with a wireless-control firing pin to register their identity.
+	if(istype(pin) && pin.attackby(I, user)) //Allows users to use their ID on a gun with a wireless-control firing pin to register their identity.
 		return
 
 	if(istype(I, /obj/item/ammo_display))

--- a/html/changelogs/geeves-ka_leftovers.yml
+++ b/html/changelogs/geeves-ka_leftovers.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "KAs no longer leave behind phantom projectiles that injure people."
+  - tweak: "KAs no longer recursively destroy rocks when one breaks, but still retain AoE effects."
+  - tweak: "KAs now have at least one tile of AoE on all modules."


### PR DESCRIPTION
* KAs no longer leave behind phantom projectiles that injure people.
* KAs no longer recursively destroy rocks when one breaks, but still retain AoE effects.
* KAs now have at least one tile of AoE on all modules.

Also fixes a runtime with pin attackby.