### PR TITLE
Ghosts can see pretty closet contents lists

### DIFF
--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -98,4 +98,7 @@
 #define isopenturf(target) istype(target, /turf/simulated/open)
 #define isweakref(target) istype(target, /datum/weakref)
 #define isopenspace(A) istype(A, /turf/simulated/open)
+#define isatom(D) istype(D, /atom)
 #define isdatum(target) istype(target, /datum)
+#define isitem(D) istype(D, /obj/item)
+#define islist(D) istype(D, /list)

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -6,10 +6,10 @@
  */
 
 // Determiner constants
-#define DET_NONE		0x00;
-#define DET_DEFINITE	0x01; // the
-#define DET_INDEFINITE	0x02; // a, an, some
-#define DET_AUTO		0x04;
+#define DET_NONE        0x00
+#define DET_DEFINITE    0x01 // the
+#define DET_INDEFINITE  0x02 // a, an, some
+#define DET_AUTO        0x04
 
 /*
  * Misc

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -11,25 +11,11 @@
 
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
-	var/total = input.len
-	if (!total)
-		return "[nothing_text]"
-	else if (total == 1)
-		return "[input[1]]"
-	else if (total == 2)
-		return "[input[1]][and_text][input[2]]"
-	else
-		var/output = ""
-		var/index = 1
-		while (index < total)
-			if (index == total - 1)
-				comma_text = final_comma_text
-
-			output += "[input[index]][comma_text]"
-			index++
-
-		return "[output][and_text][input[index]]"
-
+	switch(input.len)
+		if(0) return nothing_text
+		if(1) return "[input[1]]"
+		if(2) return "[input[1]][and_text][input[2]]"
+		else  return "[jointext(input, comma_text, 1, -1)][final_comma_text][and_text][input[input.len]]"
 
 /proc/ConvertReqString2List(var/list/source_list)
 	var/list/temp_list = params2list(source_list)

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -5,17 +5,77 @@
  *			Sorting
  */
 
+// Determiner constants
+#define DET_NONE		0x00;
+#define DET_DEFINITE	0x01; // the
+#define DET_INDEFINITE	0x02; // a, an, some
+#define DET_AUTO		0x04;
+
 /*
  * Misc
  */
 
 //Returns a list in plain english as a string
-/proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
+/proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "")
+	// this proc cannot be merged with counting_english_list to maintain compatibility
+	// with shoddy use of this proc for code logic and for cases that require original order
 	switch(input.len)
 		if(0) return nothing_text
 		if(1) return "[input[1]]"
 		if(2) return "[input[1]][and_text][input[2]]"
 		else  return "[jointext(input, comma_text, 1, -1)][final_comma_text][and_text][input[input.len]]"
