### PR TITLE
Storage Movement

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -534,7 +534,7 @@
 /obj/item/storage/dropped(mob/user as mob)
 	return
 
-/obj/item/storage/attack_hand(mob/user as mob)
+/obj/item/storage/attack_hand(mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.l_store == src && !H.get_active_hand())	//Prevents opening if it's in a pocket.
@@ -550,7 +550,7 @@
 		src.open(user)
 	else
 		..()
-		for(var/mob/M in range(1))
+		for(var/mob/M in range(1, get_turf(src)) - user)
 			if (M.s_active == src)
 				src.close(M)
 	src.add_fingerprint(user)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -671,7 +671,7 @@ default behaviour is:
 		stop_pulling()
 		. = ..()
 
-	if (s_active && !( s_active in contents ) && get_turf(s_active) != get_turf(src))	//check !( s_active in contents ) first so we hopefully don't have to call get_turf() so much.
+	if (s_active && !s_active.Adjacent(src))	//check !( s_active in contents ) first so we hopefully don't have to call get_turf() so much.
 		s_active.close(src)
 
 	if(update_slimes)

--- a/html/changelogs/geeves-storage_movement.yml
+++ b/html/changelogs/geeves-storage_movement.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Moving around will no longer close storage items, provided you are still adjacent to them."
+  - tweak: "Picking up a storage item will no longer close it."


### PR DESCRIPTION
* Moving around will no longer close storage items, provided you are still adjacent to them.
* Picking up a storage item will no longer close it.