### PR TITLE
Chem Dispenser Table Tweak

### DIFF
--- a/code/modules/reagents/dispenser/dispenser_presets.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets.dm
@@ -72,6 +72,7 @@
 	ui_title = "Soda Dispenser"
 	accept_drinking = 1
 	density = 0//It's a half-height machine that sits on a table, this allows small things to walk under that table
+	pass_flags = PASSTABLE // put it back on the table
 
 /obj/machinery/chemical_dispenser/bar_soft/full
 	spawn_cartridges = list(
@@ -108,6 +109,7 @@
 	ui_title = "Booze Dispenser"
 	accept_drinking = 1
 	density = 0//It's a half-height machine that sits on a table, this allows small things to walk under that table
+	pass_flags = PASSTABLE // put it back on the table
 
 /obj/machinery/chemical_dispenser/bar_alc/full
 	spawn_cartridges = list(
@@ -140,6 +142,7 @@
 	ui_title = "Coffee Master 3000"
 	accept_drinking = 1
 	density = 0
+	pass_flags = PASSTABLE // put it back on the table
 
 /obj/machinery/chemical_dispenser/coffeemaster/full
 	spawn_cartridges = list(
@@ -164,6 +167,7 @@
 	ui_title = "Morning Glory Coffee Mate"
 	icon_state_active = null
 	accept_drinking = 1
+	pass_flags = PASSTABLE // put it back on the table
 
 /obj/machinery/chemical_dispenser/coffee/full
 	spawn_cartridges = list(

--- a/html/changelogs/geeves-chem_dispenser_table.yml
+++ b/html/changelogs/geeves-chem_dispenser_table.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "You can now put drink dispensers back onto table by dragging them onto it."


### PR DESCRIPTION
* You can now put drink dispensers back onto table by dragging them onto it.

Inspired by https://github.com/tgstation/tgstation/pull/56503