### PR TITLE
Bugfixes and improvements for "fancy" storages

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -35,17 +35,17 @@
 		desc_info += "Alt-click to open and close the box. " //aka force override icon state. for you know, style.
 
 /obj/item/storage/box/fancy/AltClick(mob/user)
+	if(opened && !closable) // opened, non-closable items do nothing
+		return
 	if(!Adjacent(user))
 		return
 
 	opened = !opened
 	playsound(src.loc, src.use_sound, 50, 0, -5)
-	if(closable && !opened)
-		icon_state = "[initial(icon_state)]" // closed
-		cut_overlays()
+	update_icon()
+	if(!opened)
 		close(user)
 		return 1
-	update_icon()
 
 /obj/item/storage/box/fancy/update_icon(var/itemremoved = 0)
 	if(opened) //use the open icon.
@@ -53,6 +53,9 @@
 			src.icon_state = "[src.icon_type][src.storage_type][contents.len - itemremoved]"
 		else
 			icon_state = "[initial(icon_state)][src.opened]"
+	else
+		cut_overlays()
+		icon_state = "[initial(icon_state)]" // closed
 
 /obj/item/storage/box/fancy/examine(mob/user)
 	..()
@@ -166,6 +169,7 @@
 	starts_with = null
 
 /obj/item/storage/box/fancy/crayons/update_icon()
+	.=..()
 	cut_overlays()
 	add_overlay("crayonbox")
 	for(var/obj/item/pen/crayon/crayon in contents)
@@ -258,7 +262,9 @@
 		new cigarette_to_spawn(src)
 
 /obj/item/storage/box/fancy/cigarettes/update_icon()
-	icon_state = "[initial(icon_state)][contents.len]"
+	.=..()
+	if(opened)
+		icon_state = "[initial(icon_state)][contents.len]"
 
 /obj/item/storage/box/fancy/cigarettes/remove_from_storage(obj/item/W as obj, atom/new_location)
 		var/obj/item/clothing/mask/smokable/cigarette/C = W
@@ -360,6 +366,8 @@
 	can_hold = list(/obj/item/reagent_containers/glass/beaker/vial)
 	starts_with = list(/obj/item/reagent_containers/glass/beaker/vial = 6)
 	chewable = FALSE
+	opened = TRUE
+	closable = FALSE
 
 /obj/item/storage/lockbox/vials
 	name = "secure vial storage box"
@@ -381,6 +389,7 @@
 	queue_icon_update()
 
 /obj/item/storage/lockbox/vials/update_icon(var/itemremoved = 0)
+	.=..()
 	var/total_contents = src.contents.len - itemremoved
 	src.icon_state = "vialbox[total_contents]"
 	cut_overlays()

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -272,8 +272,11 @@
 		reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
 		..()
 
-/obj/item/storage/box/fancy/cigarettes/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob,var/target_zone)
+/obj/item/storage/box/fancy/cigarettes/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, target_zone)
 	if(!istype(M, /mob))
+		return
+	if(!opened)
+		to_chat(user, SPAN_NOTICE("The [src] is closed."))
 		return
 
 	if(M == user && target_zone == BP_MOUTH && contents.len > 0 && !user.wear_mask)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -35,6 +35,9 @@
 		desc_info += "Alt-click to open and close the box. " //aka force override icon state. for you know, style.
 
 /obj/item/storage/box/fancy/AltClick(mob/user)
+	if(!Adjacent(user))
+		return
+
 	opened = !opened
 	playsound(src.loc, src.use_sound, 50, 0, -5)
 	if(closable && !opened)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -89,7 +89,7 @@
 	foldable = /obj/item/stack/material/cardboard
 
 /obj/item/storage/box/fancy/donut/update_icon() // One of the few unique update_icon()s, due to having to store both regular and sprinkled donuts.
-	.=..()
+	. = ..()
 	if(opened)
 		cut_overlays()
 		var/i = 0
@@ -175,7 +175,7 @@
 	starts_with = null
 
 /obj/item/storage/box/fancy/crayons/update_icon()
-	.=..()
+	. = ..()
 	cut_overlays()
 	add_overlay("crayonbox")
 	for(var/obj/item/pen/crayon/crayon in contents)
@@ -223,7 +223,7 @@
 	return
 
 /obj/item/storage/box/fancy/matches/update_icon()
