### PR TITLE
Makes the remote warden's sensors default to off

### DIFF
--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -51,7 +51,7 @@
 
 /obj/item/clothing/under/rank/warden/remote
 	name = "remote warden's uniform"
-	desc = "It's made of a slightly sturdier material than standard jumpsuits, to allow for more robust protection. It has the words \"Remote Warden\" written on the shoulders."
+	desc = "It's made of a slightly sturdier material than standard jumpsuits. It has the words \"Remote Warden\" written on the shoulders and it's bolted straight onto the chassis."
 	canremove = FALSE
 
 /obj/item/clothing/under/rank/warden/remote/Initialize()

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -34,8 +34,8 @@
 	siemens_coefficient = 0.75
 
 /obj/item/clothing/under/rank/warden
-	desc = "It's made of a slightly sturdier material than standard jumpsuits, to allow for more robust protection. It has the word \"Warden\" written on the shoulders."
 	name = "warden's uniform"
+	desc = "It's made of a slightly sturdier material than standard jumpsuits, to allow for more robust protection. It has the word \"Warden\" written on the shoulders."
 	icon_state = "warden_standard"
 	worn_state = "warden_standard"
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
@@ -48,6 +48,15 @@
 /obj/item/clothing/under/rank/warden/dark_blue
 	icon_state = "warden_darkblue"
 	worn_state = "warden_darkblue"
+
+/obj/item/clothing/under/rank/warden/remote
+	name = "remote warden's uniform"
+	desc = "It's made of a slightly sturdier material than standard jumpsuits, to allow for more robust protection. It has the words \"Remote Warden\" written on the shoulders."
+	canremove = FALSE
+
+/obj/item/clothing/under/rank/warden/remote/Initialize()
+	. = ..()
+	sensor_mode = 0
 
 /*
  * Detective / Forensics

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -237,7 +237,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	src.set_id_info(ID)
 	ID.access = list(access_armory)
 	equip_to_slot_or_del(ID, slot_wear_id)
-	equip_to_slot_or_del(new /obj/item/clothing/under/rank/warden(src), slot_w_uniform)
+	equip_to_slot_or_del(new /obj/item/clothing/under/rank/warden/remote(src), slot_w_uniform)
 	equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(src), slot_shoes)
 	equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_warden(src), slot_l_ear)
 

--- a/html/changelogs/Ferner-201018-bugfix_remoteuniform.yml
+++ b/html/changelogs/Ferner-201018-bugfix_remoteuniform.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "The sensors of the remote warden's uniform now default to off."

--- a/html/changelogs/Ferner-201018-bugfix_remoteuniform.yml
+++ b/html/changelogs/Ferner-201018-bugfix_remoteuniform.yml
@@ -1,4 +1,4 @@
 author: Ferner
 delete-after: True
 changes: 
-  - bugfix: "The sensors of the remote warden's uniform now default to off."
+  - bugfix: "The sensors of the remote warden's uniform now default to off and it can't be removed."


### PR DESCRIPTION
Those looking at the sensors had to watch the remote warden's battery go to 0% every round, taking away attention from other elements on the sensors' listings, an annoyance for medical players.
Also made the remote warden's uniform unremovable as it seemed appropriate for it to be basically bolted on.