### PR TITLE
Earwear Fix

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_ears.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_ears.dm
@@ -1,9 +1,8 @@
-// Stuff worn on the ears. Items here go in the "ears" sort_category but they must not use
-// the slot_r_ear or slot_l_ear as the slot, or else players will spawn with no headset.
 /datum/gear/ears
 	display_name = "earmuffs"
 	path = /obj/item/clothing/ears/earmuffs
 	sort_category = "Earwear"
+	slot = slot_r_ear
 
 /datum/gear/ears/bandanna
 	display_name = "neck bandanna selection"

--- a/html/changelogs/geeves-skrell_gear.yml
+++ b/html/changelogs/geeves-skrell_gear.yml
@@ -3,5 +3,5 @@ author: Geeves
 delete-after: True
 
 changes:
-  - bugfix: "Loadout items that go on the ear slot no render correctly in the character creation menu."
+  - bugfix: "Loadout items that go on the ear slot now render correctly in the character creation menu."
   - bugfix: "Skrell loadout items that go in the ear slot included."

--- a/html/changelogs/geeves-skrell_gear.yml
+++ b/html/changelogs/geeves-skrell_gear.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Loadout items that go on the ear slot no render correctly in the character creation menu."
+  - bugfix: "Skrell loadout items that go in the ear slot included."


### PR DESCRIPTION
* Loadout items that go on the ear slot now render correctly in the character creation menu.
* Skrell loadout items that go in the ear slot included.