-	.=..()
+	. = ..()
 	if(opened)
 		if(contents.len == 0)
 			icon_state = "matchbox_e"
@@ -268,7 +268,7 @@
 		new cigarette_to_spawn(src)
 
 /obj/item/storage/box/fancy/cigarettes/update_icon()
-	.=..()
+	. = ..()
 	if(opened)
 		icon_state = "[initial(icon_state)][contents.len]"
 
@@ -398,7 +398,7 @@
 	queue_icon_update()
 
 /obj/item/storage/lockbox/vials/update_icon(var/itemremoved = 0)
-	.=..()
+	. = ..()
 	var/total_contents = src.contents.len - itemremoved
 	src.icon_state = "vialbox[total_contents]"
 	cut_overlays()

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -57,6 +57,12 @@
 		cut_overlays()
 		icon_state = "[initial(icon_state)]" // closed
 
+/obj/item/storage/box/fancy/handle_item_insertion()
+	if(!opened) // makes sure boxes are opened before inserting anything
+		opened = TRUE
+		update_icon()
+	. = ..()
+
 /obj/item/storage/box/fancy/examine(mob/user)
 	..()
 	if(contents.len <= 0)

--- a/html/changelogs/amunak-fancy-fixes.yml
+++ b/html/changelogs/amunak-fancy-fixes.yml
@@ -1,0 +1,6 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "Fancy storage boxes (donuts, matchboxes, ...) can no longer be opened/closed from anywhere - they require adjacency."
+  - bugfix: "Cigarette packs can now be opened and closed; they behave more like matchboxes and they spawn in closed."
+  - bugfix: "Other minor fixes to fancy storage boxes: sprites should behave better, stuff that shouldn't close doesn't close, etc."

--- a/html/changelogs/amunak-fancy-fixes.yml
+++ b/html/changelogs/amunak-fancy-fixes.yml
@@ -2,5 +2,6 @@ author: Amunak
 delete-after: True
 changes:
   - tweak: "Cigarette packs can now be opened and closed; they behave more like matchboxes and they spawn in closed. You cannot pull a cigarette out of a closed pack."
+  - tweak: "Fancy storage boxes will open before inserting anything."
   - bugfix: "Fancy storage boxes (donuts, matchboxes, ...) can no longer be opened/closed from anywhere - they require adjacency."
   - bugfix: "Other minor fixes to fancy storage boxes: sprites should behave better, stuff that shouldn't close doesn't close, etc."

--- a/html/changelogs/amunak-fancy-fixes.yml
+++ b/html/changelogs/amunak-fancy-fixes.yml
@@ -1,6 +1,6 @@
 author: Amunak
 delete-after: True
 changes:
+  - tweak: "Cigarette packs can now be opened and closed; they behave more like matchboxes and they spawn in closed. You cannot pull a cigarette out of a closed pack."
   - bugfix: "Fancy storage boxes (donuts, matchboxes, ...) can no longer be opened/closed from anywhere - they require adjacency."
-  - bugfix: "Cigarette packs can now be opened and closed; they behave more like matchboxes and they spawn in closed."
   - bugfix: "Other minor fixes to fancy storage boxes: sprites should behave better, stuff that shouldn't close doesn't close, etc."


### PR DESCRIPTION
This PR fixes some minor things about "fancy" storages (implemented in #9331).

* Fixed a bug where you could open them from anywhere. Adjacency is now required.
* Refactored the icon update from the `AltClick` proc to `update_icon` for more consistent behavior. I also added parent proc calls for all overriden `update_icon` calls for this to work properly, which in turn meant some other minor changes in some of the overriden procs.
* Fixed vial packs being "openable" - forced them open and non-closable. Among other things this prevents the stupid sound and (after making the previous change) breaking the sprite.
* Fixed cigarette packs spawning in opened. They can now be toggled open/closed and behave nicely like match boxes.
* Since cigarette packs can now be opened and closed I made it impossible to pull a cig from a closed packet.
* Storage will be opened before inserting anything. When inserting you can even see the box open with the empty slot and then the item is inserted.

I have tested this fix fairly rigorously on all the "special" items that override `update_icon`, as well as on the more "regular" items like candle boxes. All seems to work as expected, the sprites update nicely.