### PR TITLE
Adds time restriction to calling an ert

### DIFF
--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -155,6 +155,8 @@
 	if(SSticker.mode.ert_disabled)
 		SSticker.mode.announce_ert_disabled()
 		return 1
+	if(world.time < config.time_to_call_emergency_shuttle) //uses the same value of when people are allowed to call an emergency shuttle
+		return 1
 	else
 		return 0
 

--- a/html/changelogs/alberk-erttweak.yml
+++ b/html/changelogs/alberk-erttweak.yml
@@ -1,4 +1,4 @@
-author: ChangeMe
+author: Alberyk
 
 delete-after: True
 

--- a/html/changelogs/alberk-erttweak.yml
+++ b/html/changelogs/alberk-erttweak.yml
@@ -1,0 +1,6 @@
+author: ChangeMe
+
+delete-after: True
+
+changes:
+  - tweak: "Erts can now only be called after one hour in the round."


### PR DESCRIPTION
What it says in the title. Use the same config option used by the shuttle. So this will stop people from calling an ert before one hour passes.