### PR TITLE
Prevent regular robots from harming living things using their tools

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -71,14 +71,20 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 //I would prefer to rename this attack_as_weapon(), but that would involve touching hundreds of files.
 /obj/item/proc/attack(mob/living/M, mob/living/user, var/target_zone = BP_CHEST)
-
 	if(!force || (flags & NOBLUDGEON))
 		return 0
+
 	if(M == user && user.a_intent != I_HURT)
 		return 0
 
 	if(user.is_pacified())
 		return 0
+
+	if(issilicon(user))
+		var/mob/living/silicon/S = user
+		if (!S.allow_attack(M))
+			to_chat(S, SPAN_WARNING("Your programming prevents you from harming \the [M]."))
+			return FALSE
 
 	/////////////////////////
 	user.lastattacked = M

--- a/code/modules/mob/living/silicon/robot/presets.dm
+++ b/code/modules/mob/living/silicon/robot/presets.dm
@@ -3,6 +3,7 @@
 	mod_type = "Combat"
 	spawn_module = /obj/item/robot_module/combat
 	cell_type = /obj/item/cell/super
+	combat = TRUE
 
 /mob/living/silicon/robot/combat/ert
 	scrambled_codes = TRUE
@@ -24,6 +25,7 @@
 	law_update = FALSE
 	scrambled_codes = TRUE
 	status_flags = GODMODE
+	combat = TRUE
 
 /mob/living/silicon/robot/bluespace/verb/bstwalk()
 	set name = "Ruin Everything"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -286,6 +286,11 @@
 	QDEL_NULL(spark_system)
 	return ..()
 
+/mob/living/silicon/robot/allow_attack()
+	if(emagged)
+		return TRUE
+	return ..()
+
 /mob/living/silicon/robot/proc/set_module_sprites(var/list/new_sprites)
 	if(new_sprites && length(new_sprites))
 		module_sprites = new_sprites.Copy()

--- a/code/modules/mob/living/silicon/robot/syndicate_robot.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate_robot.dm
@@ -6,6 +6,7 @@
 	law_preset = /datum/ai_laws/syndicate_override
 	law_update = FALSE
 	scrambled_codes = TRUE
+	combat = TRUE
 
 	// Modules
 	mod_type = "Syndicate"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -19,6 +19,7 @@
 
 	// Bad Guy Stuff
 	var/syndicate = FALSE
+	var/combat = FALSE
 
 	// Laws
 	var/datum/ai_laws/laws
@@ -102,6 +103,9 @@
 
 /mob/living/silicon/drop_item()
 	return
+
+/mob/living/silicon/proc/allow_attack(mob/living/target)
+	return syndicate || combat
 
 /mob/living/silicon/emp_act(severity)
 	switch(severity)

--- a/html/changelogs/amunak-robots-no-attack.yml
+++ b/html/changelogs/amunak-robots-no-attack.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - rscadd: "Robots are no longer capable of harming living beings (except simple animals) unless they are emagged, syndicate or combat. Their programming directives forbid it."


### PR DESCRIPTION
This tries to prevent robots from attacking using their tools (they can't do unarmed attacks and whatnot regardless) unless they are syndicate, emagged or combat without breaking their ability to do surgery and use their tools. [[Feedback Thread](https://forums.aurorastation.org/topic/15072-feedback-preventing-borgs-non-antag-not-hacked-non-combat-from-harming-living-beings/)]

However I have no idea if this is the correct way to do it. It works, but:
* It requires additional code in the attack proc, which is I think a bad place for it.
* Any item can override this check (and probably does), so it's possible some have hardcoded attacks or something and my check won't apply.
* I would've preferred to add the `allow_attack` proc on a more base type, but it'd probably get _very_ complicated with how weird the attack code is.

### Screenshots
#### Regular robot
![dreamseeker_2020-10-25_17-24-35](https://user-images.githubusercontent.com/781546/97113130-9ac8b280-16e8-11eb-965c-287dcfd704c3.png)
#### Combat borg
![dreamseeker_2020-10-25_17-27-08](https://user-images.githubusercontent.com/781546/97113143-a2885700-16e8-11eb-8926-ee18ca4fe644.png)


### IC changelog
All robot chassis have been updated with latest firmware, preventing most occasions of stationbounds accidentally harming living beings.