### PR TITLE
Learner Role PDAs

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -199,3 +199,7 @@
 	satchel = /obj/item/storage/backpack/satchel_eng
 	dufflebag = /obj/item/storage/backpack/duffel/eng
 	messengerbag = /obj/item/storage/backpack/messenger/engi
+
+	tab_pda = /obj/item/modular_computer/handheld/pda/engineering/atmos
+	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/engineering/atmos
+	tablet = /obj/item/modular_computer/handheld/preset/engineering/atmos

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -200,6 +200,6 @@
 	dufflebag = /obj/item/storage/backpack/duffel/eng
 	messengerbag = /obj/item/storage/backpack/messenger/engi
 
-	tab_pda = /obj/item/modular_computer/handheld/pda/engineering/atmos
-	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/engineering/atmos
-	tablet = /obj/item/modular_computer/handheld/preset/engineering/atmos
+	tab_pda = /obj/item/modular_computer/handheld/pda/engineering
+	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/engineering
+	tablet = /obj/item/modular_computer/handheld/preset/engineering

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -266,3 +266,7 @@
 	satchel = /obj/item/storage/backpack/satchel_med
 	dufflebag = /obj/item/storage/backpack/duffel/med
 	messengerbag = /obj/item/storage/backpack/messenger/med
+
+	tab_pda = /obj/item/modular_computer/handheld/pda/medical
+	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/medical
+	tablet = /obj/item/modular_computer/handheld/preset/medical

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -201,3 +201,7 @@
 	satchel = /obj/item/storage/backpack/satchel_tox
 	dufflebag = /obj/item/storage/backpack/duffel/tox
 	messengerbag = /obj/item/storage/backpack/messenger/tox
+
+	tab_pda = /obj/item/modular_computer/handheld/pda/research
+	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/research
+	tablet = /obj/item/modular_computer/handheld/preset/research

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -289,3 +289,7 @@
 	satchel = /obj/item/storage/backpack/satchel_sec
 	dufflebag = /obj/item/storage/backpack/duffel/sec
 	messengerbag = /obj/item/storage/backpack/messenger/sec
+
+	tab_pda = /obj/item/modular_computer/handheld/pda/security
+	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/security
+	tablet = /obj/item/modular_computer/handheld/preset/security

--- a/html/changelogs/geeves-medical_codex.yml
+++ b/html/changelogs/geeves-medical_codex.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Learner roles such as medical intern, security cadet, lab assistant, and engineering apprentice, now gets PDAs of their department's variant, instead of standard civilian."


### PR DESCRIPTION
* Learner roles such as medical intern, security cadet, lab assistant, and engineering apprentice, now gets PDAs of their department's variant, instead of standard civilian.