### PR TITLE
Solves excessive runtime production from beams being created improperly

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -23,9 +23,8 @@
 	target = beam_target
 	target_oldloc = get_turf(target)
 
-	if(get_dist(origin_oldloc, target_oldloc) >= max_distance || origin_oldloc.z != target_oldloc.z)
+	if(!origin || !target || !target_oldloc || !origin_oldloc || get_dist(origin_oldloc, target_oldloc) >= max_distance || origin_oldloc.z != target_oldloc.z)
 		qdel(src)
-		crash_with("Tried to create a new beam with length beyond its maximum distance limit.")
 		return
 
 	sleep_time = beam_sleep_time

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -311,8 +311,8 @@
 	))
 
 	var/rods_count = 0
-
-	for(var/A in typecache_filter_multi_list_exclusion(oview(source, zap_range+2), things_to_shock, blacklisted_types))
+	var/beam_range = zap_range + 2
+	for(var/A in typecache_filter_multi_list_exclusion(oview(source, beam_range), things_to_shock, blacklisted_types))
 
 		if(istype(source, /obj/singularity/energy_ball) && istype(A, /obj/machinery/power/singularity_beacon/emergency))
 			var/obj/machinery/power/singularity_beacon/emergency/E = A
@@ -320,7 +320,7 @@
 			if(!E.active)
 				return
 			B.visible_message("\The [B] discharges entirely at [A] until it dissapears and [A] melts down")
-			B.Beam(E, icon_state="lightning[rand(1,12)]", icon = 'icons/effects/effects.dmi', time=2)
+			B.Beam(E, icon_state="lightning[rand(1,12)]", icon = 'icons/effects/effects.dmi', time=2, maxdistance=beam_range)
 			E.tesla_act(0, TRUE)
 			qdel(B)
 			return


### PR DESCRIPTION
Takes out the crash() and adds some extra checks to make sure origin.x and target.x exist.