### PR TITLE
Beams will now properly center on things with pixel_x and pixel_y offsets

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -22,6 +22,12 @@
 	origin_oldloc = get_turf(origin)
 	target = beam_target
 	target_oldloc = get_turf(target)
+
+	if(get_dist(origin_oldloc, target_oldloc) >= max_distance || origin_oldloc.z != target_oldloc.z)
+		qdel(src)
+		crash_with("Tried to create a new beam with length beyond its maximum distance limit.")
+		return
+
 	sleep_time = beam_sleep_time
 	if(origin_oldloc == origin && target_oldloc == target)
 		static_beam = TRUE
@@ -88,7 +94,7 @@
 	return ..()
 
 /datum/beam/proc/Draw()
-	var/Angle = round(Get_Angle(get_turf(origin), get_turf(target)))
+	var/Angle = round(Get_Angle(origin.x ? origin : get_turf(origin), target.x ? target : get_turf(target)))
 	var/matrix/rot_matrix = matrix()
 	rot_matrix.Turn(Angle)
 
@@ -99,45 +105,32 @@
 	var/length = round(sqrt((DX)**2+(DY)**2)) //hypotenuse of the triangle formed by target and origin's displacement
 
 	for(N in 0 to length-1 step world.icon_size)//-1 as we want < not <=, but we want the speed of X in Y to Z and step X
-		var/obj/effect/ebeam/X = new beam_type(origin_oldloc)
-		X.owner = src
-		elements += X
+		var/obj/effect/ebeam/segment = new beam_type(origin_oldloc)
+		segment.owner = src
+		elements += segment
 
 		//Assign icon, for main segments it's base_icon, for the end, it's icon+icon_state
 		//cropped by a transparent box of length-N pixel size
-		if(N+world.icon_size>length)
+		if(N + world.icon_size > length)
 			var/icon/II = new(icon, icon_state)
-			II.DrawBox(null,1,(length-N),world.icon_size,world.icon_size)
-			X.icon = II
+			II.DrawBox(null, 1, (length-N), world.icon_size, world.icon_size)
+			segment.icon = II
 		else
-			X.icon = base_icon
-		X.transform = rot_matrix
+			segment.icon = base_icon
+		segment.transform = rot_matrix
 
 		//Calculate pixel offsets (If necessary)
-		var/Pixel_x
-		var/Pixel_y
-		if(DX == 0)
-			Pixel_x = 0
-		else
-			Pixel_x = round(sin(Angle)+world.icon_size*sin(Angle)*(N+16)/world.icon_size)
-		if(DY == 0)
-			Pixel_y = 0
-		else
-			Pixel_y = round(cos(Angle)+world.icon_size*cos(Angle)*(N+16)/world.icon_size)
+		var/x_offset = round(sin(Angle) * (N + world.icon_size/2))
+		var/y_offset = round(cos(Angle) * (N + world.icon_size/2))
+		//Position the effect so the beam is one continuous line
+		segment.x += SIMPLE_SIGN(x_offset) * Floor(abs(x_offset)/world.icon_size)
+		x_offset %= world.icon_size
 
-		//Position the effect so the beam is one continous line
-		var/a
-		if(abs(Pixel_x)>world.icon_size)
-			a = Pixel_x > 0 ? round(Pixel_x/world.icon_size) : Ceiling(Pixel_x/world.icon_size)
-			X.x += a
-			Pixel_x %= world.icon_size
-		if(abs(Pixel_y)>world.icon_size)
-			a = Pixel_y > 0 ? round(Pixel_y/world.icon_size) : Ceiling(Pixel_y/world.icon_size)
-			X.y += a
-			Pixel_y %= world.icon_size
+		segment.y += SIMPLE_SIGN(y_offset) * Floor(abs(y_offset)/world.icon_size)
+		y_offset %= world.icon_size
 
