### PR TITLE
SMES improvements - visible hatch actions, examine to see coils, coils show rating and throughput

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -86,9 +86,9 @@
 		return
 
 	if(maxcharge <= 2500)
-		to_chat(user, "[desc]\nThe manufacturer's label states this cell has a power rating of [maxcharge], and that you should not swallow it.\nThe charge meter reads [round(src.percent() )]%.")
+		to_chat(user, "[desc]\nThe manufacturer's label states this cell has a power rating of [maxcharge]J, and that you should not swallow it.\nThe charge meter reads [round(src.percent() )]%.")
 	else
-		to_chat(user, "This power cell has an exciting chrome finish, as it is an uber-capacity cell type! It has a power rating of [maxcharge]!\nThe charge meter reads [round(src.percent() )]%.")
+		to_chat(user, "This power cell has an exciting chrome finish, as it is an uber-capacity cell type! It has a power rating of [maxcharge]J!\nThe charge meter reads [round(src.percent() )]%.")
 
 /obj/item/cell/attackby(obj/item/W, mob/user)
 	..()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -29,6 +29,7 @@
 
 	var/capacity = 5e6 // maximum charge
 	var/charge = 1e6 // actual charge
+	var/max_coils = 0
 
 	var/input_attempt = 0 			// 1 = attempting to charge, 0 = not attempting to charge
 	var/inputting = 0 				// 1 = actually inputting, 0 = not inputting
@@ -112,6 +113,16 @@
 
 	if(!should_be_mapped)
 		warning("Non-buildable or Non-magical SMES at [src.x]X [src.y]Y [src.z]Z")
+
+/obj/machinery/power/smes/examine(mob/user)
+	. = ..()
+	if(open_hatch)
+		to_chat(user, SPAN_SUBTLE("The maintenance hatch is open."))
+		if (max_coils > 1 && Adjacent(user))
+			var/list/coils = list()
+			for(var/obj/item/smes_coil/C in component_parts)
+				coils += C
+			to_chat(user, "The [max_coils] coil slots contain: [counting_english_list(coils)]")
 
 /obj/machinery/power/smes/add_avail(var/amount)
 	if(..(amount))
@@ -298,11 +309,17 @@
 	if(W.isscrewdriver())
 		if(!open_hatch)
 			open_hatch = 1
-			to_chat(user, "<span class='notice'>You open the maintenance hatch of [src].</span>")
+			user.visible_message(\
+				"<span class='notice'>\The [user] opens the maintenance hatch of \the [src].</span>",\
+				"<span class='notice'>You open the maintenance hatch of \the [src].</span>",\
+				range = 4)
 			return 0
 		else
 			open_hatch = 0
-			to_chat(user, "<span class='notice'>You close the maintenance hatch of [src].</span>")
+			user.visible_message(\
+				"<span class='notice'>\The [user] closes the maintenance hatch of \the [src].</span>",\
+				"<span class='notice'>You close the maintenance hatch of \the [src].</span>",\
+				range = 4)
 			return 0
 
 	if (!open_hatch)
@@ -322,8 +339,8 @@
 		building_terminal = 0
 		CC.use(10)
 		user.visible_message(\
-				"<span class='notice'>[user.name] has added cables to the [src].</span>",\
-				"<span class='notice'>You added cables to the [src].</span>")
+			"<span class='notice'>[user.name] has added cables to the [src].</span>",\
+			"<span class='notice'>You added cables to the [src].</span>")
 		terminal.connect_to_network()
 		stat = 0
 		return 0

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -15,7 +15,7 @@
 	var/ChargeCapacity = 5000000
 	var/IOCapacity = 250000
 
