### PR TITLE
Makes hyperzine less punishing during sustained combat.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -563,7 +563,8 @@
 
 	if((locate(/datum/reagent/adrenaline) in M.reagents.reagent_list))
 		if(M.reagents.get_reagent_amount(/datum/reagent/adrenaline) > 5) //So you can tolerate being attacked whilst hyperzine is in your system.
-			overdose = volume/2 //Straight to overdose.
+			overdose = 10 //Volume of hyperzine required to OD reduced from 15u to 10u. 
+			od_minimum_dose = 0
 
 /datum/reagent/hyperzine/overdose(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustNutritionLoss(5*removed)

--- a/html/changelogs/hyperzine_od_tweak.yml
+++ b/html/changelogs/hyperzine_od_tweak.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Kermit
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Having both hyperzine and adrenaline in your system no longer fast-tracks you to a hyperzine OD, but instead reduces the volume of hyperzine required to OD from 15u to 10u. Should be less dangerous to use hyperzine as a combat stimulant, though managing doses is still important."


### PR DESCRIPTION
Currently, having any amount of hyperzine + 5 units of adrenaline in your blood fast tracks you to a pretty punishing overdose which lasts until all hyperzine/adrenaline has left the blood which, for antagonists especially, can be game-ending. This PR alters it such that having 5 units of adrenaline in your blood reduces hyperzines OD threshold from 15 units to 10 units, meaning hyperzine can still be used while you have adrenaline in your blood, though it's best to use smaller doses, as well as meaning the OD will last a lot shorter duration instead of until all the hyperzine/adrenaline has been metabolised. This should make hyperzine a lot less punishing during sustained combat as the contraindication with adrenaline can be totally avoided if you use doses 10 units and under, instead of any amount of hyperzine leading to the contraindication.