### PR TITLE
Easy Access Replies

### DIFF
--- a/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
@@ -24,7 +24,7 @@ var/global/ntnrc_uid = 0
 
 	for(var/datum/computer_file/program/chatclient/C in clients)
 		if(C.program_state > PROGRAM_STATE_KILLED)
-			C.computer.output_message("<b>([get_title(C)]) <i>[username]</i>:</b> [message] (<a href='byond://?src=\ref[C];Reply=1;target=[src.title]'>Reply</a>)", 0)
+			C.computer.output_message("<b>([get_title(C)]) <i>[username]</i>:</b> [message] (<a href='byond://?src=\ref[C];Reply=\ref[src]'>Reply</a>)", 0)
 			if(!C.silent && C.username != username && C.program_state == PROGRAM_STATE_BACKGROUND)
 				for (var/mob/O in hearers(2, get_turf(C.computer)))
 					playsound(C.computer, 'sound/machines/twobeep.ogg', 50, 1)

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -61,14 +61,15 @@
 
 	if(href_list["Reply"])
 		. = TRUE
-		if(!channel || channel.title != href_list["target"])
-			to_chat(usr, SPAN_WARNING("The target chat isn't active on your program anymore!"))
+		var/datum/ntnet_conversation/C = locate(href_list["Reply"]) in ntnet_global.chat_channels
+		if(!istype(C))
+			to_chat(usr, SPAN_WARNING("The target channel couldn't be found and has likely been deleted!"))
 			return
 		var/message = send_message()
-		if(!channel || channel.title != href_list["target"])
-			to_chat(usr, SPAN_WARNING("The target chat isn't active on your program anymore!"))
+		if(!(C in ntnet_global.chat_channels))
+			to_chat(usr, SPAN_WARNING("The target channel couldn't be found and has likely been deleted!"))
 			return
-		add_message(message)
+		add_message(message, C)
 
 	if(href_list["PRG_joinchannel"])
 		. = TRUE
@@ -219,11 +220,16 @@
 		return
 	return message
 
-/datum/computer_file/program/chatclient/proc/add_message(var/message)
+/datum/computer_file/program/chatclient/proc/add_message(var/message, var/datum/ntnet_conversation/specific_channel)
 	if(!message)
 		return
-	channel.add_message(message, username, usr)
-	message_dead(FONT_SMALL("<b>([channel.get_dead_title()]) [username]:</b> [message]"))
+	var/datum/ntnet_conversation/sent_channel
+	if(specific_channel)
+		sent_channel = specific_channel
+	else
+		sent_channel = channel
+	sent_channel.add_message(message, username, usr)
+	message_dead(FONT_SMALL("<b>([sent_channel.get_dead_title()]) [username]:</b> [message]"))
 
 /datum/computer_file/program/chatclient/proc/direct_message()
 	var/clients = list()

--- a/html/changelogs/geeves-easy_access_replies.yml
+++ b/html/changelogs/geeves-easy_access_replies.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Hitting reply on a message to the NTIRC client will now reply to that channel directly, instead of requiring it to be the active one when doing so."


### PR DESCRIPTION
* Hitting reply on a message to the NTIRC client will now reply to that channel directly, instead of requiring it to be the active one when doing so.