### PR TITLE
Aligns the crew manifest columns and makes it spawn slightly larger

### DIFF
--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -197,7 +197,7 @@
 /datum/controller/subsystem/records/proc/open_manifest_vueui(mob/user)
 	var/datum/vueui/ui = SSvueui.get_open_ui(user, src)
 	if (!ui)
-		ui = new(user, src, "manifest", 450, 600, "Crew Manifest")
+		ui = new(user, src, "manifest", 580, 700, "Crew Manifest")
 		ui.header = "minimal"
 	ui.open()
 

--- a/code/modules/modular_computers/file_system/programs/generic/manifest.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/manifest.dm
@@ -13,11 +13,11 @@
 /datum/computer_file/program/manifest/ui_interact(mob/user)
 	var/datum/vueui/ui = SSvueui.get_open_ui(user, src)
 	if (!ui)
-		ui = new /datum/vueui/modularcomputer(user, src, "manifest", 450, 600, "Crew Manifest")
+		ui = new /datum/vueui/modularcomputer(user, src, "manifest", 580, 700, "Crew Manifest")
 	ui.open()
 
 /datum/computer_file/program/manifest/vueui_transfer(oldobj)
-	SSvueui.transfer_uis(oldobj, src, "manifest", 450, 600, "Crew Manifest")
+	SSvueui.transfer_uis(oldobj, src, "manifest", 580, 700, "Crew Manifest")
 	return TRUE
 
 // Gaters data for ui

--- a/html/changelogs/amunak-manifest-embiggening.yml
+++ b/html/changelogs/amunak-manifest-embiggening.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "Aligned Crew Manifest columns. The window had to be embiggened a bit to make this look decent."

--- a/vueui/src/components/view/manifest.vue
+++ b/vueui/src/components/view/manifest.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
     <div v-if="manifestLen(fixedmanifest) > 0">
-      <table v-for="(el, dept) in fixedmanifest" :key="dept" class="mt-2" :class="'border-dept-' + dept.toLowerCase()">
+      <table v-for="(el, dept) in fixedmanifest" :key="dept" :class="'border-dept-' + dept.toLowerCase()">
         <tr :class="'bg-dept-' + dept.toLowerCase()">
           <th colspan="3" class="fw-bold">{{ dept }}</th>
         </tr>
         <tr v-for="entry in el" :key="entry.name" :class="{'fw-bold': entry.head}">
-          <td class="pl-2">{{ entry.name }}</td>
-          <td class="px-1">{{ entry.rank }}</td>
-          <td class="pr-2 text-right">{{ entry.active }}</td>
+          <td>{{ entry.name }}</td>
+          <td>{{ entry.rank }}</td>
+          <td>{{ entry.active }}</td>
         </tr>
       </table>
     </div>
@@ -47,5 +47,22 @@ table {
   color: white;
   background-color: rgba(0, 0, 0, 0.6);
   border: 2px solid;
+  margin-top: .5rem;
+
+  td {
+    padding-left: .5rem;
+    padding-right: .5rem;
+  }
+
+  // middle (rank) column
+  td:nth-child(2) {
+    width: 12.5rem;
+  }
+
+  // last (activity) column
+  td:last-child {
+    text-align: right;
+    width: 6.5rem;
+  }
 }
 </style>


### PR DESCRIPTION
Makes the tables in Crew Manifest aligned by setting fixed width for the rank and activity columns. They now fit the widest "regular" entries and then some. The name column fills the rest of the table. I thought about making it proportional or whatever but that just didn't work well.

I had to also make the window wider by default because otherwise there would be very little space left for names. On the plus side it can now fit some ridiculously long names, to the benefit of our Vaurca players:

![image](https://user-images.githubusercontent.com/781546/99009327-301cd100-2548-11eb-8541-c0c23f36fda8.png)

How it all might look:
![firefox_2020-11-13_00-03-45](https://user-images.githubusercontent.com/781546/99010006-69097580-2549-11eb-87c5-ebee7a4636ee.png)


(refer to the first screenshot for the actual new width)