### PR TITLE
Fountain pens start with the cursive option off by default now

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -138,7 +138,7 @@ Pen exclusive commands
 	icon_state = "pen_fountain"
 	throwforce = 1 //pointy
 	colour = "#1c1713" //dark ashy brownish
-	var/cursive = TRUE
+	var/cursive = FALSE
 
 /obj/item/pen/fountain/attack_self(var/mob/user)
 	playsound(loc, 'sound/items/penclick.ogg', 50, 1)

--- a/html/changelogs/alberyk-pen.yml
+++ b/html/changelogs/alberyk-pen.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - tweak: "Fountain pens start with the cursive option off by default now."


### PR DESCRIPTION
To reduce fax problems.