### PR TITLE
Tweaks the interior layout of the research shuttle

### DIFF
--- a/html/changelogs/201007-mapping_researchshuttle.yml
+++ b/html/changelogs/201007-mapping_researchshuttle.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - maptweak: "Redesigned the layout of the research shuttle interior to be able to handle more passengers easily."

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -5705,6 +5705,10 @@
 	},
 /turf/simulated/open/airless,
 /area/turret_protected/tcomsat)
+"kA" = (
+/obj/effect/floor_decal/corner/purple,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/research)
 "kB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -5714,11 +5718,17 @@
 /turf/simulated/floor/wood,
 /area/security/bridge_surface_checkpoint)
 "kC" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/window/southright{
-	name = "Cockpit Access"
+/obj/effect/floor_decal/corner/purple{
+	dir = 6
 	},
-/turf/simulated/floor/plating,
+/obj/structure/window/reinforced{
+	layer = 6;
+	name = "adjusted window"
+	},
+/obj/structure/bed/chair/office/bridge{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "kD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7023,10 +7033,7 @@
 /area/hallway/secondary/entry/emergency)
 "mZ" = (
 /obj/machinery/computer/shuttle_control/research,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/shuttle/black,
 /area/shuttle/research)
 "na" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10602,16 +10609,8 @@
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
 "tU" = (
-/obj/item/storage/firstaid/o2,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/storage/firstaid/regular,
-/obj/structure/closet/medical_wall{
-	pixel_x = 28
-	},
-/obj/machinery/light/small,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/mech_recharger,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "tV" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{
@@ -10662,6 +10661,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
+"uc" = (
+/obj/structure/bed/roller,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/research)
 "ud" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -10700,17 +10704,17 @@
 /turf/simulated/floor/plating,
 /area/bridge/levela)
 "ug" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1380;
 	master_tag = "science_shuttle";
 	name = "interior access button";
-	pixel_x = 15;
-	pixel_y = 30
+	pixel_x = 24;
+	pixel_y = -23
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/research)
@@ -11005,11 +11009,11 @@
 /turf/simulated/floor/plating,
 /area/bridge/levela)
 "uN" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
