### PR TITLE
Up round-end time by 60 seconds

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -33,6 +33,7 @@ var/list/gamemode_cache = list()
 	var/vote_autotransfer_interval = 36000 // length of time before next sequential autotransfer vote
 	var/vote_autogamemode_timeleft = 100 //Length of time before round start when autogamemode vote is called (in seconds, default 100).
 	var/transfer_timeout = 72000		// timeout before a transfer vote can be called (deciseconds, 120 minute default)
+	var/restart_timeout = 1200			// time after round end & admin tickets are resolved until server restarts (deciseconds, 2 minute default)
 	var/vote_no_default = 0				// vote does not default to nochange/norestart (tbi)
 	var/vote_no_dead = 0				// dead people can't vote (tbi)
 //	var/enable_authentication = 0		// goon authentication
@@ -487,6 +488,9 @@ var/list/gamemode_cache = list()
 
 				if ("transfer_timeout")
 					config.transfer_timeout = text2num(value)
+
+				if ("restart_timeout")
+					config.restart_timeout = text2num(value)
 
 				if("ert_admin_only")
 					config.ert_admin_call_only = 1

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -17,7 +17,7 @@ var/datum/controller/subsystem/ticker/SSticker
 	wait = 1 SECOND
 
 	// -- Gameticker --
-	var/const/restart_timeout = 1200
+	var/restart_timeout = 1200
 	var/current_state = GAME_STATE_PREGAME
 
 	var/hide_mode = 0
@@ -68,6 +68,7 @@ var/datum/controller/subsystem/ticker/SSticker
 
 /datum/controller/subsystem/ticker/Initialize(timeofday)
 	pregame()
+	restart_timeout = config.restart_timeout
 
 /datum/controller/subsystem/ticker/stat_entry()
 	var/state = ""

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -17,7 +17,7 @@ var/datum/controller/subsystem/ticker/SSticker
 	wait = 1 SECOND
 
 	// -- Gameticker --
-	var/const/restart_timeout = 600
+	var/const/restart_timeout = 1200
 	var/current_state = GAME_STATE_PREGAME
 
 	var/hide_mode = 0

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -213,6 +213,9 @@ VOTE_AUTOGAMEMODE_TIMELEFT 100
 ## min delay (deciseconds) before a transfer vote can be called (default 120 minutes)
 TRANSFER_TIMEOUT 72000
 
+## delay (deciseconds) before round ends and server restarts after transfer/evac shuttle docks with odin and admin tickets are resolved
+RESTART_TIMEOUT 1200
+
 ## Prevets lobby-sitters and ghosts who went straight from the lobby to observing from voting.
 ## Ghosts who died will still be able to vote.
 #NO_DEAD_VOTE

--- a/html/changelogs/TheDocOct -  More round end time.yml
+++ b/html/changelogs/TheDocOct -  More round end time.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: TheDocOct
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Increased round end time by 60 seconds to allow Odin ghost roles a bit more RP time. But not too much."


### PR DESCRIPTION
We now have an Odin with roughly double the usable RP space for round-end closure, and a number of ghost-spawner roles to provide for new opportunities and experiences in the brief period after the round has ended and the next one is set to begin. While I understand that this period is not to be compared to actual round time and the Odin's ghost roles are not to be compared to actual station roles, it seems a shame for them to only have 60 seconds to offer their potential addition to the closing moments of the round. So I'd like to give them 60 more seconds. That's all.