### PR TITLE
Fixes runtime in SSRecords causing issues with Crew Manifest

### DIFF
--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -229,7 +229,7 @@
 		var/isactive = t.physical_status
 
 		var/list/departments
-		if(job.departments.len > 0 && all_in_list(job.departments, manifest))
+		if(istype(job) && job.departments.len > 0 && all_in_list(job.departments, manifest))
 			departments = job.departments
 		else // no department set or there's something weird
 			departments = list(DEPARTMENT_MISCELLANEOUS = JOBROLE_DEFAULT)

--- a/html/changelogs/amunak-manifest-runtime.yml
+++ b/html/changelogs/amunak-manifest-runtime.yml
@@ -1,0 +1,4 @@
+author: Amunak
+delete-after: True
+changes:
+  - bugfix: "Changing someone's rank will no longer cause a runtime that causes Crew Manifest to stop working / show nothing."


### PR DESCRIPTION
When the job title happens to change so that there's no job found for the person it'll no longer runtime and they'll correctly get the "miscellaneous" department assigned.