### PR TITLE
Odin Ghost Role Update

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1618,6 +1618,7 @@
 #include "code\modules\ghostroles\spawner\human\responseteams\tcfl.dm"
 #include "code\modules\ghostroles\spawner\simplemob\maintdrone.dm"
 #include "code\modules\ghostroles\spawner\simplemob\rat.dm"
+#include "code\modules\ghostroles\spawner\simplemob\simplemob.dm"
 #include "code\modules\ghostroles\spawner\simplemob\spider_queen.dm"
 #include "code\modules\ghostroles\spawnpoint\spawnpoint.dm"
 #include "code\modules\ghosttrap\trap.dm"

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -99,15 +99,3 @@
  * Parameters: var/area/departing, var/area/destination
  */
 /hook/shuttle_moved
-
-/**
- * Crew Transfer.
- * Called when a crew transfer has been started.
- */
-/hook/crew_transfer
-
- /**
- * Emergency Evacuation.
- * Called when a emergency evacuation has been started.
- */
- /hook/emergency_evac

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -99,3 +99,15 @@
  * Parameters: var/area/departing, var/area/destination
  */
 /hook/shuttle_moved
+
+/**
+ * Crew Transfer.
+ * Called when a crew transfer has been started.
+ */
+/hook/crew_transfer
+
+ /**
+ * Emergency Evacuation.
+ * Called when a emergency evacuation has been started.
+ */
+ /hook/emergency_evac

--- a/code/controllers/subsystems/emergency_shuttle.dm
+++ b/code/controllers/subsystems/emergency_shuttle.dm
@@ -100,6 +100,8 @@ var/datum/controller/subsystem/emergency_shuttle/emergency_shuttle
 /datum/controller/subsystem/emergency_shuttle/proc/call_evac()
 	if(!can_call()) return
 
+	callHook("emergency_evac")
+
 	//set the launch timer
 	autopilot = 1
 	set_launch_countdown(get_shuttle_prep_time())
@@ -117,6 +119,8 @@ var/datum/controller/subsystem/emergency_shuttle/emergency_shuttle
 //calls the shuttle for a routine crew transfer
 /datum/controller/subsystem/emergency_shuttle/proc/call_transfer()
 	if(!can_call()) return
+
+	callHook("crew_transfer")
 
 	//set the launch timer
 	autopilot = 1

--- a/code/controllers/subsystems/emergency_shuttle.dm
+++ b/code/controllers/subsystems/emergency_shuttle.dm
@@ -100,8 +100,6 @@ var/datum/controller/subsystem/emergency_shuttle/emergency_shuttle
 /datum/controller/subsystem/emergency_shuttle/proc/call_evac()
 	if(!can_call()) return
 
-	callHook("emergency_evac")
-
 	//set the launch timer
 	autopilot = 1
 	set_launch_countdown(get_shuttle_prep_time())
@@ -119,8 +117,6 @@ var/datum/controller/subsystem/emergency_shuttle/emergency_shuttle
 //calls the shuttle for a routine crew transfer
 /datum/controller/subsystem/emergency_shuttle/proc/call_transfer()
 	if(!can_call()) return
-
-	callHook("crew_transfer")
 
 	//set the launch timer
 	autopilot = 1

--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -205,3 +205,9 @@
 	if(G)
 		return G.spawn_atoms
 	return list()
+
+//Returns the spawner with the specified (short) name or null
+/datum/controller/subsystem/ghostroles/proc/get_spawner(var/spawner_name)
+	if(spawner_name in spawners)
+		return spawners[spawner_name]
+	return null

--- a/code/datums/outfits/ert/nt_ert.dm
+++ b/code/datums/outfits/ert/nt_ert.dm
@@ -21,7 +21,7 @@
 	)
 
 /datum/outfit/admin/ert/nanotrasen/get_id_access()
-	return get_all_accesses() | get_centcom_access("Emergency Response Team")
+	return get_all_station_access() | get_centcom_access("Emergency Response Team")
 
 /datum/outfit/admin/ert/nanotrasen/specialist
 	name = "Nanotrasen ERT Engineer Specialist"

--- a/code/datums/outfits/event/outfit_nanotrasen.dm
+++ b/code/datums/outfits/event/outfit_nanotrasen.dm
@@ -305,7 +305,7 @@
 
 	uniform = /obj/item/clothing/under/rank/janitor
 	pda = /obj/item/device/pda/janitor
-	shoes = /obj/item/clothing/shoes/black
+	shoes = /obj/item/clothing/shoes/galoshes
 	l_ear = /obj/item/device/radio/headset/headset_service
 	l_pocket = /obj/item/grenade/chem_grenade/cleaner
 	r_pocket = /obj/item/grenade/chem_grenade/cleaner

--- a/code/datums/outfits/event/outfit_nanotrasen.dm
+++ b/code/datums/outfits/event/outfit_nanotrasen.dm
@@ -298,10 +298,6 @@
 	shoes = /obj/item/clothing/shoes/black
 	l_ear = /obj/item/device/radio/headset/headset_service
 
-	backpack_contents = list(
-		/obj/item/storage/box/produce = 3
-	)
-
 	id_access = "Service"
 
 /datum/outfit/admin/nt/odinjanitor

--- a/code/datums/outfits/event/outfit_nanotrasen.dm
+++ b/code/datums/outfits/event/outfit_nanotrasen.dm
@@ -17,7 +17,7 @@
 	var/id_access = "NanoTrasen Representative"
 
 /datum/outfit/admin/nt/get_id_access()
-	return get_all_accesses() | get_centcom_access(id_access)
+	return get_all_station_access() | get_centcom_access(id_access)
 
 /datum/outfit/admin/nt/officer
 	name = "NanoTrasen Navy Officer"
@@ -58,6 +58,8 @@
 	implants = list(
 		/obj/item/implant/mindshield
 	)
+
+	id_access = "CCIA Agent"
 
 /datum/outfit/admin/nt/protection_detail/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 
@@ -101,6 +103,8 @@
 		/obj/item/implant/mindshield
 	)
 
+	id_access = "BlackOps Commander"
+
 /datum/outfit/admin/nt/cciaa
 	name = "CCIA Agent"
 
@@ -115,6 +119,8 @@
 	r_pocket = /obj/item/device/taperecorder/cciaa
 	l_hand = /obj/item/storage/lockbox/cciaa
 	pda = /obj/item/device/pda/central
+
+	id_access = "CCIA Agent"
 
 /datum/outfit/admin/nt/odinsec
 	name = "NTCC Odin Security Specialist"
@@ -146,6 +152,8 @@
 	implants = list(
 		/obj/item/implant/mindshield
 	)
+
+	id_access = "Odin Security"
 
 /datum/outfit/admin/nt/odinsec/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 
@@ -198,6 +206,8 @@
 		/obj/item/handcuffs = 1
 	)
 
+	id_access = "CCIA Agent"
+
 /datum/outfit/admin/nt/fib/guard
 	name = "FIB Escort"
 
@@ -217,3 +227,95 @@
 		/obj/item/storage/box/zipties = 1,
 		/obj/item/clothing/head/helmet = 1
 	)
