### PR TITLE
Smart Mob Grab Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -202,6 +202,10 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 /mob/living/simple_animal/hostile/proc/PostAttack(var/atom/target)
 	if(stat)
 		return
+	for(var/grab in grabbed_by)
+		var/obj/item/grab/G = grab
+		if(G.state >= GRAB_AGGRESSIVE)
+			return
 	facing_dir = get_dir(src, target)
 	if(ishuman(target))
 		step_away(src, pick(RANGE_TURFS(2, target)))

--- a/html/changelogs/geeves-hold_on.yml
+++ b/html/changelogs/geeves-hold_on.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Smart mobs will no longer slip out of your aggressive grabs by moving away."


### PR DESCRIPTION
* Smart mobs will no longer slip out of your aggressive grabs by moving away.

Oversight on my part, made the code where neck grabbing a mob to prevent them from attacking useless.