### PR TITLE
Beams will now be initially drawn properly when their origin and target turfs are equal

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -12,26 +12,23 @@
 	var/finished = 0
 	var/turf/target_oldloc = null
 	var/turf/origin_oldloc = null
-	var/static_beam = 0
 	var/beam_type = /obj/effect/ebeam //must be subtype
 	var/timing_id = null
 	var/recalculating = FALSE
 
 /datum/beam/New(beam_origin,beam_target,beam_icon='icons/effects/beam.dmi',beam_icon_state="b_beam",time=50,maxdistance=10,btype = /obj/effect/ebeam,beam_sleep_time=3)
 	origin = beam_origin
-	origin_oldloc = get_turf(origin)
 	target = beam_target
-	target_oldloc = get_turf(target)
+	var/turf/origin_turf = get_turf(origin)
+	var/turf/target_turf = get_turf(target)
 	max_distance = maxdistance
+	curr_distance = get_dist(origin_turf, target_turf)
 
-	if(!origin || !target || !target_oldloc || !origin_oldloc || get_dist(origin_oldloc, target_oldloc) >= max_distance || origin_oldloc.z != target_oldloc.z)
+	if((curr_distance == -1 && origin_turf != target_turf) || curr_distance >= max_distance || origin_turf.z != target_turf.z)
 		qdel(src)
 		return
 
 	sleep_time = beam_sleep_time
-	if(origin_oldloc == origin && target_oldloc == target)
-		static_beam = TRUE
-	curr_distance = get_dist(origin_oldloc, target_oldloc)
 	base_icon = new(beam_icon,beam_icon_state)
 	icon = beam_icon
 	icon_state = beam_icon_state
@@ -52,8 +49,8 @@
 	var/turf/origin_turf = get_turf(origin)
 	var/turf/target_turf = get_turf(target)
 	curr_distance = get_dist(origin_turf, target_turf)
-	if(origin_turf && target_turf && curr_distance < max_distance && origin_turf.z == target_turf.z)
-		if(!static_beam && (origin_turf != origin_oldloc || target_turf != target_oldloc))
+	if(!(curr_distance == -1 && origin_turf != target_turf) && curr_distance < max_distance && origin_turf.z == target_turf.z)
+		if((origin_turf != origin_oldloc || target_turf != target_oldloc))
 			origin_oldloc = origin_turf //so we don't keep checking against their initial positions, leading to endless Reset()+Draw() calls
 			target_oldloc = target_turf
 			Reset()

--- a/code/game/objects/items/weapons/tether.dm
+++ b/code/game/objects/items/weapons/tether.dm
@@ -71,8 +71,8 @@ var/list/global/all_tethers = list()
 
 /obj/item/tethering_device/proc/tether(var/obj/item/tethering_device/TD)
 	linked_tethers |= TD
-	var/datum/beam/exploration/B = new /datum/beam/exploration(src, TD, beam_icon_state = "explore_beam", time = -1, maxdistance = tether_range)
-	if(istype(B))
+	var/datum/beam/exploration/B = new(src, TD, beam_icon_state = "explore_beam", time = -1, maxdistance = tether_range)
+	if(istype(B) && !QDELING(B))
 		B.owner = src
 		B.Start()
 		active_beams[TD] = B

--- a/code/modules/modular_computers/hardware/tesla_link.dm
+++ b/code/modules/modular_computers/hardware/tesla_link.dm
@@ -53,7 +53,7 @@
 		return
 	source = P
 	var/datum/beam/power/B = new(src, source, beam_icon_state = "explore_beam", time = -1, maxdistance = cable_length)
-	if(istype(B))
+	if(istype(B) && !QDELING(B))
 		playsound(get_turf(src), 'sound/machines/click.ogg', 30, 0)
 		B.owner = src
 		B.Start()

--- a/html/changelogs/charging_cable_beam_fix.yml
+++ b/html/changelogs/charging_cable_beam_fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Charging cable beams will now appear properly when you initially connect them."


### PR DESCRIPTION
* Removed a bunch of checks that are made redundant by `get_dist()` returning `-1` if it is given `null` arguments.
* Removed static beam var since it caused issues with the last change I made to beams, it is unnecessary anyway.

The way static beam was acting, it prevented the first `Draw()` for the APC charging cable.