### PR TITLE
Mining Drone Stuff

### DIFF
--- a/code/controllers/subsystems/initialization/atoms.dm
+++ b/code/controllers/subsystems/initialization/atoms.dm
@@ -13,6 +13,8 @@ var/datum/controller/subsystem/atoms/SSatoms
 	var/initialized = INITIALIZATION_INSSATOMS
 	var/old_initialized
 
+	var/list/late_misc_firers // this is a list of things that fire when late misc init is called
+
 	var/list/late_loaders
 	var/list/created_atoms
 	var/list/late_qdel

--- a/code/controllers/subsystems/initialization/misc_late.dm
+++ b/code/controllers/subsystems/initialization/misc_late.dm
@@ -37,8 +37,14 @@
 	populate_code_phrases()
 
 	// this covers mapped in drone fabs
-	for(var/obj/machinery/drone_fabricator/DF in SSmachinery.all_machines)
-		DF.enable_drone_spawn()
+	for(var/thing in SSatoms.late_misc_firers)
+		if(istype(thing, /obj/machinery/drone_fabricator))
+			var/obj/machinery/drone_fabricator/DF = thing
+			DF.enable_drone_spawn()
+		else if(istype(thing, /mob/living/silicon/robot/drone/mining))
+			var/mob/living/silicon/robot/drone/mining/MD = thing
+			MD.request_player()
+		LAZYREMOVE(SSatoms.late_misc_firers, thing)
 
 	if (config.use_forumuser_api)
 		update_admins_from_api(TRUE)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -152,7 +152,7 @@
 		var/mob/M = AM
 		if(world.time - M.last_bumped <= 10) return	//Can bump-open one airlock per second. This is to prevent shock spam.
 		M.last_bumped = world.time
-		if(!M.restrained() && (!issmall(M) || ishuman(M)))
+		if(!M.restrained() && (!issmall(M) || ishuman(M) || istype(M, /mob/living/silicon/robot/drone/mining)))
 			bumpopen(M)
 		return
 

--- a/code/game/objects/items/weapons/RFD.dm
+++ b/code/game/objects/items/weapons/RFD.dm
@@ -441,13 +441,16 @@ RFD Mining-Class
 	icon_state = "rfd-m"
 	item_state = "rfd-m"
 
-/obj/item/rfd/mining/afterattack(atom/A, mob/user, proximity)
+/obj/item/rfd/mining/attack_self(mob/user)
+	return
+
+/obj/item/rfd/mining/afterattack(atom/A, mob/user, proximity, click_parameters, var/report_duplicate = TRUE)
 	if(!proximity)
 		return
 
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
-		if(R.stat || !R.cell || R.cell.charge <= 500)
+		if(R.stat || !R.cell || R.cell.charge <= 200)
 			if(last_fail <= world.time - 20) //Spam limiter.
 				last_fail = world.time
 				to_chat(user, SPAN_WARNING("You are unable to produce enough charge to use \the [src]!"))
@@ -467,7 +470,8 @@ RFD Mining-Class
 		return
 
 	if(locate(/obj/structure/track) in A)
-		to_chat(user, SPAN_WARNING("There is already a track on \the [A]!"))
+		if(report_duplicate)
+			to_chat(user, SPAN_WARNING("There is already a track on \the [A]!"))
 		return
 
 	playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
@@ -480,7 +484,7 @@ RFD Mining-Class
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
 		if(R.cell)
-			R.cell.use(500)
+			R.cell.use(200)
 	else
 		stored_matter--
 		to_chat(user, SPAN_NOTICE("The RFD now holds <b>[stored_matter]/30</b> fabrication-units."))

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -425,7 +425,7 @@ var/const/NO_EMAG_ACT = -50
 	assignment = "Minedrone"
 
 /obj/item/card/id/minedrone/New()
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station, access_external_airlocks)
 	..()
 
 /obj/item/card/id/centcom