+
+	id_access = "CCIA Agent"
+
+/datum/outfit/admin/nt/odindoc
+	name = "NTCC Odin Medical Specialist"
+
+	uniform = /obj/item/clothing/under/rank/medical/black
+	suit = /obj/item/clothing/suit/storage/toggle/labcoat/trauma
+	shoes = /obj/item/clothing/shoes/trauma
+	mask = /obj/item/clothing/mask/surgical
+	l_hand = /obj/item/storage/firstaid/adv
+	l_ear = /obj/item/device/radio/headset/headset_med
+
+	gloves = /obj/item/clothing/gloves/white
+	belt = /obj/item/storage/belt/medical
+	back = /obj/item/storage/backpack/satchel_med
+	accessory = /obj/item/clothing/accessory/storage/white_vest
+	accessory_contents = list(/obj/item/reagent_containers/hypospray/cmo = 1, /obj/item/storage/pill_bottle/dexalin_plus = 1, /obj/item/storage/pill_bottle/mortaphenyl = 1)
+
+	backpack_contents = list(
+		/obj/item/storage/box/survival = 1,
+		/obj/item/storage/firstaid/regular = 2,
+		/obj/item/storage/firstaid/surgery = 1,
+		/obj/item/storage/box/gloves = 1,
+		/obj/item/storage/box/syringes = 1,
+		/obj/item/device/flashlight/pen = 1
+	)
+
+	belt_contents = list(
+		/obj/item/stack/medical/advanced/bruise_pack = 2,
+		/obj/item/stack/medical/advanced/ointment = 2,
+		/obj/item/stack/medical/splint = 1,
+		/obj/item/reagent_containers/syringe = 1,
+		/obj/item/reagent_containers/glass/bottle/inaprovaline = 1
+	)
+
+	id_access = "Medical Doctor"
+
+/datum/outfit/admin/nt/odinpharm
+	name = "NTCC Odin Pharmacy Specialist"
+
+	uniform = /obj/item/clothing/under/rank/pharmacist
+	suit = /obj/item/clothing/suit/storage/toggle/labcoat/pharmacist
+	shoes = /obj/item/clothing/shoes/chemist
+	l_ear = /obj/item/device/radio/headset/headset_med
+
+	backpack = /obj/item/storage/backpack/pharmacy
+	satchel = /obj/item/storage/backpack/satchel_pharm
+	dufflebag = /obj/item/storage/backpack/duffel/pharm
+	messengerbag = /obj/item/storage/backpack/messenger/pharm
+
+	id_access = "Medical Doctor"
+
+/datum/outfit/admin/nt/odinbartender
+	name = "NTCC Odin Bartender"
+
+	uniform = /obj/item/clothing/under/rank/bartender
+	shoes = /obj/item/clothing/shoes/black
+	l_ear = /obj/item/device/radio/headset/headset_service
+
+	id_access = "Service"
+
+/datum/outfit/admin/nt/odinchef
+	name = "NTCC Odin Chef"
+
+	uniform = /obj/item/clothing/under/rank/chef
+	suit = /obj/item/clothing/suit/chef
+	head = /obj/item/clothing/head/chefhat
+	shoes = /obj/item/clothing/shoes/black
+	l_ear = /obj/item/device/radio/headset/headset_service
+
+	backpack_contents = list(
+		/obj/item/storage/box/produce = 3
+	)
+
+	id_access = "Service"
+
+/datum/outfit/admin/nt/odinjanitor
+	name = "NTCC Odin Sanitation Specialist"
+
+	uniform = /obj/item/clothing/under/rank/janitor
+	pda = /obj/item/device/pda/janitor
+	shoes = /obj/item/clothing/shoes/black
+	l_ear = /obj/item/device/radio/headset/headset_service
+	l_pocket = /obj/item/grenade/chem_grenade/cleaner
+	r_pocket = /obj/item/grenade/chem_grenade/cleaner
+
+	backpack_contents = list(
+		/obj/item/grenade/chem_grenade/cleaner = 14
+	)
+
+	id_access = "Service"

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -41,30 +41,25 @@
 
 /proc/get_centcom_access(job)
 	switch(job)
-		if("VIP Guest")
-			return list(access_cent_general)
-		if("Custodian")
-			return list(access_cent_general, access_cent_living, access_cent_storage)
-		if("Thunderdome Overseer")
-			return list(access_cent_general, access_cent_thunder)
-		if("Intel Officer")
+		if("CCIA Agent")
+			return list(access_cent_general, access_cent_captain, access_cent_living)
+		if("Emergency Response Team")
+			return list(access_cent_general, access_cent_specops, access_cent_living)
+		if("Odin Security")
+			return list(access_cent_general, access_cent_specops, access_cent_living)
+		if("Medical Doctor")
+			return list(access_cent_general, access_cent_medical)
+		if("Service")
 			return list(access_cent_general, access_cent_living)
-		if("Medical Officer")
-			return list(access_cent_general, access_cent_living, access_cent_medical)
 		if("Death Commando")
 			return list(access_cent_general, access_cent_specops, access_cent_living, access_cent_storage)
 		if("NanoTrasen Representative")
 			return list(access_cent_general, access_cent_living, access_cent_storage, access_cent_thunder, access_cent_medical, access_cent_specops, access_cent_teleporter)
-		if("Research Officer")
-			return list(access_cent_general, access_cent_specops, access_cent_medical, access_cent_teleporter, access_cent_storage)
 		if("BlackOps Commander")
 			return list(access_cent_general, access_cent_thunder, access_cent_specops, access_cent_living, access_cent_storage, access_cent_creed)
 		if("Supreme Commander")
 			return get_all_centcom_access()
-		if("CCIA Agent")
-			return list(access_cent_general, access_cent_captain, access_cent_living, access_cent_storage)
-		if("Emergency Response Team")
-			return list(access_cent_general, access_cent_specops, access_cent_living, access_cent_storage)
+
 	log_debug("Invalid job [job] passed to get_centcom_access")
 	return list()
 
@@ -203,23 +198,26 @@
 	return all_jobs
 
 /proc/get_all_centcom_jobs()
-	return list("VIP Guest",
-		"Custodian",
-		"Thunderdome Overseer",
-		"Intel Officer",
-		"General",
+	return list("NanoTrasen Representative",
+		"NanoTrasen Navy Officer",
+		"NanoTrasen Navy Captain",
+		"ERT Protection Detail",
+		"ERT Commander",
 		"Bluespace Technician",
-		"Internal Affairs Agent",
-		"VIP Guest",
-		"Medical Officer",
-		"Death Commando",
-		"Research Officer",
-		"BlackOps Commander",
-		"Supreme Commander",
+		"CCIA Agent",
+		"CCIA Escort",
+		"Odin Checkpoint Security",
+		"Odin Security",
+		"Aurora Prepatory Wing Security",
+		"Odin Medical Doctor",
+		"Odin Pharmacist",
+		"Odin Chef",
+		"Odin Bartender",
+		"Sanitation Specialist",
 		"Emergency Response Team",
 		"Emergency Response Team Leader",
 		"Emergency Responder",
-		"Central Command Internal Affairs Agent")
+		"Death Commando")
 
 /mob/proc/GetIdCard()
 	return null

--- a/code/modules/ghostroles/spawner/base.dm
+++ b/code/modules/ghostroles/spawner/base.dm
@@ -177,6 +177,8 @@
 
 //Proc to enable the ghostspawner
 /datum/ghostspawner/proc/enable()
+	if(usr)
+		log_and_message_admins("has enabled the ghostspawner [src.name]")
 	enabled = TRUE
 	if(enable_dmessage)
 		for(var/mob/abstract/observer/O in player_list)

--- a/code/modules/ghostroles/spawner/human/admin.dm
+++ b/code/modules/ghostroles/spawner/human/admin.dm
@@ -175,7 +175,7 @@
 	enabled = FALSE
 	spawnpoints = list("OdinChef")
 	req_perms = null
-	max_count = 1
+	max_count = 2
 
 	outfit = /datum/outfit/admin/nt/odinchef
 	possible_species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)

--- a/code/modules/ghostroles/spawner/human/admin.dm
+++ b/code/modules/ghostroles/spawner/human/admin.dm
@@ -134,6 +134,7 @@
 	enabled = FALSE
 	spawnpoints = list("OdinDoctor")
 	req_perms = null
+	req_perms_edit = R_CCIAA
 	max_count = 4
 
 	//Vars related to human mobs
@@ -155,6 +156,7 @@
 	enabled = FALSE
 	spawnpoints = list("OdinPharm")
 	req_perms = null
+	req_perms_edit = R_CCIAA
 	max_count = 1
 
 	outfit = /datum/outfit/admin/nt/odinpharm
@@ -175,6 +177,7 @@
 	enabled = FALSE
 	spawnpoints = list("OdinChef")
 	req_perms = null
+	req_perms_edit = R_CCIAA
 	max_count = 2
 
 	outfit = /datum/outfit/admin/nt/odinchef
@@ -195,6 +198,7 @@
 	enabled = FALSE
 	spawnpoints = list("OdinBartender")
 	req_perms = null
+	req_perms_edit = R_CCIAA
 	max_count = 1
 
 	outfit = /datum/outfit/admin/nt/odinbartender

--- a/code/modules/ghostroles/spawner/human/admin.dm
+++ b/code/modules/ghostroles/spawner/human/admin.dm
@@ -60,8 +60,8 @@
 	possible_species = list(SPECIES_HUMAN,SPECIES_SKRELL)
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
-	assigned_role = "Emergency Response Team Commander"
-	special_role = "ERT Commander"
+	assigned_role = "CCIA Agent"
+	special_role = "CCIA Agent"
 	respawn_flag = null
 
 	mob_name = null
@@ -125,6 +125,109 @@
 	spawnpoints = list("OdinPrepatory")
 	req_perms = R_CCIAA
 	max_count = 3
