### PR TITLE
Fix crate + table handling

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -575,14 +575,17 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	if(!user || isnull(user))
 		return 0
 
-	if (!act_target)
-		act_target = user
-
 	var/Location
+	var/act_location
 	if(use_user_turf)	//When this is true, do_after() will check whether the user's turf has changed, rather than the user's loc.
 		Location = get_turf(user)
 	else
 		Location = user.loc
+
+	if (!act_target)
+		act_target = user
+	else
+		act_location = get_turf(act_target)
 
 	var/holding = user.get_active_hand()
 
@@ -606,7 +609,11 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		else
 			user_loc_to_check = user.loc
 
-		if (!user || user.stat || user.weakened || user.stunned || (use_user_turf >= 0 && user_loc_to_check != Location))
+		if (!user || user.stat || user.weakened || user.stunned)
+			. = 0
+			break
+
+		if ((use_user_turf >= 0 && user_loc_to_check != Location) || (act_location && (get_turf(act_target) != act_location)))
 			. = 0
 			break
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -1,5 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:32
 
+#define ABOVE_TABLE 1
+#define UNDER_TABLE -1
 /obj/structure/closet/crate
 	name = "crate"
 	desc = "A rectangular steel crate."
@@ -10,14 +12,11 @@
 	climbable = 1
 	build_amt = 10
 	var/rigged = 0
-	var/tablestatus = 0
-	pass_flags = PASSTABLE
-
+	var/table_status = 0
 	slowdown = 0
 
-
 /obj/structure/closet/crate/can_open()
-	if (tablestatus != -1)//Can't be opened while under a table
+	if (table_status != UNDER_TABLE)//Can't be opened while under a table
 		return 1
 	return 0
 
@@ -84,7 +83,6 @@
 
 	icon_state = icon_closed
 	opened = 0
-	pass_flags = PASSTABLE//Crates can only slide under tables when closed
 	return 1
 
 
@@ -141,10 +139,6 @@
 				A.ex_act(severity)
 		qdel(src)
 
