### PR TITLE
Borg hyposprays can now inject people in spacesuits

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2881,6 +2881,7 @@
 #include "code\unit_tests\overmap_tests.dm"
 #include "code\unit_tests\recipe_tests.dm"
 #include "code\unit_tests\spawner_tests.dm"
+#include "code\unit_tests\species_tests.dm"
 #include "code\unit_tests\sql_tests.dm"
 #include "code\unit_tests\ss_test.dm"
 #include "code\unit_tests\unit_test.dm"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1535,8 +1535,12 @@
 		W.message = message
 		W.add_fingerprint(src)
 
+#define INJECTION_FAIL     0
+#define BASE_INJECTION_MOD 1 // x1 multiplier with no effects
+#define SUIT_INJECTION_MOD 2 // x2 multiplier if target is wearing spacesuit
+
 /mob/living/carbon/human/can_inject(var/mob/user, var/error_msg, var/target_zone)
-	. = 1
+	. = BASE_INJECTION_MOD
 
 	if(!target_zone)
 		if(!user)
@@ -1544,26 +1548,39 @@
 		else
 			target_zone = user.zone_sel.selecting
 
+	. *= species.get_injection_modifier()
+
+	if(isvaurca(src))
+		user.visible_message(SPAN_WARNING("[user] begins hunting for an injection port on [src]'s carapace!"))
+
 	var/obj/item/organ/external/affecting = get_organ(target_zone)
 	var/fail_msg
 	if(!affecting)
-		. = 0
+		. = INJECTION_FAIL
 		fail_msg = "They are missing that limb."
 	else if (affecting.status & ORGAN_ROBOT)
-		. = 0
+		. = INJECTION_FAIL
 		fail_msg = "That limb is robotic."
 	else
 		switch(target_zone)
 			if(BP_HEAD)
 				if(head && head.item_flags & THICKMATERIAL)
-					. = 0
+					. = INJECTION_FAIL
 			else
 				if(wear_suit && wear_suit.item_flags & THICKMATERIAL)
-					. = 0
+					if(istype(wear_suit, /obj/item/clothing/suit/space))
+						user.visible_message(SPAN_WARNING("[user] begins hunting for an injection port on [src]'s suit!"))
+						. *= SUIT_INJECTION_MOD
+					else
+						. = INJECTION_FAIL
 	if(!. && error_msg && user)
 		if(!fail_msg)
 			fail_msg = "There is no exposed flesh or thin material [target_zone == BP_HEAD ? "on their head" : "on their body"] to inject into."
 		to_chat(user, SPAN_ALERT("[fail_msg]"))
+
+#undef INJECTION_FAIL
+#undef BASE_INJECTION_MOD
+#undef SUIT_INJECTION_MOD
 
 /mob/living/carbon/human/print_flavor_text(var/shrink = 1)
 	var/list/equipment = list(src.head,src.wear_mask,src.glasses,src.w_uniform,src.wear_suit,src.gloves,src.shoes)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -79,6 +79,7 @@
 	var/metabolism_mod = 1					 // Reagent metabolism modifier
 	var/bleed_mod = 1						 // How fast this species bleeds.
 	var/blood_volume = DEFAULT_BLOOD_AMOUNT // Blood volume.
+	var/injection_mod = 1                    // Multiplicative time modifier on syringe injections
 
 	var/vision_flags = DEFAULT_SIGHT         // Same flags as glasses.
 	var/inherent_eye_protection              // If set, this species has this level of inherent eye protection.
@@ -633,3 +634,6 @@
 			// This assumes that if a pain-level has been defined it also has a list of emotes to go with it
 			var/decl/emote/E = decls_repository.get_decl(pick(pain_emotes))
 			return E.key
+
+/datum/species/proc/get_injection_modifier()
+	return injection_mod

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -33,6 +33,7 @@
 	oxy_mod = 0.6
 	radiation_mod = 0.2 //almost total radiation protection
 	bleed_mod = 2.2
+	injection_mod = 2
 
 	grab_mod = 1.1
 	resist_mod = 1.75

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -380,7 +380,7 @@ default behaviour is:
 			return 1
 	return 0
 
