### PR TITLE
Changes cargo defines (STOCK_ITEM_*) to fix deep recursion with eventual runtime

### DIFF
--- a/code/controllers/subsystems/initialization/misc_early.dm
+++ b/code/controllers/subsystems/initialization/misc_early.dm
@@ -44,6 +44,6 @@
 		ore_data[OD.name] = OD
 
 	// Setup cargo spawn lists.
-	global.cargo_master.setup_cargo_stock()
+	setup_cargo_spawn_lists()
 
 	..()

--- a/code/modules/cargo/random_stock/_defs.dm
+++ b/code/modules/cargo/random_stock/_defs.dm
@@ -1,4 +1,4 @@
-#define STOCK_ITEM_COMMON(id,prob) /datum/cargo_master/setup_cargo_stock() { global.random_stock_common[/proc/cargo_spawn_t1_##id] = prob; ..(); }; /proc/cargo_spawn_t1_##id(atom/L, datum/cargospawner/CS)
-#define STOCK_ITEM_UNCOMMON(id,prob) /datum/cargo_master/setup_cargo_stock() { global.random_stock_uncommon[/proc/cargo_spawn_t2_##id] = prob; ..(); }; /proc/cargo_spawn_t2_##id(atom/L, datum/cargospawner/CS)
-#define STOCK_ITEM_RARE(id,prob) /datum/cargo_master/setup_cargo_stock() { global.random_stock_rare[/proc/cargo_spawn_t3_##id] = prob; ..(); }; /proc/cargo_spawn_t3_##id(atom/L, datum/cargospawner/CS)
-#define STOCK_ITEM_LARGE(id,prob) /datum/cargo_master/setup_cargo_stock() { global.random_stock_large[/proc/cargo_spawn_xl_##id] = prob; ..(); }; /proc/cargo_spawn_xl_##id(atom/L, datum/cargospawner/CS)
+#define STOCK_ITEM_COMMON(id,prob) /datum/cargo_master/cargo_spawn_t1_##id { category = "common"; probability = prob; spawner_proc = /proc/cargo_spawn_t1_##id; }; /proc/cargo_spawn_t1_##id(atom/L, datum/cargospawner/CS)
+#define STOCK_ITEM_UNCOMMON(id,prob) /datum/cargo_master/cargo_spawn_t2_##id { category = "uncommon"; probability = prob; spawner_proc = /proc/cargo_spawn_t2_##id; }; /proc/cargo_spawn_t2_##id(atom/L, datum/cargospawner/CS)
+#define STOCK_ITEM_RARE(id,prob) /datum/cargo_master/cargo_spawn_t3_##id { category = "rare"; probability = prob; spawner_proc = /proc/cargo_spawn_t3_##id; }; /proc/cargo_spawn_t3_##id(atom/L, datum/cargospawner/CS)
+#define STOCK_ITEM_LARGE(id,prob) /datum/cargo_master/cargo_spawn_xl_##id { category = "large"; probability = prob; spawner_proc = /proc/cargo_spawn_xl_##id; }; /proc/cargo_spawn_xl_##id(atom/L, datum/cargospawner/CS)

--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -45,15 +45,41 @@ STOCK_ITEM_COMMON(bees, 2)
 
 */
 
-// This datum doesn't actually do anything beyond hold the setup_cargo_stock proc. Defining it as a global proc causes things to break.
-/var/datum/cargo_master/cargo_master = new
+// The cargo_master datum is used to hold metadata about the cargo spawners. All subtypes are instantiated in misc_early to generate the cargo lists (as Atoms runs before Cargo).
+// This also means that if you want to do something fancy with the spawning probability you can directly create a custom sub-datum of this
+// instead of using the macros and override the get_probability proc or even the register_spawner proc.
+/datum/cargo_master
+	var/category = null
+	var/probability = 0
+	var/spawner_proc = null
 
+/datum/cargo_master/proc/get_probability()
+	return src.probability
 
-// Called in misc_early to generate the cargo lists (as Atoms runs before Cargo).
-/datum/cargo_master/proc/setup_cargo_stock()
+/datum/cargo_master/proc/register_spawner()
+	var/P = src.get_probability()
+	if(P <= 0)
+		return 0
+	switch(src.category)
+		if("common")
+			return global.random_stock_common[src.spawner_proc] = P
+		if("uncommon")
+			return global.random_stock_uncommon[src.spawner_proc] = P
+		if("rare")
+			return global.random_stock_rare[src.spawner_proc] = P
+		if("large")
+			return global.random_stock_large[src.spawner_proc] = P
+	throw EXCEPTION("Cargo spawner definition '[src.type]' has invalid category '[src.category]'. Please fix your definition.")
 
+/proc/setup_cargo_spawn_lists()
+	var/i
+	for(var/type in subtypesof(/datum/cargo_master))
+		var/datum/cargo_master/def = new type()
+		def.register_spawner()
+		i++
+	log_debug("Registered [i] cargo spawners.")
 
-// These lists are populated by the files in `./random_stock`.
+// These lists are populated by the files in `./random_stock` using the above procs.
 var/list/global/random_stock_common = list()
 var/list/global/random_stock_uncommon = list()
 var/list/global/random_stock_rare = list()

--- a/html/changelogs/amunak-cargo-spawning.yml
+++ b/html/changelogs/amunak-cargo-spawning.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "Changed how cargo spawning defines (STOCK_ITEM_*) work in order to fix an issue with deep recursion and prevent a runtime from it."


### PR DESCRIPTION
The defines now create a subtype under cargo_master for every spawner proc and use that to define probability and register the spawner instead of making tons of proc overrides.

This also allows for more flexibility when defining the spawners if desired.