### PR TITLE
Flamethrower Math Fix

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -72,7 +72,7 @@
 		return
 	if(!ptank)
 		return
-	if(ptank.air_contents.get_by_flag(XGM_GAS_FUEL) < 10)
+	if(ptank.air_contents.get_by_flag(XGM_GAS_FUEL) < 1)
 		to_chat(user, SPAN_WARNING("\The [src] doesn't have enough fuel left to throw!"))
 		return
 	// Make sure our user is still holding us

--- a/html/changelogs/geeves-flamethrower_math_fix.yml
+++ b/html/changelogs/geeves-flamethrower_math_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed a maths error that caused flamethrower minimum fuel requirement to be too high."


### PR DESCRIPTION
* Fixed a maths error that caused flamethrower minimum fuel requirement to be too high.