### PR TITLE
Adds AI, telecomms, bridge consoles and some other misc. things to runtime for easier debugging

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -535,6 +535,15 @@
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 
+/obj/structure/closet/crate/secure/aimodules
+	name = "AI modules crate"
+	desc = "A secure crate full of AI modules."
+	req_access = list(access_cent_specops)
+
+/obj/structure/closet/crate/secure/aimodules/fill()
+	for(var/moduletype in subtypesof(/obj/item/aiModule))
+		new moduletype(src)
+
 /obj/structure/closet/crate/secure/weapon
 	name = "weapons crate"
 	desc = "A secure weapons crate."

--- a/html/changelogs/amunak-runtime-mapping.yml
+++ b/html/changelogs/amunak-runtime-mapping.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - backend: "Mapped (somewhat minimalistic) Telecomms, AI core, AI upload with robot charger + spawners and messaging server room to Runtime-2 for easier debugging of AI and radio related things. Also added most important consoles to bridge, some cameras and intercoms."

--- a/maps/runtime/code/runtime.dm
+++ b/maps/runtime/code/runtime.dm
@@ -19,3 +19,9 @@
 	company_name = "BanoTarsen"
 	company_short = "BT"
 	system_name = "runtime.dm"
+
+	station_networks = list(
+		NETWORK_CIVILIAN_MAIN,
+		NETWORK_COMMAND,
+		NETWORK_ENGINEERING,
+	)

--- a/maps/runtime/runtime-1.dmm
+++ b/maps/runtime/runtime-1.dmm
@@ -80,8 +80,8 @@
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/engineering)
@@ -104,8 +104,8 @@
 	pixel_y = 23
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -113,7 +113,9 @@
 /obj/machinery/power/smes/buildable{
 	charge = 1e+006;
 	input_attempt = 1;
-	output_attempt = 1
+	input_level = 200000;
+	output_attempt = 1;
+	output_level = 200000
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
@@ -133,6 +135,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Master Grid";
+	name_tag = "Master"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
@@ -170,10 +176,13 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "ay" = (
-/obj/machinery/power/rtg/advanced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/decal/warning_stripes,
+/obj/machinery/power/smes/magical{
+	output_attempt = 1
 	},
 /turf/simulated/floor/airless,
 /area/template_noop)
@@ -318,6 +327,10 @@
 	pixel_y = 5
 	},
 /obj/structure/table/standard,
