### PR TITLE
Removes antag drafting

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -636,20 +636,6 @@ var/global/list/additional_antag_types = list()
 				candidates += player.mind
 				players -= player
 
-		// If we don't have enough antags, draft people who voted for the round.
-		if(candidates.len < required_enemies)
-			var/initial_candidates = candidates.len
-
-			for(var/mob/abstract/new_player/player in players)
-				if(player.ckey in SSvote.round_voters)
-					log_debug("[player.key] voted for this round, so we are drafting them.")
-					candidates += player.mind
-					players -= player
-
-					if (candidates.len >= required_enemies)
-						log_debug("Drafted [candidates.len - initial_candidates] new antags from voters.")
-						break
-
 	return candidates		// Returns: The number of people who had the antagonist role set to yes, regardless of recomended_enemies, if that number is greater than required_enemies
 							//			required_enemies if the number of people with that role set to yes is less than recomended_enemies,
 							//			Less if there are not enough valid players in the game entirely to make required_enemies.

--- a/html/changelogs/alberyk-draft.yml
+++ b/html/changelogs/alberyk-draft.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - rscdel: "Removed antag drafting. People that voted for the round won't be selected for antag if they don't have their options enabled."


### PR DESCRIPTION
This pr removes antag drafting. People will no longer be forced to be antags just because they voted for the gamemode.
Opened this because people rarely ready up and round variety has been low lately.