### PR TITLE
NanoMed Pill Bottles

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -402,7 +402,8 @@
 		/obj/item/reagent_containers/pill/antitox = 6,
 		/obj/item/reagent_containers/pill/cetahydramine = 6,
 		/obj/item/reagent_containers/pill/perconol = 6,
-		/obj/item/reagent_containers/food/drinks/medcup = 4
+		/obj/item/reagent_containers/food/drinks/medcup = 4,
+		/obj/item/storage/pill_bottle = 4
 	)
 	contraband = list(
 		/obj/item/reagent_containers/inhaler/space_drugs = 2,

--- a/html/changelogs/geeves-need_pills.yml
+++ b/html/changelogs/geeves-need_pills.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "The NanoMed Plus vendors now dispense four pill bottles each."


### PR DESCRIPTION
* The NanoMed Plus vendors now dispense four pill bottles each.