### PR TITLE
Emergency Energy Shield Tweaks

### DIFF
--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -71,8 +71,26 @@ var/list/tape_roll_applications = list()
 /obj/item/tape/engineering
 	name = "engineering tape"
 	desc = "A length of engineering tape. Better not cross it."
-	req_one_access = list(access_engine,access_atmospherics)
+	desc_info = "You can use a multitool on this tape to allow emergency shield generators to deploy shields on this tile."
+	req_one_access = list(access_engine, access_atmospherics)
 	icon_base = "engineering"
+	var/shield_marker = FALSE
+
+/obj/item/tape/engineering/examine(mob/user, distance)
+	. = ..()
+	if(shield_marker)
+		to_chat(user, SPAN_NOTICE("This strip of tape has been modified to serve as a marker for emergency shield generators to lock onto."))
+
+/obj/item/tape/engineering/attackby(obj/item/W, mob/user)
+	if(W.ismultitool())
+		shield_marker = !shield_marker
+		to_chat(user, SPAN_NOTICE("You [shield_marker ? "" : "un"]designate \the [src] as a target for an emergency shield generator."))
+		if(shield_marker)
+			animate(src, 1 SECOND, color = color_rotation(-60))
+		else
+			animate(src, 1 SECOND, color = initial(color))
+		return
+	return ..()
 
 /obj/item/taperoll/attack_self(mob/user as mob)
 	if(icon_state == "[icon_base]_start")

--- a/html/changelogs/geeves-shield_time.yml
+++ b/html/changelogs/geeves-shield_time.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Emergency energy shields have had their health reduced to 75, down from 200."
+  - rscadd: "Attacking emergency energy shields now play an animation. The less HP they have, the more transparent they become."
+  - rscadd: "You can now use a multitool on engineering tape to mark it as an emergency shield target. An emergency shield generator will deploy shields over it."


### PR DESCRIPTION
* Emergency energy shields have had their health reduced to 75, down from 200.
* Attacking emergency energy shields now play an animation. The less HP they have, the more transparent they become.
* You can now use a multitool on engineering tape to mark it as an emergency shield target. An emergency shield generator will deploy shields over it.

Marked tape has the pink colour shown in this screenshot. The green ones were a first attempt.
![image](https://user-images.githubusercontent.com/22774890/102778300-005cb680-439b-11eb-9c06-8e90bc27ae50.png)