### PR TITLE
Adds a unit test to ensure that all game modes have a sensible required_enemies and required_players

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2880,6 +2880,7 @@
 #include "code\unit_tests\chemistry_tests.dm"
 #include "code\unit_tests\equipment_tests.dm"
 #include "code\unit_tests\foundation_tests.dm"
+#include "code\unit_tests\gamemode_tests.dm"
 #include "code\unit_tests\map_tests.dm"
 #include "code\unit_tests\mob_tests.dm"
 #include "code\unit_tests\object_tests.dm"

--- a/code/game/gamemodes/burglars/burglars.dm
+++ b/code/game/gamemodes/burglars/burglars.dm
@@ -5,6 +5,7 @@
 	config_tag = "burglars"
 	max_players = 15
 	required_enemies = 2
+	required_players = 4
 	round_description = "Something tiny is on the horizon! Is it the distance, or...?"
 	extended_round_description = "Two of the Orion Spur's best and brightest (or so they were told) have been tasked with burglarizing a station that will change the way capitalism grips this galaxy forever (or so they were told). It is up to the crew to repel them, and up to them to survive and possibly thrive."
 	end_on_antag_death = FALSE

--- a/code/game/gamemodes/mixed/acolytes.dm
+++ b/code/game/gamemodes/mixed/acolytes.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Borers and cultists spawn during this round."
 	config_tag = "acolytes"
 	required_players = 20
-	required_enemies = 5
+	required_enemies = 6
 	end_on_antag_death = 0
 	antag_tags = list(MODE_BORER, MODE_CULTIST)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/infiltration.dm
+++ b/code/game/gamemodes/mixed/infiltration.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "A malf AI and a Ninja spawn during this round."
 	config_tag = "infiltration"
 	required_players = 20
-	required_enemies = 2
+	required_enemies = 5
 	end_on_antag_death = 0
 	require_all_templates = 1
 	votable = 1

--- a/code/game/gamemodes/mixed/insurrection.dm
+++ b/code/game/gamemodes/mixed/insurrection.dm
@@ -4,6 +4,6 @@
 	extended_round_description = "Revolutionaries and borers spawn during this round."
 	config_tag = "insurrection"
 	required_players = 20
-	required_enemies = 5
+	required_enemies = 8
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST, MODE_BORER)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/siege.dm
+++ b/code/game/gamemodes/mixed/siege.dm
@@ -3,8 +3,8 @@
 	config_tag = "siege"
 	round_description = "Some crewmembers are attempting to start a revolution while a mercenary strike force is approaching the station!"
 	extended_round_description = "Getting stuck between a rock and a hard place, maybe the nice visitors can help with your internal security problem?"
-	required_players = 20
-	required_enemies = 7
+	required_players = 25
+	required_enemies = 10
 	end_on_antag_death = 0
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST, MODE_MERCENARY)
 	require_all_templates = 1

--- a/code/game/gamemodes/mixed/uprising.dm
+++ b/code/game/gamemodes/mixed/uprising.dm
@@ -3,7 +3,7 @@
 	config_tag = "uprising"
 	round_description = "Some crewmembers are attempting to start a revolution while subversive elements infest the crew!"
 	extended_round_description = "Traitors and revolutionaries spawn in this round."
-	required_players = 15
-	required_enemies = 3
+	required_players = 20
+	required_enemies = 7
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST, MODE_TRAITOR)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/veilparty.dm
+++ b/code/game/gamemodes/mixed/veilparty.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Vampires and a Cult spawn in this mode."
 	config_tag = "veilparty"
 	required_players = 15
-	required_enemies = 3
+	required_enemies = 5
 	end_on_antag_death = 0
 	require_all_templates = 1
 	votable = 1

--- a/code/game/gamemodes/mixed/visitors.dm
+++ b/code/game/gamemodes/mixed/visitors.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "A ninja and wizard spawn during this round."
 	config_tag = "visitors"
 	required_players = 15
-	required_enemies = 2
+	required_enemies = 3
 	end_on_antag_death = 0
 	antag_tags = list(MODE_WIZARD, MODE_NINJA)
 	require_all_templates = 1

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -11,7 +11,7 @@
 		friends and family as they try to use your emotions and trust to their advantage, leaving you with nothing \
 		but the painful reminder that space is cruel and unforgiving."
 	config_tag = "traitor"
