### PR TITLE
Allow observers to follow all living things on restricted levels

### DIFF
--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -186,7 +186,7 @@ Works together with spawning an observer, noted above.
 		return
 
 	if(following)
-		if(!iscarbon(following)) //If they are following something other than a carbon mob, teleport them
+		if(!isliving(following) || isanimal(following)) //If they are following something other than a living non-animal mob, teleport them
 			stop_following()
 			teleport_to_spawn("You can not follow \the [following] on this level.")
 		else

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -187,8 +187,9 @@ Works together with spawning an observer, noted above.
 
 	if(following)
 		if(!isliving(following) || isanimal(following)) //If they are following something other than a living non-animal mob, teleport them
+			var/message = "You can not follow \the [following] on this level."
 			stop_following()
-			teleport_to_spawn("You can not follow \the [following] on this level.")
+			teleport_to_spawn(message)
 		else
 			return
 	//If they are moving around freely, teleport them

--- a/html/changelogs/amunak-observer-follow-fix.yml
+++ b/html/changelogs/amunak-observer-follow-fix.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "Allows observers (ghosts) to follow all living things on restricted levels, which should allow for following exosuits and similar equipment."


### PR DESCRIPTION
* Fixes a bug when following something you are not supposed to on a restricted Z-level: the message should now correctly say what you cannot follow there (previously it was outputted after the `following` variable was already null).
* Additionally, ghosts can now follow any living mob on restricted Z-levels. This is to allow following exosuits and such (but not, say, ghosts of admins setting something up).

It fixes changes from #6670.

Note that I did not actually test these changes in-game as I'm not sure how I'd even go about that. But it seems like a simple enough change not to break anything.