### PR TITLE
More Gloves for Aliens

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_xeno/tajara.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/tajara.dm
@@ -14,8 +14,12 @@
 	taj_gloves["orange gloves"] = /obj/item/clothing/gloves/orange/tajara
 	taj_gloves["purple gloves"] = /obj/item/clothing/gloves/purple/tajara
 	taj_gloves["brown gloves"] = /obj/item/clothing/gloves/brown/tajara
+	taj_gloves["light brown gloves"] = /obj/item/clothing/gloves/light_brown/tajara
 	taj_gloves["green gloves"] = /obj/item/clothing/gloves/green/tajara
+	taj_gloves["grey gloves"] = /obj/item/clothing/gloves/grey/tajara
 	taj_gloves["white gloves"] = /obj/item/clothing/gloves/white/tajara
+	taj_gloves["rainbow gloves"] = /obj/item/clothing/gloves/rainbow/tajara
+	taj_gloves["black leather gloves"] = /obj/item/clothing/gloves/black_leather/tajara
 	taj_gloves["machinist gloves"] =  /obj/item/clothing/gloves/black/tajara/smithgloves
 	gear_tweaks += new/datum/gear_tweak/path(taj_gloves)
 

--- a/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
@@ -40,8 +40,12 @@
 	un_gloves["orange gloves"] = /obj/item/clothing/gloves/orange/unathi
 	un_gloves["purple gloves"] = /obj/item/clothing/gloves/purple/unathi
 	un_gloves["brown gloves"] = /obj/item/clothing/gloves/brown/unathi
+	un_gloves["light brown gloves"] = /obj/item/clothing/gloves/light_brown/unathi
 	un_gloves["green gloves"] = /obj/item/clothing/gloves/green/unathi
+	un_gloves["grey gloves"] = /obj/item/clothing/gloves/grey/unathi
 	un_gloves["white gloves"] = /obj/item/clothing/gloves/white/unathi
+	un_gloves["rainbow gloves"] = /obj/item/clothing/gloves/rainbow/unathi
+	un_gloves["black leather gloves"] = /obj/item/clothing/gloves/black_leather/unathi
 	gear_tweaks += new/datum/gear_tweak/path(un_gloves)
 
 /datum/gear/uniform/unathi

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -148,7 +148,7 @@
 
 /obj/item/clothing/gloves/grey/unathi
 	name = "grey gloves"
-	desc = "Grey gloves, made for Unathi use."
+	desc = "Grey gloves made for Unathi use."
 	species_restricted = list(BODYTYPE_UNATHI)
 
 /obj/item/clothing/gloves/white/unathi
@@ -158,7 +158,7 @@
 
 /obj/item/clothing/gloves/rainbow/unathi
 	name = "rainbow gloves"
-	desc = "Rainbow gloves, made for Unathi use."
+	desc = "Rainbow gloves made for Unathi use."
 	species_restricted = list(BODYTYPE_UNATHI)
 
 /obj/item/clothing/gloves/evening
@@ -174,7 +174,7 @@
 
 /obj/item/clothing/gloves/black_leather/unathi
 	name = "black leather gloves"
-	desc = "Black leather gloves, made for Unathi use."
+	desc = "Black leather gloves made for Unathi use."
 	species_restricted = list(BODYTYPE_UNATHI)
 
 /obj/item/clothing/gloves/black_leather/colour

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -148,7 +148,7 @@
 
 /obj/item/clothing/gloves/grey/unathi
 	name = "grey gloves"
-	desc = "A pair of grey gloves, made for Unathi use."
+	desc = "Grey gloves, made for Unathi use."
 	species_restricted = list(BODYTYPE_UNATHI)
 
 /obj/item/clothing/gloves/white/unathi
@@ -158,7 +158,7 @@
 
 /obj/item/clothing/gloves/rainbow/unathi
 	name = "rainbow gloves"
-	desc = "A pair of rainbow gloves, made for Unathi use."
+	desc = "Rainbow gloves, made for Unathi use."
 	species_restricted = list(BODYTYPE_UNATHI)
 
 /obj/item/clothing/gloves/evening
@@ -174,7 +174,7 @@
 
 /obj/item/clothing/gloves/black_leather/unathi
 	name = "black leather gloves"
-	desc = "A pair of black leather gloves, made for Unathi use."
+	desc = "Black leather gloves, made for Unathi use."
 	species_restricted = list(BODYTYPE_UNATHI)
 
 /obj/item/clothing/gloves/black_leather/colour

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -136,15 +136,30 @@
  	desc = "Brown gloves made for Unathi use."
  	species_restricted = list(BODYTYPE_UNATHI)
 
+/obj/item/clothing/gloves/light_brown/unathi
+	name = "light brown gloves"
+	desc = "Light brown gloves made for Unathi use."
+	species_restricted = list(BODYTYPE_UNATHI)
+
 /obj/item/clothing/gloves/green/unathi
  	name = "green gloves"
  	desc = "Green gloves made for Unathi use."
  	species_restricted = list(BODYTYPE_UNATHI)
 
