### PR TITLE
Wireless Mining ID

### DIFF
--- a/html/changelogs/geeves-mining_id.yml
+++ b/html/changelogs/geeves-mining_id.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Mining ore processors and Mining Vendors now find IDs wirelessly, allowing mining stationbounds to redeem points as well. Mining drones cannot utilize this system."


### PR DESCRIPTION
* Mining ore processors and Mining Vendors now find IDs wirelessly, allowing mining stationbounds to redeem points as well. Mining drones cannot utilize this system.