### PR TITLE
All atoms changing opacity will recalculate visibility

### DIFF
--- a/code/modules/lighting/__lighting_docs.dm
+++ b/code/modules/lighting/__lighting_docs.dm
@@ -27,7 +27,7 @@
     no_update -> if TRUE, the light will not be updated. Useful for when making several of these calls to the same object. Optional.
 
 /atom/proc/set_opacity(new_opacity)
-  desc: Sets an atom's opacity, updating affecting lights' visibility.
+  desc: Sets an atom's opacity, updating affecting lights' visibility. Returns TRUE if opacity changed, FALSE otherwise.
   args:
     new_opacity -> the new opacity value.
 

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -79,7 +79,7 @@
 			light = new/datum/light_source/sunlight(src, .)
 		else
 			light = new/datum/light_source(src, .)
-#else 
+#else
 		if (light)
 			light.update(.)
 		else
@@ -91,7 +91,7 @@
 	var/turf/T = loc
 
 	. = ..()
-	
+
 	if (opacity && istype(T))
 		T.recalc_atom_opacity()
 		T.reconsider_lights()
@@ -101,14 +101,14 @@
 // It notifies (potentially) affected light sources so they can update (if needed).
 /atom/proc/set_opacity(var/new_opacity)
 	if (new_opacity == opacity)
-		return
+		return FALSE
 
 	//L_PROF(src, "atom_setopacity")
 
 	opacity = new_opacity
 	var/turf/T = loc
 	if (!isturf(T))
-		return
+		return FALSE
 
 	if (new_opacity == TRUE)
 		T.has_opaque_atom = TRUE
@@ -121,6 +121,7 @@
 		T.recalc_atom_opacity()
 		if (old_has_opaque_atom != T.has_opaque_atom)
 			T.reconsider_lights()
+	return TRUE
 
 /atom/movable/forceMove()
 	. = ..()

--- a/code/modules/mob/abstract/freelook/update_triggers.dm
+++ b/code/modules/mob/abstract/freelook/update_triggers.dm
@@ -1,20 +1,19 @@
 //UPDATE TRIGGERS, when the chunk (and the surrounding chunks) should update.
 
-// TURFS
-
 /proc/updateVisibility(atom/A, var/opacity_check = TRUE)
 	if(SSticker)
 		for(var/datum/visualnet/VN in visual_nets)
 			VN.update_visibility(A, opacity_check)
-
-/turf/drain_power()
-	return -1
 
 /atom/Destroy()
 	if(opacity)
 		updateVisibility(src)
 	. = ..()
 
+/atom/set_opacity()
+	. = ..()
+	if(.)
+		updateVisibility(src, FALSE)
 
 /atom/movable/Move()
 	. = ..()
@@ -25,16 +24,6 @@
 	. = ..()
 	if(opacity && .)
 		updateVisibility(src)
-
-// DOORS
-
-// Simply updates the visibility of the area when it opens/closes/destroyed.
-/obj/machinery/door/update_nearby_tiles(need_rebuild)
-	. = ..(need_rebuild)
-	// Glass door glass = 1
-	// don't check then?
-	if(!glass)
-		updateVisibility(src, FALSE)
 
 /turf/ChangeTurf()
 	. = ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -166,7 +166,7 @@
 // If drain_check is set it will not actually drain power, just return a value.
 // If surge is set, it will destroy/damage the recipient and not return any power.
 // Not sure where to define this, so it can sit here for the rest of time.
-/atom/proc/drain_power(var/drain_check,var/surge, var/amount = 0)
+/atom/proc/drain_power(var/drain_check, var/surge, var/amount = 0)
 	return -1
 
 // Show a message to all mobs and objects in earshot of this one

--- a/html/changelogs/amunak-visibility-fix.yml
+++ b/html/changelogs/amunak-visibility-fix.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "All opacity changes (like when you toggle tinted windows) should now trigger camera visibility update (so that the AI can't spy through tinted windows until something else triggers the update)."


### PR DESCRIPTION
Title. All atoms that use `set_opacity` will now recalculate VisualNet visibility. Since this also applies to doors I could remove the door-specific override that did this.

I also removed the meaningless and misplaced `/turf/power_drain` proc override. The same code is already in the main `/atom/proc/power_drain` definition.

This fixes an issue where, for example, the tinted windows toggling tint would not update the AI's camera visibility even though they should.