### PR TITLE
Customise Medibot Speech

### DIFF
--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -13,7 +13,6 @@
 	var/mob/living/carbon/human/patient = null
 	var/mob/ignored = list() // Used by emag
 	var/last_newpatient_speak = 0
-	var/vocal = 1
 
 	//Healing vars
 	var/obj/item/reagent_containers/glass/reagent_glass = null //Can be set to draw from this for reagents.
@@ -37,10 +36,6 @@
 	..()
 	if(!on)
 		return
-
-	if(vocal && prob(1))
-		var/message = pick("Radar, put a mask on!", "There's always a catch, and it's the best there is.", "I knew it, I should've been a plastic surgeon.", "What kind of medbay is this? Everyone's dropping like dead flies.", "Delicious!")
-		say(message)
 
 	if(patient)
 		if(Adjacent(patient))
@@ -158,8 +153,6 @@
 
 		dat += "Treatment report is [declare_treatment ? "on" : "off"]. <a href='?src=\ref[src];declaretreatment=[1]'>Toggle</a><br>"
 
-		dat += "The speaker switch is [vocal ? "on" : "off"]. <a href='?src=\ref[src];togglevoice=[1]'>Toggle</a><br>"
-
 	var/datum/browser/bot_win = new(user, "automed", "Automatic Medibot v1.2 Controls")
 	bot_win.set_content(dat)
 	bot_win.open()
@@ -221,9 +214,6 @@
 			reagent_glass = null
 		else
 			to_chat(usr, "<span class='notice'>You cannot eject the beaker because the panel is locked.</span>")
-
-	else if (href_list["togglevoice"] && (!locked || issilicon(usr)))
-		vocal = !vocal
 
 	else if (href_list["declaretreatment"] && (!locked || issilicon(usr)))
 		declare_treatment = !declare_treatment

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -13,6 +13,8 @@
 	var/mob/living/carbon/human/patient = null
 	var/mob/ignored = list() // Used by emag
 	var/last_newpatient_speak = 0
+	var/message = null
+	var/speech = 0
 
 	//Healing vars
 	var/obj/item/reagent_containers/glass/reagent_glass = null //Can be set to draw from this for reagents.
@@ -36,6 +38,9 @@
 	..()
 	if(!on)
 		return
+
+	if(speech && prob(1))
+		say(message)
 
 	if(patient)
 		if(Adjacent(patient))
@@ -152,6 +157,8 @@
 		dat += "<a href='?src=\ref[src];use_beaker=1'>[use_beaker ? "Loaded Beaker (When available)" : "Internal Synthesizer"]</a><br>"
 
 		dat += "Treatment report is [declare_treatment ? "on" : "off"]. <a href='?src=\ref[src];declaretreatment=[1]'>Toggle</a><br>"
+		dat += "The speaker switch is [speech ? "on" : "off"]. <a href='?src=\ref[src];speaker=[1]'>Toggle</a><br>"
+		dat += "Message is [message ? message : "unset"]. <a href='?src=\ref[src];msg=[1]'>Set</a><br>"
 
 	var/datum/browser/bot_win = new(user, "automed", "Automatic Medibot v1.2 Controls")
 	bot_win.set_content(dat)
@@ -217,6 +224,16 @@
 
 	else if (href_list["declaretreatment"] && (!locked || issilicon(usr)))
 		declare_treatment = !declare_treatment
+
+	else if (href_list["msg"] && (!locked || issilicon(usr)))
+		var/I = input(usr,"What will this medbot say?", "Set Message") as text|null
+		if(!I)
+			return
+		message = I
+		speech = 1
+
+	else if (href_list["speaker"] && (!locked || issilicon(usr)))
+		speech = !speech
 
 	attack_hand(usr)
 	return

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -226,7 +226,7 @@
 		declare_treatment = !declare_treatment
 
 	else if (href_list["msg"] && (!locked || issilicon(usr)))
-		var/I = input(usr,"What will this medbot say?", "Set Message") as text|null
+		var/I = sanitize(input(usr,"What will this medbot say?", "Set Message") as text|null)
 		if(!I)
 			return
 		message = I

--- a/html/changelogs/quietmedibots.yml
+++ b/html/changelogs/quietmedibots.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - rscdel: "Removes the default medbot messages. Medbots start with speech off."
-  - rscass: "Adds the ability for robotosists or doctors to give medbots custom messages instead."
+  - rscadd: "Adds the ability for robotosists or doctors to give medbots custom messages instead."

--- a/html/changelogs/quietmedibots.yml
+++ b/html/changelogs/quietmedibots.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - rscdel: "Removes the medibot speech feature. Nobody needed to know about a medkit's job aspirations."

--- a/html/changelogs/quietmedibots.yml
+++ b/html/changelogs/quietmedibots.yml
@@ -3,4 +3,5 @@ author: Sparky_hotdog
 delete-after: True
 
 changes:
-  - rscdel: "Removes the medibot speech feature. Nobody needed to know about a medkit's job aspirations."
+  - rscdel: "Removes the default medbot messages. Medbots start with speech off."
+  - rscass: "Adds the ability for robotosists or doctors to give medbots custom messages instead."

--- a/html/changelogs/quietmedibots.yml
+++ b/html/changelogs/quietmedibots.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - rscdel: "Removes the default medbot messages. Medbots start with speech off."
-  - rscadd: "Adds the ability for robotosists or doctors to give medbots custom messages instead."
+  - rscadd: "Adds the ability for robotisists or doctors to give medbots custom messages instead."


### PR DESCRIPTION
Sets the medbot speech to off to start. Removes the old list of messages. Allows those with access to give the bot a custom message.

### IC changelog
- rscdel: "Removes the default medbot messages. Medbots start with speech off."
- rscadd: "Adds the ability for roboticists or doctors to give medbots custom messages instead."