### PR TITLE
Minor loadout tweaks

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -44,7 +44,7 @@
 	display_name = "flash-proof sunglasses selection (Security/Command)"
 	description = "A selection of flash-proof sunglasses."
 	path = /obj/item/clothing/glasses/sunglasses
-	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Captain", "Head of Personnel", "Quartermaster", "Internal Affairs Agent", "Detective", "Forensic Technician")
+	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Captain", "Head of Personnel", "Quartermaster", "Detective", "Forensic Technician")
 
 /datum/gear/eyes/sunglasses/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/loadout_religion.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_religion.dm
@@ -64,7 +64,3 @@
 /datum/gear/religion/dominia/accessory
 	display_name = "tribunal necklace"
 	path = "/obj/item/clothing/accessory/dominia"
-
-/datum/gear/religion/shaman_staff
-	display_name = "shaman staff"
-	path = /obj/item/cane/shaman

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -171,6 +171,8 @@
 	coat["trenchcoat, grey"] = /obj/item/clothing/suit/storage/toggle/trench/grey
 	coat["trenchcoat, dark brown"] = /obj/item/clothing/suit/storage/toggle/trench/alt
 	coat["trenchcoat, grey alternate"] = /obj/item/clothing/suit/storage/toggle/trench/grey_alt
+	coat["brown trenchcoat (Detective)"] = /obj/item/clothing/suit/storage/toggle/det_trench
+	coat["black trenchcoat (Detective)"] = /obj/item/clothing/suit/storage/toggle/det_trench/black
 	gear_tweaks += new/datum/gear_tweak/path(coat)
 
 /datum/gear/suit/trenchcoat_colorable
@@ -178,20 +180,6 @@
 	description = "A sleek canvas trenchcoat in 167,777,216 designer colors."
 	path = /obj/item/clothing/suit/storage/toggle/trench/colorable
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-
-/datum/gear/suit/det_trenchcoat
-	display_name = "detective trenchcoat selection"
-	description = "A selection of detective trenchcoats."
-	path = /obj/item/clothing/suit/storage/toggle/det_trench
-	allowed_roles = list("Detective")
-
-/datum/gear/suit/det_trenchcoat/New()
-	..()
-	var/coat = list()
-	coat["brown trenchcoat (Detective)"] = /obj/item/clothing/suit/storage/toggle/det_trench
-	coat["black trenchcoat (Detective)"] = /obj/item/clothing/suit/storage/toggle/det_trench/black
-	gear_tweaks += new/datum/gear_tweak/path(coat)
-
 
 /datum/gear/suit/ian
 	display_name = "worn shirt"

--- a/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
@@ -204,3 +204,9 @@
 	augs["farseer eye"] = /obj/item/organ/internal/augment/farseer_eye
 	augs["eye flashlight"] = /obj/item/organ/internal/augment/eye_flashlight
 	gear_tweaks += new /datum/gear_tweak/path(augs)
+
+/datum/gear/religion/shaman_staff
+	display_name = "shaman staff"
+	path = /obj/item/cane/shaman
+	sort_category = "Xenowear - Unathi"
+	whitelisted = list(SPECIES_UNATHI)

--- a/html/changelogs/flpfs-fixer.yml
+++ b/html/changelogs/flpfs-fixer.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Flpfs
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Rolls the detective trenchcoat in the loadout into the general trenchcoat selection."
+  - bugfix: "Removes IAA from the list of allowed jobs that can get the flash-proof sunglasses in the loadout. "
+  - tweak: "Moves the Unathi shaman staff from Religion to Xenowear - Unathi."


### PR DESCRIPTION
Rolls the detective trenchcoat in the loadout into the general trenchcoat selection
Removes IAA from the list of allowed jobs that can get the flash-proof sunglasses in the loadout
Moves the Unathi shaman staff from Religion to Xenowear - Unathi

This fixes #11343