+
+/datum/ghostspawner/human/admin/odindoc
+	short_name = "odindoc"
+	name = "Odin Medical Doctor"
+	desc = "Provide medical assistance for those arriving on the Odin."
+
+	enabled = FALSE
+	spawnpoints = list("OdinDoctor")
+	req_perms = null
+	max_count = 4
+
+	//Vars related to human mobs
+	outfit = /datum/outfit/admin/nt/odindoc
+	possible_species = list(SPECIES_HUMAN,SPECIES_SKRELL)
+	allow_appearance_change = APPEARANCE_PLASTICSURGERY
+
+	assigned_role = "Odin Medical Doctor"
+	special_role = "Odin Medical Doctor"
+	respawn_flag = null
+
+	mob_name = null
+
+/datum/ghostspawner/human/admin/odinpharm
+	short_name = "odinpharm"
+	name = "Odin Pharmacist"
+	desc = "Provide medication for the Doctors on the Odin and those in need."
+
+	enabled = FALSE
+	spawnpoints = list("OdinPharm")
+	req_perms = null
+	max_count = 1
+
+	outfit = /datum/outfit/admin/nt/odinpharm
+	possible_species = list(SPECIES_HUMAN,SPECIES_SKRELL)
+	allow_appearance_change = APPEARANCE_PLASTICSURGERY
+
+	assigned_role = "Odin Pharmacist"
+	special_role = "Odin Pharmacist"
+	respawn_flag = null
+
+	mob_name = null
+
+/datum/ghostspawner/human/admin/odinchef
+	short_name = "odinchef"
+	name = "Odin Chef"
+	desc = "Feed starving crew members on the Odin."
+
+	enabled = FALSE
+	spawnpoints = list("OdinChef")
+	req_perms = null
+	max_count = 1
+
+	outfit = /datum/outfit/admin/nt/odinchef
+	possible_species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
+	allow_appearance_change = APPEARANCE_PLASTICSURGERY
+
+	assigned_role = "Odin Chef"
+	special_role = "Odin Chef"
+	respawn_flag = null
+
+	mob_name = null
+
+/datum/ghostspawner/human/admin/odinbartender
+	short_name = "odinbartender"
+	name = "Odin Bartender"
+	desc = "Ensure enough drinks are available to the crew on the Odin."
+
+	enabled = FALSE
+	spawnpoints = list("OdinBartender")
+	req_perms = null
+	max_count = 1
+
+	outfit = /datum/outfit/admin/nt/odinbartender
+	possible_species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
+	allow_appearance_change = APPEARANCE_PLASTICSURGERY
+
+	assigned_role = "Odin Bartender"
+	special_role = "Odin Bartender"
+	respawn_flag = null
+
+	mob_name = null
+
+/datum/ghostspawner/human/admin/odinjanitor
+	short_name = "odinjanitor"
+	name = "Odin Sanitation Specialist"
+	desc = "You are a expert in your field. A true authority. The crew looks to you when they get into a sticky situation. You are a janitor on the Odin."
+
+	enabled = FALSE
+	spawnpoints = list("OdinJanitor")
+	req_perms = null
+	max_count = 1
+
+	outfit = /datum/outfit/admin/nt/odinjanitor
+	possible_species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
+	allow_appearance_change = APPEARANCE_PLASTICSURGERY
+
+	assigned_role = "Sanitation Specialist"
+	special_role = "Sanitation Specialist"
+	respawn_flag = null
+
+	mob_name = null
+	mob_name_prefix = "Spec. "
+	mob_name_pick_message = "Pick a callsign or last-name."
 
 /datum/ghostspawner/human/admin/tcflsentinel
 	short_name = "tcflsentinel"

--- a/code/modules/ghostroles/spawner/human/admin.dm
+++ b/code/modules/ghostroles/spawner/human/admin.dm
@@ -305,3 +305,32 @@
 	M.ghostize(1)
 	verbs -= /client/proc/despawn
 	qdel(M)
+
+
+/hook/crew_transfer/proc/spawn_odin_staff()
+	if(get_security_level() == "green" && prob(70))
+		var/datum/ghostspawner/G = SSghostroles.get_spawner("odinchef")
+		G.enable()
+		G = SSghostroles.get_spawner("odinbartender")
+		G.enable()
+
+	if(get_security_level() == "blue")
+		var/datum/wifi/sender/door/wifi_sender = new("odin_arrivals_lockdown", SSghostroles)
+		wifi_sender.activate("close")
+		qdel(wifi_sender)
+
+		if(prob(50))
+			var/datum/ghostspawner/G = SSghostroles.get_spawner("checkpointsec")
+			G.enable()
+	return TRUE
+
+/hook/emergency_evac/proc/enable_checkpoint()
+	if(get_security_level() != "green" )
+		var/datum/wifi/sender/door/wifi_sender = new("odin_arrivals_lockdown", SSghostroles)
+		wifi_sender.activate("close")
+		qdel(wifi_sender)
+
+		if(prob(80))
+			var/datum/ghostspawner/G = SSghostroles.get_spawner("checkpointsec")
+			G.enable()
+	return TRUE

--- a/code/modules/ghostroles/spawner/human/admin.dm
+++ b/code/modules/ghostroles/spawner/human/admin.dm
@@ -307,30 +307,33 @@
 	qdel(M)
 
 
-/hook/crew_transfer/proc/spawn_odin_staff()
-	if(get_security_level() == "green" && prob(70))
-		var/datum/ghostspawner/G = SSghostroles.get_spawner("odinchef")
-		G.enable()
-		G = SSghostroles.get_spawner("odinbartender")
-		G.enable()
 
-	if(get_security_level() == "blue")
-		var/datum/wifi/sender/door/wifi_sender = new("odin_arrivals_lockdown", SSghostroles)
-		wifi_sender.activate("close")
-		qdel(wifi_sender)
+/hook/shuttle_moved/proc/setup_odin_for_shuttle(var/obj/effect/shuttle_landmark/start_location, var/obj/effect/shuttle_landmark/destination)
+	if(start_location.landmark_tag != "nav_emergency_start")
+		return TRUE
 
-		if(prob(50))
-			var/datum/ghostspawner/G = SSghostroles.get_spawner("checkpointsec")
+	if(emergency_shuttle.evac)
+		if(get_security_level() != "green" )
+			var/datum/wifi/sender/door/wifi_sender = new("odin_arrivals_lockdown", SSghostroles)
+			wifi_sender.activate("close")
+			qdel(wifi_sender)
+
+			if(prob(80))
+				var/datum/ghostspawner/G = SSghostroles.get_spawner("checkpointsec")
+				G.enable()
+		return TRUE
+	else
+		if(get_security_level() == "green" && prob(70))
+			var/datum/ghostspawner/G = SSghostroles.get_spawner("odinchef")
 			G.enable()
-	return TRUE
-
-/hook/emergency_evac/proc/enable_checkpoint()
-	if(get_security_level() != "green" )
-		var/datum/wifi/sender/door/wifi_sender = new("odin_arrivals_lockdown", SSghostroles)
-		wifi_sender.activate("close")
-		qdel(wifi_sender)
-
-		if(prob(80))
-			var/datum/ghostspawner/G = SSghostroles.get_spawner("checkpointsec")
+			G = SSghostroles.get_spawner("odinbartender")
 			G.enable()
-	return TRUE
+		if(get_security_level() == "blue")
+			var/datum/wifi/sender/door/wifi_sender = new("odin_arrivals_lockdown", SSghostroles)
+			wifi_sender.activate("close")
+			qdel(wifi_sender)
+
+			if(prob(50))
+				var/datum/ghostspawner/G = SSghostroles.get_spawner("checkpointsec")
+				G.enable()
+		return TRUE

--- a/html/changelogs/arrow768 - odinspawner.yml
+++ b/html/changelogs/arrow768 - odinspawner.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a number of ghostspawners to the odin."
+  - bugfix: "Fixed a bug that caused all NT ghostspawners roles to have complete access to everything."
+  - tweak: "Reworked the access on the Odin."
+  - rscadd: "The Odin now responds differently depending on the alert level present at transfer/evac."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -4978,18 +4978,6 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/shuttle/skipjack)
-"aHV" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/obj/effect/ghostspawpoint{
-	identifier = "OdinDoctor";
-	name = "igs - OdinDoctor"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark2"
-	},
-/area/centcom/holding)
 "aIf" = (
 /turf/simulated/wall/shuttle/unique/transfer{
 	desc = "A large, bloated shuttle designed for automated passenger transport.";
@@ -7804,15 +7792,6 @@
 	},
 /turf/space/dynamic,
 /area/shuttle/mercenary)
