### PR TITLE
Another set of brainmed adjustment & miscellaneous things.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -257,7 +257,7 @@
 /obj/structure/bed/roller/attackby(obj/item/I, mob/user)
 	if(iswrench(I) || istype(I, /obj/item/stack) || iswirecutter(I))
 		return 1
-	if(iv_stand && !beaker && istype(I, /obj/item/reagent_containers))
+	if(iv_stand && !beaker && (istype(I, /obj/item/reagent_containers/glass/beaker) || istype(I, /obj/item/reagent_containers/blood)))
 		if(!user.unEquip(I, target = src))
 			return
 		to_chat(user, SPAN_NOTICE("You attach \the [I] to \the [src]."))
@@ -314,7 +314,7 @@
 	..()
 	if(use_check(usr) || !Adjacent(usr))
 		return
-	if(!(ishuman(usr) || isrobot(usr)))
+	if(!ishuman(usr))
 		return
 	if(over_object == buckled && beaker)
 		if(iv_attached)

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -210,11 +210,12 @@
 
 /obj/structure/bed/chair/wheelchair/MouseDrop(over_object, src_location, over_location)
 	..()
-	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
-		if(!ishuman(usr))
-			return FALSE
-		if(buckled)
-			return FALSE
+	if(!ishuman(usr))
+		return FALSE
+	if(buckled)
+		return FALSE
+	if(!usr.Adjacent(src))
+		return FALSE
 	visible_message(SPAN_NOTICE("[usr] collapses [src]."))
 	var/obj/item/wheelchair/R = new(get_turf(src))
 	R.name = src.name

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -480,6 +480,8 @@
 		var/datum/gas_mixture/breath = H.get_breath_from_environment()
 		var/fail = L.handle_breath(breath, 1)
 		if(!fail)
+			if(!L.is_bruised())
+				losebreath = 0
 			to_chat(src, "<span class='notice'>You feel a breath of fresh air enter your lungs. It feels good.</span>")
 
 	cpr(H) //Again.	

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -161,15 +161,12 @@
 
 /obj/item/organ/internal/brain/take_internal_damage(var/damage, var/silent)
 	set waitfor = 0
-	if(damage >= (max_damage / 4))
-		damage *= 2
 	..()
 	if(damage >= (max_damage / 5)) //This probably won't be triggered by oxyloss or mercury. Probably.
 		var/damage_secondary = damage * 0.20
 		owner.eye_blurry += damage_secondary
 		owner.confused += damage_secondary * 2
 		owner.Weaken(round(damage_secondary * 3, 1))
-		owner.adjustOxyLoss(damage)
 		if(prob(30))
 			addtimer(CALLBACK(src, .proc/brain_damage_callback, damage), rand(6, 20) SECONDS, TIMER_UNIQUE)
 

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -156,7 +156,7 @@
 					if(prob(damprob))
 						take_internal_damage(1)
 					if(prob(damprob))
-						take_internal_damage(2)
+						take_internal_damage(1)
 	..()
 
 /obj/item/organ/internal/brain/take_internal_damage(var/damage, var/silent)

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -1,5 +1,4 @@
 #define HUMAN_MAX_OXYLOSS 1 //Defines how much oxyloss humans can get per tick. A tile with no air at all (such as space) applies this value, otherwise it's a percentage of it.
-#define HUMAN_CRIT_MAX_OXYLOSS ( 2.0 / 6) //The amount of damage you'll get when in critical condition. We want this to be a 5 minute deal = 300s. There are 50HP to get through, so (1/6)*last_tick_duration per second. Breaths however only happen every 4 ticks. last_tick_duration = ~2.0 on average
 
 /obj/item/organ/internal/lungs
 	name = "lungs"
@@ -67,7 +66,7 @@
 				"<span class='danger'>You can't breathe!</span>",
 				"You hear someone gasp for air!",
 			)
-			owner.losebreath += round(damage/2)
+			owner.losebreath = max(round(damage / 2), owner.losebreath)
 
 	if(rescued)
 		if(is_bruised())
@@ -377,4 +376,3 @@
 	rescued = FALSE
 
 #undef HUMAN_MAX_OXYLOSS
-#undef HUMAN_CRIT_MAX_OXYLOSS

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -13,6 +13,7 @@
 	var/vital //Lose a vital limb, die immediately.
 	var/rejecting   // Is this organ already being rejected?
 	var/is_augment = FALSE
+	var/death_time
 
 	//Organ damage stats.
 	var/damage = 0 // amount of damage to the organ
@@ -128,6 +129,7 @@
 		return
 	damage = max_damage
 	status |= ORGAN_DEAD
+	death_time = world.time
 	STOP_PROCESSING(SSprocessing, src)
 	if(owner && vital)
 		owner.death()
@@ -141,8 +143,9 @@
 /obj/item/organ/proc/can_feel_pain()
 	return (!BP_IS_ROBOTIC(src) && (!species || !(species.flags & NO_PAIN)))
 
+#define ORGAN_RECOVERY_THRESHOLD (5 MINUTES)
 /obj/item/organ/proc/can_recover()
-	return max_damage > 0
+	return (max_damage > 0) && !(status & ORGAN_DEAD) || death_time >= world.time - ORGAN_RECOVERY_THRESHOLD
 
 /obj/item/organ/process()
 	if(loc != owner)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -705,7 +705,6 @@
 	if(alien != IS_DIONA)
 		if (caffeine)
 			M.add_up_to_chemical_effect(CE_SPEEDBOOST, caffeine)
-			M.add_chemical_effect(CE_PULSE, 1)
 		M.dizziness = max(0, M.dizziness + adj_dizzy)
 		M.drowsyness = max(0, M.drowsyness + adj_drowsy)
 		M.sleeping = max(0, M.sleeping + adj_sleepy)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -52,7 +52,7 @@
 
 /decl/surgery_step/internal/fix_dead_tissue		//Debridement
 	name = "Debride damaged tissue"
