### PR TITLE
Ghostspawner enable fix

### DIFF
--- a/code/modules/ghostroles/spawner/base.dm
+++ b/code/modules/ghostroles/spawner/base.dm
@@ -181,6 +181,9 @@
 
 //Proc to enable the ghostspawner
 /datum/ghostspawner/proc/enable()
+	if((max_count - count) <= 0)
+		to_chat(usr, "The ghostspawner can not be enabled - No slots available")
+		return
 	if(usr)
 		log_and_message_admins("has enabled the ghostspawner [src.name]")
 	enabled = TRUE

--- a/html/changelogs/arrow768-ghostspawner-bugfix.yml
+++ b/html/changelogs/arrow768-ghostspawner-bugfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "The ghostspawner can no longer be enabled if all the available slots have been used up."


### PR DESCRIPTION
The ghostspawner can no longer be enabled if all the available slots have been used up.