### PR TITLE
Drop hotkey now works for things held by grippers

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -63,6 +63,12 @@
 					to_chat(usr, SPAN_WARNING("You have nothing to drop in your hand."))
 					return
 				drop_item()
+			else if(isrobot(src))
+				var/mob/living/silicon/robot/R = usr
+				var/I = R.get_active_hand()
+				if(istype(I, /obj/item/gripper))
+					var/obj/item/gripper/G = I
+					G.drop_item()
 			else
 				to_chat(usr, SPAN_WARNING("This mob type cannot drop items."))
 			return

--- a/html/changelogs/drop_hotkey_grippers.yml
+++ b/html/changelogs/drop_hotkey_grippers.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "The drop hotkey (default Q) will now drop things held by robot grippers."


### PR DESCRIPTION
Press 'Q' and it if the gripper has a thing, it drops the thing.
If nothing is in the gripper, it goes back to your module list.