### PR TITLE
Removes a pick() that occurred after the antag candidate lists were carefully ordered

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -172,9 +172,9 @@
 	if(!candidates.len)
 		return 0
 
-	//Grab candidates randomly until we have enough.
+	//Grab candidates until we have enough.
 	while(candidates.len && pending_antagonists.len < spawn_target)
-		var/datum/mind/player = pick(candidates)
+		var/datum/mind/player = candidates[1]
 		candidates -= player
 		draft_antagonist(player)
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -252,6 +252,7 @@ var/global/list/additional_antag_types = list()
 		for(var/candidate in all_candidates)
 			valid_templates_per_candidate[candidate]++
 
+		valid_templates_per_candidate = shuffle(valid_templates_per_candidate) // shuffle before sorting so that candidates with the same number of templates will be in random order
 		sortTim(valid_templates_per_candidate, /proc/cmp_numeric_asc, TRUE)
 
 		for(var/datum/antagonist/antag in antag_templates)

--- a/html/changelogs/dont_pick_after_sorting.yml
+++ b/html/changelogs/dont_pick_after_sorting.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Improved multi-mode antagonist selection logic."


### PR DESCRIPTION
Back in [here](https://github.com/Aurorastation/Aurora.3/pull/9583/files#diff-81ec6c59ff95d905cb3f46f74628981867422600479e44396c401cd6e3bd85a6) I made the antagonist candidates list get ordered based on how many antag types the candidate was suited for -- So that people with less templates available would be picked first, resulting in it being more likely for a gamemode to be successfully chosen.

However I missed a `pick()` later on that disorders my carefully ordered lists and made that all pointless.

This fixes that.