### PR TITLE
Chem Effects Tweak

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -67,6 +67,8 @@
 #define CE_UNDEXTROUS   "undextrous"    // arms no work right
 #define CE_HALLUCINATE  "hallucinogen"	//Makes hallucinations stronger or weaker
 #define CE_CRYO 	    "cryogenic"     // Prevents damage from being frozen
+#define CE_CLEARSIGHT   "clearsight"    // prevents the blurry eye chem side effect
+#define CE_STRAIGHTWALK "straightwalk"  // prevents the confused walking chem side effect
 
 // Apply healing effects
 #define CE_ANTIBIOTIC   "antibiotic"	// Thetamycin

--- a/code/modules/reagents/Chemistry-Metabolism.dm
+++ b/code/modules/reagents/Chemistry-Metabolism.dm
@@ -15,7 +15,12 @@
 		if(ishuman(parent))
 			var/mob/living/carbon/human/H = parent
 			metabolism_type = H.species.reagent_tag
-
-		for(var/datum/reagent/current in reagent_list)
-			current.on_mob_life(parent, metabolism_type, metabolism_class)
+		// run this first to get all the chem effects sorted
+		for(var/thing in reagent_list)
+			var/datum/reagent/R = thing
+			R.affect_chem_effect(parent, metabolism_type, metabolism_class)
+		// then run this to actually do what the chems do
+		for(var/thing in reagent_list)
+			var/datum/reagent/R = thing
+			R.on_mob_life(parent, metabolism_type, metabolism_class)
 		update_total()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -126,6 +126,16 @@
 /datum/reagent/proc/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	return
 
+// if your chem directly affects other chems, use this to make sure all the chem_effects are applied before the standard chem affect_thing is run
+/datum/reagent/proc/affect_chem_effect(var/mob/living/carbon/M, var/alien, var/removed)
+	if(!istype(M))
+		return FALSE
+	if(!affects_dead && M.stat == DEAD)
+		return FALSE
+	if(alien & unaffected_species)
+		return FALSE
+	return TRUE
+
 /datum/reagent/proc/affect_conflicting(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagent/conflicting_reagent)
 	M.adjustToxLoss(removed)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -255,7 +255,7 @@
 	overdose = REAGENTS_OVERDOSE
 	od_minimum_dose = 2
 	scannable = TRUE
-	metabolism = REM/10 // same as before when in blood, 0.02 units per tick
+	metabolism = REM / 3.33 // 0.06ish units per tick
 	ingest_met = REM * 2 // .4 units per tick
 	breathe_met = REM * 4 // .8 units per tick
 	taste_description = "sickness"
@@ -278,7 +278,7 @@
 	overdose = 15
 	scannable = TRUE
 	od_minimum_dose = 2
-	metabolism = REM/10 // same as before when in blood, 0.02 units per tick
+	metabolism = REM / 3.33 // 0.06ish units per tick
 	ingest_met = REM * 2 // .4 units per tick
 	breathe_met = REM * 4 // .8 units per tick
 	taste_description = "sourness"
@@ -287,8 +287,10 @@
 
 /datum/reagent/mortaphenyl/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 80)
-	M.eye_blurry = max(M.eye_blurry, 5)
-	M.confused = max(M.confused, 10)
+	if(!locate(/datum/reagent/oculine) in M.reagents.reagent_list)
+		M.eye_blurry = max(M.eye_blurry, 5)
+	if(!locate(/datum/reagent/alkysine) in M.reagents.reagent_list)
+		M.confused = max(M.confused, 10)
 
 	var/mob/living/carbon/human/H = M
 	if(!istype(H))
@@ -322,8 +324,10 @@
 
 /datum/reagent/mortaphenyl/aphrodite/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 70)
-	M.eye_blurry = max(M.eye_blurry, 3)
-	M.confused = max(M.confused, 6)
+	if(!locate(/datum/reagent/oculine) in M.reagents.reagent_list)
+		M.eye_blurry = max(M.eye_blurry, 3)
+	if(!locate(/datum/reagent/alkysine) in M.reagents.reagent_list)
+		M.confused = max(M.confused, 6)
 
 /datum/reagent/oxycomorphine
 	name = "Oxycomorphine"
@@ -333,7 +337,7 @@
 	overdose = 10
 	od_minimum_dose = 2
 	scannable = TRUE
