### PR TITLE
Requires Power Bugfix

### DIFF
--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -37,7 +37,7 @@
 	if (!istype(loc, /turf/simulated/floor))
 		to_chat(usr, "<span class='danger'>\The [src] Alarm cannot be placed on this spot.</span>")
 		return
-	if (A.requires_power == FALSE || istype(A, /area/space) || istype(A, /area/mine))
+	if (istype(A, /area/space) || istype(A, /area/mine))
 		to_chat(usr, "<span class='danger'>\The [src] Alarm cannot be placed in this area.</span>")
 		return
 

--- a/html/changelogs/geeves-requires_power.yml
+++ b/html/changelogs/geeves-requires_power.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Lights, air alarms, and APCs can now be placed in areas that don't necessarily require power."


### PR DESCRIPTION
* Lights, air alarms, and APCs can now be placed in areas that don't necessarily require power.

Any area that needs to clamp down on these can modify these values here.
![image](https://user-images.githubusercontent.com/22774890/97093603-aca94780-164d-11eb-8ceb-b49ccd1fadc3.png)