### PR TITLE
White Shoes in the Med Sublevel Begone - Medical Shoes are in

### DIFF
--- a/html/changelogs/wickedcybs_whyareyouhere.yml
+++ b/html/changelogs/wickedcybs_whyareyouhere.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - maptweak: "The random pair of white shoes laying on the floor of medical's staff wing has finally been collected by its owner."
+  - maptweak: "The white shoes in the med sublevel are now medical shoes."

--- a/html/changelogs/wickedcybs_whyareyouhere.yml
+++ b/html/changelogs/wickedcybs_whyareyouhere.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: WickedCybs
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "The random pair of white shoes laying on the floor of medical's staff wing has finally been collected by its owner."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -22366,6 +22366,10 @@
 /area/medical/medbay4)
 "aVg" = (
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/item/clothing/shoes/medical{
+	pixel_x = 4;
+	pixel_y = -8
+},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
 "aVi" = (

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -22366,10 +22366,6 @@
 /area/medical/medbay4)
 "aVg" = (
 /obj/effect/floor_decal/corner/white/diagonal,
-/obj/item/clothing/shoes/white{
-	pixel_x = 4;
-	pixel_y = -8
-	},
 /turf/simulated/floor/tiled,
 /area/medical/medbay4)
 "aVi" = (


### PR DESCRIPTION
There was a pair of white shoes just randomly on the floor of med's staff wing where they get equipment for some reason. This PR removes it.