### PR TITLE
Potential goonchat fix

### DIFF
--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -32,7 +32,6 @@ var/savefile/iconCache = new("data/tmp/iconCache.sav") //Cache of icons for the 
   * Async because this is called from Client/New.
   */
 /datum/chatOutput/proc/start()
-	set waitfor = FALSE
 	//Check for existing chat
 	if(!owner)
 		return FALSE

--- a/html/changelogs/Sindorman-goonchat.yml
+++ b/html/changelogs/Sindorman-goonchat.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed race condition within goonchat initialization code. Possibly fixed issue of long loading time."


### PR DESCRIPTION
Removes race condition var that would cause start proc not wait for `load` to be done and any caller not wait for `start` proc to finish.

This could potentially fix a number of weird bugs that race conditions cause. For example possibly the long load and timeout of chat.