### PR TITLE
Makes crew manifest pop-up use a single proc, makes it prettier

### DIFF
--- a/code/_onclick/hud/screen_object_types/ai_screen_objs.dm
+++ b/code/_onclick/hud/screen_object_types/ai_screen_objs.dm
@@ -87,8 +87,8 @@
 
 /obj/screen/ai/crew_manifest/Click()
 	if (isAI(usr))
-		var/mob/living/silicon/ai/AI = usr
-		AI.show_station_manifest()
+		var/windowname = open_crew_manifest(usr)
+		onclose(usr, windowname)
 
 /obj/screen/ai/alerts
 	name = "Show Alerts"

--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -10,6 +10,7 @@
 	var/list/warrants
 	var/list/viruses
 
+	var/list/nameMap
 	var/list/excluded_fields
 	var/list/localized_fields
 
@@ -37,6 +38,7 @@
 	excluded_fields = list()
 	localized_fields = list()
 	manifest = list()
+	nameMap = list("heads" = "Heads", "sec" = "Security", "eng" = "Engineering", "med" = "Medical", "sci" = "Science", "car" = "Cargo", "civ" = "Civilian", "misc" = "Miscellaneous", "bot" = "Equipment")
 	NEW_SS_GLOBAL(SSrecords)
 	var/datum/D = new()
 	for(var/v in D.vars)
@@ -185,30 +187,19 @@
 		return
 	var/const/windowname = "manifest"
 	var/dat = {"<h2 style="text-align: center">Crew Manifest</h2>"}
-	dat += SSrecords.get_manifest(monochrome = FALSE, OOC = OOC)
+	dat += SSrecords.get_manifest(OOC)
 	send_theme_resources(user)
 	user << browse(enable_ui_theme(user, dat), "window=[windowname];size=450x600")
 	return windowname
 
