### PR TITLE
Windoor fixes and tweaks

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -135,21 +135,14 @@
 		shatter()
 		return
 
-/obj/machinery/door/window/attack_ai(mob/user as mob)
-	if(operable())
-		return src.attack_hand(user)
-
 /obj/machinery/door/window/attack_hand(mob/user as mob)
-
-	if(istype(user,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = user
-		if(H.species.can_shred(H))
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-			playsound(src.loc, 'sound/effects/glass_hit.ogg', 75, 1)
-			user.visible_message("<span class='danger'>[user] smashes against [src].</span>", "<span class='danger'>You smash against [src]!</span>")
-			take_damage(25)
-			return
-		return attackby(user, user)
+	var/mob/living/carbon/human/H = user
+	if(istype(H) && H.species.can_shred(H))
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		playsound(src.loc, 'sound/effects/glass_hit.ogg', 75, 1)
+		user.visible_message("<span class='danger'>[user] smashes against [src].</span>", "<span class='danger'>You smash against [src]!</span>")
+		take_damage(25)
+		return
 	else if(operable())
 		return attackby(user, user)
 
@@ -229,6 +222,7 @@
 
 /obj/machinery/door/window/brigdoor/allowed(mob/M)
 	if(inoperable()) // Brigdoors are the exception to the "fail open" windoor - they lock closed
+		to_chat(M, SPAN_WARNING("\The [src] refuses to budge in its unpowered state."))
 		return FALSE
 	. = ..()
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -76,6 +76,7 @@
 	. = ..()
 	if(inoperable()) // Unpowered windoors can just be slid open
 		return TRUE
+	use_power(50) // Just powering the RFID and maybe a weak motor
 	if(operable() && . == FALSE)
 		flick("[base_state]deny", src)
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -9,7 +9,6 @@
 	maxhealth = 150 //If you change this, consiter changing ../door/window/brigdoor/ health at the bottom of this .dm file
 	health = 150
 	visible = 0.0
-	use_power = 0
 	flags = ON_BORDER
 	opacity = 0
 	var/obj/item/airlock_electronics/electronics = null
@@ -73,6 +72,13 @@
 		var/time = check_access(null) ? 50 : 20
 		addtimer(CALLBACK(src, .proc/close), time)
 
+/obj/machinery/door/window/allowed(mob/M)
+	. = ..()
+	if(inoperable()) // Unpowered windoors can just be slid open
+		return TRUE
+	if(operable() && . == FALSE)
+		flick("[base_state]deny", src)
+
 /obj/machinery/door/window/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
@@ -90,35 +96,34 @@
 	else
 		return 1
 
-/obj/machinery/door/window/open()
-	if (!ROUND_IS_STARTED)
+/obj/machinery/door/window/open(var/forced=FALSE)
+	if(!can_open() && !forced)
 		return FALSE
-	if(can_open())
-		operating = TRUE
-		flick("[base_state]opening", src)
-		playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
-		icon_state = "[base_state]open"
-		sleep(10)
+	operating = TRUE
+	flick("[base_state]opening", src)
+	playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
+	icon_state = "[base_state]open"
+	sleep(1 SECOND)
 
-		explosion_resistance = 0
-		src.density = FALSE
-		update_nearby_tiles()
-		operating = FALSE
-		return 1
+	explosion_resistance = 0
+	density = FALSE
+	update_nearby_tiles()
+	operating = FALSE
+	return TRUE
 
-/obj/machinery/door/window/close()
-	if (operating || emagged == 1)
+/obj/machinery/door/window/close(var/forced=FALSE)
+	if (!can_close() && !forced)
 		return FALSE
 	operating = TRUE
 	flick("[base_state]closing", src)
 	playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
-	src.icon_state = src.base_state
+	icon_state = base_state
 
-	src.density = TRUE
+	density = TRUE
 	explosion_resistance = initial(explosion_resistance)
 	update_nearby_tiles()
 
-	sleep(10)
+	sleep(1 SECOND)
 
 	operating = FALSE
 	return 1
@@ -130,7 +135,8 @@
 		return
 
 /obj/machinery/door/window/attack_ai(mob/user as mob)
-	return src.attack_hand(user)
+	if(operable())
+		return src.attack_hand(user)
 
 /obj/machinery/door/window/attack_hand(mob/user as mob)
 
@@ -142,7 +148,9 @@
 			user.visible_message("<span class='danger'>[user] smashes against [src].</span>", "<span class='danger'>You smash against [src]!</span>")
 			take_damage(25)
 			return
-	return src.attackby(user, user)
+		return attackby(user, user)
+	else if(operable())
+		return attackby(user, user)
 
 /obj/machinery/door/window/emag_act(var/remaining_charges, var/mob/user)
 	if (density && operable())
@@ -195,14 +203,17 @@
 	if(!istype(I, /obj/item/forensics))
 		src.add_fingerprint(user)
 
-	if (src.allowed(user))
+	if(allowed(user))
+		if(inoperable())
+			user.visible_message("\The [user] begins to manually [density ? "push" : "pull"] \the [src] [density ? "open" : "closed"]!",
+				"You begin to manually [density ? "push" : "pull"] \the [src] [density ? "open" : "closed"]!", "You hear the sound of a glass door [density ? "opening" : "closing"].")
+			if(!do_after(user, 1 SECOND, TRUE, src))
+				return
+			visible_message("\The [user] [density ? "pulls" : "pushes"] \the [src] [density ? "closed" : "open"].")
 		if (src.density)
 			open()
 		else
 			close()
-
-	else if (src.density)
-		flick("[base_state]deny", src)
 
 /obj/machinery/door/window/brigdoor
 	name = "secure door"
@@ -214,6 +225,16 @@
 	maxhealth = 300
 	health = 300.0 //Stronger doors for prison (regular window door health is 150)
 
+
+/obj/machinery/door/window/brigdoor/allowed(mob/M)
+	if(inoperable()) // Brigdoors are the exception to the "fail open" windoor - they lock closed
+		return FALSE
+	. = ..()
+
+/obj/machinery/door/window/brigdoor/power_change()
+	..()
+	if((stat & NOPOWER) && !density)
+		close(TRUE)
 
 /obj/machinery/door/window/northleft
 	dir = NORTH

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -826,6 +826,8 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/attack_can_reach(var/atom/us, var/atom/them, var/range)
 	if(us.Adjacent(them))
 		return TRUE // Already adjacent.
+	else if(range <= 1)
+		return FALSE
 	if(AStar(get_turf(us), get_turf(them), /turf/proc/AdjacentTurfsRanged, /turf/proc/Distance, max_nodes=25, max_node_depth=range))
 		return TRUE
 	return FALSE

--- a/html/changelogs/johnwildkins-windoor.yml
+++ b/html/changelogs/johnwildkins-windoor.yml
@@ -1,0 +1,7 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Items can no longer be placed through closed windoors, nor can mobs be attacked past them."
+  - tweak: "Windoors are now affected by power loss; non-secure (brig) windoors no longer check for access, but must be pushed open. Brig windoors lock shut and cannot be moved without power."


### PR DESCRIPTION
Fixes #939, fixes #4951, fixes #6151, and fixes #6229.

Windoors are now affected by power. When power is lost in an area, non-reinforced windoors "fail open" - that is to say they remain shut, but can be pushed open with relative ease and don't have access checks, much like their airlock cousins. Reinforced windoors (aka security/brigdoors) fail closed and lock into place. Neither can be remotely accessed by borgs/AI while unpowered.

Probably also fixes some unrelated bugs about being able to attack/interact with things through objects you shouldn't normally.

