### PR TITLE
Animal Renaming

### DIFF
--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -471,6 +471,9 @@
 	light_range = 2
 	hunger_enabled = FALSE
 
+/mob/living/simple_animal/penguin/holodeck/can_name(var/mob/living/M)
+	return FALSE
+
 /mob/living/simple_animal/penguin/holodeck/baby
 	icon_state = "penguin_baby"
 	icon_living = "penguin_baby"

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -21,6 +21,7 @@ var/list/holder_mob_icon_cache = list()
 
 	var/last_loc_general	//This stores a general location of the object. Ie, a container or a mob
 	var/last_loc_specific	//This stores specific extra information about the location, pocket, hand, worn on head, etc. Only relevant to mobs
+	var/no_name = FALSE		//If true, removes the change animal name verb for holders that don't allow name changes
 
 /obj/item/holder/proc/setup_unsafe_list()
 	unsafe_containers = typecacheof(list(
@@ -39,6 +40,8 @@ var/list/holder_mob_icon_cache = list()
 		item_state = icon_state
 
 	flags_inv |= ALWAYSDRAW
+	if(no_name)
+		verbs -= /obj/item/holder/verb/change_animal_name
 
 	START_PROCESSING(SSprocessing, src)
 
@@ -365,6 +368,7 @@ var/list/holder_mob_icon_cache = list()
 	origin_tech = list(TECH_MAGNET = 3, TECH_BIO = 5)
 	slot_flags = SLOT_HEAD | SLOT_EARS | SLOT_HOLSTER
 	w_class = ITEMSIZE_SMALL
+	no_name = TRUE
 
 /obj/item/holder/drone
 	name = "maintenance drone"
@@ -374,6 +378,7 @@ var/list/holder_mob_icon_cache = list()
 	origin_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 5)
 	slot_flags = SLOT_HEAD
 	w_class = ITEMSIZE_LARGE
+	no_name = TRUE
 
 /obj/item/holder/drone/heavy
 	name = "construction drone"
@@ -448,6 +453,7 @@ var/list/holder_mob_icon_cache = list()
 	icon_state = "brainslug"
 	origin_tech = list(TECH_BIO = 6)
 	w_class = ITEMSIZE_TINY
+	no_name = TRUE
 
 /obj/item/holder/monkey
 	name = "monkey"
@@ -585,6 +591,7 @@ var/list/holder_mob_icon_cache = list()
 	icon = 'icons/mob/npc/pai.dmi'
 	dir = EAST
 	slot_flags = SLOT_HEAD
+	no_name = TRUE
 
 /obj/item/holder/pai/drone
 	icon_state = "repairbot_rest"

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -334,6 +334,21 @@ var/list/holder_mob_icon_cache = list()
 
 		..()
 
+/obj/item/holder/verb/change_animal_name()
+	set name = "Name Animal"
+	set category = "IC"
+	set src in usr
+
+	if(isanimal(contained))
+		var/mob/living/simple_animal/SA = contained
+		SA.change_name(usr)
+		sync(contained)
+	if(ishuman(contained))
+		var/mob/living/carbon/human/H = contained
+		if(H.isMonkey())
+			H.change_animal_name(usr)
+			sync(contained)
+
 //#TODO-MERGE
 //Port the reduced-duplication holder method from baystation upstream:
 //https://github.com/Baystation12/Baystation12/blob/master/code/modules/mob/holder.dm

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1213,7 +1213,9 @@ mob/living/carbon/human/proc/change_monitor()
 //Used to rename monkey mobs since they are humans with a monkey species applied
 /mob/living/carbon/human/proc/change_animal_name()
 	set name = "Name Animal"
+	set desc = "Name a monkeylike animal."
 	set category = "IC"
+	set src in view(1)
 
 	var/mob/living/M = usr
 	if(!M || usr == src)
@@ -1225,7 +1227,7 @@ mob/living/carbon/human/proc/change_monitor()
 			return
 		if(stat != DEAD && in_range(M,src))
 			to_chat(M, SPAN_NOTICE("You rename \the [src] to [input]."))
-			name = input
+			name = "\proper [input]"
 			real_name = input
 			named = TRUE
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1209,3 +1209,33 @@ mob/living/carbon/human/proc/change_monitor()
 
 	primary_martial_art = selected_martial_art
 	to_chat(src, SPAN_NOTICE("You will now use [primary_martial_art.name] when fighting barehanded."))
+
+//Used to rename monkey mobs since they are humans with a monkey species applied
+/mob/living/carbon/human/proc/change_animal_name()
+	set name = "Name Animal"
+	set category = "IC"
+	set src in view(1)
+
+	var/mob/living/M = usr
+	if(!M || usr == src)
+		return
+
+	if(can_name(M))
+		var/input = sanitizeSafe(input("What do you want to name \the [src]?","Choose a name") as text|null, MAX_NAME_LEN)
+		if(!input)
+			return
+		if(stat != DEAD && in_range(M,src))
+			to_chat(M, SPAN_NOTICE("You rename \the [src] to [input]."))
+			name = input
+			real_name = input
+			named = TRUE
+
+//Used only to check for renaming of monkey mobs
+/mob/living/carbon/human/can_name(var/mob/living/M)
+	if(named)
+		to_chat(M, SPAN_NOTICE("\The [src] already has a name!"))
+		return FALSE
+	if(stat == DEAD)
+		to_chat(M, SPAN_WARNING("You can't name a corpse."))
+		return FALSE
+	return TRUE

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1214,7 +1214,6 @@ mob/living/carbon/human/proc/change_monitor()
 /mob/living/carbon/human/proc/change_animal_name()
 	set name = "Name Animal"
 	set category = "IC"
-	set src in view(1)
 
 	var/mob/living/M = usr
 	if(!M || usr == src)

--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -12,6 +12,7 @@
 /mob/living/carbon/human/monkey/punpun/LateInitialize()
 	name = "Pun Pun"
 	real_name = name
+	named = TRUE
 	w_uniform = new /obj/item/clothing/under/punpun(src)
 
 /obj/item/clothing/under/nupnup

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -27,7 +27,7 @@
 	tail = "chimptail"
 
 	unarmed_types = list(/datum/unarmed_attack/bite, /datum/unarmed_attack/claws)
-	inherent_verbs = list(/mob/living/proc/ventcrawl)
+	inherent_verbs = list(/mob/living/proc/ventcrawl, /mob/living/carbon/human/proc/change_animal_name)
 	hud_type = /datum/hud_data/monkey
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/monkey
 
@@ -143,7 +143,8 @@
 	deform = 'icons/mob/human_races/monkeys/r_vkrexi.dmi'
 
 	inherent_verbs = list(
-		/mob/living/carbon/human/proc/bugbite
+		/mob/living/carbon/human/proc/bugbite,
+		/mob/living/carbon/human/proc/change_animal_name
 		)
 
 	tail = "vkrexitail"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1015,3 +1015,6 @@ default behaviour is:
 
 /mob/living/set_respawn_time()
 	set_death_time(CREW, world.time)
+//Used by simple animals and monkey species for renaming. M is the one doing the renaming
+/mob/living/proc/can_name(var/mob/living/M)
+	return FALSE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -72,3 +72,5 @@
 
 	var/limb_breaking = FALSE // used to limit people from queuing up limb-breaks
 	var/list/obj/aura/auras //Basically a catch-all aura/force-field thing.
+
+	var/named = FALSE //Affects renaming animals and monkey species. Set to TRUE for animals with unique names, such as station pets. Doesn't affect any other mob. 

--- a/code/modules/mob/living/simple_animal/bees.dm
+++ b/code/modules/mob/living/simple_animal/bees.dm
@@ -35,6 +35,8 @@
 	target_mob = null
 	return ..()
 
+/mob/living/simple_animal/bee/can_name(var/mob/living/M)
+	return FALSE
 
 //Special death behaviour. When bees accumulate enough damage to 'die', they don't outright die.  Thus no call to parent
 //Instead the swarm strength (ie, size, or quantity of bees) drops and their health is refilled

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -60,6 +60,9 @@
 	SSghostroles.remove_spawn_atom("borer", src)
 	return ..(gibbed,deathmessage)
 
+/mob/living/simple_animal/borer/can_name(var/mob/living/M)
+	return FALSE
+
 /mob/living/simple_animal/borer/Life()
 	..()
 	if(host)

--- a/code/modules/mob/living/simple_animal/constructs/constructs/cult_construct.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs/cult_construct.dm
@@ -66,6 +66,11 @@
 	ghostize()
 	qdel(src)
 
+/mob/living/simple_animal/construct/can_name(var/mob/living/M)
+	if(iscultist(M))
+		return ..()
+	return FALSE
+
 /mob/living/simple_animal/construct/get_bullet_impact_effect_type(var/def_zone)
 	return BULLET_IMPACT_METAL
 

--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -28,6 +28,11 @@
 /mob/living/simple_animal/familiar/do_animate_chat(var/message, var/datum/language/language, var/small, var/list/show_to, var/duration, var/list/message_override)
 	INVOKE_ASYNC(src, /atom/movable/proc/animate_chat, message, language, small, show_to, duration)
 
+/mob/living/simple_animal/familiar/can_name(var/mob/living/M)
+	if(M.is_wizard(TRUE))
+		return ..()
+	return FALSE
+
 /mob/living/simple_animal/familiar/carcinus
 	name = "crab"
 	desc = "A small crab said to be made of stone and starlight."

--- a/code/modules/mob/living/simple_animal/friendly/adhomai.dm
+++ b/code/modules/mob/living/simple_animal/friendly/adhomai.dm
@@ -104,6 +104,15 @@
 	butchering_products = list(/obj/item/stack/material/animalhide = 5)
 	meat_amount = 8
 
+/mob/living/simple_animal/hostile/retaliate/rafama/can_name(var/mob/living/M)
+	if(named)
+		to_chat(M, SPAN_NOTICE("\The [src] already has a name!"))
+		return FALSE
+	if(stat == DEAD)
+		to_chat(M, SPAN_WARNING("You can't name a corpse."))
+		return FALSE
+	return TRUE
+
 /mob/living/simple_animal/schlorrgo
 	name = "schlorrgo"
 	desc = "A fat creature native to the world of Hro'zamal."

--- a/code/modules/mob/living/simple_animal/friendly/adhomai.dm
+++ b/code/modules/mob/living/simple_animal/friendly/adhomai.dm
@@ -101,17 +101,10 @@
 	attacktext = "bitten"
 	attack_sound = 'sound/weapons/bite.ogg'
 
+	hostile_nameable = TRUE
+
 	butchering_products = list(/obj/item/stack/material/animalhide = 5)
 	meat_amount = 8
-
-/mob/living/simple_animal/hostile/retaliate/rafama/can_name(var/mob/living/M)
-	if(named)
-		to_chat(M, SPAN_NOTICE("\The [src] already has a name!"))
-		return FALSE
-	if(stat == DEAD)
-		to_chat(M, SPAN_WARNING("You can't name a corpse."))
-		return FALSE
-	return TRUE
 
 /mob/living/simple_animal/schlorrgo
 	name = "schlorrgo"

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -283,6 +283,7 @@
 /mob/living/simple_animal/cat/fluff/Runtime
 	name = "Runtime"
 	desc = "Her fur has the look and feel of velvet, and her tail quivers occasionally."
+	named = TRUE
 	gender = FEMALE
 	icon_state = "cat"
 	item_state = "cat"
@@ -317,6 +318,7 @@
 /mob/living/simple_animal/cat/fluff/bones
 	name = "Bones"
 	desc = "He's a laid back, black cat. Meow."
+	named = TRUE
 	gender = MALE
 	icon_state = "cat3"
 	item_state = "cat3"
@@ -334,6 +336,7 @@
 /mob/living/simple_animal/cat/penny
 	name = "Penny"
 	desc = "An important cat, straight from Central Command."
+	named = TRUE
 	icon_state = "penny"
 	item_state = "penny"
 	icon_living = "penny"

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -44,6 +44,7 @@
 	real_name = "Ian"	//Intended to hold the name without altering it.
 	gender = MALE
 	desc = "It's a corgi."
+	named = TRUE
 	//var/obj/movement_target
 	response_help  = "pets"
 	response_disarm = "bops"
@@ -127,6 +128,7 @@
 	real_name = "Lisa"
 	gender = FEMALE
 	desc = "It's a corgi with a cute pink bow."
+	named = TRUE
 	icon_state = "lisa"
 	icon_living = "lisa"
 	icon_dead = "lisa_dead"

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -40,6 +40,7 @@
 	name = "Coffee"
 	real_name = "Coffee"
 	desc = "It's Coffee, the other pet!"
+	named = TRUE
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "stomps"

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -29,6 +29,7 @@
 	canbrush = TRUE
 	emote_sounds = list('sound/effects/creatures/goat.ogg')
 	has_udder = TRUE
+	hostile_nameable = TRUE
 
 	butchering_products = list(/obj/item/stack/material/animalhide = 3)
 
@@ -42,15 +43,6 @@
 		if(locate(/obj/machinery/portable_atmospherics/hydroponics/soil/invisible) in loc)
 			var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/SP = locate() in loc
 			qdel(SP)
-
-/mob/living/simple_animal/hostile/retaliate/goat/can_name(var/mob/living/M)
-	if(named)
-		to_chat(M, SPAN_NOTICE("\The [src] already has a name!"))
-		return FALSE
-	if(stat == DEAD)
-		to_chat(M, SPAN_WARNING("You can't name a corpse."))
-		return FALSE
-	return TRUE
 
 /mob/living/simple_animal/hostile/retaliate/goat/think()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -43,6 +43,15 @@
 			var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/SP = locate() in loc
 			qdel(SP)
 
+/mob/living/simple_animal/hostile/retaliate/goat/can_name(var/mob/living/M)
+	if(named)
+		to_chat(M, SPAN_NOTICE("\The [src] already has a name!"))
+		return FALSE
+	if(stat == DEAD)
+		to_chat(M, SPAN_WARNING("You can't name a corpse."))
+		return FALSE
+	return TRUE
+
 /mob/living/simple_animal/hostile/retaliate/goat/think()
 	..()
 	//chance to go crazy and start wacking stuff

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -31,3 +31,4 @@
 	name = "Chauncey"
 	real_name = "Chauncey"
 	desc = "Chauncey, the Captain's trustworthy fox. I wonder what it says?"
+	named = TRUE

--- a/code/modules/mob/living/simple_animal/friendly/ratking.dm
+++ b/code/modules/mob/living/simple_animal/friendly/ratking.dm
@@ -47,6 +47,9 @@
 
 	..()
 
+/mob/living/simple_animal/rat/king/can_name(var/mob/living/M)
+	return FALSE
+
 /mob/living/simple_animal/rat/king/Move()
 	..()
 

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -56,6 +56,9 @@
 	verbs |= /mob/living/simple_animal/spiderbot/proc/control_integrated_radio
 	voice_name = name
 
+/mob/living/simple_animal/spiderbot/can_name(var/mob/living/M)
+	return FALSE
+
 /mob/living/simple_animal/spiderbot/attackby(var/obj/item/O as obj, var/mob/user as mob)
 
 	if(istype(O, /obj/item/device/mmi))

--- a/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
@@ -33,6 +33,8 @@
 
 	tameable = FALSE
 
+	hostile_nameable = TRUE
+
 	meat_type = /obj/item/reagent_containers/food/snacks/bearmeat
 	butchering_products = list(/obj/item/clothing/head/bearpelt = 1)
 	meat_amount = 5

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -5,6 +5,7 @@
 	melee_damage_upper = 0
 	density = FALSE
 	belongs_to_station = TRUE
+	hostile_nameable = TRUE
 	var/short_name = null
 	var/list/command_buffer = list()
 	var/list/known_commands = list("stay", "stop", "attack", "follow")
@@ -31,16 +32,10 @@
 	return 0
 
 /mob/living/simple_animal/hostile/commanded/can_name(var/mob/living/M)
-	if(named)
-		to_chat(M, SPAN_NOTICE("\The [src] already has a name!"))
-		return FALSE
 	if(master && (M != master))
 		to_chat(M, SPAN_WARNING("You can't name \the [src] because you aren't their master!"))
 		return FALSE
-	if(stat == DEAD)
-		to_chat(M, SPAN_WARNING("You can't name a corpse."))
-		return FALSE
-	return TRUE
+	return ..()
 
 /mob/living/simple_animal/hostile/commanded/do_nickname(var/mob/living/M)
 	var/input = sanitizeSafe(input("What nickname do you want to give \the [src]?","Choose a name") as null|text, MAX_NAME_LEN)

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -30,6 +30,24 @@
 		command_buffer.Add(lowertext(html_decode(message)))
 	return 0
 
+/mob/living/simple_animal/hostile/commanded/can_name(var/mob/living/M)
+	if(named)
+		to_chat(M, SPAN_NOTICE("\The [src] already has a name!"))
+		return FALSE
+	if(master && (M != master))
+		to_chat(M, SPAN_WARNING("You can't name \the [src] because you aren't their master!"))
+		return FALSE
+	if(stat == DEAD)
+		to_chat(M, SPAN_WARNING("You can't name a corpse."))
+		return FALSE
+	return TRUE
+
+/mob/living/simple_animal/hostile/commanded/do_nickname(var/mob/living/M)
+	var/input = sanitizeSafe(input("What nickname do you want to give \the [src]?","Choose a name") as null|text, MAX_NAME_LEN)
+	if(!input)
+		return
+	short_name = input
+
 /mob/living/simple_animal/hostile/commanded/think()
 	while(command_buffer.len > 0)
 		var/mob/speaker = command_buffer[1]

--- a/code/modules/mob/living/simple_animal/hostile/commanded/guard_dog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/guard_dog.dm
@@ -44,8 +44,6 @@
 
 	known_commands = list("stay", "stop", "attack", "follow")
 
-	var/name_changed = 0
-
 	destroy_surroundings = FALSE
 	attack_emote = "growls at"
 
@@ -71,31 +69,6 @@
 
 	return
 
-/mob/living/simple_animal/hostile/commanded/dog/verb/change_name()
-	set name = "Name Dog"
-	set category = "IC"
-	set src in view(1)
-
-	var/mob/M = usr
-	if(!M.mind)	return 0
-
-	if(!name_changed)
-
-		var/input = sanitizeSafe(input("What do you want to name the dog?", ,""), MAX_NAME_LEN)
-		var/short_input = sanitizeSafe(input("What nickname do you want to give the dog ?", , ""), MAX_NAME_LEN)
-
-		if(src && input && !M.stat && in_range(M,src))
-			name = input
-			real_name = input
-			if(short_input != "")
-				short_name = short_input
-			name_changed = 1
-			return 1
-
-	else
-		to_chat(usr, "<span class='notice'>[src] already has a name!</span>")
-		return
-
 /mob/living/simple_animal/hostile/commanded/dog/amaskan
 	desc = "A dog trained to listen and obey its owner commands, this one is a Tamaskan."
 
@@ -107,11 +80,10 @@
 	name = "Lt. Columbo"
 	short_name = "Columbo"
 	desc = "A dog trained to listen and obey its owner commands. This one looks about three days from retirement."
+	named = TRUE
 
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-
-	name_changed = 1
 
 	icon_state = "columbo"
 	icon_living = "columbo"

--- a/code/modules/mob/living/simple_animal/hostile/commanded/ives.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/ives.dm
@@ -46,8 +46,6 @@
 	destroy_surroundings = FALSE
 	attack_emote = "blares a tiny siren"
 
-	named = TRUE
-
 /mob/living/simple_animal/hostile/commanded/baby_harvester/get_bullet_impact_effect_type(var/def_zone)
 	return BULLET_IMPACT_METAL
 

--- a/code/modules/mob/living/simple_animal/hostile/commanded/ives.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/ives.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/commanded/baby_harvester
 	name = "Ives"
 	desc = "A mysterious docile hivebot, this type seems to be of a kind rarely seen in the Orion Spur. Look at its little tail!"
+	named = TRUE
 
 	icon = 'icons/mob/npc/pets.dmi'
 	icon_state = "ives"

--- a/code/modules/mob/living/simple_animal/hostile/commanded/ives.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/ives.dm
@@ -46,6 +46,8 @@
 	destroy_surroundings = FALSE
 	attack_emote = "blares a tiny siren"
 
+	named = TRUE
+
 /mob/living/simple_animal/hostile/commanded/baby_harvester/get_bullet_impact_effect_type(var/def_zone)
 	return BULLET_IMPACT_METAL
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -42,6 +42,12 @@
 	targets = null
 	return ..()
 
+/mob/living/simple_animal/hostile/can_name(var/mob/living/M)
+	if(faction && faction == M.faction) //In case the mob had a dociler used on it
+		return ..()
+	return FALSE
+
+
 /mob/living/simple_animal/hostile/proc/FindTarget()
 	if(!faction) //No faction, no reason to attack anybody.
 		return null

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -29,6 +29,7 @@
 
 	var/smart_melee = TRUE   // This makes melee mobs try to stay two tiles away from their target in combat, lunging in to attack only
 	var/smart_ranged = FALSE // This makes ranged mob check for friendly fire and obstacles
+	var/hostile_nameable = FALSE //If we can rename this hostile mob. Mostly to prevent repeat checks with guard dogs and hostile/retaliate farm animals
 
 /mob/living/simple_animal/hostile/Initialize()
 	. = ..()
@@ -43,6 +44,8 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/can_name(var/mob/living/M)
+	if(hostile_nameable)
+		return ..()
 	if(faction && faction == M.faction) //In case the mob had a dociler used on it
 		return ..()
 	return FALSE

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -41,6 +41,9 @@
 	new residue(loc)
 	qdel(src)
 
+/mob/living/simple_animal/shade/can_name(var/mob/living/M)
+	return FALSE
+
 /mob/living/simple_animal/shade/do_animate_chat(var/message, var/datum/language/language, var/small, var/list/show_to, var/duration, var/list/message_override)
 	INVOKE_ASYNC(src, /atom/movable/proc/animate_chat, message, language, small, show_to, duration)
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -660,7 +660,9 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 
 /mob/living/simple_animal/verb/change_name()
 	set name = "Name Animal"
+	set desc = "Rename an animal."
 	set category = "IC"
+	set src in view(1)
 
 	var/mob/living/M = usr
 	if(!M)	
@@ -674,7 +676,7 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 		//check for adjacent and dead in case something happened while naming.
 		if(in_range(M,src) && (stat != DEAD))
 			to_chat(M, SPAN_NOTICE("You rename \the [src] to [input]."))
-			name = input
+			name = "\proper [input]"
 			real_name = input
 			named = TRUE
 			do_nickname(M) //This is for commanded mobs who can have a short name, like guard dogs

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -181,6 +181,14 @@
 	else if (health < maxHealth)
 		to_chat(user, "<span class='warning'>It looks wounded.</span>")
 
+/mob/living/simple_animal/can_name(var/mob/living/M)
+	if(named)
+		to_chat(M, SPAN_NOTICE("\The [src] already has a name!"))
+		return FALSE
+	if(stat == DEAD)
+		to_chat(M, SPAN_WARNING("You can't name a corpse."))
+		return FALSE
+	return TRUE
 
 /mob/living/simple_animal/Life()
 	..()
@@ -649,6 +657,32 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	if(client)
 		sound_time = FALSE
 		addtimer(CALLBACK(src, .proc/reset_sound_time), 2 SECONDS)
+
+/mob/living/simple_animal/verb/change_name()
+	set name = "Name Animal"
+	set category = "IC"
+	set src in view(1)
+
+	var/mob/living/M = usr
+	if(!M)	
+		return
+
+	if(can_name(M))
+		var/input = sanitizeSafe(input("What do you want to name \the [src]?","Choose a name") as null|text, MAX_NAME_LEN)
+		if(!input)
+			return
+
+		//check for adjacent and dead in case something happened while naming.
+		if(in_range(M,src) && (stat != DEAD))
+			to_chat(M, SPAN_NOTICE("You rename \the [src] to [input]."))
+			name = input
+			real_name = input
+			named = TRUE
+			do_nickname(M) //This is for commanded mobs who can have a short name, like guard dogs
+
+//This is for commanded mobs who can have a short name, like guard dogs. Does nothing for other mobs for now
+/mob/living/simple_animal/proc/do_nickname(var/mob/living/M)
+
 
 /mob/living/simple_animal/proc/reset_sound_time()
 	sound_time = TRUE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -661,7 +661,6 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 /mob/living/simple_animal/verb/change_name()
 	set name = "Name Animal"
 	set category = "IC"
-	set src in view(1)
 
 	var/mob/living/M = usr
 	if(!M)	

--- a/code/modules/mob/living/simple_animal/worm.dm
+++ b/code/modules/mob/living/simple_animal/worm.dm
@@ -198,3 +198,6 @@
 				loc.contents += stomachContent
 
 		return
+
+/mob/living/simple_animal/space_worm/can_name(var/mob/living/M)
+	return FALSE

--- a/html/changelogs/doxxmedearly - animal_rename.yml
+++ b/html/changelogs/doxxmedearly - animal_rename.yml
@@ -1,0 +1,8 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - rscadd: "Most non-hostile simple animals without a name can be renamed, including monkeys and the alien equivalents. This is done via right-click menu. You have only one chance. Some cannot be named (Such as nymphs). Please bug report any simple mobs that can be renamed but should not be. It is intentional that simple mobs cannot rename themselves."
+  - rscadd: "Cult constructs and wizard familiars can be renamed by those with the proper antagonist type. Wizard apprentices cannot rename familiars."
+  - tweak: "Guard dogs can only be renamed if they have no master, or, if they have one, only by their master."


### PR DESCRIPTION
Allows renaming most animals, both simple animals as well as monkeys and their alien equivalents. 
Since animal pathing is wild with regards to things like goats and guard dogs being under the hostile path, had to add a var for hostile animals to allow renaming without repeating a bunch of code. 