### PR TITLE
Removes double '+' and '-' buttons

### DIFF
--- a/html/changelogs/dsdsdsdsdsdsadsasdsafsda.yml
+++ b/html/changelogs/dsdsdsdsdsdsadsasdsafsda.yml
@@ -1,0 +1,4 @@
+author: Karolis2011
+delete-after: True
+changes:
+  - tweak: "Vue numeric input no longer has repeated '-' and '+' symbols for larger adjustment buttons."

--- a/vueui/README.md
+++ b/vueui/README.md
@@ -224,18 +224,18 @@ Example:
 Parameters:
  - `name` - name of asset to show that was sent to client.
 Please note that regular `<img>` parameters apply here.
-### VuiItem `<vui-item>` DEPRECATED
+### ~~VuiItem `<vui-item>`~~ DEPRECATED
 (Please use VuiGroup and VuiGroupItem)
 
-Helper for making item lists using legacy nano styles.
+~~Helper for making item lists using legacy nano styles.~~
 
 Example:
 ```Vue
 <vui-item label="Current health:">75%</vui-item>
 ```
-Parameters:
- - `label` - Label to display next to contents
- - `balance` - This determines how much space is used by content compared to label. This parameter value should be between 0 and 1.
+~~Parameters:~~
+ - ~~`label` - Label to display next to contents~~
+ - ~~`balance` - This determines how much space is used by content compared to label. This parameter value should be between 0 and 1.~~
 
 ### VuiGroupItem `<vui-group-item>` and VuiGroup `<vui-group>`
 Helper for making item lists. Automatically adjusts label width for optimal layout, makes space for content.

--- a/vueui/src/components/vui/input/numeric.vue
+++ b/vueui/src/components/vui/input/numeric.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <vui-button v-for="bv in subButtons" :key="'-' + bv" :disabled="val - bv < min" @click="onUpdatedValue(-(10 ** bv))">{{"-".repeat(bv+1)}}</vui-button>
+    <vui-button v-for="bv in subButtons" :key="'-' + bv" :disabled="val - bv < min" @click="onUpdatedValue(-(10 ** bv))">-</vui-button>
     <input @keypress="onKeyPress" :style="{width: width}" ref="input" :value="val" @input="onFieldUpdate($event.target)">
-    <vui-button v-for="bv in addButtons" :key="'+' + bv" :disabled="val + bv > max" @click="onUpdatedValue(10 ** bv)">{{"+".repeat(bv+1)}}</vui-button>
+    <vui-button v-for="bv in addButtons" :key="'+' + bv" :disabled="val + bv > max" @click="onUpdatedValue(10 ** bv)">+</vui-button>
   </div>
 </template>
 

--- a/vueui/src/components/vui/item.vue
+++ b/vueui/src/components/vui/item.vue
@@ -1,11 +1,13 @@
 <template>
   <div class="item">
+    <!-- DEPRICATE PLEASE USE VUI-GROUP AND VUI-GROUP-ITEM -->
     <div v-if="label" class="itemLabel" :style="{ width: (1 - balance) * 100 + '%' }">{{ label }}</div>
     <div class="itemContent" :style="{ width: (label ? balance : 1) * 100 + '%' }"><slot/></div>
   </div>
 </template>
 
 <script>
+// DEPRICATE PLEASE USE VUI-GROUP AND VUI-GROUP-ITEM
 export default {
   name: "vui-item",
   props: {


### PR DESCRIPTION
So this removes extra `+` and `-` on adjustement buttons saving sapce on UIs. Reverts part of #10799
Example on how it looks now
![](https://cdn.discordapp.com/attachments/302201161044328450/789388734562697246/unknown.png)