### PR TITLE
Thetamycin Tweaks

### DIFF
--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -374,6 +374,7 @@
 			"bicardAmt" = null,
 			"dexAmt" = null,
 			"dermAmt" = null,
+			"thetaAmt" = null,
 			"otherAmt" = null,
 			"bodyparts" = list(),
 			"organs" = list(),
@@ -443,7 +444,8 @@
 		VUEUI_SET_CHECK(data["bicardAmt"], REAGENT_VOLUME(R, /decl/reagent/bicaridine), ., data)
 		VUEUI_SET_CHECK(data["dexAmt"], REAGENT_VOLUME(R, /decl/reagent/dexalin), ., data)
 		VUEUI_SET_CHECK(data["dermAmt"], REAGENT_VOLUME(R, /decl/reagent/dermaline), ., data)
-		VUEUI_SET_CHECK(data["otherAmt"], R.total_volume - (data["soporAmt"] + data["dexAmt"] + data["bicardAmt"] + data["norepiAmt"] + data["dermAmt"]), ., data)
+		VUEUI_SET_CHECK(data["thetaAmt"], REAGENT_VOLUME(R, /decl/reagent/thetamycin), ., data)
+		VUEUI_SET_CHECK(data["otherAmt"], R.total_volume - (data["soporAmt"] + data["dexAmt"] + data["bicardAmt"] + data["norepiAmt"] + data["dermAmt"] + data["thetaAmt"]), ., data)
 		has_internal_injuries = FALSE
 		has_external_injuries = FALSE
 		VUEUI_SET_CHECK_LIST(data["bodyparts"], get_external_wound_data(occupant), ., data)
@@ -650,6 +652,7 @@
 		"stoxin_amount" = REAGENT_VOLUME(H.reagents, /decl/reagent/soporific),
 		"bicaridine_amount" = REAGENT_VOLUME(H.reagents, /decl/reagent/bicaridine),
 		"dermaline_amount" = REAGENT_VOLUME(H.reagents, /decl/reagent/dermaline),
+		"thetamycin_amount" = REAGENT_VOLUME(H.reagents, /decl/reagent/thetamycin),
 		"blood_amount" = REAGENT_VOLUME(H.vessel, /decl/reagent/blood),
 		"disabilities" = H.sdisabilities,
 		"lung_ruptured" = H.is_lung_ruptured(),
@@ -681,9 +684,10 @@
 
 	dat += text("Inaprovaline: [] units<BR>", occ["inaprovaline_amount"])
 	dat += text("Soporific: [] units<BR>", occ["stoxin_amount"])
-	dat += text("[]\tDermaline: [] units</FONT><BR>", ("<font color='[occ["dermaline_amount"] < 30  ? "black" : "red"]'>"), occ["dermaline_amount"])
-	dat += text("[]\tBicaridine: [] units</font><BR>", ("<font color='[occ["bicaridine_amount"] < 30  ? "black" : "red"]'>"), occ["bicaridine_amount"])
-	dat += text("[]\tDexalin: [] units</font><BR>", ("<font color='[occ["dexalin_amount"] < 30  ? "black" : "red"]'>"), occ["dexalin_amount"])
+	dat += text("[]\tDermaline: [] units</FONT><BR>", ("<font color='[occ["dermaline_amount"] < 20  ? "black" : "red"]'>"), occ["dermaline_amount"])
+	dat += text("[]\tBicaridine: [] units</font><BR>", ("<font color='[occ["bicaridine_amount"] < 20  ? "black" : "red"]'>"), occ["bicaridine_amount"])
+	dat += text("[]\tDexalin: [] units</font><BR>", ("<font color='[occ["dexalin_amount"] < 20  ? "black" : "red"]'>"), occ["dexalin_amount"])
+	dat += text("[]\tThetamycin: [] units</font><BR>", ("<font color='[occ["thetamycin_amount"] < 20 ? "black" : "red"]'>"), occ["thetamycin_amount"])
 
 	dat += "<HR><table border='1'>"
 	dat += "<tr>"
