### PR TITLE
Fixes excessive runtimes with beams

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -40,7 +40,7 @@
 		addtimer(CALLBACK(src,.proc/End), time)
 
 /datum/beam/proc/Start()
-	Draw()
+	recalculate()
 	recalculate_in(sleep_time)
 
 /datum/beam/proc/recalculate()


### PR DESCRIPTION
I think this issue is caused by beam targets ceasing to exist before the beam is drawn.

By making the first Draw happen through a call to recalculate, it will check everything exists. Instead of directly calling Draw.