### PR TITLE
Antags can now show as "apprehended" at end of round

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -130,10 +130,12 @@
 #define DEFAULT_JOB_TYPE /datum/job/assistant
 
 //Area flags, possibly more to come
-#define RAD_SHIELDED 1 //shielded from radiation, clearly
-#define SPAWN_ROOF   2 // if we should attempt to spawn a roof above us.
-#define HIDE_FROM_HOLOMAP 4 // if we shouldn't be drawn on station holomaps
-#define FIRING_RANGE	8
+#define RAD_SHIELDED        1 //shielded from radiation, clearly
+#define SPAWN_ROOF          2 // if we should attempt to spawn a roof above us.
+#define HIDE_FROM_HOLOMAP   4 // if we shouldn't be drawn on station holomaps
+#define FIRING_RANGE        8
+#define NO_CREW_EXPECTED   16 // Areas where crew is not expected to ever be. Used to tell antag bases and such from crew-accessible areas on centcom level.
+#define PRISON             32 // Marks prison area for purposes of checking if brigged/imprisoned
 
 // Convoluted setup so defines can be supplied by Bay12 main server compile script.
 // Should still work fine for people jamming the icons into their repo.

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -459,11 +459,12 @@
 // have to call this periodically for the duration to work properly
 /datum/mind/proc/is_brigged(duration)
 	var/turf/T = current.loc
-	if(!istype(T))
+	if(isnull(T))
 		brigged_since = -1
 		return 0
+	var/area/A = T.loc
 	var/is_currently_brigged = 0
-	if(istype(T.loc,/area/security/brig))
+	if(A?.is_prison())
 		is_currently_brigged = 1
 		for(var/obj/item/card/id/card in current)
 			is_currently_brigged = 0

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -1,5 +1,4 @@
 /datum/antagonist/proc/print_player_summary()
-
 	if(!current_antagonists.len)
 		return 0
 
@@ -64,14 +63,23 @@
 	var/role = ply.assigned_role ? "\improper[ply.assigned_role]" : "\improper[ply.special_role]"
 	var/text = "<br><b>[ply.name]</b> as \a <b>[role]</b> ("
 	if(ply.current)
-		if(ply.current.stat == DEAD)
+		var/mob/living/M = ply.current
+		var/mob/living/carbon/C = M
+		var/turf/T = M.loc
+		var/area/A = T.loc
+		if(M.stat == DEAD)
 			text += "died"
-		else if(isNotStationLevel(ply.current.z))
+		else if(A?.is_prison() || (!A?.is_no_crew_expected() && C?.handcuffed))
+			// they are either imprisoned, or handcuffed in an area that can't be considered a hideout
+			text += "apprehended"
+		else if(isNotStationLevel(M.z))
 			text += "fled the station"
 		else
 			text += "survived"
-		if(ply.current.real_name != ply.name)
-			text += " as <b>[ply.current.real_name]</b>"
+		if(M.stat == UNCONSCIOUS)
+			text += " - unconscious"
+		if(M.real_name != ply.name)
+			text += " as <b>[M.real_name]</b>"
 	else
 		text += "body destroyed"
 	text += ")"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -92,6 +92,12 @@
 
 	. = ..()
 
+/area/proc/is_prison()
+	return flags & PRISON
+
+/area/proc/is_no_crew_expected()
+	return flags & NO_CREW_EXPECTED
+
 /area/proc/set_lightswitch(var/state)
 	lightswitch = state
 	var/obj/machinery/light_switch/L = locate() in src

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -31,7 +31,7 @@ var/hadevent    = 0
 
 	var/list/area/areas = list()
 	for(var/area/A in the_station_areas)
-		if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
+		if(A.is_prison())
 			areas += A
 
 	if(areas && areas.len > 0)

--- a/html/changelogs/amunak-antags-print-apprehended.yml
+++ b/html/changelogs/amunak-antags-print-apprehended.yml
@@ -1,0 +1,5 @@
+author: Amunak
+delete-after: True
+changes:
+  - rscadd: "End of round summary will now show antagonists as 'apprehended' if they end the round in brig or in cuffs (in 'regular' areas like station, centcom or shuttle) instead of 'fled the station'."
+  - backend: "Added two area flags: PRISON and NO_CREW_EXPECTED. The former marks prison areas while the latter marks areas where crew is never present unless for extraordinary circumstances. They are used to detect brigged people and antag status at end of round."

--- a/maps/_common/areas/shuttles.dm
+++ b/maps/_common/areas/shuttles.dm
@@ -62,13 +62,17 @@
 
 /area/shuttle/burglar
 	name = "Unidentified Transport"
+	flags = RAD_SHIELDED | SPAWN_ROOF | NO_CREW_EXPECTED
 
 /area/shuttle/skipjack