@@ -727,9 +731,9 @@
 		if(e.open)
 			open = "Open."
 
-		var/infection = "[get_infection_level(e.germ_level)] infection"
-		if (infection == "")
-			infection = "None"
+		var/infection = get_infection_level(e.germ_level)
+		if (infection != "")
+			infected = "[infection] infection"
 		if(e.rejecting)
 			infected += " (being rejected)"
 
@@ -760,8 +764,8 @@
 			mech = "Mechanical:"
 
 		var/infection = get_infection_level(i.germ_level)
-		if (infection == "")
-			infection = "None"
+		if (infection != "")
+			infection = "No Infection"
 		else
 			infection = "[infection] infection"
 		if(i.rejecting)

--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -764,7 +764,7 @@
 			mech = "Mechanical:"
 
 		var/infection = get_infection_level(i.germ_level)
-		if (infection != "")
+		if(infection == "")
 			infection = "No Infection"
 		else
 			infection = "[infection] infection"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -687,6 +687,7 @@ BREATH ANALYZER
 		"stoxin_amount" = REAGENT_VOLUME(H.reagents, /decl/reagent/soporific),
 		"bicaridine_amount" = REAGENT_VOLUME(H.reagents, /decl/reagent/bicaridine),
 		"dermaline_amount" = REAGENT_VOLUME(H.reagents, /decl/reagent/dermaline),
+		"thetamycin_amount" = REAGENT_VOLUME(H.reagents, /decl/reagent/thetamycin),
 		"blood_amount" = REAGENT_VOLUME(H.vessel, /decl/reagent/blood),
 		"disabilities" = H.sdisabilities,
 		"lung_ruptured" = H.is_lung_ruptured(),

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -291,15 +291,15 @@
 
 	var/antibiotics = owner.chem_effects[CE_ANTIBIOTIC]
 
-	if (!germ_level || antibiotics < 5)
-		return
-
-	if (germ_level < INFECTION_LEVEL_ONE)
-		germ_level = 0	//cure instantly
-	else if (germ_level < INFECTION_LEVEL_TWO)
-		germ_level -= 6	//at germ_level == 500, this should cure the infection in a minute
+	if(germ_level <= INFECTION_LEVEL_ONE)
+		if(antibiotics >= 5)
+			germ_level = 0 //just finish up this small infection
+		else
+			germ_level = max(0, germ_level - (antibiotics * 5)) //Clears very quickly, finishing up remnants of infection
+	else if(germ_level <= INFECTION_LEVEL_TWO)
+		germ_level = germ_level - min(antibiotics, 6) //Still quick, infection's not too bad. At max dose and germ_level 500, should take a minute or two
 	else
-		germ_level -= 2 //at germ_level == 1000, this will cure the infection in 5 minutes
+		germ_level = germ_level - min(antibiotics * 0.5, 3) //Big infections, very slow to stop. At max dose and germ_level 1000, should take five to six minutes
 
 //Adds autopsy data for used_weapon.
 /obj/item/organ/proc/add_autopsy_data(var/used_weapon, var/damage)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -295,11 +295,11 @@
 		if(antibiotics >= 5)
 			germ_level = 0 //just finish up this small infection
 		else
-			germ_level = max(0, germ_level - (antibiotics * 5)) //Clears very quickly, finishing up remnants of infection
+			germ_level -= antibiotics * 5 //Clears very quickly, finishing up remnants of infection
 	else if(germ_level <= INFECTION_LEVEL_TWO)
-		germ_level = germ_level - min(antibiotics, 6) //Still quick, infection's not too bad. At max dose and germ_level 500, should take a minute or two
+		germ_level -= min(antibiotics, 6) //Still quick, infection's not too bad. At max dose and germ_level 500, should take a minute or two
 	else
