### PR TITLE
Fixes regaining color sight when turning off night vision

### DIFF
--- a/code/modules/client/client_color.dm
+++ b/code/modules/client/client_color.dm
@@ -2,7 +2,7 @@
 	var/client_color = "" //Any client.color-valid value
 	var/priority = 1
 	var/override = FALSE //If set to override we will stop multiplying the moment we get here. NOTE: Priority remains, if your override is on position 4, the other 3 will still have a say.
-
+	var/disability = FALSE
 
 /mob
 	var/list/client_colors = list()
@@ -22,9 +22,10 @@
 			return TRUE
 	return FALSE
 
-/mob/proc/add_client_color(color_type)
+/mob/proc/add_client_color(color_type, set_disability = FALSE)
 	if(!has_client_color(color_type))
 		var/datum/client_color/CC = new color_type()
+		CC.disability = set_disability
 		client_colors |= CC
 		sortTim(client_colors, /proc/cmp_clientcolor_priority)
 		update_client_color()
@@ -35,7 +36,7 @@
 	color_type - a typepath (subtyped from /datum/client_color)
 	returns true if instance was found, false otherwise
 */
-/mob/proc/remove_client_color(color_type)
+/mob/proc/remove_client_color(color_type, remove_disability = FALSE)
 	if(!ispath(/datum/client_color))
 		return FALSE
 
@@ -43,6 +44,8 @@
 	for(var/cc in client_colors)
 		var/datum/client_color/CC = cc
 		if(CC.type == color_type)
+			if(CC.disability && !remove_disability)
+				continue
 			result = TRUE
 			client_colors -= CC
 			qdel(CC)

--- a/code/modules/mob/abstract/new_player/character_traits.dm
+++ b/code/modules/mob/abstract/new_player/character_traits.dm
@@ -26,28 +26,28 @@
 	desc = "You have difficulty perceiving green."
 
 /datum/character_disabilities/deuteranomaly/apply_self(var/mob/living/carbon/human/H)
-	H.add_client_color(/datum/client_color/deuteranopia)
+	H.add_client_color(/datum/client_color/deuteranopia, TRUE)
 
 /datum/character_disabilities/protanopia
 	name = "Protanopia"
 	desc = "You have difficulty perceiving red."
 
 /datum/character_disabilities/protanopia/apply_self(var/mob/living/carbon/human/H)
-	H.add_client_color(/datum/client_color/protanopia)
+	H.add_client_color(/datum/client_color/protanopia, TRUE)
 
 /datum/character_disabilities/tritanopia
 	name = "Tritanopia"
 	desc = "You have difficulty perceiving green and yellow."
 
 /datum/character_disabilities/tritanopia/apply_self(var/mob/living/carbon/human/H)
-	H.add_client_color(/datum/client_color/tritanopia)
+	H.add_client_color(/datum/client_color/tritanopia, TRUE)
 
 /datum/character_disabilities/total_colorblind
 	name = "Total Colorblindness"
 	desc = "You cannot see color, only black, white, and shades of gray."
 
 /datum/character_disabilities/total_colorblind/apply_self(var/mob/living/carbon/human/H)
-	H.add_client_color(/datum/client_color/monochrome)
+	H.add_client_color(/datum/client_color/monochrome, TRUE)
 
 /datum/character_disabilities/mute
 	name = "Muteness"

--- a/html/changelogs/NightBlindFix.yml
+++ b/html/changelogs/NightBlindFix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheGreyWolf
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Turning off species nightvision now retains the color blindness disability if they had it."


### PR DESCRIPTION
Pretty much what it says. Currently if a tajara or other species with night vision turns it on and then off again then they regain color vision. This ensures they keep being colorblind if they set it as a disability.