### PR TITLE
Alterable Organs and Vaurca Nighteyes Fix

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -204,7 +204,8 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	for(var/M in pref.disabilities)
 		out += "     [M] <a href='?src=\ref[src];trait_remove=[M]'>-</a><br>"
 	out += "Limbs: <a href='?src=\ref[src];limbs=1'>Adjust</a><br>"
-	out += "Internal Organs: <a href='?src=\ref[src];organs=1'>Adjust</a><br>"
+	if(length(mob_species.alterable_internal_organs))
+		out += "Internal Organs: <a href='?src=\ref[src];organs=1'>Adjust</a><br>"
 	out += "Prosthesis/Amputations: <a href='?src=\ref[src];reset_organs=1'>Reset</a><br>"
 
 	//display limbs below

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -130,7 +130,7 @@
 	default_accent = ACCENT_TTS
 	allowed_accents = list(ACCENT_TTS, ACCENT_ZORA, ACCENT_KLAX, ACCENT_CTHUR)
 
-	alterable_internal_organs = list()
+	alterable_internal_organs = list(BP_EYES)
 
 /datum/species/bug/before_equip(var/mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/organs/internal/species/tajara.dm
+++ b/code/modules/organs/internal/species/tajara.dm
@@ -95,9 +95,9 @@
 	night_vision = FALSE
 	owner.stop_sight_update = FALSE
 	if(status & ORGAN_ROBOT)
-		owner.add_client_color(vision_mechanical_color)
+		owner.remove_client_color(vision_mechanical_color)
 	else
-		owner.add_client_color(vision_color)
+		owner.remove_client_color(vision_color)
 
 /obj/item/organ/internal/stomach/tajara
 	name = "reinforced stomach"

--- a/code/modules/organs/internal/species/tajara.dm
+++ b/code/modules/organs/internal/species/tajara.dm
@@ -6,6 +6,7 @@
 	relative_size = 8
 	var/night_vision = FALSE
 	var/datum/client_color/vision_color = /datum/client_color/monochrome
+	var/datum/client_color/vision_mechanical_color
 	var/eye_emote = "'s eyes dilate!"
 
 /obj/item/organ/internal/eyes/night/Destroy()
@@ -38,7 +39,7 @@
 	if(is_broken())
 		return
 
-	if(status & ORGAN_ROBOT)
+	if(!vision_mechanical_color && (status & ORGAN_ROBOT))
 		return
 
 	if(!night_vision)
@@ -81,7 +82,10 @@
 	night_vision = TRUE
 	owner.stop_sight_update = TRUE
 	owner.see_invisible = SEE_INVISIBLE_NOLIGHTING
-	owner.add_client_color(vision_color)
+	if(status & ORGAN_ROBOT)
+		owner.add_client_color(vision_mechanical_color)
+	else
+		owner.add_client_color(vision_color)
 
 /obj/item/organ/internal/eyes/night/proc/disable_night_vision()
 	if(!owner)
@@ -90,7 +94,10 @@
 		return
 	night_vision = FALSE
 	owner.stop_sight_update = FALSE
-	owner.remove_client_color(vision_color)
+	if(status & ORGAN_ROBOT)
+		owner.add_client_color(vision_mechanical_color)
+	else
+		owner.add_client_color(vision_color)
 
 /obj/item/organ/internal/stomach/tajara
 	name = "reinforced stomach"

--- a/code/modules/organs/internal/species/vaurca.dm
+++ b/code/modules/organs/internal/species/vaurca.dm
@@ -2,7 +2,9 @@
 	name = "vaurcaesian eyes"
 	desc = "A set of four vaurcaesian eyes, adapted to the low or no light tunnels of Sedantis."
 	icon_state = "eyes_vaurca"
+	robotic_sprite = null
 	vision_color = /datum/client_color/vaurca
+	vision_mechanical_color = /datum/client_color/monochrome
 	eye_emote = "'s eyes gently shift."
 
 /obj/item/organ/internal/eyes/night/vaurca/flash_act()

--- a/html/changelogs/geeves-alterable_organs_fix.yml
+++ b/html/changelogs/geeves-alterable_organs_fix.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "The choice to alter internal organs in character creation no longer appears if there are no internal organs to alter."
+  - bugfix: "Vaurca can now choose to have robotic eyes."
+  - bugifx: "Vaurca night eyes now work if they're robotic."

--- a/html/changelogs/geeves-alterable_organs_fix.yml
+++ b/html/changelogs/geeves-alterable_organs_fix.yml
@@ -5,4 +5,4 @@ delete-after: True
 changes: 
   - bugfix: "The choice to alter internal organs in character creation no longer appears if there are no internal organs to alter."
   - bugfix: "Vaurca can now choose to have robotic eyes."
-  - bugifx: "Vaurca night eyes now work if they're robotic."
+  - bugfix: "Vaurca night eyes now work if they're robotic."


### PR DESCRIPTION
* The choice to alter internal organs in character creation no longer appears if there are no internal organs to alter.
* Vaurca can now choose to have robotic eyes.
* Vaurca night eyes now work if they're robotic.