### PR TITLE
Changes the font size on the emitter's shot display

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -46,9 +46,9 @@
 		if(EMITTER_WELDED)
 			to_chat(user, SPAN_WARNING("\The [src] is bolted and welded to the floor, and ready to fire."))
 	if(Adjacent(user))
-		to_chat(user, FONT_SMALL(SPAN_NOTICE("The shot counter display reads: [shot_counter]")))
+		to_chat(user, SPAN_NOTICE("The shot counter display reads: [shot_counter]"))
 		if(signaler)
-			to_chat(user, FONT_SMALL(SPAN_WARNING("\The [src] has a hidden signaler attached to it.")))
+			to_chat(user, SPAN_WARNING("\The [src] has a hidden signaler attached to it."))
 
 /obj/machinery/power/emitter/Destroy()
 	if(special_emitter)

--- a/html/changelogs/hockaa-emitterdisplay.yml
+++ b/html/changelogs/hockaa-emitterdisplay.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes:
+  - bugfix: "Emitter shot counter display text and signaller display text is now adjusted to the user's font size."


### PR DESCRIPTION
Removes FONT_SMALL on the emitter display text so that it adjusts correctly to the user's font setting, making it much easier to read. (Also does the same for the text saying that there's a signaller attached.)