### PR TITLE
Fixes premade combat mechs spawning without weapons

### DIFF
--- a/code/modules/heavy_vehicle/premade/combat.dm
+++ b/code/modules/heavy_vehicle/premade/combat.dm
@@ -61,7 +61,6 @@
 	max_damage = 200
 	power_use = 2500
 	transparent_cabin =  TRUE
-	has_hardpoints = list(HARDPOINT_BACK)
 
 /obj/item/mech_component/chassis/combat/prebuild()
 	. = ..()

--- a/html/changelogs/Ferner-201120-bugfix_combatmech.yml
+++ b/html/changelogs/Ferner-201120-bugfix_combatmech.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes:
+  - bugfix: "Fixed premade combat mechs spawning without weapons."


### PR DESCRIPTION
As the combat arms already provide the relevant hardpoint restrictions(only being able to mount things on the shoulders) it doesn't need to also be defined on the chassis itself, solving this bug.