### PR TITLE
Puts maxHealth instead of hardcoded health = 100 where it should be

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -204,7 +204,7 @@ default behaviour is:
 
 /mob/living/proc/updatehealth()
 	if(status_flags & GODMODE)
-		health = 100
+		health = maxHealth
 		stat = CONSCIOUS
 	else
 		health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss() - getHalLoss()

--- a/code/modules/mob/living/silicon/decoy/life.dm
+++ b/code/modules/mob/living/silicon/decoy/life.dm
@@ -9,7 +9,7 @@
 
 /mob/living/silicon/decoy/updatehealth()
 	if(status_flags & GODMODE)
-		health = 100
+		health = maxHealth
 		stat = CONSCIOUS
 	else
-		health = 100 - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss()
+		health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss()

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -31,10 +31,10 @@
 
 /mob/living/silicon/pai/updatehealth()
 	if(status_flags & GODMODE)
-		health = 100
+		health = maxHealth
 		stat = CONSCIOUS
 	else
-		health = 100 - getBruteLoss() - getFireLoss()
+		health = maxHealth - getBruteLoss() - getFireLoss()
 
 /mob/living/silicon/pai/Stat()
 	..()

--- a/html/changelogs/amunak-maxhealth.yml
+++ b/html/changelogs/amunak-maxhealth.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "Fixes hardcoded health checks setting to 100 instead of maxHealth (mainly in godmode checks but also pAI)."


### PR DESCRIPTION
Hopefully didn't miss anything.

Edit: Forgot to mention that this happens to fix an issue where BSTechs walk slowly unless they rejuvenate.