### PR TITLE
Adds an admin secret to turn all light switches on, off or to initial state

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1154,6 +1154,7 @@
 #include "code\modules\admin\secrets\fun_secrets\break_some_lights.dm"
 #include "code\modules\admin\secrets\fun_secrets\fix_all_lights.dm"
 #include "code\modules\admin\secrets\fun_secrets\ghost_mode.dm"
+#include "code\modules\admin\secrets\fun_secrets\light_switches.dm"
 #include "code\modules\admin\secrets\fun_secrets\make_all_areas_powered.dm"
 #include "code\modules\admin\secrets\fun_secrets\make_all_areas_unpowered.dm"
 #include "code\modules\admin\secrets\fun_secrets\only_one.dm"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -98,7 +98,10 @@
 /area/proc/is_no_crew_expected()
 	return flags & NO_CREW_EXPECTED
 
-/area/proc/set_lightswitch(var/state)
+/area/proc/set_lightswitch(var/state) // Set lights in area. TRUE for on, FALSE for off, NULL for initial state.
+	if(isnull(state))
+		state = initial(lightswitch)
+
 	lightswitch = state
 	var/obj/machinery/light_switch/L = locate() in src
 	if(L)

--- a/code/modules/admin/secrets/fun_secrets/light_switches.dm
+++ b/code/modules/admin/secrets/fun_secrets/light_switches.dm
@@ -1,0 +1,30 @@
+/datum/admin_secret_item/fun_secret/light_switches
+	name = "Set All Light Switches"
+	log = 0
+	feedback = 0
+	warn_before_use = 0
+
+/datum/admin_secret_item/fun_secret/light_switches/execute(var/mob/user)
+	. = ..()
+	if(.)
+		switch(input("What to set all light switches to?", "Set all light switches", "Cancel") in list("On", "Off", "Initial State", "Cancel"))
+			if("On")
+				log_and_message_admins("used secret '[name] ON'", user)
+				feedback_inc("admin_secrets_used", 1)
+				feedback_add_details("admin_secrets_used", "[name] ON")
+				set_switches(TRUE)
+			if("Off")
+				log_and_message_admins("used secret '[name] OFF'", user)
+				feedback_inc("admin_secrets_used", 1)
+				feedback_add_details("admin_secrets_used", "[name] OFF")
+				set_switches(FALSE)
+			if("Initial State")
+				log_and_message_admins("used secret '[name] INITIAL'", user)
+				feedback_inc("admin_secrets_used", 1)
+				feedback_add_details("admin_secrets_used", "[name] INITIAL")
+				set_switches(null)
+
+/datum/admin_secret_item/fun_secret/light_switches/proc/set_switches(var/new_state)
+	for(var/area/A in all_areas)
+		if(A.lightswitch != new_state)
+			A.set_lightswitch(new_state)

--- a/html/changelogs/amunak-lightswitches.yml
+++ b/html/changelogs/amunak-lightswitches.yml
@@ -1,0 +1,5 @@
+author: Amunak
+delete-after: True
+changes:
+  - admin: "Admins now have a new secret to turn all light switches on, off or to their initial state."
+  - backend: "The 'area/set_lightswitch' proc can now be passed 'null' to set the area lights to initial state."


### PR DESCRIPTION
Title. Also changed the `area/set_lightswitch` proc to accept `null` as argument that sets the light to initial state.

Due to the amount of admin secrets I decided to make this just a single secret instead of two.

Note that this does not change light status in APCs, which is a separate thing, so even when you turn all the light switches off stuff that's controlled only with APCs (hallways, usually) still has lights on. I thought about making that a secret as well but I don't need it and at that point just lighting/power stuff should probably have its own category in secrets.

### Screenshots
![dreamseeker_2020-10-25_18-47-26](https://user-images.githubusercontent.com/781546/97114728-8d182a80-16f2-11eb-8e64-9091e127d9b4.png)
