### PR TITLE
Fixes runtimes on early startup

### DIFF
--- a/code/controllers/subsystems/emergency_shuttle.dm
+++ b/code/controllers/subsystems/emergency_shuttle.dm
@@ -239,7 +239,7 @@ var/datum/controller/subsystem/emergency_shuttle/emergency_shuttle
 
 //returns 1 if the shuttle is currently in transit (or just leaving) to centcom
 /datum/controller/subsystem/emergency_shuttle/proc/going_to_centcom()
-	return (shuttle.direction && shuttle.moving_status != SHUTTLE_IDLE)
+	return (shuttle && shuttle.direction && shuttle.moving_status != SHUTTLE_IDLE)
 
 
 /datum/controller/subsystem/emergency_shuttle/proc/get_status_panel_eta()

--- a/code/modules/mob/abstract/new_player/menu.dm
+++ b/code/modules/mob/abstract/new_player/menu.dm
@@ -57,7 +57,7 @@
 	screen_loc = "WEST,SOUTH"
 	var/lobby_index = 1
 
-/obj/screen/new_player/title/Initialize(mapload, var/datum/hud/H)
+/obj/screen/new_player/title/Initialize()
 	if(!current_map.lobby_icon)
 		current_map.lobby_icon = pick(current_map.lobby_icons)
 	if(!length(current_map.lobby_screens))
@@ -131,7 +131,7 @@
 
 //SELECTION
 
-/obj/screen/new_player/selection/Initialize(mapload, var/datum/hud/H)
+/obj/screen/new_player/selection/New(mapload, var/datum/hud/H)
 	. = ..()
 	color = null
 	hud = H
@@ -148,7 +148,7 @@
 	animate(src, transform = null, time = 1, easing = CUBIC_EASING)
 	return ..()
 
-/obj/screen/new_player/selection/join_game/Initialize(mapload, var/datum/hud/H)
+/obj/screen/new_player/selection/join_game/Initialize()
 	. = ..()
 	var/mob/abstract/new_player/player = hud.mymob
 	update_icon(player)
@@ -201,11 +201,9 @@
 
 /obj/screen/new_player/selection/polls/Initialize()
 	. = ..()
-	var/mob/M = hud.mymob
-	if(!M)
-		return
 	if(dbcon.IsConnected())
-		var/isadmin = M.client && M.client.holder
+		var/mob/M = hud.mymob
+		var/isadmin = M && M.client && M.client.holder
 		var/DBQuery/query = dbcon.NewQuery("SELECT id FROM ss13_poll_question WHERE [(isadmin ? "" : "adminonly = false AND")] Now() BETWEEN starttime AND endtime AND id NOT IN (SELECT pollid FROM ss13_poll_vote WHERE ckey = \"[M.ckey]\") AND id NOT IN (SELECT pollid FROM ss13_poll_textreply WHERE ckey = \"[M.ckey]\")")
 		query.Execute()
 		var/newpoll = query.NextRow()

--- a/html/changelogs/amunak-runtimes.yml
+++ b/html/changelogs/amunak-runtimes.yml
@@ -1,0 +1,5 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "Fixes runtimes on HUD creation related to players joining before SSAtoms starts working."
+  - bugfix: "Fixes runtime for Runtime (the map) which has no shuttles mapped."


### PR DESCRIPTION
* Fixes runtime related to player HUD and them joining very early.
* Fixes runtime that happens on Runtime 🤔 because of no mapped shuttles.

I have removed the arguments from Initialize procs in menu.dm because they cannot be relied upon.