### PR TITLE
Diona Flashlight Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -168,7 +168,8 @@
 		if((!D.client && !D.mind) || D.stat == DEAD)
 			qdel(D)
 
-/datum/species/diona/equip_later_gear(mob/living/carbon/human/H)
+/datum/species/diona/after_equip(mob/living/carbon/human/H, visualsOnly, datum/job/J)
+	. = ..()
 	var/obj/item/storage/box/survival/SB = locate() in H
 	if(!SB)
 		for(var/obj/item/storage/S in H)

--- a/html/changelogs/geeves-hate_diona_more.yml
+++ b/html/changelogs/geeves-hate_diona_more.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Diona now spawn with their survival flashlight more often than not."


### PR DESCRIPTION
* Diona now spawn with their survival flashlight more often than not.