### PR TITLE
Taj tail swaying

### DIFF
--- a/code/modules/emotes/definitions/_species.dm
+++ b/code/modules/emotes/definitions/_species.dm
@@ -69,7 +69,14 @@
 /datum/species/tajaran
 	default_emotes = list(
 		/decl/emote/audible/howl,
-		/decl/emote/audible/hiss
+		/decl/emote/audible/hiss,
+		/decl/emote/human/swish,
+		/decl/emote/human/wag,
+		/decl/emote/human/sway,
+		/decl/emote/human/qwag,
+		/decl/emote/human/fastsway,
+		/decl/emote/human/swag,
+		/decl/emote/human/stopsway
 	)
 	pain_emotes_with_pain_level = list(
 		list(/decl/emote/audible/scream, /decl/emote/audible/whimper, /decl/emote/audible/moan, /decl/emote/audible/cry, /decl/emote/audible/howl) = 70,

--- a/html/changelogs/TajTails.yml
+++ b/html/changelogs/TajTails.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheGreyWolf
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Tajara players can now control their tail speed using the following emotes: *swish, *wag, *sway, *qwag, *fastsway, *swag and *stopsway"


### PR DESCRIPTION
This PR was discussed with Canon35 before being put up.
It adds some emotes that taj were missing that allows them to control the speed of their tails and should be as follows:
swish = sways once
wag, sway = normal speed
qwag, fastsway = fast (constantly going back & forth)
swag, stopsway = stops swaying