### PR TITLE
Cough Syrup Recipe Change

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -651,7 +651,7 @@
 	name = "Cough Syrup"
 	id = "coughsyrup"
 	result = /datum/reagent/coughsyrup
-	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/ammonia = 1, /datum/reagent/water = 1)
+	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/tungsten = 1, /datum/reagent/water = 1)
 	result_amount = 3
 
 //Mental Medication

--- a/html/changelogs/doxxmedearly - coughsyrup_recipe.yml
+++ b/html/changelogs/doxxmedearly - coughsyrup_recipe.yml
@@ -1,0 +1,5 @@
+author: Doxxmedearly
+delete-after: True
+
+changes:
+  - tweak: "Cough syrup is now made with carbon, water, and tungsten instead of carbon, water, and ammonia, to prevent recipe conflicts."


### PR DESCRIPTION
Cough syrup now uses tungsten instead of ammonia to prevent accidentally making space cleaner