### PR TITLE
Response Team Response Time

### DIFF
--- a/code/controllers/subsystems/responseteam.dm
+++ b/code/controllers/subsystems/responseteam.dm
@@ -37,6 +37,8 @@
 /datum/controller/subsystem/responseteam/proc/pick_random_team()
 	var/list/datum/responseteam/possible_teams = list()
 	for(var/datum/responseteam/ert in available_teams)
+		if(ert.minimum_call_time && ert.minimum_call_time > world.time)
+			continue
 		possible_teams[ert] = ert.chance
 
 	return pickweight(possible_teams)

--- a/code/datums/ert/nanotrasen.dm
+++ b/code/datums/ert/nanotrasen.dm
@@ -2,6 +2,7 @@
 	name = "Nanotrasen ERT"
 	chance = 20
 	spawner = /datum/ghostspawner/human/ert/nanotrasen
+	minimum_call_time = 2.5 HOURS
 
 /datum/responseteam/deathsquad
 	name = "Nanotrasen Asset Protection"

--- a/code/datums/ert/responseteam.dm
+++ b/code/datums/ert/responseteam.dm
@@ -4,3 +4,4 @@
 	var/datum/ghostspawner/human/ert/spawner        //This response type's BASE spawner type.
 	var/admin = FALSE								// if this is a special team that is not supossed to show up in regular rounds
 	var/datum/map_template/equipment_map 			// if this team spawns extra equipment
+	var/minimum_call_time = 0						// the amount of time the round has to pass before this team is eligible to respond

--- a/html/changelogs/geeves-reponse_time.yml
+++ b/html/changelogs/geeves-reponse_time.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "NT-ERT is now only available after the round has progressed two and a half hours."


### PR DESCRIPTION
* NT-ERT is now only available after the round has progressed two and a half hours.