### PR TITLE
Trolley Hitch Fix

### DIFF
--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -97,8 +97,8 @@
 /obj/vehicle/train/MouseDrop_T(var/atom/movable/C, mob/user as mob)
 	if(user.buckled || user.stat || user.restrained() || !Adjacent(user) || !user.Adjacent(C) || !istype(C) || (user == C && !user.canmove))
 		return
-	if(istype(C,/obj/vehicle/train))
-		latch(C, user)
+	if(istype(C, /obj/vehicle/train))
+		attach_to(C, user)
 	else
 		if(!load(C))
 			to_chat(user, "<span class='warning'>You were unable to load [C] on [src].</span>")

--- a/html/changelogs/geeves-trolley_fix.yml
+++ b/html/changelogs/geeves-trolley_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Unlatched trolleys can now be hitched again by dragging from the trolley you want to hitch to, to the unhitched trolley."


### PR DESCRIPTION
* Unlatched trolleys can now be hitched again by dragging from the trolley you want to hitch to, to the unhitched trolley.