### PR TITLE
VueUI Vending Machines: Once more, with performance

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -121,6 +121,16 @@
 	vending_sound = 'sound/machines/vending/vending_cans.ogg'
 	light_color = COLOR_PALE_BLUE_GRAY
 	exclusive_screen = FALSE
+	ui_size = 60
+
+/obj/machinery/vending/boozeomat/ui_interact(mob/user, var/datum/topic_state/state = default_state)
+	user.set_machine(src)
+
+	var/datum/vueui/ui = SSvueui.get_open_ui(user, src)
+	if(!ui)
+		ui = new(user, src, "machinery-vending", 900, 600, capitalize(name), state=state)
+
+	ui.open()
 
 
 /obj/machinery/vending/assist

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -22,7 +22,7 @@ var/global/list/plant_seed_sprites = list()
 	update_appearance()
 
 //Updates strings and icon appropriately based on seed datum.
-/obj/item/seeds/proc/update_appearance()
+/obj/item/seeds/proc/update_appearance(var/ret_image = FALSE)
 	if(!seed)
 		return
 
@@ -57,6 +57,17 @@ var/global/list/plant_seed_sprites = list()
 	else
 		src.name = "sample of [seed.seed_name] [seed.seed_noun]"
 		src.desc = "It's labelled as coming from \a [seed.display_name]."
+
+	if(ret_image)
+		var/icon/sm = icon('icons/obj/seeds.dmi', "[is_seeds ? "seed" : "spore"]-mask")
+		var/icon/so = icon('icons/obj/seeds.dmi', "[seed.get_trait(TRAIT_PRODUCT_ICON)]")
+		var/p_color = seed.get_trait(TRAIT_PRODUCT_COLOUR)
+		so *= p_color
+		if(is_seeds)
+			var/s_color = seed.get_trait(TRAIT_PLANT_COLOUR)
+			sm *= s_color
+		sm.Blend(so, ICON_OVERLAY)
+		return sm
 
 /obj/item/seeds/examine(mob/user)
 	..(user)

--- a/html/changelogs/johnwildkins-vend2.yml
+++ b/html/changelogs/johnwildkins-vend2.yml
@@ -1,0 +1,8 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - rscadd: "Vending machines now have a graphical, icon-based item interface based in VueUI."
+  - tweak: "Vending machines now have a search bar."
+  - bugfix: "Vending machines with large inventories (Booze-o-mat) should no longer cause excessive client lag."


### PR DESCRIPTION
for more info see #10197

changes from original PR:
- vending machines now have a search bar
- buttons now have a fixed size which allows for resizing of the window
- booze-o-mat window opens much larger
- issue with booze-o-mat causing never-ending lag has been resolved (note: the initial half-second lag upon opening it still exists, but that will only happen the first time while vue caches the images)
- seed vendor has images now