--- a/code/game/objects/items/weapons/tether.dm
+++ b/code/game/objects/items/weapons/tether.dm
@@ -35,10 +35,8 @@ var/list/global/all_tethers = list()
 
 /obj/item/tethering_device/process()
 	var/turf/our_turf = get_turf(src)
-	for(var/tether in all_tethers)
+	for(var/tether in all_tethers - src)
 		var/obj/item/tethering_device/TD = tether
-		if(TD == src)
-			continue
 		if(!TD.active)
 			continue
 		var/turf/target_turf = get_turf(TD)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -752,8 +752,16 @@
 				return
 
 		if(istype(M) && !M.incapacitated())
-			var/obj/item/gun/gun = mob.get_active_hand()
-			if(istype(gun) && gun.can_autofire())
-				M.set_dir(get_dir(M, over_object))
-				gun.Fire(get_turf(over_object), mob, params, (get_dist(over_object, mob) <= 1), FALSE)
+			var/obj/item/I = M.get_active_hand()
+			if(istype(I, /obj/item/gun))
+				var/obj/item/gun/gun = I
+				if(gun.can_autofire())
+					M.set_dir(get_dir(M, over_object))
+					gun.Fire(get_turf(over_object), M, params, (get_dist(over_object, M) <= 1), FALSE)
+
+			if(istype(I, /obj/item/rfd/mining) && isturf(over_object))
+				var/proximity = M.Adjacent(over_object)
+				var/obj/item/rfd/mining/RFDM = I
+				RFDM.afterattack(over_object, M, proximity, params, FALSE)
+
 	CHECK_TICK

--- a/code/modules/ghostroles/spawner/atom/mining_drone.dm
+++ b/code/modules/ghostroles/spawner/atom/mining_drone.dm
@@ -2,6 +2,7 @@
 	short_name = "mining_drone"
 	name = "Mining Drone"
 	desc = "Join in as a Mining Drone, assist the miners, get lost on the asteroid and cry synthetic tears."
+	show_on_job_select = FALSE
 	tags = list("Stationbound")
 
 	respawn_flag = MINISYNTH //Flag to check for when trying to spawn someone of that type (CREW, ANIMAL, MINISYNTH)

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -114,6 +114,12 @@
 		start_self_destruct(TRUE)
 	return TRUE
 
+/mob/living/silicon/robot/drone/mining/update_robot_light()
+	if(lights_on)
+		set_light(5, 1, LIGHT_COLOR_FIRE, angle = LIGHT_OMNI)
+	else
+		set_light(0)
+
 /**********************Minebot Upgrades**********************/
 
 /obj/item/device/mine_bot_upgrade
@@ -183,3 +189,10 @@
 	M.recalculate_synth_capacities()
 	qdel(src)
 	return TRUE
+
+/mob/living/silicon/robot/drone/mining/roundstart/Initialize()
+	. = ..()
+	if(SSticker.current_state == GAME_STATE_PLAYING)
+		request_player()
+	else
+		LAZYADD(SSatoms.late_misc_firers, src)

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -32,6 +32,8 @@
 	. = ..()
 	if(SSticker.current_state == GAME_STATE_PLAYING)
 		enable_drone_spawn()
