### PR TITLE
Shooting Lights

### DIFF
--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -389,6 +389,8 @@
 	else
 		user.visible_message(SPAN_WARNING("\The [user] hits \the [src], but it doesn't break."), SPAN_WARNING("You hit \the [src], but it doesn't break."), SPAN_WARNING("You hear something hitting against glass."))
 
+/obj/machinery/light/bullet_act(obj/item/projectile/P, def_zone)
+	shatter()
 
 // returns whether this light has power
 // true if area has power

--- a/html/changelogs/geeves-shooting_lights.yml
+++ b/html/changelogs/geeves-shooting_lights.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Shooting light fixtures will now cause them to break."


### PR DESCRIPTION
* Shooting light fixtures will now cause them to break.