### PR TITLE
Migration event fixes

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -25,7 +25,7 @@
 			return 0
 	return 1
 
-/proc/get_random_turf_in_range(var/atom/origin, var/outer_range, var/inner_range, var/check_density)
+/proc/get_random_turf_in_range(var/atom/origin, var/outer_range, var/inner_range, var/check_density, var/check_indoors)
 	origin = get_turf(origin)
 	if(!origin)
 		return
@@ -38,6 +38,10 @@
 				continue
 			if(check_density && turf_contains_dense_objects(T))
 				continue
+			if(check_indoors)
+				var/area/A = get_area(T)
+				if(A.station_area)
+					continue
 		if(!inner_range || get_dist(origin, T) >= inner_range)
 			turfs += T
 	if(turfs.len)

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -54,7 +54,7 @@
 		if(spawn_drones && prob(25))
 			var/drone_num = rand(1, 2)
 			for(var/d = 1, d <= drone_num, d++)
-				new /mob/living/simple_animal/hostile/icarus_drone(get_random_turf_in_range(spawn_locations[i], 10, 6, TRUE))
+				new /mob/living/simple_animal/hostile/icarus_drone(get_random_turf_in_range(spawn_locations[i], 10, 6, TRUE, TRUE))
 		for(var/j = 1, j <= group_size, j++)
 			if(prob(95))
 				var/mob/living/simple_animal/hostile/carp/carp = new(spawn_locations[i])

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -43,6 +43,8 @@
 	attack_emote = "nashes at"
 
 	flying = TRUE
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_NOLIGHTING
 
 /mob/living/simple_animal/hostile/carp/Allow_Spacemove(var/check_drift = 0)
 	return 1	//No drifting in space for space carp!	//original comments do not steal

--- a/code/modules/mob/living/simple_animal/hostile/icarus_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/icarus_drone.dm
@@ -54,6 +54,8 @@
 	tameable = FALSE
 
 	flying = TRUE
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_NOLIGHTING
 
 /mob/living/simple_animal/hostile/icarus_drone/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
@@ -30,8 +30,6 @@
 	destroy_surroundings = 1
 
 	emote_see = list("stares","hovers ominously","blinks")
-	see_in_dark = 8
-	see_invisible = SEE_INVISIBLE_NOLIGHTING
 
 	min_oxy = 0
 	max_oxy = 0
@@ -46,6 +44,8 @@
 	faction = "cavern"
 
 	flying = TRUE
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_NOLIGHTING
 
 /mob/living/simple_animal/hostile/retaliate/cavern_dweller/Allow_Spacemove(var/check_drift = 0)
 	return 1

--- a/html/changelogs/Ferner-201024-bugfix_carpsight.yml
+++ b/html/changelogs/Ferner-201024-bugfix_carpsight.yml
@@ -1,0 +1,5 @@
+author: Ferner
+delete-after: True
+changes: 
+  - bugfix: "Fixed Icarus drones sometimes spawning indoors."
+  - bugfix: "Fixed carp and Icarus drones not seeing in the dark."


### PR DESCRIPTION
 - Fixes Icarus drones sometimes spawning indoors
 - Fixed carp and drones not having night vision, leading to them only fighting if they bump into each other at times.