### PR TITLE
Makes the character preview show more than the first accessory

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -757,7 +757,8 @@
 				else if (H.equip_to_slot_or_del(CI, G.slot))
 					CI.autodrobe_no_remove = TRUE
 					to_chat(H, "<span class='notice'>Equipping you with [thing]!</span>")
-					custom_equip_slots += G.slot
+					if(G.slot != slot_tie)
+						custom_equip_slots += G.slot
 					Debug("EC/([H]): Equipped [CI] successfully.")
 				else if (leftovers)
 					leftovers += thing

--- a/html/changelogs/Ferner-201008-coding_accessorypreview.yml
+++ b/html/changelogs/Ferner-201008-coding_accessorypreview.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - tweak: "The character preview now shows more than the first accessory in your loadout and you get equipped with them all at spawn if possible."


### PR DESCRIPTION
As a lot of character customization is now tied to accessories, it's quite cumbersome to perfect the style you're looking for when only the first accessory in your loadout shows up. This also makes it so they get equipped on spawn if possible, else they get shoved in the backpack.
The accessory slot is unique in that multiple of them can be worn, so the exception here I feel is warranted.
Also tested with jobs that equip accessories.