### PR TITLE
Airlock Construction

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -1,3 +1,7 @@
+#define STATE_UNWIRED 0
+#define STATE_WIRED 1
+#define STATE_ELECTRONICS_INSTALLED 2
+
 /obj/structure/door_assembly
 	name = "airlock assembly"
 	icon = 'icons/obj/doors/door_assembly.dmi'
@@ -6,7 +10,7 @@
 	density = 1
 	w_class = ITEMSIZE_HUGE
 	build_amt = 4
-	var/state = 0
+	var/state = STATE_UNWIRED
 	var/base_icon_state = ""
 	var/base_name = "Airlock"
 	var/obj/item/airlock_electronics/electronics = null
@@ -15,8 +19,9 @@
 	var/glass = 0 // 0 = glass can be installed. -1 = glass can't be installed. 1 = glass is already installed. Text = mineral plating is installed instead.
 	var/created_name = null
 
-	New()
-		update_state()
+/obj/structure/door_assembly/Initialize(mapload)
+	. = ..()
+	update_state()
 
 /obj/structure/door_assembly/door_assembly_com
 	base_icon_state = "com"
@@ -165,43 +170,55 @@
 
 /obj/structure/door_assembly/attackby(obj/item/W as obj, mob/user as mob)
 	if(W.ispen())
-		var/t = sanitizeSafe(input(user, "Enter the name for the door.", src.name, src.created_name), MAX_NAME_LEN)
-		if(!t)	return
-		if(!in_range(src, usr) && src.loc != usr)	return
-		created_name = t
-		return
+		var/door_name = sanitizeSafe(input(user, "Enter the name for the door.", src.name, src.created_name), MAX_NAME_LEN)
+		if(!door_name)
+			return
+		if(!Adjacent(user))
+			return
+		created_name = door_name
 
-	if(W.iswelder() && ( (istext(glass)) || (glass == 1) || (!anchored) ))
+	else if(W.iswelder())
+		if(!(istext(glass) || glass == TRUE || !anchored))
+			to_chat(user, SPAN_WARNING("\The [src] isn't ready to be welded yet. It has to have glass installed to remove the glass, or it has to be unsecured to deconstruct."))
+			return
 		var/obj/item/weldingtool/WT = W
-		if (WT.remove_fuel(0, user))
+		if(WT.remove_fuel(0, user))
 			playsound(src.loc, 'sound/items/welder_pry.ogg', 50, 1)
 			if(istext(glass))
-				user.visible_message("[user] welds the [glass] plating off the airlock assembly.", "You start to weld the [glass] plating off the airlock assembly.")
-				if(do_after(user, 40/W.toolspeed))
-					if(!src || !WT.isOn()) return
-					to_chat(user, "<span class='notice'>You welded the [glass] plating off!</span>")
+				user.visible_message("<b>[user]</b> starts welding the [glass] plating off the airlock assembly.", SPAN_NOTICE("You start welding the [glass] plating off the airlock assembly."))
+				if(do_after(user, 40 / W.toolspeed))
+					if(!src || !WT.isOn())
+						return
+					to_chat(user, SPAN_NOTICE("You weld the [glass] plating off."))
 					var/M = text2path("/obj/item/stack/material/[glass]")
 					new M(src.loc, 2)
-					glass = 0
-			else if(glass == 1)
-				user.visible_message("[user] welds the glass panel out of the airlock assembly.", "You start to weld the glass panel out of the airlock assembly.")
-				if(do_after(user, 40/W.toolspeed))
-					if(!src || !WT.isOn()) return
-					to_chat(user, "<span class='notice'>You welded the glass panel out!</span>")
+					glass = FALSE
+			else if(glass == TRUE)
+				user.visible_message("<b>[user]</b> starts welding the glass panel out of the airlock assembly.", SPAN_NOTICE("You start welding the glass panel out of the airlock assembly."))
+				if(do_after(user, 40 / W.toolspeed))
+					if(!src || !WT.isOn())
+						return
+					to_chat(user, SPAN_NOTICE("You weld the glass panel out."))
 					new /obj/item/stack/material/glass/reinforced(src.loc)
