### PR TITLE
Better Energy Net

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -8,30 +8,29 @@
 	var/net_type = /obj/effect/energy_net
 
 /obj/item/energy_net/dropped()
-	spawn(10)
-		if(src) qdel(src)
+	if(!QDELETED(src))
+		QDEL_IN(src, 1)
 
 /obj/item/energy_net/throw_impact(atom/hit_atom)
 	..()
 
 	var/mob/living/M = hit_atom
-
-	if(!istype(M) || locate(/obj/effect/energy_net) in M.loc)
+	if(!istype(M))
 		qdel(src)
-		return 0
+		return
+	var/obj/effect/energy_net/EN = locate() in get_turf(M)
+	if(EN)
+		qdel(EN)
 
 	var/turf/T = get_turf(M)
 	if(T)
 		var/obj/effect/energy_net/net = new net_type(T)
-		net.layer = M.layer+1
-		M.captured = 1
+		net.layer = M.layer + 1
+		M.captured = TRUE
+		M.update_canmove()
 		net.affecting = M
-		T.visible_message("[M] was caught in an energy net!")
+		M.visible_message(SPAN_DANGER("\The [M] was caught in \the [net]!"), SPAN_DANGER("You get caught in \the [net]!"))
 		qdel(src)
-
-	// If we miss or hit an obstacle, we still want to delete the net.
-	spawn(10)
-		if(src) qdel(src)
 
 /obj/effect/energy_net
 	name = "energy net"
@@ -39,114 +38,77 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "energynet"
 
-	density = 1
-	opacity = 0
-	mouse_opacity = 1
-	anchored = 1
+	density = TRUE
+	opacity = FALSE
+	anchored = TRUE
 
-	var/health = 25
+	var/health = 50
 	var/mob/living/affecting = null //Who it is currently affecting, if anyone.
-	var/mob/living/master = null    //Who shot web. Will let this person know if the net was successful.
-	var/countdown = -1
-
-/obj/effect/energy_net/teleport
-	countdown = 60
 
 /obj/effect/energy_net/Initialize()
 	. = ..()
 	START_PROCESSING(SSprocessing, src)
 
 /obj/effect/energy_net/Destroy()
+	STOP_PROCESSING(SSprocessing, src)
 
 	if(affecting)
-		var/mob/living/carbon/M = affecting
-		M.anchored = initial(affecting.anchored)
-		M.captured = 0
-		to_chat(M, "You are free of the net!")
+		affecting.anchored = initial(affecting.anchored)
+		affecting.captured = FALSE
+		affecting.update_canmove()
+		to_chat(affecting, SPAN_GOOD("You are free of the net!"))
+		affecting = null
 
-	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 
-/obj/effect/energy_net/proc/healthcheck()
-
-	if(health <=0)
-		density = 0
-		src.visible_message("The energy net is torn apart!")
+/obj/effect/energy_net/proc/health_check()
+	if(health <= 0)
+		density = FALSE
+		src.visible_message(SPAN_WARNING("\The [src] is torn apart!"))
 		qdel(src)
-	return
 
 /obj/effect/energy_net/process()
-
-	if(isnull(affecting) || affecting.loc != loc)
+	if(isnull(affecting) || get_turf(src) != get_turf(affecting))
 		qdel(src)
 		return
