### PR TITLE
new characters now return to lobby if their job preferences are unavailable

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -89,7 +89,7 @@
 
 		// In case we return 0 data from the database.
 		if (!jobs || !jobs.len)
-			pref.alternate_option	= 0
+			pref.alternate_option	= 1
 			pref.job_civilian_high	= 0
 			pref.job_civilian_med	= 0
 			pref.job_civilian_low	= 0

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -89,7 +89,7 @@
 
 		// In case we return 0 data from the database.
 		if (!jobs || !jobs.len)
-			pref.alternate_option	= 1
+			pref.alternate_option	= 0
 			pref.job_civilian_high	= 0
 			pref.job_civilian_med	= 0
 			pref.job_civilian_low	= 0

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -642,7 +642,7 @@ datum/preferences
 		job_engsec_med = 0
 		job_engsec_low = 0
 
-		alternate_option = 0
+		alternate_option = 1
 		metadata = ""
 
 		organ_data = list()

--- a/html/changelogs/TGWLobbyReturn.yml
+++ b/html/changelogs/TGWLobbyReturn.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheGreyWolf
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "New characters now start with their preference set to return to lobby if all their job slots are taken."


### PR DESCRIPTION
In short, this should theoretically do so any new character without a preference set between becoming an assistant of all their job slots are taken or being returned to lobby will default to return to lobby. The setting can  still be changed in char setup under occupation as usual but this will prevent people from suddenly finding themselves being assistants just because they forgot to change it. 
Image of intended effect: 
![2021-03-03_00-41-40](https://user-images.githubusercontent.com/8396443/109733632-c6403a00-7bbf-11eb-99b4-7a5db02d9791.png)