### PR TITLE
Fix scrollbars not appearing on some UIs, debug icon appearing for non-devs, close handling

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -29,6 +29,14 @@
 			..()
 		return
 
+	if(href_list["vueuiclose"])
+		var/datum/vueui/ui = locate(href_list["src"])
+		if(istype(ui))
+			ui.close()
+		else // UI is an orphan, close it directly.
+			src << browse(null, "window=vueui[href_list["vueuiclose"]]")
+		return
+
 	// asset_cache
 	if(href_list["asset_cache_confirm_arrival"])
 		//to_chat(src, "ASSET JOB [href_list["asset_cache_confirm_arrival"]] ARRIVED.")
@@ -749,5 +757,3 @@
 				M.set_dir(get_dir(M, over_object))
 				gun.Fire(get_turf(over_object), mob, params, (get_dist(over_object, mob) <= 1), FALSE)
 	CHECK_TICK
-
-

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -34,7 +34,7 @@
 		if(istype(ui))
 			ui.close()
 		else // UI is an orphan, close it directly.
-			src << browse(null, "window=vueui[href_list["vueuiclose"]]")
+			src << browse(null, "window=vueui[href_list["src"]]")
 		return
 
 	// asset_cache

--- a/code/modules/vueui/ui.dm
+++ b/code/modules/vueui/ui.dm
@@ -251,9 +251,6 @@ main ui datum.
   */
 /datum/vueui/Topic(href, href_list)
 	. = update_status(FALSE)
-	if(href_list["vueuiclose"])
-		close()
-		return
 	if(status < STATUS_INTERACTIVE || user != usr)
 		return
 	if(href_list["vueuiforceresource"])
@@ -388,10 +385,10 @@ main ui datum.
   * @return themes class - text
   */
 /datum/vueui/proc/get_theme_class()
-	return SStheming.get_html_theme_class(user)
+	return "vueui " + SStheming.get_html_theme_class(user)
 
 /datum/vueui/modularcomputer
 	header = "modular-computer"
 
 /datum/vueui/modularcomputer/get_theme_class()
-	return "theme-nano dark-theme"
+	return "vueui theme-nano dark-theme"

--- a/vueui/src/assets/global.scss
+++ b/vueui/src/assets/global.scss
@@ -17,9 +17,12 @@ body {
     margin: 0px;
     padding: 8px;
     font-family: Arial, Helvetica, sans-serif;
-    overflow-y: hidden;
     overflow-x: auto;
     min-width: 240px;
+}
+
+body.vueui {
+    overflow-y: hidden;
 }
 
 #content {
@@ -160,7 +163,7 @@ a, .button, button, input[type=submit], input[type=button], input[type=reset], i
 }
 
 .hidden {
-    display: none;
+    display: none !important;
 }
 
 .notice {


### PR DESCRIPTION
turns out some barebones BYOND UIs inherited Vue styling and thus had no scrollbars, this fixes that
also makes sure the debug icon is hidden if you shouldn't be able to see it
also ports moving the close call to client_procs.dm, thanks @Karolis2011 
