### PR TITLE
Rescue RIG's Mortaphenyl Swapped for Perconol

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -347,7 +347,7 @@
 /obj/item/rig_module/chem_dispenser/injector/paramedic //downgraded version
 	charges = list(
 		list("tricordrazine",	"tricordrazine",	/decl/reagent/tricordrazine,	40),
-		list("mortaphenyl",		"mortaphenyl",		/decl/reagent/mortaphenyl,		40),
+		list("perconol",		"perconol",			/decl/reagent/perconol,		40),
 		list("dexalin",			"dexalin",			/decl/reagent/dexalin,			40),
 		list("inaprovaline",	"inaprovaline",		/decl/reagent/inaprovaline,	40)
 		)

--- a/html/changelogs/wickedcybs_injector.yml
+++ b/html/changelogs/wickedcybs_injector.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The rescue RIG's chemical injector has had its mortaphenyl replaced with perconol due to the changes with medical reagents recently."


### PR DESCRIPTION
As the title says, this swaps the mortaphenyl supply within the chemical injector to perconol. Mortaphenyl within the RIG was a relic of when the chemical could be injected with no real consequences or side effects. However, since it is a heavy duty drug now it is a bit out of place and doesn't really see use by medics.

