### PR TITLE
Revenant Tweaks

### DIFF
--- a/code/game/gamemodes/revenants/revenants.dm
+++ b/code/game/gamemodes/revenants/revenants.dm
@@ -4,6 +4,7 @@
 	required_players = 10
 	required_enemies = 0
 	round_autoantag = TRUE
+	var/first_spawn_delay = 20 MINUTES
 	min_autotraitor_delay = 3 MINUTES
 	max_autotraitor_delay = 6 MINUTES
 	antag_scaling_coeff = 4 // four people can handle one revenant pretty easily
@@ -11,7 +12,13 @@
 	extended_round_description = "This a wave defense gamemode. The crew all have to work together to repel an endless horde of bluespace horrors."
 	antag_tags = list(MODE_REVENANT)
 
+/datum/game_mode/revenants/New()
+	..()
+	first_spawn_delay = rand(20 MINUTES, 30 MINUTES)
+
 /datum/game_mode/revenants/process_autoantag()
+	if(world.time - round_start_time < first_spawn_delay)
+		return
 	var/datum/ghostspawner/revenant/R = SSghostroles.get_spawner(MODE_REVENANT)
 	var/datum/antagonist/A = all_antag_types[MODE_REVENANT]
 	A.update_current_antag_max()
@@ -21,3 +28,4 @@
 		say_dead_direct("A slot for a Revenant as opened up!<br>Spawn in as it by using the ghost spawner menu in the ghost tab, and try to be good!")
 	if(!R.enabled)
 		R.enable()
+	next_spawn = world.time + rand(min_autotraitor_delay, max_autotraitor_delay)

--- a/code/modules/ghostroles/spawner/antagonist/revenant.dm
+++ b/code/modules/ghostroles/spawner/antagonist/revenant.dm
@@ -9,7 +9,7 @@
 
 	enabled = FALSE
 	landmark_name = "Revenant"
-	max_count = 1
+	max_count = 0
 
 	spawn_mob = /mob/living/carbon/human/revenant
 	respawn_flag = ANIMAL

--- a/code/modules/ghostroles/spawner/antagonist/revenant.dm
+++ b/code/modules/ghostroles/spawner/antagonist/revenant.dm
@@ -9,11 +9,12 @@
 
 	enabled = FALSE
 	landmark_name = "Revenant"
-	max_count = 0
+	max_count = 1
 
 	spawn_mob = /mob/living/carbon/human/revenant
 	respawn_flag = ANIMAL
 
+	var/spawn_index = 1 // used to add a numerical identifier to the revenant. increases by 1 per spawn
 	var/has_fired = FALSE
 
 /datum/ghostspawner/revenant/spawn_mob(mob/user)
@@ -26,6 +27,9 @@
 		return
 
 	if(R)
+		R.real_name = "[R.real_name] ([spawn_index])"
+		R.name = R.real_name
+		spawn_index++
 		announce_ghost_joinleave(user, FALSE, "They are now a [name].")
 		R.ckey = user.ckey
 

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -104,3 +104,4 @@
 	key = "c"
 	syllables = list("grhhg", "ghrohg", "grgugh", "grrhh", "hghh", "rghghh", "gghhh", "ggrh", "aghrh")
 	flags = RESTRICTED
+	partial_understanding = list(LANGUAGE_TCB = 80)

--- a/code/modules/mob/living/carbon/human/species/outsider/revenant.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/revenant.dm
@@ -1,3 +1,6 @@
+/mob/living/carbon/human/revenant
+	universal_understand = TRUE
+
 /mob/living/carbon/human/revenant/Initialize(mapload)
 	. = ..(mapload, SPECIES_REVENANT)
 	alpha = 0

--- a/code/modules/mob/living/carbon/human/species/outsider/revenant.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/revenant.dm
@@ -1,6 +1,3 @@
-/mob/living/carbon/human/revenant
-	universal_understand = TRUE
-
 /mob/living/carbon/human/revenant/Initialize(mapload)
 	. = ..(mapload, SPECIES_REVENANT)
 	alpha = 0
@@ -120,6 +117,7 @@
 	H.name = H.real_name
 	..()
 	H.gender = NEUTER
+	H.universal_understand = TRUE
 
 /datum/species/revenant/get_random_name()
 	return "Revenant"

--- a/html/changelogs/geeves-revenant_tweaks.yml
+++ b/html/changelogs/geeves-revenant_tweaks.yml
@@ -6,3 +6,4 @@ changes:
   - rscadd: "Tau Ceti Basic speakers can now understand 80% of what revenants say."
   - tweak: "Revenants can now universally understand all languages."
   - tweak: "Revenants now spawn between 20 and 30 minutes into the round."
+  - rscadd: "Revenants now get a numerical identifier after their name that increments up from 1."

--- a/html/changelogs/geeves-revenant_tweaks.yml
+++ b/html/changelogs/geeves-revenant_tweaks.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Tau Ceti Basic speakers can now understand 80% of what revenants say."
+  - tweak: "Revenants can now universally understand all languages."
+  - tweak: "Revenants now spawn between 20 and 30 minutes into the round."


### PR DESCRIPTION
* Tau Ceti Basic speakers can now understand 80% of what revenants say.
* Revenants can now universally understand all languages.
* Revenants now spawn between 20 and 30 minutes into the round.
* Revenants now get a numerical identifier after their name that increments up from 1.