### PR TITLE
Fixes Fisanduhian Coffee missing a sprite

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -2937,7 +2937,7 @@
 	caffeine = 0.3
 	taste_description = "giving up on peaceful coexistence"
 
-	glass_icon_state = "giscoffeeglass"
+	glass_icon_state = "fiscoffeeglass"
 	glass_name = "glass of Fisanduhian coffee"
 	glass_desc = "It's like an Irish coffee, but spicy and angry about Dominia."
 	glass_center_of_mass = list("x"=15, "y"=10)

--- a/html/changelogs/coffeesprite.yml
+++ b/html/changelogs/coffeesprite.yml
@@ -1,0 +1,7 @@
+
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes Fisanduhian Coffee missing a sprite."


### PR DESCRIPTION
Fixes #10868. Spelling Mistake.

changes:
  - bugfix: "Fixes Fisanduhian Coffee missing a sprite." 