### PR TITLE
Emergency shutters can no longer close if there is a mob standing under them

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -407,6 +407,8 @@
 /obj/machinery/door/firedoor/can_close()
 	if(locate(/obj/effect/blob) in get_turf(src))
 		return FALSE
+	if(locate(/mob/living) in get_turf(src))
+		return FALSE
 	return ..()
 
 /obj/machinery/door/firedoor/close()

--- a/html/changelogs/alberyk-firedoorteak.yml
+++ b/html/changelogs/alberyk-firedoorteak.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - tweak: "Emergency shutters no longer close if there is a mob on the way."


### PR DESCRIPTION
This is to stop a couple of unintended behavior with things like projectiles.