### PR TITLE
Cyborg Packaging Fixes

### DIFF
--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -14,6 +14,18 @@
 
 /obj/item/stack/wrapping_paper/attackby(obj/item/W, mob/user)
 	..()
+	if (isrobot(user))
+		if(istype(W.loc, /obj/item/gripper))
+			var/obj/item/gripper/G = W.loc
+			if(!is_type_in_list(G, list(/obj/item/gripper/service, /obj/item/gripper/paperwork)))
+				to_chat(user, SPAN_WARNING("\The [G] isn't deft enough to wrap up \the [G.wrapped]."))
+				return
+		else if(istype(W, /obj/item/gripper))
+			return
+		else
+			to_chat(user, SPAN_WARNING("You can't wrap up a cyborg module!"))
+			// Prevent robots from accidentally wrapping any of their internal tools, and non-service borgs from wrapping up parcels
+			return
 	if (!isturf(loc))
 		to_chat(user, SPAN_WARNING("The paper must be set down for you to wrap a gift!"))
 		return

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -30,7 +30,7 @@
 	user.drop_item()
 	playsound(src.loc, 'sound/items/package_unwrap.ogg', 50,1)
 	if(src.gift)
-		user.put_in_active_hand(gift)
+		user.put_in_hands(gift)
 		src.gift.add_fingerprint(user)
 	else
 		to_chat(user, "<span class='warning'>The gift was empty!</span>")

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -231,21 +231,22 @@
 		to_chat(src, "<span class='notice'>You need to disable a module first!</span>")
 
 /mob/living/silicon/robot/put_in_hands(var/obj/item/W) // Maybe hands.
-	var/obj/item/gripper/G
+	var/obj/item/gripper/G = get_active_hand()
+	if (istype(G))
+		if(!G.wrapped && G.grip_item(W, src, TRUE))
+			return TRUE
 	if (istype(module_state_1, /obj/item/gripper))
-
 		G = module_state_1
-		if (!G.wrapped && G.grip_item(W, src, 1))
+		if (!G.wrapped && G.grip_item(W, src, TRUE))
 			return TRUE
 	else if (istype(module_state_2, /obj/item/gripper))
 		G = module_state_2
-		if (!G.wrapped && G.grip_item(W, src, 0))
+		if (!G.wrapped && G.grip_item(W, src, TRUE))
 			return TRUE
 	else if (istype(module_state_3, /obj/item/gripper))
 		G = module_state_3
-		if (!G.wrapped && G.grip_item(W, src, 0))
+		if (!G.wrapped && G.grip_item(W, src, TRUE))
 			return TRUE
-
 
 	W.forceMove(get_turf(src))
 	return FALSE

--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -24,7 +24,9 @@
 		/obj/item/smes_coil,
 		/obj/item/device/assembly,//Primarily for making improved cameras, but opens many possibilities
 		/obj/item/computer_hardware,
-		/obj/item/pipe
+		/obj/item/pipe,
+		/obj/item/smallDelivery,
+		/obj/item/gift
 		)
 
 	var/obj/item/wrapped
@@ -74,6 +76,7 @@
 
 /obj/item/gripper/update_icon()
 	underlays.Cut()
+	grippersafety(src)
 	if(wrapped && wrapped.icon)
 		var/mutable_appearance/MA = new(wrapped)
 		MA.layer = FLOAT_LAYER
@@ -107,14 +110,15 @@
 
 	drop(get_turf(src))
 
-/obj/item/gripper/proc/drop(var/atom/target)
+/obj/item/gripper/proc/drop(var/atom/target, var/feedback = TRUE)
 	if(wrapped)
 		if(wrapped.loc == src)
 			if(force_holder)
 				wrapped.force = force_holder
 			wrapped.forceMove(target)
 			force_holder = null
-		to_chat(loc, SPAN_NOTICE("You release \the [wrapped].")) // loc will always be the cyborg
+		if(feedback)
+			to_chat(loc, SPAN_NOTICE("You release \the [wrapped].")) // loc will always be the cyborg
 	wrapped = null
 	update_icon()
 	return TRUE
@@ -189,7 +193,9 @@
 		/obj/item/stock_parts,
 		/obj/item/custom_ka_upgrade,
 		/obj/item/warp_core,
-		/obj/item/extraction_pack
+		/obj/item/extraction_pack,
+		/obj/item/smallDelivery,
+		/obj/item/gift
 	)
 
 /obj/item/gripper/paperwork
@@ -204,7 +210,11 @@
 		/obj/item/book,
 		/obj/item/newspaper,
 		/obj/item/stamp,