-"bmM" = (
-/obj/effect/ghostspawpoint{
-	identifier = "OdinJanitor";
-	name = "igs - OdinJanitor"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark2"
-	},
-/area/centcom/holding)
 "bmV" = (
 /obj/item/stool/padded,
 /obj/effect/decal/cleanable/dirt,
@@ -9037,6 +9016,22 @@
 	icon_state = "15,4"
 	},
 /area/shuttle/legion)
+"cdL" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "crescent_vip_shuttle";
+	name = "VIP Shuttle Access";
+	pixel_x = -7;
+	pixel_y = -23;
+	req_access = list(101)
+	},
+/turf/unsimulated/floor,
+/area/centcom/holding)
 "cdV" = (
 /obj/effect/decal/fake_object{
 	color = "#ff0000";
@@ -11152,6 +11147,16 @@
 	name = "transport shuttle"
 	},
 /area/shuttle/escape)
+"dvE" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/ghostspawpoint{
+	identifier = "OdinDoctor";
+	name = "igs - OdinDoctor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "new_white"
+	},
+/area/centcom/holding)
 "dvO" = (
 /obj/structure/shuttle_part/mercenary{
 	icon_state = "10,1"
@@ -11212,6 +11217,15 @@
 	},
 /turf/unsimulated/floor,
 /area/centcom/legion)
+"dze" = (
+/obj/effect/ghostspawpoint{
+	identifier = "OdinJanitor";
+	name = "igs - OdinJanitor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark2"
+	},
+/area/centcom/holding)
 "dzj" = (
 /obj/structure/shuttle_part/tcfl{
 	icon_state = "15,5"
@@ -14822,6 +14836,22 @@
 /obj/effect/floor_decal/ss13/odin4,
 /turf/unsimulated/floor,
 /area/centcom/evac)
+"fLW" = (
+/obj/structure/table/reinforced/wood,
+/obj/machinery/door/blast/odin{
+	dir = 2;
+	icon_state = "shutter1";
+	icon_state_closed = "shutter1";
+	icon_state_closing = "shutterc1";
+	icon_state_open = "shutter0";
+	icon_state_opening = "shutterc0";
+	id = "CentComBarShutters";
+	name = "Bar Shutter"
+	},
+/turf/unsimulated/floor{
+	icon_state = "lino_grey"
+	},
+/area/centcom/bar)
 "fMi" = (
 /obj/structure/shuttle_part/ccia{
 	icon_state = "6,4";
@@ -15260,15 +15290,6 @@
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/administration)
-"fWO" = (
-/obj/effect/ghostspawpoint{
-	identifier = "OdinBartender";
-	name = "igs - OdinBartender"
-	},
-/turf/unsimulated/floor{
-	icon_state = "lino_grey"
-	},
-/area/centcom/bar)
 "fXq" = (
 /turf/unsimulated/floor{
 	icon_state = "wood-broken"
@@ -16178,6 +16199,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station/warehouse)
+"gxA" = (
+/obj/machinery/door/airlock/centcom{
+	locked = 1;
+	name = "Entertainment Wing Maintenance";
+	req_one_access = list(102)
+	},
+/turf/unsimulated/floor/plating,
+/area/centcom/holding)
 "gxW" = (
 /turf/simulated/wall/shuttle/unique/tcfl{
 	icon_state = "5,6"
@@ -16685,13 +16714,6 @@
 	icon_state = "steel_dirty"
 	},
 /area/antag/raider)
-"gND" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Entertainment Wing Maintenance";
-	req_access = list(108,109)
-	},
-/turf/unsimulated/floor/plating,
-/area/centcom/spawning)
 "gNM" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
@@ -17527,6 +17549,7 @@
 /area/centcom/distress_prep)
 "hmc" = (
 /obj/machinery/door/blast/odin{
+	_wifi_id = "odin_arrivals_lockdown";
 	density = 0;
 	icon_state = "pdoor0";
 	id = "CentComArrivalsAftExt";
@@ -19970,6 +19993,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/merchant_station/warehouse)
+"iOZ" = (
+/obj/effect/ghostspawpoint{
+	identifier = "OdinChef";
+	name = "igs - OdinChef"
+	},
+/turf/unsimulated/floor{
+	icon_state = "lino_grey"
+	},
+/area/centcom/bar)
 "iPr" = (
 /obj/machinery/light{
 	dir = 4;
@@ -20722,22 +20754,6 @@
 	icon_state = "dark2"
 	},
 /area/centcom/control)
-"jvw" = (
-/obj/structure/table/reinforced/wood,
-/obj/machinery/door/blast/odin{
-	dir = 2;
-	icon_state = "shutter1";
-	icon_state_closed = "shutter1";
-	icon_state_closing = "shutterc1";
-	icon_state_open = "shutter0";
-	icon_state_opening = "shutterc0";
-	id = "CentComBarShutters";
-	name = "Bar Shutter"
-	},
-/turf/unsimulated/floor{
-	icon_state = "lino_grey"
-	},
-/area/centcom/bar)
 "jvz" = (
 /obj/machinery/vending/coffee{
 	name = "Free Hot Drinks machine";
@@ -20868,6 +20884,7 @@
 	req_access = list(19)
 	},
 /obj/machinery/door/blast/odin{
+	_wifi_id = "odin_arrivals_lockdown";
 	density = 0;
 	icon_state = "pdoor0";
 	id = "CentComArrivalsCommand";
@@ -23210,6 +23227,7 @@
 /area/centcom/ferry)
 "laL" = (
 /obj/machinery/door/blast/odin{
+	_wifi_id = "odin_arrivals_lockdown";
 	density = 0;
 	icon_state = "pdoor0";
 	id = "CentComArrivalsAftInt";
@@ -23241,6 +23259,16 @@
 	icon_state = "18,7"
 	},
 /area/shuttle/merchant)
+"lct" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/effect/ghostspawpoint{
+	identifier = "OdinDoctor";
+	name = "igs - OdinDoctor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark2"
+	},
+/area/centcom/holding)
 "ldd" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Wing";
@@ -24046,16 +24074,6 @@
 "lEa" = (
 /turf/simulated/floor/carpet,
 /area/centcom/shared_dream)
-"lEC" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/effect/ghostspawpoint{
-	identifier = "OdinDoctor";
-	name = "igs - OdinDoctor"
-	},
-/turf/unsimulated/floor{
-	icon_state = "new_white"
-	},
-/area/centcom/holding)
 "lEG" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/turretid{
@@ -27051,6 +27069,7 @@
 /area/shuttle/merchant)
 "nvO" = (
 /obj/machinery/door/blast/odin{
+	_wifi_id = "odin_arrivals_lockdown";
 	density = 0;
 	icon_state = "pdoor0";
 	id = "CentComArrivalsForeExt";
@@ -28767,6 +28786,13 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/arrival)
+"oxz" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Entertainment Wing Maintenance";
+	req_access = list(108,109)
+	},
+/turf/unsimulated/floor/plating,
+/area/centcom/spawning)
 "oyh" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -30750,16 +30776,6 @@
 	name = "transport shuttle"
 	},
 /area/shuttle/escape)
-"pLt" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/effect/ghostspawpoint{
-	identifier = "OdinDoctor";
-	name = "igs - OdinDoctor"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark2"
-	},
-/area/centcom/holding)
 "pLD" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1337;
@@ -31519,6 +31535,7 @@
 /area/shuttle/burglar)
 "qqp" = (
 /obj/machinery/door/blast/odin{
+	_wifi_id = "odin_arrivals_lockdown";
 	density = 0;
 	icon_state = "pdoor0";
 	id = "CentComArrivalsForeInt";
@@ -34053,14 +34070,6 @@
 /obj/structure/railing/mapped,
 /turf/unsimulated/floor/plating,
 /area/centcom/spawning)
-"sje" = (
-/obj/machinery/door/airlock/centcom{
-	locked = 1;
-	name = "Entertainment Wing Maintenance";
-	req_one_access = list(102)
-	},
-/turf/unsimulated/floor/plating,
-/area/centcom/holding)
 "sjG" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -35865,6 +35874,7 @@
 	req_access = list(103)
 	},
 /obj/machinery/door/blast/odin{
+	_wifi_id = "odin_arrivals_lockdown";
 	dir = 2;
 	id = "odincheckpoint_starboard";
 	name = "checkpoint"
@@ -36761,15 +36771,6 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/specops)
-"ufR" = (
-/obj/effect/ghostspawpoint{
-	identifier = "OdinChef";
-	name = "igs - OdinChef"
-	},
-/turf/unsimulated/floor{
-	icon_state = "lino_grey"
-	},
-/area/centcom/bar)
 "ugm" = (
 /obj/structure/table/wood,
 /obj/item/spacecash/c1{
@@ -37301,6 +37302,15 @@
 	icon_state = "6,0"
 	},
 /area/shuttle/legion)
