### PR TITLE
Light Fixture Spark Fix

### DIFF
--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -225,7 +225,7 @@
 	active_power_usage = ((light_range * light_power) * 10)
 
 /obj/machinery/light/proc/broken_sparks()
-	if(world.time > next_spark && has_power())
+	if(world.time > next_spark && !(stat & POWEROFF) && has_power())
 		spark(src, 3, alldirs)
 		next_spark = world.time + 1 MINUTE + (rand(-15, 15) SECONDS)
 

--- a/html/changelogs/geeves-light_power.yml
+++ b/html/changelogs/geeves-light_power.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Broken lights that have been turned off with a lightswitch no longer spark."


### PR DESCRIPTION
* Broken lights that have been turned off with a lightswitch no longer spark.