### PR TITLE
Scrubber Event tweaks

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -1,4 +1,3 @@
-
 /datum/event/vent_clog
 	announceWhen	= 1
 	startWhen		= 5
@@ -6,31 +5,47 @@
 	var/interval 	= 2
 	var/list/vents  = list()
 	var/list/gunk = list(
-		/datum/reagent/water,
-		/datum/reagent/carbon,
-		/datum/reagent/nutriment/flour,
-		/datum/reagent/spacecleaner,
-		/datum/reagent/nutriment,
-		/datum/reagent/capsaicin/condensed,
-		/datum/reagent/mindbreaker,
-		/datum/reagent/lube,
-		/datum/reagent/paint,
-		/datum/reagent/paint,
-		/datum/reagent/drink/banana,
-		/datum/reagent/space_drugs,
-		/datum/reagent/water/holywater,
-		/datum/reagent/drink/hot_coco,
-		/datum/reagent/hyperzine,
-		/datum/reagent/paint,
-		/datum/reagent/luminol,
-		/datum/reagent/fuel,
-		/datum/reagent/blood,
-		/datum/reagent/sterilizine,
-		/datum/reagent/verunol,
-		/datum/reagent/toxin/fertilizer/monoammoniumphosphate
+		/datum/reagent/water = 10,
+		/datum/reagent/carbon = 5,
+		/datum/reagent/nutriment/flour = 10,
+		/datum/reagent/spacecleaner = 8,
+		/datum/reagent/nutriment = 8,
+		/datum/reagent/capsaicin/condensed = 2,
+		/datum/reagent/mindbreaker = 0.5,
+		/datum/reagent/lube = 4,
+		/datum/reagent/paint = 3,
+		/datum/reagent/drink/banana = 3,
+		/datum/reagent/space_drugs = 3,
+		/datum/reagent/water/holywater = 1,
+		/datum/reagent/drink/hot_coco = 3,
+		/datum/reagent/hyperzine = 0.75,
+		/datum/reagent/luminol = 2,
+		/datum/reagent/fuel = 3,
+		/datum/reagent/blood = 2,
+		/datum/reagent/sterilizine = 3,
+		/datum/reagent/verunol = 3,
+		/datum/reagent/toxin/fertilizer/monoammoniumphosphate = 1,
+		/datum/reagent/saline = 2,
+		/datum/reagent/mental/kokoreed = 0.5,
+		/datum/reagent/mental/vaam = 0.5,
+		/datum/reagent/toxin/tobacco = 3,
+		/datum/reagent/stone_dust = 0.5,
+		/datum/reagent/crayon_dust = 1,
+		/datum/reagent/alcohol/butanol = 2,
+		/datum/reagent/alcohol/ethanol = 2,
+		/datum/reagent/sugar = 2,
+		/datum/reagent/drink/coffee = 4,
+		/datum/reagent/wulumunusha = 0.25,
+		/datum/reagent/nutriment/virusfood = 2,
+		/datum/reagent/sodiumchloride = 2,
+		/datum/reagent/drink/zorasoda/venomgrass = 1,
+		/datum/reagent/nutriment/protein/egg = 2,
+		/datum/reagent/serotrotium = 1,
+		/datum/reagent/psilocybin = 0.5,
+		/datum/reagent/toxin/spectrocybin = 0.1
 	)
 	var/list/gunk_data = list(
-		/datum/reagent/paint = list("#FE191A", "FDFE7D")
+		/datum/reagent/paint = list("#FE191A", "#FDFE7D", "#1242A8", "#6CDB38")
 	)
 
 
@@ -51,11 +66,13 @@
 		var/obj/machinery/atmospherics/unary/vent_scrubber/vent = pick_n_take(vents)
 
 		if(vent && vent.loc && !vent.is_welded())
-
-			var/datum/reagents/R = new/datum/reagents(35)
+			var/datum/reagent/chem = pickweight(gunk)
+			var/reagent_amount = rand(3,6) * 5 //15 to 30 units
+			if(chem.overdose && chem.overdose < reagent_amount) //Some have no OD set. Those that do, we limit to that so we don't have people dropping dead.
+				reagent_amount = chem.overdose
+			var/datum/reagents/R = new/datum/reagents(reagent_amount)
 			R.my_atom = vent
