### PR TITLE
Nofall, Godmode, Bstech changes

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -10,11 +10,19 @@
 #define CANPUSH     0x8
 #define LEAPING     0x10
 #define PASSEMOTES  0x20    // Mob has a cortical borer or holders inside of it that need to see emotes.
+#define NOFALL      0x800
 #define GODMODE     0x1000
 #define FAKEDEATH   0x2000  // Replaces stuff like changeling.changeling_fakedeath.
 #define DISFIGURED  0x4000  // Set but never checked. Remove this sometime and replace occurences with the appropriate organ code
 #define XENO_HOST   0x8000  // Tracks whether we're gonna be a baby alien's mummy.
 #define NO_ANTAG    0x10000  // Players are restricted from gaining antag roles when occupying this mob
+
+// Incorporeal movement
+#define INCORPOREAL_DISABLE 0 // Disabled
+#define INCORPOREAL_GHOST   1 // Pass through matter like a ghost
+#define INCORPOREAL_NINJA   2 // Pass through matter with a cool effect
+#define INCORPOREAL_BSTECH  3 // Like ninja, but also go across Z-levels and move in space freely
+#define INCORPOREAL_SHADE   4 // Shady
 
 // Grab levels.
 #define GRAB_PASSIVE    1

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -39,7 +39,7 @@
 
 /mob/abstract/mental
 	universal_understand = 1
-	incorporeal_move = 1
+	incorporeal_move = INCORPOREAL_GHOST
 	density = 0
 
 /mob/abstract/mental/friend

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -274,16 +274,16 @@
 		suicide()
 
 /mob/living/carbon/human/bst/verb/antigrav()
-	set name = "Toggle Gravity"
-	set desc = "Toggles on/off falling for you."
+	set name = "Toggle Falling"
+	set desc = "Use bluespace technology to ignore gravity."
 	set category = "BST"
 
 	status_flags ^= NOFALL
 	to_chat(src, SPAN_NOTICE("You will [status_flags & NOFALL ? "no longer fall" : "now fall normally"]."))
 
 /mob/living/carbon/human/bst/verb/bstwalk()
-	set name = "Ruin Everything"
-	set desc = "Uses bluespace technology to phase through solid matter and move quickly."
+	set name = "Toggle Incorporeal Movement"
+	set desc = "Use bluespace technology to phase through solid matter and move quickly."
 	set category = "BST"
 	set popup_menu = 0
 
@@ -296,8 +296,8 @@
 	return
 
 /mob/living/carbon/human/bst/verb/bstrecover()
-	set name = "Rejuv"
-	set desc = "Use the bluespace within you to restore your health"
+	set name = "Restore Health"
+	set desc = "Use bluespace to teleport in a fresh, healthy body."
 	set category = "BST"
 	set popup_menu = 0
 
@@ -313,7 +313,7 @@
 
 /mob/living/carbon/human/bst/verb/bstquit()
 	set name = "Teleport out"
-	set desc = "Activate bluespace to leave and return to your original mob (if you have one)."
+	set desc = "Jump into bluespace and continue wherever you left off. Deletes the BSTech and returns to your original mob if you have one."
 	set category = "BST"
 
 	var/client/C = src.client
@@ -328,7 +328,7 @@
 
 /mob/living/carbon/human/bst/verb/tgm()
 	set name = "Toggle Godmode"
-	set desc = "Enable or disable god mode. For testing things that require you to be vulnerable."
+	set desc = "For when you want to be vulnerable."
 	set category = "BST"
 
 	status_flags ^= GODMODE

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -134,8 +134,7 @@
 
 /mob/living/carbon/human/bst
 	universal_understand = 1
-	status_flags = GODMODE
-	var/fall_override = TRUE
+	status_flags = GODMODE|NOFALL
 
 /mob/living/carbon/human/bst/can_inject(var/mob/user, var/error_msg, var/target_zone)
 	to_chat(user, SPAN_ALERT("The [src] disarms you before you can inject them."))
@@ -279,12 +278,8 @@
 	set desc = "Toggles on/off falling for you."
 	set category = "BST"
 
