### PR TITLE
Console AI Eject Fix

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -79,7 +79,7 @@
 		verbs += /obj/item/modular_computer/proc/eject_usb
 	if(battery_module && battery_module.hotswappable)
 		verbs += /obj/item/modular_computer/proc/eject_battery
-	if(ai_slot && ai_slot.stored_card)
+	if(ai_slot)
 		verbs += /obj/item/modular_computer/proc/eject_ai
 	if(personal_ai)
 		verbs += /obj/item/modular_computer/proc/eject_personal_ai

--- a/html/changelogs/geeves-intellicard_console.yml
+++ b/html/changelogs/geeves-intellicard_console.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the Eject AI option not appearing on consoles that spawn with an AI slot."


### PR DESCRIPTION
* Fixes the Eject AI option not appearing on consoles that spawn with an AI slot.