### PR TITLE
Fixes Odin bartenders/chefs sometimes spawning shoeless

### DIFF
--- a/code/datums/outfits/event/outfit_nanotrasen.dm
+++ b/code/datums/outfits/event/outfit_nanotrasen.dm
@@ -284,7 +284,7 @@
 	name = "NTCC Odin Bartender"
 
 	uniform = /obj/item/clothing/under/rank/bartender
-	shoes = /obj/item/clothing/shoes/black
+	shoes = /obj/item/clothing/shoes/laceup/all_species
 	l_ear = /obj/item/device/radio/headset/headset_service
 
 	id_access = "Service"
@@ -295,7 +295,7 @@
 	uniform = /obj/item/clothing/under/rank/chef
 	suit = /obj/item/clothing/suit/chef
 	head = /obj/item/clothing/head/chefhat
-	shoes = /obj/item/clothing/shoes/black
+	shoes = /obj/item/clothing/shoes/laceup/all_species
 	l_ear = /obj/item/device/radio/headset/headset_service
 
 	id_access = "Service"

--- a/html/changelogs/Ferner-201018-bugfix_odinshoes.yml
+++ b/html/changelogs/Ferner-201018-bugfix_odinshoes.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Odin bartenders and chefs that are tajara or unathi no longer spawn shoeless."


### PR DESCRIPTION
Odin chefs/bartenders that were unathi or tajara spawned shoeless, this fixes that.