### PR TITLE
Blood Overlay Fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -153,6 +153,7 @@
 	density = 0
 	attacktext = "cut"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
+	blood_overlay_icon = null
 	faction = "syndicate"
 	min_oxy = 0
 	max_oxy = 0

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -540,7 +540,7 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	. = ..()
 	handle_blood_overlay()
 
-/mob/living/proc/heal_organ_damage(var/brute, var/burn)
+/mob/living/simple_animal/heal_organ_damage(var/brute, var/burn)
 	. = ..()
 	handle_blood_overlay()
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -540,6 +540,10 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	. = ..()
 	handle_blood_overlay()
 
+/mob/living/proc/heal_organ_damage(var/brute, var/burn)
+	. = ..()
+	handle_blood_overlay()
+
 /mob/living/simple_animal/movement_delay()
 	var/tally = 0 //Incase I need to add stuff other than "speed" later
 

--- a/html/changelogs/geeves-blood_overlay_fixes.yml
+++ b/html/changelogs/geeves-blood_overlay_fixes.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Viscerators no longer have funky blood overlays."
+  - bugfix: "Healing animals now properly update their blood overlays."


### PR DESCRIPTION
* Viscerators no longer have funky blood overlays.
* Healing animals now properly update their blood overlays.