### PR TITLE
Varedit remembers search (+ minor styling improvements)

### DIFF
--- a/code/js/view_variables.js
+++ b/code/js/view_variables.js
@@ -14,7 +14,10 @@ function updateSearch() {
 		} else {
 			li.style.display = "none";
 		}
-	}
+  }
+
+  var refresh_link = document.getElementById('refresh');
+  refresh_link.href = refresh_link.getAttribute('data-initial-href') + filter;
 }
 
 function selectTextField() {

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -521,6 +521,6 @@
 	if(href_list["datumrefresh"])
 		var/datum/DAT = locate(href_list["datumrefresh"])
 		if(istype(DAT, /datum) || istype(DAT, /client))
-			debug_variables(DAT)
+			debug_variables_open(DAT, href_list["search"])
 
 	return

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -12,7 +12,9 @@
 /client/proc/debug_variables(datum/D in world)
 	set category = "Debug"
 	set name = "View Variables"
+	debug_variables_open(D)
 
+/client/proc/debug_variables_open(var/datum/D, var/search = "")
 	if(!check_rights(0))
 		return
 
@@ -34,11 +36,12 @@
 			<script src='view_variables.js'></script>
 			<title>[D] (\ref[D] - [D.type])</title>
 			<style>
-				body { font-family: Verdana, sans-serif; font-size: 9pt; }
-				.value { font-family: "Courier New", monospace; font-size: 8pt; }
+				body { font-family: Arial, "Helvetica Neue", Helvetica, sans-serif; font-size: 10pt; }
+				.key, .value { font-family: "Fira Code", Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace, sans-serif; font-size: 9pt; }
+				.key { font-weight: bold }
 			</style>
 		</head>
-		<body onload='selectTextField(); updateSearch()'; onkeyup='updateSearch()'>
+		<body onload='selectTextField(); updateSearch()'>
 			<div align='center'>
 				<table width='100%'><tr>
 					<td width='50%'>
@@ -53,7 +56,7 @@
 					</td>
 					<td width='50%'>
 						<div align='center'>
-							<a href='?_src_=vars;datumrefresh=\ref[D]'>Refresh</a>
+							<a id='refresh' data-initial-href='?_src_=vars;datumrefresh=\ref[D];search=' href='?_src_=vars;datumrefresh=\ref[D];search=[search]'>Refresh</a>
 							<form>
 								<select name='file'
 								        size='1'
@@ -89,7 +92,9 @@
 					<input type='text'
 					       id='filter'
 					       name='filter_text'
-					       value=''
+					       value='[search]'
+					       onkeyup='updateSearch()'
+					       onchange='updateSearch()'
 					       style='width:100%;' />
 				</td>
 			</tr></table>
@@ -101,7 +106,7 @@
 		</html>
 		"}
 
-	usr << browse(html, "window=variables\ref[D];size=475x650")
+	usr << browse(html, "window=variables\ref[D];size=520x720")
 
 
 /proc/make_view_variables_var_list(datum/D)
@@ -166,4 +171,4 @@
 
 	var/valuestr = make_view_variables_value(value, varname)
 
-	return "<li>[ecm][varname] = [valuestr]</li>"
+	return "<li>[ecm]<span class='key'>[varname]</span> = [valuestr]</li>"

--- a/html/changelogs/amunak-varedit.yml
+++ b/html/changelogs/amunak-varedit.yml
@@ -1,0 +1,5 @@
+author: Amunak
+delete-after: True
+changes:
+  - admin: "Varedit now remembers what was in the 'search' field when you click the 'refresh' link."
+  - admin: "Tweaked varedit styles ever so slightly: it will now likely use a more preferred monospace font. Keys are bold and also monospace."


### PR DESCRIPTION
* Varedit now remembers what was in the 'search' field when you click the 'refresh' link. This makes our miserable lives a little less miserable.
* Tweaked varedit styles ever so slightly: it will now likely use a "better" monospace font depending on what's on your system. Var names are now bold and also monospace.
* The window spawns a tiny bit bigger.

#### Preview (notice the charge changing)
![2020-10-28_23-19-39](https://user-images.githubusercontent.com/781546/97502758-138f6f00-1974-11eb-9563-487d33e460ed.gif)

Also the font in the gif is Fira Code. Probably.