+"uxp" = (
+/obj/effect/ghostspawpoint{
+	identifier = "OdinBartender";
+	name = "igs - OdinBartender"
+	},
+/turf/unsimulated/floor{
+	icon_state = "lino_grey"
+	},
+/area/centcom/bar)
 "uxs" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/fancy/donut{
@@ -38845,22 +38855,6 @@
 	icon_state = "dark2"
 	},
 /area/centcom/checkpoint/aft)
-"vCZ" = (
-/obj/effect/floor_decal/corner/grey/diagonal{
-	dir = 4
-	},
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "crescent_vip_shuttle";
-	name = "VIP Shuttle Access";
-	pixel_x = -7;
-	pixel_y = -23;
-	req_access = list(101)
-	},
-/turf/unsimulated/floor,
-/area/centcom/holding)
 "vDf" = (
 /obj/effect/landmark{
 	name = "ninjastart"
@@ -42700,6 +42694,18 @@
 /obj/structure/table/reinforced/steel,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/administration)
+"xLR" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/effect/ghostspawpoint{
+	identifier = "OdinDoctor";
+	name = "igs - OdinDoctor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark2"
+	},
+/area/centcom/holding)
 "xMf" = (
 /obj/machinery/light{
 	dir = 1;
@@ -65204,7 +65210,7 @@ qcl
 qcl
 qcl
 qcl
-vCZ
+cdL
 rcX
 qAm
 ugV
@@ -67242,9 +67248,9 @@ mJt
 kSB
 bQP
 yjE
-lEC
+dvE
 wKb
-lEC
+dvE
 xnZ
 bQP
 ddo
@@ -68551,7 +68557,7 @@ qxN
 qxN
 qxN
 qxN
-sje
+gxA
 avk
 aiz
 cqK
@@ -69297,9 +69303,9 @@ rTg
 tVM
 eBz
 vrQ
-pLt
+lct
 jGV
-aHV
+xLR
 mNl
 dxC
 bQP
@@ -69318,7 +69324,7 @@ mAD
 bLK
 lOO
 kzj
-bmM
+dze
 tql
 bQP
 qxN
@@ -69801,10 +69807,10 @@ sIC
 eBz
 fIR
 lMz
-fWO
+uxp
 lMz
 lMz
-jvw
+fLW
 hWU
 vpg
 pxm
@@ -72674,7 +72680,7 @@ tRw
 tRw
 tRw
 tRw
-gND
+oxz
 aJH
 nfY
 aaM
@@ -72881,7 +72887,7 @@ apU
 eBz
 evC
 lMz
-ufR
+iOZ
 lMz
 lMz
 lMz
@@ -73652,7 +73658,7 @@ apU
 avR
 eBh
 lMz
-ufR
+iOZ
 lMz
 lMz
 lMz

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -3880,7 +3880,8 @@
 /obj/machinery/door/airlock/glass_centcom{
 	icon = 'icons/obj/doors/Doorglass.dmi';
 	name = "To: Lower Shuttle Terminal";
-	req_access = list(109)
+	req_access = null;
+	req_one_access = list(108,109)
 	},
 /turf/unsimulated/floor,
 /area/centcom/spawning)
@@ -4977,6 +4978,18 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/shuttle/skipjack)
+"aHV" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/effect/ghostspawpoint{
+	identifier = "OdinDoctor";
+	name = "igs - OdinDoctor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark2"
+	},
+/area/centcom/holding)
 "aIf" = (
 /turf/simulated/wall/shuttle/unique/transfer{
 	desc = "A large, bloated shuttle designed for automated passenger transport.";
@@ -6539,7 +6552,7 @@
 "aSf" = (
 /obj/machinery/door/airlock/centcom{
 	name = "The Big Empty";
-	req_access = list(109)
+	req_access = list(103)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -7410,6 +7423,13 @@
 	pixel_x = -12;
 	pixel_y = 5
 	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "CentComBarShutters";
+	name = "Bar Shutters";
+	pixel_x = -24;
+	req_access = list(105)
+	},
 /turf/unsimulated/floor{
 	icon_state = "lino_grey"
 	},
@@ -7784,6 +7804,15 @@
 	},
 /turf/space/dynamic,
 /area/shuttle/mercenary)
+"bmM" = (
+/obj/effect/ghostspawpoint{
+	identifier = "OdinJanitor";
+	name = "igs - OdinJanitor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark2"
+	},
+/area/centcom/holding)
 "bmV" = (
 /obj/item/stool/padded,
 /obj/effect/decal/cleanable/dirt,
@@ -7813,7 +7842,8 @@
 	dir = 4;
 	id = "CentComKitchenShutters";
 	name = "Kitchen Shutters";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list(105)
 	},
 /obj/structure/table/stone/marble,
 /obj/machinery/chemical_dispenser/bar_soft/full{
@@ -9578,7 +9608,7 @@
 	name = "starboard blast door";
 	pixel_x = 23;
 	pixel_y = -22;
-	req_access = null
+	req_access = list(103)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -9727,7 +9757,8 @@
 	dir = 8;
 	id = "CentComArrivalsForeChkpt";
 	name = "Fore Checkpoint Blast Doors";
-	pixel_x = -23
+	pixel_x = -23;
+	req_access = list(103)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -10104,7 +10135,7 @@
 /obj/machinery/door/window/southright{
 	dir = 8;
 	name = "Escort Post";
-	req_access = list(101)
+	req_access = list(109)
 	},
 /obj/effect/floor_decal/corner/grey{
 	dir = 9
@@ -12809,7 +12840,7 @@
 "ezv" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Telecommunications Monitoring";
-	req_access = list(106)
+	req_access = list(107)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -14976,7 +15007,7 @@
 "fRm" = (
 /obj/machinery/door/airlock/glass_centcom{
 	name = "Valkyrie's Rest Kitchen";
-	req_access = list(101)
+	req_access = list(105)
 	},
 /turf/unsimulated/floor{
 	icon_state = "lino_grey"
@@ -15229,6 +15260,15 @@
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/administration)
+"fWO" = (
+/obj/effect/ghostspawpoint{
+	identifier = "OdinBartender";
+	name = "igs - OdinBartender"
+	},
+/turf/unsimulated/floor{
+	icon_state = "lino_grey"
+	},
+/area/centcom/bar)
 "fXq" = (
 /turf/unsimulated/floor{
 	icon_state = "wood-broken"
@@ -16156,7 +16196,7 @@
 	opacity = 0
 	},
 /obj/machinery/door/window/brigdoor/northright{
-	req_access = list(109)
+	req_access = list(103)
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/blast_door{
@@ -16165,7 +16205,7 @@
 	name = "inner blast door";
 	pixel_x = -24;
 	pixel_y = -3;
-	req_access = list(109)
+	req_access = list(103)
 	},
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -16173,7 +16213,7 @@
 	name = "outer blast door";
 	pixel_x = 27;
 	pixel_y = -3;
-	req_access = list(109)
+	req_access = list(103)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/centcom/spawning)
@@ -16645,6 +16685,13 @@
 	icon_state = "steel_dirty"
 	},
 /area/antag/raider)
+"gND" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Entertainment Wing Maintenance";
+	req_access = list(108,109)
+	},
+/turf/unsimulated/floor/plating,
+/area/centcom/spawning)
 "gNM" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
@@ -17924,7 +17971,7 @@
 "hDo" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Security Checkpoint";
-	req_access = list(109)
+	req_access = list(103)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -18827,7 +18874,7 @@
 	name = "Command Blast Doors";
 	pixel_x = -9;
 	pixel_y = 10;
-	req_access = list(101)
+	req_access = list(103)
 	},
 /turf/unsimulated/wall/darkshuttlewall,
 /area/centcom/bar)