-	if (fall_override)
-		fall_override = FALSE
-		to_chat(usr, "<span class='notice'>You will now fall normally.</span>")
-	else
-		fall_override = TRUE
-		to_chat(usr, "<span class='notice'>You will no longer fall.</span>")
+	status_flags ^= NOFALL
+	to_chat(src, SPAN_NOTICE("You will [status_flags & NOFALL ? "no longer fall" : "now fall normally"]."))
 
 /mob/living/carbon/human/bst/verb/bstwalk()
 	set name = "Ruin Everything"
@@ -293,10 +288,10 @@
 	set popup_menu = 0
 
 	if(!src.incorporeal_move)
-		src.incorporeal_move = 2
+		src.incorporeal_move = INCORPOREAL_BSTECH
 		to_chat(src, SPAN_NOTICE("You will now phase through solid matter."))
 	else
-		src.incorporeal_move = 0
+		src.incorporeal_move = INCORPOREAL_DISABLE
 		to_chat(src, SPAN_NOTICE("You will no-longer phase through solid matter."))
 	return
 

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -424,7 +424,7 @@
 	canremove = 0
 	flash_protection = FLASH_PROTECTION_MAJOR
 
-/obj/item/clothing/glasses/sunglasses/bst/verb/toggle_xray(mode in list("X-Ray without Lighting", "X-Ray with Lighting", "Normal"))
+/obj/item/clothing/glasses/sunglasses/bst/verb/toggle_xray(mode in list("X-Ray without Lighting", "X-Ray with Lighting", "Darkvision", "Normal vision"))
 	set name = "Change Vision Mode"
 	set desc = "Changes your glasses' vision mode."
 	set category = "BST"
@@ -437,7 +437,10 @@
 		if ("X-Ray with Lighting")
 			vision_flags = (SEE_TURFS|SEE_OBJS|SEE_MOBS)
 			see_invisible = -1
-		if ("Normal")
+		if ("Darkvision")
+			vision_flags = SEE_SELF
+			see_invisible = SEE_INVISIBLE_NOLIGHTING
+		if ("Normal vision")
 			vision_flags = 0
 			see_invisible = -1
 

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -432,13 +432,13 @@
 
 	switch (mode)
 		if ("X-Ray without Lighting")
-			vision_flags = (SEE_TURFS|SEE_OBJS|SEE_MOBS)
+			vision_flags = SEE_TURFS|SEE_OBJS|SEE_MOBS|SEE_BLACKNESS|SEE_SELF
 			see_invisible = SEE_INVISIBLE_NOLIGHTING
 		if ("X-Ray with Lighting")
-			vision_flags = (SEE_TURFS|SEE_OBJS|SEE_MOBS)
+			vision_flags = SEE_TURFS|SEE_OBJS|SEE_MOBS|SEE_BLACKNESS|SEE_SELF
 			see_invisible = -1
 		if ("Darkvision")
-			vision_flags = SEE_SELF
+			vision_flags = SEE_BLACKNESS|SEE_SELF
 			see_invisible = SEE_INVISIBLE_NOLIGHTING
 		if ("Normal vision")
 			vision_flags = 0

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -32,7 +32,7 @@
 	var/ghost_cooldown = 0
 
 	var/obj/item/device/multitool/ghost_multitool
-	incorporeal_move = 1
+	incorporeal_move = INCORPOREAL_GHOST
 
 	mob_thinks = FALSE
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -5,7 +5,7 @@
 		tally = species.slowdown
 
 	tally += get_pulling_movement_delay()
-    
+
 	if (istype(loc, /turf/space) || isopenturf(loc))
 		if(!(locate(/obj/structure/lattice, loc) || locate(/obj/structure/stairs, loc) || locate(/obj/structure/ladder, loc)))
 			return 0

--- a/code/modules/mob/living/silicon/robot/presets.dm
+++ b/code/modules/mob/living/silicon/robot/presets.dm
@@ -27,15 +27,15 @@
 
 /mob/living/silicon/robot/bluespace/verb/antigrav()
 	set name = "Toggle Gravity"
