### PR TITLE
Spider Blood Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -21,7 +21,6 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "pokes"
-	blood_overlay_icon = null
 	stop_automated_movement_when_pulled = 0
 	maxHealth = 200
 	health = 200

--- a/html/changelogs/geeves-spider_blood_fix.yml
+++ b/html/changelogs/geeves-spider_blood_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed giant spiders not having a blood overlay."


### PR DESCRIPTION
* Fixed giant spiders not having a blood overlay.

I dunno why I set it to null in the first place. Might've confused it with the giant spider squeen.