### PR TITLE
Hidden Slots Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -339,6 +339,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 		if(gear["slot"] == slot)
 			W.screen_loc = gear["loc"]
 			break
+	hud_used.hidden_inventory_update()
 
 	if(W.action_button_name)
 		update_action_buttons()

--- a/html/changelogs/geeves-hidden_slots.yml
+++ b/html/changelogs/geeves-hidden_slots.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Equipping clothing when the inventory slots are hidden no longer makes the item float in space."


### PR DESCRIPTION
* Equipping clothing when the inventory slots are hidden no longer makes the item float in space.