-	set desc = "Toggles on/off falling for you."
+	set desc = "Use bluespace technology to ignore gravity."
 	set category = "BST"
 
 	status_flags ^= NOFALL
 	to_chat(src, SPAN_NOTICE("You will [status_flags & NOFALL ? "no longer fall" : "now fall normally"]."))
 
 /mob/living/silicon/robot/bluespace/verb/bstwalk()
-	set name = "Ruin Everything"
-	set desc = "Uses bluespace technology to phase through solid matter and move quickly."
+	set name = "Toggle Incorporeal Movement"
+	set desc = "Use bluespace technology to phase through solid matter and move quickly."
 	set category = "BST"
 	set popup_menu = 0
 
@@ -48,8 +48,8 @@
 	return
 
 /mob/living/silicon/robot/bluespace/verb/bstrecover()
-	set name = "Rejuv"
-	set desc = "Use the bluespace within you to restore your health"
+	set name = "Restore Health"
+	set desc = "Use bluespace to teleport in a fresh, healthy body."
 	set category = "BST"
 	set popup_menu = 0
 
@@ -57,7 +57,7 @@
 
 /mob/living/silicon/robot/bluespace/verb/bstquit()
 	set name = "Teleport out"
-	set desc = "Activate bluespace to leave and return to your original mob (if you have one)."
+	set desc = "Jump into bluespace and continue wherever you left off. Deletes the BSTech and returns to your original mob if you have one."
 	set category = "BST"
 
 	src.custom_emote(VISIBLE_MESSAGE, "politely beeps as its lights start to flash.")
@@ -78,7 +78,7 @@
 
 /mob/living/silicon/robot/bluespace/verb/tgm()
 	set name = "Toggle Godmode"
-	set desc = "Enable or disable god mode. For testing things that require you to be vulnerable."
+	set desc = "For when you want to be vulnerable."
 	set category = "BST"
 
 	status_flags ^= GODMODE

--- a/code/modules/mob/living/silicon/robot/presets.dm
+++ b/code/modules/mob/living/silicon/robot/presets.dm
@@ -23,7 +23,15 @@
 	overclocked = TRUE
 	law_update = FALSE
 	scrambled_codes = TRUE
-	status_flags = GODMODE
+	status_flags = GODMODE|NOFALL
+
+/mob/living/silicon/robot/bluespace/verb/antigrav()
+	set name = "Toggle Gravity"
+	set desc = "Toggles on/off falling for you."
+	set category = "BST"
+
+	status_flags ^= NOFALL
+	to_chat(src, SPAN_NOTICE("You will [status_flags & NOFALL ? "no longer fall" : "now fall normally"]."))
 
 /mob/living/silicon/robot/bluespace/verb/bstwalk()
 	set name = "Ruin Everything"
@@ -32,10 +40,10 @@
 	set popup_menu = 0
 
 	if(!src.incorporeal_move)
-		src.incorporeal_move = 2
+		src.incorporeal_move = INCORPOREAL_BSTECH
 		to_chat(src, SPAN_NOTICE("You will now phase through solid matter."))
 	else
-		src.incorporeal_move = 0
+		src.incorporeal_move = INCORPOREAL_DISABLE
 		to_chat(src, SPAN_NOTICE("You will no-longer phase through solid matter."))
 	return
 

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -83,7 +83,7 @@
 	heat_damage_per_tick = 0
 	cold_damage_per_tick = 0
 	unsuitable_atoms_damage = 0
-	incorporeal_move = 3
+	incorporeal_move = INCORPOREAL_SHADE
 	mob_size = 0
 	density = 0
 	speed = 1

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -90,7 +90,7 @@
 	var/lying_prev = 0
 	var/canmove = 1
 	//Allows mobs to move through dense areas without restriction. For instance, in space or out of holder objects.
