### PR TITLE
Body bag Label Fix

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -71,7 +71,14 @@
 			src.name = "body bag - "
 			src.name += t
 			playsound(src, pick('sound/bureaucracy/pen1.ogg','sound/bureaucracy/pen2.ogg'), 20)
-			add_overlay("bodybag_label")
+			if(istype(buckled_to, /obj/structure/bed/roller))
+				var/obj/structure/bed/roller/R = buckled_to
+				if(R.bag_strap)
+					LAZYREMOVE(overlays, image(R.icon, R.bag_strap))
+					LAZYADD(overlays, image(icon, "bodybag_label"))
+					LAZYADD(overlays, image(R.icon, R.bag_strap))
+			else
+				LAZYADD(overlays, image(icon, "bodybag_label"))
 		else
 			src.name = "body bag"
 		return
@@ -79,7 +86,7 @@
 		to_chat(user, "You cut the tag off the bodybag.")
 		playsound(src.loc, 'sound/items/wirecutter.ogg', 50, 1)
 		src.name = "body bag"
-		cut_overlays()
+		LAZYREMOVE(overlays, image(icon, "bodybag_label"))
 
 /obj/structure/closet/body_bag/store_mobs(var/stored_units)
 	contains_body = ..()

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -252,7 +252,7 @@
 			iv.pixel_y = 6
 		overlays += iv
 	if(bag_strap && istype(buckled, /obj/structure/closet/body_bag))
-		buckled.overlays += image(icon, bag_strap)
+		LAZYADD(buckled.overlays, image(icon, bag_strap))
 
 /obj/structure/bed/roller/attackby(obj/item/I, mob/user)
 	if(iswrench(I) || istype(I, /obj/item/stack) || iswirecutter(I))
@@ -360,8 +360,7 @@
 			if(iv_attached)
 				detach_iv(M, usr)
 		else
-			MA.overlays.Cut() //Remove straps
-			MA.update_icon() //Add label back (if it had one)
+			LAZYREMOVE(MA.overlays, image(icon, bag_strap)) //Remove straps
 		density = FALSE
 		MA.pixel_y = 0
 		update_icon()

--- a/html/changelogs/label.yml
+++ b/html/changelogs/label.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed bodybags losing their labels after being unbuckled to roller beds."


### PR DESCRIPTION
Title.

changes:
  - bugfix: "Fixed bodybags losing their labels after being unbuckled to roller beds."