### PR TITLE
Reagent Tweaks and QoL

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -107,7 +107,7 @@
 	// Take blood
 	else
 		var/amount = REAGENTS_FREE_SPACE(beaker.reagents)
-		amount = min(amount, 4)
+		amount = min(amount, transfer_amount)
 		// If the beaker is full, ping
 		if(amount == 0)
 			if(prob(5))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -696,10 +696,7 @@
 	for(var/_R in chem_doses)
 		if ((_R in bloodstr.reagent_volumes) || (_R in ingested.reagent_volumes) || (_R in breathing.reagent_volumes) || (_R in touching.reagent_volumes))
 			continue
-		var/decl/reagent/R = decls_repository.get_decl(_R)
-		chem_doses[_R] -= R.metabolism
-		if(chem_doses[_R] <= 0)
-			chem_doses -= _R
+		chem_doses -= _R //We're no longer metabolizing this reagent. Remove it from chem_doses
 
 	updatehealth()
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -189,7 +189,7 @@
 
 /datum/reagents/proc/has_all_reagents(var/list/check_reagents)
 	for(var/current in check_reagents)
-		if(!has_reagent(current))
+		if(!has_reagent(current, check_reagents[current]))
 			return FALSE
 	return TRUE
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -159,3 +159,7 @@
 
 /decl/reagent/proc/mix_data(var/newdata, var/newamount, var/datum/reagents/holder) // You have a reagent with data, and new reagent with its own data get added, how do you deal with that?
 	return REAGENT_DATA(holder, type)
+
+//Check to use when seeing if the person has the minimum dose of the reagent. Useful for stopping minimum transfer rate IV drips from applying chem effects
+/decl/reagent/proc/check_min_dose(var/mob/living/carbon/M, var/min_dose = 1)
+	return (M.chem_doses[type] >= min_dose)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -162,4 +162,4 @@
 
 //Check to use when seeing if the person has the minimum dose of the reagent. Useful for stopping minimum transfer rate IV drips from applying chem effects
 /decl/reagent/proc/check_min_dose(var/mob/living/carbon/M, var/min_dose = 1)
-	return (M.chem_doses[type] >= min_dose)
+	return (REAGENT_VOLUME(M, type) >= min_dose)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -162,4 +162,4 @@
 
 //Check to use when seeing if the person has the minimum dose of the reagent. Useful for stopping minimum transfer rate IV drips from applying chem effects
 /decl/reagent/proc/check_min_dose(var/mob/living/carbon/M, var/min_dose = 1)
-	return (REAGENT_VOLUME(M, type) >= min_dose)
+	return (REAGENT_VOLUME(M.reagents, type) >= min_dose)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -13,8 +13,9 @@
 	taste_description = "bitterness"
 
 /decl/reagent/inaprovaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	M.add_chemical_effect(CE_STABLE)