-/obj/item/smes_coil/New(loc, ...)
+/obj/item/smes_coil/Initialize()
 	. = ..()
 	desc += {"
 The label reads:

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -15,14 +15,14 @@
 	var/ChargeCapacity = 5000000
 	var/IOCapacity = 250000
 
-/obj/item/smes_coil/Initialize()
+/obj/item/smes_coil/examine(mob/user)
 	. = ..()
-	desc += {"
-The label reads:
-<span class='notice'>Only certified professionals are allowed to handle and install this component.
-Charge capacity: [ChargeCapacity/1000000] MJ
-Input/Output rating: [IOCapacity/1000] kW</span>
-"}
+	if(Adjacent(user))
+		to_chat(user, "The label reads:\
+			<div class='notice' style='padding-left:2rem'>Only certified professionals are allowed to handle and install this component.<br>\
+			Charge capacity: [ChargeCapacity/1000000] MJ<br>\
+			Input/Output rating: [IOCapacity/1000] kW</div>",
+			trailing_newline = FALSE)
 
 // 20% Charge Capacity, 60% I/O Capacity. Used for substation/outpost SMESs.
 /obj/item/smes_coil/weak

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -8,31 +8,40 @@
 //MAGNETIC COILS - These things actually store and transmit power within the SMES. Different types have different
 /obj/item/smes_coil
 	name = "superconductive magnetic coil"
-	desc = "Standard superconductive magnetic coil with average capacity and I/O rating."
+	desc = "Standard superconductive magnetic coil with balanced capacity and I/O rating."
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "smes_coil"			// Just few icons patched together. If someone wants to make better icon, feel free to do so!
-	w_class = ITEMSIZE_LARGE 						// It's LARGE (backpack size)
+	w_class = ITEMSIZE_LARGE 			// It's LARGE (backpack size)
 	var/ChargeCapacity = 5000000
 	var/IOCapacity = 250000
+
+/obj/item/smes_coil/New(loc, ...)
+	. = ..()
+	desc += {"
+The label reads:
+<span class='notice'>Only certified professionals are allowed to handle and install this component.
+Charge capacity: [ChargeCapacity/1000000] MJ
+Input/Output rating: [IOCapacity/1000] kW</span>
+"}
 
 // 20% Charge Capacity, 60% I/O Capacity. Used for substation/outpost SMESs.
 /obj/item/smes_coil/weak
 	name = "basic superconductive magnetic coil"
-	desc = "Cheaper model of standard superconductive magnetic coil. It's capacity and I/O rating are considerably lower."
+	desc = "Cheaper model of the standard superconductive magnetic coil. Its capacity and I/O rating are considerably lower."
 	ChargeCapacity = 1000000
 	IOCapacity = 150000
 
 // 1000% Charge Capacity, 20% I/O Capacity
 /obj/item/smes_coil/super_capacity
 	name = "superconductive capacitance coil"
-	desc = "Specialised version of standard superconductive magnetic coil. This one has significantly stronger containment field, allowing for significantly larger power storage. It's IO rating is much lower, however."
+	desc = "Specialised version of the standard superconductive magnetic coil. It has significantly stronger containment field, allowing for immense power storage. However its I/O rating is much lower."
 	ChargeCapacity = 50000000
 	IOCapacity = 50000
 
 // 10% Charge Capacity, 400% I/O Capacity. Technically turns SMES into large super capacitor.Ideal for shields.
 /obj/item/smes_coil/super_io
 	name = "superconductive transmission coil"
-	desc = "Specialised version of standard superconductive magnetic coil. While this one won't store almost any power, it rapidly transfers power, making it useful in systems which require large throughput."
+	desc = "Specialised version of the standard superconductive magnetic coil. While it's almost useless for power storage it can rapidly transfer power, making it useful in systems that require large throughput."
 	ChargeCapacity = 500000
 	IOCapacity = 1000000
 
@@ -57,7 +66,7 @@
 
 // SMES itself
 /obj/machinery/power/smes/buildable
-	var/max_coils = 6 			//30M capacity, 1.5MW input/output when fully upgraded /w default coils
+	max_coils = 6 				// 30M capacity, 1.5MW input/output when fully upgraded /w default coils
 	var/cur_coils = 1 			// Current amount of installed coils
 	var/safeties_enabled = 1 	// If 0 modifications can be done without discharging the SMES, at risk of critical failure.
 	var/failing = 0 			// If 1 critical failure has occured and SMES explosion is imminent.

--- a/html/changelogs/amunak-smes-improvements.yml
+++ b/html/changelogs/amunak-smes-improvements.yml
@@ -1,0 +1,5 @@
+author: Amunak
+delete-after: True
+changes:
+  - rscadd: "SMES now show whether the maintenance hatch is open, they visibly show (in short range) that the hatch was opened/closed, and when open you can examine the SMES and see what coils are inside."
+  - rscadd: "SMES coils' descriptions now read its 'label' with the coils' charge capacity and I/O rating. Also tweaked the descriptions and fixed some typos."

--- a/html/changelogs/amunak-smes-improvements.yml
+++ b/html/changelogs/amunak-smes-improvements.yml
@@ -2,4 +2,4 @@ author: Amunak
 delete-after: True
 changes:
   - rscadd: "SMES now show whether the maintenance hatch is open, they visibly show (in short range) that the hatch was opened/closed, and when open you can examine the SMES and see what coils are inside."
-  - rscadd: "SMES coils' descriptions now read its 'label' with the coils' charge capacity and I/O rating. Also tweaked the descriptions and fixed some typos."
+  - rscadd: "SMES coils, when examined closely, will now show a label with the charge capacity and I/O rating. Also tweaked descriptions of SMES coils and fixed some typos."


### PR DESCRIPTION
* SMES coils when examined closely now show a "label" with capacity and IO throughput.
* Mobs within a small distance can see when you open and close the SMES hatch. This also reflects in the examine info.
* When the hatch is open and you stand next to the SMES you can examine it and see what the coil slots are populated with (and how many there are in total).
* Also tacked on a description change for power cells when examining: capacity is now shown excplicitly in Joules.

I pondered about just adding the totals into the UI or at least make it a "thought" when inspecting the open hatch, but I think this adds most to the experience of an engineer. The equipment doesn't help you too much but if you know the specs (aka read the labels) and do some math you can get some exact numbers.

Example SMES upgrade also showing the new "labels" on coils:
![SMES upgrade chat log](https://user-images.githubusercontent.com/781546/96378627-9f8fe280-118d-11eb-8537-72c98454476e.png)

-----

**Latest** appearance of SMES coil examine:
![SMES coil examine](https://user-images.githubusercontent.com/781546/96595731-48545400-12ec-11eb-9035-8273d552d708.png)

