### PR TITLE
Auto Local Admin

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -162,6 +162,7 @@ var/list/gamemode_cache = list()
 	var/animal_delay = 0
 
 
+	var/auto_local_admin = FALSE
 	var/admin_legacy_system = 0	//Defines whether the server uses the legacy admin system with admins.txt or the SQL system. Config option in config.txt
 	var/ban_legacy_system = 0	//Defines whether the server uses the legacy banning system with the files in /data or the SQL system. Config option in config.txt
 	var/use_age_restriction_for_jobs = 0 //Do jobs use account age restrictions? --requires database
@@ -365,6 +366,9 @@ var/list/gamemode_cache = list()
 
 		if(type == "config")
 			switch (name)
+				if ("auto_local_admin")
+					config.auto_local_admin = TRUE
+
 				if ("admin_legacy_system")
 					config.admin_legacy_system = 1
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -397,7 +397,7 @@ var/list/localhost_addresses = list(
 /client/proc/InitClient()
 	to_chat(src, "<span class='alert'>If the title screen is black, resources are still downloading. Please be patient until the title screen appears.</span>")
 
-	var/local_connection = (config.auto_local_admin && (isnull(address) || localhost_addresses[address]))
+	var/local_connection = (config.auto_local_admin && !config.use_forumuser_api && (isnull(address) || localhost_addresses[address]))
 	// Automatic admin rights for people connecting locally.
 	// Concept stolen from /tg/ with deepest gratitude.
 	// And ported from Nebula with love.

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -1,3 +1,8 @@
+var/list/localhost_addresses = list(
+	"127.0.0.1" = TRUE,
+	"::1" = TRUE
+)
+
 	////////////
 	//SECURITY//
 	////////////
@@ -391,6 +396,13 @@
 
 /client/proc/InitClient()
 	to_chat(src, "<span class='alert'>If the title screen is black, resources are still downloading. Please be patient until the title screen appears.</span>")
+
+	var/local_connection = (config.auto_local_admin && (isnull(address) || localhost_addresses[address]))
+	// Automatic admin rights for people connecting locally.
+	// Concept stolen from /tg/ with deepest gratitude.
+	// And ported from Nebula with love.
+	if(local_connection && !admin_datums[ckey])
+		new /datum/admins("Local Host", R_ALL, ckey)
 
 	//Admin Authorisation
 	holder = admin_datums[ckey]

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -10,6 +10,9 @@ ALERT_RED_UPTO There is an immediate serious threat to the station. Security may
 ALERT_RED_DOWNTO The self-destruct mechanism has been deactivated, there is still however an immediate serious threat to the station. Security may have weapons unholstered at all times, random searches are allowed and advised.
 ALERT_DELTA The station's self-destruct mechanism has been engaged. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill.
 
+## Add a # in front of this to disable automatic admin rights for users connecting from the host the server is running on.
+AUTO_LOCAL_ADMIN
+
 ## Add a # infront of this if you want to use the SQL based admin system, the legacy system uses admins.txt. You need to set up your database to use the SQL based system.
 ADMIN_LEGACY_SYSTEM
 


### PR DESCRIPTION
Connecting locally to the server from the thing you host it on will now grant you admin access. This can be disabled through the config.

Ported from https://github.com/NebulaSS13/Nebula/pull/1315 who got inspired by /tg/'s implementation.