### PR TITLE
High damage bullets now gib limbs, fixes projectile used_weapon fuckery.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -89,7 +89,7 @@
 			P.damage_flags &= ~DAM_LASER
 
 	if(!P.nodamage)
-		damaged = apply_damage(P.damage, P.damage_type, def_zone, absorb, 0, P, damage_flags = P.damage_flags, used_weapon = "\a [P.name]")
+		damaged = apply_damage(P.damage, P.damage_type, def_zone, absorb, 0, P, damage_flags = P.damage_flags, used_weapon = P)
 		bullet_impact_visuals(P, def_zone, damaged)
 	P.on_hit(src, absorb, def_zone)
 	return absorb

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -379,7 +379,6 @@
 
 				var/edge_eligible = FALSE
 				var/blunt_eligible = FALSE
-				var/limb_destroy_mod = 1
 				var/maim_bonus = 0
 
 				if(isitem(used_weapon))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -377,20 +377,22 @@
 
 			if((brute_dam + burn_dam) >= (max_damage * config.organ_health_multiplier))
 
-				var/edge_eligible = 0
+				var/edge_eligible = FALSE
+				var/blunt_eligible = FALSE
+				var/limb_destroy_mod = 1
 				var/maim_bonus = 0
 
-				if(istype(used_weapon,/obj/item))
+				if(isitem(used_weapon))
 					var/obj/item/W = used_weapon
 					if(isprojectile(W))
 						var/obj/item/projectile/P = W
+						if(P.damage_flags & DAM_BULLET)
+							blunt_eligible = TRUE
 						maim_bonus += P.maim_rate
 					else if(W.w_class >= w_class && edge)
-						edge_eligible = 1
-				else if(edge)
-					edge_eligible = 1
+						edge_eligible = TRUE
 
-				if(edge_eligible && brute >= max_damage / (DROPLIMB_THRESHOLD_EDGE + maim_bonus))
+				if(!blunt_eligible && edge_eligible && brute >= max_damage / (DROPLIMB_THRESHOLD_EDGE + maim_bonus))
 					droplimb(0, DROPLIMB_EDGE)
 				else if(burn >= max_damage / (DROPLIMB_THRESHOLD_DESTROY + maim_bonus))
 					droplimb(0, DROPLIMB_BURN)
@@ -1316,6 +1318,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(!(limb_flags & ORGAN_HAS_TENDON) || (status & ORGAN_ROBOT) || (status & ORGAN_TENDON_CUT))
 		return FALSE
 
+	. = TRUE
+	playsound(src.loc, 'sound/effects/snap.ogg', 40, 1, -2)
+	status |= ORGAN_TENDON_CUT
+	if(!owner)
+		return
+
 	var/message = pick("tore apart", "ripped away")
 	owner.visible_message(\
 		"<span class='warning'><font size=2>You hear a loud snapping sound coming from \the [owner]!</font></span>",\
@@ -1324,10 +1332,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(owner.species && owner.can_feel_pain())
 		owner.emote("scream")
 		owner.flash_strong_pain()
-
-	playsound(src.loc, 'sound/effects/snap.ogg', 40, 1, -2)
-	status |= ORGAN_TENDON_CUT
-	return TRUE
 
 // Damage procs
 /obj/item/organ/external/proc/get_brute_damage()

--- a/html/changelogs/mattatlas-organstuff.yml
+++ b/html/changelogs/mattatlas-organstuff.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "High damage bullets will now gib limbs instead of tearing them off."
+  - bugfix: "Fixed projectile maim bonuses not being applied and some other projectile-related bugs."


### PR DESCRIPTION
See title. This fixes bugs that were caused by items trying to read used_weapon's variables. If used_weapon was a projectile, it would get passed as a string because... reasons, I guess.