### PR TITLE
Tweaks the construction of steel wool

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -378,11 +378,6 @@
 	path = /obj/item/device/destTagger
 	category = "General"
 
-/datum/autolathe/recipe/steelwool
-	name = "steel wool"
-	path = /obj/item/steelwool
-	category = "Tools"
-
 /datum/autolathe/recipe/debugger
 	name = "debugger"
 	path = /obj/item/device/debugger

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -66,7 +66,8 @@
 			new /datum/stack_recipe("key", /obj/item/key, 1, time = 10, one_per_turf = 0, on_floor = 1),
 			new /datum/stack_recipe("custodial cart", /obj/structure/janitorialcart, BUILD_AMT, time = 120, one_per_turf = 1, on_floor = 1),
 			new /datum/stack_recipe("closet", /obj/structure/closet, BUILD_AMT, time = 15, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister, 10, time = 15, one_per_turf = 1, on_floor = 1)
+			new /datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister, 10, time = 15, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("steel wool", /obj/item/steelwool, 1, time = 15, one_per_turf = 1, on_floor = 1)
 		))
 
 	recipes += new /datum/stack_recipe_list("airlock assemblies",

--- a/html/changelogs/hockaa-steelwooltweaks.yml
+++ b/html/changelogs/hockaa-steelwooltweaks.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes:
+  - tweak: "Steel wool is now made from a steel sheet under the miscellaneous construction category. They are no longer made in autolathes."


### PR DESCRIPTION
Steel wool can now be constructed with 1 steel sheet under the 'miscellaneous construction' category and is no longer sourced from autolathes.