### PR TITLE
Makes buckets, sinks and tanks transfer more by default and adds info about changing the transfer amount

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -396,9 +396,10 @@
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "sink"
 	desc = "A sink used for washing one's hands and face."
+	desc_info = "You can right-click this and change the amount transferred per use."
 	anchored = 1
 	var/busy = 0 	//Something's being washed at the moment
-	var/amount_per_transfer_from_this = 10
+	var/amount_per_transfer_from_this = 300
 	var/possible_transfer_amounts = list(5,10,15,25,30,50,60,100,120,250,300)
 
 /obj/structure/sink/verb/set_APTFT() //set amount_per_transfer_from_this

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -209,7 +209,7 @@
 	accuracy = 1
 	matter = list(DEFAULT_WALL_MATERIAL = 200)
 	w_class = ITEMSIZE_NORMAL
-	amount_per_transfer_from_this = 20
+	amount_per_transfer_from_this = 120
 	possible_transfer_amounts = list(10,20,30,60,120)
 	volume = 120
 	flags = OPENCONTAINER

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -1,6 +1,7 @@
 /obj/structure/reagent_dispensers
 	name = "strange dispenser"
 	desc = "What the fuck is this?"
+	desc_info = "You can right-click this and change the amount transferred per use."
 	icon = 'icons/obj/reagent_dispensers.dmi'
 	icon_state = "watertank"
 	density = 1
@@ -18,6 +19,7 @@
 	create_reagents(capacity)
 	if (!possible_transfer_amounts)
 		src.verbs -= /obj/structure/reagent_dispensers/verb/set_APTFT
+		desc_info = ""
 
 /obj/structure/reagent_dispensers/examine(mob/user)
 	if(!..(user, 2))
@@ -94,7 +96,7 @@
 	name = "extinguisher tank"
 	desc = "A tank filled with extinguisher fluid."
 	icon_state = "extinguisher_tank"
-	amount_per_transfer_from_this = 10
+	amount_per_transfer_from_this = 30
 	reagents_to_add = list(/datum/reagent/toxin/fertilizer/monoammoniumphosphate = 1000)
 
 // Tanks
@@ -102,14 +104,14 @@
 	name = "water tank"
 	desc = "A tank filled with water."
 	icon_state = "watertank"
-	amount_per_transfer_from_this = 10
+	amount_per_transfer_from_this = 100
 	reagents_to_add = list(/datum/reagent/water = 1000)
 
 /obj/structure/reagent_dispensers/lube
 	name = "lube tank"
 	desc = "A tank filled with a silly amount of lube."
 	icon_state = "lubetank"
-	amount_per_transfer_from_this = 10
+	amount_per_transfer_from_this = 30
 	reagents_to_add = list(/datum/reagent/lube = 1000)
 
 /obj/structure/reagent_dispensers/fueltank
@@ -117,7 +119,7 @@
 	desc = "A tank filled with welding fuel."
 	icon_state = "weldtank"
 	accept_any_reagent = FALSE
-	amount_per_transfer_from_this = 10
+	amount_per_transfer_from_this = 30
 	var/defuse = 0
 	var/armed = 0
 	var/obj/item/device/assembly_holder/rig = null

--- a/html/changelogs/amunak-buckets.yml
+++ b/html/changelogs/amunak-buckets.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - tweak: "Buckets and sinks now transfer maximum amount per use. Sinks also have new info description reminding people that they can change the amount transferred."

--- a/html/changelogs/amunak-buckets.yml
+++ b/html/changelogs/amunak-buckets.yml
@@ -1,4 +1,5 @@
 author: Amunak
 delete-after: True
 changes:
-  - tweak: "Buckets and sinks now transfer maximum amount per use. Sinks also have new info description reminding people that they can change the amount transferred."
+  - tweak: "Buckets and sinks now transfer maximum amount per use. Water tanks transfer 100 by default, extinguisher, lube and fuel tank 30."
+  - tweak: "Sinks and water/extinguisher/etc tanks now also have new info description reminding people that they can change the amount transferred."


### PR DESCRIPTION
By default buckets and sinks now transfer maximum, water tanks 100 units, other "regular" tanks (extinguisher, welding, lube) transfer 30.

Also adds info-description to tanks and sinks noting that the amount can be changed by right-clicking, as people don't seem to really know that.

fixes #10409
(I mean it's not really a bug, but it adresses the underlying problem)