### PR TITLE
Fix kebab.

### DIFF
--- a/code/modules/cooking/machinery/cooking_machines/_cooker_output.dm
+++ b/code/modules/cooking/machinery/cooking_machines/_cooker_output.dm
@@ -46,7 +46,7 @@
 	return name
 
 /obj/item/reagent_containers/food/snacks/variable/get_name_sans_prefix()
-	return jointext(splittext(get_name_sans_prefix(), " ") - prefix, " ")
+	return jointext(splittext(..(), " ") - prefix, " ")
 
 /obj/item/reagent_containers/food/snacks/variable/proc/update_scale()
 	if (reagents && reagents.total_volume)

--- a/code/modules/cooking/machinery/cooking_machines/container.dm
+++ b/code/modules/cooking/machinery/cooking_machines/container.dm
@@ -12,7 +12,9 @@
 		/obj/item/reagent_containers/food/snacks,
 		/obj/item/holder,
 		/obj/item/paper,
-		/obj/item/flame/candle
+		/obj/item/flame/candle,
+		/obj/item/stack/rods,
+		/obj/item/organ/internal/brain
 		)
 	var/appliancetype // Bitfield, uses the same as appliances
 	w_class = ITEMSIZE_NORMAL

--- a/html/changelogs/FirinMaLazors-fixkebab.yml
+++ b/html/changelogs/FirinMaLazors-fixkebab.yml
@@ -1,0 +1,4 @@
+author: FirinMaLazors
+delete-after: True
+changes: 
+  - bugfix: "Fixed the hardcoded kebab and brain sandwhich recipes to let you use rods and brains, respectively, in recipes.  Also fixed a recursion error in the variable recipes."


### PR DESCRIPTION
Adds rods and brains to the permissible list of items that can be inserted into a cooking container, so you can make the hardcoded kebabs and brain sammiches.

Also fixes a problem with the variable food code that would cause recursion and fail to give the output food a name.

(Tbqh you can technically make kebabs and sandwiches out of anything buuuuuut.  Kebab.)