### PR TITLE
Fixes hostile mobs attacking unraised turrets

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -182,6 +182,8 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 		return B
 	if(istype(target_mob, /obj/machinery/porta_turret))
 		var/obj/machinery/porta_turret/T = target_mob
+		if(!T.raising && !T.raised)
+			return
 		src.do_attack_animation(T)
 		T.take_damage(max(melee_damage_lower, melee_damage_upper) / 2)
 		visible_message(SPAN_DANGER("\The [src] [attacktext] \the [T]!"))

--- a/html/changelogs/Ferner-201022-bugfix_hostile-turret-attack.yml
+++ b/html/changelogs/Ferner-201022-bugfix_hostile-turret-attack.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Hostile mobs no longer attack turrets that aren't raised."


### PR DESCRIPTION
As they can't damage them in that state they shouldn't attack them either, spamming chat logs.