### PR TITLE
Adds announcement of server restart to clients

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -211,14 +211,11 @@ var/list/world_api_rate_limit = list()
 	else if (!world.TgsAvailable() && hard_reset)
 		hard_reset = FALSE
 
-	var/msg = "<br><span class='danger'>The server is restarting.</span><br>You should automatically reconnect in a minute or so...<br><hr><br>"
-	world << msg
-	if(SSchat)
-		SSchat.queue(world, msg)
-	sleep(8) // this gives clients time to receive the message
-
 	SSpersist_config.save_to_file("data/persistent_config.json")
 	Master.Shutdown()
+
+	to_chat_immediate(world, "<br><span class='danger'>The server is restarting.</span><br>You should automatically reconnect in a minute or so...<br><hr><br>")
+	sleep(1) // this gives clients time to receive the message
 
 	if(config.server)	//if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
 		for(var/client/C in clients)

--- a/code/world.dm
+++ b/code/world.dm
@@ -211,6 +211,12 @@ var/list/world_api_rate_limit = list()
 	else if (!world.TgsAvailable() && hard_reset)
 		hard_reset = FALSE
 
+	var/msg = "<br><span class='danger'>The server is restarting.</span><br>You should automatically reconnect in a minute or so...<br><hr><br>"
+	world << msg
+	if(SSchat)
+		SSchat.queue(world, msg)
+	sleep(8) // this gives clients time to receive the message
+
 	SSpersist_config.save_to_file("data/persistent_config.json")
 	Master.Shutdown()
 

--- a/html/changelogs/amunak-announce-restart.yml
+++ b/html/changelogs/amunak-announce-restart.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - rscadd: "All clients will now be warned just before server restarts."


### PR DESCRIPTION
This should tell all clients the server is restarting just before it happens, also telling them to just wait it out. Should help especially new players.

I had to use `world << msg` since there's almost nothing available in this file. I also tried sending the message directly essentially copying goonchat code but I couldn't get it to work, so it's sent using the SSchat global which should be fine (though it unfortunately requires us to sleep a bit so that the SSchat fires enough times and delivers the message).

![dreamseeker_2020-10-30_16-27-18](https://user-images.githubusercontent.com/781546/97728790-451e4c80-1ad2-11eb-8d52-871f27a74e0d.png)
