### PR TITLE
Changing ammo types in the lemat is now tied to the unique action button

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -177,16 +177,8 @@
 	for(var/i in 1 to secondary_max_shells)
 		secondary_loaded += new secondary_ammo_type(src)
 
-/obj/item/gun/projectile/revolver/lemat/verb/swap_firingmode()
-	set name = "Swap Firing Mode"
-	set category = "Object"
-	set desc = "Click to swap from one method of firing to another."
-
-	var/mob/living/carbon/human/M = usr
-	if(!M.mind)
-		return 0
-
-	to_chat(M, "<span class='notice'>You change the firing mode on \the [src].</span>")
+/obj/item/gun/projectile/revolver/lemat/unique_action(mob/living/user)
+	to_chat(user, "<span class='notice'>You change the firing mode on \the [src].</span>")
 	if(!flipped_firing)
 		if(max_shells && secondary_max_shells)
 			max_shells = secondary_max_shells

--- a/html/changelogs/alberyk-lemat.yml
+++ b/html/changelogs/alberyk-lemat.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - tweak: "Changing ammo types in the lemat is now tied to the unique action button."


### PR DESCRIPTION
This will help reduce all the verbs in the gun.