### PR TITLE
Blood Overlay Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -336,9 +336,11 @@
 	else
 		blood_state = BLOOD_HEAVY
 
-	if(force_reset || (blood_state != BLOOD_NONE && current_blood_state != blood_state))
+	if(force_reset || current_blood_state != blood_state)
 		if(blood_overlay)
 			cut_overlay(blood_overlay)
+		if(blood_state == BLOOD_NONE)
+			return
 		var/blood_overlay_name = get_blood_overlay_name()
 		var/image/I = image(blood_overlay_icon, src, "[blood_overlay_name]-[blood_state]")
 		I.color = blood_type

--- a/html/changelogs/geeves-blood_overlay_fix.yml
+++ b/html/changelogs/geeves-blood_overlay_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed blood overlays not disappearing when mobs are completely healed."


### PR DESCRIPTION
* Fixed blood overlays not disappearing when mobs are completely healed.