### PR TITLE
Midgame Antagonist

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -410,7 +410,8 @@
 			antag_count += A.get_active_antag_count()
 		for(var/antag_type in SSticker.mode.antag_tags)
 			var/datum/antagonist/A = all_antag_types[antag_type]
-			if((A.role_type in H.client.prefs.be_special_role) && !(A.flags & ANTAG_OVERRIDE_JOB) && antag_count < A.hard_cap_round && antag_count <= (length(player_list) / SSticker.mode.antag_scaling_coeff))
+			A.update_current_antag_max()
+			if((A.role_type in H.client.prefs.be_special_role) && !(A.flags & ANTAG_OVERRIDE_JOB) && antag_count < A.cur_max)
 				A.add_antagonist(H.mind)
 				break
 

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -408,13 +408,9 @@
 		for(var/antag_type in SSticker.mode.antag_tags)
 			var/list/cur_antags = get_antags(antag_type)
 			antag_count += length(cur_antags)
-		message_admins(antag_count)
-		var/player_count = length(player_list)
-		message_admins(player_count)
-		message_admins(player_count / SSticker.mode.antag_scaling_coeff)
 		for(var/antag_type in SSticker.mode.antag_tags)
 			var/datum/antagonist/A = all_antag_types[antag_type]
-			if(A.can_become_antag(H.mind) && (A.role_type in H.client.prefs.be_special_role) && !(A.flags & ANTAG_OVERRIDE_JOB) && antag_count < A.hard_cap_round && antag_count <= (player_count / SSticker.mode.antag_scaling_coeff))
+			if(A.can_become_antag(H.mind) && (A.role_type in H.client.prefs.be_special_role) && !(A.flags & ANTAG_OVERRIDE_JOB) && antag_count < A.hard_cap_round && antag_count <= (length(player_list) / SSticker.mode.antag_scaling_coeff))
 				A.add_antagonist(H.mind)
 
 	Debug("ER/([H]): Completed.")

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -403,6 +403,20 @@
 
 	INVOKE_ASYNC(GLOBAL_PROC, .proc/show_location_blurb, H.client, 30)
 
+	if(SSticker.mode != "Extended" && joined_late)
+		var/antag_count = 0
+		for(var/antag_type in SSticker.mode.antag_tags)
+			var/list/cur_antags = get_antags(antag_type)
+			antag_count += length(cur_antags)
+		message_admins(antag_count)
+		var/player_count = length(player_list)
+		message_admins(player_count)
+		message_admins(player_count / SSticker.mode.antag_scaling_coeff)
+		for(var/antag_type in SSticker.mode.antag_tags)
+			var/datum/antagonist/A = all_antag_types[antag_type]
+			if(A.can_become_antag(H.mind) && (A.role_type in H.client.prefs.be_special_role) && !(A.flags & ANTAG_OVERRIDE_JOB) && antag_count < A.hard_cap_round && antag_count <= (player_count / SSticker.mode.antag_scaling_coeff))
+				A.add_antagonist(H.mind)
+
 	Debug("ER/([H]): Completed.")
 
 	return H

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -403,14 +403,14 @@
 
 	INVOKE_ASYNC(GLOBAL_PROC, .proc/show_location_blurb, H.client, 30)
 
-	if(SSticker.mode != "Extended" && joined_late)
+	if(joined_late)
 		var/antag_count = 0
 		for(var/antag_type in SSticker.mode.antag_tags)
-			var/list/cur_antags = get_antags(antag_type)
-			antag_count += length(cur_antags)
+			var/datum/antagonist/A = all_antag_types[antag_type]
+			antag_count += A.get_active_antag_count()
 		for(var/antag_type in SSticker.mode.antag_tags)
 			var/datum/antagonist/A = all_antag_types[antag_type]
-			if(A.can_become_antag(H.mind) && (A.role_type in H.client.prefs.be_special_role) && !(A.flags & ANTAG_OVERRIDE_JOB) && antag_count < A.hard_cap_round && antag_count <= (length(player_list) / SSticker.mode.antag_scaling_coeff))
+			if((A.role_type in H.client.prefs.be_special_role) && !(A.flags & ANTAG_OVERRIDE_JOB) && antag_count < A.hard_cap_round && antag_count <= (length(player_list) / SSticker.mode.antag_scaling_coeff))
 				A.add_antagonist(H.mind)
 				break
 

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -412,6 +412,7 @@
 			var/datum/antagonist/A = all_antag_types[antag_type]
 			if(A.can_become_antag(H.mind) && (A.role_type in H.client.prefs.be_special_role) && !(A.flags & ANTAG_OVERRIDE_JOB) && antag_count < A.hard_cap_round && antag_count <= (length(player_list) / SSticker.mode.antag_scaling_coeff))
 				A.add_antagonist(H.mind)
+				break
 
 	Debug("ER/([H]): Completed.")
 

--- a/html/changelogs/geeves-midgame_antag.yml
+++ b/html/changelogs/geeves-midgame_antag.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes: 
+  - rscadd: "People who latejoin can now be turned into antags as well, provided they have the role preference selected, it's a station antag, and amount of antags is lower than or equal to the living player count divided by the antag count coeff."


### PR DESCRIPTION
* People who latejoin can now be turned into antags as well, provided they have the role preference selected, it's a station antag, and amount of antags is lower than or equal to the living player count divided by the antag count coeff.