### PR TITLE
Medical's Sublevel Lockers Renamed & Now Contain One Medical Helmet Each

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -87,6 +87,7 @@
 	new /obj/item/clothing/glasses/eyepatch/hud/medical(src)
 	new /obj/item/clothing/suit/storage/medical_chest_rig(src)
 	new /obj/item/clothing/suit/storage/medical_chest_rig/first_responder(src)
+	new /obj/item/clothing/head/hardhat/first_responder(src)
 
 
 /obj/structure/closet/secure_closet/CMO

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -42,7 +42,7 @@
 	new /obj/item/clothing/mask/breath/medical(src)
 
 /obj/structure/closet/secure_closet/medical3
-	name = "physician's locker"
+	name = "medical equipment locker"
 	req_access = list(access_medical_equip)
 	icon_state = "securemed1"
 	icon_closed = "securemed"

--- a/html/changelogs/example - Copy.yml
+++ b/html/changelogs/example - Copy.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: WickedCybs
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Physician lockers now contain one medical helmet."

--- a/html/changelogs/wickedcybs_medlocker.yml
+++ b/html/changelogs/wickedcybs_medlocker.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Physician lockers now contain one medical helmet."
+  - tweak: "The sublevel 'physician lockers' are renamed to 'medical equipment locker' and have had one medical helmet added to their storages."


### PR DESCRIPTION
The medical helmet is an item only First Responders could spawn with, and it was fairly easy to just have it be totally removed somehow or lost with no replacement. Now there's one spare each to go with the rest of the First Responder's kit contained within the medical lockers at the sublevel.

Additionally, as the lockers were not just exclusive to Physicians. The lockers medical staff get their equipment from has been renamed from "Physician's locker" to "Medical equipment locker."