-		germ_level = germ_level - min(antibiotics * 0.5, 3) //Big infections, very slow to stop. At max dose and germ_level 1000, should take five to six minutes
+		germ_level -= min(antibiotics * 0.5, 3) //Big infections, very slow to stop. At max dose and germ_level 1000, should take five to six minutes
 
 //Adds autopsy data for used_weapon.
 /obj/item/organ/proc/add_autopsy_data(var/used_weapon, var/damage)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -286,7 +286,7 @@
 
 //Germs
 /obj/item/organ/proc/handle_antibiotics()
-	if(!owner || !(CE_ANTIBIOTIC in owner.chem_effects))
+	if(!owner || !(CE_ANTIBIOTIC in owner.chem_effects) || (germ_level <= 0))
 		return
 
 	var/antibiotics = owner.chem_effects[CE_ANTIBIOTIC]

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -618,9 +618,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 */
 /obj/item/organ/external/proc/update_germs()
 
-	if(status & (ORGAN_ROBOT) || (owner.species && owner.species.flags & IS_PLANT)) //Robotic limbs shouldn't be infected, nor should nonexistant limbs.
+	if(status & (ORGAN_ROBOT) || (owner.species && owner.species.flags & NO_BLOOD)) //Robotic limbs shouldn't be infected, nor should nonexistant limbs, or bloodless species.
 		germ_level = 0
 		return
+
+	if(germ_level <= 0) //Catch any weirdness that might happen with negative values
+		germ_level = 0 
 
 	if(owner.bodytemperature >= 170)	//cryo stops germs from moving and doing their bad stuffs
 		//** Syncing germ levels with external wounds

--- a/html/changelogs/doxxmedearly - theta_tweaks.yml
+++ b/html/changelogs/doxxmedearly - theta_tweaks.yml
@@ -1,0 +1,9 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - tweak: "Thetamycin starts fighting infections right away (Instead of requiring 5u to metabolize first), which means minor infections treated early will be cured quickly, and major ones have a slightly reduced treatment time."
+  - rscadd: "Added thetamycin to the reagents shown in the body scanner, instead of filing them under 'other.'"
+  - bugfix: "Golems and other bloodless species should no longer get infections."
+  - bugfix: "Infections now show up on printed scans from the body scanner."

--- a/vueui/src/components/view/medical/bodyscanner.vue
+++ b/vueui/src/components/view/medical/bodyscanner.vue
@@ -56,6 +56,7 @@
             <vui-group-item label="Bicaridine:" v-if="Math.round(bicardAmt)"> {{ Math.round(bicardAmt) }} unit(s)</vui-group-item>
             <vui-group-item label="Dermaline:" v-if="Math.round(dermAmt)"> {{ Math.round(dermAmt) }} unit(s)</vui-group-item>
             <vui-group-item label="Dexalin:" v-if="Math.round(dexAmt)"> {{ Math.round(dexAmt) }} unit(s)</vui-group-item>
+            <vui-group-item label="Thetamycin:" v-if="Math.round(thetaAmt)"> {{ Math.round(thetaAmt) }} unit(s)</vui-group-item>
             <vui-group-item label="Other:" v-if="Math.round(otherAmt)"> {{ Math.round(otherAmt) }} unit(s)</vui-group-item>
           </vui-group>
         </div>


### PR DESCRIPTION
Theta starts working right away instead of having to process 5u before it does anything. This was pretty frustrating for medical and patients because they had to just sit there for even a small infection. 

Also made theta amount show up on scans, and fixed a bug where infections weren't showing up on the printed scans, despite showing up while inside the scanner. 

Some mobs like golems were able to get infections but not die. Now anything without blood can't get infections.

Also adjusted the scanner printout format for Dex/Bicard/Inaprov amounts as they were only showing up as red/dangerous above 30, which was the old OD threshold. Changed to 20. 