### PR TITLE
Making nymph ghost pull a separate thing. Improving it

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -18,6 +18,7 @@
 #define BE_PLANT "BE_PLANT"
 #define BE_SYNTH "BE_SYNTH"
 #define BE_PAI   "BE_PAI"
+#define BE_NYMPH "BE_NYMPH"
 
 // Antagonist datum flags.
 #define ANTAG_OVERRIDE_JOB        0x1 // Assigned job is set to MODE when spawning.

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -139,10 +139,17 @@ var/list/ghost_traps
 
 /datum/ghosttrap/plant/welcome_candidate(var/mob/target)
 	to_chat(target, "<span class='alium'><B>You awaken slowly, stirring into sluggish motion as the air caresses you.</B></span>")
-	// This is a hack, replace with some kind of species blurb proc.
-	if(istype(target,/mob/living/carbon/alien/diona))
-		to_chat(target, "<B>You are \a [target], one of a race of drifting interstellar plantlike creatures that sometimes share their seeds with human traders.</B>")
-		to_chat(target, "<B>Too much darkness will send you into shock and starve you, but light will help you heal.</B>")
+
+/datum/ghosttrap/nymph
+	object = "living nymph"
+	ban_checks = list("Dionaea")
+	pref_check = BE_NYMPH
+	ghost_trap_message = "They are occupying a living nymph now."
+	ghost_trap_role = "Nymph"
+
+/datum/ghosttrap/nymph/welcome_candidate(var/mob/target)
+	to_chat(target, "<B>You are \a [target], one of a race of drifting interstellar plantlike creatures that sometimes share their seeds with human traders.</B>")
+	to_chat(target, "<B>Too much darkness will send you into shock and starve you, but light will help you heal.</B>")
 
 /*****************
 * Cortical Borer *

--- a/code/modules/hydroponics/seed_mobs.dm
+++ b/code/modules/hydroponics/seed_mobs.dm
@@ -3,17 +3,23 @@
 
 	if(!host || !istype(host)) return
 
-	var/datum/ghosttrap/plant/P = get_ghost_trap("living plant")
-	P.request_player(host, "Someone is harvesting \a [display_name].")
+	if(host.is_diona() == DIONA_NYMPH)
+		var/datum/ghosttrap/nymph/N = get_ghost_trap("living nymph")
+		N.request_player(host, "Someone is harvesting \a [display_name].", 1 MINUTE)
+	else
+		var/datum/ghosttrap/plant/P = get_ghost_trap("living plant")
+		P.request_player(host, "Someone is harvesting \a [display_name].", 1 MINUTE)
 
-	spawn(75)
-		if(!host.ckey && !host.client)
-			host.death()  // This seems redundant, but a lot of mobs don't
-			host.stat = DEAD // handle death() properly. Better safe than etc.
-			host.visible_message("<span class='danger'>[host] is malformed and unable to survive. It expires pitifully, leaving behind some seeds.</span>")
+	addtimer(CALLBACK(src, .proc/check_spawn_filled, host), 1 MINUTE)
 
-			var/total_yield = rand(1,3)
-			for(var/j = 0;j<=total_yield;j++)
-				var/obj/item/seeds/S = new(get_turf(host))
-				S.seed_type = name
-				S.update_seed()
+/datum/seed/proc/check_spawn_filled(var/mob/living/host)
+	if(!host.ckey && !host.client)
+		host.death()  // This seems redundant, but a lot of mobs don't
+		host.stat = DEAD // handle death() properly. Better safe than etc.
+		host.visible_message("<span class='danger'>[host] is malformed and unable to survive. It expires pitifully, leaving behind some seeds.</span>")
+
+		var/total_yield = rand(1, 3)
+		for(var/j = 0; j <= total_yield; j++)
+			var/obj/item/seeds/S = new(get_turf(host))
+			S.seed_type = name
+			S.update_seed()

--- a/code/modules/organs/subtypes/diona.dm
+++ b/code/modules/organs/subtypes/diona.dm
@@ -8,12 +8,16 @@
 
 /turf/proc/create_diona_nymph()
 	var/mob/living/carbon/alien/diona/D = new(src)
-	var/datum/ghosttrap/plant/P = get_ghost_trap("living plant")
-	P.request_player(D, "A diona nymph has split off from its gestalt. ")
-	sleep(120)
-	if(D)
-		if(!D.ckey || !D.client)
-			D.death()
+	var/datum/ghosttrap/nymph/P = get_ghost_trap("living nymph")
+	P.request_player(D, "A diona nymph has split off from its gestalt. ", 1 MINUTE)
+	addtimer(CALLBACK(src, .proc/check_diona_filled, D), 1 MINUTE)
+
+/turf/proc/check_diona_filled(var/mob/living/carbon/alien/diona/diona)
+	if(!diona)
+		return
+
+	if(!diona.ckey || !diona.client)
+		diona.death()
 
 //Probable future TODO: Refactor diona organs to be /obj/item/organ/external/bodypart/diona
 //Having them not inherit from specific bodypart classes is a problem

--- a/html/changelogs/Sindorman-nymph.yml
+++ b/html/changelogs/Sindorman-nymph.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Nymphs now have their own ghost request instead of using plant request. The timeout now is 1 minute."
+  - tweak: "Living plant ghost timeout is now 1 minute."


### PR DESCRIPTION
This pull request is in accordance with this [thread](https://forums.aurorastation.org/topic/15325-fixing-nymphs/)
In this pull request:

- Create its own BE_NYMPH preference
- Create its own nymph ghosttrap and moving code for nymph out of plant ghosttrap.
- Improving code for calling ghosttrap for nymph and living plant. Increasing timer for both to 1 minute.

I have tested the preference. But was unable to test entire functionality of this as I need another person to be the client. But I have statically tracked how code works and it should work. I think test merge should be made for this