@@ -19276,7 +19323,9 @@
 /turf/unsimulated/floor,
 /area/centcom/legion/hangar5)
 "ivI" = (
-/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/southleft{
+	req_access = list(105)
+	},
 /turf/unsimulated/floor{
 	icon_state = "lino_grey"
 	},
@@ -19647,7 +19696,8 @@
 	id = "CentComArrivalsForeInt";
 	name = "Interior Checkpoint";
 	pixel_x = -6;
-	pixel_y = -1
+	pixel_y = -1;
+	req_access = list(103)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -20120,7 +20170,7 @@
 /obj/machinery/door/window/northright{
 	health = 2000;
 	maxhealth = 2000;
-	req_access = list(109)
+	req_access = list(101)
 	},
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -20672,6 +20722,22 @@
 	icon_state = "dark2"
 	},
 /area/centcom/control)
+"jvw" = (
+/obj/structure/table/reinforced/wood,
+/obj/machinery/door/blast/odin{
+	dir = 2;
+	icon_state = "shutter1";
+	icon_state_closed = "shutter1";
+	icon_state_closing = "shutterc1";
+	icon_state_open = "shutter0";
+	icon_state_opening = "shutterc0";
+	id = "CentComBarShutters";
+	name = "Bar Shutter"
+	},
+/turf/unsimulated/floor{
+	icon_state = "lino_grey"
+	},
+/area/centcom/bar)
 "jvz" = (
 /obj/machinery/vending/coffee{
 	name = "Free Hot Drinks machine";
@@ -22284,7 +22350,8 @@
 	id = "CentComArrivalsForeExt";
 	name = "Exterior Checkpoint";
 	pixel_x = 6;
-	pixel_y = -1
+	pixel_y = -1;
+	req_access = list(103)
 	},
 /obj/machinery/turretid{
 	ailock = 1;
@@ -22414,7 +22481,7 @@
 	name = "checkpoint shutters";
 	pixel_x = 25;
 	pixel_y = 8;
-	req_access = list(109)
+	req_access = list(103)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -22873,7 +22940,8 @@
 	id = "CentComArrivalsAftExt";
 	name = "Exterior Checkpoint";
 	pixel_x = 6;
-	pixel_y = 5
+	pixel_y = 5;
+	req_access = list(103)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -23360,7 +23428,7 @@
 "liD" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Port Checkpoint Door";
-	req_access = list(101)
+	req_access = list(103)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -23978,6 +24046,16 @@
 "lEa" = (
 /turf/simulated/floor/carpet,
 /area/centcom/shared_dream)
+"lEC" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/ghostspawpoint{
+	identifier = "OdinDoctor";
+	name = "igs - OdinDoctor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "new_white"
+	},
+/area/centcom/holding)
 "lEG" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/turretid{
@@ -26524,7 +26602,8 @@
 	dir = 4
 	},
 /obj/machinery/door/window/eastright{
-	name = "desk access"
+	name = "desk access";
+	req_access = list(109)
 	},
 /obj/machinery/light{
 	icon_state = "tube1"
@@ -27201,7 +27280,7 @@
 "nDp" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Civil Protection Station";
-	req_access = list(101)
+	req_access = list(103)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -27335,7 +27414,7 @@
 	check_records = 0;
 	pixel_x = -28;
 	pixel_y = 9;
-	req_access = list(101)
+	req_access = list(108)
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -28165,6 +28244,16 @@
 	c_tag = "Crescent Bar Center";
 	pixel_x = 20
 	},
+/obj/machinery/door/blast/odin{
+	dir = 4;
+	icon_state = "shutter1";
+	icon_state_closed = "shutter1";
+	icon_state_closing = "shutterc1";
+	icon_state_open = "shutter0";
+	icon_state_opening = "shutterc0";
+	id = "CentComBarShutters";
+	name = "Bar Shutter"
+	},
 /turf/unsimulated/floor{
 	icon_state = "lino_grey"
 	},
@@ -28334,6 +28423,12 @@
 	dir = 4;
 	id = "commander_aft";
 	name = "Commander's Office"
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "commander_aft";
+	name = "aft blast door";
+	pixel_x = 22;
+	req_access = list(108)
 	},
 /turf/unsimulated/floor{
 	dir = 1;
@@ -28574,7 +28669,8 @@
 /obj/machinery/door/airlock/glass_centcom{
 	icon = 'icons/obj/doors/Doorglass.dmi';
 	name = "To: Lower Shuttle Terminal";
-	req_access = list(109)
+	req_access = null;
+	req_one_access = list(108,109)
 	},
 /turf/unsimulated/floor,
 /area/centcom/spawning)
@@ -30654,6 +30750,16 @@
 	name = "transport shuttle"
 	},
 /area/shuttle/escape)
+"pLt" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/effect/ghostspawpoint{
+	identifier = "OdinDoctor";
+	name = "igs - OdinDoctor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark2"
+	},
+/area/centcom/holding)
 "pLD" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1337;
@@ -32655,6 +32761,16 @@
 /area/centcom/control)
 "rky" = (
 /obj/structure/table/reinforced/wood,
+/obj/machinery/door/blast/odin{
+	dir = 4;
+	icon_state = "shutter1";
+	icon_state_closed = "shutter1";
+	icon_state_closing = "shutterc1";
+	icon_state_open = "shutter0";
+	icon_state_opening = "shutterc0";
+	id = "CentComBarShutters";
+	name = "Bar Shutter"
+	},
 /turf/unsimulated/floor{
 	icon_state = "lino_grey"
 	},
@@ -33824,7 +33940,7 @@
 /obj/machinery/door/window/northleft{
 	health = 2000;
 	maxhealth = 2000;
-	req_access = list(109)
+	req_access = list(101)
 	},
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -33937,6 +34053,14 @@
 /obj/structure/railing/mapped,
 /turf/unsimulated/floor/plating,
 /area/centcom/spawning)
+"sje" = (
+/obj/machinery/door/airlock/centcom{
+	locked = 1;
+	name = "Entertainment Wing Maintenance";
+	req_one_access = list(102)
+	},
+/turf/unsimulated/floor/plating,
+/area/centcom/holding)
 "sjG" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -33969,7 +34093,9 @@
 	dir = 5
 	},
 /obj/item/folder/blue,
-/obj/machinery/door/window/northleft,
+/obj/machinery/door/window/northleft{
+	req_access = list(109)
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
 	},
@@ -34481,19 +34607,6 @@
 	icon_state = "floor"
 	},
 /area/centcom/legion)
-"sBW" = (
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/machinery/button/remote/blast_door{
-	id = "commander_aft";
-	name = "aft blast door";
-	pixel_x = 23;
-	pixel_y = -22;
-	req_access = list(108)
-	},
-/turf/unsimulated/floor{
-	icon_state = "wood"
-	},
-/area/centcom/specops)
 "sCz" = (
 /obj/structure/shuttle_part/mercenary{
 	icon_state = "11,20"
@@ -34785,7 +34898,8 @@
 /area/centcom/bar)
 "sNE" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Personnel Files"
+	name = "Personnel Files";
+	req_access = list(109)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -35083,7 +35197,8 @@
 	dir = 8;
 	id = "CentComArrivalsAftChkpt";
 	name = "Aft Checkpoint Blast Doors";
-	pixel_x = -23
+	pixel_x = -23;
+	req_access = list(103)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -35458,6 +35573,10 @@
 /area/shuttle/legion)
 "tql" = (
 /obj/machinery/light/small,
+/obj/structure/table/rack,
+/obj/item/gun/launcher/grenade{
+	name = "active cleaning utility dispenser"
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
 	},
@@ -35743,7 +35862,7 @@
 "tyu" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Starboard Checkpoint Door";
-	req_access = list(101)
+	req_access = list(103)
 	},
 /obj/machinery/door/blast/odin{
 	dir = 2;
@@ -35874,7 +35993,7 @@
 "tDo" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Emergency Surgery";
-	req_access = list(5)
+	req_one_access = list(104)
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/unsimulated/floor{
@@ -36642,6 +36761,15 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/specops)
+"ufR" = (
+/obj/effect/ghostspawpoint{
+	identifier = "OdinChef";
+	name = "igs - OdinChef"
+	},
+/turf/unsimulated/floor{
+	icon_state = "lino_grey"
+	},
+/area/centcom/bar)
 "ugm" = (
 /obj/structure/table/wood,
 /obj/item/spacecash/c1{
@@ -37163,9 +37291,8 @@
 /area/centcom/control)
 "uxc" = (
 /obj/machinery/door/airlock/centcom{
-	locked = 1;
 	name = "Entertainment Wing Maintenance";
-	req_access = list(106)
+	req_one_access = list(102,106)
 	},
 /turf/unsimulated/floor/plating,
 /area/centcom/holding)
@@ -38704,19 +38831,36 @@
 	id = "CentComArrivalsAftInt";
 	name = "Interior Checkpoint";
 	pixel_x = -6;
-	pixel_y = 5
+	pixel_y = 5;
+	req_access = list(103)
 	},
 /obj/machinery/turretid{
 	ailock = 1;
 	check_arrest = 0;
 	check_records = 0;
 	pixel_x = -31;
-	req_access = list(101)
+	req_access = list(103)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
 	},
 /area/centcom/checkpoint/aft)
