### PR TITLE
Microbattery Asystole

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -224,9 +224,9 @@
 /mob/living/carbon/human/is_asystole()
 	if(isSynthetic())
 		var/obj/item/organ/internal/cell/C = internal_organs_by_name[BP_CELL]
-		if(istype(C))
-			if(!C.is_usable() || !C.percent())
-				return TRUE
+		if(istype(C) && C.is_usable() && C.percent())
+			return FALSE
+		return TRUE
 	else if(should_have_organ(BP_HEART))
 		var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
 		if(!istype(heart) || !heart.is_working())

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -742,7 +742,7 @@
 			if (species.tail)
 				animate_tail_reset()
 			if(prob(2) && is_asystole() && isSynthetic())
-				visible_message("<b>[src]</b> [pick("emits low pitched whirr","beeps urgently")]")
+				visible_message("<b>[src]</b> [pick("emits low pitched whirr","beeps urgently")].")
 
 		if(paralysis)
 			AdjustParalysis(-1)
@@ -957,7 +957,7 @@
 
 			if(isSynthetic())
 				var/obj/item/organ/internal/cell/IC = internal_organs_by_name[BP_CELL]
-				if (istype(IC))
+				if(istype(IC) && IC.is_usable())
 					var/chargeNum = Clamp(Ceiling(IC.percent()/25), 0, 4)	//0-100 maps to 0-4, but give it a paranoid clamp just in case.
 					cells.icon_state = "charge[chargeNum]"
 				else
@@ -1073,16 +1073,22 @@
 /mob/living/carbon/human/proc/handle_shock()
 	if(status_flags & GODMODE)
 		return 0
+	var/is_asystole = is_asystole()
+	if(is_asystole && isSynthetic())
+		if(!lying && !buckled_to)
+			to_chat(src, SPAN_WARNING("You don't have enough energy to function!"))
+		Paralyse(3)
+		return
 	if(!can_feel_pain())
 		return
 
-	if(is_asystole())
+	if(is_asystole)
 		shock_stage = max(shock_stage + 1, 61)
 
 	var/traumatic_shock = get_shock()
 	if(traumatic_shock >= max(30, 0.8*shock_stage))
 		shock_stage += 1
-	else if (!is_asystole())
+	else if (!is_asystole)
 		shock_stage = min(shock_stage, 160)
 		var/recovery = 1
 		if(traumatic_shock < 0.5 * shock_stage) //lower shock faster if pain is gone completely

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -64,7 +64,6 @@
 	icon_state = "scell"
 	organ_tag = BP_CELL
 	parent_organ = BP_CHEST
-	vital = TRUE
 	max_damage = 80
 	relative_size = 80
 	var/open = FALSE
@@ -89,11 +88,6 @@
 		return 0
 	return round(cell.charge*(1 - damage/max_damage))
 
-/obj/item/organ/internal/cell/proc/checked_use(var/amount)
-	if(!is_usable() || !cell)
-		return FALSE
-	return cell.checked_use(amount)
-
 /obj/item/organ/internal/cell/proc/use(var/amount)
 	if(!is_usable() || !cell)
 		return
@@ -108,12 +102,9 @@
 	var/cost = get_power_drain()
 	if(world.time - owner.l_move_time < 15)
 		cost *= 2
-	if(!checked_use(cost) && owner.isSynthetic())
-		if(!owner.lying && !owner.buckled_to)
-			to_chat(owner, "<span class='warning'>You don't have enough energy to function!</span>")
-		owner.Paralyse(3)
+	use(cost)
 
-/obj/item/organ/internal/cell/proc/get_power_drain()	
+/obj/item/organ/internal/cell/proc/get_power_drain()
 	return servo_cost
 
 /obj/item/organ/internal/cell/emp_act(severity)
@@ -122,7 +113,7 @@
 		cell.emp_act(severity)
 
 /obj/item/organ/internal/cell/attackby(obj/item/W, mob/user)
-	if(isscrewdriver(W))
+	if(W.isscrewdriver())
 		if(open)
 			open = FALSE
 			to_chat(user, SPAN_NOTICE("You screw the battery panel in place."))
@@ -130,20 +121,26 @@
 			open = TRUE
 			to_chat(user, SPAN_NOTICE("You unscrew the battery panel."))
 
-	if(iscrowbar(W))
+	if(W.iscrowbar())
 		if(open)
 			if(cell)
 				user.put_in_hands(cell)
 				to_chat(user, SPAN_NOTICE("You remove \the [cell] from \the [src]."))
 				cell = null
+			else
+				to_chat(user, SPAN_WARNING("There is no cell to remove."))
+		else
+			to_chat(user, SPAN_WARNING("You need to unscrew the battery panel first."))
 
-	if (istype(W, /obj/item/cell))
+	if(istype(W, /obj/item/cell))
 		if(open)
 			if(cell)
 				to_chat(user, SPAN_WARNING("There is a power cell already installed."))
 			else if(user.unEquip(W, src))
 				replace_cell(W)
 				to_chat(user, SPAN_NOTICE("You insert \the [cell]."))
+		else
+			to_chat(user, SPAN_WARNING("You need to unscrew the battery panel first."))
 
 /obj/item/organ/internal/cell/proc/replace_cell(var/obj/item/cell/C)
 	if(istype(cell))

--- a/html/changelogs/geeves-microbattery_asystole.yml
+++ b/html/changelogs/geeves-microbattery_asystole.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Removing an IPC's microbattery will no longer kill them, it will just put them in a no-power state until it's reinstalled."
+  - bugfix: "Taking the cell out of a microbattery now works again."


### PR DESCRIPTION
* Removing an IPC's microbattery will no longer kill them, it will just put them in a no-power state until it's reinstalled.
* Taking the cell out of a microbattery now works again.