-					glass = 0
+					glass = FALSE
 			else if(!anchored)
-				user.visible_message("[user] dissassembles the airlock assembly.", "You start to dissassemble the airlock assembly.")
-				if(do_after(user, 40/W.toolspeed))
-					if(!src || !WT.isOn()) return
-					to_chat(user, "<span class='notice'>You dissasembled the airlock assembly!</span>")
+				user.visible_message("<b>[user]</b> starts disassembling the airlock assembly.", SPAN_NOTICE("You start disassembling the airlock assembly."))
+				if(do_after(user, 40 / W.toolspeed))
+					if(!src || !WT.isOn())
+						return
+					to_chat(user, SPAN_NOTICE("You disassemble the airlock assembly."))
 					dismantle()
 		else
-			to_chat(user, "<span class='notice'>You need more welding fuel.</span>")
+			to_chat(user, SPAN_WARNING("You need more welding fuel."))
 			return
 
-	else if(W.iswrench() && state == 0)
+	else if(W.iswrench())
+		if(state != STATE_UNWIRED)
+			to_chat(user, SPAN_WARNING("\The [src] can only be wrenched once it's in an unwired state."))
+			return
+
 		playsound(src.loc, W.usesound, 100, 1)
+	
 		if(anchored)
 			user.visible_message("<b>[user]</b> begins unsecuring the airlock assembly from the floor.", \
 								SPAN_NOTICE("You start unsecuring the airlock assembly from the floor."))
@@ -209,99 +226,132 @@
 			user.visible_message("<b>[user]</b> begins securing the airlock assembly to the floor.", \
 								SPAN_NOTICE("You start securing the airlock assembly to the floor."))
 
-		if(do_after(user, 40/W.toolspeed))
-			if(!src) return
-			to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured the airlock assembly!</span>")
+		if(do_after(user, 40 / W.toolspeed))
+			if(!src)
+				return
+			to_chat(user, SPAN_NOTICE("You [anchored? "un" : ""]secure \the [src]."))
 			anchored = !anchored
 
-	else if(W.iscoil() && state == 0 && anchored)
+	else if(W.iscoil())
+		if(state > STATE_UNWIRED)
+			to_chat(user, SPAN_WARNING("\The [src] has already been wired."))
+			return
+		if(!anchored)
+			to_chat(user, SPAN_WARNING("\The [src] must be anchored before it can be wired."))
+			return
 		var/obj/item/stack/cable_coil/C = W
 		if (C.get_amount() < 1)
-			to_chat(user, "<span class='warning'>You need one length of coil to wire the airlock assembly.</span>")
+			to_chat(user, SPAN_WARNING("You need one length of coil to wire the airlock assembly."))
 			return
-		user.visible_message("[user] wires the airlock assembly.", "You start to wire the airlock assembly.")
-		if(do_after(user, 40) && state == 0 && anchored)
-			if (C.use(1))
-				src.state = 1
-				to_chat(user, "<span class='notice'>You wire the airlock.</span>")
+		user.visible_message("<b>[user]</b> starts wiring the airlock assembly.", SPAN_NOTICE("You start wiring the airlock assembly."))
+		if(do_after(user, 40) && state == STATE_UNWIRED && anchored)
+			if(C.use(1))
+				state = STATE_WIRED
+				to_chat(user, SPAN_NOTICE("You wire the airlock."))
 
-	else if(W.iswirecutter() && state == 1 )
+	else if(W.iswirecutter())
+		if(state == STATE_UNWIRED)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't have any wires to remove."))
+			return
+		else if(state > STATE_WIRED)
+			to_chat(user, SPAN_WARNING("\The [src]'s wires cannot be reached, take out the electronics first."))
+			return
+
 		playsound(src.loc, 'sound/items/wirecutter.ogg', 100, 1)
