### PR TITLE
Fixes a missing include

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1619,6 +1619,7 @@
 #include "code\modules\ghostroles\spawner\human\responseteams\tcfl.dm"
 #include "code\modules\ghostroles\spawner\simplemob\maintdrone.dm"
 #include "code\modules\ghostroles\spawner\simplemob\rat.dm"
+#include "code\modules\ghostroles\spawner\simplemob\simplemob.dm"
 #include "code\modules\ghostroles\spawner\simplemob\spider_queen.dm"
 #include "code\modules\ghostroles\spawnpoint\spawnpoint.dm"
 #include "code\modules\ghosttrap\trap.dm"


### PR DESCRIPTION
As it sais on the tin. Fixes a missing include of the simplemob.dm of the ghostspawners