-	var/incorporeal_move = 0 //0 is off, 1 is normal, 2 is for ninjas.
+	var/incorporeal_move = INCORPOREAL_DISABLE
 	var/lastpuke = 0
 	var/unacidable = 0
 	var/list/pinned = list()            // List of things pinning this creature to walls (see living_defense.dm)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -296,7 +296,7 @@
 		if (mob_is_human)
 			var/mob/living/carbon/human/H = mob
 			//If we're sprinting and able to continue sprinting, then apply the sprint bonus ontop of this
-			if (H.m_intent == "run" && H.species.handle_sprint_cost(H, tally)) //This will return false if we collapse from exhaustion
+			if (H.m_intent == "run" && (H.status_flags & GODMODE || H.species.handle_sprint_cost(H, tally))) //This will return false if we collapse from exhaustion
 				tally = (tally / (1 + H.sprint_speed_factor)) * config.run_delay_multiplier
 			else
 				tally = max(tally * config.walk_delay_multiplier, H.min_walk_delay) //clamp walking speed if its limited
@@ -384,7 +384,7 @@
 /client/proc/Process_Incorpmove(direct)
 	var/turf/mobloc = get_turf(mob)
 	switch(mob.incorporeal_move)
-		if(1)
+		if(INCORPOREAL_GHOST)
 			var/turf/T = get_step(mob, direct)
 			if(mob.check_holy(T))
 				to_chat(mob, SPAN_WARNING("You cannot get past holy grounds while you are in this plane of existence!"))
@@ -392,12 +392,11 @@
 			else
 				mob.forceMove(get_step(mob, direct))
 				mob.dir = direct
-		if(2)
-			anim(mobloc,mob,'icons/mob/mob.dmi',,"shadow",,mob.dir)
+		if(INCORPOREAL_NINJA, INCORPOREAL_BSTECH)
+			anim(mobloc, mob, 'icons/mob/mob.dmi', null, "shadow", null, mob.dir)
 			mob.forceMove(get_step(mob, direct))
 			mob.dir = direct
-
-		if(3)
+		if(INCORPOREAL_SHADE)
 			if(!mob.canmove || mob.anchored)
 				return
 			move_delay = 1 + world.time
@@ -456,6 +455,9 @@
 // Return 1 for movement, 0 for none,
 // -1 to allow movement but with a chance of slipping
 /mob/proc/Allow_Spacemove(var/check_drift = 0)
+	if(status_flags & NOFALL || incorporeal_move == INCORPOREAL_BSTECH)
+		return 1
+
 	if(!Check_Dense_Object()) //Nothing to push off of so end here
 		return 0
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -46,6 +46,10 @@
 		to_chat(src, SPAN_NOTICE("There is nothing of interest in this direction."))
 		return FALSE
 
+	if(incorporeal_move == INCORPOREAL_BSTECH)
+		forceMove(destination)
+		return TRUE
+
 	var/turf/start = get_turf(src)
 	if(!start.CanZPass(src, direction))
 		to_chat(src, SPAN_WARNING("\The [start] is in the way."))
@@ -113,13 +117,6 @@
 	else
 		to_chat(src, SPAN_NOTICE("There is nothing of interest in this direction."))
 
-/mob/living/carbon/human/bst/zMove(direction)
-	var/turf/destination = (direction == UP) ? GetAbove(src) : GetBelow(src)
-	if(destination)
-		forceMove(destination)
-	else
-		to_chat(src, SPAN_NOTICE("There is nothing of interest in this direction."))
-
 /**
  * An initial check for Z-level travel. Called relatively early in mob/proc/zMove.
  *
@@ -129,6 +126,8 @@
  *			FALSE otherwise.
  */
 /mob/proc/can_ztravel(var/direction)
+	if(incorporeal_move == INCORPOREAL_BSTECH)
+		return TRUE
 	return FALSE
 
 /mob/abstract/observer/can_ztravel(var/direction)
@@ -137,6 +136,9 @@
 /mob/living/carbon/human/can_ztravel(var/direction)
 	if(incapacitated())
 		return FALSE
+
+	if(incorporeal_move == INCORPOREAL_BSTECH)
+		return TRUE
 
 	if(Allow_Spacemove())
 		return TRUE
