### PR TITLE
Renames toggle burst fire to the correct toggle firing mode.

### DIFF
--- a/code/_onclick/hud/gun_mode.dm
+++ b/code/_onclick/hud/gun_mode.dm
@@ -66,8 +66,8 @@
 	return 0
 
 /obj/screen/gun/burstfire
-	name = "Toggle Burst Fire"
-	desc = "This can be used in a macro as toggle-burst-fire."
+	name = "Toggle Firing Mode"
+	desc = "This can be used in a macro as toggle-firing-mode."
 	icon_state = "toggle_burst_fire"
 	screen_loc = ui_burstfire
 

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -369,11 +369,11 @@
 	mymob.radio_use_icon.color = ui_color
 	mymob.radio_use_icon.alpha = ui_alpha
 
-	mymob.toggle_burst_fire_icon = new /obj/screen/gun/burstfire(null)
-	mymob.toggle_burst_fire_icon.icon = ui_style
-	mymob.toggle_burst_fire_icon.color = ui_color
-	mymob.toggle_burst_fire_icon.alpha = ui_alpha
-	hud_elements |= mymob.toggle_burst_fire_icon
+	mymob.toggle_firing_mode = new /obj/screen/gun/burstfire(null)
+	mymob.toggle_firing_mode.icon = ui_style
+	mymob.toggle_firing_mode.color = ui_color
+	mymob.toggle_firing_mode.alpha = ui_alpha
+	hud_elements |= mymob.toggle_firing_mode
 
 	mymob.unique_action_icon = new /obj/screen/gun/uniqueaction(null)
 	mymob.unique_action_icon.icon = ui_style

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -130,7 +130,7 @@ var/obj/screen/robot_inventory
 	mymob.item_use_icon = new /obj/screen/gun/item(null)
 	mymob.gun_move_icon = new /obj/screen/gun/move(null)
 	mymob.radio_use_icon = new /obj/screen/gun/radio(null)
-	mymob.toggle_burst_fire_icon = new /obj/screen/gun/burstfire(null)
+	mymob.toggle_firing_mode = new /obj/screen/gun/burstfire(null)
 	mymob.unique_action_icon = new /obj/screen/gun/uniqueaction(null)
 
 	mymob.client.screen = null
@@ -145,7 +145,7 @@ var/obj/screen/robot_inventory
 		mymob.pullin,
 		robot_inventory,
 		mymob.gun_setting_icon,
-		mymob.toggle_burst_fire_icon,
+		mymob.toggle_firing_mode,
 		mymob.unique_action_icon,
 		r.computer
 		)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -36,7 +36,7 @@
 	var/obj/screen/gun/run/gun_run_icon = null
 	var/obj/screen/gun/mode/gun_setting_icon = null
 	var/obj/screen/gun/unique_action_icon = null
-	var/obj/screen/gun/toggle_burst_fire_icon = null
+	var/obj/screen/gun/toggle_firing_mode = null
 	var/obj/screen/up_hint = null
 
 	//spells hud icons - this interacts with add_spell and remove_spell

--- a/html/changelogs/mattatlas-aaaaaa.yml
+++ b/html/changelogs/mattatlas-aaaaaa.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The toggle burst fire button is now correctly called Toggle Firing Mode. The verb is also toggle-firing-mode."


### PR DESCRIPTION
I forgot to rename all occurrances of toggle burst fire to toggle firing mode. Unfortunately this was also in the CL. This fixes that.