### PR TITLE
Autoinjector Sprite Fix

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -107,7 +107,7 @@
 	icon_state = "autoinjector1"
 	item_state = "autoinjector1"
 	var/empty_state = "autoinjector0"
-	flags = OPENCONTAINER
+	flags = null
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = null
 	volume = 5

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -107,7 +107,7 @@
 	icon_state = "autoinjector1"
 	item_state = "autoinjector1"
 	var/empty_state = "autoinjector0"
-	flags = null
+	flags = 0
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = null
 	volume = 5

--- a/html/changelogs/geeves-autoinjector_sprite.yml
+++ b/html/changelogs/geeves-autoinjector_sprite.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Autoinjectors now start secured, which properly sets their sprite. Remember to use screwdrivers to unsecure them, and to use them in-hand to resecure them."


### PR DESCRIPTION
* Autoinjectors now start secured, which properly sets their sprite. Remember to use screwdrivers to unsecure them, and to use them in-hand to resecure them.