-	metabolism = REM/10 // same as before when in blood, 0.02 units per tick
+	metabolism = REM / 3.33 // 0.06ish units per tick
 	ingest_met = REM * 2 // .4 units per tick
 	breathe_met = REM * 4 // .8 units per tick
 	taste_description = "bitterness"
@@ -342,8 +346,10 @@
 
 /datum/reagent/oxycomorphine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 200)
-	M.eye_blurry = max(M.eye_blurry, 5)
-	M.confused = max(M.confused, 20)
+	if(!locate(/datum/reagent/oculine) in M.reagents.reagent_list)
+		M.eye_blurry = max(M.eye_blurry, 5)
+	if(!locate(/datum/reagent/alkysine) in M.reagents.reagent_list)
+		M.confused = max(M.confused, 20)
 
 	var/mob/living/carbon/human/H = M
 	if(!istype(H))
@@ -390,8 +396,10 @@
 	M.AdjustWeakened(-1)
 	holder.remove_reagent(/datum/reagent/mindbreaker, 5)
 	M.hallucination = max(0, M.hallucination - 10)
-	M.eye_blurry = max(M.eye_blurry - 5, 0)
-	M.confused = max(M.confused - 10, 0)
+	if(!locate(/datum/reagent/oculine) in M.reagents.reagent_list)
+		M.eye_blurry = max(M.eye_blurry - 5, 0)
+	if(!locate(/datum/reagent/alkysine) in M.reagents.reagent_list)
+		M.confused = max(M.confused - 10, 0)
 	M.adjustToxLoss(5 * removed) // It used to be incredibly deadly due to an oversight. Not anymore!
 	M.add_chemical_effect(CE_PAINKILLER, 40)
 	M.add_chemical_effect(CE_HALLUCINATE, -1)
@@ -1158,7 +1166,8 @@
 
 /datum/reagent/mental/neurapan/overdose(var/mob/living/carbon/M, var/alien)
 	M.add_chemical_effect(CE_PACIFIED, 1)
-	M.eye_blurry = max(M.eye_blurry, 30)
+	if(!locate(/datum/reagent/oculine) in M.reagents.reagent_list)
+		M.eye_blurry = max(M.eye_blurry, 30)
 	if((locate(/datum/reagent/oxycomorphine) in M.reagents.reagent_list))
 		M.ear_deaf = 20
 		M.drowsyness = max(M.drowsyness, 10)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -287,9 +287,9 @@
 
 /datum/reagent/mortaphenyl/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 80)
-	if(!(CE_CLEARSIGHT in M.chem_effects))
+	if(!M.chem_effects[CE_CLEARSIGHT])
 		M.eye_blurry = max(M.eye_blurry, 5)
-	if(!(CE_STRAIGHTWALK in M.chem_effects))
+	if(!M.chem_effects[CE_STRAIGHTWALK])
 		M.confused = max(M.confused, 10)
 
 	var/mob/living/carbon/human/H = M
@@ -324,9 +324,9 @@
 
 /datum/reagent/mortaphenyl/aphrodite/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 70)
-	if(!(CE_CLEARSIGHT in M.chem_effects))
+	if(!M.chem_effects[CE_CLEARSIGHT])
 		M.eye_blurry = max(M.eye_blurry, 3)
-	if(!(CE_STRAIGHTWALK in M.chem_effects))
+	if(!M.chem_effects[CE_STRAIGHTWALK])
 		M.confused = max(M.confused, 6)
 
 /datum/reagent/oxycomorphine
@@ -346,9 +346,9 @@
 
 /datum/reagent/oxycomorphine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 200)
-	if(!(CE_CLEARSIGHT in M.chem_effects))
+	if(!M.chem_effects[CE_CLEARSIGHT])
 		M.eye_blurry = max(M.eye_blurry, 5)
-	if(!(CE_STRAIGHTWALK in M.chem_effects))
+	if(!M.chem_effects[CE_STRAIGHTWALK])
 		M.confused = max(M.confused, 20)
 
 	var/mob/living/carbon/human/H = M
@@ -390,22 +390,26 @@
 
 /datum/reagent/synaptizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.drowsyness = max(M.drowsyness - 5, 0)
-	if(!(volume > 10)) // Will prevent synaptizine interrupting a seizure caused by its own overdose.
-		M.AdjustParalysis(-1) 
+	if(volume < 10) // Will prevent synaptizine interrupting a seizure caused by its own overdose.
+		M.AdjustParalysis(-1)
 	M.AdjustStunned(-1)
 	M.AdjustWeakened(-1)
 	holder.remove_reagent(/datum/reagent/mindbreaker, 5)
 	M.hallucination = max(0, M.hallucination - 10)
