### PR TITLE
Bugfix Shotgun

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -201,7 +201,7 @@ var/obj/screen/robot_inventory
 				r.module.modules -= r.module.emag
 
 		if(r.malf_AI_module)
-			if(!((r.module.malf_AI_module in r.module.modules) && r.module.malf_AI_module == null))
+			if(!((r.module.malf_AI_module in r.module.modules) || r.module.malf_AI_module == null))
 				r.module.modules += r.module.malf_AI_module
 		else
 			if(r.module.malf_AI_module in r.module.modules)

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -125,6 +125,11 @@
 
 	// Upgrades!
 	if(is_type_in_list(W, possible_upgrades) && !is_type_in_list(W, upgrades)) // Is a possible upgrade and isn't in the camera already.
+		if(istype(W, /obj/item/stock_parts/scanning_module))
+			var/obj/item/stock_parts/scanning_module/SM = W
+			if(SM.rating < 2)
+				to_chat(user, SPAN_WARNING("That scanning module doesn't seem advanced enough."))
+				return
 		to_chat(user, "You attach \the [W] into the assembly inner circuits.")
 		upgrades += W
 		user.remove_from_mob(W)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -25,7 +25,7 @@
 	return attack_hand(user)
 
 /obj/machinery/computer/security/check_eye(var/mob/user as mob)
-	if (user.stat || ((get_dist(user, src) > 1 || !( user.canmove ) || user.blinded) && !istype(user, /mob/living/silicon))) //user can't see - not sure why canmove is here.
+	if (use_check_and_message(user) || user.blinded || inoperable())
 		return -1
 	if(!current_camera)
 		return 0

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -52,6 +52,9 @@
 	if(pulledby)
 		crumble()
 
+/obj/effect/decal/remains/can_fall()
+	return TRUE
+
 /obj/effect/decal/remains/attack_hand(mob/user)
 	crumble()
 

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -574,11 +574,11 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 		switch(new_state)
 			if("Normal")
-				pref.organ_data[limb] = null
-				pref.rlimb_data[limb] = null
+				pref.organ_data -= limb
+				pref.rlimb_data -= limb
 				if(third_limb)
-					pref.organ_data[third_limb] = null
-					pref.rlimb_data[third_limb] = null
+					pref.organ_data -= third_limb
+					pref.rlimb_data -= third_limb
 			if("Amputated")
 				pref.organ_data[limb] = "amputated"
 				pref.rlimb_data[limb] = null
@@ -744,4 +744,3 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		pref.rlimb_data[organ] = null
 	while(null in pref.rlimb_data)
 		pref.rlimb_data -= null*/
-

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1509,7 +1509,7 @@
 	var/direction = input(src,"Which way?","Tile selection") as anything in list("Here","North","South","East","West")
 	if (direction != "Here")
 		T = get_step(T,text2dir(direction))
-	if (!istype(T))
+	if (!istype(T) || !Adjacent(T))
 		to_chat(src, SPAN_WARNING("You cannot doodle there."))
 		return
 
@@ -1525,6 +1525,9 @@
 	var/message = sanitize(input("Write a message. It cannot be longer than [max_length] characters.","Blood writing", ""))
 
 	if (message)
+		if(!Adjacent(T))
+			to_chat(src, SPAN_WARNING("You're too far away!"))
+			return
 		var/used_blood_amount = round(length(message) / 30, 1)
 		bloody_hands = max(0, bloody_hands - used_blood_amount) //use up some blood
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -267,7 +267,7 @@ emp_act
 	// Handle striking to cripple.
 	if(user.a_intent == I_DISARM)
 		effective_force /= 2 //half the effective force
-		if(!..(I, effective_force, blocked, hit_zone))
+		if(!..(I, user, effective_force, blocked, hit_zone))
 			return 0
 
 		attack_joint(affecting, I, blocked) //but can dislocate joints

--- a/code/modules/modular_computers/file_system/programs/security/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/security/camera.dm
@@ -152,6 +152,12 @@
 	current_camera = null
 
 /datum/nano_module/camera_monitor/check_eye(var/mob/user as mob)
+	if(istype(ui_host(), /obj/machinery/computer))
+		var/obj/machinery/computer/C = ui_host()
+		if (C.use_check_and_message(user) || C.inoperable())
+			return -1
+	if(user.blinded)
+		return -1
 	if(!current_camera)
 		return 0
 	var/viewflag = current_camera.check_eye(user)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -737,7 +737,11 @@
 	L.visible_message(SPAN_DANGER("\The [L] had \the [src] fall onto [src.get_pronoun("him")]!"),
 		SPAN_DANGER("You had \the [src] fall onto you and strike you!"))
 
