### PR TITLE
Unapologetic Help Intent Shuffle Buffs

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -83,6 +83,11 @@
 		name = "[material.display_name] [initial(name)]"
 		desc += " It's made of [material.use_name]."
 
+/obj/structure/bed/forceMove(atom/dest)
+	. = ..()
+	if(buckled_mob)
+		buckled_mob.forceMove(dest)
+
 /obj/structure/bed/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -98,11 +98,29 @@ default behaviour is:
 				return
 
 			if(can_swap_with(tmob)) // mutual brohugs all around!
-				var/turf/oldloc = loc
-				forceMove(tmob.loc)
-				tmob.forceMove(oldloc)
+				var/turf/tmob_oldloc = tmob.loc
+				var/turf/src_oldloc = loc
+				if(pulling?.density)
+					tmob.forceMove(pulling.loc)
+					forceMove(tmob_oldloc)
+					pulling.forceMove(src_oldloc)
+				else if(tmob.pulling?.density)
+					forceMove(tmob.pulling.loc)
+					tmob.forceMove(src_oldloc)
+					tmob.pulling.forceMove(tmob_oldloc)
+				else
+					forceMove(tmob_oldloc)
+					if(pulling)
+						pulling.forceMove(src_oldloc)
+					tmob.forceMove(src_oldloc)
+					if(tmob.pulling)
+						tmob.pulling.forceMove(tmob_oldloc)
+				for(var/obj/item/grab/G in list(l_hand, r_hand))
+					G.affecting.forceMove(loc)
+				for(var/obj/item/grab/G in list(tmob.l_hand, tmob.r_hand))
+					G.affecting.forceMove(tmob.loc)
 				now_pushing = FALSE
-				for(var/mob/living/carbon/slime/slime in view(1,tmob))
+				for(var/mob/living/carbon/slime/slime in view(2, tmob))
 					if(slime.victim == tmob)
 						slime.UpdateFeed()
 				return
@@ -190,6 +208,9 @@ default behaviour is:
 
 	if(swap_density_check(tmob, src))
 		return 0
+
+	if(pulling?.density && tmob.pulling?.density) // if both are pulling, don't shuffle
+		return FALSE
 
 	return can_move_mob(tmob, 1, 0)
 

--- a/html/changelogs/geeves-super_shuffle.yml
+++ b/html/changelogs/geeves-super_shuffle.yml
@@ -1,0 +1,10 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Buffed the help intent shuffle. Pulled objects will no longer be dropped."
+  - rscadd: "When doing the shuffle and pulling a dense object, shuffling through someone will move both you and the object past your target."
+  - rscadd: "When doing the shuffle and you're pulling a non-dense object, you will shuffle as normal, but your object will move to beneath the target's feet, allowing movement."
+  - rscadd: "Shuffling past someone while grabbing someone will move the grabbed person / peoples to your tile after the shuffle completes, maintaining your grip."
+  - tweak: "When both you and your shuffle target are pulling dense objects, the help intent shuffle will no longer occur."


### PR DESCRIPTION
* Buffed the help intent shuffle. Pulled objects will no longer be dropped.
* When doing the shuffle and pulling a dense object, shuffling through someone will move both you and the object past your target.
* When doing the shuffle and you're pulling a non-dense object, you will shuffle as normal, but your object will move to beneath the target's feet, allowing movement.
* Shuffling past someone while grabbing someone will move the grabbed person / peoples to your tile after the shuffle completes, maintaining your grip.
* When both you and your shuffle target are pulling dense objects, the help intent shuffle will no longer occur.

https://gfycat.com/ReasonableKindEuropeanfiresalamander
https://gfycat.com/RashSingleFurseal
https://gfycat.com/ArcticCompleteArcticduck