-	M.add_chemical_effect(CE_CLEARSIGHT)
 	M.eye_blurry = max(M.eye_blurry - 5, 0)
-	M.add_chemical_effect(CE_STRAIGHTWALK)
 	M.confused = max(M.confused - 10, 0)
-	if(prob(25))
-		M.add_chemical_effect(CE_HEPATOTOXIC)
-	M.add_chemical_effect(CE_PAINKILLER, 40)
-	M.add_chemical_effect(CE_HALLUCINATE, -1)
-	if (!modifier)
+	if(!modifier)
 		modifier = M.add_modifier(/datum/modifier/adrenaline, MODIFIER_REAGENT, src, _strength = 1, override = MODIFIER_OVERRIDE_STRENGTHEN)
+
+/datum/reagent/synaptizine/affect_chem_effect(var/mob/living/carbon/M, var/alien, var/removed)
+	. = ..()
+	if(.)
+		M.add_chemical_effect(CE_CLEARSIGHT)
+		M.add_chemical_effect(CE_STRAIGHTWALK)
+		if(prob(25))
+			M.add_chemical_effect(CE_HEPATOTOXIC)
+		M.add_chemical_effect(CE_PAINKILLER, 40)
+		M.add_chemical_effect(CE_HALLUCINATE, -1)
 
 /datum/reagent/synaptizine/overdose(var/mob/living/carbon/M, var/alien)
 	if(prob(dose / 2))
@@ -432,12 +436,7 @@
 	metabolism_min = REM * 0.075
 
 /datum/reagent/alkysine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_STRAIGHTWALK)
-	if(volume < 2) //Increased effectiveness & no side-effects if given via IV drip with low transfer rate.
-		M.add_chemical_effect(CE_BRAIN_REGEN, 40) //1 unit of Alkysine fed via drip at a low transfer rate will raise activity by 10%.
-	else
-		M.add_chemical_effect(CE_BRAIN_REGEN, 30) //1 unit of Alkysine will raise brain activity by 7.5%.
-		M.add_chemical_effect(CE_PAINKILLER, 10)
+	if(volume >= 2) //Increased effectiveness & no side-effects if given via IV drip with low transfer rate.
 		M.dizziness = max(125, M.dizziness)
 		M.make_dizzy(5)
 		if(!(volume > 10))
@@ -445,6 +444,16 @@
 			if(B && M.species && M.species.has_organ[BP_BRAIN] && !isipc(M))
 				if(prob(dose/5) && !B.has_trauma_type(BRAIN_TRAUMA_MILD))
 					B.gain_trauma_type(pick(/datum/brain_trauma/mild/dumbness, /datum/brain_trauma/mild/muscle_weakness, /datum/brain_trauma/mild/colorblind)) //Handpicked suggested traumas considered less disruptive and conducive to roleplay.
+
+/datum/reagent/alkysine/affect_chem_effect(var/mob/living/carbon/M, var/alien, var/removed)
+	. = ..()
+	if(.)
+		M.add_chemical_effect(CE_STRAIGHTWALK)
+		if(volume < 2) //Increased effectiveness & no side-effects if given via IV drip with low transfer rate.
+			M.add_chemical_effect(CE_BRAIN_REGEN, 40) //1 unit of Alkysine fed via drip at a low transfer rate will raise activity by 10%.
+		else
+			M.add_chemical_effect(CE_BRAIN_REGEN, 30) //1 unit of Alkysine will raise brain activity by 7.5%.
+			M.add_chemical_effect(CE_PAINKILLER, 10)
 
 /datum/reagent/alkysine/overdose(var/mob/living/carbon/M, var/alien, var/removed)
 	M.hallucination = max(M.hallucination, 15)
@@ -467,7 +476,6 @@
 	taste_description = "dull toxin"
 
 /datum/reagent/oculine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.add_chemical_effect(CE_CLEARSIGHT)
 	M.eye_blurry = max(M.eye_blurry - 5 * removed, 0)
 	M.eye_blind = max(M.eye_blind - 5 * removed, 0)
 	if(ishuman(M))
@@ -476,6 +484,11 @@
 		if(E && istype(E))
 			if(E.damage > 0)
 				E.damage = max(E.damage - 5 * removed, 0)
