### PR TITLE
Throw Tweaks

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -92,7 +92,7 @@
 					continue
 				throw_impact(A, speed)
 			if(isobj(A))
-				if(A.density && !A.throwpass)	// **TODO: Better behaviour for windows which are dense, but shouldn't always stop movement
+				if(A.density && !A.throwpass && !A.CanPass(src, target))
 					src.throw_impact(A,speed)
 
 // Prevents robots dropping their modules

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -367,7 +367,7 @@ emp_act
 		var/miss_chance = 15
 		if (O.throw_source)
 			var/distance = get_dist(O.throw_source, loc)
-			miss_chance = max(15*(distance-2), 0)
+			miss_chance = 15 * (distance - 2)
 		zone = get_zone_with_miss_chance(zone, src, miss_chance, ranged_attack=1)
 
 		if(zone && O.thrower != src)

--- a/html/changelogs/geeves-throw_things.yml
+++ b/html/changelogs/geeves-throw_things.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "It is now impossible to miss pointblank throwing something at someone."
+  - rscadd: "You can now throw things past windows without it bumping into them."


### PR DESCRIPTION
* It is now impossible to miss pointblank throwing something at someone.
* You can now throw things past windows without it bumping into them.

Funnily enough, the `max(thing, 0)` for the hit calculation only came into play if you were right on top of, or right next to the thing you're throwing stuff at. When you're adjacent, it gives `-10` prob to miss, with the added `10` by the zone miss check, it rounds up to a clean 0%. Neat.