### PR TITLE
Prosthetic Groin Cap

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -16,6 +16,8 @@
 	dir = SOUTH
 	organ_tag = "limb"
 
+	var/force_prosthetic_name
+
 	var/icon_name = null
 	var/body_part = null
 	var/icon_position = 0
@@ -58,6 +60,7 @@
 
 	var/obj/item/organ/external/parent
 	var/list/obj/item/organ/external/children
+	var/supports_children = TRUE
 	var/list/internal_organs = list() 	// Internal organs of this body part
 
 	var/damage_msg = "<span class='warning'>You feel an intense pain!</span>"
@@ -1089,9 +1092,15 @@ Note that amputating the affected organ does in fact remove the infection from t
 				force_icon = R.icon
 			if(R.lifelike)
 				status |= ORGAN_LIFELIKE
-				name = "[initial(name)]"
+				if(force_prosthetic_name)
+					name = force_prosthetic_name
+				else
+					name = "[initial(name)]"
 			else
-				name = "[R.company] [initial(name)]"
+				if(force_prosthetic_name)
+					name = force_prosthetic_name
+				else
+					name = "[R.company] [initial(name)]"
 				desc = "[R.desc]"
 			if(R.paintable)
 				painted = 1

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -591,6 +591,22 @@
 	encased = "support frame"
 	robotize_type = "Unbranded"
 
+/obj/item/organ/external/groin/ipc/unbranded/cap // extreme nugget action
+	force_prosthetic_name = "prosthetic groin cap"
+	supports_children = FALSE
+
+/obj/item/organ/external/groin/ipc/unbranded/cap/Initialize(mapload)
+	. = ..()
+	var/obj/item/organ/internal/kidneys/K = new(src)
+	K.robotize()
+	internal_organs += K
+	var/obj/item/organ/internal/liver/L = new(src)
+	L.robotize()
+	internal_organs += L
+	var/obj/item/organ/internal/stomach/S = new(src)
+	S.robotize()
+	internal_organs += S
+
 /obj/item/organ/external/arm/ipc/unbranded
 	dislocated = -1
 	encased = "support frame"

--- a/code/modules/research/designs/mechfab/prosthetics/external.dm
+++ b/code/modules/research/designs/mechfab/prosthetics/external.dm
@@ -1,16 +1,18 @@
 /datum/design/item/mechfab/prosthetic
 	category = "Prosthetic (External)"
+	var/use_direct_buildpath = FALSE
 
 //if the fabricator is a mech fab we need to construct the proper typepath for the manufacturer
 /datum/design/item/mechfab/prosthetic/Fabricate(var/newloc, var/fabricator)
 	if(istype(fabricator, /obj/machinery/mecha_part_fabricator))
-		var/obj/machinery/mecha_part_fabricator/mechfab = fabricator
-		for(var/model_path in subtypesof(build_path))
-			var/obj/item/organ/external/E = new model_path
-			if(E.robotize_type == mechfab.manufacturer)
+		if(!use_direct_buildpath)
+			var/obj/machinery/mecha_part_fabricator/mechfab = fabricator
+			for(var/model_path in subtypesof(build_path))
+				var/obj/item/organ/external/E = new model_path
+				if(E.robotize_type == mechfab.manufacturer)
+					qdel(E)
+					return new model_path(newloc)
 				qdel(E)
-				return new model_path(newloc)
-			qdel(E)
 		return new build_path(newloc) // We didn't find our manufacturer in the list, so return an unbranded one
 	return ..()
 
@@ -61,3 +63,9 @@
 	build_path = /obj/item/organ/external/foot/right/ipc
 	time = 20
 	materials = list(DEFAULT_WALL_MATERIAL = 8000)
+
+/datum/design/item/mechfab/prosthetic/groin_cap
+	name = "Prosthetic Groin Cap"
+	build_path = /obj/item/organ/external/groin/ipc/unbranded/cap
+	use_direct_buildpath = TRUE
+	materials = list(DEFAULT_WALL_MATERIAL = 25000)

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -17,7 +17,7 @@
 	var/obj/item/organ/external/E = tool
 	if(E?.parent_organ)
 		var/obj/item/organ/external/P = target.organs_by_name[E.parent_organ]
-		if(!P || P.is_stump() || (BP_IS_ROBOTIC(P) && !BP_IS_ROBOTIC(E)))
+		if(!P || P.is_stump() || !P.supports_children || (BP_IS_ROBOTIC(P) && !BP_IS_ROBOTIC(E)))
 			return FALSE // Parent organ non-existant or unsuitable
 	return !isnull(organ_data)
 

--- a/html/changelogs/geeves-hubcap.yml
+++ b/html/changelogs/geeves-hubcap.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Allows robotics to print prosthetic groin caps. These come with all the organs that groins normally come with, but they do not support attachment of legs."


### PR DESCRIPTION
* Allows robotics to print prosthetic groin caps. These come with all the organs that groins normally come with, but they do not support attachment of legs.