### PR TITLE
Makes ghosts see contents of any storage item

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -53,6 +53,11 @@
 	QDEL_NULL(closer)
 	return ..()
 
+/obj/item/storage/examine(mob/user)
+	. = ..()
+	if(isobserver(user))
+		to_chat(user, "It contains: [counting_english_list(contents)]")
+
 /obj/item/storage/MouseDrop(obj/over_object)
 	if(!canremove)
 		return

--- a/html/changelogs/amunak-ghosts-see-storage-contents.yml
+++ b/html/changelogs/amunak-ghosts-see-storage-contents.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - rscadd: "Added pretty listing of storage contents for ghosts. Applies to all bags, boxes, satchels, ... (every descendant of /obj/item/storage)."


### PR DESCRIPTION
This is a continuation of #10258. I should've really put that in there, but whatever.

* Everything that inherits from /obj/item/storage will now reveal its contents to ghosts.

![chatlog screenshot examining contents of boxes, satchels and backpacks](https://user-images.githubusercontent.com/781546/96294107-21480a80-0fec-11eb-980c-565be46a8769.png)