### PR TITLE
Bugfix Shotgun 3: The Revengeance

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -154,7 +154,7 @@
 	var/datum/gas_mixture/airtank
 
 	var/stasis_power = 20
-	var/degradation_time = 2 MINUTES //ticks until stasis power degrades
+	var/degradation_time = 60 // 2 minutes: 60 ticks * 2 seconds per tick
 
 /obj/structure/closet/body_bag/cryobag/Initialize()
 	. = ..()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -14,6 +14,7 @@
 	build_amt = 2
 	var/material/reinf_material
 	var/reinforcing = 0
+	var/plating = FALSE
 
 /obj/structure/girder/examine(mob/user, distance, infix, suffix)
 	. = ..()
@@ -213,10 +214,17 @@
 		to_chat(user, "<span class='notice'>This material is too soft for use in wall construction.</span>")
 		return 0
 
-	to_chat(user, "<span class='notice'>You begin adding the plating...</span>")
+	if(!plating)
+		to_chat(user, "<span class='notice'>You begin adding the plating...</span>")
+		plating = TRUE
+	else
+		return TRUE
 
 	if(!do_after(user,40) || !S.use(2))
+		plating = FALSE
 		return 1 //once we've gotten this far don't call parent attackby()
+
+	plating = FALSE
 
 	if(anchored)
 		to_chat(user, "<span class='notice'>You added the plating!</span>")

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -454,6 +454,9 @@
 
 	// Filling/emptying open reagent containers
 	var/obj/item/reagent_containers/RG = O
+	if (istype(RG, /obj/item/reagent_containers/glass/rag))
+		return
+
 	if (istype(RG) && RG.is_open_container())
 		var/atype = alert(usr, "Do you want to fill or empty \the [RG] at \the [src]?", "Fill or Empty", "Fill", "Empty", "Cancel")
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -599,6 +599,7 @@
 /obj/item/clothing/mask/proc/adjust_mask(mob/user, var/self = TRUE)
 	set name = "Adjust Mask"
 	set category = "Object"
+	set src in usr
 
 	if(!adjustable)
 		return

--- a/code/modules/cooking/recipes/recipes_meat.dm
+++ b/code/modules/cooking/recipes/recipes_meat.dm
@@ -85,3 +85,15 @@
 		/obj/item/reagent_containers/food/snacks/fish
 	)
 	result = /obj/item/reagent_containers/food/snacks/fishandchips
+
+/decl/recipe/lasagna
+	appliance = OVEN
+	fruit = list("tomato" = 2, "eggplant" = 1)
+	items = list(
+		/obj/item/reagent_containers/food/snacks/sliceable/flatdough,
+		/obj/item/reagent_containers/food/snacks/sliceable/flatdough,
+		/obj/item/reagent_containers/food/snacks/meat,
+		/obj/item/reagent_containers/food/snacks/meat
+	)
+	result = /obj/item/reagent_containers/food/snacks/lasagna
+	reagent_mix = RECIPE_REAGENT_REPLACE

--- a/code/modules/cooking/recipes/recipes_mix.dm
+++ b/code/modules/cooking/recipes/recipes_mix.dm
@@ -74,8 +74,8 @@
 /decl/recipe/monkeykabob
 	items = list(
 		/obj/item/stack/rods,
-		/obj/item/reagent_containers/food/snacks/meat/monkey,
-		/obj/item/reagent_containers/food/snacks/meat/monkey
+		/obj/item/reagent_containers/food/snacks/meat,
+		/obj/item/reagent_containers/food/snacks/meat
 	)
 	result = /obj/item/reagent_containers/food/snacks/monkeykabob
 
@@ -265,6 +265,16 @@
 		/obj/item/reagent_containers/food/snacks/bacon
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/bacon
+
+/decl/recipe/blt
+	fruit = list("tomato" = 1, "cabbage" = 1)
+	items = list(
+		/obj/item/reagent_containers/food/snacks/breadslice,
+		/obj/item/reagent_containers/food/snacks/breadslice,
+		/obj/item/reagent_containers/food/snacks/bacon,
+		/obj/item/reagent_containers/food/snacks/bacon
+	)
+	result = /obj/item/reagent_containers/food/snacks/blt
 
 /decl/recipe/fish_taco
 	appliance = MIX | SKILLET

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -181,7 +181,7 @@
 	if(!proximity)
 		return
 
-	if(istype(A, /obj/structure/reagent_dispensers) || istype(A, /obj/structure/mopbucket) || istype(A, /obj/item/reagent_containers/glass))
+	if(istype(A, /obj/structure/reagent_dispensers) || istype(A, /obj/structure/mopbucket) || istype(A, /obj/item/reagent_containers/glass) || istype(A, /obj/structure/sink))
 		if(!reagents.get_free_space())
 			to_chat(user, SPAN_WARNING("\The [src] is already soaked."))
 			return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -580,7 +580,8 @@
 			log_and_message_admins("[key_name(user)] commited suicide using \a [src]")
 			user.apply_damage(in_chamber.damage*2.5, in_chamber.damage_type, BP_HEAD, used_weapon = "Point blank shot in the mouth with \a [in_chamber]", damage_flags = DAM_SHARP)
 			user.death()
-		qdel(in_chamber)
+
+		handle_post_fire(user, user, FALSE, FALSE, FALSE)
 		mouthshoot = FALSE
 		return
 	else

--- a/html/changelogs/johnwildkins-bugfixshotgun-3.yml
+++ b/html/changelogs/johnwildkins-bugfixshotgun-3.yml
@@ -1,0 +1,11 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "It is no longer possible to send hundreds of sheets of metal to the shadow realm by clicking on a girder repeatedly."
+  - bugfix: "Meat kabobs can now be made using normal slabs of meat once again. Lasagna (2 flat dough, 2 meat, 2 tomato and 1 eggplant in the oven) and BLTs have had their recipes re-added as well."
+  - bugfix: "Stasis bags should now degrade properly."
+  - bugfix: "Committing suicide with a gun no longer summons bullets from hammerspace, nor does it completely break the gun."
+  - bugfix: "Adjust Mask verb should now work properly."
+  - bugfix: "Attempting to wet dry rags with sinks should no longer attempt to wipe down the sink (and thus the floor below it)."


### PR DESCRIPTION
As some were confused last time, no, this is not a bugfix for shotguns. (Although, this one _does_ include a bugfix for guns in general.)

  - bugfix: "It is no longer possible to send hundreds of sheets of metal to the shadow realm by clicking on a girder repeatedly."
  - bugfix: "Meat kabobs can now be made using normal slabs of meat once again. Lasagna (2 flat dough, 2 meat, 2 tomato and 1 eggplant in the oven) and BLTs have had their recipes re-added as well."
  - bugfix: "Stasis bags should now degrade properly."
  - bugfix: "Committing suicide with a gun no longer summons bullets from hammerspace, nor does it completely break the gun."
  - bugfix: "Adjust Mask verb should now work properly."
  - bugfix: "Attempting to wet dry rags with sinks should no longer attempt to wipe down the sink (and thus the floor below it)."

Fixes #9880 
Fixes #9892 
Fixes #10198 
Fixes #10193 
Fixes #10260 
Fixes #3761 
Fixes #4997
Fixes #5118