### PR TITLE
Antagonist end-of-round text will now display when the antag is inside something

### DIFF
--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -65,8 +65,7 @@
 	if(ply.current)
 		var/mob/living/M = ply.current
 		var/mob/living/carbon/C = M
-		var/turf/T = M.loc
-		var/area/A = T.loc
+		var/area/A = get(M.loc, /area)
 		if(M.stat == DEAD)
 			text += "died"
 		else if(A?.is_prison() || (!A?.is_no_crew_expected() && C?.handcuffed))

--- a/html/changelogs/antag_no_hide_in_box.yml
+++ b/html/changelogs/antag_no_hide_in_box.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Antagonists hiding inside something (locker, chameleon projection, etc.) at round end will now appear properly in the end-of-round antag display text."


### PR DESCRIPTION
Runtime with `A.is_prison()` because mob.loc.loc is not an area if the antagonist is inside another object.