### PR TITLE
Disruptor Counter-Nerf

### DIFF
--- a/code/modules/projectiles/guns/energy/disrupter.dm
+++ b/code/modules/projectiles/guns/energy/disrupter.dm
@@ -17,7 +17,6 @@
 	secondary_projectile_type = /obj/item/projectile/energy/blaster
 	max_shots = 8
 	charge_cost = 150
-	fire_delay = 8
 	accuracy = 1
 	has_item_ratio = FALSE
 	modifystate = "disruptorpistolstun"
@@ -35,7 +34,7 @@
 	name = "miniature disruptor pistol"
 	desc = "A Nanotrasen designed blaster pistol with two settings: stun and lethal. This is the miniature version."
 	icon = 'icons/obj/guns/disruptorpistol/disruptorpistolc.dmi'
-	max_shots = 5
+	max_shots = 6
 	force = 3
 	slot_flags = SLOT_BELT|SLOT_HOLSTER|SLOT_POCKET
 	w_class = ITEMSIZE_SMALL

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -208,7 +208,7 @@
 /obj/item/projectile/energy/disruptorstun
 	name = "disruptor bolt"
 	icon_state = "blue_laser"
-	agony = 25
+	agony = 30
 	speed = 0.4
 	damage_type = PAIN // Can't blow your own head off with a stunbolt.
 	taser_effect = TRUE

--- a/html/changelogs/geeves-disruptor_buffs.yml
+++ b/html/changelogs/geeves-disruptor_buffs.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Disruptor firerate has been increased back to 0.6s, up from 0.8s."
+  - tweak: "Mini-disruptors now have 6 shots, up from 5."
+  - tweak: "Disruptor stun shots now do 30 agony damage, up from 25."


### PR DESCRIPTION
* Disruptor firerate has been increased back to 0.6s, up from 0.8s.
* Mini-disruptors now have 6 shots, up from 5.
* Disruptor stun shots now do 30 agony damage, up from 25.

Feedback Thread: https://forums.aurorastation.org/topic/15240-feedback-disruptor-nerf