+	flags = RAD_SHIELDED | SPAWN_ROOF | NO_CREW_EXPECTED
 
 /area/shuttle/mercenary
+	flags = RAD_SHIELDED | SPAWN_ROOF | NO_CREW_EXPECTED
 
 /area/shuttle/syndicate_elite
 	name = "Naval Transport Shuttle"
+	flags = RAD_SHIELDED | SPAWN_ROOF | NO_CREW_EXPECTED
 
 /area/shuttle/administration
 	name = "Unidentified Corvette"
@@ -82,6 +86,7 @@
 /area/shuttle/legion
 	name = "Foreign Legion Shuttle"
 	base_turf = /turf/unsimulated/floor/plating
+	flags = RAD_SHIELDED | SPAWN_ROOF | NO_CREW_EXPECTED
 
 /area/shuttle/distress
 	name = "Unidentified Shuttle"
@@ -89,6 +94,6 @@
 
 /area/shuttle/merchant
 	name = "Merchant Ship"
-	flags = RAD_SHIELDED | SPAWN_ROOF
 	base_turf = /turf/space
 	sound_env = LARGE_ENCLOSED
+	flags = RAD_SHIELDED | SPAWN_ROOF | NO_CREW_EXPECTED

--- a/maps/_common/areas/special.dm
+++ b/maps/_common/areas/special.dm
@@ -5,6 +5,7 @@
 	name = "CentComm Solitary Confinement"
 	icon_state = "brig"
 	centcomm_area = 1
+	flags = PRISON
 
 /area/centcom
 	name = "Centcom"
@@ -78,6 +79,7 @@
 /area/centcom/legion
 	name = "BLV The Tower - Deck 1"
 	icon_state = "blvtower"
+	flags = NO_CREW_EXPECTED
 
 /area/centcom/legion/hangar5
 	name = "BLV The Tower - Hangar 5"
@@ -96,6 +98,7 @@
 	dynamic_lighting = 1
 	no_light_control = 1
 	centcomm_area = 1
+	flags = NO_CREW_EXPECTED
 	ambience = AMBIENCE_HIGHSEC
 
 /area/merchant_station/warehouse
@@ -111,6 +114,7 @@
 	requires_power = FALSE
 	no_light_control = TRUE
 	centcomm_area = TRUE
+	flags = NO_CREW_EXPECTED
 
 /area/antag/mercenary
 	name = "Mercenary Barracks"
@@ -143,6 +147,7 @@
 	sound_env = ARENA
 	no_light_control = 1
 	centcomm_area = 1
+	flags = NO_CREW_EXPECTED
 
 /area/tdome/tdome1
 	name = "Thunderdome (Team 1)"
@@ -169,6 +174,7 @@
 	dynamic_lighting = 1
 	no_light_control = 0
 	base_turf = /turf/space
+	flags = NO_CREW_EXPECTED
 
 /area/kataphract_chapter/bridge
 	name = "Kataphract Chapter - Bridge"

--- a/maps/_common/areas/station/security.dm
+++ b/maps/_common/areas/station/security.dm
@@ -25,6 +25,7 @@
 /area/security/brig
 	name = "Security - Brig"
 	lightswitch = TRUE
+	flags = PRISON
 	icon_state = "brig"
 
 /area/security/brig/prison_break()
@@ -38,6 +39,7 @@
 /area/security/prison
 	name = "Security - Prison Wing"
 	lightswitch = TRUE
+	flags = PRISON
 	icon_state = "sec_prison"
 
 /area/security/prison/prison_break()
@@ -155,7 +157,7 @@
 	icon_state = "security"
 	icon_state = "security"
 	holomap_color = null
-	flags = HIDE_FROM_HOLOMAP
+	flags = HIDE_FROM_HOLOMAP | PRISON
 	sound_env = LARGE_ENCLOSED
 	ambience = AMBIENCE_HIGHSEC
 


### PR DESCRIPTION
* Antags that end the round in a prison-type area or in cuffs in a player-accessible area (not the antag bases/shuttles, but centcom, station, anything else) show as "apprehended" at end of round.
* Added two area flags to facilitate this change, and replaced checks for specific area types with a check for the flag where it makes sense.
* Also added a little "unconscious" note for antags that end the round technically neither apprehended nor dead, but still unconscious.

(ended in a brig area)
![end of round example 1](https://user-images.githubusercontent.com/781546/96517767-d63b2b00-1269-11eb-836e-6c296c73fb4e.png)

(ended in cuffs on station)
![end of round example 2](https://user-images.githubusercontent.com/781546/96517769-d76c5800-1269-11eb-9181-11077d857562.png)

Note: I did not change the success status of their mission, as I'm unsure if getting apprehended can really count against it.