-			var/chem = pick(gunk)
-			R.add_reagent(chem, 35, pick(gunk_data[chem]))
+			R.add_reagent(chem, reagent_amount, pick(gunk_data[chem]))
 
 			var/datum/effect/effect/system/smoke_spread/chem/smoke = new
 			smoke.show_log = 0 // This displays a log on creation

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -7,9 +7,9 @@
 	var/list/gunk = list(
 		/datum/reagent/water = 10,
 		/datum/reagent/carbon = 5,
-		/datum/reagent/nutriment/flour = 10,
-		/datum/reagent/spacecleaner = 8,
-		/datum/reagent/nutriment = 8,
+		/datum/reagent/nutriment/flour = 8,
+		/datum/reagent/spacecleaner = 6,
+		/datum/reagent/nutriment = 6,
 		/datum/reagent/capsaicin/condensed = 2,
 		/datum/reagent/mindbreaker = 0.5,
 		/datum/reagent/lube = 4,
@@ -45,7 +45,7 @@
 		/datum/reagent/toxin/spectrocybin = 0.1
 	)
 	var/list/gunk_data = list(
-		/datum/reagent/paint = list("#FE191A", "#FDFE7D", "#1242A8", "#6CDB38")
+		/datum/reagent/paint = list("#FE191A", "#aaaa79", "#5f89e6", "#6CDB38", "#B474B6")
 	)
 
 
@@ -67,9 +67,7 @@
 
 		if(vent && vent.loc && !vent.is_welded())
 			var/datum/reagent/chem = pickweight(gunk)
-			var/reagent_amount = rand(3,6) * 5 //15 to 30 units
-			if(chem.overdose && chem.overdose < reagent_amount) //Some have no OD set. Those that do, we limit to that so we don't have people dropping dead.
-				reagent_amount = chem.overdose
+			var/reagent_amount = rand(2,5) * 5 //10 to 25 units
 			var/datum/reagents/R = new/datum/reagents(reagent_amount)
 			R.my_atom = vent
 			R.add_reagent(chem, reagent_amount, pick(gunk_data[chem]))

--- a/html/changelogs/doxxmedearly - ventclogrework.yml
+++ b/html/changelogs/doxxmedearly - ventclogrework.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+delete-after: True
+
+changes:
+  - tweak: "Reworked scrubber backsurge odds to make certain things like mindbreaker less common. Reagent amounts are randomized now, instead of always being 35u."
+  - rscadd: "Added more reagent variety to backsurge events, as well as paint color variety."
+  - rscadd: "Added a cap so that backsurge sprays will never exceed a reagent's overdose threshold, which should help prevent deaths due to the event."

--- a/html/changelogs/doxxmedearly - ventclogrework.yml
+++ b/html/changelogs/doxxmedearly - ventclogrework.yml
@@ -2,6 +2,5 @@ author: Doxxmedearly
 delete-after: True
 
 changes:
-  - tweak: "Reworked scrubber backsurge odds to make certain things like mindbreaker less common. Reagent amounts are randomized now, instead of always being 35u."
+  - tweak: "Reworked scrubber backsurge odds to make certain things like mindbreaker less common. Reagent amounts are randomized between 10u and 25u now, instead of always being 35u."
   - rscadd: "Added more reagent variety to backsurge events, as well as paint color variety."
-  - rscadd: "Added a cap so that backsurge sprays will never exceed a reagent's overdose threshold, which should help prevent deaths due to the event."


### PR DESCRIPTION
- Makes it use pickweight instead of making all choices equal.
- Adds much more variety, including paint colors.
- Made the reagent amount it sprays randomized and generally lower. Ever since the chem rework, most OD thresholds were reduced to 20, but this was left at 35, leading to a lot of unnecessary stress on medical. These events should give them patients to see, not bodies to tally. As funny as it is to me to see someone get melted by a scrubber, it's not great for the server. 