### PR TITLE
Changes the freelancer ERT description to remove self-antagging.

### DIFF
--- a/code/modules/ghostroles/spawner/human/responseteams/mercenary.dm
+++ b/code/modules/ghostroles/spawner/human/responseteams/mercenary.dm
@@ -3,7 +3,7 @@
 	short_name = "mercr"
 	max_count = 2
 	desc = "Rank and file of a freelancer mercenary team."
-	welcome_message = "You're part of a freelancing mercenary team who just picked up a distress beacon coming from the Aurora. You have no affiliation to anyone, but you sure do want a quick buck."
+	welcome_message = "Your crew has been hired by Nanotrasen to sort out a distress signal. While you wouldn't do anything violent to the crew, maybe they won't miss that one fancy artifact..."
 	outfit = /datum/outfit/admin/ert/mercenary
 	possible_species = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_MSAI, SPECIES_TAJARA_ZHAN, SPECIES_SKRELL, SPECIES_DIONA, SPECIES_UNATHI, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_WORKER, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
 

--- a/html/changelogs/mattatlas-thankseveryone.yml
+++ b/html/changelogs/mattatlas-thankseveryone.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "The freelancer mercenary description has been changed so as to no longer allow self-antagonistic actions."


### PR DESCRIPTION
An annoying little trend that has been popping up is freelancer ERTs taking the vagueness of their welcome prompt and interpreting it as "I can side with the antags and kill everyone". They are no longer allowed to do this.