### PR TITLE
Feeling Around

### DIFF
--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -377,9 +377,8 @@
 		return
 
 	else if(!istype(W,/obj/item/rfd/construction) && !istype(W, /obj/item/reagent_containers))
-		//At this point we know that they probably wanna hit it.
 		if(user.a_intent != I_HURT || !W.force)
-			return attack_hand(user)
+			return
 
 		var/damage_to_deal = W.force
 		var/weaken = 0

--- a/html/changelogs/geeves-feeling_around.yml
+++ b/html/changelogs/geeves-feeling_around.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Using an item on a wall will no longer cause it to play the feeling around message. If you want to feel for an opening, use an empty hand."


### PR DESCRIPTION
* Using an item on a wall will no longer cause it to play the feeling around message. If you want to feel for an opening, use an empty hand.