### PR TITLE
Adding scrubber procs to scrubbers and change default filter settings

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -21,7 +21,7 @@
 
 	var/hibernate = 0 //Do we even process?
 	var/scrubbing = 1 //0 = siphoning, 1 = scrubbing
-	var/list/scrubbing_gas = list(GAS_CO2)
+	var/list/scrubbing_gas
 
 	var/panic = 0 //is this scrubber panicked?
 
@@ -51,6 +51,9 @@
 	radio_filter_out = frequency==initial(frequency)?(RADIO_TO_AIRALARM):null
 	if (frequency)
 		set_frequency(frequency)
+
+	if (!scrubbing_gas)
+		reset_scrubbing()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/proc/reset_scrubbing()
 	if (initial(scrubbing_gas))

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -52,6 +52,21 @@
 	if (frequency)
 		set_frequency(frequency)
 
+/obj/machinery/atmospherics/unary/vent_scrubber/proc/reset_scrubbing()
+	if (initial(scrubbing_gas))
+		scrubbing_gas = initial(scrubbing_gas)
+	else
+		scrubbing_gas = list()
+		for (var/g in gas_data.gases)
+			if (g != GAS_OXYGEN && g != GAS_NITROGEN)
+				add_to_scrubbing(g)
+
+/obj/machinery/atmospherics/unary/vent_scrubber/proc/add_to_scrubbing(new_gas)
+	scrubbing_gas |= new_gas
+
+/obj/machinery/atmospherics/unary/vent_scrubber/proc/remove_from_scrubbing(old_gas)
+	scrubbing_gas -= old_gas
+
 /obj/machinery/atmospherics/unary/vent_scrubber/atmos_init()
 	..()
 	broadcast_status()
@@ -243,7 +258,7 @@
 		toggle += GAS_N2O
 	else if(signal.data["toggle_n2o_scrub"])
 		toggle += GAS_N2O
-	
+
 	if(!isnull(signal.data["h2_scrub"]) && text2num(signal.data["h2_scrub"]) != (GAS_HYDROGEN in scrubbing_gas))
 		toggle += GAS_HYDROGEN
 	else if(signal.data["toggle_h2_scrub"])

--- a/html/changelogs/sierrakomodo-scrubber-procs.yml
+++ b/html/changelogs/sierrakomodo-scrubber-procs.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Scrubbers now filter all non-air gasses by default, instead of jsut CO2."


### PR DESCRIPTION
Port of my PR to BS12: https://github.com/Baystation12/Baystation12/pull/30076

Also includes changes to the default scrubber filter settings that can be reverted while keeping the new procs if requested.

Adds new procs to scrubbers to make it possible to change what gasses a scrubber is filtering without need to mess with VVing lists, and being able to mass-update them using SDQL.

Intended as a method of countering a specific form of atmos grief.

Adds these three new proc calls:
 - `reset_scrubbing()` will reset the scrubber to it's initial values as if it was just spawned (This is probably what you want to use for grief fixing).
 - `add_to_scrubbing(new_gas)` will add the gas name to the scrubber's filtering list
 - `remove_from_scrubbing(old_gas)` will remove the gas name from the scrubber's filtering list

### IC changelog
 - The default filtration setting for all station scrubbers have been updated. Scrubbers will now, by default, filter all gasses except oxygen and nitrogen.