### PR TITLE
Radiator Venting Windows

### DIFF
--- a/html/changelogs/geeves-radiator_venting.yml
+++ b/html/changelogs/geeves-radiator_venting.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added borosillicate windows to the supermatter engine bay to prevent it from being vented when the radiators get breached."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -23658,11 +23658,13 @@
 "aOp" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/effect/floor_decal/industrial/warning,
+/obj/effect/map_effect/wingrille_spawn/reinforced_phoron/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "aOq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/floor_decal/industrial/warning,
+/obj/effect/map_effect/wingrille_spawn/reinforced_phoron/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "aOr" = (


### PR DESCRIPTION
* Added borosillicate windows to the supermatter engine bay to prevent it from being vented when the radiators get breached.
