### PR TITLE
Total enemies now considers unique players over all modes instead of per mode

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -173,7 +173,6 @@ var/global/list/additional_antag_types = list()
 		log_debug("GAMEMODE: Checking antag templates...")
 		if(antag_tags && antag_tags.len)
 			log_debug("GAMEMODE: Checking antag tags...")
-			var/total_enemy_count = 0
 			for(var/antag_tag in antag_tags)
 				var/datum/antagonist/antag = all_antag_types[antag_tag]
 				if(!antag)
@@ -191,17 +190,25 @@ var/global/list/additional_antag_types = list()
 							potential -= potential_antag
 							antag.candidates -= player
 							log_debug("GAMEMODE: Player [player.name] ([player.key]) was removed from the potential antags list due to being given the role [player.assigned_role] which is a restricted job!")
-					if(potential.len)
-						log_debug("GAMEMODE: Found [potential.len] potential antagonists for [antag.role_text].")
-						total_enemy_count += potential.len
-						if(antag.initial_spawn_req && require_all_templates && potential.len < antag.initial_spawn_req)
-							log_debug("GAMEMODE: There are not enough antagonists ([potential.len]/[antag.initial_spawn_req]) for the role [antag.role_text]!")
-							returning |= GAME_FAILURE_NO_ANTAGS
 
-			log_debug("GAMEMODE: Found [total_enemy_count] total enemies for [name].")
+			// Split the for loop here so that we can have a complete set of potential lists for each antag_tag before continuing
+			var/list/total_enemies = list()
+			for(var/antag_tag in antag_tags)
+				var/datum/antagonist/antag = all_antag_types[antag_tag]
+				if(!antag)
+					continue
+				var/list/potential = antag.candidates
+				if(potential.len)
+					log_debug("GAMEMODE: Found [potential.len] potential antagonists for [antag.role_text]. [english_list(potential)]")
+					total_enemies |= potential //Only count candidates once for our total enemy pool
+					if(antag.initial_spawn_req && require_all_templates && potential.len < antag.initial_spawn_req)
+						log_debug("GAMEMODE: There are not enough antagonists ([potential.len]/[antag.initial_spawn_req]) for the role [antag.role_text]!")
+						returning |= GAME_FAILURE_NO_ANTAGS
 
-			if(required_enemies && total_enemy_count < required_enemies)
-				log_debug("GAMEMODE: There are not enough total antagonists ([total_enemy_count]/[required_enemies]) to start [name]!")
+			log_debug("GAMEMODE: Found [total_enemies.len] total enemies for [name]. [english_list(total_enemies)]")
+
+			if(required_enemies && total_enemies.len < required_enemies)
+				log_debug("GAMEMODE: There are not enough total antagonists ([total_enemies.len]/[required_enemies]) to start [name]!")
 				returning |= GAME_FAILURE_NO_ANTAGS
 
 	log_debug("GAMEMODE: Finished gamemode checking. [name] returned [returning].")

--- a/html/changelogs/multi_mode_candidate_fix.yml
+++ b/html/changelogs/multi_mode_candidate_fix.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed an issue where multi-modes (e.g. Uprising (Rev+Traitor)) would consider players multiple times to see if we had enough enemies, although the player could not play multiple roles simultaneously. Therefore multi-rounds could be considered valid modes when they were not, and rounds would start with too few players in one or more roles."


### PR DESCRIPTION
When calculating the total enemies available for a round, the game added the candidates for each role together, not considering that a player may be a candidate for more than one role. Therefore `total_enemy_count` was not equal to the sum of unique candidates across all roles. This could cause games to start with too few players, despite each antag role itself being satisfied.
