### PR TITLE
Emagged Pest Gun

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -197,9 +197,12 @@
 
 /obj/item/gun/energy/mousegun/emag_act(var/remaining_charges, var/mob/user)
 	if(!emagged)
-		to_chat(user, "<span class='warning'>You overload \the [src]'s shock modulator.</span>")
+		to_chat(user, SPAN_WARNING("You overload \the [src]'s shock modulator."))
+		max_shots = 10
 		projectile_type = /obj/item/projectile/beam/mousegun/emag
 		emagged = TRUE
+		QDEL_NULL(power_supply)
+		power_supply = new /obj/item/cell/device/variable(src, max_shots * charge_cost)
 		return TRUE
 
 /obj/item/gun/energy/net

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -176,6 +176,7 @@
 /obj/item/gun/energy/mousegun
 	name = "pest gun"
 	desc = "The NT \"Arodentia\" Pesti-Shock is a highly sophisticated and probably safe beamgun designed for rapid pest-control."
+	desc_antag = "This gun can be emagged to make it fire damaging beams and get more max shots. It doesn't do a lot of damage, but it is concealable."
 	icon = 'icons/obj/guns/pestishock.dmi'
 	icon_state = "pestishock"
 	item_state = "pestishock"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -242,8 +242,10 @@
 /obj/item/projectile/beam/mousegun/emag
 	name = "diffuse electrical arc"
 
-	taser_effect = 1
-	agony = 60
+	nodamage = FALSE
+	damage_type = BURN
+	damage = 15
+	agony = 30
 
 /obj/item/projectile/beam/mousegun/emag/mousepulse(turf/epicenter, range, log=0)
 	if(!epicenter)

--- a/html/changelogs/geeves-emagged_pest_gun.yml
+++ b/html/changelogs/geeves-emagged_pest_gun.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "Emagging the pest gun now increases its shot capacity to 10."
+  - tweak: "An emagged pest gun now does 15 burn damage per shot, as well as 30 halloss damage. Changed from only doing 60 halloss."


### PR DESCRIPTION
* Emagging the pest gun now increases its shot capacity to 10.
* An emagged pest gun now does 15 burn damage per shot, as well as 30 halloss damage. Changed from only doing 60 halloss.