### PR TITLE
Remote Guntracker Usage Tweak

### DIFF
--- a/code/modules/modular_computers/file_system/programs/security/guntracker.dm
+++ b/code/modules/modular_computers/file_system/programs/security/guntracker.dm
@@ -65,7 +65,7 @@
 		return TRUE
 
 	if(issilicon(usr) && !computer.Adjacent(usr))
-		to_chat(usr, SPAN_WARNING("Remote transmissions to this program is prohibited!"))
+		to_chat(usr, SPAN_WARNING("Remote transmissions to this program are prohibited!"))
 		return TRUE
 
 	//Try and get the pin if a pin is passed

--- a/code/modules/modular_computers/file_system/programs/security/guntracker.dm
+++ b/code/modules/modular_computers/file_system/programs/security/guntracker.dm
@@ -64,6 +64,10 @@
 	if(..())
 		return TRUE
 
+	if(issilicon(usr) && !computer.Adjacent(usr))
+		to_chat(usr, SPAN_WARNING("Remote transmissions to this program is prohibited!"))
+		return TRUE
+
 	//Try and get the pin if a pin is passed
 	var/obj/item/device/firing_pin/wireless/P = null
 	if(href_list["pin"])

--- a/code/modules/modular_computers/file_system/programs/security/guntracker.dm
+++ b/code/modules/modular_computers/file_system/programs/security/guntracker.dm
@@ -64,7 +64,7 @@
 	if(..())
 		return TRUE
 
-	if(issilicon(usr) && !computer.Adjacent(usr))
+	if(issilicon(usr) && !computer.Adjacent(usr) && !player_is_antag(usr.mind))
 		to_chat(usr, SPAN_WARNING("Remote transmissions to this program are prohibited!"))
 		return TRUE
 

--- a/html/changelogs/geeves-sorry_little_one.yml
+++ b/html/changelogs/geeves-sorry_little_one.yml
@@ -3,4 +3,4 @@ author: Geeves
 delete-after: True
 
 changes:
-  - tweak: "AIs and stationbounds can no longer remotely use the buttons on the guntracker program."
+  - tweak: "Non-antag AIs and stationbounds can no longer remotely use the buttons on the guntracker program."

--- a/html/changelogs/geeves-sorry_little_one.yml
+++ b/html/changelogs/geeves-sorry_little_one.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "AIs and stationbounds can no longer remotely use the buttons on the guntracker program."


### PR DESCRIPTION
* Non-antag AIs and stationbounds can no longer remotely use the buttons on the guntracker program.