### PR TITLE
Encased Organ Rebalance

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -361,7 +361,7 @@
 	organ_hit_chance += 5 * damage_amt / organ_damage_threshold
 
 	if(encased && !(status & ORGAN_BROKEN)) //ribs protect
-		organ_hit_chance *= 0.6
+		organ_hit_chance *= 0.2
 
 	organ_hit_chance = min(organ_hit_chance, 100)
 	if(prob(organ_hit_chance))

--- a/html/changelogs/geeves-organ_rebalance.yml
+++ b/html/changelogs/geeves-organ_rebalance.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Internal organs protected by bones (like a ribcage) now have a x0.2 modifier to being hit, adjusted from x0.6."


### PR DESCRIPTION
* Internal organs protected by bones (like a ribcage) now have a x0.2 modifier to being hit, adjusted from x0.6.