### PR TITLE
Restricts required_enemies more via unit test

### DIFF
--- a/code/game/gamemodes/borer/borer.dm
+++ b/code/game/gamemodes/borer/borer.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Borers spawn in this game mode."
 	config_tag = "borer"
 	required_players = 15
-	required_enemies = 3
+	required_enemies = 2
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_BORER)
 	votable = TRUE

--- a/code/game/gamemodes/burglars/burglars.dm
+++ b/code/game/gamemodes/burglars/burglars.dm
@@ -4,7 +4,7 @@
 	name = "burglars"
 	config_tag = "burglars"
 	max_players = 15
-	required_enemies = 2
+	required_enemies = 1
 	required_players = 4
 	round_description = "Something tiny is on the horizon! Is it the distance, or...?"
 	extended_round_description = "Two of the Orion Spur's best and brightest (or so they were told) have been tasked with burglarizing a station that will change the way capitalism grips this galaxy forever (or so they were told). It is up to the crew to repel them, and up to them to survive and possibly thrive."

--- a/code/game/gamemodes/changeling/helpers/changeling.dm
+++ b/code/game/gamemodes/changeling/helpers/changeling.dm
@@ -12,7 +12,7 @@
 		certain though... there is never just one of them. Good luck."
 	config_tag = "changeling"
 	required_players = 10
-	required_enemies = 3
+	required_enemies = 1
 	end_on_antag_death = 1
 	antag_scaling_coeff = 8
 	antag_tags = list(MODE_CHANGELING)

--- a/code/game/gamemodes/mixed/conflict.dm
+++ b/code/game/gamemodes/mixed/conflict.dm
@@ -4,6 +4,6 @@
 	extended_round_description = "Burglars and heisters spawn during this round."
 	config_tag = "conflict"
 	required_players = 15
-	required_enemies = 6
+	required_enemies = 5
 	antag_tags = list(MODE_RAIDER, MODE_BURGLAR)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/feeding.dm
+++ b/code/game/gamemodes/mixed/feeding.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Vampires and Changelings spawn during this round."
 	config_tag = "feeding"
 	required_players = 20
-	required_enemies = 5
+	required_enemies = 2
 	end_on_antag_death = 0
 	require_all_templates = 1
 	votable = 1

--- a/code/game/gamemodes/mixed/infestation.dm
+++ b/code/game/gamemodes/mixed/infestation.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Two alien antagonists (Cortical Borers or Changelings) may spawn during this round."
 	config_tag = "infestation"
 	required_players = 15
-	required_enemies = 5
+	required_enemies = 3
 	end_on_antag_death = 1
 	antag_tags = list(MODE_BORER, MODE_CHANGELING)
 	require_all_templates = 1

--- a/code/game/gamemodes/mixed/infiltration.dm
+++ b/code/game/gamemodes/mixed/infiltration.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "A malf AI and a Ninja spawn during this round."
 	config_tag = "infiltration"
 	required_players = 20
-	required_enemies = 5
+	required_enemies = 3
 	end_on_antag_death = 0
 	require_all_templates = 1
 	votable = 1

--- a/code/game/gamemodes/mixed/intrigue.dm
+++ b/code/game/gamemodes/mixed/intrigue.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Traitors and a ninja spawn during this round."
 	config_tag = "intrigue"
 	required_players = 15
-	required_enemies = 4
+	required_enemies = 3
 	end_on_antag_death = 0
 	antag_tags = list(MODE_NINJA, MODE_TRAITOR)
 	require_all_templates = 1

--- a/code/game/gamemodes/mixed/paranoia.dm
+++ b/code/game/gamemodes/mixed/paranoia.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Rampant AIs, traitors and changelings spawn in this mode."
 	config_tag = "paranoia"
 	required_players = 15
-	required_enemies = 5
+	required_enemies = 3
 	end_on_antag_death = 1
 	require_all_templates = 1
 	votable = 1

--- a/code/game/gamemodes/mixed/traitorling.dm
+++ b/code/game/gamemodes/mixed/traitorling.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Traitors and changelings both spawn during this mode."
 	config_tag = "traitorling"
 	required_players = 10
-	required_enemies = 5
+	required_enemies = 2
 	end_on_antag_death = 1
 	require_all_templates = 1
 	antag_tags = list(MODE_CHANGELING, MODE_TRAITOR)

--- a/code/unit_tests/gamemode_tests.dm
+++ b/code/unit_tests/gamemode_tests.dm
@@ -19,7 +19,7 @@
             else
                 min_antag_count = max(min_antag_count, A.initial_spawn_req)
 
-        if(min_antag_count > GM.required_enemies)
+        if(min_antag_count != GM.required_enemies)
             failed += "[ascii_red]--------------- [GM] ([GM.type]) requires [GM.required_enemies] enemies but its antagonist roles require [min_antag_count] players!"
         if(min_antag_count > GM.required_players)
             failed += "[ascii_red]--------------- [GM] ([GM.type]) requires [GM.required_players] players but its antagonist roles require [min_antag_count] players!"

--- a/html/changelogs/fixes_burglar_gamemode_selection.yml
+++ b/html/changelogs/fixes_burglar_gamemode_selection.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Burglar gamemode only requires one antagonist to start."


### PR DESCRIPTION
Made a (some?) mistakes with setting required_enemies too high in the last PR.

Lets see what errors the adjusted unit test throws at me.

Restricted `required_enemies` so that it is equal to the minimum required antagonists, rather than just higher than it.