### PR TITLE
Dropper + Goggles Fix (Third Time's the Charm)

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -52,7 +52,7 @@
 					if (victim.head.body_parts_covered & EYES)
 						safe_thing = victim.head
 				if(victim.glasses)
-					if (!safe_thing && victim.glasses.body_parts_covered & EYES)
+					if (victim.glasses.body_parts_covered & EYES)
 						safe_thing = victim.glasses
 
 				if(safe_thing)

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -52,7 +52,7 @@
 					if (victim.head.body_parts_covered & EYES)
 						safe_thing = victim.head
 				if(victim.glasses)
-					if (victim.glasses.body_parts_covered & EYES)
+					if (!safe_thing && victim.glasses.body_parts_covered & EYES)
 						safe_thing = victim.glasses
 
 				if(safe_thing)

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -52,7 +52,7 @@
 					if (victim.head.body_parts_covered & EYES)
 						safe_thing = victim.head
 				if(victim.glasses)
-					if (!safe_thing)
+					if (victim.glasses.body_parts_covered & EYES)
 						safe_thing = victim.glasses
 
 				if(safe_thing)

--- a/html/changelogs/gogglesanddroppersfix.yml
+++ b/html/changelogs/gogglesanddroppersfix.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - bugfix: "Goggles worn on your forehead no longer block droppers."


### PR DESCRIPTION
Same as before, fixes goggles on your forehead interfering with droppers

### IC changelog
- bugfix: "Goggles worn on your forehead no longer block droppers."