### PR TITLE
Fixes maintenance drones not being able to travel through disposals

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -227,7 +227,7 @@
 		return
 
 /// makes it so synths can't be flushed
-	if (istype(target, /mob/living/silicon/robot))
+	if (isrobot(target) && !isDrone(target))
 		to_chat(user, SPAN_NOTICE("[target] is a bit too clunky to fit!"))
 		return
 

--- a/html/changelogs/amunak-dronefix.yml
+++ b/html/changelogs/amunak-dronefix.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "Maintenance drones can be disposaled again properly."


### PR DESCRIPTION
This was broken by #10169.