### PR TITLE
Minor Security Mapping Alterations & Investigations Tweak.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -383,6 +383,7 @@
 	//Appearance
 	new /obj/item/clothing/suit/storage/det_jacket(src)
 	new /obj/item/clothing/under/det(src)
+	new /obj/item/clothing/suit/storage/toggle/labcoat(src)
 	new /obj/item/clothing/under/det/black(src)
 	new /obj/item/clothing/under/det/classic(src)
 	new /obj/item/clothing/accessory/badge/dia(src)

--- a/html/changelogs/wickedcybs_secfix.yml
+++ b/html/changelogs/wickedcybs_secfix.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: WickedCybs
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a labcoat to the investigator lockers."
+  - rscadd: "Added a drill to the autopsy lab. You can crack open Vaurca now."
+  - maptweak: "The sec breakroom had its donk pockets exchanged with a corporate care package. A water cooler has also been installed to give the paper cups some use."
+  - maptweak: "Fully enclosed the morgue by adding an additional wall, sec maint's pipe and wire layout was also tweaked to accomodate this."
+  - bugfix: "The security sublevel will now properly send its trash along the disposals network, it used to shoot out into the training wing."

--- a/html/changelogs/wickedcybs_secfix.yml
+++ b/html/changelogs/wickedcybs_secfix.yml
@@ -40,6 +40,6 @@ delete-after: True
 changes:
   - rscadd: "Added a labcoat to the investigator lockers."
   - rscadd: "Added a drill to the autopsy lab. You can crack open Vaurca now."
-  - maptweak: "The sec breakroom had its donk pockets exchanged with a corporate care package. A water cooler has also been installed to give the paper cups some use."
+  - maptweak: "The sec breakroom had its donk pockets exchanged with a corporate care package."
   - maptweak: "Fully enclosed the morgue by adding an additional wall, sec maint's pipe and wire layout was also tweaked to accomodate this."
   - bugfix: "The security sublevel will now properly send its trash along the disposals network, it used to shoot out into the training wing."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -4380,10 +4380,6 @@
 /area/security/forensics_morgue)
 "aiI" = (
 /obj/structure/disposalpipe/up,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /obj/structure/window/reinforced{
@@ -59350,24 +59346,6 @@
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"dcZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/vault)
 "dde" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -70536,6 +70514,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_hallway_main)
+"xkB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/vault)
 "xlC" = (
 /obj/machinery/optable{
 	name = "Autopsy Table"
@@ -107237,7 +107233,7 @@ klC
 klC
 aiI
 ajy
-dcZ
+xkB
 nHe
 nHe
 vFG

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -3270,6 +3270,10 @@
 /area/security/forensics_morgue)
 "agv" = (
 /obj/structure/table/standard,
+/obj/item/surgery/surgicaldrill{
+	pixel_x = 1;
+	pixel_y = -2
+	},
 /obj/item/surgery/hemostat,
 /obj/item/surgery/retractor,
 /obj/item/surgery/circular_saw,
@@ -4375,20 +4379,24 @@
 	},
 /area/security/forensics_morgue)
 "aiI" = (
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "12-0"
-	},
 /obj/structure/disposalpipe/up,
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
+/obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "12-0"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
@@ -4723,11 +4731,11 @@
 /area/maintenance/vault)
 "ajy" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
 "ajz" = (
@@ -5065,19 +5073,18 @@
 /area/maintenance/vault)
 "ake" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
@@ -59343,6 +59350,24 @@
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"dcZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/vault)
 "dde" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -61030,6 +61055,7 @@
 	req_access = list(63)
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
 "gen" = (
@@ -106952,8 +106978,8 @@ klC
 klC
 klC
 klC
-aiI
-ajy
+klC
+tzU
 ake
 lQu
 nHe
@@ -107209,9 +107235,9 @@ klC
 klC
 klC
 klC
-tzU
-tzU
-tzU
+aiI
+ajy
+dcZ
 nHe
 nHe
 vFG

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -2089,11 +2089,12 @@
 /turf/simulated/wall,
 /area/security/training_crimescene)
 "eF" = (
+/obj/structure/table/standard,
+/obj/item/storage/box/fancy/donut,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/white,
 /area/security/break_room)
 "eG" = (
@@ -2220,7 +2221,6 @@
 "eT" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/storage/box/fancy/donut,
 /turf/simulated/floor/tiled/white,
 /area/security/break_room)
 "eU" = (
@@ -2740,22 +2740,6 @@
 "gO" = (
 /obj/structure/table/rack,
 /obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/security_interstitial)
-"gS" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_interstitial)
 "gY" = (
@@ -6069,6 +6053,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering_ladder)
+"sC" = (
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/plating,
+/area/maintenance/security_interstitial)
 "sE" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -8339,6 +8327,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/medbay_virology)
+"Hx" = (
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security_interstitial)
 "HC" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Construction Level"
@@ -9516,10 +9520,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
-"LU" = (
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor/plating,
-/area/maintenance/security_interstitial)
 "LY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -47151,7 +47151,7 @@ gd
 et
 WO
 hg
