### PR TITLE
Fixes rogue maint drones all spawning in the same area

### DIFF
--- a/code/modules/events/maint_drones.dm
+++ b/code/modules/events/maint_drones.dm
@@ -2,8 +2,8 @@
 	var/drons = severity * 2 - 1
 	var/groups = rand(3, 8)
 
-	var/list/spots = get_infestation_turfs()
 	for(var/i = 0 to groups)
+		var/list/spots = get_infestation_turfs()
 		if(!LAZYLEN(spots))
 			break
 		var/turf/T = pick(spots)

--- a/html/changelogs/Ferner-201219-bugfix_droneevent.yml
+++ b/html/changelogs/Ferner-201219-bugfix_droneevent.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes:
+  - bugfix: "Fixed an issue which caused the rogue maint drone event to spawn all the drones in the same area."


### PR DESCRIPTION
As the area selection was before the for() loop, it meant all the rogue maint drones spawned in the same area, instead of spread across maintenance.