-		X.pixel_x = Pixel_x
-		X.pixel_y = Pixel_y
+		segment.pixel_x = x_offset
+		segment.pixel_y = y_offset
 		CHECK_TICK
 	afterDraw()
 
@@ -183,10 +176,10 @@
 	return ..()
 
 /datum/beam/power/get_x_translation_vector()
-	return (world.icon_size * target_oldloc.x) - (world.icon_size * origin_oldloc.x)
+	return (world.icon_size * target_oldloc.x + target.pixel_x) - (world.icon_size * origin_oldloc.x + origin.pixel_x)
 
 /datum/beam/power/get_y_translation_vector()
-	return (world.icon_size * target_oldloc.y) - (world.icon_size * origin_oldloc.y)
+	return (world.icon_size * target_oldloc.y + target.pixel_y) - (world.icon_size * origin_oldloc.y + origin.pixel_y)
 
 /datum/beam/power/afterDraw()
 	for(var/beam in elements)

--- a/code/modules/modular_computers/hardware/tesla_link.dm
+++ b/code/modules/modular_computers/hardware/tesla_link.dm
@@ -31,29 +31,30 @@
 
 /obj/item/computer_hardware/tesla_link/charging_cable/proc/toggle(var/obj/machinery/power/power_source, mob/user)
 	if(!source)
-		to_chat(user, SPAN_NOTICE("You connect \the [src] to \the [power_source]."))
-		activate(power_source)
+		if(in_range(power_source, src))
+			to_chat(user, SPAN_NOTICE("You connect \the [src] to \the [power_source]."))
+			activate(power_source)
+		else
+			to_chat(SPAN_NOTICE("\The [src] is too far from \the [power_source] to connect."))
 	else
 		deactivate()
 
-/obj/item/computer_hardware/tesla_link/charging_cable/proc/activate(var/power_source)
-	var/obj/machinery/power/P = power_source
-	if(!istype(P))
-		return
-	tether(P)
+/obj/item/computer_hardware/tesla_link/charging_cable/proc/activate(var/obj/machinery/power/power_source)
+	if(istype(power_source))
+		tether(power_source)
 
 /obj/item/computer_hardware/tesla_link/charging_cable/proc/deactivate()
 	untether()
 
 /obj/item/computer_hardware/tesla_link/charging_cable/check_functionality()
-	. = ..()
+	..()
 	if(!source || !enabled)
 		return FALSE
 	return TRUE
 
 /obj/item/computer_hardware/tesla_link/charging_cable/proc/tether(var/obj/machinery/power/P)
 	source = P
-	var/datum/beam/power/B = new/datum/beam/power(src, source, beam_icon_state = "explore_beam", time = -1, maxdistance = cable_length)
+	var/datum/beam/power/B = new(src, source, beam_icon_state = "explore_beam", time = -1, maxdistance = cable_length)
 	B.owner = src
 	B.Start()
 	beam = B

--- a/html/changelogs/charging_beam_centering.yml
+++ b/html/changelogs/charging_beam_centering.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Charging cables, such as those on PDAs, will now connect properly to the APC icon rather than the turf infront of it."
+  - bugfix: "Beams, such as charging cables, will no longer exist for one tick then delete themselves when being engaged from beyond max range."


### PR DESCRIPTION
- Charging cables won't be able to appear for 1 tick when a connection was attempted beyond their max range anymore.

- Cleared up a bunch of unnecessary checks/maths, and made it properly center on things that aren't in the center of turfs (e.g. APCs with their offset which is important for charging cables)

- Also changed some var names because `X.pixel_x = Pixel_x` made me sad.

**Current Behavior**
![pda_charging_cable_offset](https://user-images.githubusercontent.com/47489928/97963531-3c1dcb80-1daf-11eb-9e53-76d98a3a5111.PNG)

**New Behavior**
![reely_good](https://user-images.githubusercontent.com/47489928/97963584-50fa5f00-1daf-11eb-971a-aeb3206cb0d8.gif)
