### PR TITLE
Adrenaline generation cap, tear gas buff, stun baton pain adjustment.

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -188,7 +188,7 @@
 				L.visible_message("<span class='danger'>[L] has been prodded with \the [src] by [user]!</span>")
 
 	//stun effects
-	L.stun_effect_act(stun, agony, target_zone, src)
+	L.stun_effect_act(stun, agony, used_weapon = src, damage_flags = DAM_DISPERSED)
 
 	playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -377,9 +377,12 @@ This function restores all organs.
 	return
 
 
-/mob/living/carbon/human/proc/get_organ(var/zone)
+/mob/living/carbon/human/proc/get_organ(var/zone, var/allow_no_result = FALSE)
 	if(!zone)
-		zone = BP_CHEST
+		if(allow_no_result)
+			return
+		else
+			zone = BP_CHEST
 	if (zone in list(BP_EYES, BP_MOUTH))
 		zone = BP_HEAD
 	return organs_by_name[zone]
@@ -390,7 +393,7 @@ This function restores all organs.
 			to_chat(src, "<span class='danger'>You are now visible.</span>")
 			src.invisibility = 0
 
-	var/obj/item/organ/external/organ = get_organ(def_zone)
+	var/obj/item/organ/external/organ = get_organ(def_zone, TRUE)
 	if(!organ)
 		if(isorgan(def_zone))
 			organ = def_zone
@@ -430,7 +433,8 @@ This function restores all organs.
 		return FALSE
 
 	if(damage > 15 && prob(damage*4) && organ.can_feel_pain())
-		make_adrenaline(round(damage/10))
+		if(REAGENT_VOLUME(reagents, /decl/reagent/adrenaline) < 15)
+			make_adrenaline(round(damage/10))
 
 	switch(damagetype)
 		if(BRUTE)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -51,7 +51,7 @@ emp_act
 
 	return blocked
 
-/mob/living/carbon/human/stun_effect_act(var/stun_amount, var/agony_amount, var/def_zone)
+/mob/living/carbon/human/stun_effect_act(var/stun_amount, var/agony_amount, var/def_zone, var/used_weapon, var/damage_flags)
 	var/obj/item/organ/external/affected = get_organ(check_zone(def_zone))
 	var/siemens_coeff = get_siemens_coefficient_organ(affected)
 	stun_amount *= siemens_coeff
@@ -78,7 +78,7 @@ emp_act
 					var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")
 					visible_message("<b>[src]</b> [(!can_feel_pain()) ? "" : emote_scream ]drops what they were holding in their [affected.name]!")
 
-	..(stun_amount, agony_amount, def_zone)
+	..(stun_amount, agony_amount, def_zone, used_weapon, damage_flags)
 
 /mob/living/carbon/human/get_blocked_ratio(def_zone, damage_type, damage_flags, armor_pen, damage)
 	if(!def_zone && (damage_flags & DAM_DISPERSED))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -87,7 +87,7 @@
 	return BULLET_IMPACT_MEAT
 
 //Handles the effects of "stun" weapons
-/mob/living/proc/stun_effect_act(var/stun_amount, var/agony_amount, var/def_zone, var/used_weapon=null)
+/mob/living/proc/stun_effect_act(var/stun_amount, var/agony_amount, var/def_zone, var/used_weapon, var/damage_flags)
 	flash_pain(stun_amount)
 
 	if(stun_amount)
@@ -97,7 +97,7 @@
 		apply_effect(stun_amount, EYE_BLUR)
 
 	if(agony_amount)
-		apply_damage(agony_amount, PAIN, def_zone, 0, used_weapon = used_weapon)
+		apply_damage(agony_amount, PAIN, def_zone, used_weapon, damage_flags)
 		apply_effect(agony_amount / 10, STUTTER)
 		apply_effect(agony_amount / 10, EYE_BLUR)
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -260,7 +260,8 @@ var/list/global/organ_rel_size = list(
 )
 
 /proc/check_zone(zone)
-	if(!zone)	return BP_CHEST
+	if(!zone)
+		return BP_CHEST
 	switch(zone)
 		if(BP_EYES)
 			zone = BP_HEAD

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -640,7 +640,7 @@
 		message = "<span class='danger'>Your face and throat burn!</span>"
 		if(prob(25))
 			M.visible_message("<b>[M]</b> [pick("coughs!","coughs hysterically!","splutters!")]")
-			M.apply_effect(30, PAIN)
+		M.apply_effect(30, PAIN)
 
 /decl/reagent/capsaicin/condensed/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(ishuman(M))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -640,14 +640,14 @@
 		message = "<span class='danger'>Your face and throat burn!</span>"
 		if(prob(25))
 			M.visible_message("<b>[M]</b> [pick("coughs!","coughs hysterically!","splutters!")]")
-		M.apply_effect(40, PAIN, 0)
+			M.apply_effect(30, PAIN)
 
 /decl/reagent/capsaicin/condensed/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(!H.can_feel_pain())
 			return
-	M.apply_effect(4, PAIN, 0)
+	M.apply_effect(10, PAIN)
 	if(prob(5))
 		M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>", "<span class='danger'>You feel like your insides are burning!</span>")
 	if(istype(M, /mob/living/carbon/slime))

--- a/html/changelogs/mattatlas-teargasfix.yml
+++ b/html/changelogs/mattatlas-teargasfix.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Tear gas should now be much more effective."
+  - tweak: "Stun batons now disperse pain all over the body. What happened previously was that hitting the same body part would not cause spillover, thus keeping the mob's pain at that limb's total pain cap."
+  - tweak: "Adrenaline generation is now capped and will not be generated if there is more than 15u in the system."


### PR DESCRIPTION
Here are the three issues tackled by this PR.
- Tear gas was very inconsistent due to me misunderstanding how exactly it worked. This has been fixed and tear gas actually does pain damage now!

- You could previously generate inane quantities of adrenaline by spamming jointlock or teargas on mobs, since there was no cap on generation. This has been fixed.

- Stun batons only hit one bodypart. This means that the pain damage dealt would eventually be capped at that limb's `max_damage` variable, thus making them unable to drop people unless you quickly changed def_zone to other limbs. This has been fixed.