### PR TITLE
Species Unrestricted Arm Guards/Leg Guards 

### DIFF
--- a/code/modules/clothing/gloves/arm_guard.dm
+++ b/code/modules/clothing/gloves/arm_guard.dm
@@ -10,6 +10,7 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_MINOR
 	)
+	species_restricted = null
 	punch_force = 3
 	w_class = ITEMSIZE_NORMAL
 	siemens_coefficient = 0.35
@@ -35,6 +36,7 @@
 		laser = ARMOR_LASER_RIFLES,
 		energy = ARMOR_ENERGY_RESISTANT
 	)
+	species_restricted = null
 
 /obj/item/clothing/gloves/arm_guard/bulletproof
 	name = "ballistic arm guards"
@@ -46,6 +48,7 @@
 		laser = ARMOR_LASER_SMALL,
 		energy = ARMOR_ENERGY_MINOR
 	)
+	species_restricted = null
 
 /obj/item/clothing/gloves/arm_guard/riot
 	name = "riot arm guards"
@@ -56,6 +59,7 @@
 		laser = ARMOR_LASER_SMALL,
 		energy = ARMOR_ENERGY_MINOR
 	)
+	species_restricted = null
 
 /obj/item/clothing/gloves/arm_guard/mercs
 	name = "heavy arm guards"

--- a/code/modules/clothing/shoes/leg_guard.dm
+++ b/code/modules/clothing/shoes/leg_guard.dm
@@ -12,6 +12,7 @@
 		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_PADDED
 	)
+	species_restricted = null
 	siemens_coefficient = 0.35
 	force = 3
 	drop_sound = 'sound/items/drop/boots.ogg'
@@ -37,6 +38,7 @@
 		energy = ARMOR_ENERGY_RESISTANT,
 		bomb = ARMOR_BOMB_PADDED
 	)
+	species_restricted = null
 
 /obj/item/clothing/shoes/leg_guard/bulletproof
 	name = "ballistic leg guards"
@@ -49,6 +51,7 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 	)
+	species_restricted = null
 
 /obj/item/clothing/shoes/leg_guard/riot
 	name = "riot leg guards"
@@ -60,6 +63,7 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 	)
+	species_restricted = null
 
 /obj/item/clothing/shoes/leg_guard/merc
 	name = "heavy leg guards"

--- a/html/changelogs/wickedcybs_commando.yml
+++ b/html/changelogs/wickedcybs_commando.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Arm guards and leg guards now have no species restrictions."


### PR DESCRIPTION
This PR unrestricts all arm guard and leg guard items so anyone can wear them. In game, one would have to use wirecutters to make the arm guards wearable for certain xeno types. All leg guards couldn't be worn at all. 

I believe this should be fine, as it never really made much sense why alien security would need to tamper with their presumably modular equipment with wirecutters, and now they can use the boots. Antags never had this issue, as their own specific heavy armour kit was already species unrestricted. 