### PR TITLE
Removes a carp spawnpoint by the surface access stairwell

### DIFF
--- a/html/changelogs/Ferner-201222-mapping_stairwellcarp.yml
+++ b/html/changelogs/Ferner-201222-mapping_stairwellcarp.yml
@@ -1,0 +1,4 @@
+author: Ferner
+delete-after: True
+changes:
+  - maptweak: "Removed a carp spawnpoint by the surface access stairwell."

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -38793,7 +38793,7 @@ ab
 ab
 ab
 ab
-QW
+ab
 ab
 ab
 ab


### PR DESCRIPTION
Due to the nearby windows getting broken, leading to too frequent widespread venting throughout the service wing. The dweller spawnpoint will remain though..
The spawnpoint at the very top of the stairs still remains as well, but that one being behind an airlock leads to less overall issues.

As originally suggested in this thread: https://forums.aurorastation.org/topic/8983-minor-mapping-suggestions/?do=findComment&comment=143591 Though instead removing the spawnpoint rather than the window.