### PR TITLE
Species Restricted Spam Fix

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -81,7 +81,8 @@
 					wearable = 1
 
 			if(!wearable && !(slot in list(slot_l_store, slot_r_store, slot_s_store)))
-				to_chat(H, SPAN_DANGER("Your species cannot wear [src]."))
+				if(!disable_warning)
+					to_chat(H, SPAN_DANGER("Your species cannot wear [src]."))
 				return 0
 	return 1
 

--- a/html/changelogs/geeves-your_species_cannot_spam.yml
+++ b/html/changelogs/geeves-your_species_cannot_spam.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes hovering over slots with species restricted clothes spamming the chat with Your species cannot wear this messages."


### PR DESCRIPTION
* Fixes hovering over slots with species restricted clothes spamming the chat with Your species cannot wear this messages.