-	admin_attack_log((ismob(src) ? src : null), L, "fell onto", "was fallen on by", "fell ontop of")
+	if(istype(src, /mob/living/heavy_vehicle))
+		var/mob/living/heavy_vehicle/HV = src
+		admin_attack_log((HV.pilots.len ? HV.pilots[1] : null), L, "fell onto", "was fallen on by", "fell ontop of")
+	else
+		admin_attack_log((ismob(src) ? src : null), L, "fell onto", "was fallen on by", "fell ontop of")
 
 	playsound(L.loc, "sound/waepons/genhit[rand(1, 3)].ogg", 75, 1)
 

--- a/code/modules/nano/modules/lighting_ctrl.dm
+++ b/code/modules/nano/modules/lighting_ctrl.dm
@@ -2,7 +2,7 @@
 	name = "Lighting Control"
 	var/context = "pub"
 	var/lstate = "full"
-	var/mob/lusr = null 	// for admin logs
+	var/lusr = null 	// for admin logs
 
 /datum/nano_module/lighting_ctrl/New()
 	..()
@@ -35,7 +35,7 @@
 		update_lighting()
 
 /datum/nano_module/lighting_ctrl/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
-	lusr = user
+	lusr = WEAKREF(user)
 	var/list/data = host.initial_data()
 
 	data["context"] = context

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -81,7 +81,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		look(user)
 
 /obj/machinery/computer/ship/check_eye(var/mob/user)
-	if (!get_dist(user, src) > 1 || user.blinded || !linked )
+	if (use_check_and_message(user) || user.blinded || inoperable() || !linked)
 		unlook(user)
 		return -1
 	else

--- a/code/modules/power/sensors/sensor_monitoring.dm
+++ b/code/modules/power/sensors/sensor_monitoring.dm
@@ -32,12 +32,10 @@
 /obj/machinery/computer/power_monitor/update_icon()
 	if(stat & NOPOWER)
 		icon_screen = null
-		return
-	if(alerting)
+	else if(alerting)
 		icon_screen = "power_alert"
-		return
-	icon_screen = "power"
-
+	else
+		icon_screen = "power"
 	..()
 
 // On creation automatically connects to active sensors. This is delayed to ensure sensors already exist.

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -145,6 +145,9 @@
 			bolt = W
 			user.visible_message("<b>[user]</b> slides \the [bolt] into \the [src].", SPAN_NOTICE("You slide \the [bolt] into \the [src]."))
 			update_icon()
+			if(istype(W, /obj/item/arrow/rod) && W.throwforce < 15)
+				// un-heated converted arrow rod
+				superheat_rod(user)
 			return
 		else if(istype(W, /obj/item/stack/rods))
 			var/obj/item/stack/rods/R = W

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -398,7 +398,7 @@
 	if(!temp_set) // so initial temperature-setting doesn't make stuff explode
 		temp_set = TRUE
 		return
-	if(abs(added_energy) > (specific_heat * 5 / volume)) // can explode via cold or heat shock
+	if(added_energy > (specific_heat * 5 / volume))
 		explode()
 
 /datum/reagent/nitroglycerin/apply_force(var/force)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3972,42 +3972,49 @@
 	desc = "A portion sized chip good for dipping. This one has salsa on it."
 	icon_state = "chip_salsa"
 	bitten_state = "chip_half"
+	bitesize = 2
 
 /obj/item/reagent_containers/food/snacks/chip/guac
 	name = "guac chip"
 	desc = "A portion sized chip good for dipping. This one has guac on it."
 	icon_state = "chip_guac"
 	bitten_state = "chip_half"
+	bitesize = 2
 
 /obj/item/reagent_containers/food/snacks/chip/cheese
 	name = "cheese chip"
 	desc = "A portion sized chip good for dipping. This one has cheese sauce on it."
 	icon_state = "chip_cheese"
 	bitten_state = "chip_half"
+	bitesize = 2
 
 /obj/item/reagent_containers/food/snacks/chip/nacho
 	name = "nacho chip"
 	desc = "A nacho ship stray from a plate of cheesy nachos."
 	icon_state = "chip_nacho"
 	bitten_state = "chip_half"
+	bitesize = 2
 
 /obj/item/reagent_containers/food/snacks/chip/nacho/salsa
 	name = "nacho chip"
 	desc = "A nacho ship stray from a plate of cheesy nachos. This one has salsa on it."
 	icon_state = "chip_nacho_salsa"
 	bitten_state = "chip_half"
