### PR TITLE
Sniper Ammo Count Fix

### DIFF
--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -31,6 +31,14 @@
 	recoil_wielded = 2
 	accuracy_wielded = -1
 
+/obj/item/gun/projectile/heavysniper/get_ammo()
+	var/ammo_count = 0
+	for(var/thing in loaded)
+		var/obj/item/ammo_casing/AC = thing
+		if(AC.BB) // my favourite band - geeves
+			ammo_count++
+	return ammo_count
+
 /obj/item/gun/projectile/heavysniper/update_icon()
 	..()
 	if(bolt_open)
@@ -130,11 +138,6 @@
 				LH.take_damage(30)
 			else
 				RH.take_damage(30)
-
-/obj/item/gun/projectile/heavysniper/unathi/get_ammo()
-	if(chambered)
-		return TRUE
-	return FALSE
 
 /obj/item/gun/projectile/heavysniper/tranq
 	name = "tranquilizer rifle"

--- a/html/changelogs/geeves-sniper_get_ammo_fix.yml
+++ b/html/changelogs/geeves-sniper_get_ammo_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "AMRs, tranq rifles, and Hegemony Sluggers will now report their ammo counts correctly."


### PR DESCRIPTION
* AMRs, tranq rifles, and Hegemony Sluggers will now report their ammo counts correctly.