-		/obj/item/ducttape
+		/obj/item/ducttape,
+		/obj/item/smallDelivery,
+		/obj/item/gift,
+		/obj/item/stack/packageWrap,
+		/obj/item/stack/wrapping_paper
 		)
 
 /obj/item/gripper/research //A general usage gripper, used for toxins/robotics/xenobio/etc
@@ -238,7 +248,9 @@
 		/obj/item/slimesteroid2,
 		/obj/item/slimepotion,
 		/obj/item/slimepotion2,
-		/obj/item/remote_mecha
+		/obj/item/remote_mecha,
+		/obj/item/smallDelivery,
+		/obj/item/gift
 		)
 
 /obj/item/gripper/chemistry //A gripper designed for chemistry, to allow borgs to work efficiently in the lab
@@ -258,7 +270,9 @@
 		/obj/item/stack/material/phoron,
 		/obj/item/reagent_containers/blood,
 		/obj/item/reagent_containers/food/drinks/sillycup,
-		/obj/item/reagent_containers/food/drinks/medcup
+		/obj/item/reagent_containers/food/drinks/medcup,
+		/obj/item/smallDelivery,
+		/obj/item/gift
 		)
 
 /obj/item/gripper/service //Used to handle food, drinks, and seeds.
@@ -274,7 +288,11 @@
 		/obj/item/trash,
 		/obj/item/reagent_containers/cooking_container,
 		/obj/item/material/kitchen,
-		/obj/item/reagent_containers/food/snacks
+		/obj/item/reagent_containers/food/snacks,
+		/obj/item/smallDelivery,
+		/obj/item/gift,
+		/obj/item/stack/packageWrap,
+		/obj/item/stack/wrapping_paper
 		)
 
 /obj/item/gripper/no_use //Used when you want to hold and put items in other things, but not able to 'use' the item

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -18,7 +18,7 @@
 	unwrap()
 
 /obj/structure/bigDelivery/attack_ai(mob/user)
-	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Robots can open packages.
+	if(isrobot(user) && Adjacent(user)) // Robots can open packages.
 		attack_hand(user)
 
 /obj/structure/bigDelivery/proc/unwrap()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -17,6 +17,10 @@
 /obj/structure/bigDelivery/attack_hand(mob/user as mob)
 	unwrap()
 
+/obj/structure/bigDelivery/attack_ai(mob/user)
+	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Robots can open packages.
+		attack_hand(user)
+
 /obj/structure/bigDelivery/proc/unwrap()
 	playsound(loc, 'sound/items/package_unwrap.ogg', 50, 1)
 	if(wrapped) //sometimes items can disappear. For example, bombs. --rastaf0
@@ -129,8 +133,20 @@
 /obj/item/smallDelivery/attack_self(mob/user as mob)
 	if (src.wrapped) //sometimes items can disappear. For example, bombs. --rastaf0
 		wrapped.forceMove(user.loc)
+		to_chat(user, SPAN_NOTICE("You tear open the parcel, revealing \a [wrapped]!"))
 		if(ishuman(user))
 			user.put_in_hands(wrapped)
+		else if(isrobot(user))
+			var/obj/item/gripper/G = user.get_active_hand()
+			if(istype(G))
+				G.drop(src, FALSE)
+				if(is_type_in_list(wrapped, G.can_hold))
+					G.grip_item(wrapped, user, FALSE)
+				else
+					to_chat(user, SPAN_WARNING("\The [wrapped] tumbles from \the [G] as you unwrap it!"))
+					wrapped.forceMove(get_turf(src))
+			else
+				wrapped.forceMove(get_turf(src))
 		else
 			wrapped.forceMove(get_turf(src))
 

--- a/html/changelogs/johnwildkins-parcels.yml
+++ b/html/changelogs/johnwildkins-parcels.yml
@@ -1,0 +1,9 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - rscadd: "Cyborgs may now carry gifts and packages in magnetic grippers."
+  - rscadd: "Service and paperwork grippers are now able to wrap items into gifts and parcels."
+  - bugfix: "Cyborgs are now able to open parcels by hitting with no module selected (large parcels on the ground) or activating the parcel in their gripper (small parcels)."
+  - bugfix: "Cyborg grippers will no longer be eaten by package wrap, leaving a borg gripper-less forever."


### PR DESCRIPTION
changes:
  - rscadd: "Cyborgs may now carry gifts and packages in magnetic grippers."
  - rscadd: "Service and paperwork grippers are now able to wrap items into gifts and parcels."
  - bugfix: "Cyborgs are now able to open parcels by hitting with no module selected (large parcels on the ground) or activating the parcel in their gripper (small parcels)."
  - bugfix: "Cyborg grippers will no longer be eaten by package wrap, leaving a borg gripper-less forever."

Fixes #3647