### PR TITLE
Fixes asteroid rocks spawning in the hydrogen tank's viewport

### DIFF
--- a/html/changelogs/hockaa-morefixes.yml
+++ b/html/changelogs/hockaa-morefixes.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes:
+  - bugfix: "Removes the chasm mask from the hydrogen tank viewport which was causing asteroid rocks to spawn in the window."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -34289,7 +34289,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor,
-/turf/unsimulated/chasm_mask,
+/turf/simulated/floor,
 /area/engineering/atmos)
 "tdu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{


### PR DESCRIPTION
I forgot to replace a chasm mask with a plating turf, so sometimes asteroid rocks spawned inside the window and blocked the view. This PR rectifies this.