### PR TITLE
Makes Odin medical specialists/pharmacists spawn with medhuds

### DIFF
--- a/code/datums/outfits/event/outfit_nanotrasen.dm
+++ b/code/datums/outfits/event/outfit_nanotrasen.dm
@@ -244,6 +244,7 @@
 	mask = /obj/item/clothing/mask/surgical
 	l_hand = /obj/item/storage/firstaid/adv
 	l_ear = /obj/item/device/radio/headset/headset_med
+	glasses = /obj/item/clothing/glasses/hud/health
 
 	gloves = /obj/item/clothing/gloves/white
 	belt = /obj/item/storage/belt/medical
@@ -277,6 +278,7 @@
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/pharmacist
 	shoes = /obj/item/clothing/shoes/chemist
 	l_ear = /obj/item/device/radio/headset/headset_med
+	glasses = /obj/item/clothing/glasses/hud/health
 
 	backpack = /obj/item/storage/backpack/pharmacy
 	satchel = /obj/item/storage/backpack/satchel_pharm

--- a/html/changelogs/Ferner-201117-coding_odinmedhud.yml
+++ b/html/changelogs/Ferner-201117-coding_odinmedhud.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes:
+  - tweak: "Odin medical specialists and pharmacists now spawn with medhuds instead of sunglasses."


### PR DESCRIPTION
Previously it defaulted to sunglasses from the parent outfit