### PR TITLE
Flamethrower Fix

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -68,7 +68,13 @@
 	return
 
 /obj/item/flamethrower/afterattack(atom/target, mob/user, proximity)
-	if(proximity) return
+	if(proximity)
+		return
+	if(!ptank)
+		return
+	if(ptank.air_contents.get_by_flag(XGM_GAS_FUEL) < 10)
+		to_chat(user, SPAN_WARNING("\The [src] doesn't have enough fuel left to throw!"))
+		return
 	// Make sure our user is still holding us
 	if(user && user.get_active_hand() == src)
 		var/turf/target_turf = get_turf(target)
@@ -148,7 +154,10 @@
 			ptank = null
 			lit = FALSE
 		if("Light")
-			if(!ptank || !secured || ptank.air_contents.gas[GAS_PHORON] < 1)
+			if(!ptank || !secured)
+				return
+			if(ptank.air_contents.get_by_flag(XGM_GAS_FUEL) < 1)
+				to_chat(user, SPAN_WARNING("\The [src] doesn't have any flammable fuel to light!"))
 				return
 			lit = !lit
 			to_chat(user, SPAN_NOTICE("You [lit ? "light" : "extinguish"] \the [src]."))
@@ -190,21 +199,19 @@
 
 
 /obj/item/flamethrower/proc/ignite_turf(turf/target)
-	//TODO: DEFERRED Consider checking to make sure tank pressure is high enough before doing this...
-	//Transfer 5% of current tank air contents to turf
-	var/datum/gas_mixture/air_transfer = ptank.air_contents.remove_ratio(0.02*(throw_amount/100))
-	new/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel(target,air_transfer.gas[GAS_PHORON]*15,get_dir(loc,target))
-	air_transfer.gas[GAS_PHORON] = 0
+	var/datum/gas_mixture/air_transfer = ptank.air_contents.remove_ratio(0.02 * (throw_amount / 100))
+	new /obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel(target, air_transfer.get_by_flag(XGM_GAS_FUEL) * 15, get_dir(loc, target))
+	for(var/g in air_transfer.gas)
+		if(gas_data.flags[g] & XGM_GAS_FUEL)
+			air_transfer.gas[g] = 0
 	target.assume_air(air_transfer)
 	target.hotspot_expose((ptank.air_contents.temperature*2) + 400, 500)
-	return
 
-/obj/item/flamethrower/full/New(var/loc)
-	..()
+/obj/item/flamethrower/full/Initialize()
+	. = ..()
 	weldtool = new /obj/item/weldingtool(src)
-	weldtool.secured = 0
+	weldtool.status = FALSE
 	igniter = new /obj/item/device/assembly/igniter(src)
-	igniter.secured = 0
-	secured = 1
+	igniter.secured = FALSE
+	secured = TRUE
 	update_icon()
-	return

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -13,7 +13,7 @@
 	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_COMBAT = 1, TECH_PHORON = 1)
 	matter = list(DEFAULT_WALL_MATERIAL = 500)
-	var/status = 0
+	var/secured = 0
 	var/throw_amount = 100
 	var/lit = FALSE	//on or off
 	var/operating = FALSE //cooldown
@@ -57,7 +57,7 @@
 /obj/item/flamethrower/update_icon()
 	cut_overlays()
 	if(igniter)
-		add_overlay("+igniter[status]")
+		add_overlay("+igniter[secured]")
 	if(ptank)
 		add_overlay("+ptank")
 	if(lit)
@@ -78,7 +78,7 @@
 
 /obj/item/flamethrower/attackby(obj/item/W as obj, mob/user as mob)
 	if(user.stat || user.restrained() || user.lying)	return
-	if(W.iswrench() && !status)//Taking this apart
+	if(W.iswrench() && !secured)//Taking this apart
 		var/turf/T = get_turf(src)
 		if(weldtool)
 			weldtool.forceMove(T)
@@ -94,8 +94,8 @@
 		return
 
 	if(W.isscrewdriver() && igniter && !lit)
-		status = !status
-		to_chat(user, "<span class='notice'>[igniter] is now [status ? "secured" : "unsecured"]!</span>")
+		secured = !secured
+		to_chat(user, "<span class='notice'>[igniter] is now [secured ? "secured" : "unsecured"]!</span>")
 		update_icon()
 		return
 
@@ -148,7 +148,7 @@
 			ptank = null
 			lit = FALSE
 		if("Light")
-			if(!ptank || !status || ptank.air_contents.gas[GAS_PHORON] < 1)
+			if(!ptank || !secured || ptank.air_contents.gas[GAS_PHORON] < 1)
 				return
 			lit = !lit
 			to_chat(user, SPAN_NOTICE("You [lit ? "light" : "extinguish"] \the [src]."))
@@ -202,9 +202,9 @@
 /obj/item/flamethrower/full/New(var/loc)
 	..()
 	weldtool = new /obj/item/weldingtool(src)
-	weldtool.status = 0
+	weldtool.secured = 0
 	igniter = new /obj/item/device/assembly/igniter(src)
 	igniter.secured = 0
-	status = 1
+	secured = 1
 	update_icon()
 	return

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -95,7 +95,7 @@
 
 	if (istype(W, /obj/item/flamethrower))
 		var/obj/item/flamethrower/F = W
-		if ((!F.status)||(F.ptank))	return
+		if ((!F.secured)||(F.ptank))	return
 		src.master = F
 		F.ptank = src
 		user.remove_from_mob(src)

--- a/html/changelogs/geeves-flamer_fix.yml
+++ b/html/changelogs/geeves-flamer_fix.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Flamethrowers can no longer fire with empty fuel tanks."
+  - bugfix: "Flamethrowers now work with any flammable gas."


### PR DESCRIPTION
* Flamethrowers can no longer fire with empty fuel tanks.
* Flamethrowers now work with any flammable gas.