### PR TITLE
Chemical Burn Damage Cap Tweak

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -349,11 +349,11 @@
 		return
 	var/temperature = src.get_temperature()
 	if(temperature >= REAGENTS_BURNING_TEMP_HIGH)
-		var/burn_damage = Clamp(total_volume*(temperature - REAGENTS_BURNING_TEMP_HIGH)*REAGENTS_BURNING_TEMP_HIGH_DAMAGE,0,REAGENTS_BURNING_TEMP_HIGH_DAMAGE_CAP)
+		var/burn_damage = Clamp(total_volume*(temperature - REAGENTS_BURNING_TEMP_HIGH)*REAGENTS_BURNING_TEMP_HIGH_DAMAGE,0,min(total_volume*2,REAGENTS_BURNING_TEMP_HIGH_DAMAGE_CAP))
 		target.adjustFireLoss(burn_damage)
 		target.visible_message(SPAN_DANGER("The hot liquid burns [target]!"))
 	else if(temperature <= REAGENTS_BURNING_TEMP_LOW)
-		var/burn_damage = Clamp(total_volume*(REAGENTS_BURNING_TEMP_LOW - temperature)*REAGENTS_BURNING_TEMP_LOW_DAMAGE,0,REAGENTS_BURNING_TEMP_LOW_DAMAGE_CAP)
+		var/burn_damage = Clamp(total_volume*(REAGENTS_BURNING_TEMP_LOW - temperature)*REAGENTS_BURNING_TEMP_LOW_DAMAGE,0,min(total_volume*2,REAGENTS_BURNING_TEMP_LOW_DAMAGE_CAP))
 		target.adjustFireLoss(burn_damage)
 		target.visible_message(SPAN_DANGER("The freezing liquid burns [target]!"))
 

--- a/html/changelogs/geeves-no_hand_cannon.yml
+++ b/html/changelogs/geeves-no_hand_cannon.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Superheated or supercooled chemical damage caps are now also calculated by total volume, so spritzing someone doesn't do 40 damage a pop."


### PR DESCRIPTION
* Superheated or supercooled chemical damage caps are now also calculated by total volume, so spritzing someone doesn't do 40 damage a pop.