### PR TITLE
Unapologetic changeling buffs

### DIFF
--- a/code/game/gamemodes/changeling/helpers/_store.dm
+++ b/code/game/gamemodes/changeling/helpers/_store.dm
@@ -88,7 +88,7 @@ var/list/datum/power/changeling/powerinstances = list()
 
 /datum/power/changeling/hivemind_morph
 	name = "Hivemind Release Morph"
-	desc = "We release a hivemind member as a morph at the cost of a limb. They will be able to crawl inside vents and disguise themselves as objects."
+	desc = "We release a hivemind member as a morph. They will be able to crawl inside vents and disguise themselves as objects."
 	genomecost = 0
 	verbpath = /mob/living/carbon/human/proc/changeling_release_morph
 
@@ -508,4 +508,3 @@ var/list/datum/power/changeling/powerinstances = list()
 		call(M.current, power.verbpath)()
 	else if(remake_verbs)
 		M.current.make_changeling()
-

--- a/code/game/gamemodes/changeling/helpers/_store.dm
+++ b/code/game/gamemodes/changeling/helpers/_store.dm
@@ -89,7 +89,7 @@ var/list/datum/power/changeling/powerinstances = list()
 /datum/power/changeling/hivemind_morph
 	name = "Hivemind Release Morph"
 	desc = "We release a hivemind member as a morph at the cost of a limb. They will be able to crawl inside vents and disguise themselves as objects."
-	genomecost = 2
+	genomecost = 0
 	verbpath = /mob/living/carbon/human/proc/changeling_release_morph
 
 //Stings and sting accessorries
@@ -156,7 +156,7 @@ var/list/datum/power/changeling/powerinstances = list()
 	name = "Adrenaline Sacs"
 	desc = "We evolve additional ways of producing stimulants throughout our body."
 	helptext = "Gives us the ability to instantly shrug off stuns, as well as producing some painkiller and stimulants."
-	genomecost = 3
+	genomecost = 1
 	verbpath = /mob/proc/changeling_unstun
 
 /datum/power/changeling/ChemicalSynth

--- a/code/game/gamemodes/changeling/implements/powers/hivemind.dm
+++ b/code/game/gamemodes/changeling/implements/powers/hivemind.dm
@@ -52,22 +52,6 @@
 	if(!chosen_player)
 		return
 
-	var/list/selectable_limb = list()
-	for(var/organ_name in list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG))
-		var/obj/item/organ/external/limb = organs_by_name[organ_name]
-		if(limb && !limb.is_stump())
-			selectable_limb += limb
-
-	if(!length(selectable_limb))
-		to_chat(src, SPAN_WARNING("We have no limbs to sacrifice!"))
-		return
-
-	var/obj/item/organ/external/chosen_limb = input("Choose a limb to sacrifice.", "Limb Sacrifice") as null|anything in selectable_limb
-	if(!chosen_limb)
-		return
-
-	chosen_limb.droplimb(TRUE, DROPLIMB_BLUNT)
-
 	var/mob/abstract/hivemind/M = mind.changeling.hivemind_members[chosen_player]
 	M.release_as_morph()
 	return TRUE

--- a/html/changelogs/dansemacabre-morphyworphy.yml
+++ b/html/changelogs/dansemacabre-morphyworphy.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Made changeling morph a free ability that does not require a limb sacrifice. Also makes adrenaline sacs cheaper."


### PR DESCRIPTION
Morphs are just too mediocre right now to be worth using - the same goes for adrenaline sacs. The chems that the sacs give you aren't particularly strong while being short-lasting, and they cost an absurd three genome points. Morphs, on the other hand, are only slightly less expensive while also costing you a limb to use the ability.

Most changelings will only absorb one or two people successfully. It isn't like this will cause hundreds of morphs to run around the station - all it will do is make this ability far more worthwhile, and at the same time keep players who got killed in the game.