### PR TITLE
Force Away Mission Verb

### DIFF
--- a/code/controllers/subsystems/initialization/map_finalization.dm
+++ b/code/controllers/subsystems/initialization/map_finalization.dm
@@ -94,14 +94,15 @@
 	log_ss("map_finalization", "Loaded ruin config.")
 
 	//Check if we have a enforced mission we should try to load.
-	if(SSpersist_config.forced_awaymission in mission_list)
-		selected_mission = mission_list[SSpersist_config.forced_awaymission]
-		log_ss("map_finalization", "Selected enforced away mission.")
-		admin_notice(SPAN_DANGER("Selected enforced away mission."), R_DEBUG)
-		return
-	else
-		log_ss("map_finalization", "Failed to selected enforced away mission. Fallback to weighted selection.")
-		admin_notice(SPAN_DANGER("Failed to selected enforced away mission. Fallback to weighted selection."), R_DEBUG)
+	if(SSpersist_config.forced_awaymission)
+		if(SSpersist_config.forced_awaymission in mission_list)
+			selected_mission = mission_list[SSpersist_config.forced_awaymission]
+			log_ss("map_finalization", "Selected enforced away mission.")
+			admin_notice(SPAN_DANGER("Selected enforced away mission."), R_DEBUG)
+			return
+		else
+			log_ss("map_finalization", "Failed to selected enforced away mission. Fallback to weighted selection.")
+			admin_notice(SPAN_DANGER("Failed to selected enforced away mission. Fallback to weighted selection."), R_DEBUG)
 
 	var/mission_name = pickweight(weighted_mission_list)
 	selected_mission = mission_list[mission_name]

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -98,7 +98,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/wipe_ai,	// allow admins to force-wipe AIs
 	/client/proc/fix_player_list,
 	/client/proc/reset_openturf,
-	/client/proc/toggle_aooc
+	/client/proc/toggle_aooc,
+	/client/proc/force_away_mission
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -176,7 +177,8 @@ var/list/admin_verbs_server = list(
 	/client/proc/cmd_ss_panic,
 	/client/proc/configure_access_control,
 	/datum/admins/proc/togglehubvisibility, //toggles visibility on the BYOND Hub
-	/client/proc/dump_memory_usage
+	/client/proc/dump_memory_usage,
+	/client/proc/force_away_mission
 	)
 var/list/admin_verbs_debug = list(
 	/client/proc/getruntimelog,                     // allows us to access runtime logs to somebody,
@@ -401,7 +403,8 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/print_logout_report,
 	/client/proc/edit_admin_permissions,
 	/proc/possess,
-	/proc/release
+	/proc/release,
+	/client/proc/force_away_mission
 	)
 var/list/admin_verbs_mod = list(
 	/client/proc/cmd_admin_pm_context,	// right-click adminPM interface,
@@ -1320,3 +1323,20 @@ var/list/admin_verbs_cciaa = list(
 		to_chat(usr, SPAN_WARNING("File creation failed. Please check to see if the data/logs/memory folder actually exists."))
 	else
 		to_chat(usr, SPAN_NOTICE("Memory dump completed."))
+
+
+/client/proc/force_away_mission()
+	set category = "Server"
+	set name = "Force Away Mission"
+	set desc = "Force a specific away mission to occur."
+
+	if (!check_rights(R_SERVER))
+		return
+
+	var/mission_name = input("Enter Mission Name or press cancel to Reset","Mission Name") as null|text
+	SSpersist_config.forced_awaymission = mission_name
+
+	if(!mission_name)
+		log_and_message_admins("reset the forced away mission.")
+	else
+		log_and_message_admins("forced the following away mission: [mission_name].")


### PR DESCRIPTION
Adds a admin verb to force a specific away mission.
(So there is no need to dig around the the SSpersist_config controller)

Bugfix because that really should have been there in the first place.