### PR TITLE
Plastic Flaps no longer get stuck while deconstructing

### DIFF
--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -50,16 +50,15 @@
 
 /obj/structure/plasticflaps/attackby(obj/item/W, mob/user)
 	if(manipulating)	return
-	manipulating = TRUE
 	if(W.iswirecutter() || W.sharp && !W.noslice)
+		manipulating = TRUE
 		visible_message(SPAN_NOTICE("[user] begins cutting down \the [src]."),
 					SPAN_NOTICE("You begin cutting down \the [src]."))
 		if(!do_after(user, 30/W.toolspeed))
 			manipulating = FALSE
 			return
 		playsound(src.loc, 'sound/items/wirecutter.ogg', 50, 1)
-		visible_message(SPAN_NOTICE("[user] cuts down \the [src]."),
-		SPAN_NOTICE("You cut down \the [src]."))
+		visible_message(SPAN_NOTICE("[user] cuts down \the [src]."), SPAN_NOTICE("You cut down \the [src]."))
 		dismantle()
 
 /obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates

--- a/html/changelogs/doxxmedearly - flapfix.yml
+++ b/html/changelogs/doxxmedearly - flapfix.yml
@@ -3,4 +3,4 @@ author: Doxxmedearly
 delete-after: True
 
 changes:
-  - bugfiz: "Plastic flaps no longer get stuck while trying to deconstruct them."
+  - bugfix: "Plastic flaps no longer get stuck while trying to deconstruct them."

--- a/html/changelogs/doxxmedearly - flapfix.yml
+++ b/html/changelogs/doxxmedearly - flapfix.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfiz: "Plastic flaps no longer get stuck while trying to deconstruct them."


### PR DESCRIPTION
Accidentally had the manipulating set to TRUE before the item check, so clicking on it with any item made it unable to be deconstructed without admin intervention. Fixed now. 