### PR TITLE
Animal Renaming Fixes

### DIFF
--- a/code/game/objects/items/devices/dociler.dm
+++ b/code/game/objects/items/devices/dociler.dm
@@ -50,6 +50,7 @@
 			H.LoseTarget()
 			H.attack_same = 0
 			H.friends += user
+			H.hostile_nameable = TRUE
 
 	L.desc += "<br><span class='notice'>It looks especially docile.</span>"
 	var/name = input(user, "Would you like to rename \the [L]?", "Dociler", L.name) as text

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -44,11 +44,10 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/can_name(var/mob/living/M)
-	if(hostile_nameable)
-		return ..()
-	if(faction && faction == M.faction) //In case the mob had a dociler used on it
-		return ..()
-	return FALSE
+	if(!hostile_nameable)
+		to_chat(M, SPAN_WARNING("\The [src] cannot be renamed."))
+		return FALSE
+	return ..()
 
 
 /mob/living/simple_animal/hostile/proc/FindTarget()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -662,9 +662,9 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	set category = "IC"
 	set src in view(1)
 
-	var/mob/living/M = usr
+	var/mob/living/carbon/M = usr
 	if(!istype(M))
-		to_chat(usr, SPAN_NOTICE("You aren't able to rename \the [src]."))
+		to_chat(usr, SPAN_WARNING("You aren't allowed to rename \the [src]."))
 		return
 
 	if(can_name(M))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -663,7 +663,8 @@ mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	set src in view(1)
 
 	var/mob/living/M = usr
-	if(!M)	
+	if(!istype(M))
+		to_chat(usr, SPAN_NOTICE("You aren't able to rename \the [src]."))
 		return
 
 	if(can_name(M))

--- a/html/changelogs/Doxxmedearly - Animal_Name_Fixes.yml
+++ b/html/changelogs/Doxxmedearly - Animal_Name_Fixes.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Ghosts can no longer rename animals."
+  - bugfix: "Combat drones can no longer be renamed."


### PR DESCRIPTION
Never trust old code. 
Properly checks if mob is living when trying to rename an animal.
Bumped it up to carbon just in case bots think they have rights.
Handled dociler allowing animals to be renamed in a better way. 

Fixes #11472 