+
+/datum/reagent/oculine/affect_chem_effect(var/mob/living/carbon/M, var/alien, var/removed)
+	. = ..()
+	if(.)
+		M.add_chemical_effect(CE_CLEARSIGHT)
 
 /datum/reagent/oculine/overdose(var/mob/living/carbon/M, var/alien, var/removed)
 	M.hallucination = max(M.hallucination, 15)
@@ -591,7 +604,6 @@
 	M.dizziness = max(0, M.dizziness - DP)
 	M.drowsyness = max(0, M.drowsyness - DP)
 	M.stuttering = max(0, M.stuttering - DP)
-	M.add_chemical_effect(CE_STRAIGHTWALK)
 	M.confused = max(0, M.confused - DP)
 
 	var/datum/reagents/ingested = M.get_ingested_reagents()
@@ -619,6 +631,11 @@
 		var/amount = min(M.intoxication * ETHYL_INTOX_COST, P)
 		M.intoxication = max(0, (M.intoxication - (amount / ETHYL_INTOX_COST)))
 		P -= amount
+
+/datum/reagent/ethylredoxrazine/affect_chem_effect(var/mob/living/carbon/M, var/alien, var/removed)
+	. = ..()
+	if(.)
+		M.add_chemical_effect(CE_STRAIGHTWALK)
 
 /datum/reagent/hyronalin
 	name = "Hyronalin"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -255,7 +255,7 @@
 	overdose = REAGENTS_OVERDOSE
 	od_minimum_dose = 2
 	scannable = TRUE
-	metabolism = REM / 3.33 // 0.06ish units per tick
+	metabolism = REM/10 // same as before when in blood, 0.02 units per tick
 	ingest_met = REM * 2 // .4 units per tick
 	breathe_met = REM * 4 // .8 units per tick
 	taste_description = "sickness"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -287,9 +287,9 @@
 
 /datum/reagent/mortaphenyl/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 80)
-	if(!locate(/datum/reagent/oculine) in M.reagents.reagent_list)
+	if(!(CE_CLEARSIGHT in M.chem_effects))
 		M.eye_blurry = max(M.eye_blurry, 5)
-	if(!locate(/datum/reagent/alkysine) in M.reagents.reagent_list)
+	if(!(CE_STRAIGHTWALK in M.chem_effects))
 		M.confused = max(M.confused, 10)
 
 	var/mob/living/carbon/human/H = M
@@ -324,9 +324,9 @@
 
 /datum/reagent/mortaphenyl/aphrodite/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 70)
-	if(!locate(/datum/reagent/oculine) in M.reagents.reagent_list)
+	if(!(CE_CLEARSIGHT in M.chem_effects))
 		M.eye_blurry = max(M.eye_blurry, 3)
-	if(!locate(/datum/reagent/alkysine) in M.reagents.reagent_list)
+	if(!(CE_STRAIGHTWALK in M.chem_effects))
 		M.confused = max(M.confused, 6)
 
 /datum/reagent/oxycomorphine
@@ -346,9 +346,9 @@
 
 /datum/reagent/oxycomorphine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 200)
-	if(!locate(/datum/reagent/oculine) in M.reagents.reagent_list)
+	if(!(CE_CLEARSIGHT in M.chem_effects))
 		M.eye_blurry = max(M.eye_blurry, 5)
-	if(!locate(/datum/reagent/alkysine) in M.reagents.reagent_list)
+	if(!(CE_STRAIGHTWALK in M.chem_effects))
 		M.confused = max(M.confused, 20)
 
 	var/mob/living/carbon/human/H = M
@@ -396,11 +396,12 @@
 	M.AdjustWeakened(-1)
 	holder.remove_reagent(/datum/reagent/mindbreaker, 5)
 	M.hallucination = max(0, M.hallucination - 10)
-	if(!locate(/datum/reagent/oculine) in M.reagents.reagent_list)
-		M.eye_blurry = max(M.eye_blurry - 5, 0)
-	if(!locate(/datum/reagent/alkysine) in M.reagents.reagent_list)
-		M.confused = max(M.confused - 10, 0)
-	M.adjustToxLoss(5 * removed) // It used to be incredibly deadly due to an oversight. Not anymore!
+	M.add_chemical_effect(CE_CLEARSIGHT)
+	M.eye_blurry = max(M.eye_blurry - 5, 0)
+	M.add_chemical_effect(CE_STRAIGHTWALK)
+	M.confused = max(M.confused - 10, 0)
+	if(prob(25))
+		M.add_chemical_effect(CE_HEPATOTOXIC)
 	M.add_chemical_effect(CE_PAINKILLER, 40)
 	M.add_chemical_effect(CE_HALLUCINATE, -1)
 	if (!modifier)
