### PR TITLE
First Responder Bay Facelift

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -88,6 +88,39 @@
 	new /obj/item/clothing/suit/storage/medical_chest_rig(src)
 	new /obj/item/clothing/suit/storage/medical_chest_rig/first_responder(src)
 
+/obj/structure/closet/secure_closet/medical_fr
+	name = "first responder's locker"
+	desc = "An immobile, card-locked storage unit containing all the necessary equipment for a first responder."
+	req_access = list(access_first_responder)
+	icon_state = "securemed1"
+	icon_closed = "securemed"
+	icon_locked = "securemed1"
+	icon_opened = "securemedopen"
+	icon_broken = "securemedbroken"
+	icon_off = "securemedoff"
+
+/obj/structure/closet/secure_closet/medical_fr/fill()
+	..()
+	new /obj/item/storage/backpack/satchel_med(src)
+	new /obj/item/storage/backpack/duffel/med(src)
+	new /obj/item/clothing/head/hardhat/first_responder(src)
+	new /obj/item/device/radio/headset/headset_med(src)
+	new /obj/item/clothing/glasses/hud/health(src)
+	new /obj/item/clothing/suit/storage/medical_chest_rig(src)
+	new /obj/item/clothing/suit/storage/medical_chest_rig/first_responder(src)
+	new /obj/item/clothing/under/rank/medical/first_responder(src)
+	new /obj/item/clothing/shoes/jackboots(src)
+	new /obj/item/device/flashlight/pen(src)
+	new /obj/item/clothing/accessory/stethoscope(src)
+	new /obj/item/storage/belt/medical/first_responder(src)
+	new /obj/item/device/gps(src)
+	new /obj/item/reagent_containers/hypospray(src)
+	new /obj/item/taperoll/medical(src)
+	new /obj/item/device/radio(src)
+	new /obj/item/roller(src)
+	new /obj/item/crowbar/red(src)
+
+
 
 /obj/structure/closet/secure_closet/CMO
 	name = "chief medical officer's locker"

--- a/html/changelogs/unclejo-emtbay-remodel.yml
+++ b/html/changelogs/unclejo-emtbay-remodel.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: UncleJo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added two unique, access-locked lockers to the EMT bay and relocated most of the existing table clutter into them. They additionally come with a full uniform, a stethoscope, a penlight, a roller bed, and a crowbar. No more trips to the sub-level."
+  - rscadd: "Added a box of nitrile gloves, a medical suit cycler into the EMT bay to store voidsuits inside of, and two roller beds by the central ring doorway."
+  - tweak: "Gave the EMT bay itself a bit of a facelift. It should be a bit cleaner and a bit roomier now."
+  - tweak: "Replaced the wall-mounted NanoMed vendor in the EMT bay with the alternative variant that doesn't shoot dylovene syringes at you during rampant brand intelligence events. Thank God."

--- a/html/changelogs/unclejo-emtbay-remodel.yml
+++ b/html/changelogs/unclejo-emtbay-remodel.yml
@@ -39,6 +39,6 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Added two unique, access-locked lockers to the EMT bay and relocated most of the existing table clutter into them. They additionally come with a full uniform, a stethoscope, a penlight, a roller bed, and a crowbar. No more trips to the sub-level."
-  - rscadd: "Added a box of nitrile gloves, a medical suit cycler into the EMT bay to store voidsuits inside of, and two roller beds by the central ring doorway."
+  - rscadd: "Added a box of nitrile gloves, a medical suit cycler, and two spare roller beds into the EMT bay."
   - tweak: "Gave the EMT bay itself a bit of a facelift. It should be a bit cleaner and a bit roomier now."
   - tweak: "Replaced the wall-mounted NanoMed vendor in the EMT bay with the alternative variant that doesn't shoot dylovene syringes at you during rampant brand intelligence events. Thank God."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -31616,6 +31616,9 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
+/obj/effect/floor_decal/corner/grey{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
 "bcb" = (
@@ -32452,6 +32455,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
@@ -42124,31 +42130,21 @@
 /turf/simulated/wall,
 /area/medical/first_responder)
 "bwe" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
-	},
 /obj/machinery/computer/guestpass{
 	pixel_x = -28
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "bwf" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/turf/simulated/floor/tiled,
+/area/medical/first_responder)
 "bwg" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -42936,6 +42932,7 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bxv" = (
