### PR TITLE
Closet Teleporter Tweak

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -155,9 +155,12 @@
 	if(linked_teleporter)
 		if(linked_teleporter.last_use + 600 > world.time)
 			return
+		var/did_teleport = FALSE
 		for(var/mob/M in contents)
+			did_teleport = TRUE
 			linked_teleporter.do_teleport(M)
-		linked_teleporter.last_use = world.time
+		if(did_teleport)
+			linked_teleporter.last_use = world.time
 
 	playsound(get_turf(src), close_sound, 25, 0, -3)
 	density = initial(density)

--- a/html/changelogs/geeves-closet_teleporter_sanity.yml
+++ b/html/changelogs/geeves-closet_teleporter_sanity.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Closet Teleporters now only go on cooldown if they successfully teleported a mob."


### PR DESCRIPTION
* Closet Teleporters now only go on cooldown if they successfully teleported a mob.
