### PR TITLE
Psionic Energistics Fix

### DIFF
--- a/code/modules/psionics/faculties/energistics.dm
+++ b/code/modules/psionics/faculties/energistics.dm
@@ -101,15 +101,16 @@
 	use_description = "Target a non-living target in melee range on harm intent to cause some sparks to appear. This can light fires."
 
 /datum/psionic_power/energistics/spark/invoke(var/mob/living/user, var/mob/living/target)
-	if(isnull(target) || istype(target)) return FALSE
+	if(isnull(target) || istype(target))
+		return FALSE
 	. = ..()
 	if(.)
 		if(istype(target,/obj/item/clothing/mask/smokable/cigarette))
 			var/obj/item/clothing/mask/smokable/cigarette/S = target
 			S.light(SPAN_NOTICE("\The [user] snaps [user.get_pronoun("his")] fingers and \the [S] lights up."))
 			playsound(S.loc, /decl/sound_category/spark_sound, 50, 1)
-		else
-			var/datum/effect_system/sparks/spark_system
-			spark_system = bind_spark(src, 3)
-			spark_system.queue()
+			return TRUE
+		if(!isturf(target))
+			return FALSE
+		spark(target, 3)
 		return TRUE

--- a/html/changelogs/geeves-psionic_fix.yml
+++ b/html/changelogs/geeves-psionic_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "The sparks psionic ability now properly generates sparks, and no longer disallows you from operating your inventory."


### PR DESCRIPTION
* The sparks psionic ability now properly generates sparks, and no longer disallows you from operating your inventory.