-		user.visible_message("[user] cuts the wires from the airlock assembly.", "You start to cut the wires from airlock assembly.")
+		user.visible_message("<b>[user]</b> starts cutting the wires from the airlock assembly.", SPAN_NOTICE("You start cutting the wires from airlock assembly."))
 
-		if(do_after(user, 40/W.toolspeed))
-			if(!src) return
-			to_chat(user, "<span class='notice'>You cut the airlock wires.!</span>")
-			new/obj/item/stack/cable_coil(src.loc, 1)
-			src.state = 0
+		if(do_after(user, 40 / W.toolspeed))
+			if(!src)
+				return
+			to_chat(user, SPAN_NOTICE("You cut the airlock wires."))
+			new /obj/item/stack/cable_coil(src.loc, 1)
+			state = STATE_UNWIRED
 
-	else if(istype(W, /obj/item/airlock_electronics) && state == 1)
+	else if(istype(W, /obj/item/airlock_electronics))
+		if(state == STATE_UNWIRED)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't have any wires, use some cable coil on it first."))
+			return
+		else if(state > STATE_WIRED)
+			to_chat(user, SPAN_WARNING("\The [src] already has airlock electronics installed."))
+			return
 		var/obj/item/airlock_electronics/EL = W
 		if(!EL.is_installed)
 			playsound(src.loc, 'sound/items/screwdriver.ogg', 100, 1)
-			user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
-			EL.is_installed = 1
-			if(do_after(user, 40/W.toolspeed))
-				EL.is_installed = 0
-				if(!src) return
-				user.drop_from_inventory(EL,src)
-				to_chat(user, "<span class='notice'>You installed the airlock electronics!</span>")
-				src.state = 2
-				src.name = "Near finished Airlock Assembly"
-				src.electronics = EL
+			user.visible_message("<b>[user]</b> starts installing the electronics into the airlock assembly.", SPAN_NOTICE("You start installing electronics into the airlock assembly."))
+			EL.is_installed = TRUE
+			if(do_after(user, 40 / W.toolspeed) && state == STATE_WIRED)
+				EL.is_installed = FALSE
+				if(!src)
+					return
+				user.drop_from_inventory(EL, src)
+				to_chat(user, SPAN_NOTICE("You install the airlock electronics."))
+				state = STATE_ELECTRONICS_INSTALLED
+				electronics = EL
 			else
-				EL.is_installed = 0
+				EL.is_installed = FALSE
 
-	else if(W.iscrowbar() && state == 2 )
+	else if(W.iscrowbar())
+		if(state != STATE_ELECTRONICS_INSTALLED)
+			to_chat(user, SPAN_WARNING("\The [src] has no electronics to remove."))
+			return
+
 		//This should never happen, but just in case I guess
-		if (!electronics)
-			to_chat(user, "<span class='notice'>There was nothing to remove.</span>")
-			src.state = 1
+		if(!electronics)
+			to_chat(user, SPAN_WARNING("There was nothing to remove."))
+			state = STATE_WIRED
 			return
 
 		playsound(src.loc, W.usesound, 100, 1)
-		user.visible_message("\The [user] starts removing the electronics from the airlock assembly.", "You start removing the electronics from the airlock assembly.")
+		user.visible_message("<b>[user]</b> starts removing the electronics from the airlock assembly.", SPAN_NOTICE("You start removing the electronics from the airlock assembly."))
 
-		if(do_after(user, 40/W.toolspeed))
-			if(!src) return
-			to_chat(user, "<span class='notice'>You removed the airlock electronics!</span>")
-			src.state = 1
-			src.name = "Wired Airlock Assembly"
+		if(do_after(user, 40 / W.toolspeed))
+			if(!src)
+				return
+			to_chat(user, SPAN_NOTICE("You remove the airlock electronics."))
+			state = STATE_WIRED
 			electronics.forceMove(src.loc)
 			electronics = null
 
-	else if(istype(W, /obj/item/stack/material) && !glass)
+	else if(istype(W, /obj/item/stack/material))
+		if(glass)
+			to_chat(user, SPAN_WARNING("\The [src] already has material plating installed."))
+			return
 		var/obj/item/stack/S = W
 		var/material_name = S.get_material_name()