@@ -243,6 +245,8 @@
  *			FALSE otherwise.
  */
 /mob/proc/CanAvoidGravity()
+	if(status_flags & NOFALL || incorporeal_move == INCORPOREAL_BSTECH)
+		return TRUE
 	return FALSE
 
 // Humans and borgs have jetpacks which allows them to override gravity! Or rather,
@@ -326,6 +330,11 @@
 	if((locate(/obj/structure/disposalpipe/up) in below) || (locate(/obj/machinery/atmospherics/pipe/zpipe/up) in below))
 		return FALSE
 
+/mob/can_fall()
+	if(status_flags & NOFALL || incorporeal_move == INCORPOREAL_BSTECH)
+		return FALSE
+	return ..()
+
 /mob/living/heavy_vehicle/can_ztravel(var/direction)
 	if(legs)
 		if(legs.hover && legs.motivator.is_functional())
@@ -378,9 +387,6 @@
 		if(G.state >= GRAB_AGGRESSIVE)
 			return FALSE
 	return ..()
-
-/mob/living/carbon/human/bst/can_fall()
-	return fall_override ? FALSE : ..()
 
 /mob/abstract/eye/can_fall()
 	return FALSE
@@ -447,6 +453,11 @@
 	if (istype(loc, /turf/space) || (area && !area.has_gravity()))
 		return FALSE
 
+	if(status_flags & GODMODE) // Godmode
+		visible_message(SPAN_NOTICE("\The [src] lands flawlessly on their legs, bending their knee to the floor. They promptly stand up."))
+		playsound(src.loc, /decl/sound_category/swing_hit_sound, 50, 1)
+		return FALSE
+
 	visible_message("\The [src] falls and lands on \the [loc]!",
 		"With a loud thud, you land on \the [loc]!", "You hear a thud!")
 
@@ -485,6 +496,11 @@
 					SPAN_NOTICE("You hear an electric <i>*whirr*</i> right after the slam!"))
 				return FALSE
 
+	if(status_flags & GODMODE) // Godmode
+		visible_message(SPAN_NOTICE("\The [src] lands flawlessly on their legs, bending their knee to the floor. They promptly stand up."))
+		playsound(src.loc, /decl/sound_category/swing_hit_sound, 50, 1)
+		return FALSE
+
 	var/combat_roll = 1
 	if(lying)
 		combat_roll = 0.7 //If you're sleeping, you take less damage because your body is less rigid. It's science 'n shit.
@@ -501,7 +517,6 @@
 
 	var/z_velocity = 5*(levels_fallen**2)
 	var/damage = (((40 * species.fall_mod) + z_velocity) + rand(-20,20)) * combat_roll * damage_mod * aug_mod
-
 	var/limb_damage = rand(0,damage/2)
 
 	if(prob(30) && combat_roll >= 1) //landed on their legs
@@ -639,9 +654,6 @@
 /mob/living/carbon/human/proc/post_fall_death_check()
 	if (stat == DEAD)
 		SSfeedback.IncrementSimpleStat("openturf_human_deaths")
-
-/mob/living/carbon/human/bst/fall_impact(var/damage_mod)
-	return FALSE
 
 /obj/vehicle/fall_impact(levels_fallen, stopped_early = FALSE, var/damage_mod = 1)
 	. = ..()

--- a/html/changelogs/amunak-nofall.yml
+++ b/html/changelogs/amunak-nofall.yml
@@ -1,0 +1,11 @@
+author: Amunak
+delete-after: True
+changes:
+  - admin: "'NOFALL' is now a status flag instead of being a var specific to BSTechs. It allows the mob to move between Z-levels and through empty space; even to 'fly up' against gravity. However the tech can no longer use this to 'phase into' matter if there is something above them."
+  - admin: "For that you want to use Ruin-Everything instead: incorporeal movement now has an additional type that's just like a ninja's, but it also allows you to move between Z-levels."
+  - admin: "Adds the anti-gravity verb to the Bluespace Robot preset and starts them with 'NOFALL' on."
+  - admin: "When using 'GODMODE' you will no longer take damage when you fall; instead a cool message will be shown and a quiet thump will be played."
+  - admin: "'GODMODE' now protects you from the awful effects of running - you can run indefinitely and won't take damage from it."
+  - refactor: "Thanks to the above changes the BST is now self-contained in a single file (well except for the robot preset)."
+  - refactor: "To facilitate the above changes several godmode and incorporeal checks have been added (mostly to movement procs). It cuts on some extra proc overrides and type checks. Also results in a more 'natural' experience when using NOFALL, GODMODE or incorporeal movement."
+  - refactor: "Changed incorporeal values to defines."

