### PR TITLE
Some Robotic Things

### DIFF
--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -12,7 +12,8 @@
 
 /obj/item/device/mmi/digital/posibrain/Initialize()
 	. = ..()
-	brainmob.name = "[pick(list("PBU","HIU","SINA","ARMA","OSI"))]-[rand(100, 999)]"
+	var/datum/language/L = all_languages[LANGUAGE_EAL]
+	brainmob.name = L.get_random_name()
 	brainmob.real_name = brainmob.name
 
 /obj/item/device/mmi/digital/posibrain/attack_self(mob/user)

--- a/code/modules/mob/living/silicon/robot/items/robot_parts.dm
+++ b/code/modules/mob/living/silicon/robot/items/robot_parts.dm
@@ -255,7 +255,11 @@
 					return
 
 				var/mob/living/carbon/human/new_shell = new(get_turf(src), chest.linked_frame)
-				forceMove(new_shell) //so people won't mess around with the chassis until it is deleted
+				// replace the IPC's microbattery cell with the one that was in the robot chest
+				var/obj/item/organ/internal/cell/C = new_shell.internal_organs_by_name[BP_CELL]
+				C.replace_cell(chest.cell)
+				//so people won't mess around with the chassis until it is deleted
+				forceMove(new_shell)
 				M.brainmob.mind.transfer_to(new_shell)
 				qdel(M)
 				new_shell.add_language(LANGUAGE_EAL)
@@ -265,6 +269,8 @@
 					newname = L.get_random_name()
 				new_shell.real_name = newname
 				new_shell.name = new_shell.real_name
+				var/obj/item/organ/internal/mmi_holder/posibrain/P = new_shell.internal_organs_by_name[BP_BRAIN]
+				P.setup_brain()
 				new_shell.change_appearance(APPEARANCE_ALL_HAIR | APPEARANCE_SKIN | APPEARANCE_EYE_COLOR, new_shell.loc, new_shell)
 				qdel(src)
 				return

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -74,7 +74,7 @@
 
 /obj/item/organ/internal/cell/Initialize()
 	robotize()
-	cell = new cell(src)
+	replace_cell(new cell(src))
 	. = ..()
 
 /obj/item/organ/internal/cell/proc/percent()
@@ -142,8 +142,16 @@
 			if(cell)
 				to_chat(user, SPAN_WARNING("There is a power cell already installed."))
 			else if(user.unEquip(W, src))
-				cell = W
+				replace_cell(W)
 				to_chat(user, SPAN_NOTICE("You insert \the [cell]."))
+
+/obj/item/organ/internal/cell/proc/replace_cell(var/obj/item/cell/C)
+	if(istype(cell))
+		qdel(cell)
+	if(C.loc != src)
+		C.forceMove(src)
+	cell = C
+	name = "[initial(name)] ([C.name])"
 
 /obj/item/organ/internal/cell/listen()
 	if(get_charge())

--- a/html/changelogs/geeves-some_robotic_things.yml
+++ b/html/changelogs/geeves-some_robotic_things.yml
@@ -1,0 +1,9 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Making an IPC at robotics will give its microbattery the cell you used when you made the endoskeleton."
+  - bugfix: "IPCs made at robotics will now have posibrains designations that match their names."
+  - rscadd: "Microbatteries will now have the class of cell installed next to its name, which allows self-diagnostics to show which cell you have as an IPC."
+  - tweak: "Posibrains can now get any names from the EAL language selection options."


### PR DESCRIPTION
* Making an IPC at robotics will give its microbattery the cell you used when you made the endoskeleton.
* IPCs made at robotics will now have posibrains designations that match their names.
* Microbatteries will now have the class of cell installed next to its name, which allows self-diagnostics to show which cell you have as an IPC.
* Posibrains can now get any names from the EAL language selection options.