### PR TITLE
Grammar for Buckling

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -91,8 +91,8 @@
 				"<span class='notice'>You hear metal clanking.</span>")
 		else
 			MA.visible_message(\
-				"<span class='danger'>[MA.name] is buckled_to to [src] by [user.name]!</span>",\
-				"<span class='danger'>You are buckled_to to [src] by [user.name]!</span>",\
+				"<span class='danger'>[MA.name] is buckled to [src] by [user.name]!</span>",\
+				"<span class='danger'>You are buckled to [src] by [user.name]!</span>",\
 				"<span class='notice'>You hear metal clanking.</span>")
 
 /obj/proc/user_unbuckle(mob/user)

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -24,7 +24,7 @@
 		return prob(60)
 
 	var/obj/structure/bed/B = A
-	if (istype(A, /obj/structure/bed) && B.buckled)//if it's a bed/chair and someone is buckled_to, it will not pass
+	if (istype(A, /obj/structure/bed) && B.buckled)//if it's a bed/chair and someone is buckled, it will not pass
 		return 0
 
 	if(istype(A, /obj/vehicle))	//no vehicles

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -157,8 +157,8 @@
 			spawn(0)
 				if(buckle(affecting))
 					affecting.visible_message(\
-						"<span class='danger'>[affecting.name] is buckled_to to [src] by [user.name]!</span>",\
-						"<span class='danger'>You are buckled_to to [src] by [user.name]!</span>",\
+						"<span class='danger'>[affecting.name] is buckled to [src] by [user.name]!</span>",\
+						"<span class='danger'>You are buckled to [src] by [user.name]!</span>",\
 						"<span class='notice'>You hear metal clanking.</span>")
 			qdel(W)
 

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -113,7 +113,7 @@
 
 		var/buckle_message_user = ""
 		var/buckle_message_other = ""
-		if(buckled_to) //If the person is buckled_to, also unbuckle the person
+		if(buckled_to) //If the person is buckled, also unbuckle the person
 			buckle_message_user = " and unbuckle yourself"
 			buckle_message_other = " and to unbuckle themself"
 			buckled_to.user_unbuckle(src)

--- a/html/changelogs/grammar.yml
+++ b/html/changelogs/grammar.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - spellcheck: "Fixed a few grammar issues when buckling people to things."


### PR DESCRIPTION
Fixes a couple of grammar errors from replace all in the buckling code.

Changes:
  - spellcheck: "Fixed a few grammar issues when buckling people to things."