-
-	// Countdown begin set to -1 will stop the teleporter from firing.
-	// Clientless mobs can be netted but they will not teleport or decrement the timer.
-	var/mob/living/M = affecting
-	if(countdown == -1 || (istype(M) && !M.client))
-		return
-
-	if(countdown > 0)
-		countdown--
-		return
-
-	// TODO: consider removing or altering this; energy nets are useful on their own
-	// merits and the teleportation was never properly implemented; it's halfassed.
-	density = 0
-	invisibility = 101 //Make the net invisible so all the animations can play out.
-	health = INFINITY  //Make the net invincible so that an explosion/something else won't kill it during anims.
-
-	playsound(affecting.loc, 'sound/effects/sparks4.ogg', 50, 1)
-	anim(affecting.loc,affecting,'icons/mob/mob.dmi',,"phaseout",,affecting.dir)
-
-	affecting.visible_message("[affecting] vanishes in a flare of light!")
-
-	if(holdingfacility.len)
-		affecting.forceMove(pick(holdingfacility))
-
-	to_chat(affecting, "You appear in a strange place!")
-
-	playsound(affecting.loc, 'sound/effects/phasein.ogg', 25, 1)
-	playsound(affecting.loc, 'sound/effects/sparks2.ogg', 50, 1)
-	anim(affecting.loc,affecting,'icons/mob/mob.dmi',,"phasein",,affecting.dir)
-
-	qdel(src)
 
 /obj/effect/energy_net/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.get_structure_damage()
-	healthcheck()
-	return 0
+	health_check()
+	return FALSE
 
 /obj/effect/energy_net/ex_act(var/severity = 2.0)
 	health = 0
-	healthcheck()
+	health_check()
 
 /obj/effect/energy_net/attack_hand(var/mob/user)
-
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.do_attack_animation(src, FIST_ATTACK_ANIMATION)
+	if(user == affecting)
+		to_chat(user, SPAN_WARNING("You can't claw at \the [src] while trapped inside it! You need to use a weapon."))
+		return
 	var/mob/living/carbon/human/H = user
 	if(istype(H))
 		if(H.species.can_shred(H))
 			playsound(src.loc, 'sound/weapons/slash.ogg', 80, 1)
 			health -= rand(10, 20)
 		else
-			health -= rand(1,3)
-
+			health -= rand(1, 3)
 	else if (HULK in user.mutations)
 		health = 0
 	else
-		health -= rand(5,8)
+		health -= rand(5, 8)
 
-	to_chat(H, "<span class='danger'>You claw at the energy net.</span>")
+	user.visible_message(SPAN_WARNING("\The [user] claws at \the [src]!"), SPAN_WARNING("You claw at \the [src]!"))
+	health_check()
 
-	healthcheck()
-	return
-
-/obj/effect/energy_net/attackby(obj/item/W as obj, mob/user as mob)
-	health -= W.force
-	healthcheck()
-	..()
+/obj/effect/energy_net/attackby(obj/item/W, mob/user)
+	user.do_attack_animation(src, W)
+	var/attack_force = W.force
+	if(user == affecting)
+		attack_force /= 2
+	health -= attack_force
+	health_check()
 
 /obj/item/canesword
 	name = "thin sword"

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -165,8 +165,8 @@
 	category = MODULE_SPECIAL
 
 /obj/item/rig_module/fabricator/energy_net/engage(atom/target, mob/user)
-	if(holder && holder.wearer)
-		if(..(target) && target)
+	if(holder?.wearer && target)
+		if(..())
 			holder.wearer.Beam(target, "n_beam", , 10)
 		return TRUE
 	return FALSE

--- a/html/changelogs/geeves-better_energy_net.yml
+++ b/html/changelogs/geeves-better_energy_net.yml
@@ -1,0 +1,10 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Energy net projectors can now directly fire energy nets again."
+  - tweak: "Improved energy net code a little. It should be more reliable when firing at people."
+  - tweak: "Raised energy net health to 50, up from 25."
+  - rscadd: "You can no longer damage an energy net with an empty hand while trapped inside it."
+  - rscadd: "Damaging an energy net with a weapon while trapped inside it will do reduced damage."


### PR DESCRIPTION
* Energy net projectors can now directly fire energy nets again.
* Improved energy net code a little. It should be more reliable when firing at people.
* Raised energy net health to 50, up from 25.
* You can no longer damage an energy net with an empty hand while trapped inside it.
* Damaging an energy net with a weapon while trapped inside it will do reduced damage."