### PR TITLE
Lazarus injectors reset text on revived mobs

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -816,6 +816,7 @@
 					M.faction = initial(M.faction)
 				M.revive()
 				M.icon_state = M.icon_living
+				M.desc = initial(M.desc)
 				loaded = FALSE
 				user.visible_message(SPAN_NOTICE("\The [user] revives \the [M] by injecting it with \the [src]."))
 				feedback_add_details("lazarus_injector", "[M.type]")

--- a/html/changelogs/hockaa-lazarusfix.yml
+++ b/html/changelogs/hockaa-lazarusfix.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+  - bugfix: "Simple mobs revived by lazarus injectors now show their alive description text."


### PR DESCRIPTION
Makes lazarus injectors reset the descriptions of mobs they revive.

Now people can't metagame when I accidentally kill Ginny.