### PR TITLE
Optimizing recursive_content_check and get_mobs_or_objects_in_view

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -128,11 +128,12 @@
 // Will recursively loop through an atom's contents and check for mobs, then it will loop through every atom in that atom's contents.
 // It will keep doing this until it checks every content possible. This will fix any problems with mobs, that are inside objects,
 // being unable to hear people due to being in a box within a bag.
+// Does not return list, as list is passed as reference.
 
 /proc/recursive_content_check(var/atom/O,  var/list/L = list(), var/recursion_limit = 3, var/client_check = 1, var/sight_check = 1, var/include_mobs = 1, var/include_objects = 1)
 
 	if(!recursion_limit)
-		return L
+		return 
 
 	for(var/I in O.contents)
 
@@ -152,8 +153,6 @@
 				recursive_content_check(I, L, recursion_limit - 1, client_check, sight_check, include_mobs, include_objects)
 				if(include_objects)
 					L += I
-
-	return L
 
 // Returns a list of mobs and/or objects in range of R from source. Used in radio and say code.
 

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -138,20 +138,20 @@
 
 		if(ismob(I))
 			if(!sight_check || isInSight(I, O))
-				L |= recursive_content_check(I, L, recursion_limit - 1, client_check, sight_check, include_mobs, include_objects)
+				recursive_content_check(I, L, recursion_limit - 1, client_check, sight_check, include_mobs, include_objects)
 				if(include_mobs)
 					if(client_check)
 						var/mob/M = I
 						if(M.client)
-							L |= M
+							L += M
 					else
-						L |= I
+						L += I
 
-		else if(istype(I,/obj/))
+		else if(isobj(I))
 			if(!sight_check || isInSight(I, O))
-				L |= recursive_content_check(I, L, recursion_limit - 1, client_check, sight_check, include_mobs, include_objects)
+				recursive_content_check(I, L, recursion_limit - 1, client_check, sight_check, include_mobs, include_objects)
 				if(include_objects)
-					L |= I
+					L += I
 
 	return L
 
@@ -169,13 +169,13 @@
 
 	for(var/I in range)
 		if(ismob(I))
-			hear |= recursive_content_check(I, hear, 3, 1, 0, include_mobs, include_objects)
+			recursive_content_check(I, hear, 3, 1, 0, include_mobs, include_objects)
 			if(include_mobs)
 				var/mob/M = I
 				if(M.client)
 					hear += M
-		else if(istype(I,/obj/))
-			hear |= recursive_content_check(I, hear, 3, 1, 0, include_mobs, include_objects)
+		else if(istype(I, /obj/))
+			recursive_content_check(I, hear, 3, 1, 0, include_mobs, include_objects)
 			if(include_objects)
 				hear += I
 


### PR DESCRIPTION
- `recursive_content_check` was optimized. There was no need to add lists, as the lists that are added refer to the same list. In addition, there is no need to worry about duplicates in the list, as they should not be present in a given context.

- `get_mobs_or_objects_in_view` was optimized to not add lists all the time, as the list is manipulated already inside of `recursive_content_check` and in DM lists are passed by a reference.