### PR TITLE
Fix broken accent icons

### DIFF
--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -463,19 +463,13 @@ var/list/asset_datums = list()
 		"vueui.css" = 'vueui/dist/app.css'
 	)
 
-// /datum/asset/simple/accents
-// 	verify = FALSE
-
-// /datum/asset/simple/accents/register()
-// 	for(var/A in subtypesof(/datum/accent)) //yes we have to do this here, SSrecords isn't initialized yet
-// 		var/datum/accent/accent = new A
-// 		var/name = "[accent.tag_icon].png"
-// 		assets[name] = icon('./icons/accent_tags.dmi', accent.tag_icon)
-// 	..()
-
 /datum/asset/spritesheet/goonchat
 	name = "chat"
 
 /datum/asset/spritesheet/goonchat/register()
-	InsertAll(null, './icons/accent_tags.dmi')
+	var/icon/I = icon('icons/accent_tags.dmi')
+	for(var/path in subtypesof(/datum/accent))
+		var/datum/accent/A = new path
+		if(A.tag_icon)
+			Insert(A.tag_icon, I, A.tag_icon)
 	..()

--- a/html/changelogs/johnwildkins-accentfix.yml
+++ b/html/changelogs/johnwildkins-accentfix.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed certain accents having incorrect or missing icons in chat."


### PR DESCRIPTION
Fixes #10306 

now the code actually grabs all the language icons as opposed to shoving the entire.dmi into a spritesheet (because no-name templates apparently break it)