### PR TITLE
VueUI Chemical Dispenser

### DIFF
--- a/html/changelogs/MDP-vuechem.yml
+++ b/html/changelogs/MDP-vuechem.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MoondancerPony
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Includes core-js for IE/ECMAscript compatibility shims.."
+  - tweak: "Tweaks the numeric VueUI input to look more like the old NanoUI equivalent, with one plus/minus sign per power of 10 (+, ++, +++ for 1, 10, 100) instead of just identical buttons side-by-side."
+  - refactor: "Converts the chemical dispenser to use VueUI."
+  - rscadd: "Adds a numeric input selector to the chemical dispenser."

--- a/vueui/src/components/view/machinery/chemdisp.vue
+++ b/vueui/src/components/view/machinery/chemdisp.vue
@@ -1,0 +1,70 @@
+<template>
+	<div>
+		<div style="clear:both; margin:auto; width:20em">
+			<vui-button v-for="n in [5, 10, 20, 30, 40]" icon="cog" :params="{ amount : n }" :class="{selected : (state.amount == n)}" :key="amount-button-n">{{n}}</vui-button>
+			<br><br>
+      <div style="text-align:center">
+			  <vui-input-numeric width="2.5em" v-model="state.amount" @input="s({amount : state.amount})" :buttonCount="2" :min="1" :max="state.beakerMaxVolume || 120"/>
+      </div>
+		</div>
+		<div style="clear:both;">&nbsp;</div>
+		<div style="float:left; width: 100%;">
+			<div v-if="state.chemicals.length">
+				<vui-button icon="arrow-alt-circle-down" class="fixedLeftWide" v-for="chem in state.chemicals" :params="{dispense : chem.label}" :key="chem-btn">{{chem.label}} ({{chem.amount}})</vui-button>
+			</div>
+			<span v-else class='bad'>No cartridges installed!</span>
+		</div>
+		<div style="clear:both;">&nbsp;</div>
+		<vui-button icon="eject" style="float:right;" :class="state.isBeakerLoaded && disabled" :params="{ejectBeaker : 1}">Eject {{state.glass ? "Glass" : "Beaker"}}</vui-button>
+		<div class="statusDisplay" style="clear:both; min-height: 180px;">
+			<div v-if="state.isBeakerLoaded">
+				<b>Volume:&nbsp;{{state.beakerCurrentVolume}}&nbsp;/&nbsp;{{state.beakerMaxVolume}}</b><br>
+				<div v-if="state.beakerContents.length">
+					<span v-for="beakerchem in state.beakerContents" :key="beakerchem-amt" class="highlight">{{u(beakerchem.volume)}} of {{beakerchem.name}}<br></span>
+				</div>
+				<span v-else class="bad">{{state.glass ? "Glass" : "Beaker"}} is empty.</span>
+			</div>
+			<div v-else><span class="average"><i>No {{state.glass ? "glass" : "beaker"}} loaded.</i></span></div>
+		</div>
+	</div>
+</template>
+
+<script>
+import Utils from "../../../utils.js";
+export default {
+	data() {
+		return this.$root.$data;
+	},
+	methods: {
+		u(num) {
+			if(num == 1) {
+				return `${num} unit`
+			} else {
+				return `${num} units`
+			}
+    },
+    s(parameters) {
+      Utils.sendToTopic(parameters);
+    }
+	}
+}
+</script>
+
+<style lang="scss" scoped>
+	.statusDisplay {
+			background: #000000;
+			color: #ffffff;
+			border: 1px solid #40628a;
+			padding: 4px;
+			margin: 3px 0;
+	}
+	.fixedLeftWide {
+			width: 165px;
+			float: left;
+  }
+  .item {
+    width: 100%;
+    margin: 4px 0 0 0;
+    clear: both;
+  }
+</style>

--- a/vueui/src/components/vui/input/numeric.vue
+++ b/vueui/src/components/vui/input/numeric.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <vui-button v-for="bv in subButtons" :key="'-' + bv" :disabled="val - bv < min" @click="onUpdatedValue(-bv)">-</vui-button>
+    <vui-button v-for="bv in subButtons" :key="'-' + bv" :disabled="val - bv < min" @click="onUpdatedValue(-(10 ** bv))">{{"-".repeat(bv+1)}}</vui-button>
     <input @keypress="onKeyPress" :style="{width: width}" ref="input" :value="val" @input="onFieldUpdate($event.target)">
-    <vui-button v-for="bv in addButtons" :key="'+' + bv" :disabled="val + bv > max" @click="onUpdatedValue(bv)">+</vui-button>
+    <vui-button v-for="bv in addButtons" :key="'+' + bv" :disabled="val + bv > max" @click="onUpdatedValue(10 ** bv)">{{"+".repeat(bv+1)}}</vui-button>
   </div>
 </template>
 
@@ -49,7 +49,7 @@ export default {
       if(!this.buttonCount) return [];
       let buttons = []
       for (let i = this.buttonCount - 1; i >= 0; i--) {
-        buttons.push(10 ** i)
+        buttons.push(i)
       }
       return buttons
     },
@@ -57,7 +57,7 @@ export default {
       if(!this.buttonCount) return [];
       let buttons = []
       for (let i = 0; i < this.buttonCount; i++) {
-        buttons.push(10 ** i)
+        buttons.push(i)
       }
       return buttons
     }

--- a/vueui/src/main.js
+++ b/vueui/src/main.js
@@ -2,6 +2,7 @@
  * Vue.js based ui framework for SS13
  * Made for Aurora, by Karolis K.
  */
+import "core-js/stable"
 import Vue from 'vue'
 import upperFirst from 'lodash/upperFirst'
 import camelCase from 'lodash/camelCase'


### PR DESCRIPTION
* Tweaks the numeric VueUI input to look more like the old NanoUI equivalent, with one plus/minus sign per power of 10 (+, ++, +++ for 1, 10, 100) instead of just identical buttons side-by-side.
* Includes core-js for IE/ECMAscript compatibility shims.
* Converts the chemical dispenser UI to VueUI.
* Adds a numeric input to the chemical dispenser.