### PR TITLE
Hand labelers are no longer eaten by storage containers

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -518,6 +518,11 @@
 			to_chat(user, "<span class='warning'>Trying to place a loaded tray into [src] was a bad idea.</span>")
 			return
 
+	if(istype(W, /obj/item/hand_labeler))
+		var/obj/item/hand_labeler/HL = W
+		if(HL.mode == 1)
+			return
+
 	W.add_fingerprint(user)
 	return handle_item_insertion(W)
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -336,6 +336,12 @@
 			)
 		else
 			attack_hand(user)
+	else if(istype(W, /obj/item/hand_labeler))
+		var/obj/item/hand_labeler/HL = W
+		if (HL.mode == 1)
+			return
+		else
+			attack_hand(user)
 	else
 		attack_hand(user)
 	return

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -148,6 +148,12 @@
 				playsound(loc, W.usesound, 50, 1)
 				wrenched = 1
 				anchored = 1
+	else if(istype(W, /obj/item/hand_labeler))
+		var/obj/item/hand_labeler/HL = W
+		if (HL.mode == 1)
+			return
+		else
+			togglelock(user)
 	else if(!opened)
 		if(!broken && istype(W,/obj/item/material/twohanded/chainsaw))
 			var/obj/item/material/twohanded/chainsaw/ChainSawVar = W

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -115,6 +115,12 @@
 			playsound(loc, 'sound/items/wirecutter.ogg', 100, 1)
 			rigged = 0
 			return
+	else if(istype(W, /obj/item/hand_labeler))
+		var/obj/item/hand_labeler/HL = W
+		if (HL.mode == 1)
+			return
+		else
+			attack_hand(user)
 	else return attack_hand(user)
 
 /obj/structure/closet/crate/ex_act(severity)
@@ -340,7 +346,14 @@
 		return ..()
 	if(istype(W, /obj/item/melee/energy/blade))
 		emag_act(INFINITY, user)
-	if(!opened)
+	if(istype(W, /obj/item/hand_labeler))
+		var/obj/item/hand_labeler/HL = W
+		if (HL.mode == 1)
+			return
+		else if(!opened)
+			togglelock(user)
+			return
+	else if(!opened)
 		togglelock(user)
 		return
 	return ..()

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -49,6 +49,8 @@
 		return
 	if(A == loc)	// if placing the labeller into something (e.g. backpack)
 		return		// don't set a label
+	if(loc != user)
+		return
 
 	if(!labels_left)
 		to_chat(user, "<span class='notice'>No labels left.</span>")

--- a/html/changelogs/johnwildkins-labeler.yml
+++ b/html/changelogs/johnwildkins-labeler.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - tweak: "Hand labelers set 'on' will no longer go inside storage containers (backpacks, closets, crates), and will instead label them."


### PR DESCRIPTION
- Hand labelers set to "on" now are no longer placed inside backpacks, satchels, etc. They also no longer unlock storage closets while on, instead labeling them.