+
+//Returns a newline-separated list that counts equal-ish items, outputting count and item names, optionally with icons and specific determiners
+/proc/counting_english_list(var/list/input, output_icons = TRUE, determiners = DET_NONE, nothing_text = "nothing", line_prefix = "\t", first_item_prefix = "\n", last_item_suffix = "\n", and_text = "\n", comma_text = "\n", final_comma_text = "")
+	var/list/counts = list() // counted input items
+	var/list/items = list() // actual objects for later reference (for icons and formatting)
+
+	// count items
+	for(var/item in input)
+		var/name = "[item]" // index items by name; usually works fairly well for loose equality
+		if(name in counts)
+			counts[name]++
+		else
+			counts[name] = 1
+			items.Add(item)
+
+	// assemble the output list
+	var/list/out = list()
+	var/i = 0
+	for(var/item in items)
+		var/name = "[item]"
+		var/count = counts[name]
+		var/item_str = line_prefix
+
+		if(count > 1)
+			item_str += "[count]x&nbsp;"
+
+		// atoms use special string conversion rules
+		if(isatom(item))
+			// atoms/items/objects can be pretty and whatnot
+			var/atom/A = item
+			if(output_icons && isicon(A.icon) && !ismob(A)) // mobs tend to have unusable icons
+				item_str += "[icon2html(A, viewers(get_turf(A)))]&nbsp;"
+			switch(determiners)
+				if(DET_NONE) item_str += A.name
+				if(DET_DEFINITE) item_str += "\the [A]"
+				if(DET_INDEFINITE) item_str += "\a [A]"
+				else item_str += name
+
+		if(i == 0)
+			item_str = first_item_prefix + item_str
+		if(i == items.len - 1)
+			item_str = item_str + last_item_suffix
+
+		out.Add(item_str)
+		i++
+
+	// finally return the list using regular english_list builder
+	return english_list(out, nothing_text, and_text, comma_text, final_comma_text)
+
+//A "preset" for counting_english_list that displays the list "inline" (comma separated)
+/proc/inline_counting_english_list(var/list/input, output_icons = TRUE, determiners = DET_NONE, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "", line_prefix = "", first_item_prefix = "", last_item_suffix = "")
+	return counting_english_list(input, output_icons, determiners, nothing_text, and_text, comma_text, final_comma_text)
 
 /proc/ConvertReqString2List(var/list/source_list)
 	var/list/temp_list = params2list(source_list)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -68,13 +68,17 @@
 		to_chat(user, "\The [src] is full.")
 
 /obj/structure/closet/examine(mob/user)
-	if(..(user, 1) && !opened)
+	if(!src.opened && (..(user, 1) || isobserver(user)))
 		var/content_size = 0
 		for(var/obj/item/I in contents)
 			if(!I.anchored)
 				content_size += Ceiling(I.w_class/2)
 		content_info(user, content_size)
-	if(linked_teleporter && Adjacent(user) && opened)
+
+	if(!src.opened && isobserver(user))
+		to_chat(user, "It contains: [counting_english_list(contents)]")
+
+	if(src.opened && linked_teleporter && (Adjacent(user) || isobserver(user)))
 		to_chat(user, FONT_SMALL(SPAN_NOTICE("There appears to be a device attached to the interior backplate of \the [src]...")))
 
 /obj/structure/closet/proc/stored_weight()

--- a/code/modules/client/preference_setup/global/03_language.dm
+++ b/code/modules/client/preference_setup/global/03_language.dm
@@ -29,7 +29,7 @@
 
 /datum/category_item/player_setup_item/player_global/language/content(var/mob/user)
 	. += "<b>Language Keys</b><br>"
-	. += " [english_list(pref.language_prefixes, and_text = " ", comma_text = " ")] <a href='?src=\ref[src];change_prefix=1'>Change</a> <a href='?src=\ref[src];reset_prefix=1'>Reset</a><br>"
+	. += " [jointext(pref.language_prefixes, " ")] <a href='?src=\ref[src];change_prefix=1'>Change</a> <a href='?src=\ref[src];reset_prefix=1'>Reset</a><br>"
 
 /datum/category_item/player_setup_item/player_global/language/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(href_list["change_prefix"])

--- a/html/changelogs/amunak-lists.yml
+++ b/html/changelogs/amunak-lists.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - rscadd: "Added pretty listing of closet contents for ghosts (incl. fullness and attached teleporter info)."


### PR DESCRIPTION
* Ports minor code changes to english_list from 2016 Baycode for patch compatibility:
  * Baystation12/Baystation12#13852
  * Baystation12/Baystation12#13853
* Adds missing is* macros for basic classes (I needed just `isatom` but felt like we should also really be using `isitem` and `islist`; it's not used anywhere at the moment though).
* Applies my closet patch from PolarisSS13/Polaris#6656 (they already had a kind of contents display, here it is a new feature).

This is what it looks like:

![chatlog screenshot](https://user-images.githubusercontent.com/781546/96054036-0ad17000-0e81-11eb-8d69-6d58eab9fd63.png)