+"vCZ" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "crescent_vip_shuttle";
+	name = "VIP Shuttle Access";
+	pixel_x = -7;
+	pixel_y = -23;
+	req_access = list(101)
+	},
+/turf/unsimulated/floor,
+/area/centcom/holding)
 "vDf" = (
 /obj/effect/landmark{
 	name = "ninjastart"
@@ -38772,9 +38916,13 @@
 "vFX" = (
 /obj/machinery/door/window/northright{
 	name = "dispensary";
-	req_access = list(5)
+	req_access = list(104)
 	},
 /obj/effect/floor_decal/corner/orange/diagonal,
+/obj/effect/ghostspawpoint{
+	identifier = "OdinPharm";
+	name = "igs - OdinPharmacist"
+	},
 /turf/unsimulated/floor{
 	icon_state = "new_white"
 	},
@@ -39370,7 +39518,9 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
-/obj/machinery/door/window/northright,
+/obj/machinery/door/window/northright{
+	req_access = list(109)
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
 	},
@@ -40530,7 +40680,8 @@
 /obj/machinery/door/airlock/glass_centcom{
 	icon = 'icons/obj/doors/Doorglass.dmi';
 	name = "To: Upper Shuttle Terminal";
-	req_access = list(109)
+	req_access = null;
+	req_one_access = list(108,109)
 	},
 /turf/unsimulated/floor,
 /area/centcom/spawning)
@@ -42174,7 +42325,6 @@
 /area/centcom/specops)
 "xyx" = (
 /obj/machinery/door/airlock/centcom{
-	locked = 1;
 	name = "Arrival Hangar Maintenance";
 	req_access = list(106)
 	},
@@ -42559,13 +42709,6 @@
 	icon_state = "dark2"
 	},
 /area/centcom/specops)
-"xMh" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Arrival Hangar Maintenance";
-	req_access = list(101)
-	},
-/turf/unsimulated/floor/plating,
-/area/centcom/evac)
 "xMn" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/fire{
@@ -43117,6 +43260,16 @@
 /obj/structure/window/reinforced/crescent{
 	dir = 8
 	},
+/obj/machinery/door/blast/odin{
+	dir = 2;
+	icon_state = "shutter1";
+	icon_state_closed = "shutter1";
+	icon_state_closing = "shutterc1";
+	icon_state_open = "shutter0";
+	icon_state_opening = "shutterc0";
+	id = "CentComBarShutters";
+	name = "Bar Shutter"
+	},
 /turf/unsimulated/floor{
 	icon_state = "lino_grey"
 	},
@@ -43285,7 +43438,8 @@
 "ylt" = (
 /obj/machinery/door/airlock/glass_centcom{
 	name = "Sector Administration Copula";
-	req_access = list(109)
+	req_access = null;
+	req_one_access = list(109,108)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark2"
@@ -64007,7 +64161,7 @@ jTO
 nlQ
 nGs
 vjQ
-sBW
+ocD
 oik
 vjQ
 oCD
@@ -65050,7 +65204,7 @@ qcl
 qcl
 qcl
 qcl
-qxH
+vCZ
 rcX
 qAm
 ugV
@@ -67088,9 +67242,9 @@ mJt
 kSB
 bQP
 yjE
-tRr
+lEC
 wKb
-tRr
+lEC
 xnZ
 bQP
 ddo
@@ -68397,7 +68551,7 @@ qxN
 qxN
 qxN
 qxN
-bQP
+sje
 avk
 aiz
 cqK
@@ -69143,9 +69297,9 @@ rTg
 tVM
 eBz
 vrQ
-mNl
+pLt
 jGV
-mDt
+aHV
 mNl
 dxC
 bQP
@@ -69164,7 +69318,7 @@ mAD
 bLK
 lOO
 kzj
-kYq
+bmM
 tql
 bQP
 qxN
@@ -69647,10 +69801,10 @@ sIC
 eBz
 fIR
 lMz
+fWO
 lMz
 lMz
-lMz
-rky
+jvw
 hWU
 vpg
 pxm
@@ -72520,7 +72674,7 @@ tRw
 tRw
 tRw
 tRw
-gYa
+gND
 aJH
 nfY
 aaM
@@ -72727,7 +72881,7 @@ apU
 eBz
 evC
 lMz
-lMz
+ufR
 lMz
 lMz
 lMz
@@ -73498,7 +73652,7 @@ apU
 avR
 eBh
 lMz
-lMz
+ufR
 lMz
 lMz
 lMz
@@ -74812,7 +74966,7 @@ ddK
 xFd
 xbK
 rFJ
-xMh
+rYv
 aJH
 cHx
 aJH

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -4978,6 +4978,18 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/shuttle/skipjack)
+"aHV" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/effect/ghostspawpoint{
+	identifier = "OdinDoctor";
+	name = "igs - OdinDoctor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark2"
+	},
+/area/centcom/holding)
 "aIf" = (
 /turf/simulated/wall/shuttle/unique/transfer{
 	desc = "A large, bloated shuttle designed for automated passenger transport.";
@@ -7712,7 +7724,9 @@
 	},
 /area/centcom/legion/hangar5)
 "bkg" = (
-/obj/machinery/appliance/cooker/stove,
+/obj/machinery/appliance/cooker/stove{
+	stat = 0
+	},
 /turf/unsimulated/floor{
 	icon_state = "lino_grey"
 	},
@@ -7792,6 +7806,15 @@
 	},
 /turf/space/dynamic,
 /area/shuttle/mercenary)
+"bmM" = (
+/obj/effect/ghostspawpoint{
+	identifier = "OdinJanitor";
+	name = "igs - OdinJanitor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark2"
+	},
+/area/centcom/holding)
 "bmV" = (
 /obj/item/stool/padded,
 /obj/effect/decal/cleanable/dirt,
@@ -8276,7 +8299,9 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape)
 "bDu" = (
-/obj/machinery/appliance/cooker/fryer,
+/obj/machinery/appliance/cooker/fryer{
+	stat = 0
+	},
 /turf/unsimulated/floor{
 	icon_state = "lino_grey"
 	},
@@ -9016,22 +9041,6 @@
 	icon_state = "15,4"
 	},
 /area/shuttle/legion)
-"cdL" = (
-/obj/effect/floor_decal/corner/grey/diagonal{
-	dir = 4
-	},
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "crescent_vip_shuttle";
-	name = "VIP Shuttle Access";
-	pixel_x = -7;
-	pixel_y = -23;
-	req_access = list(101)
-	},
-/turf/unsimulated/floor,
-/area/centcom/holding)
 "cdV" = (
 /obj/effect/decal/fake_object{
 	color = "#ff0000";
@@ -9236,7 +9245,9 @@
 /turf/unsimulated/floor/plating,
 /area/antag/mercenary)
 "clb" = (
-/obj/machinery/appliance/cooker/oven,
+/obj/machinery/appliance/cooker/oven{
+	stat = 0
+	},
 /turf/unsimulated/floor{
 	icon_state = "lino_grey"
 	},
@@ -11147,16 +11158,6 @@
 	name = "transport shuttle"
 	},
 /area/shuttle/escape)
-"dvE" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/effect/ghostspawpoint{
-	identifier = "OdinDoctor";
-	name = "igs - OdinDoctor"
-	},
-/turf/unsimulated/floor{
-	icon_state = "new_white"
-	},
-/area/centcom/holding)
 "dvO" = (
 /obj/structure/shuttle_part/mercenary{
 	icon_state = "10,1"
@@ -11217,15 +11218,6 @@
 	},
 /turf/unsimulated/floor,
 /area/centcom/legion)
