### PR TITLE
Charge Card Cargo

### DIFF
--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -168,7 +168,7 @@ proc/spawn_money(var/sum, spawnloc, mob/living/carbon/human/human_user as mob)
 	return
 
 /obj/item/spacecash/ewallet
-	name = "Charge card"
+	name = "charge card"
 	icon_state = "efundcard"
 	desc = "A card that holds an amount of money."
 	var/owner_name = "" //So the ATM can set it so the EFTPOS can put a valid name on transactions.

--- a/html/changelogs/geeves-charge_card_payments.yml
+++ b/html/changelogs/geeves-charge_card_payments.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "You can now pay for cargo orders with a charge card. To do so, do not have an ID card in the computer, have a charge card in your active hand when you press the pay button."


### PR DESCRIPTION
* You can now pay for cargo orders with a charge card. To do so, do not have an ID card in the computer, have a charge card in your active hand when you press the pay button.