-		if (S)
-			if (S.get_amount() >= 1)
+		if(S)
+			if(S.get_amount() >= 1)
 				if(material_name == "rglass")
 					playsound(src.loc, /decl/sound_category/crowbar_sound, 100, 1)
-					user.visible_message("[user] adds [S.name] to the airlock assembly.", "You start to install [S.name] into the airlock assembly.")
+					user.visible_message("<b>[user]</b> starts installing \the [S] into the airlock assembly.", "You start installing \the [S] into the airlock assembly.")
 					if(do_after(user, 40) && !glass)
-						if (S.use(1))
-							to_chat(user, "<span class='notice'>You installed reinforced glass windows into the airlock assembly.</span>")
+						if(S.use(1))
+							to_chat(user, SPAN_NOTICE("You install reinforced glass windows into the airlock assembly."))
 							glass = 1
 				else if(material_name)
 					// Ugly hack, will suffice for now. Need to fix it upstream as well, may rewrite mineral walls. ~Z
 					if(!(material_name in list("gold", "silver", "diamond", "uranium", "phoron", "sandstone")))
-						to_chat(user, "You cannot make an airlock out of that material.")
+						to_chat(user, SPAN_WARNING("You cannot make an airlock out of that material."))
 						return
 					if(S.get_amount() >= 2)
 						playsound(src.loc, /decl/sound_category/crowbar_sound, 100, 1)
-						user.visible_message("[user] adds [S.name] to the airlock assembly.", "You start to install [S.name] into the airlock assembly.")
+						user.visible_message("<b>[user]</b> starts installing \the [S] into the airlock assembly.", "You start installing \the [S] into the airlock assembly.")
 						if(do_after(user, 40) && !glass)
 							if (S.use(2))
-								to_chat(user, "<span class='notice'>You installed [SSmaterials.material_display_name(material_name)] plating into the airlock assembly.</span>")
+								to_chat(user, SPAN_NOTICE("You install [SSmaterials.material_display_name(material_name)] plating into the airlock assembly."))
 								glass = material_name
 
-	else if(W.isscrewdriver() && state == 2 )
-		playsound(src.loc, W.usesound, 100, 1)
-		to_chat(user, "<span class='notice'>Now finishing the airlock.</span>")
+	else if(W.isscrewdriver())
+		if(state != STATE_ELECTRONICS_INSTALLED)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't have any electronics installed."))
+			return
 
-		if(do_after(user, 40/W.toolspeed))
-			if(!src) return
-			to_chat(user, "<span class='notice'>You finish the airlock!</span>")
+		playsound(src.loc, W.usesound, 100, 1)
+		user.visible_message("<b>[user]</b> starts finishing \the [src].", SPAN_NOTICE("You start finishing \the [src]."))
+
+		if(do_after(user, 40 / W.toolspeed))
+			if(!src)
+				return
+			to_chat(user, SPAN_NOTICE("You finish the airlock!"))
 			var/path
 			if(istext(glass))
 				path = text2path("/obj/machinery/door/airlock/[glass]")
@@ -312,32 +362,33 @@
 
 			new path(src.loc, src)
 			qdel(src)
+
 	else if(istype(W, /obj/item/material/twohanded/chainsaw))
 		var/obj/item/material/twohanded/chainsaw/ChainSawVar = W
 		if(!ChainSawVar.wielded)
-			to_chat(user, "<span class='notice'>Cutting the airlock requires the strength of two hands.</span>")
+			to_chat(user, SPAN_WARNING("Cutting the airlock requires the strength of two hands."))
 		else if(ChainSawVar.cutting)
-			to_chat(user, "<span class='notice'>You are already cutting an airlock open.</span>")
+			to_chat(user, SPAN_WARNING("You are already cutting an airlock open."))
 		else if(!ChainSawVar.powered)
