### PR TITLE
Lowers the max number of players for the burglar roundtype from 20 to 15

### DIFF
--- a/code/game/gamemodes/burglars/burglars.dm
+++ b/code/game/gamemodes/burglars/burglars.dm
@@ -3,7 +3,7 @@
 /datum/game_mode/burglars
 	name = "burglars"
 	config_tag = "burglars"
-	max_players = 20
+	max_players = 15
 	required_enemies = 2
 	round_description = "Something tiny is on the horizon! Is it the distance, or...?"
 	extended_round_description = "Two of the Orion Spur's best and brightest (or so they were told) have been tasked with burglarizing a station that will change the way capitalism grips this galaxy forever (or so they were told). It is up to the crew to repel them, and up to them to survive and possibly thrive."

--- a/html/changelogs/Ferner-201114-coding_burglarlimit.yml
+++ b/html/changelogs/Ferner-201114-coding_burglarlimit.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes:
+  - tweak: "Lowered the max number of players for the burglar gamemode from 20 to 15."


### PR DESCRIPTION
After watching numerous burglar rounds, even with their crafty tools, they do not tend to survive on higher pop rounds with a full security department for long.