### PR TITLE
Add exit restrictions to brig exit doors.

### DIFF
--- a/html/changelogs/Varoxus-Brig-mapchange.yml
+++ b/html/changelogs/Varoxus-Brig-mapchange.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Varoxus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Removed unrestriced access present on the brig exit doors."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -20015,9 +20015,6 @@
 	name = "Security Wing";
 	req_access = list(63)
 	},
-/obj/effect/map_effect/door_helper/unres{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "aIk" = (
@@ -20065,9 +20062,6 @@
 	id_tag = "BrigFoyer";
 	name = "Security Wing";
 	req_access = list(63)
-	},
-/obj/effect/map_effect/door_helper/unres{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
@@ -21199,9 +21193,6 @@
 	id = "Security Lockdown";
 	name = "Security Blast Door";
 	opacity = 0
-	},
-/obj/effect/map_effect/door_helper/unres{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -27966,9 +27957,6 @@
 	layer = 2.8;
 	name = "Security Aft Entrance";
 	req_access = list(63)
-	},
-/obj/effect/map_effect/door_helper/unres{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)


### PR DESCRIPTION
The brig is a secure area, and I've heard many security officers lament that the doors to exit the brig do not require access to leave. potential escapees can still make an exit using the disposals network so I think that escaping won't be affected too much.

> # IC Changelog
> All members of the station security team are advised that access restrictions on the doors allowing entry and exit from the brig area have now changed. Brig doors that exit out into the hallways will no longer provide unrestricted exit access.

![Before](https://user-images.githubusercontent.com/46449731/110408216-d5553b00-804a-11eb-9a31-cbbb5e9afd2b.png)
![After](https://user-images.githubusercontent.com/46449731/110408217-d5edd180-804a-11eb-8435-8699edf054bd.png)

