### PR TITLE
Diona Name Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/diona_gestalt.dm
+++ b/code/modules/mob/living/carbon/human/diona_gestalt.dm
@@ -24,7 +24,7 @@
 	//These initial nymphs are the nymph which grows into a gestalt, and any others it had inside it
 	//There are no initial nymphs for a newly spawned diona player
 
-		if (mind && mind.name && name && mind.name != name)
+		if (mind?.name && mind.name != real_name)
 			verbs += /mob/living/carbon/human/proc/gestalt_set_name
 			var/datum/language/L = locate(/datum/language/diona) in languages
 			var/newname

--- a/html/changelogs/geeves-diona_name_fix.yml
+++ b/html/changelogs/geeves-diona_name_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Diona that spawn from cryo no longer have randomized names."


### PR DESCRIPTION
* Diona that spawn from cryo no longer have randomized names.

Fixes https://github.com/Aurorastation/Aurora.3/issues/10232