+/obj/item/clothing/gloves/grey/unathi
+	name = "grey gloves"
+	desc = "A pair of grey gloves, made for Unathi use."
+	species_restricted = list(BODYTYPE_UNATHI)
+
 /obj/item/clothing/gloves/white/unathi
  	name = "white gloves"
  	desc = "White gloves made for Unathi use."
  	species_restricted = list(BODYTYPE_UNATHI)
+
+/obj/item/clothing/gloves/rainbow/unathi
+	name = "rainbow gloves"
+	desc = "A pair of rainbow gloves, made for Unathi use."
+	species_restricted = list(BODYTYPE_UNATHI)
 
 /obj/item/clothing/gloves/evening
 	name = "evening gloves"
@@ -156,6 +171,11 @@
 	desc = "A pair of tight-fitting synthleather gloves."
 	icon_state = "black_leather"
 	item_state = "black_leather"
+
+/obj/item/clothing/gloves/black_leather/unathi
+	name = "black leather gloves"
+	desc = "A pair of black leather gloves, made for Unathi use."
+	species_restricted = list(BODYTYPE_UNATHI)
 
 /obj/item/clothing/gloves/black_leather/colour
 	icon_state = "full_leather_colour"

--- a/code/modules/clothing/gloves/xeno/tajara.dm
+++ b/code/modules/clothing/gloves/xeno/tajara.dm
@@ -27,13 +27,29 @@
  	desc = "Brown gloves made for Tajaran use."
  	species_restricted = list(BODYTYPE_TAJARA)
 
+/obj/item/clothing/gloves/light_brown/tajara
+	desc = "Light brown gloves made for Tajaran use."
+	species_restricted = list(BODYTYPE_TAJARA)
+
 /obj/item/clothing/gloves/green/tajara
  	desc = "Green gloves made for Tajaran use."
  	species_restricted = list(BODYTYPE_TAJARA)
 
+/obj/item/clothing/gloves/grey/tajara
+	desc = "A pair of grey gloves, made for Tajaran use."
+	species_restricted = list(BODYTYPE_TAJARA)
+
 /obj/item/clothing/gloves/white/tajara
  	desc = "White gloves made for Tajaran use."
  	species_restricted = list (BODYTYPE_TAJARA)
+
+/obj/item/clothing/gloves/rainbow/tajara
+	desc = "A pair of rainbow gloves, made for Tajaran use."
+	species_restricted = list(BODYTYPE_TAJARA)
+
+/obj/item/clothing/gloves/black_leather/tajara
+	desc = "A pair of black leather gloves, made for Tajaran use."
+	species_restricted = list(BODYTYPE_TAJARA)
 
 /obj/item/clothing/gloves/black/tajara/smithgloves
 	name = "machinist gloves"

--- a/code/modules/clothing/gloves/xeno/tajara.dm
+++ b/code/modules/clothing/gloves/xeno/tajara.dm
@@ -36,7 +36,7 @@
  	species_restricted = list(BODYTYPE_TAJARA)
 
 /obj/item/clothing/gloves/grey/tajara
-	desc = "A pair of grey gloves, made for Tajaran use."
+	desc = "Grey gloves made for Tajaran use."
 	species_restricted = list(BODYTYPE_TAJARA)
 
 /obj/item/clothing/gloves/white/tajara
@@ -44,11 +44,11 @@
  	species_restricted = list (BODYTYPE_TAJARA)
 
 /obj/item/clothing/gloves/rainbow/tajara
-	desc = "A pair of rainbow gloves, made for Tajaran use."
+	desc = "Rainbow gloves made for Tajaran use."
 	species_restricted = list(BODYTYPE_TAJARA)
 
 /obj/item/clothing/gloves/black_leather/tajara
-	desc = "A pair of black leather gloves, made for Tajaran use."
+	desc = "Black leather gloves made for Tajaran use."
 	species_restricted = list(BODYTYPE_TAJARA)
 
 /obj/item/clothing/gloves/black/tajara/smithgloves

--- a/html/changelogs/wickedcybs-gloves.yml
+++ b/html/changelogs/wickedcybs-gloves.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - rscadd: "Four missing glove types added to the Unathi & Tajara loadout selection, bringing it in parity with the normal glove selection humans have. Added options are light brown, grey, rainbow and black leather."


### PR DESCRIPTION
Adds in four missing glove types that Unathi and Tajara couldn't select before. Light brown, grey, rainbow and black leather. These were in the human glove selection already, but not in the alien glove selections

Here is an example of the added selection.
![image](https://user-images.githubusercontent.com/52309324/104148873-47820a00-5391-11eb-860d-0589940899e8.png)