+/obj/structure/closet/hydrant{
+	pixel_x = 28;
+	pixel_y = -4
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "uO" = (
 /turf/simulated/wall,
@@ -11109,12 +11113,18 @@
 /turf/simulated/floor/tiled/old,
 /area/store)
 "uZ" = (
+/obj/machinery/atmospherics/binary/passive_gate{
+	name = "shuttle airlock pressure regulator";
+	target_pressure = 75;
+	unlocked = 1
+	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/glass_research{
 	frequency = 1380;
 	icon_state = "door_locked";
-	id_tag = "science_shuttle_in"
+	id_tag = "science_shuttle_in";
+	name = "Crew Cabin";
+	open_layer = 2.8
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/research)
@@ -11772,8 +11782,8 @@
 	frequency = 1380;
 	master_tag = "science_shuttle";
 	name = "exterior access button";
-	pixel_x = 6;
-	pixel_y = -19
+	pixel_x = 5;
+	pixel_y = -20
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
@@ -11784,16 +11794,8 @@
 	frequency = 1380;
 	id_tag = "science_shuttle_pump"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "science_shuttle_sensor";
-	pixel_y = 38
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
-	},
-/obj/machinery/light/small{
-	dir = 1
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
@@ -12015,25 +12017,15 @@
 	},
 /area/shuttle/research)
 "wM" = (
-/obj/structure/closet/crate/internals{
-	name = "emergency equipment"
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
 	},
-/obj/item/roller{
-	pixel_y = 8
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -25
 	},
-/obj/item/roller{
-	pixel_y = 8
-	},
-/obj/item/airbubble,
-/obj/item/airbubble,
-/obj/item/storage/firstaid/o2{
-	pixel_y = 2
-	},
-/obj/item/storage/briefcase/inflatable,
-/obj/item/device/flashlight/flare/glowstick/red,
-/obj/item/device/flashlight/flare/glowstick/red,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "wN" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -12625,16 +12617,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/bridge/levela)
-"xW" = (
-/obj/structure/table/reinforced/steel,
-/obj/effect/landmark{
-	name = "Mission Paper"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/shuttle/research)
 "xX" = (
 /turf/simulated/wall/shuttle/unique/research{
 	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
@@ -12643,10 +12625,7 @@
 	},
 /area/shuttle/research)
 "xY" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/ramp,
 /area/shuttle/research)
 "xZ" = (
 /turf/simulated/wall/shuttle/unique/escape_pod{
@@ -12858,6 +12837,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
+"yv" = (
+/obj/structure/bed/chair/shuttle,
+/obj/effect/floor_decal/corner/purple/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/research)
 "yw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -13083,17 +13067,18 @@
 /turf/simulated/floor/wood,
 /area/security/bridge_surface_checkpoint)
 "yK" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/floor_decal/corner/purple/full{
+	dir = 1
 	},
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "expedition armory";
-	req_access = null
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
-/obj/item/gun/energy/laser/shotgun/research,
-/obj/item/gun/energy/laser/shotgun/research,
-/turf/simulated/floor/plating,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "yL" = (
 /obj/item/modular_computer/console/preset/security,
@@ -13182,12 +13167,23 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "yT" = (
-/obj/machinery/recharge_station,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small{
+/obj/effect/floor_decal/corner/lime/full{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/closet/medical_wall{
+	pixel_y = 31
+	},
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/storage/firstaid/o2,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "yU" = (
 /obj/structure/table/standard{
@@ -14455,9 +14451,17 @@
 	},
 /area/mine/explored)
 "AY" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/item/stool/padded,
-/turf/simulated/floor/plating,
+/obj/structure/bed/roller,
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "blood closet";
+	pixel_x = 30;
+	pixel_y = -30;
+	req_access = null;
+	store_mobs = 0
+	},
+/obj/item/reagent_containers/blood/OMinus,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "AZ" = (
 /turf/simulated/wall,
@@ -14811,15 +14815,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness/changing)
 "BJ" = (
+/obj/structure/closet/walllocker/emerglocker/west{
+	pixel_x = -27;
+	pixel_y = 3;
+	spawnitems = list(/obj/item/tank/emergency_oxygen/double,/obj/item/clothing/mask/breath)
+	},
+/obj/effect/floor_decal/corner/purple{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
+	layer = 6;
+	name = "adjusted window"
+	},
 /obj/structure/bed/chair/office/bridge{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/structure/closet/walllocker/emerglocker/west,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "BK" = (
 /obj/structure/cable{
@@ -15910,10 +15921,9 @@
 	},
 /area/shuttle/research)
 "DK" = (
-/obj/structure/shuttle_part/research{
-	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
+/obj/structure/window/shuttle/unique/research{
 	icon_state = "7,16";
-	name = "survey shuttle"
+	outside_window = 1
 	},
 /turf/unsimulated/floor/asteroid/ash,
 /area/shuttle/research)
@@ -15928,13 +15938,11 @@
 /obj/structure/bed/chair/shuttle{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/purple/diagonal,
+/obj/effect/floor_decal/corner/purple{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "DN" = (
 /obj/effect/floor_decal/spline/plain{
@@ -16042,12 +16050,8 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/aft)
 "Ea" = (
-/obj/structure/closet/walllocker/emerglocker/north,
-/obj/structure/bed/chair/shuttle{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Eb" = (
 /obj/structure/window/reinforced{
@@ -18519,12 +18523,11 @@
 /area/solar/port)
 "Iw" = (
 /obj/machinery/atmospherics/pipe/tank/air{
-	dir = 8
+	dir = 8;
+	layer = 3.5
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Ix" = (
 /obj/machinery/light{
@@ -19144,15 +19147,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod/pod2)
-"JJ" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -26
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/research)
 "JK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -19765,6 +19759,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/sconference_room)
+"KZ" = (
+/obj/machinery/iv_drip{
+	pixel_x = 7
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/research)
 "La" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1;
@@ -20422,11 +20422,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "LZ" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/hatch{
-	name = "Storage"
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/medical{
+	name = "Infirmary"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Ma" = (
 /obj/machinery/status_display{
@@ -20551,9 +20551,13 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "Mn" = (
-/obj/structure/dispenser/oxygen,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/structure/bed/chair/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Mo" = (
 /obj/structure/cryofeed,
@@ -20755,13 +20759,6 @@
 /obj/machinery/door/window/westleft,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
-"MM" = (
-/turf/simulated/wall/shuttle/unique/research{
-	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
-	icon_state = "6,9";
-	name = "survey shuttle"
-	},
-/area/shuttle/research)
 "MN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20970,11 +20967,20 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "Nh" = (
-/turf/simulated/wall/shuttle/unique/research{
-	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
-	icon_state = "4,7";
-	name = "survey shuttle"
+/obj/structure/bed/chair/shuttle{
+	dir = 4
 	},
+/obj/effect/floor_decal/corner/purple/diagonal{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/corner/purple{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Ni" = (
 /obj/structure/cable{
@@ -21144,11 +21150,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/emergency)
-"NC" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/closet/walllocker/emerglocker/north,
-/turf/simulated/floor/plating,
-/area/shuttle/research)
 "ND" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating,
@@ -21500,17 +21501,25 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/aft)
 "Os" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 4;
-	pixel_y = 23
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "expedition armory";
+	req_access = null
 	},
-/obj/structure/bed/chair/shuttle{
-	dir = 8
+/obj/effect/floor_decal/corner/purple/diagonal,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/purple{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/item/gun/energy/laser/shotgun/research,
+/obj/item/gun/energy/laser/shotgun/research,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 32;
+	pixel_y = -13
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Ot" = (
 /obj/structure/grille,
@@ -21693,9 +21702,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/store)
 "OJ" = (
-/obj/machinery/mech_recharger,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/obj/structure/bed/chair/shuttle{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/corner/purple/diagonal,
+/obj/effect/floor_decal/corner/purple{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "OK" = (
 /obj/structure/cable{
@@ -21713,10 +21731,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/telecoms_ladder)
 "OL" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/shuttle/research)
 "OM" = (
@@ -21738,6 +21756,7 @@
 /area/crew_quarters/fitness/pool)
 "OO" = (
 /obj/structure/shuttle_part/research{
+	density = 0;
 	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
 	icon_state = "8,15";
 	name = "survey shuttle"
@@ -21851,15 +21870,14 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/locker)
 "Pa" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/shuttle/research)
-"Pb" = (
-/obj/machinery/door/airlock/science{
-	name = "Compilation Office"
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/closet/walllocker/emerglocker/west{
+	pixel_x = -29;
+	spawnitems = list(/obj/item/tank/emergency_oxygen/double,/obj/item/clothing/mask/breath)
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Pc" = (
 /obj/machinery/alarm{
@@ -22036,18 +22054,6 @@
 	},
 /turf/simulated/floor/tiled/old,
 /area/store)
-"Pw" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = -26
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/research)
 "Px" = (
 /turf/simulated/wall,
 /area/maintenance/cargo/surface)
@@ -22112,10 +22118,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/stairs)
 "PF" = (
-/obj/structure/shuttle_part/research{
-	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
+/obj/structure/window/shuttle/unique/research{
 	icon_state = "5,16";
-	name = "survey shuttle"
+	outside_window = 1
 	},
 /turf/unsimulated/floor/asteroid/ash,
 /area/shuttle/research)
@@ -22253,11 +22258,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/dock)
 "PR" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Infirmary"
+/obj/machinery/door/airlock/research{
+	name = "Storage 2"
 	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "PS" = (
 /obj/effect/floor_decal/corner/lime{
@@ -22316,9 +22321,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/store)
 "PZ" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/rd,
-/turf/simulated/floor/carpet,
+/obj/machinery/light{
+	icon_state = "tube1";
+	name = "adjusted light fixture";
+	pixel_x = 16
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Qa" = (
 /obj/structure/table/standard{
@@ -22349,11 +22359,18 @@
 /turf/simulated/floor/tiled,
 /area/storage/tools)
 "Qd" = (
-/turf/simulated/wall/shuttle/unique/research{
-	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
-	icon_state = "4,10";
-	name = "survey shuttle"
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/corner/purple/diagonal{
+	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/corner/purple{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Qe" = (
 /obj/effect/floor_decal/corner/blue{
@@ -22361,9 +22378,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
-"Qf" = (
-/turf/simulated/floor/tiled/white,
-/area/shuttle/research)
 "Qg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -22441,11 +22455,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/arrivals)
 "Qn" = (
-/turf/simulated/wall/shuttle/unique/research{
-	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
-	icon_state = "5,10";
-	name = "survey shuttle"
+/obj/structure/bed/chair/shuttle,
+/obj/effect/floor_decal/corner/purple/diagonal{
+	dir = 4
 	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Qo" = (
 /obj/machinery/door/firedoor,
@@ -22798,13 +22812,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/port)
-"QZ" = (
-/turf/simulated/wall/shuttle/unique/research{
-	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
-	icon_state = "6,10";
-	name = "survey shuttle"
-	},
-/area/shuttle/research)
 "Ra" = (
 /turf/simulated/wall/shuttle/unique/research{
 	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
@@ -23078,16 +23085,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/arrivals)
 "RD" = (
-/obj/machinery/sleeper{
-	dir = 4
+/obj/machinery/light{
+	icon_state = "tube1";
+	name = "adjusted light fixture";
+	pixel_x = 16
 	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -26
-	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "RE" = (
 /obj/effect/floor_decal/corner/blue{
@@ -23132,9 +23136,17 @@
 /turf/simulated/floor/plating,
 /area/sconference_room)
 "RI" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/spot/weak{
+	dir = 8
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "science_shuttle_sensor";
+	pixel_y = -23
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/research)
@@ -23247,9 +23259,10 @@
 	},
 /area/crew_quarters/fitness/pool)
 "RU" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/machinery/door/window/southright{
+	name = "Cockpit Access"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "RV" = (
 /turf/simulated/wall/shuttle/unique/research{
@@ -24280,10 +24293,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "TQ" = (
-/obj/structure/bed/chair/office/bridge{
+/obj/effect/floor_decal/corner/purple{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "TR" = (
 /obj/effect/floor_decal/corner/blue{
@@ -24646,11 +24659,29 @@
 /turf/simulated/wall,
 /area/hallway/secondary/entry/departure_lounge)
 "UF" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/closet/hydrant{
-	pixel_x = 30
+/obj/machinery/light{
+	icon_state = "tube1";
+	name = "adjusted light fixture";
+	pixel_x = -16
 	},
-/turf/simulated/floor/plating,
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/item/nitrilebox{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/glass/bottle/inaprovaline{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "UG" = (
 /obj/structure/closet,
@@ -24722,13 +24753,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/departure_lounge)
-"UP" = (
-/turf/simulated/wall/shuttle/unique/research{
-	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
-	icon_state = "5,7";
-	name = "survey shuttle"
-	},
-/area/shuttle/research)
 "UQ" = (
 /obj/structure/table/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -24883,12 +24907,23 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "Vg" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/obj/item/storage/firstaid/regular{
+	layer = 3.01;
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire{
+	layer = 3.01
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Vh" = (
 /obj/structure/window/reinforced,
@@ -24902,6 +24937,17 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/emergency)
+"Vi" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 5
+	},
+/obj/machinery/vending/wallmed1{
+	pixel_x = -1;
+	pixel_y = 29;
+	req_access = null
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/research)
 "Vj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -24977,7 +25023,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/shuttle/research)
 "Vs" = (
@@ -25757,19 +25802,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/fitness)
 "WQ" = (
-/obj/structure/table/reinforced/steel,
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
-	pixel_x = -26
+	pixel_x = -20
 	},
-/obj/machinery/light/small{
+/obj/effect/floor_decal/corner/purple/full{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/table/reinforced,
+/obj/effect/landmark{
+	name = "Mission Paper"
+	},
+/obj/item/device/camera{
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "WR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25951,6 +26002,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/emergency)
+"Xh" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/research)
 "Xi" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -26008,12 +26068,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/cargo/surface)
 "Xo" = (
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/shuttle_landmark/research/start,
-/turf/simulated/wall/shuttle/unique/research{
-	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
-	icon_state = "6,7";
-	name = "survey shuttle"
-	},
+/turf/simulated/floor/plating,
 /area/shuttle/research)
 "Xp" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -26516,14 +26573,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
 /area/sconference_room)
-"Yn" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = 26;
-	req_access = null
-	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/research)
 "Yo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -26579,6 +26628,7 @@
 /area/hallway/secondary/entry/emergency)
 "Yt" = (
 /obj/structure/shuttle_part/research{
+	density = 0;
 	desc = "The largest commercially available sublight engine, with a shuttle built around it and painted in NanoTrasen research division colors. Looks sleek, and fast.";
 	icon_state = "4,15";
 	name = "survey shuttle"
@@ -26757,10 +26807,7 @@
 /area/hallway/secondary/entry/dock)
 "YJ" = (
 /obj/structure/bed/chair/office/bridge/pilot,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/shuttle/black,
 /area/shuttle/research)
 "YK" = (
 /obj/structure/bed/chair,
@@ -26777,9 +26824,31 @@
 /turf/simulated/floor/plating,
 /area/maintenance/solarmaint)
 "YM" = (
-/obj/structure/table/steel,
-/obj/item/device/flashlight/lamp,
-/turf/simulated/floor/carpet,
+/obj/structure/closet/crate/internals{
+	name = "emergency equipment"
+	},
+/obj/item/roller{
+	pixel_y = 8
+	},
+/obj/item/roller{
+	pixel_y = 8
+	},
+/obj/item/airbubble,
+/obj/item/airbubble,
+/obj/item/storage/briefcase/inflatable,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/tank/oxygen,
+/obj/item/tank/oxygen,
+/obj/item/tank/oxygen,
+/obj/item/tank/oxygen,
+/obj/item/clothing/suit/space,
+/obj/item/clothing/mask/gas/alt,
+/obj/item/clothing/head/helmet/space,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "YN" = (
 /obj/machinery/door/firedoor,
@@ -26818,10 +26887,11 @@
 /turf/simulated/floor/wood,
 /area/sconference_room)
 "YR" = (
-/obj/machinery/door/airlock{
-	name = "Private Quarters"
+/obj/machinery/door/airlock/research{
+	name = "Storage 1"
 	},
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "YS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -26868,6 +26938,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
+"YW" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/firedoor{
+	layer = 2.8;
+	open_layer = 2.8
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/research)
 "YX" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -27014,11 +27092,16 @@
 /turf/simulated/floor/tiled,
 /area/turret_protected/tcomfoyer)
 "Zk" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/device/flashlight/lamp,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/white,
+/obj/structure/bed/chair/shuttle{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/diagonal{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "Zl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27174,10 +27257,10 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
 "ZD" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/research)
 "ZE" = (
 /obj/structure/ladder{
@@ -69435,9 +69518,9 @@ Pl
 Qj
 Zx
 kE
-DA
-DA
-DA
+Vi
+KZ
+uc
 AY
 UF
 WO
@@ -69947,7 +70030,7 @@ uS
 yb
 Qd
 Zk
-JJ
+Zk
 Nh
 DA
 BC
@@ -70204,9 +70287,9 @@ WQ
 BJ
 Qn
 TQ
-Qf
-UP
-NC
+TQ
+TQ
+DA
 YR
 ZD
 uN
@@ -70457,13 +70540,13 @@ Qv
 mZ
 YJ
 xY
-DA
+Xh
 RU
-QZ
-MM
-Pb
+DA
+DA
+DA
 Xo
-Pw
+DA
 XU
 VJ
 RN
@@ -70716,10 +70799,10 @@ Ut
 Pd
 yK
 kC
-DA
-DA
-DA
-DA
+yv
+kA
+kA
+kA
 DA
 Sy
 Ea
@@ -70975,11 +71058,11 @@ SB
 xX
 Os
 DM
-xW
+DM
 OJ
 DA
 PR
-Yn
+ZD
 tU
 Ow
 Vw
@@ -71234,7 +71317,7 @@ BH
 wL
 xl
 Bb
-DA
+YW
 Ik
 Dd
 Pm


### PR DESCRIPTION
 - Expanded the crew cabin to more easily handle a greater number of passengers and redesigned the other rooms to be more practical. Will be of use for future events and expeditions in general, and there's room for 6 more seats that can be added to the main compartment if the need arises.
 - Interior airlock is now glass so it's easier to see what's going on from inside, as moving crew in and out at expedition sites could be a bit confusing.

![shuddle](https://user-images.githubusercontent.com/35879136/95286937-f7ad1780-0864-11eb-8a3b-516990c46b1e.PNG)
