### PR TITLE
Vaurca Night Eyes

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2274,6 +2274,7 @@
 #include "code\modules\organs\internal\stomach.dm"
 #include "code\modules\organs\internal\species\diona.dm"
 #include "code\modules\organs\internal\species\tajara.dm"
+#include "code\modules\organs\internal\species\vaurca.dm"
 #include "code\modules\organs\subtypes\augment.dm"
 #include "code\modules\organs\subtypes\autakh.dm"
 #include "code\modules\organs\subtypes\diona.dm"

--- a/code/modules/client/client_color.dm
+++ b/code/modules/client/client_color.dm
@@ -92,6 +92,10 @@
 	client_color = list(0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.05, 0.05, 0.05)
 	priority = 300
 
+/datum/client_color/vaurca
+	client_color = list(0, 0, 0.297, 0, 0, 0.739, 0, 0, 0.100)
+	priority = 100
+
 /datum/client_color/deuteranopia
 	client_color = list(0.47, 0.38, 0.15, 0.54, 0.31, 0.15, 0, 0.3, 0.7)
 	priority = 100

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -102,7 +102,7 @@
 		BP_KIDNEYS             = /obj/item/organ/internal/kidneys/vaurca,
 		BP_STOMACH             = /obj/item/organ/internal/stomach,
 		BP_BRAIN               = /obj/item/organ/internal/brain/vaurca,
-		BP_EYES                = /obj/item/organ/internal/eyes/vaurca
+		BP_EYES                = /obj/item/organ/internal/eyes/night/vaurca
 	)
 
 	has_limbs = list(

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -153,7 +153,7 @@
 		BP_VAURCA_KIDNEYS  = /obj/item/organ/internal/kidneys/vaurca/robo,
 		BP_STOMACH            = /obj/item/organ/internal/stomach,
 		BP_BRAIN              = /obj/item/organ/internal/brain/vaurca,
-		BP_EYES               = /obj/item/organ/internal/eyes/vaurca,
+		BP_EYES               = /obj/item/organ/internal/eyes/night/vaurca,
 		BP_FILTRATION_BIT      = /obj/item/organ/vaurca/filtrationbit
 	)
 

--- a/code/modules/organs/internal/species/vaurca.dm
+++ b/code/modules/organs/internal/species/vaurca.dm
@@ -10,6 +10,7 @@
 	if(!.)
 		return
 
+	owner.Weaken(10)
 	take_damage(rand(10, 11))
 	if(damage > 12)
 		owner.eye_blurry += rand(3,6)

--- a/code/modules/organs/internal/species/vaurca.dm
+++ b/code/modules/organs/internal/species/vaurca.dm
@@ -1,0 +1,23 @@
+/obj/item/organ/internal/eyes/night/vaurca
+	name = "vaurcaesian eyes"
+	desc = "A set of four vaurcaesian eyes, adapted to the low or no light tunnels of Sedantis."
+	icon_state = "eyes_vaurca"
+	vision_color = /datum/client_color/vaurca
+	eye_emote = "'s eyes gently shift."
+
+/obj/item/organ/internal/eyes/night/vaurca/flash_act()
+	. = ..()
+	if(!.)
+		return
+
+	take_damage(rand(10, 11))
+	if(damage > 12)
+		owner.eye_blurry += rand(3,6)
+
+	if(damage >= min_broken_damage)
+		owner.sdisabilities |= BLIND
+	else if(damage >= min_bruised_damage)
+		owner.eye_blind = 5
+		owner.eye_blurry = 5
+		owner.disabilities |= NEARSIGHTED
+		addtimer(CALLBACK(owner, /mob/.proc/reset_nearsighted), 100)

--- a/code/modules/organs/subtypes/vaurca.dm
+++ b/code/modules/organs/subtypes/vaurca.dm
@@ -12,29 +12,6 @@
 /obj/item/organ/internal/kidneys/vaurca
 	icon_state = "kidney_vaurca"
 
-/obj/item/organ/internal/eyes/vaurca
-	icon_state = "eyes_vaurca"
-
-/obj/item/organ/internal/eyes/vaurca/flash_act()
-	if(!owner)
-		return
-
-	to_chat(owner, "<span class='warning'>Your eyes burn with the intense light of the flash!</span>")
-	owner.Weaken(10)
-	take_damage(rand(10, 11))
-
-	if(damage > 12)
-		owner.eye_blurry += rand(3,6)
-
-	if(damage >= min_broken_damage)
-		owner.sdisabilities |= BLIND
-
-	else if(damage >= min_bruised_damage)
-		owner.eye_blind = 5
-		owner.eye_blurry = 5
-		owner.disabilities |= NEARSIGHTED
-		addtimer(CALLBACK(owner, /mob/.proc/reset_nearsighted), 100)
-
 /obj/item/organ/internal/kidneys/vaurca/robo
 	icon_state = "kidney_vaurca"
 	organ_tag = BP_VAURCA_KIDNEYS

--- a/html/changelogs/geeves-vaurca_night_eyes.yml
+++ b/html/changelogs/geeves-vaurca_night_eyes.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Vaurca have gained night eyes similar to Tajara, but receive a blue filter instead of a monochrome one. They remain weak to flashes."


### PR DESCRIPTION
* Vaurca have gained night eyes similar to Tajara, but receive a blue filter instead of a monochrome one. They remain weak to flashes.

![image](https://user-images.githubusercontent.com/22774890/95025164-2cb04300-0688-11eb-83ba-ed53f6ac6786.png)