### PR TITLE
Prevents AIs from right-click "inspecting" stuff they shouldn't be able to see

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -117,6 +117,23 @@
 	..()
 	return QDEL_HINT_IWILLGC
 
+/client
+	var/restore_popup_menus = FALSE
+
+/turf/MouseEntered(location, control, params)
+	if(isAI(usr) && !usr.client.buildmode)
+		var/datum/visualnet/v = usr?.eyeobj?.visualnet
+		if(!isnull(v))
+			if(usr.client.show_popup_menus && !v.is_turf_visible(src))
+				usr.client.restore_popup_menus = TRUE
+				usr.client.show_popup_menus = FALSE
+			else if(usr.client.restore_popup_menus && !usr.client.show_popup_menus && v.is_turf_visible(src))
+				usr.client.restore_popup_menus = FALSE
+				usr.client.show_popup_menus = TRUE
+	else if(usr.client.restore_popup_menus && !usr.client.show_popup_menus)
+		usr.client.restore_popup_menus = FALSE
+		usr.client.show_popup_menus = TRUE
+
 /turf/proc/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	underlay_appearance.appearance = src
 	underlay_appearance.dir = adjacency_dir

--- a/html/changelogs/amunak-ai-cheating.yml
+++ b/html/changelogs/amunak-ai-cheating.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "AIs are no longer able to right-click outside their camera coverage."


### PR DESCRIPTION
Title. Basically prevents AIs from cheating by looking outside of their camera coverage using the right-click popup menu.

I have tested that it doesn't break build menu (though you should probably use it when aghosted anyway).