### PR TITLE
Brain Death Fix

### DIFF
--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -101,7 +101,7 @@
 		blinded = 1
 		silent = 0
 	else				//ALIVE. LIGHTS ARE ON
-		if( !container && (health < config.health_threshold_dead || ((world.time - timeofhostdeath) > config.revival_brain_life)) )
+		if(!container && (health < config.health_threshold_dead || (config.revival_brain_life != -1 && world.time - timeofhostdeath > config.revival_brain_life)))
 			death()
 			blinded = 1
 			silent = 0

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -101,7 +101,7 @@
 		blinded = 1
 		silent = 0
 	else				//ALIVE. LIGHTS ARE ON
-		if(!container && (health < config.health_threshold_dead || (config.revival_brain_life != -1 && world.time - timeofhostdeath > config.revival_brain_life)))
+		if(!container && (health < config.health_threshold_dead || ((config.revival_brain_life != -1) && world.time - timeofhostdeath > config.revival_brain_life)))
 			death()
 			blinded = 1
 			silent = 0

--- a/html/changelogs/geeves-brain_death.yml
+++ b/html/changelogs/geeves-brain_death.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed brains dying instantly when the head gets decapitated or the body explodes. This will give roboticists enough time to retrieve and borg them."


### PR DESCRIPTION
* Fixed brains dying instantly when the head gets decapitated or the body explodes. This will give roboticists enough time to retrieve and borg them.