### PR TITLE
Silicon Adjacency Fix

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -168,10 +168,19 @@ var/list/slot_equipment_priority = list( \
 //Puts the item our active hand if possible. Failing that it tries our inactive hand. Returns 1 on success.
 //If both fail it drops it on the floor and returns 0.
 //This is probably the main one you need to know :)
-/mob/proc/put_in_hands(var/obj/item/W)
+/mob/proc/put_in_hands(var/obj/item/W, var/check_adjacency = FALSE)
 	if(!W || !istype(W))
 		return 0
-	W.forceMove(get_turf(src))
+	var/move_to_src = TRUE
+	if(check_adjacency)
+		move_to_src = FALSE
+		var/turf/origin = get_turf(W)
+		if(Adjacent(origin))
+			move_to_src = TRUE
+	if(move_to_src)
+		W.forceMove(get_turf(src))
+	else
+		W.forceMove(get_turf(W))
 	W.layer = initial(W.layer)
 	W.dropped()
 	return 0

--- a/code/modules/mob/living/silicon/silicon_procs.dm
+++ b/code/modules/mob/living/silicon/silicon_procs.dm
@@ -8,3 +8,6 @@
 
 	accent = chosen_accent
 	to_chat(src, SPAN_NOTICE("You have set your synthesizer to mimic the [chosen_accent] accent."))
+
+/mob/living/silicon/put_in_hands(obj/item/W)
+	..(W, TRUE)

--- a/html/changelogs/geeves-silicon_adjacency.yml
+++ b/html/changelogs/geeves-silicon_adjacency.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Robots and AI no longer teleport things to themselves when ejecting them. (Like chem dispenser beakers)."


### PR DESCRIPTION
* Robots and AI no longer teleport things to themselves when ejecting them. (Like chem dispenser beakers).

Fixes https://github.com/Aurorastation/Aurora.3/issues/9991