### PR TITLE
Fixes colorable bandanas, berets and softcaps being darker than they're supposed to

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -32,7 +32,7 @@
 
 	gear_tweaks += new/datum/gear_tweak/path(bandanas)
 
-/datum/gear/head/bandana/colorable
+/datum/gear/head/bandana_color
 	display_name = "bandana (colorable)"
 	path = /obj/item/clothing/head/bandana/colorable
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
@@ -62,7 +62,7 @@
 
 	gear_tweaks += new/datum/gear_tweak/path(softcaps)
 
-/datum/gear/head/softcap/colorable
+/datum/gear/head/softcap_color
 	display_name = "softcap (colorable)"
 	path = /obj/item/clothing/head/softcap/colorable
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
@@ -91,7 +91,7 @@
 
 	gear_tweaks += new/datum/gear_tweak/path(berets)
 
-/datum/gear/head/beret/color
+/datum/gear/head/beret_color
 	display_name = "beret (colorable)"
 	path = /obj/item/clothing/head/beret/colorable
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION

--- a/html/changelogs/Ferner-201203-bugfix_coloredhats.yml
+++ b/html/changelogs/Ferner-201203-bugfix_coloredhats.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes:
+  - bugfix: "Fixed colorable bandanas, softcaps and berets being darker than they're suppposed to be."


### PR DESCRIPTION
The parents of these ended up overwriting the path, meaning the colorable versions were using the base version instead of the colorable one(which is white, instead of gray).