### PR TITLE
Stack Icon Bugfix

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -166,6 +166,7 @@
 		if (istype(O, /obj/item/stack))
 			var/obj/item/stack/S = O
 			S.amount = produced
+			S.update_icon()
 			S.add_to_stacks(user)
 
 		if (istype(O, /obj/item/storage)) //BubbleWrap - so newly formed boxes are empty
@@ -322,6 +323,7 @@
 		var/transfer = src.transfer_to(item)
 		if (transfer)
 			to_chat(user, SPAN_NOTICE("You add a new [item.singular_name] to the stack. It now contains [item.amount] [item.singular_name]\s."))
+		item.update_icon()
 		if(!amount)
 			break
 

--- a/html/changelogs/geeves-stack_icon_update.yml
+++ b/html/changelogs/geeves-stack_icon_update.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - bugfix: "Creating stacks from material recipes will now update their icons to display their true fullness, such as making rods out of steel."


### PR DESCRIPTION
* Creating stacks from material recipes will now update their icons to display their true fullness, such as making rods out of steel.