### PR TITLE
Circuit Imprinter Category Fix

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -316,7 +316,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		updateUsrDialog()
 
 	else if(href_list["imprinter_category"])
-		var/choice = input("Which category do you wish to display?") as null|anything in designs_protolathe_categories+"All"
+		var/choice = input("Which category do you wish to display?") as null|anything in designs_imprinter_categories+"All"
 		if(!choice)
 			return
 		imprinter_category = choice

--- a/html/changelogs/geeves-circuit_imprinter_category_fix.yml
+++ b/html/changelogs/geeves-circuit_imprinter_category_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the circuit imprinter machine having the protolathe category selection instead of its own."


### PR DESCRIPTION
* Fixed the circuit imprinter machine having the protolathe category selection instead of its own.