### PR TITLE
Debug Mob Lists can now list frozen crew

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -418,7 +418,7 @@
 	set name = "Debug Mob Lists"
 	set desc = "For when you just gotta know"
 
-	switch(input("Which list?") in list("Players","Staff","Mobs","Living Mobs","Dead Mobs", "Clients"))
+	switch(input("Which list?") in list("Players","Staff","Mobs","Living Mobs","Dead Mobs","Frozen Mobs","Clients"))
 		if("Players")
 			to_chat(usr, jointext(player_list,", "))
 		if("Staff")
@@ -429,6 +429,8 @@
 			to_chat(usr, jointext(living_mob_list,", "))
 		if("Dead Mobs")
 			to_chat(usr, jointext(dead_mob_list,", "))
+		if("Frozen Mobs")
+			to_chat(usr, jointext(frozen_crew,", "))
 		if("Clients")
 			to_chat(usr, jointext(clients,", "))
 

--- a/html/changelogs/frozen_mob_debug.yml
+++ b/html/changelogs/frozen_mob_debug.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - admin: "The 'Debug Mob Lists' verb can now list mobs that have gone to cryo this round."


### PR DESCRIPTION
This came up today with a dev that was trying to figure out something on the server. Would be convenient to have, maybe also handy for mods that are trying to figure out where someone went.