### PR TITLE
Power cells now drain to zero

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -59,11 +59,10 @@
 // Checks if the specified amount can be provided. If it can, it removes the amount
 // from the cell and returns 1. Otherwise drains the charge to exactly 0 and returns 0.
 /obj/item/cell/proc/checked_use(var/amount)
+	. = TRUE
 	if(!check_charge(amount))
-		charge = 0
-		return 0
+		. = FALSE
 	use(amount)
-	return 1
 
 // recharge the cell
 /obj/item/cell/proc/give(var/amount)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -57,9 +57,10 @@
 	return used
 
 // Checks if the specified amount can be provided. If it can, it removes the amount
-// from the cell and returns 1. Otherwise does nothing and returns 0.
+// from the cell and returns 1. Otherwise drains the charge to exactly 0 and returns 0.
 /obj/item/cell/proc/checked_use(var/amount)
 	if(!check_charge(amount))
+		charge = 0
 		return 0
 	use(amount)
 	return 1

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -59,9 +59,7 @@
 // Checks if the specified amount can be provided. If it can, it removes the amount
 // from the cell and returns 1. Otherwise drains the charge to exactly 0 and returns 0.
 /obj/item/cell/proc/checked_use(var/amount)
-	. = TRUE
-	if(!check_charge(amount))
-		. = FALSE
+	. = check_charge(amount)
 	use(amount)
 
 // recharge the cell

--- a/html/changelogs/cell_drain_to_zero.yml
+++ b/html/changelogs/cell_drain_to_zero.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Power cells now drain to exactly zero when it fails to completely satisfy a power demand. This will solve cases where the game thought cells with an extremely small amount of power weren't empty. e.g. Out of power robots that could not move not being able to use their Power Warning verb."


### PR DESCRIPTION
Fixes #10269
Fixes #6559

Power cells with an extremely small amount of power left were not satisfying `charge == 0` checks, but was too small to satisfy any power demands -- And thus never actually becomes zero.

There are many checks that just do `!cell?.charge` that expect a 'no charge left' state to be exactly zero.