### PR TITLE
NTNet Ethernet Bugfix

### DIFF
--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -73,6 +73,9 @@ var/global/ntnet_card_uid = 1
 				return 2
 			else
 				return 1
+		var/area/A = get_area(parent_computer)
+		if(A.centcomm_area && ethernet)
+			return 3
 
 	if(long_range) // Computer is not on station, but it has upgraded network card. Low signal.
 		return 1

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -60,16 +60,16 @@ var/global/ntnet_card_uid = 1
 		return 0
 	if(!check_functionality())
 		return 0
-	if(ethernet) // Computer is connected via wired connection.
-		return 3
-	if(!ntnet_global || !ntnet_global.check_function(specific_action)) // NTNet is down and we are not connected via wired connection. No signal.
+	if(!ntnet_global || !ntnet_global.check_function(specific_action))
 		return 0
 
 	if(parent_computer)
 		var/turf/T = get_turf(parent_computer)
 		if((T && istype(T)) && isStationLevel(T.z))
 			// Computer is on station. Low/High signal depending on what type of network card you have
-			if(long_range)
+			if(ethernet)
+				return 3
+			else if(long_range)
 				return 2
 			else
 				return 1

--- a/html/changelogs/geeves-ntnet_comp_stuff.yml
+++ b/html/changelogs/geeves-ntnet_comp_stuff.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Ethernet connections no longer allow computers to connect to an NTNet relay that's offline or doesn't exist."

--- a/html/changelogs/geeves-ntnet_comp_stuff.yml
+++ b/html/changelogs/geeves-ntnet_comp_stuff.yml
@@ -3,4 +3,4 @@ author: Geeves
 delete-after: True
 
 changes: 
-  - tweak: "Ethernet connections no longer allow computers to connect to an NTNet relay that's offline or doesn't exist."
+  - bugfix: "Ethernet connections no longer allow computers to connect to an NTNet relay that's offline or doesn't exist."


### PR DESCRIPTION
* Ethernet connections no longer allow computers to connect to an NTNet relay that's offline or doesn't exist.