### PR TITLE
Unique Visitor Tweak

### DIFF
--- a/code/modules/ghostroles/spawner/human/visitor.dm
+++ b/code/modules/ghostroles/spawner/human/visitor.dm
@@ -9,6 +9,8 @@
 	req_perms = null
 	max_count = 1
 
+	show_on_job_select = FALSE
+
 	//Vars related to human mobs
 	outfit = /datum/outfit/admin/random/visitor
 	possible_species = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_TAJARA, SPECIES_UNATHI)

--- a/html/changelogs/geeves-visitor_isnt_unique.yml
+++ b/html/changelogs/geeves-visitor_isnt_unique.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "The visitor ghostrole no longer appears as a unique role on the join menu."


### PR DESCRIPTION
* The visitor ghostrole no longer appears as a unique role on the join menu.