### PR TITLE
Grown Crop Glow Timer

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -181,7 +181,7 @@
 				var/clr
 				if(get_trait(TRAIT_BIOLUM_COLOUR))
 					clr = get_trait(TRAIT_BIOLUM_COLOUR)
-				splat.set_light(get_trait(TRAIT_POTENCY)/10, pwr, clr)
+				splat.set_light(get_trait(TRAIT_POTENCY)/10, pwr, clr, 50)
 			var/flesh_colour = get_trait(TRAIT_FLESH_COLOUR)
 			if(!flesh_colour) flesh_colour = get_trait(TRAIT_PRODUCT_COLOUR)
 			if(flesh_colour) splat.color = get_trait(TRAIT_PRODUCT_COLOUR)
@@ -759,7 +759,7 @@
 		var/clr
 		if(get_trait(TRAIT_BIOLUM_COLOUR))
 			clr = get_trait(TRAIT_BIOLUM_COLOUR)
-		product.set_light(get_trait(TRAIT_POTENCY)/10, pwr, clr)
+		product.set_light(get_trait(TRAIT_POTENCY)/10, pwr, clr, 50)
 
 	//Handle spawning in living, mobile products (like dionaea).
 	if(istype(product,/mob/living))

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -181,7 +181,8 @@
 				var/clr
 				if(get_trait(TRAIT_BIOLUM_COLOUR))
 					clr = get_trait(TRAIT_BIOLUM_COLOUR)
-				splat.set_light(get_trait(TRAIT_POTENCY)/10, pwr, clr, 50)
+				splat.set_light(get_trait(TRAIT_POTENCY)/10, pwr, clr)
+				addtimer(CALLBACK(splat, /atom/.proc/set_light, 0), rand(3 MINUTES, 5 MINUTES))
 			var/flesh_colour = get_trait(TRAIT_FLESH_COLOUR)
 			if(!flesh_colour) flesh_colour = get_trait(TRAIT_PRODUCT_COLOUR)
 			if(flesh_colour) splat.color = get_trait(TRAIT_PRODUCT_COLOUR)
@@ -759,7 +760,8 @@
 		var/clr
 		if(get_trait(TRAIT_BIOLUM_COLOUR))
 			clr = get_trait(TRAIT_BIOLUM_COLOUR)
-		product.set_light(get_trait(TRAIT_POTENCY)/10, pwr, clr, 50)
+		product.set_light(get_trait(TRAIT_POTENCY)/10, pwr, clr)
+		addtimer(CALLBACK(product, /atom/.proc/set_light, 0), rand(5 MINUTES, 7 MINUTES))
 
 	//Handle spawning in living, mobile products (like dionaea).
 	if(istype(product,/mob/living))

--- a/html/changelogs/geeves-glowshroom_nerf.yml
+++ b/html/changelogs/geeves-glowshroom_nerf.yml
@@ -3,4 +3,4 @@ author: Geeves
 delete-after: True
 
 changes:
-  - tweak: "Grown bioluminescent crops' UV intensity has been lowered drastically."
+  - tweak: "Grown bioluminescent crops now lose their glow after 5-7 minutes. Splattered glowing crops glow for 3-5 minutes."

--- a/html/changelogs/geeves-glowshroom_nerf.yml
+++ b/html/changelogs/geeves-glowshroom_nerf.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Grown bioluminescent crops' UV intensity has been lowered drastically."


### PR DESCRIPTION
* Grown bioluminescent crops now lose their glow after 5-7 minutes. Splattered glowing crops glow for 3-5 minutes.