### PR TITLE
Replaces instances of ARE_Z_CONNECTED with AreConnectedZLevels

### DIFF
--- a/code/__defines/subsystem-defines.dm
+++ b/code/__defines/subsystem-defines.dm
@@ -89,9 +89,6 @@
 // Connection prefixes for player-editable fields
 #define WP_ELECTRONICS "elec_"
 
-// -- SSatlas --
-#define ARE_Z_CONNECTED(ZA, ZB) ((ZA == ZB) || ((SSatlas.connected_z_cache.len >= ZA && SSatlas.connected_z_cache[ZA]) ? SSatlas.connected_z_cache[ZA][ZB] : AreConnectedZLevels(ZA, ZB)))
-
 // -- SSicon_cache --
 #define LIGHT_FIXTURE_CACHE(icon,state,color) SSicon_cache.light_fixture_cache["[icon]_[state]_[color]"] || (SSicon_cache.light_fixture_cache["[icon]_[state]_[color]"] = SSicon_cache.generate_color_variant(icon,state,color))
 

--- a/code/controllers/subsystems/explosives.dm
+++ b/code/controllers/subsystems/explosives.dm
@@ -325,7 +325,7 @@ var/datum/controller/subsystem/explosives/SSexplosives
 			CHECK_TICK
 			continue
 
-		if (!ARE_Z_CONNECTED(T.z, epicenter.z))
+		if (!AreConnectedZLevels(T.z, epicenter.z))
 			CHECK_TICK
 			continue
 

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -104,7 +104,7 @@ Possible to do for anyone motivated enough:
 			var/list/holopadlist = list()
 			for(var/obj/machinery/hologram/holopad/H in SSmachinery.processing_machines - src)
 				if(AreConnectedZLevels(H.z, z) && H.operable())
-					holopadlist[H.holopad_id] = H
+					holopadlist["[H.holopad_id]"] = H	//Define a list and fill it with the area of every holopad in the world
 			holopadlist = sortAssoc(holopadlist)
 			var/chosen_pad = input(user, "Which holopad would you like to contact?", "Holopad List") as null|anything in holopadlist
 			if(!chosen_pad)

--- a/code/modules/modular_computers/file_system/programs/civilian/janitor.dm
+++ b/code/modules/modular_computers/file_system/programs/civilian/janitor.dm
@@ -75,7 +75,7 @@
 			continue
 
 		var/turf/AT = get_turf(A)
-		if(AT && ARE_Z_CONNECTED(AT.z, p.z))
+		if(AT && AreConnectedZLevels(AT.z, p.z))
 			dir = dir2text(get_dir(p, AT))
 		if(!dir)
 			dir = "ERR"

--- a/code/modules/modular_computers/file_system/programs/security/guntracker.dm
+++ b/code/modules/modular_computers/file_system/programs/security/guntracker.dm
@@ -47,7 +47,7 @@
 		if(!istype(P) || !P.gun)
 			continue
 		var/turf/Ts = get_turf(P)
-		if(ARE_Z_CONNECTED(T.z, Ts.z))
+		if(AreConnectedZLevels(T.z, Ts.z))
 			var/list/guntracker_info = list(
 				"gun_name" = capitalize_first_letters(P.gun.name),
 				"registered_info" = P.registered_user ? P.registered_user : "Unregistered",


### PR DESCRIPTION
`ARE_Z_CONNECTED(ZA, ZB)` can runtime in cases where ZB > ZA and the z-level cache has not been fully populated yet. This was the cause of a recent bug with the holocomm PR.

I could add extra checks into `ARE_Z_CONNECTED`, but then it would end up essentially being `AreConnectedZLevels()` so I'm just going to replace the former with the latter, which works for all ZA & ZB.