### PR TITLE
Fixes MC tab crashing, debug-controller verb now shows all SS.

### DIFF
--- a/code/controllers/master/subsystem.dm
+++ b/code/controllers/master/subsystem.dm
@@ -178,7 +178,7 @@
 	return time
 
 //hook for printing stats to the "MC" statuspanel for admins to see performance and related stats etc.
-/datum/controller/subsystem/stat_entry(msg)
+/datum/controller/subsystem/stat_entry(var/msg)
 	if(!statclick)
 		statclick = new/obj/effect/statclick/debug(null, "Initializing...", src)
 

--- a/code/controllers/verbs.dm
+++ b/code/controllers/verbs.dm
@@ -8,30 +8,19 @@
 		usr.client.debug_variables(antag)
 		message_admins("Admin [key_name_admin(usr)] is debugging the [antag.role_text] template.")
 
-/var/list/controller_debug_list = list(
-	"Configuration",
-	"Cameras",
-	"Gas Data",
-	"Observation"
-)
-
-/client/proc/debug_controller(controller in controller_debug_list)
+/client/proc/debug_controller()
 	set category = "Debug"
 	set name = "Debug Controller"
 	set desc = "Debug the various periodic loop controllers for the game (be careful!)"
 
-	if(!holder)	return
-	switch(controller)
-		if("Configuration")
-			debug_variables(config)
-			feedback_add_details("admin_verb","DConf")
-		if("Cameras")
-			debug_variables(cameranet)
-			feedback_add_details("admin_verb","DCameras")
-		if("Gas Data")
-			debug_variables(gas_data)
-			feedback_add_details("admin_verb","DGasdata")
-		if("Observation")
-			debug_variables(all_observable_events)
-			feedback_add_details("admin_verb", "DObservation")
-	message_admins("Admin [key_name_admin(usr)] is debugging the [controller] controller.")
+	if(!holder)
+		return
+	var/list/available_controllers = list()
+	for(var/datum/controller/subsystem/SS in Master.subsystems)
+		if (!Master.initializing && SS.flags & SS_NO_DISPLAY)
+			continue
+		available_controllers[SS.name] = SS
+	var/css = input("What controller would you like to debug?", "Controllers") as null|anything in available_controllers
+	debug_variables(available_controllers[css])
+	
+	message_admins("Admin [key_name_admin(usr)] is debugging the [css] controller.")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -873,10 +873,13 @@
 					stat("Failsafe Controller:", "ERROR")
 				if (Master)
 					stat(null, "- Subsystems -")
+					var/amt = 0
 					for(var/datum/controller/subsystem/SS in Master.subsystems)
 						if (!Master.initializing && SS.flags & SS_NO_DISPLAY)
 							continue
-
+						if(amt >= 70)
+							break
+						amt++
 						SS.stat_entry()
 
 		if(listed_turf && client)

--- a/html/changelogs/mattatlas-mctab.yml
+++ b/html/changelogs/mattatlas-mctab.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The MC tab should no longer hardcrash you."
+  - rscadd: "The debug-controller verb now shows all controllers."


### PR DESCRIPTION
The title says "fixes", but in reality the crashing seems to be caused by the sheer quantity of subsystems we have. The hard crash limit is 74, so I've limited the amount of subsystems shown to 70. Thanks, BYOND.

As an additional thing to tide us over until a gentle soul ports JavaScript stat browsers, debug-controller now shows all subsystems.