@@ -431,9 +432,10 @@
 	metabolism_min = REM * 0.075
 
 /datum/reagent/alkysine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.add_chemical_effect(CE_STRAIGHTWALK)
 	if(volume < 2) //Increased effectiveness & no side-effects if given via IV drip with low transfer rate.
 		M.add_chemical_effect(CE_BRAIN_REGEN, 40) //1 unit of Alkysine fed via drip at a low transfer rate will raise activity by 10%.
-	else 
+	else
 		M.add_chemical_effect(CE_BRAIN_REGEN, 30) //1 unit of Alkysine will raise brain activity by 7.5%.
 		M.add_chemical_effect(CE_PAINKILLER, 10)
 		M.dizziness = max(125, M.dizziness)
@@ -465,6 +467,7 @@
 	taste_description = "dull toxin"
 
 /datum/reagent/oculine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.add_chemical_effect(CE_CLEARSIGHT)
 	M.eye_blurry = max(M.eye_blurry - 5 * removed, 0)
 	M.eye_blind = max(M.eye_blind - 5 * removed, 0)
 	if(ishuman(M))
@@ -588,6 +591,7 @@
 	M.dizziness = max(0, M.dizziness - DP)
 	M.drowsyness = max(0, M.drowsyness - DP)
 	M.stuttering = max(0, M.stuttering - DP)
+	M.add_chemical_effect(CE_STRAIGHTWALK)
 	M.confused = max(0, M.confused - DP)
 
 	var/datum/reagents/ingested = M.get_ingested_reagents()
@@ -1166,8 +1170,7 @@
 
 /datum/reagent/mental/neurapan/overdose(var/mob/living/carbon/M, var/alien)
 	M.add_chemical_effect(CE_PACIFIED, 1)
-	if(!locate(/datum/reagent/oculine) in M.reagents.reagent_list)
-		M.eye_blurry = max(M.eye_blurry, 30)
+	M.eye_blurry = max(M.eye_blurry, 30)
 	if((locate(/datum/reagent/oxycomorphine) in M.reagents.reagent_list))
 		M.ear_deaf = 20
 		M.drowsyness = max(M.drowsyness, 10)

--- a/html/changelogs/geeves-chem_effects.yml
+++ b/html/changelogs/geeves-chem_effects.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - tweak: "Perconol, mortaphenyl, and oxycomorphine now metabolize three times faster."
+  - rscadd: "Alkysine can now be used to counteract confused moving chem side effects, while oculine can be used to counteract eyeblur chem side effects."

--- a/html/changelogs/geeves-chem_effects.yml
+++ b/html/changelogs/geeves-chem_effects.yml
@@ -3,5 +3,5 @@ author: Geeves
 delete-after: True
 
 changes: 
-  - tweak: "Perconol, mortaphenyl, and oxycomorphine now metabolize three times faster."
+  - tweak: "Mortaphenyl and oxycomorphine now metabolize three times faster."
   - rscadd: "Alkysine can now be used to counteract confused moving chem side effects, while oculine can be used to counteract eyeblur chem side effects."

--- a/html/changelogs/geeves-chem_effects.yml
+++ b/html/changelogs/geeves-chem_effects.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes: 
   - tweak: "Mortaphenyl and oxycomorphine now metabolize three times faster."
   - rscadd: "Alkysine can now be used to counteract confused moving chem side effects, while oculine can be used to counteract eyeblur chem side effects."
+  - tweak: "Synaptizine no longer wildly damages all organs, instead having a chance each time it metabolizes to damage the liver, which is fine, unless the liver has been damaged already, or is taking damage from multiple sources."


### PR DESCRIPTION
* Perconol, mortaphenyl, and oxycomorphine now metabolize three times faster.
* Alkysine can now be used to counteract confused moving chem side effects, while oculine can be used to counteract eyeblur chem side effects.
* Synaptizine no longer wildly damages all organs, instead having a chance each time it metabolizes to damage the liver, which is fine, unless the liver has been damaged already, or is taking damage from multiple sources.