### PR TITLE
Z-Move Fix

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -35,9 +35,6 @@
 	if (eyeobj)
 		return eyeobj.zMove(direction)
 
-	if(istype(src.loc,/obj/machinery/cryopod)||istype(src.loc,/obj/machinery/recharge_station))
-		return FALSE
-
 	// Check if we can actually travel a Z-level.
 	if (!can_ztravel(direction))
 		to_chat(src, SPAN_WARNING("You lack means of travel in that direction."))

--- a/code/modules/multiz/zmimic/mimic_common.dm
+++ b/code/modules/multiz/zmimic/mimic_common.dm
@@ -12,7 +12,8 @@
  * @return	TRUE if A can pass in the movement direction, FALSE if not.
  */
 /turf/proc/CanZPass(atom/A, direction)
-	if(z == A.z) //moving FROM this turf
+	var/turf/T = get_turf(A)
+	if(z == T.z) //moving FROM this turf
 		return direction == UP //can't go below
 	else
 		if(direction == UP) //on a turf below, trying to enter

--- a/html/changelogs/geeves-z_move_fix.yml
+++ b/html/changelogs/geeves-z_move_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Being inside something will no longer allow you to teleport through floors by attempting to move up or down a level."


### PR DESCRIPTION
* Being inside something will no longer allow you to teleport through floors by attempting to move up or down a level.

Fixes https://github.com/Aurorastation/Aurora.3/issues/10233