-	required_players = 0
+	required_players = 1
 	required_enemies = 1
 	end_on_antag_death = 1
 	antag_tags = list(MODE_TRAITOR)

--- a/code/unit_tests/gamemode_tests.dm
+++ b/code/unit_tests/gamemode_tests.dm
@@ -1,0 +1,29 @@
+/datum/unit_test/gamemode
+	name = "GAMEMODE template"
+
+/datum/unit_test/gamemode/required_enemies_check
+    name = "GAMEMODE: All multi-modes shall have a required_enemies greater than or equal to their component modes."
+
+/datum/unit_test/gamemode/required_enemies_check/start_test()
+    var/list/failed = list()
+
+    for(var/mode in subtypesof(/datum/game_mode))
+        var/datum/game_mode/GM = new mode
+
+        var/min_antag_count = 0
+        for(var/antag_type in GM.antag_tags)
+            var/datum/antagonist/A = all_antag_types[antag_type]
+            min_antag_count += A.initial_spawn_req
+
+        if(min_antag_count > GM.required_enemies)
+            failed += "[ascii_red]--------------- [GM] ([GM.type]) requires [GM.required_enemies] but its antagonist roles require [min_antag_count]!"
+
+
+    if(failed.len)
+        fail("Some gamemodes did not have high enough required_enemies.")
+        for(var/failed_message in failed)
+            log_unit_test(failed_message)
+    else
+        pass("All gamemodes had enough required_enemies.")
+
+    return 1

--- a/code/unit_tests/gamemode_tests.dm
+++ b/code/unit_tests/gamemode_tests.dm
@@ -13,17 +13,23 @@
         var/min_antag_count = 0
         for(var/antag_type in GM.antag_tags)
             var/datum/antagonist/A = all_antag_types[antag_type]
-            min_antag_count += A.initial_spawn_req
+            
+            if(GM.require_all_templates)
+                min_antag_count += A.initial_spawn_req
+            else
+                min_antag_count = max(min_antag_count, A.initial_spawn_req)
 
         if(min_antag_count > GM.required_enemies)
-            failed += "[ascii_red]--------------- [GM] ([GM.type]) requires [GM.required_enemies] but its antagonist roles require [min_antag_count]!"
+            failed += "[ascii_red]--------------- [GM] ([GM.type]) requires [GM.required_enemies] enemies but its antagonist roles require [min_antag_count] players!"
+        if(min_antag_count > GM.required_players)
+            failed += "[ascii_red]--------------- [GM] ([GM.type]) requires [GM.required_players] players but its antagonist roles require [min_antag_count] players!"
 
 
     if(failed.len)
-        fail("Some gamemodes did not have high enough required_enemies.")
+        fail("Some gamemodes did not have high enough required_enemies or required_players.")
         for(var/failed_message in failed)
             log_unit_test(failed_message)
     else
-        pass("All gamemodes had enough required_enemies.")
+        pass("All gamemodes had suitable required_enemies and required_players.")
 
     return 1

--- a/code/unit_tests/gamemode_tests.dm
+++ b/code/unit_tests/gamemode_tests.dm
@@ -2,7 +2,7 @@
 	name = "GAMEMODE template"
 
 /datum/unit_test/gamemode/required_enemies_check
-    name = "GAMEMODE: All multi-modes shall have a required_enemies greater than or equal to their component modes."
+    name = "GAMEMODE: All modes shall have required_players and required_enemies greater than the required number of players for their antagonist types."
 
 /datum/unit_test/gamemode/required_enemies_check/start_test()
     var/list/failed = list()

--- a/html/changelogs/required_players_gamemodes.yml
+++ b/html/changelogs/required_players_gamemodes.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Gamemodes will no longer fail to start with enough antagonists due to a mismatch between expected enemies and actual required enemies due to the antagonist role types."
+  - tweak: "Siege (Rev+Merc) now requires 25 minimum players (10 antagonists) instead of 20."
+  - tweak: "Uprising (Rev+Traitor) now requires 20 minimum players (7 antagonists) instead of 15."


### PR DESCRIPTION
Makes sure that game modes have enough `required_players` and `required_enemies`, since these being wrong can lead to modes starting without sufficient antagonists.

Changes to `required_enemies` match actual values required by their antag types.
Changes to `required_players` are more arbitrary and I could probably use some input on those. 