### PR TITLE
Fixes VueUI not updating (or closing or working properly) when re-opening existing UI

### DIFF
--- a/code/modules/vueui/ui.dm
+++ b/code/modules/vueui/ui.dm
@@ -62,7 +62,6 @@ main ui datum.
 	if (ntitle)
 		title = ntitle
 
-	SSvueui.ui_opened(src)
 	windowid = "vueui\ref[src]"
 	name = "Vueui [object]/[user]"
 
@@ -74,14 +73,18 @@ main ui datum.
 /datum/vueui/proc/open(var/datum/asset/spritesheet/load_asset)
 	if(QDELETED(object))
 		return
+
 	if(!user.client)
 		return
 
 	if(!data)
 		data = object.vueui_data_change(null, user, src)
+
 	update_status()
 	if(!status || status == STATUS_CLOSE)
 		return
+
+	SSvueui.ui_opened(src) // this starts processing and adds the UI to the mob and whatnot
 
 	var/params = "window=[windowid];file=[windowid];"
 	if(width && height)
@@ -101,7 +104,7 @@ main ui datum.
   */
 /datum/vueui/proc/close()
 	object.vueui_on_close(src)
-	SSvueui.ui_closed(src)
+	SSvueui.ui_closed(src) // this stops processing and cleans up references to this UI
 	user << browse(null, "window=[windowid]")
 	status = null
 

--- a/html/changelogs/amunak-vuerefresh-fix.yml
+++ b/html/changelogs/amunak-vuerefresh-fix.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "Fixed VueUI not refreshing (or closing or working properly) when re-opened after being closed."


### PR DESCRIPTION
I'm not sure how many UIs this actually fixes, but definitely at least the late-join UI. There were several issues:
* A major one where the UI after calling `close()` stopped processing and didn't resume it even after calling `open()` again.
* A medium one where when cleaning up after the UI in `close()` it would also delete references to *all other UIs for a given object* whether they exist or not.
* A minor one where the UI would start processing right after being created, even though that doesn't necessarily mean it would have been opened immediately, wasting updates.

I have also moved the "wasn't open check" in the close proc _after_ it's cleaned up in the mob so that we don't have dangling references to improperly closed UIs (which shouldn't happen but you never know).

This also means that we could theoretically use the same UI for multiple people and at multiple occasions without constantly re-creating it, which is what I thought was already the case, but probably not since someone would've noticed this issue otherwise. Right? ...RIGHT?