### PR TITLE
Laser Vest Fix

### DIFF
--- a/code/modules/clothing/sets/laser_tag.dm
+++ b/code/modules/clothing/sets/laser_tag.dm
@@ -38,7 +38,8 @@
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			var/obj/item/card/id/ID = H.GetIdCard()
-			user_name = ID.registered_name
+			if(ID)
+				user_name = ID.registered_name
 		var/list/num_to_word = list("one", "two", "three", "four", "five")
 		visible_message("<b>[capitalize_first_letters(name)]</b> says, \"[SPAN_NOTICE("[user_name] armor health set to [num_to_word[set_health]].")]\".")
 		return

--- a/html/changelogs/geeves-laser_vest_fix.yml
+++ b/html/changelogs/geeves-laser_vest_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes laser tag vests gently breaking when you try to change their health without an ID on your person."


### PR DESCRIPTION
* Fixes laser tag vests gently breaking when you try to change their health without an ID on your person.