### PR TITLE
Disable Click Macros

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -394,3 +394,27 @@ var/global/list/click_catchers
 		if(T)
 			T.Click(location, control, params)
 	. = 1
+
+// Suppress the mouse macros
+/client/var/next_mouse_macro_warning
+/mob/proc/LogMouseMacro(verbused, params)
+	if(!client)
+		return
+	if(!client.next_mouse_macro_warning) // Log once
+		log_admin("[key_name(usr)] attempted to use a mouse macro: [verbused] [params]")
+		message_admins("[key_name_admin(usr)] attempted to use a mouse macro: [verbused] [html_encode(params)]")
+	if(client.next_mouse_macro_warning < world.time) // Warn occasionally
+		usr.playsound_to(get_turf(usr), sound('sound/misc/sadtrombone.ogg'), FALSE)
+		client.next_mouse_macro_warning = world.time + 600
+/mob/verb/ClickSubstitute(params as command_text)
+	set hidden = 1
+	set name = ".click"
+	LogMouseMacro(".click", params)
+/mob/verb/DblClickSubstitute(params as command_text)
+	set hidden = 1
+	set name = ".dblclick"
+	LogMouseMacro(".dblclick", params)
+/mob/verb/MouseSubstitute(params as command_text)
+	set hidden = 1
+	set name = ".mouse"
+	LogMouseMacro(".mouse", params)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -396,16 +396,12 @@ var/global/list/click_catchers
 	. = 1
 
 // Suppress the mouse macros
-/client/var/next_mouse_macro_warning
+/client/var/has_mouse_macro_warning
 /mob/proc/LogMouseMacro(verbused, params)
 	if(!client)
 		return
-	if(!client.next_mouse_macro_warning) // Log once
+	if(!client.has_mouse_macro_warning) // Log once
 		log_admin("[key_name(usr)] attempted to use a mouse macro: [verbused] [params]")
-		message_admins("[key_name_admin(usr)] attempted to use a mouse macro: [verbused] [html_encode(params)]")
-	if(client.next_mouse_macro_warning < world.time) // Warn occasionally
-		usr.playsound_to(get_turf(usr), sound('sound/misc/sadtrombone.ogg'), FALSE)
-		client.next_mouse_macro_warning = world.time + 600
 /mob/verb/ClickSubstitute(params as command_text)
 	set hidden = 1
 	set name = ".click"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -484,40 +484,6 @@ var/list/global/slot_flags_enumeration = list(
 /obj/item/proc/on_give(var/mob/giver, var/mob/receiver)
 	return
 
-/mob/living/carbon/verb/verb_pickup(obj/item/I in range(1))
-	set category = "Object"
-	set name = "Pick up"
-
-	if(!(usr)) //BS12 EDIT
-		return
-	if (!(I in view(1, src)))
-		return
-	if (istype(I, /obj/item/storage/internal))
-		return
-	if(!usr.canmove || usr.stat || usr.restrained() || !Adjacent(usr))
-		return
-	if((!istype(usr, /mob/living/carbon)) || (istype(usr, /mob/living/carbon/brain)))//Is humanoid, and is not a brain
-		to_chat(usr, "<span class='warning'>You can't pick things up!</span>")
-		return
-	if( usr.stat || usr.restrained() )//Is not asleep/dead and is not restrained
-		to_chat(usr, "<span class='warning'>You can't pick things up!</span>")
-		return
-	if(I.anchored) //Object isn't anchored
-		to_chat(usr, "<span class='warning'>You can't pick that up!</span>")
-		return
-	if(!usr.hand && usr.r_hand) //Right hand is not full
-		to_chat(usr, "<span class='warning'>Your right hand is full.</span>")
-		return
-	if(usr.hand && usr.l_hand) //Left hand is not full
-		to_chat(usr, "<span class='warning'>Your left hand is full.</span>")
-		return
-	if(!istype(I.loc, /turf)) //Object is on a turf
-		to_chat(usr, "<span class='warning'>You can't pick that up!</span>")
-		return
-	//All checks are done, time to pick it up!
-	usr.UnarmedAttack(I)
-	return
-
 
 //This proc is executed when someone clicks the on-screen UI button. To make the UI button show, set the 'icon_action_button' to the icon_state of the image of the button in screen1_action.dmi
 //The default action is attack_self().

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2034,3 +2034,21 @@
 	if(!(accent in species.allowed_accents))
 		accent = species.default_accent
 	return TRUE
+
+/mob/living/carbon/human/verb/click_belt()
+	set hidden = 1
+	set name = "click_belt"
+	if(belt)
+		belt.Click()
+
+/mob/living/carbon/human/verb/click_uniform()
+	set hidden = 1
+	set name = "click_uniform"
+	if(w_uniform)
+		w_uniform.Click()
+
+/mob/living/carbon/human/verb/click_back()
+	set hidden = 1
+	set name = "click_back"
+	if(back)
+		back.Click()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -975,3 +975,9 @@ default behaviour is:
 			if(src)
 				clear_fullscreen("flash", 25)
 		return 1
+
+/mob/living/verb/toggle_run_intent()
+	set hidden = 1
+	set name = "mov_intent"
+	if(hud_used?.move_intent)
+		hud_used.move_intent.Click()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1449,3 +1449,9 @@
 		return
 	var/obj/screen/zone_sel/selector = mob.zone_sel
 	selector.set_selected_zone(next_in_list(mob.zone_sel.selecting,zones))
+
+/mob/living/verb/toggle_run_intent()
+	set hidden = 1
+	set name = "mov_intent"
+	if(hud_used?.move_intent)
+		hud_used.move_intent.Click()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1449,9 +1449,3 @@
 		return
 	var/obj/screen/zone_sel/selector = mob.zone_sel
 	selector.set_selected_zone(next_in_list(mob.zone_sel.selecting,zones))
-
-/mob/living/verb/toggle_run_intent()
-	set hidden = 1
-	set name = "mov_intent"
-	if(hud_used?.move_intent)
-		hud_used.move_intent.Click()

--- a/html/changelogs/geeves-disable_click_macros.yml
+++ b/html/changelogs/geeves-disable_click_macros.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscdel: ".click, .dblclick, and .mouse macros have been disabled."
+  - rscdel: "Pick-up macros have been disabled."
+  - rscadd: "Added a replacement verb for clicking your mov_intent. Simply make a macro with 'mov_intent' as the command."

--- a/html/changelogs/geeves-disable_click_macros.yml
+++ b/html/changelogs/geeves-disable_click_macros.yml
@@ -6,3 +6,4 @@ changes:
   - rscdel: ".click, .dblclick, and .mouse macros have been disabled."
   - rscdel: "Pick-up macros have been disabled."
   - rscadd: "Added a replacement verb for clicking your mov_intent. Simply make a macro with 'mov_intent' as the command."
+  - rscadd: "Added replacement verbs for clicking on your uniform, belt, and backpack. These macros are 'click_uniform', 'click_belt' and 'click_back' respectively."


### PR DESCRIPTION
* .click, .dblclick, and .mouse macros have been disabled.
* Pick-up macros have been disabled.
* Added a replacement verb for clicking your mov_intent. Simply make a macro with 'mov_intent' as the command.
* Added replacement verbs for clicking on your uniform, belt, and backpack. These macros are 'click_uniform', 'click_belt' and 'click_back' respectively.