### PR TITLE
HUD Fixes

### DIFF
--- a/code/defines/procs/hud.dm
+++ b/code/defines/procs/hud.dm
@@ -4,6 +4,7 @@ the HUD updates properly! */
 
 //HUD image type used to properly clear client.images precisely
 /image/hud_overlay
+	appearance_flags = RESET_COLOR|RESET_ALPHA
 
 //Medical HUD outputs. Called by the Life() proc of the mob using it, usually.
 proc/process_med_hud(var/mob/M, var/local_scanner, var/mob/Alt)

--- a/code/modules/mob/floating_messages.dm
+++ b/code/modules/mob/floating_messages.dm
@@ -52,13 +52,7 @@ var/list/floating_chat_colors = list()
 	I.plane = FLOAT_PLANE
 	I.layer = HUD_LAYER - 0.01
 	I.pixel_x = -round(I.maptext_width/2) + 16
-
-	if(ishuman(holder))
-		var/mob/living/carbon/human/H = holder
-		if(H.lying)
-			var/matrix/M = matrix()
-			M.Turn(-90)
-			animate(I, transform = M, time = 1)
+	I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM
 
 	style = "font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: [size]px; [style]"
 	I.maptext = "<center><span style=\"[style]\">[message]</span></center>"
@@ -76,12 +70,3 @@ var/list/floating_chat_colors = list()
 /proc/remove_floating_text(atom/movable/holder, image/I)
 	animate(I, 2, pixel_y = I.pixel_y + 10, alpha = 0)
 	LAZYREMOVE(holder.stored_chat_text, I)
-
-/mob/proc/handle_floating_message_orientation()
-	return
-
-/mob/living/carbon/human/handle_floating_message_orientation()
-	var/matrix/M = matrix()
-	M.Turn(lying ? -90 : 0)
-	for(var/thing in stored_chat_text)
-		animate(thing, transform = M, time = ANIM_LYING_TIME)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -174,7 +174,6 @@ There are several things that need to be remembered:
 			M.Scale(size_multiplier)
 			M.Translate(0, 16*(size_multiplier-1))
 			animate(src, transform = M, time = ANIM_LYING_TIME)
-		handle_floating_message_orientation()
 
 	compile_overlays()
 	lying_prev = lying

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -284,6 +284,7 @@ proc/get_radio_key_from_channel(var/channel)
 
 	var/speech_bubble_test = say_test(message)
 	var/image/speech_bubble = image('icons/mob/talk.dmi',src,"h[speech_bubble_test]")
+	speech_bubble.appearance_flags = RESET_COLOR|RESET_ALPHA
 	INVOKE_ASYNC(GLOBAL_PROC, /proc/animate_speechbubble, speech_bubble, hear_clients, 30)
 	do_animate_chat(message, speaking, italics, hear_clients, 30)
 

--- a/html/changelogs/geeves-hud_list_time.yml
+++ b/html/changelogs/geeves-hud_list_time.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "HUD icons are no longer coloured if you're blasted by paint, or are slightly transparent."
+  - bugfix: "Fixed the wonkiness of floating chat when transformations are applied on something."


### PR DESCRIPTION
* HUD icons are no longer coloured if you're blasted by paint, or are slightly transparent.
* Fixed the wonkiness of floating chat when transformations are applied on something.

![image](https://user-images.githubusercontent.com/22774890/102719339-309e4980-42f6-11eb-8892-2a6ecb6bd1fa.png)

RIP, pour one out for my over-engineered, under-performing fix that was a gorillion times longer than just applying appearance_flags.