### PR TITLE
Infection Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -70,6 +70,8 @@
 
 		handle_medical_side_effects()
 
+		handle_fever()
+
 		//Handles regenerating stamina if we have sufficient air and no oxyloss
 		handle_stamina()
 
@@ -638,23 +640,6 @@
 			sprint_speed_factor += 0.2 * chem_effects[CE_SPEEDBOOST]
 			stamina_recovery *= 1 + 0.3 * chem_effects[CE_SPEEDBOOST]
 			move_delay_mod += -1.5 * chem_effects[CE_SPEEDBOOST]
-
-		if(CE_FEVER in chem_effects)
-			var/normal_temp = species?.body_temperature || (T0C+37)
-			var/fever = chem_effects[CE_FEVER]
-			if(CE_NOFEVER in chem_effects)
-				fever -= chem_effects[CE_NOFEVER] // a dose of 16u Perconol should offset a stage 4 virus
-			bodytemperature = Clamp(bodytemperature+fever, normal_temp, normal_temp + 9) // temperature should range from 37C to 46C, 98.6F to 115F
-			if(fever > 1)
-				if(prob(20/3)) // every 30 seconds, roughly
-					to_chat(src, SPAN_WARNING(pick("You feel cold and clammy...", "You shiver as if a breeze has passed through.", "Your muscles ache.", "You feel tired and fatigued.")))
-				if(prob(20)) // once every 10 seconds, roughly
-					drowsyness += 4
-				if(prob(20))
-					adjustHalLoss(15) // muscle pain from fever
-			if(fever >= 5) // your organs are boiling, figuratively speaking
-				var/obj/item/organ/internal/IO = pick(internal_organs)
-				IO.take_internal_damage(1)
 
 		var/total_phoronloss = 0
 		for(var/obj/item/I in src)
@@ -1406,3 +1391,51 @@
 		damageoverlay.cut_overlay(last_oxy_overlay)
 		last_oxy_overlay = null
 
+//Fevers
+//This handles infection fevers as well as fevers caused by chem effects
+/mob/living/carbon/human/proc/handle_fever()
+	var/normal_temp = species?.body_temperature || (T0C+37)
+	//If we have infections, they give us a fever. Get all of their germ levels and find what our bodytemp will raise by.
+	var/fever = get_infection_germ_level() / INFECTION_LEVEL_ONE
+	//See what chemicals in our body affect our fever for better or worse
+	if(CE_FEVER in chem_effects)
+		fever += chem_effects[CE_FEVER]
+	if(CE_NOFEVER in chem_effects)
+		fever -= chem_effects[CE_NOFEVER]
+
+	//Apply changes to body temp. I absolutely hate body temp code -Doxx
+	if(fever < 0) //If we have enough anti-fever meds to bring us back towards normal temperature, do so.
+		if(bodytemperature >= normal_temp)  //We don't have any effect if we're colder than normal.
+			bodytemperature = max(bodytemperature + fever, normal_temp)
+		return
+	if(fever > 0) //We're getting a fever, raise body temp. 10C above normal is our max for fevers.
+		if(bodytemperature < normal_temp) //If we're colder than usual, we'll slowly raise to normal temperature
+			bodytemperature = min(bodytemperature + fever, normal_temp)
+		else if(bodytemperature <= normal_temp + 10) //If we're hotter than max due to like, being on fire, don't keep increasing.
+			bodytemperature = normal_temp + min(fever, 10) //We use normal_temp here to maintain a steady temperature, otherwise even a small infection steadily increases bodytemp to max. This way it's easier to diagnose the intensity of an infection based on how bad the fever is.
+	//Apply side effects for having a fever. Separate from body temp changes. 
+	if(fever >= 2)
+		do_fever_effects(fever)
+
+		
+//Getting the total germ level for all infected organs, affects fever
+/mob/living/carbon/human/proc/get_infection_germ_level()
+	var/germs
+	for(var/obj/item/organ/I in internal_organs)
+		if(I.is_infected())
+			germs += I.germ_level
+	for(var/obj/item/organ/external/E in organs)
+		if(E.is_infected())
+			germs += E.germ_level
+	return germs
+
+/mob/living/carbon/human/proc/do_fever_effects(var/fever)
+	if(prob(20/3)) // every 30 seconds, roughly
+		to_chat(src, SPAN_WARNING(pick("You feel cold and clammy...", "You shiver as if a breeze has passed through.", "Your muscles ache.", "You feel tired and fatigued.")))
+	if(prob(20)) // once every 10 seconds, roughly
+		drowsyness += 4
+	if(prob(20))
+		adjustHalLoss(5 * min(fever, 5)) // muscle pain from fever
+	if(fever >= 7 && prob(10)) // your organs are boiling, figuratively speaking
+		var/obj/item/organ/internal/IO = pick(internal_organs)
+		IO.take_internal_damage(1)

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -35,6 +35,10 @@
 		if(H.getOxyLoss() >= 20)
 			to_chat(user, "<span class='warning'>[H]'s skin is unusually pale.</span>")
 			bad = 1
