### PR TITLE
CCIA Recorder Fix

### DIFF
--- a/code/modules/cciaa/cciaa_items.dm
+++ b/code/modules/cciaa/cciaa_items.dm
@@ -46,7 +46,7 @@
 	set name = "Start Recording"
 	set category = "Recorder"
 
-	if(!check_rights(R_CCIAA,FALSE))
+	if(!check_rights(R_CCIAA,FALSE) || usr.character_id)
 		to_chat(usr, "<span class='notice'>The device beeps and flashes \"Unauthorised user.\".</span>")
 		return
 	if(use_check_and_message(usr))
@@ -87,7 +87,7 @@
 			selected_report = new(report_id, time2text(world.realtime, "YYYY_MM_DD"), report_name)
 		return
 	//If we are ready to record, but no interviewee is selected
-	else if(!selected_report && !interviewee_id)
+	else if(selected_report && !interviewee_id)
 		to_chat(usr,"<span class='notice'>The device beeps and flashes \"Fingerprint of interviewee required\"</span>")
 		return
 	//If the report has been selected and the person scanned their frinterprint
@@ -130,7 +130,7 @@
 
 	if(use_check_and_message(usr))
 		return
-	if(!check_rights(R_CCIAA,FALSE))
+	if(!check_rights(R_CCIAA,FALSE) || usr.character_id)
 		to_chat(usr, "<span class='notice'>The device beeps and flashes \"Unauthorised user.\".</span>")
 		return
 	if(!recording)
@@ -189,7 +189,7 @@
 	set name = "Reset Recorder"
 	set category = "Recorder"
 
-	if(!check_rights(R_CCIAA,FALSE))
+	if(!check_rights(R_CCIAA,FALSE) || usr.character_id)
 		to_chat(usr, "<span class='notice'>The device beeps and flashes \"Unauthorised user.\".</span>")
 		return
 
@@ -231,7 +231,7 @@
 
 	if(use_check_and_message(usr))
 		return
-	if(!check_rights(R_CCIAA,FALSE))
+	if(!check_rights(R_CCIAA,FALSE) || usr.character_id)
 		to_chat(usr, "<span class='notice'>The device beeps and flashes \"Unauthorised user\".</span>")
 		return
 	if(recording)
@@ -249,7 +249,7 @@
 
 	if(use_check_and_message(usr))
 		return
-	if(!check_rights(R_CCIAA,FALSE))
+	if(!check_rights(R_CCIAA,FALSE) || usr.character_id)
 		to_chat(usr, "<span class='notice'>The device beeps and flashes \"Unauthorised user\".</span>")
 		return
 	if(!recording)
@@ -270,7 +270,7 @@
 
 /obj/item/device/taperecorder/cciaa/attack_self(mob/user)
 	//If we are a ccia agent, then always go to the record function (to prompt for the report or start the recording)
-	if(check_rights(R_CCIAA,FALSE))
+	if(check_rights(R_CCIAA,FALSE) && !user.character_id)
 		record()
 		return
 

--- a/html/changelogs/arrow768-ccia-recorder-fix.yml
+++ b/html/changelogs/arrow768-ccia-recorder-fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Changes the CCIA Recorder, so it can be used to interview other ccia agents."


### PR DESCRIPTION
Changes the CCIA Recorder so it can be used to interview other CCIA Agents.
Currently there is a inbuilt protection that prevents a ccia agent from registering himself as the interviewee.
This has been extended to check for the presence of R_CCIA and the absence of a character_id.