### PR TITLE
Fixes the level 4 aurora map file being unopenable

### DIFF
--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -33260,7 +33260,7 @@
 /area/crew_quarters/heads/hop)
 "bfz" = (
 /obj/machinery/door/airlock{
-	id_tag = command_unit_1;
+	id_tag = "command_unit_1";
 	name = "Unit 1"
 	},
 /turf/simulated/floor/tiled/freezer,


### PR DESCRIPTION
Missing quotation marks on an id_tag made the default editor unable to read it