### PR TITLE
Sets burglars required enemies to the intended number

### DIFF
--- a/code/game/antagonist/outsider/burglar.dm
+++ b/code/game/antagonist/outsider/burglar.dm
@@ -17,7 +17,7 @@ var/datum/antagonist/burglar/burglars
 
 	hard_cap = 2
 	hard_cap_round = 3
-	initial_spawn_req = 1
+	initial_spawn_req = 2
 	initial_spawn_target = 2
 
 	faction = "syndicate"

--- a/code/game/gamemodes/burglars/burglars.dm
+++ b/code/game/gamemodes/burglars/burglars.dm
@@ -4,7 +4,7 @@
 	name = "burglars"
 	config_tag = "burglars"
 	max_players = 15
-	required_enemies = 1
+	required_enemies = 2
 	required_players = 4
 	round_description = "Something tiny is on the horizon! Is it the distance, or...?"
 	extended_round_description = "Two of the Orion Spur's best and brightest (or so they were told) have been tasked with burglarizing a station that will change the way capitalism grips this galaxy forever (or so they were told). It is up to the crew to repel them, and up to them to survive and possibly thrive."

--- a/code/game/gamemodes/mixed/conflict.dm
+++ b/code/game/gamemodes/mixed/conflict.dm
@@ -4,6 +4,6 @@
 	extended_round_description = "Burglars and heisters spawn during this round."
 	config_tag = "conflict"
 	required_players = 15
-	required_enemies = 5
+	required_enemies = 6
 	antag_tags = list(MODE_RAIDER, MODE_BURGLAR)
 	require_all_templates = TRUE

--- a/html/changelogs/Ferner-201215-bugfix_burglarsenemies.yml
+++ b/html/changelogs/Ferner-201215-bugfix_burglarsenemies.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes:
+  - bugfix: "Fixed burglars starting with a less required number of enemies than intended."


### PR DESCRIPTION
This was mistakenly set to 1 in #10613 when burglars is meant to spawn with 2 antags.