### PR TITLE
Less Log Spam

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -212,7 +212,8 @@
 		no_clients = TRUE
 		if(istype(target_mob, /mob/living/heavy_vehicle))
 			var/mob/living/heavy_vehicle/HV = target_mob
-			for(var/mob/M in HV.pilots)
+			for(var/pilot in HV.pilots)
+			    var/mob/M = pilot
 				if(M.client)
 					no_clients = TRUE
 					break

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -207,7 +207,7 @@
 		target_mob.visible_message("<span class='danger'>\The [target_mob] is hit by \a [src] in the [impacted_organ]!</span>", "<span class='danger'><font size=2>You are hit by \a [src] in the [impacted_organ]!</font></span>")//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
 
 	//admin logs
-	if(!firer.client && !target_mob.client)
+	if((!ismob(firer) || !firer.client) && !target_mob.client)
 		no_attack_log = TRUE
 	if(!no_attack_log)
 		if(ismob(firer))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -207,6 +207,8 @@
 		target_mob.visible_message("<span class='danger'>\The [target_mob] is hit by \a [src] in the [impacted_organ]!</span>", "<span class='danger'><font size=2>You are hit by \a [src] in the [impacted_organ]!</font></span>")//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
 
 	//admin logs
+	if(!firer.client && !target_mob.client)
+		no_attack_log = TRUE
 	if(!no_attack_log)
 		if(ismob(firer))
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -213,9 +213,9 @@
 		if(istype(target_mob, /mob/living/heavy_vehicle))
 			var/mob/living/heavy_vehicle/HV = target_mob
 			for(var/pilot in HV.pilots)
-			    var/mob/M = pilot
+				var/mob/M = pilot
 				if(M.client)
-					no_clients = TRUE
+					no_clients = FALSE
 					break
 	if(no_clients)
 		no_attack_log = TRUE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -206,8 +206,17 @@
 	else
 		target_mob.visible_message("<span class='danger'>\The [target_mob] is hit by \a [src] in the [impacted_organ]!</span>", "<span class='danger'><font size=2>You are hit by \a [src] in the [impacted_organ]!</font></span>")//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
 
+	var/no_clients = FALSE
 	//admin logs
 	if((!ismob(firer) || !firer.client) && !target_mob.client)
+		no_clients = TRUE
+		if(istype(target_mob, /mob/living/heavy_vehicle))
+			var/mob/living/heavy_vehicle/HV = target_mob
+			for(var/mob/M in HV.pilots)
+				if(M.client)
+					no_clients = TRUE
+					break
+	if(no_clients)
 		no_attack_log = TRUE
 	if(!no_attack_log)
 		if(ismob(firer))

--- a/html/changelogs/geeves-no_log_spam.yml
+++ b/html/changelogs/geeves-no_log_spam.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - admin: "Projectiles hitting mobs will now not display an admin log if both the firer and the target has no client connected."


### PR DESCRIPTION
* Projectiles hitting mobs will now not display an admin log if both the firer and the target has no client connected.

Added the high priority tag, because there are events that spawn mobs that start firefights with eachother, and it makes reading logs very difficult for staff.