-
+// Returns injection time modifier, if 0 then injection fails
 /mob/living/proc/can_inject()
 	return 1
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -203,7 +203,7 @@ var/global/list/robot_modules = list(
 /obj/item/robot_module/medical/general/Initialize()
 	. = ..()
 	src.modules += new /obj/item/device/healthanalyzer(src)
-	src.modules += new /obj/item/reagent_containers/borghypo/medical(src)
+	src.modules += new /obj/item/reagent_containers/hypospray/borghypo/medical(src)
 	src.modules += new /obj/item/surgery/scalpel(src)
 	src.modules += new /obj/item/surgery/hemostat(src)
 	src.modules += new /obj/item/surgery/retractor(src)
@@ -288,7 +288,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/mass_spectrometer(src)
 	src.modules += new /obj/item/device/breath_analyzer(src)
 	src.modules += new /obj/item/roller_holder(src)
-	src.modules += new /obj/item/reagent_containers/borghypo/rescue(src)
+	src.modules += new /obj/item/reagent_containers/hypospray/borghypo/rescue(src)
 	src.modules += new /obj/item/reagent_containers/dropper/industrial(src)
 	src.modules += new /obj/item/reagent_containers/syringe(src)
 	src.modules += new /obj/item/gripper/chemistry(src)
@@ -635,7 +635,7 @@ var/global/list/robot_modules = list(
 	src.modules += L
 
 	src.modules += new /obj/item/tray/robotray(src)
-	src.modules += new /obj/item/reagent_containers/borghypo/service(src)
+	src.modules += new /obj/item/reagent_containers/hypospray/borghypo/service(src)
 	src.emag = new /obj/item/reagent_containers/food/drinks/bottle/small/beer(src)
 
 	var/datum/reagents/RG = new /datum/reagents(50)
@@ -838,7 +838,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/crowbar/robotic(src) // Base crowbar that all 'borgs should have access to.
 	src.modules += new /obj/item/roller_holder(src)
 	src.modules += new /obj/item/device/healthanalyzer(src)
-	src.modules += new /obj/item/reagent_containers/borghypo/medical(src)
+	src.modules += new /obj/item/reagent_containers/hypospray/borghypo/medical(src)
 	src.modules += new /obj/item/plastique/cyborg(src)
 	src.modules += new /obj/item/grenade/smokebomb/cyborg(src)
 	supported_upgrades = list(/obj/item/robot_parts/robot_component/jetpack)
@@ -1062,7 +1062,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/inflatable_dispenser(src)
 	// Medical
 	src.modules += new /obj/item/device/healthanalyzer(src)
-	src.modules += new /obj/item/reagent_containers/borghypo/medical(src)
+	src.modules += new /obj/item/reagent_containers/hypospray/borghypo/medical(src)
 	src.modules += new /obj/item/surgery/scalpel(src)
 	src.modules += new /obj/item/surgery/hemostat(src)
 	src.modules += new /obj/item/surgery/retractor(src)
@@ -1075,7 +1075,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/gripper/chemistry(src)
 	src.modules += new /obj/item/reagent_containers/dropper/industrial(src)
 	src.modules += new /obj/item/reagent_containers/syringe(src)
-	src.modules += new /obj/item/reagent_containers/borghypo/rescue(src)
+	src.modules += new /obj/item/reagent_containers/hypospray/borghypo/rescue(src)
 	src.modules += new /obj/item/roller_holder(src)
 	// Security
 	src.modules += new /obj/item/handcuffs/cyborg(src)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -189,7 +189,7 @@
 /mob/living/silicon/can_inject(mob/user, error_msg)
 	if(error_msg)
 		to_chat(user, SPAN_ALERT("The armored plating is too tough."))
-	return FALSE
+	return 0
 
 //Silicon mob language procs
 

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -1,4 +1,4 @@
-/obj/item/reagent_containers/borghypo
+/obj/item/reagent_containers/hypospray/borghypo
 	name = "cyborg hypospray"
 	desc = "An advanced chemical synthesizer and injection system, designed for heavy-duty medical equipment."
 	icon = 'icons/obj/syringe.dmi'
@@ -19,13 +19,13 @@
 
 	center_of_mass = null
 
-/obj/item/reagent_containers/borghypo/medical
+/obj/item/reagent_containers/hypospray/borghypo/medical
 	reagent_ids = list(/datum/reagent/bicaridine, /datum/reagent/kelotane, /datum/reagent/dylovene, /datum/reagent/dexalin, /datum/reagent/inaprovaline, /datum/reagent/perconol, /datum/reagent/mortaphenyl, /datum/reagent/thetamycin)
 
-/obj/item/reagent_containers/borghypo/rescue
+/obj/item/reagent_containers/hypospray/borghypo/rescue
 	reagent_ids = list(/datum/reagent/tricordrazine, /datum/reagent/inaprovaline, /datum/reagent/dylovene, /datum/reagent/perconol, /datum/reagent/mortaphenyl, /datum/reagent/dexalin, /datum/reagent/adrenaline)
 
-/obj/item/reagent_containers/borghypo/Initialize()
+/obj/item/reagent_containers/hypospray/borghypo/Initialize()
 	. = ..()
 
 	for(var/T in reagent_ids)
@@ -35,11 +35,14 @@
 
 	START_PROCESSING(SSprocessing, src)
 
-/obj/item/reagent_containers/borghypo/Destroy()
+/obj/item/reagent_containers/hypospray/borghypo/update_icon()
+	return
+
+/obj/item/reagent_containers/hypospray/borghypo/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 
-/obj/item/reagent_containers/borghypo/process() //Every [recharge_time] seconds, recharge some reagents for the cyborg+
+/obj/item/reagent_containers/hypospray/borghypo/process() //Every [recharge_time] seconds, recharge some reagents for the cyborg+
 	if(++charge_tick < recharge_time)
 		return 0
 	charge_tick = 0
@@ -53,7 +56,7 @@
 					reagent_volumes[T] = min(reagent_volumes[T] + 5, volume)
 	return 1
 
-/obj/item/reagent_containers/borghypo/afterattack(var/mob/living/M, var/mob/user, proximity)
+/obj/item/reagent_containers/hypospray/borghypo/afterattack(var/mob/living/M, var/mob/user, proximity)
 
 	if(!proximity)
 		return
@@ -87,7 +90,7 @@
 			to_chat(user,"<span class='notice'>[t] units injected. [reagent_volumes[reagent_ids[mode]]] units remaining.</span>")
 	return
 
-/obj/item/reagent_containers/borghypo/attack_self(mob/user as mob) //Change the mode
+/obj/item/reagent_containers/hypospray/borghypo/attack_self(mob/user as mob) //Change the mode
 	var/t = ""
 	for(var/i = 1 to reagent_ids.len)
 		if(t)
@@ -101,7 +104,7 @@
 
 	return
 
-/obj/item/reagent_containers/borghypo/Topic(var/href, var/list/href_list)
+/obj/item/reagent_containers/hypospray/borghypo/Topic(var/href, var/list/href_list)
 	if(href_list["reagent"])
 		var/t = reagent_ids.Find(text2path(href_list["reagent"]))
 		if(t)
@@ -110,7 +113,7 @@
 			var/datum/reagent/R = SSchemistry.chemical_reagents[reagent_ids[mode]]
 			to_chat(usr, "<span class='notice'>Synthesizer is now producing '[R.name]'.</span>")
 
-/obj/item/reagent_containers/borghypo/examine(mob/user)
+/obj/item/reagent_containers/hypospray/borghypo/examine(mob/user)
 	if(!..(user, 2))
 		return
 
@@ -118,7 +121,7 @@
 
 	to_chat(user, "<span class='notice'>It is currently producing [R.name] and has [reagent_volumes[reagent_ids[mode]]] out of [volume] units left.</span>")
 
-/obj/item/reagent_containers/borghypo/service
+/obj/item/reagent_containers/hypospray/borghypo/service
 	name = "cyborg drink synthesizer"
 	desc = "A portable drink dispenser."
 	icon = 'icons/obj/drinks.dmi'
@@ -129,10 +132,10 @@
 	possible_transfer_amounts = list(5, 10, 20, 30)
 	reagent_ids = list(/datum/reagent/alcohol/ethanol/beer, /datum/reagent/alcohol/ethanol/coffee/kahlua, /datum/reagent/alcohol/ethanol/whiskey, /datum/reagent/alcohol/ethanol/wine, /datum/reagent/alcohol/ethanol/vodka, /datum/reagent/alcohol/ethanol/gin, /datum/reagent/alcohol/ethanol/rum, /datum/reagent/alcohol/ethanol/tequila, /datum/reagent/alcohol/ethanol/vermouth, /datum/reagent/alcohol/ethanol/cognac, /datum/reagent/alcohol/ethanol/ale, /datum/reagent/alcohol/ethanol/mead, /datum/reagent/water, /datum/reagent/sugar, /datum/reagent/drink/ice, /datum/reagent/drink/tea, /datum/reagent/drink/icetea, /datum/reagent/drink/space_cola, /datum/reagent/drink/spacemountainwind, /datum/reagent/drink/dr_gibb, /datum/reagent/drink/spaceup, /datum/reagent/drink/tonic, /datum/reagent/drink/sodawater, /datum/reagent/drink/lemon_lime, /datum/reagent/drink/orangejuice, /datum/reagent/drink/limejuice, /datum/reagent/drink/watermelonjuice, /datum/reagent/drink/coffee, /datum/reagent/drink/coffee/espresso)
 
-/obj/item/reagent_containers/borghypo/service/attack(var/mob/M, var/mob/user)
+/obj/item/reagent_containers/hypospray/borghypo/service/attack(var/mob/M, var/mob/user)
 	return
 
-/obj/item/reagent_containers/borghypo/service/afterattack(var/obj/target, var/mob/user, var/proximity)
+/obj/item/reagent_containers/hypospray/borghypo/service/afterattack(var/obj/target, var/mob/user, var/proximity)
 	if(!proximity)
 		return
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -46,13 +46,16 @@
 
 /obj/item/reagent_containers/hypospray/attack(var/mob/M, var/mob/user, target_zone)
 	. = ..()
-	var/mob/living/carbon/human/H = M
-	if(istype(H))
-		user.visible_message(SPAN_WARNING("\The [user] is trying to inject \the [M] with \the [src]!"), SPAN_NOTICE("You are trying to inject \the [M] with \the [src]."))
+	if(isliving(M))
+		var/mob/living/L = M
 		var/inj_time = time
-		if(armorcheck && H.run_armor_check(target_zone,"melee",0,"Your armor slows down the injection!","Your armor slows down the injection!"))
+		inj_time *= L.can_inject(user, TRUE)
+		if(!inj_time)
+			return
+		user.visible_message(SPAN_WARNING("\The [user] is trying to inject \the [L] with \the [src]!"), SPAN_NOTICE("You are trying to inject \the [L] with \the [src]."))
+		if(armorcheck && L.run_armor_check(target_zone,"melee",0,"Your armor slows down the injection!","Your armor slows down the injection!"))
 			inj_time += 6 SECONDS
-		if(!do_mob(user, M, inj_time))
+		if(!do_mob(user, L, inj_time))
 			return 1
 
 /obj/item/reagent_containers/hypospray/update_icon()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -232,36 +232,17 @@
 					return
 
 			if(ismob(target) && target != user)
-
-				var/injtime = time //Injecting through a voidsuit takes longer due to needing to find a port.
-
-				if(istype(H))
-					if(H.wear_suit)
-						if(istype(H.wear_suit, /obj/item/clothing/suit/space))
-							injtime = injtime * 2
-						else if(!H.can_inject(user, 1))
-							return
-					if(isvaurca(H))
-						injtime = injtime * 2
-
-				else if(isliving(target))
-
-					var/mob/living/M = target
-					if(!M.can_inject(user, 1))
+				if(isliving(target))
+					var/mob/living/L = target
+					var/injtime = L.can_inject(user, TRUE, user.zone_sel.selecting)
+					if(!injtime)
 						return
-
-				if(injtime == time)
-					user.visible_message(SPAN_WARNING("[user] is trying to inject [target] with [visible_name]!"))
-				else
-					if(isvaurca(H))
-						user.visible_message(SPAN_WARNING("[user] begins hunting for an injection port on [target]'s carapace!"))
-					else
-						user.visible_message(SPAN_WARNING("[user] begins hunting for an injection port on [target]'s suit!"))
+					time *= injtime
 
 				user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 				user.do_attack_animation(target)
 
-				if(!do_mob(user, target, injtime))
+				if(!do_mob(user, target, time))
 					return
 
 				user.visible_message(SPAN_WARNING("[user] injects [target] with the syringe!"))

--- a/code/unit_tests/species_tests.dm
+++ b/code/unit_tests/species_tests.dm
@@ -1,0 +1,26 @@
+/datum/unit_test/species
+	name = "SPECIES template"
+
+/datum/unit_test/species/injection_mod
+	name = "SPECIES: All species shall have a valid injection_mod"
+
+// Check that injection_mod is larger than 0. 0 injection_mod is indistinguishable from a failed injection, and a negative injection_mod is meaningless.
+/datum/unit_test/species/injection_mod/start_test()
+	var/list/failed_species = list()
+
+	for(var/S in typesof(/datum/species))
+		var/datum/species/species = S
+
+		if(initial(species.injection_mod) > 0)
+			continue
+		else
+			failed_species |= species.type
+
+	if(failed_species.len)
+		for(var/fail in failed_species)
+		fail("SPECIES: Invalid injection_mod var set on species: [english_list(failed_species)]")
+	else
+		pass("SPECIES: All species had valid injection_mod vars set.")
+
+
+	return 1

--- a/html/changelogs/borg_hypospray.yml
+++ b/html/changelogs/borg_hypospray.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Borg Hyposprays now act like normal hyposprays, can inject people in spacesuits and are non-instantaneous."


### PR DESCRIPTION
Fixes #10462

Borg Hyposprays now inherit the behavior of hyposprays, they do not need to be a separate type. This means they are not instant and can inject people in spacesuits.

I have (begrudgingly) decided that syringes should stay separate from hyposprays, and so left them alone.