### PR TITLE
Runtime is now always well lit

### DIFF
--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -31,6 +31,7 @@
 	var/light_type = /obj/item/light/tube		// the type of light item
 	var/obj/item/light/inserted_light = /obj/item/light/tube
 	var/fitting = "tube"
+	var/must_start_working = FALSE // Whether the bulb can break during Initialize or not
 	var/switchcount = 0			// count of number of times switched on/off
 								// this is used to calc the probability the light burns out
 
@@ -122,7 +123,7 @@
 	if (start_with_cell && !no_emergency)
 		cell = new /obj/item/cell/device/emergency_light(src)
 
-	if (mapload && loc && isNotAdminLevel(z))
+	if (!must_start_working && mapload && loc && isNotAdminLevel(z))
 		switch(fitting)
 			if("tube")
 				if(prob(2))

--- a/maps/runtime/runtime-1.dmm
+++ b/maps/runtime/runtime-1.dmm
@@ -249,6 +249,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -385,6 +387,8 @@
 /area/engineering/gravity_gen)
 "aU" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -464,7 +468,10 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1
+	},
 /obj/item/device/analyzer,
 /obj/item/wrench,
 /obj/structure/table/standard,
@@ -490,7 +497,10 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "bk" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 9
 	},
@@ -508,7 +518,10 @@
 /turf/simulated/floor/plating,
 /area/engineering)
 "bm" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1
+	},
 /obj/item/storage/box/lights/mixed,
 /obj/item/device/lightreplacer,
 /obj/structure/table/standard,
@@ -565,6 +578,8 @@
 /area/hallway/secondary/entry)
 "bw" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -718,6 +733,8 @@
 /area/hallway/secondary/entry)
 "bR" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 1
 	},
 /obj/structure/closet/emcloset,
@@ -901,12 +918,17 @@
 /area/hallway/secondary/entry)
 "ck" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "cl" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1
+	},
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/floor_decal/corner/blue/full,
 /obj/item/modular_computer/console/preset/ai,
@@ -919,7 +941,10 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "cn" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1
+	},
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 4
 	},
@@ -937,6 +962,8 @@
 "cp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -988,6 +1015,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
@@ -1024,6 +1053,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
@@ -1086,7 +1117,10 @@
 /obj/item/stack/rods{
 	amount = 50
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1
+	},
 /obj/effect/floor_decal/corner/blue,
 /obj/effect/floor_decal/corner/white{
 	dir = 8
@@ -1228,6 +1262,8 @@
 /area/storage/primary)
 "dd" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -1240,6 +1276,8 @@
 /area/construction)
 "df" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -1249,12 +1287,16 @@
 /area/construction)
 "dg" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "dh" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -1361,7 +1403,10 @@
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "dA" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1
+	},
 /obj/item/material/twohanded/fireaxe,
 /obj/item/extinguisher,
 /obj/structure/table/standard,
@@ -1375,7 +1420,10 @@
 "dC" = (
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/tubes,
-/obj/machinery/light,
+/obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1
+	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
@@ -1440,7 +1488,10 @@
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Airlock"
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	brightness_range = 16;
+	must_start_working = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering)
 "mn" = (
@@ -1459,6 +1510,8 @@
 /area/bridge)
 "ob" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /obj/structure/cable{
@@ -1548,6 +1601,8 @@
 /area/maintenance/maintcentral)
 "HK" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{

--- a/maps/runtime/runtime-2.dmm
+++ b/maps/runtime/runtime-2.dmm
@@ -30,6 +30,8 @@
 /area/tcommsat/computer)
 "cB" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -390,6 +392,8 @@
 /area/tcommsat/chamber)
 "sK" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 4
 	},
 /obj/structure/cable/cyan{
@@ -683,6 +687,8 @@
 /area/construction/Storage)
 "Dd" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 1
 	},
 /turf/simulated/floor/tiled{
@@ -708,6 +714,8 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 4
 	},
 /turf/simulated/floor/tiled{
@@ -720,6 +728,8 @@
 /area/tcommsat/computer)
 "DR" = (
 /obj/machinery/light/small{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 4
 	},
 /obj/machinery/camera/network/command{
@@ -768,6 +778,8 @@
 "Fq" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 1
 	},
 /turf/simulated/floor/bluegrid{
@@ -816,6 +828,8 @@
 /area/tcommsat/computer)
 "Jd" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -945,6 +959,8 @@
 "Ox" = (
 /obj/machinery/telecomms/bus/preset_four,
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 1
 	},
 /turf/simulated/floor/bluegrid{
@@ -970,6 +986,8 @@
 /area/tcommsat/chamber)
 "Pl" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -979,6 +997,8 @@
 /area/construction/Storage)
 "Pv" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /obj/machinery/status_display{
@@ -1026,7 +1046,10 @@
 /turf/simulated/floor/tiled,
 /area/construction/Storage)
 "RM" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1
+	},
 /turf/simulated/floor/tiled{
 	name = "cooled floor";
 	temperature = 278
@@ -1108,6 +1131,8 @@
 /area/tcommsat/chamber)
 "VK" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /turf/simulated/floor/tiled{
@@ -1165,6 +1190,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 4
 	},
 /obj/structure/closet/crate/secure/aimodules,

--- a/maps/runtime/runtime-3.dmm
+++ b/maps/runtime/runtime-3.dmm
@@ -46,6 +46,8 @@
 /area/construction/hallway)
 "i" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -67,6 +69,8 @@
 /area/construction/hallway)
 "l" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -185,6 +189,8 @@
 /area/construction/hallway)
 "J" = (
 /obj/machinery/light{
+	brightness_range = 16;
+	must_start_working = 1;
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{


### PR DESCRIPTION
Having the lights change each time I fire up Runtime to test if my code is working yet is really annoying.

This makes runtime perfectly lit and never have broken lights.