### PR TITLE
Fire Stack Health Indicator

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -872,6 +872,8 @@
 				// Apply a fire overlay if we're burning.
 				if(on_fire)
 					var/image/burning_image = image('icons/mob/screen1_health.dmi', "burning", pixel_x = species.healths_overlay_x)
+					var/midway_point = FIRE_MAX_STACKS / 2
+					burning_image.color = color_rotation((midway_point - fire_stacks) * 3)
 					health_images += burning_image
 
 				// Show a general pain/crit indicator if needed.

--- a/html/changelogs/geeves-fire_stacks.yml
+++ b/html/changelogs/geeves-fire_stacks.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a colour based fire system to the health indicator, which displays just how on fire you are. Green-ish means you're only a bit on fire, while red-purplish means even firesuits won't protect you anymore."


### PR DESCRIPTION
* Added a colour based fire system to the health indicator, which displays just how on fire you are. Green-ish means you're only a bit on fire, while red-purplish means even firesuits won't protect you anymore.