-			to_chat(user, "<span class='notice'>The [W] needs to be on in order to open this door.</span>")
+			to_chat(user, SPAN_WARNING("The [W] needs to be on in order to tear \the [src] apart."))
 		else
-			ChainSawVar.cutting = 1
+			ChainSawVar.cutting = TRUE
 			user.visible_message(\
-				"<span class='danger'>[user.name] starts cutting the rest of the airlock with the [W]!</span>",\
-				"<span class='warning'>You start cutting the rest of the airlock...</span>",\
-				"<span class='notice'>You hear a loud buzzing sound and metal grinding on metal...</span>"\
+				SPAN_DANGER("[user] starts cutting \the [src] apart with the [W]!"), \
+				SPAN_NOTICE("You start cutting \the [src] apart..."), \
+				SPAN_WARNING("You hear a loud buzzing sound and metal grinding on metal...") \
 			)
 			if(do_after(user, ChainSawVar.opendelay SECONDS, act_target = user, extra_checks  = CALLBACK(src, .proc/CanChainsaw, W)))
 				user.visible_message(\
-					"<span class='warning'>[user.name] finishes cutting the airlock with the [W].</span>",\
-					"<span class='warning'>You finish cutting the airlock.</span>",\
-					"<span class='notice'>You hear a metal clank and some sparks.</span>"\
+					SPAN_DANGER("[user] finishes cutting \the [src] apart with the [W]."), \
+					SPAN_NOTICE("You finish cutting \the [src] apart."), \
+					SPAN_WARNING("You hear a metal clank and some sparks.") \
 				)
 				new /obj/item/stack/material/steel(src.loc, 2)
-				ChainSawVar.cutting = 0
+				ChainSawVar.cutting = FALSE
 				qdel(src)
 			else
-				ChainSawVar.cutting = 0
+				ChainSawVar.cutting = FALSE
 	else
 		..()
 	update_state()
@@ -349,11 +400,16 @@
 	icon_state = "door_as_[glass == 1 ? "g" : ""][istext(glass) ? glass : base_icon_state][state]"
 	name = ""
 	switch (state)
-		if(0)
-			if (anchored)
-				name = "Secured "
-		if(1)
+		if(STATE_UNWIRED)
+			name = anchored ? "Secured " : "Unsecured "
+		if(STATE_WIRED)
 			name = "Wired "
-		if(2)
-			name = "Near Finished "
+		if(STATE_ELECTRONICS_INSTALLED)
+			name = "Near-finished "
 	name += "[glass == 1 ? "Window " : ""][istext(glass) ? "[glass] Airlock" : base_name] Assembly"
+	if(created_name)
+		name += " ([created_name])"
+
+#undef STATE_UNWIRED
+#undef STATE_WIRED
+#undef STATE_ELECTRONICS_INSTALLED

--- a/html/changelogs/geeves-airlock_construction.yml
+++ b/html/changelogs/geeves-airlock_construction.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Revamped airlock construction messages, you will no longer keep hitting it like an orangutan if you do it out of sequence."

--- a/html/changelogs/geeves-airlock_construction.yml
+++ b/html/changelogs/geeves-airlock_construction.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes:
   - rscadd: "Revamped airlock construction messages, you will no longer keep hitting it like an orangutan if you do it out of sequence."
   - rscadd: "An airlock assembly's given finished name will now appear in brackets next to the assembly's name."
+  - tweak: "Airlock construction now uses three lengths of coil, instead of one."

--- a/html/changelogs/geeves-airlock_construction.yml
+++ b/html/changelogs/geeves-airlock_construction.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - rscadd: "Revamped airlock construction messages, you will no longer keep hitting it like an orangutan if you do it out of sequence."
+  - rscadd: "An airlock assembly's given finished name will now appear in brackets next to the assembly's name."


### PR DESCRIPTION
* Revamped airlock construction messages, you will no longer keep hitting it like an orangutan if you do it out of sequence.
* An airlock assembly's given finished name will now appear in brackets next to the assembly's name.
* Airlock construction now uses three lengths of coil, instead of one.