### PR TITLE
pAI Radio Fixes and Oversights

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -79,8 +79,7 @@
 		recalculateChannels()
 
 /obj/item/device/paicard/proc/recalculateChannels()
-	radio.channels = list()
-
+	radio.channels = list("Common" = radio.FREQ_LISTENING, "Entertainment" = radio.FREQ_LISTENING)
 	for(var/keyslot in installed_encryptionkeys)
 		var/obj/item/device/encryptionkey/EK = keyslot
 		for(var/ch_name in (EK.channels | EK.additional_channels))

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -17,7 +17,7 @@
 	var/list/software = list()
 	var/userDNA		// The DNA string of our assigned user
 	var/obj/item/device/paicard/card	// The card we inhabit
-	var/obj/item/device/radio/radio		// Our primary radio
+	var/obj/item/device/radio/pai/radio		// Our primary radio
 
 
 	var/chassis = "repairbot"   // A record of your chosen chassis.
@@ -165,8 +165,9 @@
 	sradio = new(src)
 	if(card)
 		if(!card.radio)
-			card.radio = new /obj/item/device/radio(src.card)
+			card.radio = new /obj/item/device/radio/pai(src.card)
 		radio = card.radio
+		card.recalculateChannels()
 
 	//Default languages without universal translator software
 
@@ -523,3 +524,6 @@
 
 	var/selection = input(src, "Choose an icon for you card.") in pai_emotions
 	card.setEmotion(pai_emotions[selection])
+
+/obj/item/device/radio/pai
+	canhear_range = 0 // only people on their tile

--- a/code/modules/modular_computers/file_system/programs/pai/radio.dm
+++ b/code/modules/modular_computers/file_system/programs/pai/radio.dm
@@ -35,6 +35,9 @@
 
 	data["listening"] = host.radio.broadcasting
 	data["frequency"] = format_frequency(host.radio.frequency)
+	VUEUI_SET_CHECK_IFNOTSET(data["radio_range"], host.radio.canhear_range, ., data)
+	host.radio.canhear_range = data["radio_range"]
+	message_admins(host.radio.canhear_range)
 
 	var/list/pai_channels = list()
 	for(var/ch_name in host.radio.channels)

--- a/code/modules/modular_computers/file_system/programs/pai/radio.dm
+++ b/code/modules/modular_computers/file_system/programs/pai/radio.dm
@@ -37,7 +37,6 @@
 	data["frequency"] = format_frequency(host.radio.frequency)
 	VUEUI_SET_CHECK_IFNOTSET(data["radio_range"], host.radio.canhear_range, ., data)
 	host.radio.canhear_range = data["radio_range"]
-	message_admins(host.radio.canhear_range)
 
 	var/list/pai_channels = list()
 	for(var/ch_name in host.radio.channels)

--- a/html/changelogs/geeves-pai_radios.yml
+++ b/html/changelogs/geeves-pai_radios.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "pAI radios no longer let people two tiles away hear them, now you need to be on top of them to hear, or vice versa. The range can be configured in the radio configuration app."
+  - bugfix: "Actually gave pAI access to common and entertainment, the standard for user radios."

--- a/vueui/src/components/view/mcomputer/pai/radio.vue
+++ b/vueui/src/components/view/mcomputer/pai/radio.vue
@@ -12,6 +12,9 @@
         <vui-button :params="{freq:2, nowindow:1}">+</vui-button>
         <vui-button :params="{freq:10, nowindow:1}">++</vui-button>
       </vui-group-item>
+      <vui-item label="Range:">
+        <vui-input-slider :min="0" :max="4" v-model="radio_range"/>
+      </vui-item>
       <hr>
       <vui-group-item v-for="channel in channels" :label="channel.name" :key="channel.name">
         <vui-button


### PR DESCRIPTION
* pAI radios no longer let people two tiles away hear them, now you need to be on top of them to hear, or vice versa. The range can be configured in the radio configuration app.
* Actually gave pAI access to common and entertainment, the standard for user radios.