+	else
+		LAZYADD(SSatoms.late_misc_firers, src)
 
 /obj/machinery/drone_fabricator/Destroy()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -119,7 +119,7 @@ var/global/list/robot_modules = list(
 		else if(F.times_used)
 			F.times_used--
 
-	if(E?.reagents.total_volume < E.reagents.maximum_volume)
+	if(E && E.reagents.total_volume < E.reagents.maximum_volume)
 		E.reagents.add_reagent(/datum/reagent/toxin/fertilizer/monoammoniumphosphate, E.max_water * 0.2)
 
 	if(!synths.len)
@@ -975,12 +975,19 @@ var/global/list/robot_modules = list(
 	modules += new /obj/item/mining_scanner(src)
 	modules += new /obj/item/device/gps/mining(src)
 	modules += new /obj/item/tank/jetpack/carbondioxide(src)
+	modules += new /obj/item/rfd/mining(src)
+	modules += new /obj/item/tethering_device(src)
 
 	var/datum/matter_synth/metal = new /datum/matter_synth/metal(20000)
 	synths += metal
+
 	var/obj/item/stack/rods/cyborg/rods = new /obj/item/stack/rods/cyborg(src)
 	rods.synths = list(metal)
 	modules += rods
+
+	var/obj/item/stack/flag/purple/borg/beacons = new /obj/item/stack/flag/purple/borg(src)
+	beacons.synths = list(metal)
+	modules += beacons
 
 	emag = new /obj/item/gun/energy/plasmacutter/mounted(src)
 	emag.name = "Mounted Plasma Cutter"

--- a/html/changelogs/geeves-mining_stuff.yml
+++ b/html/changelogs/geeves-mining_stuff.yml
@@ -1,0 +1,13 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Mapped in two basic mining drones in the external tool storage area (where the minecarts are)."
+  - rscadd: "Mining drones now come equipped with an RFD-M, a tethering device, and a stack of purple flags."
+  - rscadd: "Mining drones can now bump against doors to open them."
+  - rscadd: "Mining drones now have external airlock access."
+  - rscadd: "You can now click-drag with the RFD-M to lay down track."
+  - tweak: "The charge cost for robots using the RFD-M has been lowered to 200, down from 500."
+  - rscdel: "Mining drones no longer appear as a unique role on the round join menu."
+  - tweak: "Mining drone lights are now much brighter, and illuminate in a circle around the drone."

--- a/html/changelogs/geeves-mining_stuff.yml
+++ b/html/changelogs/geeves-mining_stuff.yml
@@ -3,7 +3,6 @@ author: Geeves
 delete-after: True
 
 changes:
-  - rscadd: "Mapped in two basic mining drones in the external tool storage area (where the minecarts are)."
   - rscadd: "Mining drones now come equipped with an RFD-M, a tethering device, and a stack of purple flags."
   - rscadd: "Mining drones can now bump against doors to open them."
   - rscadd: "Mining drones now have external airlock access."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -62284,6 +62284,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig/processing)
+"iyN" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/mob/living/silicon/robot/drone/mining/roundstart,
+/turf/simulated/floor/tiled/asteroid/airless,
+/area/outpost/mining_main/eva)
 "izh" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
@@ -63888,6 +63893,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/asteroid/airless,
 /area/outpost/mining_main/eva)
 "mya" = (
@@ -93343,7 +93349,7 @@ cbQ
 cev
 ceN
 cfh
-ceN
+iyN
 cfx
 cey
 cgm
@@ -93600,7 +93606,7 @@ cbQ
 cex
 ceO
 cfi
-ceN
+iyN
 cfx
 cey
 cgn

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -62284,11 +62284,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig/processing)
-"iyN" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/mob/living/silicon/robot/drone/mining/roundstart,
-/turf/simulated/floor/tiled/asteroid/airless,
-/area/outpost/mining_main/eva)
 "izh" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
@@ -93349,7 +93344,7 @@ cbQ
 cev
 ceN
 cfh
-iyN
+ceN
 cfx
 cey
 cgm
@@ -93606,7 +93601,7 @@ cbQ
 cex
 ceO
 cfi
-iyN
+ceN
 cfx
 cey
 cgn


### PR DESCRIPTION
* Mining drones now come equipped with an RFD-M, a tethering device, and a stack of purple flags.
* Mining drones can now bump against doors to open them.
* Mining drones now have external airlock access.
* You can now click-drag with the RFD-M to lay down track.
* The charge cost for robots using the RFD-M has been lowered to 200, down from 500.
* Mining drones no longer appear as a unique role on the round join menu.
* Mining drone lights are now much brighter, and illuminate in a circle around the drone.