-	M.add_chemical_effect(CE_PAINKILLER, 25)
+	if(check_chem_dose(M, 0.25))
+		M.add_chemical_effect(CE_STABLE)
+		M.add_chemical_effect(CE_PAINKILLER, 25)
 
 /decl/reagent/inaprovaline/overdose(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(prob(2))
@@ -134,7 +135,8 @@
 	if(remove_generic)
 		M.drowsyness = max(0, M.drowsyness - 6 * removed)
 		M.hallucination -= (2 * removed)
-		M.add_up_to_chemical_effect(CE_ANTITOXIN, 1)
+		if(check_min_dose(M, 0.5))
+			M.add_up_to_chemical_effect(CE_ANTITOXIN, 1)
 
 	var/removing = (4 * removed)
 	var/datum/reagents/ingested = M.get_ingested_reagents()
@@ -165,7 +167,8 @@
 	var/strength = 6
 
 /decl/reagent/dexalin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	M.add_chemical_effect(CE_OXYGENATED, strength/6) // 1 for dexalin, 2 for dexplus
+	if(check_min_dose(M, 0.5))
+		M.add_chemical_effect(CE_OXYGENATED, strength/6) // 1 for dexalin, 2 for dexplus
 	holder.remove_reagent(/decl/reagent/lexorin, strength/3 * removed)
 
 //Hyperoxia causes brain and eye damage
@@ -261,8 +264,9 @@
 	breathe_mul = 0
 
 /decl/reagent/perconol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	M.add_chemical_effect(CE_PAINKILLER, 50)
-	M.add_up_to_chemical_effect(CE_NOFEVER, 5) //Good enough to handle fevers for a few light infections or one bad one.
+	if(check_min_dose(M))
+		M.add_chemical_effect(CE_PAINKILLER, 50)
+		M.add_up_to_chemical_effect(CE_NOFEVER, 5) //Good enough to handle fevers for a few light infections or one bad one.
 
 /decl/reagent/perconol/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
 	..()
@@ -284,11 +288,12 @@
 	breathe_mul = 0
 
 /decl/reagent/mortaphenyl/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	M.add_chemical_effect(CE_PAINKILLER, 80)
-	if(!M.chem_effects[CE_CLEARSIGHT])
-		M.eye_blurry = max(M.eye_blurry, 5)
-	if(!M.chem_effects[CE_STRAIGHTWALK])
-		M.confused = max(M.confused, 10)
+	if(check_min_dose(M))
+		M.add_chemical_effect(CE_PAINKILLER, 80)
+		if(!M.chem_effects[CE_CLEARSIGHT])
+			M.eye_blurry = max(M.eye_blurry, 5)
+		if(!M.chem_effects[CE_STRAIGHTWALK])
+			M.confused = max(M.confused, 10)
 
 	var/mob/living/carbon/human/H = M
 	if(!istype(H))
@@ -343,11 +348,12 @@
 	breathe_mul = 0
 
 /decl/reagent/oxycomorphine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	M.add_chemical_effect(CE_PAINKILLER, 200)
-	if(!M.chem_effects[CE_CLEARSIGHT])
-		M.eye_blurry = max(M.eye_blurry, 5)
-	if(!M.chem_effects[CE_STRAIGHTWALK])
-		M.confused = max(M.confused, 20)
+	if(check_min_dose(M))
+		M.add_chemical_effect(CE_PAINKILLER, 200)
+		if(!M.chem_effects[CE_CLEARSIGHT])
+			M.eye_blurry = max(M.eye_blurry, 5)
+		if(!M.chem_effects[CE_STRAIGHTWALK])
+			M.confused = max(M.confused, 20)
 
 	var/mob/living/carbon/human/H = M
 	if(!istype(H))
@@ -386,6 +392,8 @@
 	metabolism_min = REM * 0.0125
 
 /decl/reagent/synaptizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
+	if(!check_min_dose(M, 0.5))
+		return
 	M.drowsyness = max(M.drowsyness - 5, 0)
 	if(REAGENT_VOLUME(holder, type) < 10) // Will prevent synaptizine interrupting a seizure caused by its own overdose.
 		M.AdjustParalysis(-1)
@@ -426,7 +434,7 @@
 	metabolism_min = REM * 0.075
 
 /decl/reagent/alkysine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	if(REAGENT_VOLUME(holder, type) >= 2) //Increased effectiveness & no side-effects if given via IV drip with low transfer rate.
+	if(check_min_dose(M, 2)) //Increased effectiveness & no side-effects if given via IV drip with low transfer rate.
 		M.dizziness = max(125, M.dizziness)
 		M.make_dizzy(5)
 		if(!(REAGENT_VOLUME(holder, type) > 10))
@@ -478,7 +486,8 @@
 /decl/reagent/oculine/affect_chem_effect(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	. = ..()
 	if(.)
-		M.add_chemical_effect(CE_CLEARSIGHT)
+		if(check_min_dose(M))
+			M.add_chemical_effect(CE_CLEARSIGHT)
 
 /decl/reagent/oculine/overdose(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	M.hallucination = max(M.hallucination, 15)
@@ -558,8 +567,9 @@
 /decl/reagent/hyperzine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(prob(5))
 		M.emote(pick("twitch", "blink_r", "shiver"))
-	M.add_chemical_effect(CE_SPEEDBOOST, 1)
-	M.add_chemical_effect(CE_PULSE, 1)
+	if(check_min_dose(M, 0.5))
+		M.add_chemical_effect(CE_SPEEDBOOST, 1)
+		M.add_chemical_effect(CE_PULSE, 1)
 
 /decl/reagent/hyperzine/overdose(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	M.adjustNutritionLoss(5*removed)
@@ -629,7 +639,8 @@
 /decl/reagent/ethylredoxrazine/affect_chem_effect(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	. = ..()
 	if(.)
-		M.add_chemical_effect(CE_STRAIGHTWALK)
+		if(check_min_dose(M))
+			M.add_chemical_effect(CE_STRAIGHTWALK)
 
 /decl/reagent/hyronalin
 	name = "Hyronalin"
@@ -745,7 +756,8 @@
 	glass_desc = "You'd better not."
 
 /decl/reagent/coughsyrup/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	M.add_chemical_effect(CE_PAINKILLER, 5) // very slight painkiller effect at low doses
+	if(check_min_dose(M))
+		M.add_chemical_effect(CE_PAINKILLER, 5) // very slight painkiller effect at low doses
 
 /decl/reagent/coughsyrup/overdose(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder) // effects based loosely on DXM
 	M.hallucination = max(M.hallucination, 40)
@@ -820,6 +832,8 @@
 	taste_description = "bitterness"
 
 /decl/reagent/leporazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
+	if(!check_min_dose(M))
+		return
 	M.add_up_to_chemical_effect(CE_NOFEVER, 5) //Also handles the effects of fevers
 	if(!(REAGENT_VOLUME(holder, type) > 20))
 		if(M.bodytemperature > 310)
@@ -1439,7 +1453,7 @@
 	. = ..()
 
 /decl/reagent/pulmodeiectionem/affect_ingest(var/mob/living/carbon/human/H, var/alien, var/removed, var/datum/reagents/holder)
-	if(REAGENT_VOLUME(holder, type) > 5)
+	if(check_min_dose(H, 5))
 		if(prob(50))
 			H.visible_message("<b>[H]</b> splutters, coughing up a cloud of purple dust.", "You cough up a cloud of purple dust.")
 			remove_self(10, holder)
@@ -1586,7 +1600,7 @@
 	else
 		M.adjustHydrationLoss(-removed*5)
 	if(REAGENT_VOLUME(holder, type) < 3)
-		M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
+		M.add_chemical_effect(CE_BLOODRESTORE, 2 * removed)
 
 /decl/reagent/saline/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
 	M.confused = max(M.confused, 20)
@@ -1650,7 +1664,8 @@
 	taste_description = "numbness"
 
 /decl/reagent/pacifier/affect_blood(var/mob/living/carbon/H, var/alien, var/removed, var/datum/reagents/holder)
-	H.add_chemical_effect(CE_PACIFIED, 1)
+	if(check_min_dose(H))
+		H.add_chemical_effect(CE_PACIFIED, 1)
 
 /decl/reagent/pacifier/overdose(var/mob/living/carbon/H, var/alien, var/datum/reagents/holder)
 	H.add_chemical_effect(CE_EMETIC, H.chem_doses[type] / 6)
@@ -1683,8 +1698,9 @@
 
 /decl/reagent/coagzolug/affect_blood(mob/living/carbon/M, alien, removed)
 	. = ..()
-	M.add_chemical_effect(CE_BLOODCLOT)
-	M.make_dizzy(5)
+	if(check_min_dose(M, 0.5))
+		M.add_chemical_effect(CE_BLOODCLOT)
+		M.make_dizzy(5)
 
 /decl/reagent/coagzolug/overdose(var/mob/living/carbon/H, var/alien)
 	if(prob(2))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -13,7 +13,7 @@
 	taste_description = "bitterness"
 
 /decl/reagent/inaprovaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	if(check_chem_dose(M, 0.25))
+	if(check_min_dose(M, 0.25))
 		M.add_chemical_effect(CE_STABLE)
 		M.add_chemical_effect(CE_PAINKILLER, 25)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -392,8 +392,6 @@
 	metabolism_min = REM * 0.0125
 
 /decl/reagent/synaptizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	if(!check_min_dose(M, 0.5))
-		return
 	M.drowsyness = max(M.drowsyness - 5, 0)
 	if(REAGENT_VOLUME(holder, type) < 10) // Will prevent synaptizine interrupting a seizure caused by its own overdose.
 		M.AdjustParalysis(-1)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -470,12 +470,12 @@
 		return
 	M.add_chemical_effect(CE_PULSE, -2)
 	var/dose = M.chem_doses[type]
-	if(dose < 1)
+	if(dose < 2)
 		if(dose == metabolism * 2 || prob(5))
 			M.emote("yawn")
-	else if(dose < 1.5)
+	else if(dose < 3.5)
 		M.eye_blurry = max(M.eye_blurry, 10)
-	else if(dose < 5)
+	else if(dose < 7)
 		if(prob(50))
 			M.Weaken(2)
 		M.drowsyness = max(M.drowsyness, 20)

--- a/html/changelogs/doxxmedearly - reagent_tweaks_qol.yml
+++ b/html/changelogs/doxxmedearly - reagent_tweaks_qol.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - bugfix: "Fixed bugged recipes that were 'eating' reagents unless the exact amount was added all at once, such as cheese wheels."
+  - bugfix: "IV drips now respect the transfer amount when TAKING blood, instead of using the max rate. Blood donations should be much safer now."
+  - tweak: "Removed the undetectable chem_dose that would linger after a reagent was totally metabolized. This prevents weird interactions when being given a dose of a reagent soon after metabolizing a previous dose of the same reagent."
+  - tweak: "Soporific takes a little longer to kick in and knock someone out."
+  - tweak: "Some medicines now have a minimum dosage before certain affects will be applied. This minimum is typically 1u or less, and prevents abusing IV drips on 0.01u transfer rate to get the full power of some medications, mainly Dexalin and painkillers."
+  - tweak: "Saline Plus restores blood at half the rate. It is still the most effect way to restore blood outside of transfusions."
+  


### PR DESCRIPTION
Mostly cleans up some bugs and weird behavior w/ reagents.

- has_all_reagents() check for chemical reactions wasn't taking amount into play. Most things use a small minimum so it was hard to notice, but for cheese wheels which used 40u milk, it would "eat" the reagents unless you added exactly 40.
- Fixed IV drips not using transfer_amount for TAKING blood.
- Added a minimum dose check to some add_chemical_effect chems (like dexalin's CE_OXYGENATED) since those could be abused to their full strength with a 0.01u IV drip.
- Soporific is a little slower. Should prevent some abuse of hyposprays and give the target some leeway for reacting. Not a huge decrease.
- Saline Plus is slower to restore blood because oh my god it was so fast. It outpaced extremely severe wounds. Still way faster than iron/copper/sulfur pills and should remain the prime method for blood restoration outside of transfusions.

Made chem_doses clear when the reagent is done metabolizing instead of slowly counting down. If you dose someone with something they've metabolized fully, but chem_doses isn't 0, you get some weird behavior, such as:
- Any initial_effect wouldn't trigger, since chem_dose has to be zero for that.
- Accidental overdoses (Medical has no way of tracking chem_dose, and chem_dose is what's used to check if you're ODing)
- Applying side effects at a much stronger level than the provided dose (ie: CE_ITCH applied at chem_dose/6 strength)
- And really just anything that depends on chem_dose to function.

This should allow us to utilize chem_dose more freely with reagent effects, as it's a good way to track how much total was metabolized and apply effects based on that. However, if this doesn't clear with the reagent, it mucks up any new doses if you give them too quickly after metabolizing the first. 

Fixes #11019 