### PR TITLE
Mobs reappearing in grabs fix

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -325,7 +325,7 @@
 
 //This is used to make sure the victim hasn't managed to yackety sax away before using the grab.
 /obj/item/grab/proc/confirm()
-	if(!assailant || !affecting)
+	if(!assailant || !affecting || QDELETED(affecting))
 		qdel(src)
 		return 0
 

--- a/html/changelogs/doxxmedearly - holodeck grabs.yml
+++ b/html/changelogs/doxxmedearly - holodeck grabs.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed a bug where deleted mobs would sometimes reappear in someone's hands if grabbed, such as holodeck penguins."


### PR DESCRIPTION
Mobs would sometimes reappear in grabs if qdeleted in certain cases. Notably happened with neckgrabbing penguins to bring them outside the holodeck. It now checks if they're deleted or being deleted.

Fixes #4795