### PR TITLE
Nicotine Fix

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -951,6 +951,7 @@
 		/datum/brain_trauma/mild/phobia = 0.1,
 		/datum/brain_trauma/mild/muscle_weakness/ = 0.05
 	)
+	suppressing_reagents = list(/decl/reagent/mental/nicotine) //The way to suppress nicotine withdrawal... is nicotine.
 	conflicting_reagent = null
 	min_dose = 0.0064 * REM
 

--- a/html/changelogs/doxxmedearly - nicotine_fix.yml
+++ b/html/changelogs/doxxmedearly - nicotine_fix.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - bugfix: "Fixed an issue where you'd get messages about needing your nicotine fix while smoking."


### PR DESCRIPTION
Nicotine wasn't preventing nicotine withdrawals, which kept telling the user they needed the fix... as they were currently smoking. 