### PR TITLE
Adds proc to show variable type as string, adds this info to Varedit

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1026,9 +1026,9 @@ var/global/known_proc = new /proc/get_type_ref_bytes
 	if(isfile(V))
 		return "file"
 	// Types that don't inherit from /datum (note that /world is not here because you can't hold a reference to it)
-	if(istype(V, /list))
+	if(islist(V))
 		return details && list_lengths ? "list([length(V)])" : "list"
-	if(istype(V, /client))
+	if(isclient(V))
 		return "client"
 	if(istype(V, /savefile))
 		return "savefile"

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1001,6 +1001,7 @@ var/list/wall_items = typecacheof(list(
 
 // Returns a variable type as string, optionally with some details:
 // Objects (datums) get their type, paths get the type name, scalars show length (text) and value (numbers), lists show length.
+var/global/known_proc = new /proc/get_type_ref_bytes
 /proc/get_debug_type(var/V, var/details = TRUE, var/print_numbers = TRUE, var/path_names = TRUE, var/text_lengths = TRUE, var/list_lengths = TRUE)
 	// scalars / basic types
 	if(isnull(V))
@@ -1047,8 +1048,18 @@ var/list/wall_items = typecacheof(list(
 		return details ? "movable([D.type])" : "movable"
 	if(isatom(D))
 		return details ? "atom([D.type])" : "atom"
+	if(istype(D, /database))
+		return details ? "database([D.type])" : "database"
+	if(istype(D, /exception))
+		return details ? "exception([D.type])" : "exception"
+	if(istype(D, /mutable_appearance)) // must come before /image
+		return details ? "mutable_appearance([D.type])" : "mutable_appearance"
 	if(istype(D, /image))
 		return details ? "image([D.type])" : "image"
+	if(istype(D, /matrix))
+		return details ? "matrix([D.type])" : "matrix"
+	if(istype(D, /sound))
+		return details ? "sound([D.type])" : "sound"
 	if(istype(D, /decl))
 		return details ? "decl([D.type])" : "decl"
 	if(isdatum(D))
@@ -1056,10 +1067,10 @@ var/list/wall_items = typecacheof(list(
 	if(istype(D)) // let's future proof ourselves
 		return details ? "unknown-object([D.type])" : "unknown-object"
 	// some undetectable types
-	var/refType = lowertext(copytext(ref(V), 4, 6))
+	var/refType = get_type_ref_bytes(V)
 	if(refType == "")
 		return "unknown"
-	if(refType == "26") // it's a proc of some kind
+	if(refType == get_type_ref_bytes(known_proc)) // it's a proc of some kind
 		if(istext(V?:name) && V:name != "") // procs with names are generally verbs
 			return "verb"
 		return "proc"
@@ -1068,6 +1079,9 @@ var/list/wall_items = typecacheof(list(
 	if(refType == "3a")
 		return "appearance"
 	return "unknown-object([refType])" // If you see this you found a new undetectable type. Feel free to add it here.
+
+/proc/get_type_ref_bytes(var/V) // returns first 4 bytes from \ref which denote the object type (for objects that is)
+	return lowertext(copytext(ref(V), 4, 6))
 
 /proc/format_text(text)
 	return replacetext(replacetext(text,"\proper ",""),"\improper ","")

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1056,16 +1056,18 @@ var/list/wall_items = typecacheof(list(
 	if(istype(D)) // let's future proof ourselves
 		return details ? "unknown-object([D.type])" : "unknown-object"
 	// some undetectable types
-#ifdef SPACEMAN_DMM  // remove when https://github.com/SpaceManiac/SpacemanDMM/issues/227 is fixed
-	var/P = V
-#else
-	var/proc/P = V
-#endif
-	if(P) // it's a proc of some kind
-		if(istext(P?:name) && P:name != "") // procs with names are generally verbs
+	var/refType = lowertext(copytext(ref(V), 4, 6))
+	if(refType == "")
+		return "unknown"
+	if(refType == "26") // it's a proc of some kind
+		if(istext(V?:name) && V:name != "") // procs with names are generally verbs
 			return "verb"
 		return "proc"
-	return "unknown" // if you see this there are some undetectable types in Byond, or there's a small chance that there's actually a new type
+	if(refType == "53")
+		return "filters"
+	if(refType == "3a")
+		return "appearance"
+	return "unknown-object([refType])" // If you see this you found a new undetectable type. Feel free to add it here.
 
 /proc/format_text(text)
 	return replacetext(replacetext(text,"\proper ",""),"\improper ","")

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1001,8 +1001,9 @@ var/list/wall_items = typecacheof(list(
 
 // Returns a variable type as string, optionally with some details:
 // Objects (datums) get their type, paths get the type name, scalars show length (text) and value (numbers), lists show length.
+// Also attempts some detection of otherwise undetectable types using ref IDs
 var/global/known_proc = new /proc/get_type_ref_bytes
-/proc/get_debug_type(var/V, var/details = TRUE, var/print_numbers = TRUE, var/path_names = TRUE, var/text_lengths = TRUE, var/list_lengths = TRUE)
+/proc/get_debug_type(var/V, var/details = TRUE, var/print_numbers = TRUE, var/path_names = TRUE, var/text_lengths = TRUE, var/list_lengths = TRUE, var/show_useless_subtypes = TRUE)
 	// scalars / basic types
 	if(isnull(V))
 		return "null"
@@ -1034,8 +1035,6 @@ var/global/known_proc = new /proc/get_type_ref_bytes
 	// Finally actual objects that inherit from /datum
 	// We want to differentiate at least the basic "special" Byond types
 	var/datum/D = V
-	if(istype(V, /regex))
-		return "regex"
 	if(isarea(D))
 		return details ? "area([D.type])" : "area"
 	if(isturf(D))
@@ -1049,15 +1048,17 @@ var/global/known_proc = new /proc/get_type_ref_bytes
 	if(isatom(D))
 		return details ? "atom([D.type])" : "atom"
 	if(istype(D, /database))
-		return details ? "database([D.type])" : "database"
+		return details && show_useless_subtypes ? "database([D.type])" : "database"
 	if(istype(D, /exception))
-		return details ? "exception([D.type])" : "exception"
+		return details && show_useless_subtypes ? "exception([D.type])" : "exception"
 	if(istype(D, /mutable_appearance)) // must come before /image
-		return details ? "mutable_appearance([D.type])" : "mutable_appearance"
+		return details && show_useless_subtypes ? "mutable_appearance([D.type])" : "mutable_appearance"
 	if(istype(D, /image))
 		return details ? "image([D.type])" : "image"
 	if(istype(D, /matrix))
-		return details ? "matrix([D.type])" : "matrix"
+		return details && show_useless_subtypes ? "matrix([D.type])" : "matrix"
+	if(istype(D, /regex))
+		return details && show_useless_subtypes ? "regex([D.type])" : "regex"
 	if(istype(D, /sound))
 		return details ? "sound([D.type])" : "sound"
 	if(istype(D, /decl))

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1055,6 +1055,12 @@ var/list/wall_items = typecacheof(list(
 		return details ? "datum([D.type])" : "datum"
 	if(istype(D)) // let's future proof ourselves
 		return details ? "unknown-object([D.type])" : "unknown-object"
+	// some undetectable types
+	var/proc/P = V
+	if(P) // it's a proc of some kind
+		if(istext(P?:name) && P:name != "") // procs with names are generally verbs
+			return "verb"
+		return "proc"
 	return "unknown" // if you see this there are some undetectable types in Byond, or there's a small chance that there's actually a new type
 
 /proc/format_text(text)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1056,7 +1056,11 @@ var/list/wall_items = typecacheof(list(
 	if(istype(D)) // let's future proof ourselves
 		return details ? "unknown-object([D.type])" : "unknown-object"
 	// some undetectable types
+#ifdef SPACEMAN_DMM  // remove when https://github.com/SpaceManiac/SpacemanDMM/issues/227 is fixed
+	var/P = V
+#else
 	var/proc/P = V
+#endif
 	if(P) // it's a proc of some kind
 		if(istext(P?:name) && P:name != "") // procs with names are generally verbs
 			return "verb"

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -999,6 +999,64 @@ var/list/wall_items = typecacheof(list(
 			return 1
 	return 0
 
+// Returns a variable type as string, optionally with some details:
+// Objects (datums) get their type, paths get the type name, scalars show length (text) and value (numbers), lists show length.
+/proc/get_debug_type(var/V, var/details = TRUE, var/print_numbers = TRUE, var/path_names = TRUE, var/text_lengths = TRUE, var/list_lengths = TRUE)
+	// scalars / basic types
+	if(isnull(V))
+		return "null"
+	if(ispath(V))
+		return details && path_names ? "path([V])" : "path"
+	if(istext(V))
+		return details && text_lengths ? "text([length(V) ])" : "text"
+	if(isnum(V)) // Byond doesn't really differentiate between floats and ints, but we can sort of guess here
+		// also technically we could also say that 0 and 1 are boolean but that'd be quite silly
+		if(IsInteger(V) && V < 16777216 && V > -16777216)
+			return details && print_numbers ? "int([V])" : "int"
+		if(V >= INFINITY)
+			return details ? "float(+INF)" : "float"
+		if(V <= -INFINITY)
+			return details ? "float(-INF)" : "float"
+		return details && print_numbers ? "float([V])" : "float"
+	// Resource types
+	if(isicon(V))
+		return "icon"
+	if(isfile(V))
+		return "file"
+	// Types that don't inherit from /datum (note that /world is not here because you can't hold a reference to it)
+	if(istype(V, /list))
+		return details && list_lengths ? "list([length(V)])" : "list"
+	if(istype(V, /client))
+		return "client"
+	if(istype(V, /savefile))
+		return "savefile"
+	// Finally actual objects that inherit from /datum
+	// We want to differentiate at least the basic "special" Byond types
+	var/datum/D = V
+	if(istype(V, /regex))
+		return "regex"
+	if(isarea(D))
+		return details ? "area([D.type])" : "area"
+	if(isturf(D))
+		return details ? "turf([D.type])" : "turf"
+	if(ismob(D))
+		return details ? "mob([D.type])" : "mob"
+	if(isobj(D))
+		return details ? "obj([D.type])" : "obj"
+	if(istype(D, /atom/movable)) // according to DM docs there should be no defined types under this but there certainly are some
+		return details ? "movable([D.type])" : "movable"
+	if(isatom(D))
+		return details ? "atom([D.type])" : "atom"
+	if(istype(D, /image))
+		return details ? "image([D.type])" : "image"
+	if(istype(D, /decl))
+		return details ? "decl([D.type])" : "decl"
+	if(isdatum(D))
+		return details ? "datum([D.type])" : "datum"
+	if(istype(D)) // let's future proof ourselves
+		return details ? "unknown-object([D.type])" : "unknown-object"
+	return "unknown" // if you see this there are some undetectable types in Byond, or there's a small chance that there's actually a new type
+
 /proc/format_text(text)
 	return replacetext(replacetext(text,"\proper ",""),"\improper ","")
 

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -37,8 +37,9 @@
 			<title>[D] (\ref[D] - [D.type])</title>
 			<style>
 				body { font-family: Arial, "Helvetica Neue", Helvetica, sans-serif; font-size: 10pt; }
-				.key, .value { font-family: "Fira Code", Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace, sans-serif; font-size: 9pt; }
+				.key, .type, .value { font-family: "Fira Code", Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace, sans-serif; font-size: 9pt; }
 				.key { font-weight: bold }
+				.type { text-decoration: underline; color: gray }
 			</style>
 		</head>
 		<body onload='selectTextField(); updateSearch()'>
@@ -50,7 +51,7 @@
 							<td><div align='center'>[D.get_view_variables_header()]</div></td>
 						</tr></table>
 						<div align='center'>
-							<b><font size='1'>[replacetext("[D.type]", "/", "/<wbr>")]</font></b>
+							<b><font size='1'>[replacetext("[get_debug_type(D)]", "/", "/<wbr>")]</font></b>
 							[holder.marked_datum == D ? "<br/><font size='1' color='red'><b>Marked Object</b></font>" : ""]
 						</div>
 					</td>
@@ -124,10 +125,12 @@
 
 /proc/make_view_variables_value(value, varname = "*")
 	var/vtext = ""
+	var/debug_type = get_debug_type(value, FALSE)
 	var/extra = list()
 	if(isnull(value))
-		vtext = "null"
+		// get_debug_type displays this
 	else if(istext(value))
+		debug_type = null // it's kinda annoying here; we can tell the type by the quotes
 		vtext = "\"[value]\""
 	else if(isicon(value))
 		vtext = "[value]"
@@ -144,7 +147,7 @@
 		vtext = "<a href='?_src_=vars;Vars=\ref[C]'>\ref[C]</a> - [C] ([C.type])"
 	else if(islist(value))
 		var/list/L = value
-		vtext = "/list ([L.len])"
+		vtext = "([L.len])"
 		if(!(varname in view_variables_dont_expand) && L.len > 0 && L.len < 100)
 			extra += "<ul>"
 			for (var/index = 1 to L.len)
@@ -157,7 +160,7 @@
 	else
 		vtext = "[value]"
 
-	return "<span class=value>[vtext]</span>[jointext(extra, "")]"
+	return "<span class=type>[debug_type]</span> <span class=value>[vtext]</span>[jointext(extra, "")]"
 
 /proc/make_view_variables_var_entry(datum/D, varname, value, level=0)
 	var/ecm = null

--- a/html/changelogs/amunak-varedit-types.yml
+++ b/html/changelogs/amunak-varedit-types.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - admin: "Slightly improves varedit by adding the variable type to the display."


### PR DESCRIPTION
Adds a proc that prints the variable type, optionally with some extra info like text/list length, types, etc. Mostly useful for debugging. In this journey I found out that there are some types that are simply "undetectable"... Like filters, procs/callables, etc.

Uses this in Varedit to make it slightly more clear which var is which. I played a lot with how it's displayed and it's kind of hard to make it visible _enough_ but not distracting or taking up too much space. In the end I opted for a simple approach that just shows the short type and keeps varedit mostly untouched otherwise:

![dreamseeker_2020-11-03_02-28-24](https://user-images.githubusercontent.com/781546/97936885-47580380-1d7d-11eb-9d81-598f77887013.png)