-/datum/controller/subsystem/records/proc/get_manifest(var/monochrome = FALSE, var/OOC = FALSE)
-	if(!manifest.len)
-		get_manifest_json()
-	var/style = {".manifest {border-collapse: collapse; width: 100%}"}
-	if (!monochrome)
-		style += {"
+/datum/controller/subsystem/records/proc/get_manifest(var/OOC = FALSE)
+	var/const/style = {"
+			.manifest {border-collapse: collapse; width: 100%}
 			.manifest td, th {border: 1px solid #DEF; background-color: white; color:black; padding: .25em}
 			.manifest th {height: 2em; background-color: #3F668F; color: white}
 			.manifest tr.head th {background-color: #006E7A;}
 			.manifest td:first-child {text-align: right}
 			.manifest tr.alt td {background-color: #DEF}
-		"}
-	else
-		style += {"
-			.manifest td, th {border: 1px solid black; padding: .25em}
-			.manifest th {height: 2em; border-top-width: 3px}
-			.manifest tr.head th {border-top-width: 1px}
-			.manifest td:first-child {text-align:right}
-			.manifest tr.alt td {border-top-width: 2px}
 		"}
 	var/dat = {"
 			<head><style>[style]</style></head>
@@ -226,7 +217,7 @@
 		else
 			isactive[M.real_name] = 0
 
-	var/nameMap = list("heads" = "Heads", "sec" = "Security", "eng" = "Engineering", "med" = "Medical", "sci" = "Science", "car" = "Cargo", "civ" = "Civilian", "misc" = "Miscellaneous", "bot" = "Equipment")
+	var/manifest = get_manifest_list()
 	for(var/dep in manifest)
 		var/list/depI = manifest[dep]
 		if(depI.len > 0)
@@ -237,6 +228,18 @@
 	dat += "</table>"
 	dat = replacetext(dat, "\n", "") // so it can be placed on paper correctly
 	dat = replacetext(dat, "\t", "")
+	return dat
+
+/datum/controller/subsystem/records/proc/get_manifest_text()
+	var/dat = "<h2>Crew Manifest</h2><em>as of [worlddate2text()] [worldtime2text()]</em>"
+	var/manifest = get_manifest_list()
+	for(var/dep in manifest)
+		var/list/depI = manifest[dep]
+		if(depI.len > 0)
+			var/depDat
+			for(var/list/item in depI)
+				depDat += "<li><strong>[item["name"]]</strong> - [item["rank"]] ([item["active"]])</li>"
+			dat += "<h3>[nameMap[dep]]</h3><ul>[depDat]</ul>"
 	return dat
 
 /datum/controller/subsystem/records/proc/get_manifest_list()

--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -179,21 +179,42 @@
 /datum/controller/subsystem/records/proc/reset_manifest()
 	manifest.Cut()
 
-/datum/controller/subsystem/records/proc/get_manifest(var/monochrome = 0, var/OOC = 0)
+// The one and only method for showing a pop-up crew manifest (browser) window
+/proc/open_crew_manifest(var/mob/user, var/OOC = FALSE)
+	if(!user)
+		return
+	var/const/windowname = "manifest"
+	var/dat = {"<h2 style="text-align: center">Crew Manifest</h2>"}
+	dat += SSrecords.get_manifest(monochrome = FALSE, OOC = OOC)
+	send_theme_resources(user)
+	user << browse(enable_ui_theme(user, dat), "window=[windowname];size=450x600")
+	return windowname
+
+/datum/controller/subsystem/records/proc/get_manifest(var/monochrome = FALSE, var/OOC = FALSE)
 	if(!manifest.len)
 		get_manifest_json()
+	var/style = {".manifest {border-collapse: collapse; width: 100%}"}
+	if (!monochrome)
+		style += {"
+			.manifest td, th {border: 1px solid #DEF; background-color: white; color:black; padding: .25em}
+			.manifest th {height: 2em; background-color: #3F668F; color: white}
+			.manifest tr.head th {background-color: #006E7A;}
+			.manifest td:first-child {text-align: right}
+			.manifest tr.alt td {background-color: #DEF}
+		"}
+	else
+		style += {"
+			.manifest td, th {border: 1px solid black; padding: .25em}
+			.manifest th {height: 2em; border-top-width: 3px}
+			.manifest tr.head th {border-top-width: 1px}
+			.manifest td:first-child {text-align:right}
+			.manifest tr.alt td {border-top-width: 2px}
+		"}
 	var/dat = {"
-	<head><style>
-		.manifest {border-collapse:collapse;}
-		.manifest td, th {border:1px solid [monochrome?"black":"#DEF; background-color:white; color:black"]; padding:.25em}
-		.manifest th {height: 2em; [monochrome?"border-top-width: 3px":"background-color: #48C; color:white"]}
-		.manifest tr.head th { [monochrome?"border-top-width: 1px":"background-color: #488;"] }
-		.manifest td:first-child {text-align:right}
-		.manifest tr.alt td {[monochrome?"border-top-width: 2px":"background-color: #DEF"]}
-	</style></head>
-	<table class="manifest" width='350px'>
-	<tr class='head'><th>Name</th><th>Rank</th><th>Activity</th></tr>
-	"}
+			<head><style>[style]</style></head>
+			<table class="manifest">
+			<tr class='head'><th>Name</th><th>Rank</th><th>Activity</th></tr>
+		"}
 	var/even = 0
 	var/list/isactive = new()
 	for(var/mob/M in player_list)

--- a/code/modules/admin/secrets/admin_secrets/show_crew_manifest.dm
+++ b/code/modules/admin/secrets/admin_secrets/show_crew_manifest.dm
@@ -5,8 +5,4 @@
 	. = ..()
 	if(!.)
 		return
-	var/dat
-	dat += "<h4>Crew Manifest</h4>"
-	dat += SSrecords.get_manifest()
-
-	user << browse(dat, "window=manifest;size=370x420;can_close=1")
+	open_crew_manifest(user)

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -406,12 +406,7 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 	return new_character
 
 /mob/abstract/new_player/proc/ViewManifest()
-	var/dat = "<html><body>"
-	dat += "<h4>Show Crew Manifest</h4>"
-	dat += SSrecords.get_manifest(OOC = 1)
-
-	send_theme_resources(src)
-	src << browse(enable_ui_theme(src, dat), "window=manifest;size=370x420;can_close=1")
+	open_crew_manifest(src, OOC = TRUE)
 
 /mob/abstract/new_player/Move()
 	return 0

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -581,7 +581,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else
 		return bestvent
 
-/mob/abstract/observer/verb/view_manfiest()
+/mob/abstract/observer/verb/view_manifest()
 	set name = "Show Crew Manifest"
 	set category = "Ghost"
 	open_crew_manifest(src, OOC = TRUE)

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -584,12 +584,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/abstract/observer/verb/view_manfiest()
 	set name = "Show Crew Manifest"
 	set category = "Ghost"
-
-	var/dat
-	dat += "<h4>Crew Manifest</h4>"
-	dat += SSrecords.get_manifest(OOC = 1)
-
-	src << browse(dat, "window=manifest;size=370x420;can_close=1")
+	open_crew_manifest(src, OOC = TRUE)
 
 //This is called when a ghost is drag clicked to something.
 /mob/abstract/observer/MouseDrop(atom/over)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -379,7 +379,8 @@ var/list/ai_verbs_default = list(
 /mob/living/silicon/ai/proc/ai_roster()
 	set category = "AI Commands"
 	set name = "Show Crew Manifest"
-	show_station_manifest()
+	var/windowname = open_crew_manifest(src)
+	onclose(src, windowname)
 
 //AI Examine code
 /mob/living/silicon/ai/proc/ai_examine(atom/A as mob|obj|turf in view(src.eyeobj))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -412,7 +412,8 @@
 /mob/living/silicon/robot/verb/cmd_station_manifest()
 	set category = "Robot Commands"
 	set name = "Show Crew Manifest"
-	show_station_manifest()
+	var/windowname = open_crew_manifest(src)
+	onclose(src, windowname)
 
 /mob/living/silicon/robot/proc/self_diagnosis()
 	if(!is_component_functioning("diagnosis unit"))

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -186,15 +186,6 @@
 		show_malf_ai()
 	..()
 
-// this function displays the stations manifest in a separate window
-/mob/living/silicon/proc/show_station_manifest()
-	var/dat
-	dat += "<h4>Crew Manifest</h4>"
-	dat += SSrecords.get_manifest(1) // make it monochrome
-	dat += "<br>"
-	src << browse(dat, "window=airoster")
-	onclose(src, "airoster")
-
 //can't inject synths
 /mob/living/silicon/can_inject(mob/user, error_msg)
 	if(error_msg)

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -151,7 +151,7 @@
 				else
 					var/contents = {"<h4>Crew Manifest</h4>
 									<br>
-									[SSrecords.get_manifest(1)]
+									[SSrecords.get_manifest(monochrome = 1)]
 									"}
 					if(!computer.nano_printer.print_text(contents,text("crew manifest ([])", worldtime2text())))
 						to_chat(usr, SPAN_WARNING(">Hardware error: Printer was unable to print the file. It may be out of paper."))

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -149,11 +149,7 @@
 						else
 							computer.visible_message(SPAN_NOTICE("\The [computer] prints out paper."))
 				else
-					var/contents = {"<h4>Crew Manifest</h4>
-									<br>
-									[SSrecords.get_manifest(monochrome = 1)]
-									"}
-					if(!computer.nano_printer.print_text(contents,text("crew manifest ([])", worldtime2text())))
+					if(!computer.nano_printer.print_text(SSrecords.get_manifest_text(), text("crew manifest ([])", worldtime2text())))
 						to_chat(usr, SPAN_WARNING(">Hardware error: Printer was unable to print the file. It may be out of paper."))
 						return
 					else

--- a/html/changelogs/amunak-crewmanifest.yml
+++ b/html/changelogs/amunak-crewmanifest.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - tweak: "Unified crew manifest pop-ups, made them all look nicer."

--- a/html/changelogs/amunak-crewmanifest.yml
+++ b/html/changelogs/amunak-crewmanifest.yml
@@ -1,4 +1,4 @@
 author: Amunak
 delete-after: True
 changes:
-  - tweak: "Unified crew manifest pop-ups, made them all look nicer."
+  - tweak: "Unified crew manifest pop-ups, made them all look nicer. Changed printed manifest format a bit."


### PR DESCRIPTION
* All crew manifest pop-ups now use a single global proc.
* They all look closer to what was shown in the lobby - now ghosts, AIs, admins (from the Secres panel) see the same pretty styling.
* Improved styling:
  * It always uses the players' set UI theme.
  * The table now fills the width of the window no matter how wide it is.
  * The window shows up slightly bigger; we have bigger resolutions than in 2008 or whenever it was originally set.
  * Improved readability (by darkening the header backgrounds), also hopefully the palette is now closer to the rest of the UIs. If I knew how to use the UI stylesheets I'd probably add the styling there, but I don't know how and there are no generic background CSS classes.
* The printed manifest (using the print option in ID card modification program) has new format because the `monochrome` option has been removed.
* With this change I took the liberty to give the nice UI also to AIs and robots; that coincidentally ever so slightly simplifies the code.

Old vs. new in the spawned window width/height (though GitHub seems to display it like crap):
![old crew manifest UI](https://user-images.githubusercontent.com/781546/96336195-3a010080-107e-11eb-8631-a1d69da4d52c.png)
![new crew manifest UI](https://user-images.githubusercontent.com/781546/96336196-3f5e4b00-107e-11eb-8296-b69d16711102.png)
![new printed manifest format](https://user-images.githubusercontent.com/781546/96371572-92a9c980-1162-11eb-9897-2ec5aaeed321.png)



Note: This _does not change_ what the manifest looks like in modular computers, or whether it shows or does not show OOC info (activity) in the manifest from a given call.