-LU
+sC
 WX
 WX
 WX
@@ -47921,7 +47921,7 @@ so
 eO
 et
 hi
-gS
+Hx
 WX
 ab
 ab

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -2089,24 +2089,26 @@
 /turf/simulated/wall,
 /area/security/training_crimescene)
 "eF" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/fancy/donut,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/white,
 /area/security/break_room)
 "eG" = (
 /obj/structure/table/standard,
-/obj/item/storage/box/cups,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/storage/box/cups,
 /turf/simulated/floor/tiled/white,
 /area/security/break_room)
 "eH" = (
-/obj/item/storage/box/donkpockets,
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/storage/box/snack{
+	desc = "A box full of snack foods. A label is attached that reads, 'Sorry about the microwaves.'";
+	name = "corporate care package"
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/break_room)
 "eI" = (
@@ -2218,6 +2220,7 @@
 "eT" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/storage/box/fancy/donut,
 /turf/simulated/floor/tiled/white,
 /area/security/break_room)
 "eU" = (
@@ -2469,8 +2472,8 @@
 /area/security/training_theoretical)
 "fF" = (
 /obj/structure/bed/chair/comfy/sofa/left{
-	icon_state = "sofaend_left_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "sofaend_left_preview"
 	},
 /turf/simulated/floor/wood,
 /area/security/break_room)
@@ -2538,22 +2541,22 @@
 /area/security/training_theoretical)
 "gb" = (
 /obj/structure/bed/chair/comfy/sofa/corner{
-	icon_state = "sofacorner_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "sofacorner_preview"
 	},
 /turf/simulated/floor/wood,
 /area/security/break_room)
 "gc" = (
 /obj/structure/bed/chair/comfy/sofa{
-	icon_state = "sofamiddle_preview";
-	dir = 1
+	dir = 1;
+	icon_state = "sofamiddle_preview"
 	},
 /turf/simulated/floor/wood,
 /area/security/break_room)
 "gd" = (
 /obj/structure/bed/chair/comfy/sofa/left{
-	icon_state = "sofaend_left_preview";
-	dir = 1
+	dir = 1;
+	icon_state = "sofaend_left_preview"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/wood,
@@ -2731,22 +2734,29 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_interstitial)
 "gN" = (
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/security_interstitial)
 "gO" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/drop{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/zpipe/down/supply,
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
+/obj/structure/table/rack,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/security_interstitial)
+"gS" = (
 /obj/structure/cable/green{
-	d1 = 32;
-	d2 = 2;
-	icon_state = "11-2"
+	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/down,
-/turf/simulated/open,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/security_interstitial)
 "gY" = (
 /obj/effect/floor_decal/corner/blue{
@@ -2882,7 +2892,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light/small/emergency,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2906,20 +2915,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_interstitial)
 "hi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply,
+/obj/structure/disposalpipe/down,
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	d1 = 32;
+	d2 = 2;
+	icon_state = "11-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/sign/drop{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/open,
 /area/maintenance/security_interstitial)
 "hq" = (
 /obj/effect/floor_decal/corner/blue{
@@ -9508,6 +9516,10 @@
 	icon_state = "asteroidplating"
 	},
 /area/mine/unexplored)
+"LU" = (
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/plating,
+/area/maintenance/security_interstitial)
 "LY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -47139,7 +47151,7 @@ gd
 et
 WO
 hg
-WX
+LU
 WX
 WX
 WX
@@ -47397,7 +47409,7 @@ et
 gN
 hh
 WX
-ab
+WX
 ab
 ab
 ab
@@ -47652,7 +47664,7 @@ fJ
 gf
 et
 gO
-hi
+hh
 WX
 ab
 ab
@@ -47908,8 +47920,8 @@ eC
 so
 eO
 et
-WX
-WX
+hi
+gS
 WX
 ab
 ab
@@ -48164,10 +48176,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+WX
+WX
+WX
+WX
 ab
 ab
 ab


### PR DESCRIPTION
PR adds a surgical drill to the morgue so they can crack open vaurca, and a labcoat to the Investigator lockers. Additionally, the morgue is now enclosed with a wall added to its bottom right corner.

![image](https://user-images.githubusercontent.com/52309324/111759337-16c3c280-8863-11eb-85b9-4274a2e19158.png)

Red circle here shows that tweak, wall was added, the disposals and wires were shifted a tile to the right. This also fixes the issue with items put into outlets on the sec sublevel being shot into the sec training room, as there was no disposal pipe under the maintenance airlock in the main level.

This meant tweaking the interstitial sec maint as well, I extended out by a tile to align it with the tweak to the main level and added a bit of flavour by changing the layout slightly too, adding a rack and some trash.

![image](https://user-images.githubusercontent.com/52309324/111760798-c188b080-8864-11eb-94dc-d38fe69ea508.png)

Unrelated to all this, swapped the donk pockets in the sec break room for a corporate care package, not like anyone could warm the donks anymore!