### PR TITLE
Antag Roles Uplink Tweak

### DIFF
--- a/code/datums/uplink/announcements.dm
+++ b/code/datums/uplink/announcements.dm
@@ -31,11 +31,8 @@
 /datum/uplink_item/abstract/announcements/fake_crew_arrival
 	name = "Crew Arrival Announcement/Records"
 	desc = "Creates a fake crew arrival announcement as well as fake crew records, using your current appearance (including held items!) and worn id card. Trigger with care!"
-	item_cost = 8
-
-/datum/uplink_item/abstract/announcements/fake_crew_arrival/New()
-	..()
 	antag_roles = list(MODE_MERCENARY)
+	item_cost = 8
 
 /datum/uplink_item/abstract/announcements/fake_crew_arrival/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/user, var/list/args)
 	if(!user)

--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -53,13 +53,13 @@
 ****************/
 /datum/uplink_item/item/badassery/surplus
 	name = "Surplus Crate"
+	antag_roles = list(MODE_MERCENARY)
 	item_cost = DEFAULT_TELECRYSTAL_AMOUNT * 4
 	var/item_worth = DEFAULT_TELECRYSTAL_AMOUNT * 6
 	var/icon
 
 /datum/uplink_item/item/badassery/surplus/New()
 	..()
-	antag_roles = list(MODE_MERCENARY)
 	desc = "A crate containing [item_worth] telecrystal\s worth of surplus leftovers."
 
 /datum/uplink_item/item/badassery/surplus/get_goods(var/obj/item/device/uplink/U, var/loc)

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -70,7 +70,7 @@ var/datum/uplink/uplink
 
 /datum/uplink_item/proc/can_view(obj/item/device/uplink/U)
 	// Making the assumption that if no uplink was supplied, then we don't care about antag roles
-	if(!U || (!LAZYLEN(antag_roles) && !antag_job))
+	if(!U || (!length(antag_roles) && !antag_job))
 		return 1
 
 	// With no owner, there's no need to check antag status.

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -36,10 +36,6 @@ var/datum/uplink/uplink
 /datum/uplink_item/item
 	var/path = null
 
-/datum/uplink_item/New()
-	..()
-	antag_roles = list()
-
 /datum/uplink_item/proc/buy(var/obj/item/device/uplink/U, var/mob/user)
 	var/extra_args = extra_args(user)
 	if(!extra_args)
@@ -74,7 +70,7 @@ var/datum/uplink/uplink
 
 /datum/uplink_item/proc/can_view(obj/item/device/uplink/U)
 	// Making the assumption that if no uplink was supplied, then we don't care about antag roles
-	if(!U || (!antag_roles.len && !antag_job))
+	if(!U || (!LAZYLEN(antag_roles) && !antag_job))
 		return 1
 
 	// With no owner, there's no need to check antag status.


### PR DESCRIPTION
Just a small PR that makes antag_roles not get set in new, which allows people to place it in a nice place instead of having to put it in a New().