### PR TITLE
Window Vote Flash

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -543,3 +543,13 @@ datum/projectile_data
 		if(M.client)
 			viewing += M.client
 	flick_overlay(I, viewing, duration)
+
+// makes peoples byond icon flash on the taskbar
+/proc/window_flash(client/C)
+	if(ismob(C))
+		var/mob/M = C
+		if(M.client)
+			C = M.client
+	if(!C)
+		return
+	winset(C, "mainwindow", "flash=5")

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -49,6 +49,9 @@ var/datum/controller/subsystem/vote/SSvote
 	log_debug("The server has called a crew transfer vote")
 
 /datum/controller/subsystem/vote/proc/autogamemode()
+	for(var/thing in clients)
+		var/client/C = thing
+		window_flash(C)
 	initiate_vote("gamemode","the server", 1)
 	log_debug("The server has called a gamemode vote")
 

--- a/html/changelogs/geeves-window_flash.yml
+++ b/html/changelogs/geeves-window_flash.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "The byond icon on your taskbar now flashes when the gamemode vote starts, if you're tabbed out."


### PR DESCRIPTION
* The byond icon on your taskbar now flashes when the gamemode vote starts, if you're tabbed out.

Inspired by https://github.com/tgstation/tgstation/pull/22690