+		if(E.is_infected())
+			var/severity = E.germ_level < INFECTION_LEVEL_TWO ? "slightly" : E.germ_level < INFECTION_LEVEL_THREE ? "moderately" : "extremely"
+			to_chat(user, SPAN_WARNING("[H]'s skin is [severity] warm and reddened."))
+			bad = 1
 		if(E.status & ORGAN_DEAD)
 			to_chat(user, "<span class='warning'>[E] is decaying!</span>")
 			bad = 1

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -235,9 +235,6 @@
 		if(antibiotics < 5 && prob(round(germ_level/6)))
 			germ_level++
 
-	if(germ_level >= INFECTION_LEVEL_ONE)
-		owner.add_chemical_effect(CE_FEVER, germ_level/INFECTION_LEVEL_ONE) //10u of Perconol minimum for a level 3 infection
-
 	if (germ_level >= INFECTION_LEVEL_TWO)
 		var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 		//spread germs
@@ -283,6 +280,9 @@
 
 /obj/item/organ/proc/is_usable()
 	return !(status & (ORGAN_CUT_AWAY|ORGAN_MUTATED|ORGAN_DEAD))
+
+/obj/item/organ/proc/is_infected()
+	return (germ_level >= INFECTION_LEVEL_ONE)
 
 //Germs
 /obj/item/organ/proc/handle_antibiotics()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -90,6 +90,9 @@
 
 	var/augment_limit //how many augments you can fit inside this limb
 
+	var/obj/item/organ/infect_target_internal //make internal organs become infected one at a time instead of all at once
+	var/obj/item/organ/infect_target_external //make child and parent organs become infected one at a time instead of all at once
+
 /obj/item/organ/external/proc/invalidate_marking_cache()
 	cached_markings = null
 
@@ -104,6 +107,9 @@
 	if(internal_organs)
 		for(var/obj/item/organ/O in internal_organs)
 			qdel(O)
+
+	infect_target_internal = null
+	infect_target_external = null
 
 	applied_pressure = null
 
@@ -642,46 +648,65 @@ Note that amputating the affected organ does in fact remove the infection from t
 				germ_level++
 				break	//limit increase to a maximum of one per second
 
-/obj/item/organ/external/handle_germ_effects()
+/obj/item/organ/external/proc/get_infect_target(var/list/infect_candidates = list())
+	var/obj/item/organ/temp_target
+	shuffle(infect_candidates) //Slightly randomizes since if all germ levels are zero, it'll always be the first pick of the list
 
-	if(germ_level < INFECTION_LEVEL_TWO)
-		return ..()
+	//figure out which organs we can spread germs to
+	for (var/obj/item/organ/I in infect_candidates)
+		if(I.germ_level < min(germ_level, INFECTION_LEVEL_TWO)) //Only choose organs that have less germs than us AND are below level two
+			//The below will always be the organ with the highest germ level. It picks a temp_target first then cycles through to find which, if any, has more germs.
+			if(!temp_target || I.germ_level > temp_target.germ_level)
+				temp_target = I //This will always be the organ with the highest germ level
+
+	return temp_target
+
+/obj/item/organ/external/handle_germ_effects()
 
 	var/antibiotics = 0
 	if(CE_ANTIBIOTIC in owner.chem_effects)
 		antibiotics = owner.chem_effects[CE_ANTIBIOTIC]
 
-	if(germ_level >= INFECTION_LEVEL_TWO)
-		//spread the infection to internal organs
-		var/obj/item/organ/target_organ = null	//make internal organs become infected one at a time instead of all at once
-		for (var/obj/item/organ/I in internal_organs)
-			if (I.germ_level > 0 && I.germ_level < min(germ_level, INFECTION_LEVEL_TWO))	//once the organ reaches whatever we can give it, or level two, switch to a different one
-				if (!target_organ || I.germ_level > target_organ.germ_level)	//choose the organ with the highest germ_level
-					target_organ = I
+	if(germ_level < INFECTION_LEVEL_TWO)
+		//null out the infect targets since at this point we're not in danger of spreading our infection. 
+		infect_target_internal = null
+		infect_target_external = null
+		return ..()
 
-		if (!target_organ)
-			//figure out which organs we can spread germs to and pick one at random
-			var/list/candidate_organs = list()
-			for (var/obj/item/organ/I in internal_organs)
-				if (I.germ_level < germ_level)
-					candidate_organs |= I
-			if (candidate_organs.len)
-				target_organ = pick(candidate_organs)
+	germ_level++
 
-		if (target_organ)
-			target_organ.germ_level++
+	if(germ_level >= INFECTION_LEVEL_TWO && REAGENT_VOLUME(owner.reagents, /decl/reagent/thetamycin) < 5) //The presence of 5 units of thetamycin will stop infections spreading
+		//SPREADING TO INTERNAL ORGANS
+		if(isnull(infect_target_internal) || QDELETED(infect_target_internal))
+			infect_target_internal = get_infect_target(internal_organs)
 
