### PR TITLE
Makes NT-ERT Adminspawn Only

### DIFF
--- a/code/datums/ert/nanotrasen.dm
+++ b/code/datums/ert/nanotrasen.dm
@@ -1,6 +1,7 @@
 /datum/responseteam/nanotrasen
 	name = "Nanotrasen ERT"
-	chance = 20
+	admin = TRUE
+	chance = 1
 	spawner = /datum/ghostspawner/human/ert/nanotrasen
 
 /datum/responseteam/deathsquad

--- a/code/datums/ert/tcfl.dm
+++ b/code/datums/ert/tcfl.dm
@@ -1,4 +1,4 @@
 /datum/responseteam/tcfl
 	name = "Tau Ceti Foreign Legion"
-	chance = 20
+	chance = 25
 	spawner = /datum/ghostspawner/human/ert/tcfl

--- a/html/changelogs/snakebittenn-fuckert.yml
+++ b/html/changelogs/snakebittenn-fuckert.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: Snakebittenn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "NT ERT is adminspawn only."
+  - tweak: "Raises TCFL chance just a bit."


### PR DESCRIPTION
To combat rampant imbalance and other stuff listed in https://forums.aurorastation.org/topic/15036-erts-are-bad-for-gameplay-and-roleplay-destroy-them/, I decided it would probably be cool if NT ERT was aspawn only as opposed to just randomly appearing.
Also raises TCFL chance a bit.