### PR TITLE
Proper fake events

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -49,7 +49,7 @@
 										 "Advertising is legalized lying! But don't let that put you off our great deals!", \
 										 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either."))
 
-/datum/event/brand_intelligence/end()
+/datum/event/brand_intelligence/end(var/faked)
 	for(var/obj/machinery/vending/infectedMachine in infectedVendingMachines)
 		infectedMachine.shut_up = 1
 		infectedMachine.shoot_inventory = 0

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -90,7 +90,7 @@
 			CHECK_TICK
 		i++
 
-/datum/event/carp_migration/end()
+/datum/event/carp_migration/end(var/faked)
 	for (var/carp_ref in spawned_carp)
 		var/datum/weakref/carp_weakref = carp_ref
 		var/mob/living/simple_animal/hostile/carp/fish = carp_weakref.resolve()

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -107,7 +107,8 @@
 //the activeFor variable.
 //For example: if(activeFor == myOwnVariable + 30) doStuff()
 //Only called once.
-/datum/event/proc/end()
+//faked indicates this is a false alarm. Used to prevent announcements and other things from happening during false alarms.
+/datum/event/proc/end(var/faked)
 	return
 
 //Returns the latest point of event processing.

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -6,15 +6,16 @@
 /datum/event/false_alarm
 	announceWhen	= 0
 	endWhen	=	90
+	no_fake = TRUE //Can't fake itself
 	var/datum/event_meta/EM
 	var/eventname
 	var/datum/event/E = null
 
 
-/datum/event/false_alarm/end()
+/datum/event/false_alarm/end(var/faked)
 	command_announcement.Announce("Error, It appears our previous announcement about [eventname] was a sensor glitch. There is no cause for alarm, please return to your stations.", "False Alarm", new_sound = 'sound/AI/falsealarm.ogg')
 	if(two_part)
-		E.end()
+		E.end()	//This does not return TRUE for var/faked because two-part events like radiation storms need to do things such as revoking maint access
 	if (EM)
 		qdel(EM)
 		EM = null
@@ -31,14 +32,13 @@
 	var/fake_allowed = 0
 	while (!fake_allowed)
 		if (E)
-			E.end()
+			E.end(TRUE)
 			E.kill()
 			qdel(E)
 			E = null
 		EM = pick(EC.available_events)
 		E = new EM.event_type(EM,1)
 		fake_allowed = !E.no_fake
-
 	if (E.ic_name)
 		eventname = E.ic_name
 	else
@@ -47,6 +47,6 @@
 		two_part = 1
 		E.start()
 
-	E.end()
+	E.end(TRUE)
 	E.kill()
 	E.announce()

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -92,7 +92,7 @@
 			if(prob(botEmagChance))
 				bot.emag_act(1)
 
-/datum/event/ionstorm/end()
+/datum/event/ionstorm/end(var/faked)
 	spawn(rand(5000,8000))
 		if(prob(50))
 			ion_storm_announcement()

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -39,7 +39,9 @@
 		else
 			endWhen = next_wave + wave_delay
 
-/datum/event/meteor_wave/end()
+/datum/event/meteor_wave/end(var/faked)
+	if(faked)
+		return
 	spawn(100)//We give 10 seconds before announcing, for the last wave of meteors to hit the station
 		command_announcement.Announce("The station has survived the meteor storm, it is now safe to commence repairs.", "Meteor Alert")
 
@@ -61,7 +63,9 @@
 	command_announcement.Announce("Meteors have reached the station. Please stay away from outer areas until the shower has passed.", "Meteor Alert")
 
 
-/datum/event/meteor_wave/shower/end()
+/datum/event/meteor_wave/shower/end(var/faked)
+	if(faked)
+		return
 	spawn(100)
 		command_announcement.Announce("The station has cleared the meteor shower, please return to your stations.", "Meteor Alert")
 
@@ -83,6 +87,8 @@
 /datum/event/meteor_wave/downed_ship/start()
 	command_announcement.Announce("Ship debris colliding now, all hands brace for impact.", "Ship Debris Alert")
 
-/datum/event/meteor_wave/downed_ship/end()
+/datum/event/meteor_wave/downed_ship/end(var/faked)
+	if(faked)
+		return
 	spawn(100)//We give 10 seconds before announcing, for the last wave of meteors to hit the station
 		command_announcement.Announce("The last of the ship debris has hit or passed by the station, it is now safe to commence repairs.", "Ship Debris Alert")

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -31,9 +31,9 @@
 	else
 		endWhen = activeFor + 10
 
