### PR TITLE
Removes camera monitor from wristbounds/tablets.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/security/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/security/camera.dm
@@ -36,7 +36,7 @@
 	requires_ntnet = TRUE
 	required_access_download = access_heads
 	color = LIGHT_COLOR_ORANGE
-	usage_flags = PROGRAM_ALL_REGULAR
+	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
 
 /datum/nano_module/camera_monitor
 	name = "Camera Monitoring program"

--- a/html/changelogs/johnwildkins-monitornerf.yml
+++ b/html/changelogs/johnwildkins-monitornerf.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - tweak: "Camera monitoring is no longer available on tablets or wristbound computers."


### PR DESCRIPTION
title

camera monitoring program can now only be operated from laptops and workstations