-		//spread the infection to child and parent organs
-		if (children)
-			for (var/obj/item/organ/external/child in children)
-				if (child.germ_level < germ_level && !(child.status & ORGAN_ROBOT))
-					if (child.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
-						child.germ_level++
+		else
+			if(prob(25) || !infect_target_internal.is_infected()) //Increase steadily until infection_level_one, then only bump the germ level now and then
+				infect_target_internal.germ_level++ //slowly increase the infection level
+			//Check to see if the other organ is as infected or more infected than us. If so, we need to get a new target on the next process
+			if(infect_target_internal.germ_level >= min(germ_level, INFECTION_LEVEL_TWO))
+				infect_target_internal = null
 
-		if (parent)
-			if (parent.germ_level < germ_level && !(parent.status & ORGAN_ROBOT))
-				if (parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
-					parent.germ_level++
+		//SPREADING TO CHILD AND PARENT EXTERNAL ORGANS
+		if(isnull(infect_target_external) || QDELETED(infect_target_internal))
+			var/list/temp_targets = list()
+			if(children)
+				for (var/obj/item/organ/external/child in children)
+					if (child.germ_level < germ_level && !(child.status & ORGAN_ROBOT))
+						temp_targets += child
+
+			if(parent)
+				if(parent.germ_level < germ_level && !(parent.status & ORGAN_ROBOT))
+					temp_targets += parent
+			if(length(temp_targets))
+				infect_target_external = get_infect_target(temp_targets)
+
+		else
+			if(prob(25) || !infect_target_external.is_infected()) //Increase steadily until sufficiently infected, then only bump the germ level now and then
+				infect_target_external.germ_level++ //slowly increase the infection level
+			//Check to see if the other organ is as infected or more infected than us. If so, we need to get a new target on the next process
+			if(infect_target_external.germ_level >= min(germ_level, INFECTION_LEVEL_TWO))
+				infect_target_external = null
 
 	if(germ_level >= INFECTION_LEVEL_THREE && antibiotics < 20)	//overdosing is necessary to stop severe infections
 		if (!(status & ORGAN_DEAD))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -264,7 +264,7 @@
 
 /decl/reagent/perconol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_PAINKILLER, 50)
-	M.add_chemical_effect(CE_NOFEVER, ((M.chem_doses[type]/2)^2-(REAGENT_VOLUME(holder, type)-M.chem_doses[type]/2))/(M.chem_doses[type]/4)) // creates a smooth curve peaking at half the dose metabolised
+	M.add_up_to_chemical_effect(CE_NOFEVER, 5) //Good enough to handle fevers for a few light infections or one bad one.
 
 /decl/reagent/perconol/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
 	..()
@@ -824,6 +824,7 @@
 	taste_description = "bitterness"
 
 /decl/reagent/leporazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
+	M.add_up_to_chemical_effect(CE_NOFEVER, 5) //Also handles the effects of fevers
 	if(!(REAGENT_VOLUME(holder, type) > 20))
 		if(M.bodytemperature > 310)
 			M.bodytemperature = max(310, M.bodytemperature - (40 * TEMPERATURE_DAMAGE_COEFFICIENT))

--- a/html/changelogs/Doxxmedearly - Infection_edits.yml
+++ b/html/changelogs/Doxxmedearly - Infection_edits.yml
@@ -1,0 +1,11 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "People with infections should experience fevers once again. The intensity of all active infections dictates how strong the fever is."
+  - bugfix: "Fixed perconol's anti-fever strength being in the millions at certain doses. It now has a flat rate."
+  - tweak: "Each infection will now only spread to one internal organ and one limb at a time, instead of spreading to all limbs it can touch."
+  - tweak: "Having 5u of thetamycin in the bloodstream will now prevent infections from spreading. It will still need to metabolize to the proper dose before it begins to cure them."
+  - rscadd: "Grab examine will now indicate if you see in infection on that limb, and how bad it is. Look for messages that say the skin is warm and reddened."
+  - rscadd: "Leporazine now also acts as a fever reducer."


### PR DESCRIPTION
Tweaks some stuff with infections.
Fevers weren't working because infections added the CE_FEVER chem effect. Except without a chemical to actively process in the body, the effect gets removed on the next tick. So there's specific handling for it now.

Also whatever equation was in perconol was making the CE_NOFEVER chem effect return like some number + e007 at 15u dose. Simplified that.

Talking with medical, they were hoping for ways to notice infections that weren't reliant on the scanner. Fevers + the new grab examine message are steps towards that.

Infection spreading was out of control. If it was on a limb, like the chest, it would spread to every child limb all at once. Combined with the slow acting thetamycin and lack of indication to the patient that they HAVE an infection (fever messages should help with that, too), infections were a headache to treat. Hopefully addressing all of these factors makes it a bit easier.

Also re-added the whole "having 5u of antibiotic in your body stops the spread" thing, since that's useful for management. 

Leporazine manages fevers because it's a medication that regulates your body temperature. 