### PR TITLE
Holopad Animal Language Fix

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -203,6 +203,10 @@ Possible to do for anyone motivated enough:
 For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/hologram/holopad/hear_talk(mob/living/M, text, verb, datum/language/speaking)
 	var/name_used = M.GetVoice()
+	if(isanimal(M))
+		var/mob/living/simple_animal/SA = M
+		if(!SA.universal_speak && !length(SA.languages))
+			text = pick(SA.speak)
 	for(var/mob/living/silicon/ai/master in active_holograms)
 		if(!master.say_understands(M, speaking))//The AI will be able to understand most mobs talking through the holopad.
 			if(speaking)

--- a/html/changelogs/geeves-holopad_animal_language.yml
+++ b/html/changelogs/geeves-holopad_animal_language.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Simple animals such as rats that don't have universal speak or a language can no longer be translated by holopads."


### PR DESCRIPTION
* Simple animals such as rats that don't have universal speak or a language can no longer be translated by holopads.