### PR TITLE
Splits cargo item definition proc by category to prevent a runtime from too many definitions

### DIFF
--- a/code/controllers/subsystems/initialization/misc_early.dm
+++ b/code/controllers/subsystems/initialization/misc_early.dm
@@ -44,6 +44,9 @@
 		ore_data[OD.name] = OD
 
 	// Setup cargo spawn lists.
-	global.cargo_master.setup_cargo_stock()
+	global.cargo_master.setup_cargo_stock_common()
+	global.cargo_master.setup_cargo_stock_uncommon()
+	global.cargo_master.setup_cargo_stock_rare()
+	global.cargo_master.setup_cargo_stock_large()
 
 	..()

--- a/code/modules/cargo/random_stock/_defs.dm
+++ b/code/modules/cargo/random_stock/_defs.dm
@@ -1,4 +1,4 @@
-#define STOCK_ITEM_COMMON(id,prob) /datum/cargo_master/setup_cargo_stock() { global.random_stock_common[/proc/cargo_spawn_t1_##id] = prob; ..(); }; /proc/cargo_spawn_t1_##id(atom/L, datum/cargospawner/CS)
-#define STOCK_ITEM_UNCOMMON(id,prob) /datum/cargo_master/setup_cargo_stock() { global.random_stock_uncommon[/proc/cargo_spawn_t2_##id] = prob; ..(); }; /proc/cargo_spawn_t2_##id(atom/L, datum/cargospawner/CS)
-#define STOCK_ITEM_RARE(id,prob) /datum/cargo_master/setup_cargo_stock() { global.random_stock_rare[/proc/cargo_spawn_t3_##id] = prob; ..(); }; /proc/cargo_spawn_t3_##id(atom/L, datum/cargospawner/CS)
-#define STOCK_ITEM_LARGE(id,prob) /datum/cargo_master/setup_cargo_stock() { global.random_stock_large[/proc/cargo_spawn_xl_##id] = prob; ..(); }; /proc/cargo_spawn_xl_##id(atom/L, datum/cargospawner/CS)
+#define STOCK_ITEM_COMMON(id,prob) /datum/cargo_master/setup_cargo_stock_common() { global.random_stock_common[/proc/cargo_spawn_t1_##id] = prob; ..(); }; /proc/cargo_spawn_t1_##id(atom/L, datum/cargospawner/CS)
+#define STOCK_ITEM_UNCOMMON(id,prob) /datum/cargo_master/setup_cargo_stock_uncommon() { global.random_stock_uncommon[/proc/cargo_spawn_t2_##id] = prob; ..(); }; /proc/cargo_spawn_t2_##id(atom/L, datum/cargospawner/CS)
+#define STOCK_ITEM_RARE(id,prob) /datum/cargo_master/setup_cargo_stock_rare() { global.random_stock_rare[/proc/cargo_spawn_t3_##id] = prob; ..(); }; /proc/cargo_spawn_t3_##id(atom/L, datum/cargospawner/CS)
+#define STOCK_ITEM_LARGE(id,prob) /datum/cargo_master/setup_cargo_stock_large() { global.random_stock_large[/proc/cargo_spawn_xl_##id] = prob; ..(); }; /proc/cargo_spawn_xl_##id(atom/L, datum/cargospawner/CS)

--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -49,8 +49,13 @@ STOCK_ITEM_COMMON(bees, 2)
 /var/datum/cargo_master/cargo_master = new
 
 
-// Called in misc_early to generate the cargo lists (as Atoms runs before Cargo).
-/datum/cargo_master/proc/setup_cargo_stock()
+// Called in misc_early to generate the cargo lists (as Atoms runs before Cargo)
+// The procs are split to prevent reaching recursion limits (and runtiming on them) when lots of stock items are defined,
+// since every definition adds additional override of the proc and calls its parent, deepening the call stack.
+/datum/cargo_master/proc/setup_cargo_stock_common()
+/datum/cargo_master/proc/setup_cargo_stock_uncommon()
+/datum/cargo_master/proc/setup_cargo_stock_rare()
+/datum/cargo_master/proc/setup_cargo_stock_large()
 
 
 // These lists are populated by the files in `./random_stock`.

--- a/html/changelogs/amunak-cargo-runtime.yml
+++ b/html/changelogs/amunak-cargo-runtime.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "Fixed runtime that happens because we have too many cargo item defines and reach the recursion limit."


### PR DESCRIPTION
I tried a variety of other, better fixes, but this seems to be the only way to fix it without changing the whole system (or separating the probability setting from the actual procs).

If we plan to add tons of new definitions in the future this won't actually help, but it would also be trivial to just add another macro and procs.

Ideally Byond would have attributes/annotations for procs that we could use to populate the lists dynamically, but it doesn't so we're stuck with non-ideal solutions.