### PR TITLE
Goggles/Dropper Fix

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -52,7 +52,7 @@
 					if (victim.head.body_parts_covered & EYES)
 						safe_thing = victim.head
 				if(victim.glasses)
-					if (!safe_thing & victim.glasses.body_parts_covered & EYES)
+					if (!safe_thing && (victim.glasses.body_parts_covered & EYES))
 						safe_thing = victim.glasses
 
 				if(safe_thing)

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -52,7 +52,7 @@
 					if (victim.head.body_parts_covered & EYES)
 						safe_thing = victim.head
 				if(victim.glasses)
-					if (!safe_thing)
+					if (!safe_thing & victim.glasses.body_parts_covered & EYES)
 						safe_thing = victim.glasses
 
 				if(safe_thing)

--- a/html/changelogs/goggles.yml
+++ b/html/changelogs/goggles.yml
@@ -1,0 +1,6 @@
+author: Sparky_Hotdog
+
+delete-after: True
+
+changes:
+  - bugfix: "Goggles worn of your forehead no longer block people squirting stuff into your eyes with droppers"


### PR DESCRIPTION
Same as before. Goggles on your forehead don't block droppers.

### IC changelog
- bugfix: "Goggles worn of your forehead no longer block people squirting stuff into your eyes with droppers"