### PR TITLE
Makes airlocks display crush messages

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1358,6 +1358,7 @@ About the new airlock wires panel:
 		adjustBruteLoss(round(crush_damage / AIRLOCK_CRUSH_DIVISOR))
 	SetStunned(5)
 	SetWeakened(5)
+	visible_message(SPAN_DANGER("[src] is crushed in the airlock!"), SPAN_DANGER("You are crushed in the airlock!"), SPAN_NOTICE("You hear airlock actuators momentarily struggle."))
 
 	var/turf/T = get_turf(src)
 

--- a/html/changelogs/hockaa-airlockcrushfix.yml
+++ b/html/changelogs/hockaa-airlockcrushfix.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+  - tweak: "Airlocks now display messages when crushing people."


### PR DESCRIPTION
Adds a short line to the mob airlock_crush proc to display a message when people get crushed in airlocks, making it easier to identify (especially in the case of simple mobs/animals) that someone is being crushed by an airlock.