### PR TITLE
Floodlight Stuff

### DIFF
--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -34,6 +34,9 @@
 /proc/Modulus(x, y)
 	return ( (x) - (y) * round((x) / (y)) )
 
+/proc/Percent(current_value, max_value, rounding = 1)
+	return round((current_value / max_value) * 100, rounding)
+
 // Greatest Common Divisor: Euclid's algorithm.
 /proc/Gcd(a, b)
 	while (1)

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -1,12 +1,13 @@
 
 /obj/machinery/floodlight
-	name = "emergency floodlight"
+	name = "industrial floodlight"
+	desc = "A series of large LEDs housed in a reflective frame, this is a cheap and easy way of lighting large areas during construction."
 	icon = 'icons/obj/machines/floodlight.dmi'
 	icon_state = "flood00"
 	density = TRUE
 	obj_flags = OBJ_FLAG_ROTATABLE
 	var/on = FALSE
-	var/obj/item/cell/high/cell = null
+	var/obj/item/cell/cell = null
 	var/use = 200 // 200W light
 	var/unlocked = FALSE
 	var/open = FALSE
@@ -16,9 +17,17 @@
 
 /obj/machinery/floodlight/Initialize()
 	. = ..()
-	cell = new(src)
-	cell.maxcharge = 1000
-	cell.charge = 1000 // 41minutes @ 200W
+	cell = new /obj/item/cell/device(src) // 41minutes @ 200W
+
+/obj/machinery/floodlight/examine(mob/user)
+	. = ..()
+	if(cell)
+		if(!cell.charge)
+			to_chat(user, SPAN_WARNING("The installed [cell.name] is completely flat!"))
+			return
+		to_chat(user, SPAN_NOTICE("The installed [cell.name] has [Percent(cell.charge, cell.maxcharge)]% charge remaining."))
+	else
+		to_chat(user, SPAN_WARNING("\The [src] has no cell installed!"))
 
 /obj/machinery/floodlight/update_icon()
 	cut_overlays()
@@ -34,13 +43,14 @@
 
 	// If the cell is almost empty rarely "flicker" the light. Aesthetic only.
 	if((cell.percent() < 10) && prob(5))
-		set_light(brightness_on/2, 0.5)
-		spawn(20)
-			if(on)
-				set_light(brightness_on, 1)
+		set_light(brightness_on/3, 0.5)
+		addtimer(CALLBACK(src, .proc/stop_flicker), 5, TIMER_UNIQUE)
 
 	cell.use(use*CELLRATE)
 
+/obj/machinery/floodlight/proc/stop_flicker()
+	if(on)
+		set_light(brightness_on, 1)
 
 // Returns 0 on failure and 1 on success
 /obj/machinery/floodlight/proc/turn_on(var/loud = FALSE)

--- a/html/changelogs/geeves-floodlight_qol.yml
+++ b/html/changelogs/geeves-floodlight_qol.yml
@@ -1,0 +1,9 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Emergency floodlights are now called industrial floodlights."
+  - bugfix: "Floodlights now spawn with a device class cell. It used to spawn with a high cap, with the max charge manually lowered. No change in total charge duration."
+  - rscadd: "Examining a floodlight now gives you an idea about the status of the cell."
+  - tweak: "Tweaked floodlight flickering to make it less bad."


### PR DESCRIPTION
* Emergency floodlights are now called industrial floodlights.
* Floodlights now spawn with a device class cell. It used to spawn with a high cap, with the max charge manually lowered. No change in total charge duration.
* Examining a floodlight now gives you an idea about the status of the cell.
* Tweaked floodlight flickering to make it less bad.