+/obj/item/device/radio/intercom{
+	name = "Common Channel";
+	pixel_x = -27
+	},
 /turf/simulated/floor/plating,
 /area/engineering)
 "aP" = (
@@ -425,6 +438,10 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Engine Airlock";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_gen)
 "be" = (
@@ -443,9 +460,9 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/light,
 /obj/item/device/analyzer,
@@ -484,6 +501,10 @@
 /obj/item/screwdriver,
 /obj/item/wirecutters,
 /obj/structure/table/standard,
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Technical Storage";
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering)
 "bm" = (
@@ -558,9 +579,9 @@
 	},
 /obj/structure/cable,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/alarm{
 	locked = 0;
@@ -598,9 +619,9 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/closet/secure_closet/captains,
 /obj/effect/floor_decal/corner/blue{
@@ -679,9 +700,9 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/closet/firecloset/full,
 /obj/effect/floor_decal/corner/blue{
@@ -888,6 +909,7 @@
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/floor_decal/corner/blue/full,
+/obj/item/modular_computer/console/preset/ai,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "cm" = (
@@ -901,6 +923,7 @@
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 4
 	},
+/obj/machinery/account_database,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "co" = (
@@ -977,6 +1000,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "cA" = (
@@ -1002,6 +1028,9 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -1357,6 +1386,18 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"eI" = (
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Central Corridor 1";
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = -21
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 "ie" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable{
@@ -1374,6 +1415,48 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engineering/gravity_gen)
+"kc" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Engine Output";
+	name_tag = "Engine Output"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering)
+"kM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Airlock"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/engineering)
+"mn" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Bridge";
+	departmentType = 5;
+	name = "Bridge RC";
+	pixel_y = -30
+	},
+/obj/machinery/computer/security,
+/turf/simulated/floor/tiled,
+/area/bridge)
 "ob" = (
 /obj/machinery/light{
 	dir = 8
@@ -1395,12 +1478,52 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"tT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/bridge)
+"wk" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/item/modular_computer/console/preset/command,
+/turf/simulated/floor/tiled,
+/area/bridge)
+"yC" = (
+/obj/structure/lattice,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"zP" = (
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Central Corridor 2";
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = -21
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 "Bd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/construction)
+"FZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_one)
 "Go" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1435,6 +1558,42 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction)
+"Kz" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 4
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Atmospherics";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
+"Ly" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/civilian_main{
+	c_tag = "Central Corridor 3";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"RL" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge";
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = -21
+	},
+/obj/machinery/computer/station_alert/all,
+/turf/simulated/floor/tiled,
+/area/bridge)
 "TP" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -1444,6 +1603,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction)
+"UF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
+"YP" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/item/modular_computer/console/preset/command/captain,
+/turf/simulated/floor/tiled,
+/area/bridge)
 
 (1,1,1) = {"
 aa
@@ -2379,7 +2557,7 @@ ae
 af
 ak
 ax
-aL
+Kz
 aL
 bk
 af
@@ -2389,7 +2567,7 @@ ck
 bB
 cx
 bB
-bB
+eI
 cK
 cV
 de
@@ -2486,7 +2664,7 @@ ad
 ab
 ab
 ab
-ab
+yC
 ab
 ab
 ab
@@ -2547,7 +2725,7 @@ ab
 bs
 bE
 cb
-cm
+wk
 bs
 cA
 bB
@@ -2601,7 +2779,7 @@ ab
 bs
 bE
 cb
-cm
+mn
 br
 cA
 bB
@@ -2654,7 +2832,7 @@ ab
 ab
 bs
 bF
-cb
+tT
 cm
 cs
 cA
@@ -2709,7 +2887,7 @@ aa
 bs
 bG
 cb
-cm
+RL
 br
 cA
 bB
@@ -2763,7 +2941,7 @@ aa
 bs
 bH
 cb
-cm
+YP
 bs
 cA
 bB
@@ -2810,7 +2988,7 @@ ad
 aa
 aa
 ah
-aC
+kM
 ah
 aa
 aa
@@ -2819,9 +2997,9 @@ bI
 cc
 cn
 br
-cA
+UF
 bB
-bB
+zP
 cP
 cP
 cP
@@ -2923,7 +3101,7 @@ aO
 ba
 bl
 bt
-bJ
+FZ
 ce
 cp
 bJ
@@ -3026,7 +3204,7 @@ ac
 ae
 ah
 ap
-aC
+kc
 aC
 bc
 bm
@@ -3251,7 +3429,7 @@ bP
 bY
 ck
 bB
-cx
+Ly
 bB
 bB
 cS

--- a/maps/runtime/runtime-2.dmm
+++ b/maps/runtime/runtime-2.dmm
@@ -1,256 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/template_noop,
-/area/template_noop)
-"c" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
-"d" = (
-/turf/simulated/floor/airless,
-/area/template_noop)
-"e" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/construction/Storage)
-"f" = (
-/obj/machinery/alarm{
-	locked = 0;
-	pixel_y = 23
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"g" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"h" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"i" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"j" = (
-/turf/simulated/open,
-/area/construction/Storage)
-"k" = (
-/obj/structure/lattice/catwalk,
-/turf/simulated/open,
-/area/construction/Storage)
-"l" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"m" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"n" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"o" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/simulated/open,
-/area/construction/Storage)
-"p" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"q" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"r" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"s" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"t" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"u" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"v" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"w" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"x" = (
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"y" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"z" = (
-/obj/structure/stairs/south,
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"A" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"B" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"C" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"E" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/wall/r_wall,
-/area/construction/Storage)
-"F" = (
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "12-0"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/zpipe/up/supply,
-/turf/simulated/floor/airless,
-/area/construction/Storage)
-"J" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/wall/r_wall,
-/area/construction/Storage)
-"K" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"L" = (
-/turf/simulated/wall/r_wall,
-/area/construction/Storage)
-"N" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/wall/r_wall,
-/area/construction/Storage)
-"O" = (
-/obj/structure/cable{
-	d1 = 32;
-	d2 = 2;
-	icon_state = "11-2"
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/zpipe/down/supply,
-/turf/simulated/open,
-/area/construction/Storage)
-"T" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/construction/Storage)
-"U" = (
+"aa" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -264,2816 +13,4007 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/airless,
 /area/construction/Storage)
-"Y" = (
+"aO" = (
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"aQ" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"cB" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"dr" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"dB" = (
+/obj/machinery/computer/telecomms/monitor{
+	network = "tcommsat"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"dZ" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"eb" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 5
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"el" = (
+/obj/machinery/message_server,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"eN" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "AICore";
+	name = "AI core maintenance hatch";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Core";
+	req_access = list(16)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/plasticflaps/airtight,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"gD" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "AICore";
+	name = "AI core maintenance hatch";
+	opacity = 0
+	},
+/obj/structure/plasticflaps/airtight,
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload";
+	req_access = list(16)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/turret_protected/ai_upload_foyer)
+"gF" = (
+/obj/machinery/telecomms/server/presets/common,
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"gG" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/computer/aiupload,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"gV" = (
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"hh" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"hp" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/structure/plasticflaps/airtight,
+/obj/machinery/door/window/brigdoor/eastleft,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"hB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/wall/r_wall,
+/area/construction/Storage)
+"hD" = (
+/turf/simulated/floor/airless,
+/area/template_noop)
+"hG" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"hJ" = (
+/turf/simulated/open,
+/area/construction/Storage)
+"iE" = (
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "12-0"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/zpipe/up/supply,
+/turf/simulated/floor/airless,
+/area/construction/Storage)
+"iR" = (
+/turf/template_noop,
+/area/template_noop)
+"jM" = (
+/obj/machinery/telecomms/hub/preset,
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"ki" = (
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai_upload_foyer)
+"kI" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"lK" = (
+/obj/machinery/telecomms/broadcaster/preset_right,
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"ma" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"nc" = (
+/obj/machinery/alarm{
+	locked = 0;
+	pixel_y = 23
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"nR" = (
+/obj/machinery/power/apc/super{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"nV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"ov" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"ow" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"oF" = (
+/obj/machinery/bluespacerelay,
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"pA" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"pY" = (
+/obj/structure/table/standard,
+/obj/item/book/manual/ntsl2,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"qn" = (
+/obj/machinery/atmospherics/unary/freezer{
+	icon_state = "freezer_1";
+	set_temperature = 73;
+	use_power = 1
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"qL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/wall/r_wall,
+/area/construction/Storage)
+"sF" = (
+/obj/machinery/telecomms/relay/preset/station,
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"sK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/ai_status_display{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"sL" = (
+/obj/effect/landmark/start{
+	name = "AI"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/decal/warning_stripes,
+/obj/item/device/radio/intercom{
+	name = "Common Channel";
+	pixel_x = 27;
+	pixel_y = -3
+	},
+/obj/item/device/radio/intercom{
+	frequency = 1343;
+	name = "Private Channel";
+	pixel_y = -26
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the AI core maintenance door.";
+	id = "AICore";
+	name = "AI Maintenance Hatch";
+	pixel_x = 17;
+	pixel_y = 25;
+	req_access = list(20)
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/machinery/requests_console{
+	department = "AI";
+	departmentType = 5;
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"sZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"tv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"tD" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"tO" = (
+/obj/machinery/ntnet_relay,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"tS" = (
+/obj/machinery/power/sensor{
+	long_range = 1;
+	name = "Powernet Sensor - AI Subgrid";
+	name_tag = "AI Subgrid"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"uT" = (
+/obj/machinery/blackbox_recorder,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"vk" = (
+/obj/effect/decal/warning_stripes,
+/obj/machinery/porta_turret{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"vP" = (
+/obj/item/modular_computer/console/preset/ai,
+/obj/machinery/camera/network/command{
+	c_tag = "AI Core";
+	dir = 8
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"vY" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"wb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/wall/r_wall,
+/area/construction/Storage)
+"wf" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"wp" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 5
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"wx" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/item/device/radio/intercom/locked{
+	frequency = 1343;
+	locked_frequency = 1343;
+	name = "Private AI Channel";
+	pixel_x = -5;
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"wJ" = (
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"xC" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"xI" = (
+/obj/structure/cable{
+	d1 = 32;
+	d2 = 2;
+	icon_state = "11-2"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply,
+/turf/simulated/open,
+/area/construction/Storage)
+"xN" = (
+/obj/machinery/telecomms/receiver/preset_right,
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"xP" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/plasticflaps/airtight,
+/obj/machinery/door/airlock/hatch{
+	name = "Telecoms Satellite";
+	req_access = list(61)
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"xU" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"zQ" = (
+/obj/structure/lattice/catwalk,
+/turf/simulated/open,
+/area/construction/Storage)
+"Ab" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"Bq" = (
+/obj/item/modular_computer/console/preset/ai,
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"BM" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"Cv" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"CY" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"Dd" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"Dv" = (
+/obj/machinery/power/apc/super/critical{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"Dx" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Messaging Server";
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"DO" = (
+/turf/simulated/wall/r_wall,
+/area/tcommsat/computer)
+"DR" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Telecomms Control Room";
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"Ei" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	icon_state = "map_vent_out";
+	pressure_checks = 0;
+	pressure_checks_default = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"Ex" = (
+/turf/simulated/wall/r_wall,
+/area/construction/Storage)
+"Fo" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"Fq" = (
+/obj/machinery/telecomms/server/presets/engineering,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"Gf" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"GG" = (
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"GJ" = (
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"GR" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecoms Control Room";
+	req_access = list(61)
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"HX" = (
+/obj/machinery/computer/telecomms/traffic{
+	network = "tcommsat"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"Jd" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"Jr" = (
+/obj/structure/table/standard,
+/obj/item/paper/monitorkey,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"JH" = (
+/obj/machinery/computer/message_monitor,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"JR" = (
+/obj/machinery/alarm/cold{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"KT" = (
+/obj/machinery/computer/telecomms/server{
+	network = "tcommsat"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/computer)
+"La" = (
+/obj/machinery/atmospherics/unary/vent_pump,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"Ml" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"MD" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"MO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
 /area/construction/Storage)
+"MW" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"Nz" = (
+/turf/simulated/wall/r_wall,
+/area/turret_protected/ai)
+"NJ" = (
+/obj/machinery/power/smes/buildable{
+	charge = 5e+006;
+	input_attempt = 1;
+	input_level = 200000;
+	output_attempt = 1;
+	output_level = 200000
+	},
+/obj/structure/cable/cyan,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"Ot" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"Ox" = (
+/obj/machinery/telecomms/bus/preset_four,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"OX" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"Pc" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Telecomms";
+	dir = 8
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"Pl" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"Pv" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"Pw" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"QF" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"QX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"RB" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"RK" = (
+/obj/structure/stairs/south,
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"RM" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"Sx" = (
+/obj/machinery/alarm/cold{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/machinery/turretid/stun{
+	name = "AI Upload turret control";
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"SP" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"SX" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"Um" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "AI Access";
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	frequency = 1343;
+	name = "Private Channel";
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"Vd" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/construction/Storage)
+"Vp" = (
+/turf/simulated/wall/r_wall,
+/area/tcommsat/chamber)
+"VK" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"Ws" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/computer/borgupload,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"Wt" = (
+/obj/machinery/telecomms/processor/preset_four,
+/turf/simulated/floor/bluegrid{
+	name = "cooled mainframe floor";
+	temperature = 278
+	},
+/area/tcommsat/chamber)
+"Wz" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/simulated/open,
+/area/construction/Storage)
+"Xd" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"Xt" = (
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai)
+"XS" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/crate/secure/aimodules,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"Zd" = (
+/obj/machinery/door/window{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
+"Zg" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"Zz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/construction/Storage)
+"ZL" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/computer/robotics,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (2,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (3,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (4,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (5,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (6,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (7,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (8,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (9,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (10,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (11,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-L
-N
-Y
-J
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+DO
+DO
+DO
+DO
+DO
+DO
+DO
+ki
+ki
+ki
+ki
+Ex
+hB
+MO
+qL
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (12,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-O
-U
-F
-E
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+DO
+pY
+HX
+dB
+KT
+tO
+DO
+Jr
+uT
+el
+ki
+xI
+aa
+iE
+wb
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (13,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-L
-e
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+DO
+qn
+wp
+ow
+DR
+aQ
+GR
+wJ
+Dx
+JH
+ki
+Ex
+Zz
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (14,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-f
-i
-T
-m
-m
-m
-m
-m
-p
-m
-K
-A
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+DO
+GJ
+hp
+GJ
+DO
+DO
+DO
+Zd
+ki
+ki
+ki
+nc
+Jd
+MW
+Pw
+Pw
+Pw
+Pw
+Pw
+Gf
+Pw
+cB
+kI
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (15,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-q
-j
-j
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+Vp
+sF
+hh
+nR
+Vp
+tD
+Pv
+RB
+VK
+Sx
+ki
+SX
+hJ
+hJ
+zQ
+hJ
+hJ
+hJ
+hJ
+CY
+hJ
+hJ
+Vd
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (16,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-r
-v
-v
-B
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+Vp
+Ox
+Ot
+eb
+xP
+dZ
+wJ
+tv
+QX
+Ab
+gD
+ov
+hJ
+hJ
+zQ
+hJ
+hJ
+hJ
+hJ
+sZ
+xU
+xU
+dr
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (17,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-k
-k
-o
-k
-k
-k
-k
-o
-k
-k
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+Vp
+Wt
+pA
+Ei
+Vp
+Fo
+gV
+BM
+gV
+Cv
+ki
+wx
+zQ
+zQ
+Wz
+zQ
+zQ
+zQ
+zQ
+Wz
+zQ
+zQ
+Vd
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (18,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-k
-j
-j
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+Vp
+jM
+GG
+xN
+Vp
+ZL
+vk
+Ml
+vk
+Um
+ki
+wf
+hJ
+hJ
+zQ
+hJ
+hJ
+hJ
+hJ
+zQ
+hJ
+hJ
+Vd
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (19,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-k
-j
-j
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+Vp
+Fq
+GG
+oF
+Vp
+Ws
+wJ
+Ml
+wJ
+Xd
+ki
+wf
+hJ
+hJ
+zQ
+hJ
+hJ
+hJ
+hJ
+zQ
+hJ
+hJ
+Vd
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (20,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-k
-j
-j
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+Vp
+gF
+Pc
+lK
+Vp
+gG
+sK
+MD
+XS
+NJ
+ki
+wf
+hJ
+hJ
+zQ
+hJ
+hJ
+hJ
+hJ
+zQ
+hJ
+hJ
+Vd
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (21,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-k
-j
-j
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+Vp
+Vp
+Vp
+Vp
+Vp
+ki
+ki
+eN
+ki
+ki
+ki
+wf
+hJ
+hJ
+zQ
+hJ
+hJ
+hJ
+hJ
+zQ
+hJ
+hJ
+Vd
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (22,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-k
-k
-o
-k
-k
-k
-k
-o
-k
-k
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+Nz
+Xt
+La
+SP
+Dv
+JR
+Nz
+wf
+zQ
+zQ
+Wz
+zQ
+zQ
+zQ
+zQ
+Wz
+zQ
+zQ
+Vd
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (23,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-s
-w
-y
-C
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+Nz
+Dd
+Bq
+tS
+vP
+RM
+Nz
+wf
+hJ
+hJ
+zQ
+hJ
+hJ
+hJ
+hJ
+vY
+nV
+QF
+ma
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (24,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-g
-j
-j
-k
-j
-j
-j
-j
-t
-x
-z
-t
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+Nz
+Xt
+Nz
+sL
+Nz
+Xt
+Nz
+wf
+hJ
+hJ
+zQ
+hJ
+hJ
+hJ
+hJ
+Vd
+aO
+RK
+Vd
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (25,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-h
-l
-n
-n
-n
-n
-n
-n
-u
-h
-l
-u
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+Nz
+Nz
+Nz
+Nz
+Nz
+Nz
+Nz
+hG
+Pl
+xC
+xC
+xC
+xC
+xC
+xC
+OX
+hG
+Pl
+OX
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (26,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-L
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+Ex
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (27,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (28,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (29,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (30,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (31,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (32,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (33,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (34,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (35,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (36,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (37,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (38,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (39,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (40,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (41,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (42,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-d
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+hD
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (43,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (44,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (45,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (46,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (47,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (48,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (49,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (50,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (51,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}
 (52,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 "}


### PR DESCRIPTION
* Added a new secure crate preset (locked to ERT) with _every single AI module_.

Runtime-2 additions:
* Telecomms (general and engineering channel should work fully, a NTnet relay is also present). Includes cooling and consoles.
* AI core, AI upload with borg spawners and charger, turrets, blast doors. The upload also contains the aforementioned AI modules crate.
* Messaging server room.
* Added cameras all over the place (3 networks total, also added networks to map descriptor).
* Added some intercoms, holopads and displays (both statin and AI status).
* Added some important consoles to bridge.
* Mapped in the magical SMES instead of one of the RTGs - there's no way any number of RTGs would be able to power the tcomms (~75kW) and an AI (50kW).
* Added some newscasters and a bridge and AI requests console.
* Added powernet sensors for the 3 powernets we now have for the power console to be of any use.

This means we can now debug radio-related stuff, PDA messaging, anything AI/borg related.

Marked as `backend` in changelog not to scare people about changes to a map they won't ever see. Hope that is fine?