### PR TITLE
Untagged Shell Records

### DIFF
--- a/code/datums/records.dm
+++ b/code/datums/records.dm
@@ -148,7 +148,7 @@
 		age = H.age
 		fingerprint = md5(H.dna.uni_identity)
 		sex = H.gender
-		species = H.get_species()
+		species = H.get_species(FALSE, TRUE)
 		citizenship = H.citizenship
 		employer = H.employer_faction
 		religion = SSrecords.get_religion_record_name(H.religion)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -865,13 +865,10 @@
 	dna.check_integrity(src)
 	return
 
-/mob/living/carbon/human/get_species(var/reference = 0)
+/mob/living/carbon/human/get_species(var/reference = FALSE, var/records = FALSE)
 	if(!species)
 		set_species()
-	if (reference)
-		return species
-	else
-		return species.name
+	return species.get_species(reference, src, records)
 
 /mob/living/carbon/human/proc/play_xylophone()
 	if(!src.xylophone)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -659,3 +659,9 @@
 	
 /datum/species/proc/is_naturally_insulated()
 	return FALSE
+
+// the records var is so that untagged shells can appear human
+/datum/species/proc/get_species(var/reference, var/mob/living/carbon/human/H, var/records)
+	if(reference)
+		return src
+	return name

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -76,6 +76,14 @@
 	allowed_accents = list(ACCENT_CETI, ACCENT_GIBSON, ACCENT_SOL, ACCENT_COC, ACCENT_ERIDANI, ACCENT_ERIDANIDREG, ACCENT_ELYRA, ACCENT_KONYAN, ACCENT_JUPITER, ACCENT_MARTIAN, ACCENT_LUNA,
 							ACCENT_HIMEO, ACCENT_VENUS, ACCENT_VENUSJIN, ACCENT_PHONG, ACCENT_SILVERSUN, ACCENT_TTS, ACCENT_EUROPA, ACCENT_EARTH)
 
+/datum/species/machine/shell/get_species(var/reference, var/mob/living/carbon/human/H, var/records)
+	if(reference)
+		return src
+	// it's illegal for shells in Tau Ceti space to not have tags, so their records would have to be falsified
+	if(records && !H.internal_organs_by_name[BP_IPCTAG])
+		return "Human"
+	return name
+
 /datum/species/machine/shell/get_light_color()
 	return
 

--- a/html/changelogs/geeves-shell_hell.yml
+++ b/html/changelogs/geeves-shell_hell.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Untagged shells now appear as Human in their employment records."


### PR DESCRIPTION
* Untagged shells now appear as Human in their employment records.

it's illegal for shells in Tau Ceti space to not have tags, so their records would have to be falsified

also this makes the hunt for untagged shells more fun