### PR TITLE
Noticeboards no longer dispense paper on the floor immediately

### DIFF
--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -53,8 +53,8 @@
 		if((usr.stat || usr.restrained()))	//For when a player is handcuffed while they have the notice window open
 			return
 		var/obj/item/P = locate(href_list["remove"])
-		if(P && P.loc == src)
-			P.forceMove(get_turf(src))	//dump paper on the floor because you're a clumsy fuck
+		if(P && P.loc == src && Adjacent(usr))
+			usr.put_in_hands(P) // we are no longer clumsy fucks
 			P.add_fingerprint(usr)
 			add_fingerprint(usr)
 			notices--

--- a/html/changelogs/hockaa-noticeboardhands.yml
+++ b/html/changelogs/hockaa-noticeboardhands.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes: 
+  - tweak: "Noticeboards now try to put paper directly into your hands instead of immediately on the floor."


### PR DESCRIPTION
Utilizes the put_in_hands proc on noticeboards.