### PR TITLE
Misc Chat Fix

### DIFF
--- a/html/changelogs/geeves-chat_fix.yml
+++ b/html/changelogs/geeves-chat_fix.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "You can now reply to a chat even without a channel active."
+  - bugfix: "Direct messaging will no longer fail silently if you're the only client active."


### PR DESCRIPTION
* You can now reply to a chat even without a channel active.
* Direct messaging will no longer fail silently if you're the only client active.