### PR TITLE
Drill Gripper Additions

### DIFF
--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -16,7 +16,7 @@
 /obj/structure/ore_box/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/ore))
 		user.drop_from_inventory(W, src)
-	if(istype(W, /obj/item/storage/bag/ore))
+	else if(istype(W, /obj/item/storage/bag/ore))
 		var/obj/item/storage/bag/ore/satchel = W
 		if(satchel.linked_beacon)
 			if(!warp_core)
@@ -25,7 +25,7 @@
 			satchel.linked_box = src
 			to_chat(user, SPAN_NOTICE("You link \the [satchel] to \the [src]."))
 			return
-	if(istype(W, /obj/item/storage))
+	else if(istype(W, /obj/item/storage))
 		var/obj/item/storage/S = W
 		S.hide_from(user)
 		for(var/obj/item/ore/O in S.contents)
@@ -33,13 +33,23 @@
 			CHECK_TICK
 		S.post_remove_from_storage_deferred(loc, user)
 		to_chat(user, SPAN_NOTICE("You empty the satchel into the box."))
-	if(istype(W, /obj/item/warp_core))
+	else if(istype(W, /obj/item/warp_core))
 		if(warp_core)
 			to_chat(user, SPAN_WARNING("\The [src] already has a warp core attached!"))
 			return
 		user.drop_from_inventory(W, src)
 		warp_core = W
 		to_chat(user, SPAN_NOTICE("You carefully attach \the [W] to \the [src], connecting it to the bluespace network."))
+	else if(istype(W, /obj/item/gripper/miner)) // myazaki's gonna be so mad at me
+		var/obj/item/gripper/miner/GM = W
+		if(!warp_core)
+			to_chat(user, SPAN_WARNING("\The [src] has no warp core to detach."))
+			return
+		// we don't need to check if it has a held item because the gripper code attacks with the held item if it has one, not the gripper itself
+		warp_core.forceMove(get_turf(src))
+		GM.grip_item(warp_core, user, FALSE)
+		to_chat(user, SPAN_NOTICE("You detach \the [warp_core] from \the [src], disconnecting it from the bluespace network."))
+		warp_core = null
 
 	update_ore_count()
 	return

--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -57,6 +57,8 @@
 			if(istype(I,typepath))
 				if(feedback)
 					to_chat(user, SPAN_NOTICE("You collect \the [I]."))
+				if(isturf(I.loc) && I.Adjacent(user))
+					I.do_pickup_animation(user)
 				I.forceMove(src)
 				wrapped = I
 				wrapped.pixel_x = 0
@@ -179,13 +181,15 @@
 // VEEEEERY limited version for mining borgs. Basically only for swapping cells, upgrading the drills, and upgrading custom KAs.
 /obj/item/gripper/miner
 	name = "drill maintenance gripper"
-	desc = "A simple grasping tool for the maintenance of heavy drilling machines."
+	desc = "A simple grasping tool for the maintenance and upgrade of heavy drilling machines."
 	icon_state = "gripper-mining"
 
 	can_hold = list(
 		/obj/item/cell,
 		/obj/item/stock_parts,
-		/obj/item/custom_ka_upgrade
+		/obj/item/custom_ka_upgrade,
+		/obj/item/warp_core,
+		/obj/item/extraction_pack
 	)
 
 /obj/item/gripper/paperwork

--- a/html/changelogs/geeves-drill_gripper.yml
+++ b/html/changelogs/geeves-drill_gripper.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Mining drone and stationbound drill maintenance grippers can now pick up warp extraction gear, pack and core. They can also be used to remove the core from an ore box."
+  - rscadd: "Gripping an item with a gripper now plays a pick-up animation."


### PR DESCRIPTION
* Mining drone and stationbound drill maintenance grippers can now pick up warp extraction gear, pack and core. They can also be used to remove the core from an ore box.
* Gripping an item with a gripper now plays a pick-up animation.