### PR TITLE
Fixed medical gumball jar sprite

### DIFF
--- a/code/game/objects/items/glassjar.dm
+++ b/code/game/objects/items/glassjar.dm
@@ -219,6 +219,8 @@
 	for(var/i = 1 to GUMBALL_MAX)
 		var/obj/item/clothing/mask/chewable/candy/gum/gumball/medical/G = new(src)
 		contained += G
+		
+	return INITIALIZE_HINT_LATELOAD
 
 #undef JAR_NOTHING
 #undef JAR_MONEY

--- a/html/changelogs/medballs.yml
+++ b/html/changelogs/medballs.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the medical gumball jar not loading its underlay on roundstart."


### PR DESCRIPTION
Title. Most of you have seen it. 2021's off to a good start.
Fixes #10869 

changes:
  - bugfix: "Fixes the medical gumball jar not loading its underlay on roundstart."