-/datum/event/money_hacker/end()
+/datum/event/money_hacker/end(var/faked)
 	var/message
-	if(affected_account && !affected_account.suspended)
+	if(affected_account && !affected_account.suspended && !faked)
 		//hacker wins
 		message = "The hack attempt has succeeded."
 

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -68,6 +68,6 @@
 					L.flicker(10)
 
 
-/datum/event/prison_break/end()
+/datum/event/prison_break/end(var/faked)
 	for(var/area/A in shuffle(areas))
 		A.prison_break()

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -37,7 +37,9 @@
 
 
 /datum/event/radiation_storm/end(var/faked)
-	revoke_maint_all_access(faked)
+	if(faked)
+		return
+	revoke_maint_all_access()
 
 /datum/event/radiation_storm/syndicate/radiate()
 	return

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -36,8 +36,8 @@
 		C.apply_radiation_effects()
 
 
-/datum/event/radiation_storm/end()
-	revoke_maint_all_access()
+/datum/event/radiation_storm/end(var/faked)
+	revoke_maint_all_access(faked)
 
 /datum/event/radiation_storm/syndicate/radiate()
 	return

--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -27,7 +27,7 @@
 		msg = "Unidentified hackers have targetted a combat drone wing deployed from the NDV Icarus. If any are sighted in the area, approach with caution."
 	command_announcement.Announce(msg, "Rogue drone alert", new_sound = 'sound/AI/combatdrones.ogg')
 
-/datum/event/rogue_drone/end()
+/datum/event/rogue_drone/end(var/faked)
 	var/num_recovered = 0
 	for(var/drone in drones_list)
 		var/mob/living/simple_animal/hostile/icarus_drone/malf/D = drone
@@ -35,7 +35,8 @@
 		D.beam_out()
 		num_recovered++
 
-	if(num_recovered > length(drones_list) * 0.75)
-		command_announcement.Announce("Icarus drone control reports the malfunctioning wing has been recovered safely.", "Rogue drone alert")
-	else
-		command_announcement.Announce("Icarus drone control registers disappointment at the loss of the drones, but the survivors have been recovered.", "Rogue drone alert")
+	if(!faked)
+		if(num_recovered > length(drones_list) * 0.75)
+			command_announcement.Announce("Icarus drone control reports the malfunctioning wing has been recovered safely.", "Rogue drone alert")
+		else
+			command_announcement.Announce("Icarus drone control registers disappointment at the loss of the drones, but the survivors have been recovered.", "Rogue drone alert")

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -164,8 +164,9 @@ var/global/maint_all_access = 0
 	maint_all_access = 1
 	security_announcement.Announce("The maintenance access requirement has been revoked on all airlocks.","Attention!")
 
-/proc/revoke_maint_all_access()
-	maint_all_access = 0
+/proc/revoke_maint_all_access(var/announce_only)
+	if(!announce_only)
+		maint_all_access = 0
 	security_announcement.Announce("The maintenance access requirement has been readded on all maintenance airlocks.","Attention!")
 
 /obj/machinery/door/airlock/allowed(mob/M)

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -164,9 +164,8 @@ var/global/maint_all_access = 0
 	maint_all_access = 1
 	security_announcement.Announce("The maintenance access requirement has been revoked on all airlocks.","Attention!")
 
-/proc/revoke_maint_all_access(var/announce_only)
-	if(!announce_only)
-		maint_all_access = 0
+/proc/revoke_maint_all_access()
+	maint_all_access = 0
 	security_announcement.Announce("The maintenance access requirement has been readded on all maintenance airlocks.","Attention!")
 
 /obj/machinery/door/airlock/allowed(mob/M)

--- a/html/changelogs/doxxmedearly - false_alarm_fix.yml
+++ b/html/changelogs/doxxmedearly - false_alarm_fix.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the false alarm event causing it to seem like some events (including itself) were ending as soon as they began."


### PR DESCRIPTION
Fixed the false alarm from making it seem like some events were ending as soon as (or before) they began, such as Icarus drones, radiation storms, etc. This was happening because the false alarms calls end() on the faked event, which triggered announcements. 