### PR TITLE
Ashtray Emptying + Tweaks

### DIFF
--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -91,8 +91,7 @@
 	else
 		health = max(0,health - W.force)
 		user.visible_message(user, SPAN_DANGER("[user] hits [src] with [W]!"), SPAN_DANGER("You hit [src] with [W]."))
-		if(W.hitsound)
-			playsound(get_turf(src), W.hitsound, 50, 1, -1)
+		playsound(get_turf(src), material.hitsound, 25)
 		if (health < 1)
 			shatter()
 	return

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -17,6 +17,24 @@
 	update_icon()
 	return
 
+/obj/item/material/ashtray/shatter()
+	if(emptyout(get_turf(src)))
+		visible_message(SPAN_DANGER("The contents of [src] spill everywhere!"))
+
+/obj/item/material/ashtray/proc/emptyout(atom/dest)
+	var/count = 0
+	for (var/obj/item/clothing/mask/smokable/cigarette/O in contents)
+		count++
+		O.forceMove(dest)
+	return count > 0
+
+/obj/item/material/ashtray/attack_self(mob/user)
+	var/turf/dest = get_turf(src)
+	if(emptyout(dest))
+		user.visible_message("<b>[user]</b> pours [src] out onto [dest].", SPAN_NOTICE("You pour [src] out onto [dest]."))
+		return
+	to_chat(user, SPAN_WARNING("[src] is empty, there's nothing to pour out!"))
+
 /obj/item/material/ashtray/update_icon()
 	color = null
 	cut_overlays()
@@ -50,7 +68,7 @@
 		if (istype(W,/obj/item/clothing/mask/smokable/cigarette))
 			var/obj/item/clothing/mask/smokable/cigarette/cig = W
 			if (cig.lit == TRUE)
-				src.visible_message("[user] crushes [cig] in \the [src], putting it out.")
+				user.visible_message("<b>[user]</b> crushes [cig] in \the [src], putting it out.", SPAN_NOTICE(""))
 				playsound(src.loc, 'sound/items/cigs_lighters/cig_snuff.ogg', 50, 1)
 				STOP_PROCESSING(SSprocessing, cig)
 				var/obj/item/butt = new cig.type_butt(src)
@@ -60,7 +78,10 @@
 				//spawn(1)
 				//	TemperatureAct(150)
 			else if (cig.lit == FALSE)
-				to_chat(user, "You place [cig] in [src] without even smoking it. Why would you do that?")
+				user.visible_message(
+					"<b>[user]</b> places [cig] in [src] without even smoking it.",
+					SPAN_NOTICE("You place [cig] in [src] without even smoking it. Why would you do that?")
+				)
 
 		src.visible_message("[user] places [W] in [src].")
 		user.update_inv_l_hand()
@@ -69,7 +90,9 @@
 		update_icon()
 	else
 		health = max(0,health - W.force)
-		to_chat(user, "You hit [src] with [W].")
+		user.visible_message(user, SPAN_DANGER("[user] hits [src] with [W]!"), SPAN_DANGER("You hit [src] with [W]."))
+		if(W.hitsound)
+			playsound(get_turf(src), W.hitsound, 50, 1, -1)
 		if (health < 1)
 			shatter()
 	return
@@ -77,10 +100,8 @@
 /obj/item/material/ashtray/throw_impact(atom/hit_atom)
 	if (health > 0)
 		health = max(0,health - 3)
-		if (contents.len)
-			src.visible_message("<span class='danger'>\The [src] slams into [hit_atom], spilling its contents!</span>")
-		for (var/obj/item/clothing/mask/smokable/cigarette/O in contents)
-			O.forceMove(src.loc)
+		if(emptyout(get_turf(src)))
+			visible_message(SPAN_DANGER("[src] slams into [hit_atom], spilling its contents everywhere!"))
 		if (health < 1)
 			shatter()
 			return

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -163,6 +163,12 @@
 		update()
 		return
 
+	else if (istype (I, /obj/item/material/ashtray) && user.a_intent != I_HURT)
+		var/obj/item/material/ashtray/A = I
+		if(A.emptyout(get_turf(src)))
+			user.visible_message("<b>[user]</b> pours [I] out into [src].", SPAN_NOTICE("You pour [I] out into [src]."))
+		return
+
 	else if (istype (I, /obj/item/device/lightreplacer))
 		var/count = 0
 		var/obj/item/device/lightreplacer/R = I

--- a/html/changelogs/MDP-ashestoashes.yml
+++ b/html/changelogs/MDP-ashestoashes.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MoondancerPony
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "You can now empty ashtrays into disposal units by clicking the disposal unit with the ashtray in hand. On harm intent, you will disposal the ashtray instead."
+  - tweak: "Tweaks messages when ashtrays are emptied out, hit, and used."
+  - rscadd: "Ashtrays spill their contents when destroyed."
+  - rscadd: "Using an ashtray in hand will dump its contents onto the ground."
+  - rscadd: "Hitting an ashtray will now produce a sound and a visible message."


### PR DESCRIPTION
* You can now empty ashtrays into disposal units by clicking the disposal unit with the ashtray in hand. On harm intent, you will disposal the ashtray instead.
* Tweaks messages when ashtrays are emptied out, hit, and used.
* Ashtrays now spill their contents when destroyed.
* Using an ashtray in hand will dump its contents onto the ground.
* Hitting an ashtray will now produce a sound and a visible message.