-	priority = 3
+	priority = 4
 	allowed_tools = list(
 		/obj/item/surgery/scalpel = 100,
 		/obj/item/material/knife = 75,
@@ -77,7 +77,7 @@
 			break
 	if(!organ)
 		return
-	if(organ.damage >= organ.max_damage)
+	if(organ.damage > organ.max_damage)
 		to_chat(user, SPAN_WARNING("\The [organ] is too damaged. Repair it first."))
 		return 0
 
@@ -105,6 +105,7 @@
 	user.visible_message(SPAN_NOTICE("[user] has cut away necrotic tissue from [target]'s [organ_to_fix.name] with \the [tool]."), \
 		SPAN_NOTICE("You have cut away necrotic tissue in [target]'s [organ_to_fix.name] with \the [tool]."))
 	organ_to_fix.status &= ~ORGAN_DEAD
+	organ_to_fix.heal_damage(10) //so that they don't insta-die again
 
 /decl/surgery_step/internal/fix_dead_tissue/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -114,7 +115,7 @@
 
 /decl/surgery_step/treat_necrosis
 	name = "Treat necrosis"
-	priority = 2
+	priority = 4
 	allowed_tools = list(
 		/obj/item/reagent_containers/dropper = 100,
 		/obj/item/reagent_containers/glass/bottle = 75,
@@ -126,8 +127,8 @@
 	can_infect = FALSE
 	blood_level = 0
 
-	min_duration = 50
-	max_duration = 60
+	min_duration = 100
+	max_duration = 110
 
 /decl/surgery_step/treat_necrosis/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())

--- a/html/changelogs/mattatlas-killmealready.yml
+++ b/html/changelogs/mattatlas-killmealready.yml
@@ -1,0 +1,51 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Suffocating will no longer continuously apply losebreath. This is capped now, thus making recovery periods for suffocation much shorter."
+  - bugfix: "The necrotic (dead) organ surgery has been fixed. For internal organs, use a scalpel! Cancel out of the organ removal prompt and the surgery will begin."
+  - bugfix: "Wheelchairs no longer interact with the paranormal entities."
+  - tweak: "CPR now removes losebreath, thus making it a convenient option if people aren't breathing."
+  - tweak: "It is now obvious if the organ is dead following an organ repair surgery."
+  - balance: "Getting headshots no longer multiplies damage exponentially if the damage is extremely high."
+  - balance: "Headshots no longer make you lose breath."
+  - balance: "Organs now need necrotic surgery if they've been dead for over five minutes."
+  - balance: "The necrotic organ surgery is now longer, at about ten seconds. It also heals ten damage so that organs don't instantly die anymore."
+  - tweak: "Non-beaker or non-bloodbag reagent containers may no longer be put onto roller beds."
+  - tweak: "Coffee no longer applies CE_PULSE, which means you won't get spammed by heartbeat for having the audacity to drink it."

--- a/html/changelogs/mattatlas-killmealready.yml
+++ b/html/changelogs/mattatlas-killmealready.yml
@@ -47,5 +47,6 @@ changes:
   - balance: "Headshots no longer make you lose breath."
   - balance: "Organs now need necrotic surgery if they've been dead for over five minutes."
   - balance: "The necrotic organ surgery is now longer, at about ten seconds. It also heals ten damage so that organs don't instantly die anymore."
+  - balance: "Slowed brain decay while in cardiac arrest."
   - tweak: "Non-glass (beakers, bottles) or non-bloodbag reagent containers may no longer be put onto roller beds."
   - tweak: "Coffee no longer applies CE_PULSE, which means you won't get spammed by heartbeat for having the audacity to drink it."

--- a/html/changelogs/mattatlas-killmealready.yml
+++ b/html/changelogs/mattatlas-killmealready.yml
@@ -47,5 +47,5 @@ changes:
   - balance: "Headshots no longer make you lose breath."
   - balance: "Organs now need necrotic surgery if they've been dead for over five minutes."
   - balance: "The necrotic organ surgery is now longer, at about ten seconds. It also heals ten damage so that organs don't instantly die anymore."
-  - tweak: "Non-beaker or non-bloodbag reagent containers may no longer be put onto roller beds."
+  - tweak: "Non-glass (beakers, bottles) or non-bloodbag reagent containers may no longer be put onto roller beds."
   - tweak: "Coffee no longer applies CE_PULSE, which means you won't get spammed by heartbeat for having the audacity to drink it."


### PR DESCRIPTION
At this point, this is basically cleanup for code that may either be debug code, or code put as a bandaid until the armor rework, which has finally happened.

  - Suffocating will no longer continuously apply losebreath. This is capped now, thus making recovery periods for suffocation much shorter.
  - The necrotic (dead) organ surgery has been fixed. For internal organs, use a scalpel! Cancel out of the organ removal prompt and the surgery will begin.
  - Wheelchairs no longer interact with the paranormal entities.
  - CPR now removes losebreath, thus making it a convenient option if people aren't breathing.
  - It is now obvious if the organ is dead following an organ repair surgery.
  - Getting headshots no longer multiplies damage exponentially if the damage is extremely high.
  - Headshots no longer make you lose breath.
  - Organs now need necrotic surgery if they've been dead for over five minutes.
  - The necrotic organ surgery is now longer, at about ten seconds. It also heals ten damage so that organs don't instantly die anymore.
  - Non-beaker or non-bloodbag reagent containers may no longer be put onto roller beds.
  - Coffee no longer applies CE_PULSE, which means you won't get spammed by heartbeat for having the audacity to drink it.