--- a/html/changelogs/amunak-nofall.yml
+++ b/html/changelogs/amunak-nofall.yml
@@ -7,6 +7,7 @@ changes:
   - admin: "When using 'GODMODE' you will no longer take damage when you fall; instead a cool message will be shown and a quiet thump will be played."
   - admin: "'GODMODE' now protects you from the awful effects of running - you can run indefinitely and won't take damage from it."
   - admin: "BSTechs now have additional vision mode - 'darkvision' for seeing normally but without lighting."
+  - admin: "Some of the more arcane BSTech verbs have been renamed and descriptions improved (with some added flavour). Rejuv -> Restore Health. Toggle-Gravity -> Toggle-Falling (we now have actual gravity on the station, so let's not confuse people). And finally Ruin-Everything -> Toggle Incorporeal Movement - as lovely as the name is, it doesn't make much sense. This isn't Kill-Everyone or whatever."
   - refactor: "Thanks to the above changes the BST is now self-contained in a single file (well except for the robot preset)."
   - refactor: "To facilitate the above changes several godmode and incorporeal checks have been added (mostly to movement procs). It cuts on some extra proc overrides and type checks. Also results in a more 'natural' experience when using NOFALL, GODMODE or incorporeal movement."
   - refactor: "Changed incorporeal values to defines."

--- a/html/changelogs/amunak-nofall.yml
+++ b/html/changelogs/amunak-nofall.yml
@@ -6,6 +6,7 @@ changes:
   - admin: "Adds the anti-gravity verb to the Bluespace Robot preset and starts them with 'NOFALL' on."
   - admin: "When using 'GODMODE' you will no longer take damage when you fall; instead a cool message will be shown and a quiet thump will be played."
   - admin: "'GODMODE' now protects you from the awful effects of running - you can run indefinitely and won't take damage from it."
+  - admin: "BSTechs now have additional vision mode - 'darkvision' for seeing normally but without lighting."
   - refactor: "Thanks to the above changes the BST is now self-contained in a single file (well except for the robot preset)."
   - refactor: "To facilitate the above changes several godmode and incorporeal checks have been added (mostly to movement procs). It cuts on some extra proc overrides and type checks. Also results in a more 'natural' experience when using NOFALL, GODMODE or incorporeal movement."
   - refactor: "Changed incorporeal values to defines."


### PR DESCRIPTION
- 'NOFALL' is now a status flag instead of being a var specific to BSTechs. It allows the mob to move between Z-levels and through empty space; even to 'fly up' against gravity. However the tech can no longer use this to 'phase into' matter if there is something above them.
- ...for that you want to use Ruin-Everything instead: incorporeal movement now has an additional type that's (still) just like a ninja's, but it also allows you to move between Z-levels.
- Adds the anti-gravity verb to the Bluespace Robot preset and starts them with 'NOFALL' on.
- When using 'GODMODE' you will no longer take damage when you fall; instead a cool message will be shown and a quiet thump will be played.
- 'GODMODE' now protects you from the awful effects of running - you can run indefinitely and won't take damage from it.
- Thanks to the above changes the BST is now self-contained in a single file (well except for the robot preset).
- To facilitate the above changes several godmode and incorporeal checks have been added (mostly to movement procs). It cuts on some extra proc overrides and type checks. Also results in a more 'natural' experience when using NOFALL, GODMODE or incorporeal movement.
- Changed incorporeal values to defines.
- Added a "darkvision" mode for the BST goggles.
- I also updated some of the BST verbs to be more descriptive.