### PR TITLE
Ready Names

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -17,6 +17,7 @@
 	var/list/datum/job/type_occupations = list()	//Dict of all jobs, keys are types
 	var/list/mob/abstract/new_player/unassigned = list()
 	var/list/job_debug = list()
+	var/list/bitflag_to_job = list()
 
 	var/list/factions = list()
 	var/list/name_factions = list()
@@ -59,6 +60,9 @@
 		occupations += job
 		name_occupations[job.title] = job
 		type_occupations[J] = job
+		if(!length(bitflag_to_job["[job.department_flag]"]))
+			bitflag_to_job["[job.department_flag]"] = list()
+		bitflag_to_job["[job.department_flag]"]["[job.flag]"] = job
 		if (config && config.use_age_restriction_for_jobs)
 			job.fetch_age_restriction()
 

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -49,9 +49,9 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			totalPlayers = 0
 			totalPlayersReady = 0
 			for(var/mob/abstract/new_player/player in player_list)
-				stat("[player.key]", (player.ready)?("(Playing)"):(null))
 				totalPlayers++
 				if(player.ready)
+					stat("[copytext_char(player.client.prefs.real_name, 1, 18)]", ("[player.client.prefs.return_chosen_high_job(TRUE)]"))
 					totalPlayersReady++
 
 /mob/abstract/new_player/Topic(href, href_list[])

--- a/code/modules/mob/abstract/new_player/preferences_setup.dm
+++ b/code/modules/mob/abstract/new_player/preferences_setup.dm
@@ -203,18 +203,7 @@
 	if(job_civilian_low & ASSISTANT)
 		previewJob = SSjobs.GetJob("Assistant")
 	else
-		for(var/datum/job/job in SSjobs.occupations)
-			var/job_flag
-			switch(job.department_flag)
-				if(CIVILIAN)
-					job_flag = job_civilian_high
-				if(MEDSCI)
-					job_flag = job_medsci_high
-				if(ENGSEC)
-					job_flag = job_engsec_high
-			if(job.flag == job_flag)
-				previewJob = job
-				break
+		previewJob = return_chosen_high_job()
 
 	if(previewJob)
 		mannequin.job = previewJob.title
@@ -236,6 +225,19 @@
 			mannequin.regenerate_icons()
 		else
 			mannequin.update_icon()
+
+/datum/preferences/proc/return_chosen_high_job(var/title = FALSE)
+	var/datum/job/chosenJob
+	if(job_civilian_high)
+		chosenJob = SSjobs.bitflag_to_job["[CIVILIAN]"]["[job_civilian_high]"]
+	else if(job_medsci_high)
+		chosenJob = SSjobs.bitflag_to_job["[MEDSCI]"]["[job_medsci_high]"]
+	else if(job_engsec_high)
+		chosenJob = SSjobs.bitflag_to_job["[ENGSEC]"]["job_engsec_high"]
+
+	if(title)
+		return chosenJob.title
+	return chosenJob
 
 /datum/preferences/proc/update_mannequin()
 	var/mob/living/carbon/human/dummy/mannequin/mannequin = SSmob.get_mannequin(client.ckey)

--- a/html/changelogs/geeves-ready_names.yml
+++ b/html/changelogs/geeves-ready_names.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Readying up now shows your character name and the job they have set to high in the Lobby stat panel. No ckeys are exposed."


### PR DESCRIPTION
* Readying up now shows your character name and the job they have set to high in the Lobby stat panel. No ckeys are exposed.

Based on https://github.com/discordia-space/CEV-Eris/pull/3293

![image](https://user-images.githubusercontent.com/22774890/108990588-bbf1dd80-769f-11eb-8a6a-ff90170656e3.png)