### PR TITLE
Cult Ghost Mouse Opacity Fix

### DIFF
--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -747,6 +747,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(src, "<span class='info'>You are now visible!</span>")
 
 	invisibility = invisibility == INVISIBILITY_OBSERVER ? 0 : INVISIBILITY_OBSERVER
+	mouse_opacity = invisibility == INVISIBILITY_OBSERVER ? 0 : initial(mouse_opacity)
 	// Give the ghost a cult icon which should be visible only to itself
 	toggle_icon("cult")
 

--- a/html/changelogs/geeves-no_ghost_clicks.yml
+++ b/html/changelogs/geeves-no_ghost_clicks.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Cult ghosts can no longer be clicked on or hovered over, thus they cannot block clicks."


### PR DESCRIPTION
* Cult ghosts can no longer be clicked on or hovered over, thus they cannot block clicks.

Fixes https://github.com/Aurorastation/Aurora.3/issues/5362