@@ -42944,10 +42941,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/toxin{
@@ -42959,25 +42952,19 @@
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bxw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/adv{
 	pixel_x = 4;
 	pixel_y = 4
 	},
 /obj/item/storage/firstaid/fire,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bxx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Stabilization Kit";
@@ -42990,45 +42977,25 @@
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/bruise_pack,
 /obj/item/storage/pill_bottle/mortaphenyl,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/item/reagent_containers/hypospray/autoinjector/coagzolug,
 /obj/item/reagent_containers/hypospray/autoinjector/coagzolug,
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bxy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	is_critical = 1;
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bxz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Medication Closet";
@@ -43041,98 +43008,62 @@
 /obj/item/storage/pill_bottle/dylovene,
 /obj/item/reagent_containers/syringe/antibiotic,
 /obj/item/reagent_containers/syringe/antibiotic,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bxA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/suit_cycler/medical,
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bxB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/rack,
+/obj/item/rig/medical/equipped{
+	pixel_y = -2
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/southright{
+	name = "Rescue Hardsuit";
+	req_access = list(67)
+	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bxC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_medical{
-	name = "First Responder Quarters";
-	req_access = list(67)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white/diagonal,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bxD" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
 /obj/effect/floor_decal/corner/grey{
-	dir = 9
-	},
-/obj/effect/floor_decal/sign/first_responder,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -43143,15 +43074,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "bxJ" = (
@@ -43679,18 +43610,20 @@
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "byU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "byV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "byW" = (
@@ -43704,40 +43637,60 @@
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/misc_lab)
 "byY" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/table/rack,
-/obj/item/rig/medical/equipped,
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Rescue Hardsuit";
-	req_access = list(67)
-	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "byZ" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/effect/floor_decal/sign/first_responder,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "bza" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "bzc" = (
@@ -44223,43 +44176,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/lab)
-"bzW" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/medical/first_responder)
 "bzX" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "First Responder Garage Access";
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/door/window/southleft{
 	req_access = list(67)
 	},
-/obj/effect/floor_decal/corner/white/diagonal,
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bzY" = (
+/obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
+/obj/structure/flora/pottedplant/random,
+/turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bzZ" = (
 /obj/structure/grille,
@@ -44284,16 +44213,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/first_responder)
-"bAa" = (
-/obj/machinery/firealarm/south,
-/obj/effect/floor_decal/corner/white/diagonal,
-/turf/simulated/floor/tiled,
-/area/medical/first_responder)
 "bAb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bAc" = (
@@ -44307,6 +44242,9 @@
 	},
 /obj/structure/bed/chair/plastic{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -44594,36 +44532,11 @@
 /area/rnd/misc_lab)
 "bAN" = (
 /obj/structure/table/standard,
-/obj/machinery/vending/wallmed2{
-	pixel_x = 28
-	},
-/obj/machinery/light{
-	dir = 4;
-	name = "broken light fixture";
-	status = 2
-	},
-/obj/item/storage/toolbox/emergency,
-/obj/item/device/radio{
-	frequency = 1487;
-	name = "Medbay Emergency Radio Link";
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/device/radio{
-	frequency = 1487;
-	name = "Medbay Emergency Radio Link";
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/effect/floor_decal/corner/white/diagonal,
-/obj/item/taperoll/medical{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/machinery/light_switch{
+	pixel_x = 22
 	},
-/obj/item/taperoll/medical{
-	pixel_x = -6;
-	pixel_y = 6
-	},
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bAO" = (
@@ -44691,6 +44604,9 @@
 "bAX" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/medical/first_responder)
 "bAZ" = (
@@ -44702,25 +44618,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"bBa" = (
-/obj/structure/table/standard,
-/obj/item/roller{
-	pixel_y = 4
-	},
-/obj/item/roller{
-	pixel_y = 4
-	},
-/obj/effect/floor_decal/corner/white/diagonal,
-/turf/simulated/floor/tiled,
-/area/medical/first_responder)
 "bBb" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = -24
-	},
 /obj/item/modular_computer/console/preset/medical,
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bBc" = (
@@ -44952,15 +44853,10 @@
 	c_tag = "Medical - First Responder Quarters";
 	dir = 1
 	},
-/obj/item/storage/belt/medical/first_responder,
-/obj/item/storage/belt/medical/first_responder,
-/obj/item/device/gps{
-	gpstag = "MED1"
-	},
-/obj/item/device/gps{
-	gpstag = "MED0"
-	},
 /obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/vending/wallmed1{
+	pixel_y = -30
+	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bBH" = (
@@ -45034,12 +44930,12 @@
 	pixel_y = -26;
 	req_access = list(5)
 	},
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 8
-	},
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical - First Responder Garage";
 	dir = 1
+	},
+/obj/effect/floor_decal/industrial/loading/yellow{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/medical/first_responder)
@@ -45397,11 +45293,15 @@
 /area/rnd/research)
 "bCz" = (
 /obj/structure/table/standard,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/red,
 /obj/effect/floor_decal/corner/white/diagonal,
-/obj/item/reagent_containers/hypospray,
-/obj/item/reagent_containers/hypospray,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = -24
+	},
+/obj/item/nitrilebox{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "bCC" = (
@@ -60329,6 +60229,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/old_dark,
 /area/maintenance/bar)
+"enx" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/window/reinforced,
+/obj/structure/table/standard,
+/obj/item/roller{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/roller{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled,
+/area/medical/first_responder)
 "eqc" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -61635,6 +61549,29 @@
 /obj/item/stool/padded,
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
+"gZD" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_medical{
+	name = "First Responder Quarters";
+	req_access = list(67)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/medical/first_responder)
 "gZP" = (
 /obj/effect/floor_decal/corner_wide/orange{
 	dir = 9
@@ -64457,6 +64394,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/atmos_control)
+"naQ" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled,
+/area/medical/first_responder)
 "ncB" = (
 /obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
@@ -67597,6 +67539,11 @@
 	temperature = 278
 	},
 /area/crew_quarters/kitchen/freezer)
+"tiv" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/closet/secure_closet/medical_fr,
+/turf/simulated/floor/tiled,
+/area/medical/first_responder)
 "tjb" = (
 /obj/item/material/shard,
 /turf/unsimulated/floor/asteroid/ash/rocky,
@@ -100989,7 +100936,7 @@ bwd
 bxu
 byT
 byW
-bzW
+enx
 bAV
 aVs
 bDA
@@ -101758,10 +101705,10 @@ btZ
 bvk
 bwd
 bxx
+bwf
 byW
-bAa
-bwd
-bwd
+byW
+tiv
 aVs
 aVs
 bED
@@ -102015,10 +101962,10 @@ btZ
 aVk
 bwd
 bxy
+bxC
 byW
-bAc
-bBa
-bwd
+byW
+tiv
 aVs
 bDD
 bEE
@@ -102273,7 +102220,7 @@ bvm
 bwd
 bxz
 bAb
-byW
+naQ
 bBb
 bBP
 bBP
@@ -102529,7 +102476,7 @@ btZ
 bvn
 bwd
 bxA
-byW
+byY
 bAc
 bBG
 bBP
@@ -103042,8 +102989,8 @@ bsY
 buc
 bld
 bwd
-bxC
 bwd
+gZD
 bwd
 bwd
 bBP
@@ -103555,7 +103502,7 @@ bpy
 bta
 bpy
 bpy
-bwf
+bpy
 bxE
 bza
 bAe

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -31616,9 +31616,6 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
 "bcb" = (
@@ -32455,9 +32452,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)


### PR DESCRIPTION
First PR, please don't crucify me.

- rscadd: "Added two unique, access-locked lockers to the EMT bay and relocated most of the existing table clutter into them. They additionally come with a full uniform, a stethoscope, a penlight, a roller bed, and a crowbar. No more trips to the sub-level."
  - rscadd: "Added a box of nitrile gloves, a medical suit cycler, and two spare roller beds into the EMT bay.
  - tweak: "Gave the EMT bay itself a bit of a facelift. It should be a bit cleaner and a bit roomier now."
  - tweak: "Replaced the wall-mounted NanoMed vendor in the EMT bay with the alternative variant that doesn't shoot dylovene syringes at you during rampant brand intelligence events. Thank God."

![ZqLtvJ6](https://user-images.githubusercontent.com/44004468/109324729-123b5980-7823-11eb-9def-20486ceef0ec.png)
![dddd](https://user-images.githubusercontent.com/44004468/109324736-14051d00-7823-11eb-90a2-0bccc94cb874.png)