+	bitesize = 2
 
 /obj/item/reagent_containers/food/snacks/chip/nacho/guac
 	name = "nacho chip"
 	desc = "A nacho ship stray from a plate of cheesy nachos. This one has guac on it."
 	icon_state = "chip_nacho_guac"
 	bitten_state = "chip_half"
+	bitesize = 2
 
 /obj/item/reagent_containers/food/snacks/chip/nacho/cheese
 	name = "nacho chip"
 	desc = "A nacho ship stray from a plate of cheesy nachos. This one has extra cheese on it."
 	icon_state = "chip_nacho_cheese"
 	bitten_state = "chip_half"
+	bitesize = 2
 
 // chip plates
 /obj/item/reagent_containers/food/snacks/chipplate
@@ -4862,4 +4869,3 @@
 	reagents_to_add = list(/datum/reagent/nutriment = 6)
 	trash = /obj/item/trash/diona_bites
 	bitesize = 3
-

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -156,6 +156,12 @@
 	..()
 
 /decl/surgery_step/robotics/repair_brute/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if(tool.iswelder())
+		var/obj/item/weldingtool/welder = tool
+		if(!welder.isOn())
+			user.visible_message(SPAN_WARNING("[user]'s [tool] shut off before the procedure was finished."), \
+			SPAN_WARNING("Your [tool] is shut off!"))
+			return
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<b>[user]</b> finishes patching damage to [target]'s [affected.name] with \the [tool].", \
 		SPAN_NOTICE("You finish patching damage to [target]'s [affected.name] with \the [tool]."))

--- a/html/changelogs/johnwildkins-bugfixgalore.yml
+++ b/html/changelogs/johnwildkins-bugfixgalore.yml
@@ -3,6 +3,7 @@ author: JohnWildkins
 delete-after: True
 
 changes:
+  - tweak: "Repairing a robotic body part with a welding tool now fails (without damage) if it runs out of fuel before completion."
   - bugfix: "Nitroglycerin no longer explodes upon mixing, nor does it explode due to cold temperatures."
   - bugfix: "IPCs are no longer able to make their limbs human in character setup."
   - bugfix: "Stowing or equipping the RCD-T (malf fabricator) as a construction borg should no longer create an infinite inventory."

--- a/html/changelogs/johnwildkins-bugfixgalore.yml
+++ b/html/changelogs/johnwildkins-bugfixgalore.yml
@@ -1,0 +1,14 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Nitroglycerin no longer explodes upon mixing, nor does it explode due to cold temperatures."
+  - bugfix: "IPCs are no longer able to make their limbs human in character setup."
+  - bugfix: "Stowing or equipping the RCD-T (malf fabricator) as a construction borg should no longer create an infinite inventory."
+  - bugfix: "Using too low of a quality of scanning module in the camera upgrade process will now produce a warning."
+  - bugfix: "Camera monitors should no longer trap players inside them if they lose power."
+  - bugfix: "Writing in blood now checks for adjacency to the tile at each step of the writing process."
+  - bugfix: "Rat skeletons (and other remains) now feel the effects of gravity, and should fall appropriately."
+  - bugfix: "The unbitten half of a bitten chip is no longer able to infinitely produce nutrition via salsa or other dips."
+  - bugfix: "Rods should no longer fail to superheat on a properly charged crossbow."


### PR DESCRIPTION
Video for reference: https://youtu.be/E6SwOQ_56Lc?t=14

  - tweak: "Repairing a robotic body part with a welding tool now fails (without damage) if it runs out of fuel before completion."
  - bugfix: "Nitroglycerin no longer explodes upon mixing, nor does it explode due to cold temperatures."
  - bugfix: "IPCs are no longer able to make their limbs human in character setup."
  - bugfix: "Stowing or equipping the RCD-T (malf fabricator) as a construction borg should no longer create an infinite inventory."
  - bugfix: "Using too low of a quality of scanning module in the camera upgrade process will now produce a warning."
  - bugfix: "Camera monitors should no longer trap players inside them if they lose power."
  - bugfix: "Writing in blood now checks for adjacency to the tile at each step of the writing process."
  - bugfix: "Rat skeletons (and other remains) now feel the effects of gravity, and should fall appropriately."
  - bugfix: "The unbitten half of a bitten chip is no longer able to infinitely produce nutrition via salsa or other dips."
  - bugfix: "Rods should no longer fail to superheat on a properly charged crossbow."

Also some back-end refactoring of things for logging and the like. See linked issues below for more info.

Fixes #7148
Fixes #7286
Fixes #6169
Fixes #6073
Fixes #5402
Fixes #4707
Fixes #4537
Fixes #4491
Fixes #4332
Fixes #4255
Fixes #3938
Fixes #3844
Fixes #3808