-"dze" = (
-/obj/effect/ghostspawpoint{
-	identifier = "OdinJanitor";
-	name = "igs - OdinJanitor"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark2"
-	},
-/area/centcom/holding)
 "dzj" = (
 /obj/structure/shuttle_part/tcfl{
 	icon_state = "15,5"
@@ -14836,22 +14828,6 @@
 /obj/effect/floor_decal/ss13/odin4,
 /turf/unsimulated/floor,
 /area/centcom/evac)
-"fLW" = (
-/obj/structure/table/reinforced/wood,
-/obj/machinery/door/blast/odin{
-	dir = 2;
-	icon_state = "shutter1";
-	icon_state_closed = "shutter1";
-	icon_state_closing = "shutterc1";
-	icon_state_open = "shutter0";
-	icon_state_opening = "shutterc0";
-	id = "CentComBarShutters";
-	name = "Bar Shutter"
-	},
-/turf/unsimulated/floor{
-	icon_state = "lino_grey"
-	},
-/area/centcom/bar)
 "fMi" = (
 /obj/structure/shuttle_part/ccia{
 	icon_state = "6,4";
@@ -15290,6 +15266,15 @@
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/administration)
+"fWO" = (
+/obj/effect/ghostspawpoint{
+	identifier = "OdinBartender";
+	name = "igs - OdinBartender"
+	},
+/turf/unsimulated/floor{
+	icon_state = "lino_grey"
+	},
+/area/centcom/bar)
 "fXq" = (
 /turf/unsimulated/floor{
 	icon_state = "wood-broken"
@@ -16199,14 +16184,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station/warehouse)
-"gxA" = (
-/obj/machinery/door/airlock/centcom{
-	locked = 1;
-	name = "Entertainment Wing Maintenance";
-	req_one_access = list(102)
-	},
-/turf/unsimulated/floor/plating,
-/area/centcom/holding)
 "gxW" = (
 /turf/simulated/wall/shuttle/unique/tcfl{
 	icon_state = "5,6"
@@ -16714,6 +16691,13 @@
 	icon_state = "steel_dirty"
 	},
 /area/antag/raider)
+"gND" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Entertainment Wing Maintenance";
+	req_access = list(108,109)
+	},
+/turf/unsimulated/floor/plating,
+/area/centcom/spawning)
 "gNM" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
@@ -19993,15 +19977,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/merchant_station/warehouse)
-"iOZ" = (
-/obj/effect/ghostspawpoint{
-	identifier = "OdinChef";
-	name = "igs - OdinChef"
-	},
-/turf/unsimulated/floor{
-	icon_state = "lino_grey"
-	},
-/area/centcom/bar)
 "iPr" = (
 /obj/machinery/light{
 	dir = 4;
@@ -20754,6 +20729,22 @@
 	icon_state = "dark2"
 	},
 /area/centcom/control)
+"jvw" = (
+/obj/structure/table/reinforced/wood,
+/obj/machinery/door/blast/odin{
+	dir = 2;
+	icon_state = "shutter1";
+	icon_state_closed = "shutter1";
+	icon_state_closing = "shutterc1";
+	icon_state_open = "shutter0";
+	icon_state_opening = "shutterc0";
+	id = "CentComBarShutters";
+	name = "Bar Shutter"
+	},
+/turf/unsimulated/floor{
+	icon_state = "lino_grey"
+	},
+/area/centcom/bar)
 "jvz" = (
 /obj/machinery/vending/coffee{
 	name = "Free Hot Drinks machine";
@@ -23259,16 +23250,6 @@
 	icon_state = "18,7"
 	},
 /area/shuttle/merchant)
-"lct" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/effect/ghostspawpoint{
-	identifier = "OdinDoctor";
-	name = "igs - OdinDoctor"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark2"
-	},
-/area/centcom/holding)
 "ldd" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Wing";
@@ -24074,6 +24055,16 @@
 "lEa" = (
 /turf/simulated/floor/carpet,
 /area/centcom/shared_dream)
+"lEC" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/ghostspawpoint{
+	identifier = "OdinDoctor";
+	name = "igs - OdinDoctor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "new_white"
+	},
+/area/centcom/holding)
 "lEG" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/turretid{
@@ -28786,13 +28777,6 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/arrival)
-"oxz" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Entertainment Wing Maintenance";
-	req_access = list(108,109)
-	},
-/turf/unsimulated/floor/plating,
-/area/centcom/spawning)
 "oyh" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -30776,6 +30760,16 @@
 	name = "transport shuttle"
 	},
 /area/shuttle/escape)
+"pLt" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/effect/ghostspawpoint{
+	identifier = "OdinDoctor";
+	name = "igs - OdinDoctor"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark2"
+	},
+/area/centcom/holding)
 "pLD" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1337;
@@ -34070,6 +34064,14 @@
 /obj/structure/railing/mapped,
 /turf/unsimulated/floor/plating,
 /area/centcom/spawning)
+"sje" = (
+/obj/machinery/door/airlock/centcom{
+	locked = 1;
+	name = "Entertainment Wing Maintenance";
+	req_one_access = list(102)
+	},
+/turf/unsimulated/floor/plating,
+/area/centcom/holding)
 "sjG" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -36771,6 +36773,15 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/specops)
+"ufR" = (
+/obj/effect/ghostspawpoint{
+	identifier = "OdinChef";
+	name = "igs - OdinChef"
+	},
+/turf/unsimulated/floor{
+	icon_state = "lino_grey"
+	},
+/area/centcom/bar)
 "ugm" = (
 /obj/structure/table/wood,
 /obj/item/spacecash/c1{
@@ -37302,15 +37313,6 @@
 	icon_state = "6,0"
 	},
 /area/shuttle/legion)
-"uxp" = (
-/obj/effect/ghostspawpoint{
-	identifier = "OdinBartender";
-	name = "igs - OdinBartender"
-	},
-/turf/unsimulated/floor{
-	icon_state = "lino_grey"
-	},
-/area/centcom/bar)
 "uxs" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/fancy/donut{
@@ -38855,6 +38857,22 @@
 	icon_state = "dark2"
 	},
 /area/centcom/checkpoint/aft)
+"vCZ" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "crescent_vip_shuttle";
+	name = "VIP Shuttle Access";
+	pixel_x = -7;
+	pixel_y = -23;
+	req_access = list(101)
+	},
+/turf/unsimulated/floor,
+/area/centcom/holding)
 "vDf" = (
 /obj/effect/landmark{
 	name = "ninjastart"
@@ -42694,18 +42712,6 @@
 /obj/structure/table/reinforced/steel,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/administration)
-"xLR" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/obj/effect/ghostspawpoint{
-	identifier = "OdinDoctor";
-	name = "igs - OdinDoctor"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark2"
-	},
-/area/centcom/holding)
 "xMf" = (
 /obj/machinery/light{
 	dir = 1;
@@ -65210,7 +65216,7 @@ qcl
 qcl
 qcl
 qcl
-cdL
+vCZ
 rcX
 qAm
 ugV
@@ -67248,9 +67254,9 @@ mJt
 kSB
 bQP
 yjE
-dvE
+lEC
 wKb
-dvE
+lEC
 xnZ
 bQP
 ddo
@@ -68557,7 +68563,7 @@ qxN
 qxN
 qxN
 qxN
-gxA
+sje
 avk
 aiz
 cqK
@@ -69303,9 +69309,9 @@ rTg
 tVM
 eBz
 vrQ
-lct
+pLt
 jGV
-xLR
+aHV
 mNl
 dxC
 bQP
@@ -69324,7 +69330,7 @@ mAD
 bLK
 lOO
 kzj
-dze
+bmM
 tql
 bQP
 qxN
@@ -69807,10 +69813,10 @@ sIC
 eBz
 fIR
 lMz
-uxp
+fWO
 lMz
 lMz
-fLW
+jvw
 hWU
 vpg
 pxm
@@ -72680,7 +72686,7 @@ tRw
 tRw
 tRw
 tRw
-oxz
+gND
 aJH
 nfY
 aaM
@@ -72887,7 +72893,7 @@ apU
 eBz
 evC
 lMz
-iOZ
+ufR
 lMz
 lMz
 lMz
@@ -73658,7 +73664,7 @@ apU
 avR
 eBh
 lMz
-iOZ
+ufR
 lMz
 lMz
 lMz


### PR DESCRIPTION
* Overhauls Odin Access according to the existing access levels
* Overhauls the get_centcom_access proc
* Fixes nt ghost roles having complete access to everything (instead of just the station)
* Updates get_centcom_access with actually used roles
* Updates jobs in get_all_centcom_jobs
* Adds a bartender / chef job to the odin
* Adds a janitor job to the odin
* Adds a medical doctor / pharmacist job to the odin
* Add a chance that the odin chef / bartender role is enabled upon crew transfer
* Locks down the odin and spawns in the checkpoint security if a crew transfer / emergency shuttle is called under certain conditions