### PR TITLE
Skrell Fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
@@ -83,20 +83,21 @@
 	zombie_type = SPECIES_ZOMBIE_SKRELL
 
 /datum/species/skrell/handle_post_spawn(mob/living/carbon/human/H)
+	..()
 	H.set_psi_rank(PSI_COERCION, PSI_RANK_OPERANT)
 
 /datum/species/skrell/handle_strip(var/mob/user, var/mob/living/carbon/human/H, var/action)
 	switch(action)
 		if("headtail")
-			if(!H.head)
+			if(!H.organs_by_name[BP_HEAD] || istype(H.organs_by_name[BP_HEAD], /obj/item/organ/external/stump))
 				to_chat(user, SPAN_WARNING("\The [H] doesn't have a head!"))
 				return
 			user.visible_message(SPAN_WARNING("\The [user] is trying to remove something from \the [H]'s headtails!"))
-			if(do_after(usr, HUMAN_STRIP_DELAY, act_target = H))
-				var/obj/item/storage/internal/skrell/S = locate() in H.head
+			if(do_after(user, HUMAN_STRIP_DELAY, act_target = H))
+				var/obj/item/storage/internal/skrell/S = locate() in H.organs_by_name[BP_HEAD]
 				var/obj/item/I = locate() in S
 				if(!I)
-					to_chat(usr, SPAN_WARNING("\The [H] had nothing in their headtail storage."))
+					to_chat(user, SPAN_WARNING("\The [H] had nothing in their headtail storage."))
 					return
 				S.remove_from_storage(I, get_turf(H))
 				return

--- a/html/changelogs/geeves-skrell_fixes.yml
+++ b/html/changelogs/geeves-skrell_fixes.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Removing items from skrell headtail pocket storage now works properly. It used to check if they had a hat, not a head."


### PR DESCRIPTION
* Removing items from skrell headtail pocket storage now works properly. It used to check if they had a hat, not a head.

Fixes https://github.com/Aurorastation/Aurora.3/issues/11212