-
-
-
-
 /*
 ==========================
 	Table interactions
@@ -153,67 +147,60 @@
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if (istype(mover, /obj/structure/closet/crate))//Handle interaction with other crates
 		var/obj/structure/closet/crate/C = mover
-		if (tablestatus == 1 && C.tablestatus != 1 && !C.opened)//Allow the crate to slide under us if we're ontop of a table
-			return 1
-		else if (tablestatus == -1 && C.tablestatus == 1)//Allow it to slide over us if we're underneath a table
-			return 1
-		else//Otherwise, block it. Don't allow two crates on the same level of a tile
-			return 0
-	if(istype(mover,/obj/item/projectile))
-		if (tablestatus == 1)//They always block shots on a table
-			return 0
-		else if (!tablestatus && prob(15))//Usually will not block shots when lying on the floor
-			return 0
-		else return 1
-	else if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
+		if (table_status && table_status != C.table_status) // Crates can go under tables with crates on top of them, and vice versa
+			return TRUE
+		else
+			return FALSE
+	if (istype(mover,/obj/item/projectile))
+		// Crates on a table always block shots, otherwise they only occasionally do so.
+		return table_status == ABOVE_TABLE ? FALSE : (prob(15) ? FALSE : TRUE)
+	else if(istype(mover) && mover.checkpass(PASSTABLE) && table_status == ABOVE_TABLE)
+		return TRUE
 	return ..()
 
 /obj/structure/closet/crate/Move(var/turf/destination, dir)
 	if(..())
 		if (locate(/obj/structure/table) in destination)
-			if (tablestatus != 1)
-				set_tablestatus(-1)//Slide under the table
+			if(locate(/obj/structure/table/rack) in destination)
+				set_table_status(ABOVE_TABLE)
+			else if(table_status != ABOVE_TABLE)
+				set_table_status(UNDER_TABLE)//Slide under the table
 		else
-			set_tablestatus(0)
-
+			set_table_status(FALSE)
 
 /obj/structure/closet/crate/toggle(var/mob/user)
-	if (!opened && tablestatus == -1)
-		to_chat(user, SPAN_WARNING("You can't open that while it's under the table"))
-		return 0
+	if (!opened && table_status == UNDER_TABLE)
+		to_chat(user, SPAN_WARNING("You can't open that while the lid is obstructed!"))
+		return FALSE
 	else
 		return ..()
 
-/obj/structure/closet/crate/proc/set_tablestatus(var/target)
-	if (tablestatus != target)
-		tablestatus = target
+/obj/structure/closet/crate/proc/set_table_status(var/target)
+	if (table_status != target)
+		table_status = target
 
 	spawn(3)//Short spawn prevents things popping up where they shouldnt
 		switch (target)
-			if (1)
+			if (ABOVE_TABLE)
 				layer = LAYER_ABOVE_TABLE
 				pixel_y = 8
-			if (0)
+			if (FALSE)
 				layer = initial(layer)
 				pixel_y = 0
-			if (-1)
+			if (UNDER_TABLE)
 				layer = LAYER_UNDER_TABLE
 				pixel_y = -4
-
 
 //For putting on tables
 /obj/structure/closet/crate/MouseDrop(atom/over_object)
 	if (istype(over_object, /obj/structure/table))
 		put_on_table(over_object, usr)
-		return 1
+		return TRUE
 	else
 		return ..()
 
-
-
 /obj/structure/closet/crate/proc/put_on_table(var/obj/structure/table/table, var/mob/user)
-	if (!table || !user || (tablestatus == -1))
+	if (!table || !user || (table_status == UNDER_TABLE))
 		return
 
 	//User must be in reach of the crate
@@ -226,24 +213,20 @@
 		to_chat(user, SPAN_WARNING("Take the crate closer to the table!"))
 		return
 
-
 	for (var/obj/structure/closet/crate/C in get_turf(table))
-		if (C.tablestatus != -1)
+		if (C.table_status != UNDER_TABLE)
 			to_chat(user, SPAN_WARNING("There's already a crate on this table!"))
 			return
 
 	//Crates are heavy, hauling them onto tables is hard.
 	//The more stuff thats in it, the longer it takes
 	//Good place to factor in Strength in future
-	var/timeneeded = 20
-	var/success = 0
+	var/timeneeded = 2 SECONDS
 
-
-
-	if (tablestatus == 1 && Adjacent(table))
+	if (table_status == ABOVE_TABLE && Adjacent(table))
 		//Sliding along a tabletop we're already on. Instant and silent
 		timeneeded = 0
-		success = 1
+		return TRUE
 	else
 		//Add time based on mass of contents
 		for (var/obj/O in contents)
@@ -252,16 +235,14 @@
 			timeneeded += 3* M.mob_size
 
 	if (timeneeded > 0)
-		user.visible_message("[user] starts hoisting [src] onto the [table]", "You start hoisting [src] onto the [table]. This will take about [timeneeded*0.1] seconds")
+		user.visible_message("[user] starts hoisting \the [src] onto \the [table].", "You start hoisting \the [src] onto \the [table]. This will take about [timeneeded * 0.1] seconds.")
 		user.face_atom(src)
-		if (do_after(user, timeneeded, needhand = 1))
-			success = 1
-
-
-	if (success == 1)
-		forceMove(get_turf(table))
-		set_tablestatus(1)
-
+		if (!do_after(user, timeneeded, needhand = TRUE, act_target = src))
+			return FALSE
+		else
+			forceMove(get_turf(table))
+			set_table_status(ABOVE_TABLE)
+			return TRUE
 
 /*
 =====================

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -12,11 +12,11 @@
 	climbable = 1
 	build_amt = 10
 	var/rigged = 0
-	var/table_status = 0
+	var/tablestatus = 0
 	slowdown = 0
 
 /obj/structure/closet/crate/can_open()
-	if (table_status != UNDER_TABLE)//Can't be opened while under a table
+	if (tablestatus != UNDER_TABLE)//Can't be opened while under a table
 		return 1
 	return 0
 
@@ -147,14 +147,14 @@
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if (istype(mover, /obj/structure/closet/crate))//Handle interaction with other crates
 		var/obj/structure/closet/crate/C = mover
-		if (table_status && table_status != C.table_status) // Crates can go under tables with crates on top of them, and vice versa
+		if (tablestatus && tablestatus != C.tablestatus) // Crates can go under tables with crates on top of them, and vice versa
 			return TRUE
 		else
 			return FALSE
 	if (istype(mover,/obj/item/projectile))
 		// Crates on a table always block shots, otherwise they only occasionally do so.
-		return table_status == ABOVE_TABLE ? FALSE : (prob(15) ? FALSE : TRUE)
-	else if(istype(mover) && mover.checkpass(PASSTABLE) && table_status == ABOVE_TABLE)
+		return tablestatus == ABOVE_TABLE ? FALSE : (prob(15) ? FALSE : TRUE)
+	else if(istype(mover) && mover.checkpass(PASSTABLE) && tablestatus == ABOVE_TABLE)
 		return TRUE
 	return ..()
 
@@ -162,22 +162,22 @@
 	if(..())
 		if (locate(/obj/structure/table) in destination)
 			if(locate(/obj/structure/table/rack) in destination)
-				set_table_status(ABOVE_TABLE)
-			else if(table_status != ABOVE_TABLE)
-				set_table_status(UNDER_TABLE)//Slide under the table
+				set_tablestatus(ABOVE_TABLE)
+			else if(tablestatus != ABOVE_TABLE)
+				set_tablestatus(UNDER_TABLE)//Slide under the table
 		else
-			set_table_status(FALSE)
+			set_tablestatus(FALSE)
 
 /obj/structure/closet/crate/toggle(var/mob/user)
-	if (!opened && table_status == UNDER_TABLE)
+	if (!opened && tablestatus == UNDER_TABLE)
 		to_chat(user, SPAN_WARNING("You can't open that while the lid is obstructed!"))
 		return FALSE
 	else
 		return ..()
 
-/obj/structure/closet/crate/proc/set_table_status(var/target)
-	if (table_status != target)
-		table_status = target
+/obj/structure/closet/crate/proc/set_tablestatus(var/target)
+	if (tablestatus != target)
+		tablestatus = target
 
 	spawn(3)//Short spawn prevents things popping up where they shouldnt
 		switch (target)
@@ -200,7 +200,7 @@
 		return ..()
 
 /obj/structure/closet/crate/proc/put_on_table(var/obj/structure/table/table, var/mob/user)
-	if (!table || !user || (table_status == UNDER_TABLE))
+	if (!table || !user || (tablestatus == UNDER_TABLE))
 		return
 
 	//User must be in reach of the crate
@@ -214,7 +214,7 @@
 		return
 
 	for (var/obj/structure/closet/crate/C in get_turf(table))
-		if (C.table_status != UNDER_TABLE)
+		if (C.tablestatus != UNDER_TABLE)
 			to_chat(user, SPAN_WARNING("There's already a crate on this table!"))
 			return
 
@@ -223,7 +223,7 @@
 	//Good place to factor in Strength in future
 	var/timeneeded = 2 SECONDS
 
-	if (table_status == ABOVE_TABLE && Adjacent(table))
+	if (tablestatus == ABOVE_TABLE && Adjacent(table))
 		//Sliding along a tabletop we're already on. Instant and silent
 		timeneeded = 0
 		return TRUE
@@ -241,7 +241,7 @@
 			return FALSE
 		else
 			forceMove(get_turf(table))
-			set_table_status(ABOVE_TABLE)
+			set_tablestatus(ABOVE_TABLE)
 			return TRUE
 
 /*

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -8,6 +8,8 @@
 			return !density
 		else
 			return 1
+	if(istype(mover, /obj/structure/closet/crate))
+		return TRUE
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return 1
 	if(locate(/obj/structure/table) in get_turf(mover))

--- a/html/changelogs/johnwildkins-cratefix.yml
+++ b/html/changelogs/johnwildkins-cratefix.yml
@@ -1,0 +1,7 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Crates no longer pass through barricades or other objects that allow small objects (PASSTABLE) through."
+  - refactor: "Crates being lifted (and other timed interactions with objects) now stop being lifted if the crate is moved."


### PR DESCRIPTION
changes:
  - bugfix: "Crates no longer pass through barricades or other objects that allow small objects (PASSTABLE) through."
  - refactor: "Crates being lifted (and other timed interactions with objects) now stop being lifted if the crate is moved."

also crates pushed onto racks now sit on top of the racks rather than going beneath them, see below
![](https://i.imgur.com/GQeBcBD.gif)

backend changes: 
essentially any `do_after` call that sends an `act_target` now cancels if the `act_target` moves;
there might be something else broken by this change but I can't imagine anything intends for its acted target to be able to move while being acted upon

Fixes #2306
Fixes #5090