### PR TITLE
Adding integrated holomap view ability to the cyborgs

### DIFF
--- a/code/game/machinery/station_holomap.dm
+++ b/code/game/machinery/station_holomap.dm
@@ -194,6 +194,48 @@
 
 // TODO: Make these constructable.
 
+/obj/machinery/station_map/robot/Initialize()
+	return
+
+/obj/machinery/station_map/robot/proc/init_map(var/Z)
+	holomap_datum = new()
+	original_zLevel = Z
+	SSholomap.station_holomaps += src
+	flags |= ON_BORDER // Why? It doesn't help if its not density
+	bogus = FALSE
+	var/turf/T = get_turf(src)
+	original_zLevel = T.z
+	if(!("[HOLOMAP_EXTRA_STATIONMAP]_[original_zLevel]" in SSholomap.extra_minimaps))
+		bogus = TRUE
+		holomap_datum.initialize_holomap_bogus()
+		update_icon()
+		return
+
+	holomap_datum.initialize_holomap(T, reinit = TRUE)
+
+	small_station_map = image(SSholomap.extra_minimaps["[HOLOMAP_EXTRA_STATIONMAPSMALL]_[original_zLevel]"], dir = dir)
+	small_station_map.layer = EFFECTS_ABOVE_LIGHTING_LAYER
+	small_station_map.filters = filter(type = "drop_shadow", color = light_color + "F0", size = 1, offset = 1, x = 0, y = 0)
+
+	floor_markings = image('icons/obj/machines/stationmap.dmi', "decal_station_map")
+	floor_markings.dir = src.dir
+	floor_markings.layer = ON_TURF_LAYER
+	update_icon()
+
+/obj/machinery/station_map/robot/startWatching(var/mob/user)
+	src.init_map(user.loc.z)
+	if(!watching_mob && isliving(user))
+		..()
+
+/obj/machinery/station_map/robot/stopWatching()
+	var/mob/living/silicon/robot/R = watching_mob
+	if (R)
+		R.holo_map = null
+		. = ..()
+		qdel(src)
+	else
+		. = ..()
+
 // Simple datum to keep track of a running holomap. Each machine capable of displaying the holomap will have one.
 /datum/station_holomap
 	var/image/station_map

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -131,6 +131,7 @@
 	var/image/panel_overlay
 	var/list/image/cached_panel_overlays
 	var/image/shield_overlay
+	var/datum/weakref/holo_map
 
 /mob/living/silicon/robot/Initialize(mapload, unfinished = FALSE)
 	spark_system = bind_spark(src, 5)
@@ -490,6 +491,20 @@
 	var/datum/robot_component/C = components[toggle]
 	to_chat(src, SPAN_NOTICE("You [C.toggled ? "disable" : "enable"] [C.name]."))
 	C.toggled = !C.toggled
+
+/mob/living/silicon/robot/verb/view_holomap()
+	set category = "Robot Commands"
+	set name = "View Holomap"
+	set desc = "View Holomap of the current level."
+	
+	var/obj/machinery/station_map/robot/holo_map
+	if(src.holo_map)
+		holo_map = src.holo_map.resolve()
+
+	if(!holo_map)
+		holo_map = new(src)
+		holo_map.startWatching(src)
+		src.holo_map = WEAKREF(holo_map)
 
 /obj/item/robot_module/janitor/verb/toggle_mop()
 	set category = "Robot Commands"

--- a/html/changelogs/Sindorman-cyborg-map.yml
+++ b/html/changelogs/Sindorman-cyborg-map.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Cyborgs now have a View Holomap verb to see holomap from their position."


### PR DESCRIPTION
In this pull request, I added the ability to view holomap for the cyborgs on-demand at their present location

- Added new robot holomap object. With a bit of tweaks, you could make it a generic on-demand object to add to other things like PDA, etc.
- Added view holomap verb