### PR TITLE
Multi-Page Faxes and More

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -60,7 +60,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 
 	//Form intregration
 	var/SQLquery
-	var/paperstock = 10
+	var/paperstock = 20
 	var/lid = 0
 	//End Form Integration
 	var/datum/announcement/announcement = new
@@ -240,20 +240,19 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 
 	if( href_list["department"] && message )
 		var/log_msg = message
-		var/pass = 0
+		var/pass = FALSE
 		screen = RCS_SENTFAIL
-		for (var/obj/machinery/message_server/MS in SSmachinery.processing_machines)
-			if(!MS.active) continue
-			MS.send_rc_message(ckey(href_list["department"]),department,log_msg,msgStamped,msgVerified,priority)
-			pass = 1
-		for (var/obj/item/modular_computer/P in alert_pdas)
-			P.get_notification(log_msg, 1, "[href_list["department"]] ([src])")
-			pass = 1
+		for(var/obj/machinery/message_server/MS in SSmachinery.processing_machines)
+			if(!MS.active)
+				continue
+			MS.send_rc_message(ckey(href_list["department"]), department, log_msg, msgStamped, msgVerified, priority)
+			pass = TRUE
 		if(pass)
 			screen = RCS_SENTPASS
 			message_log += "<B>Message sent to [recipient]</B><BR>[message]"
 		else
-			audible_message(text("[icon2html(src, viewers(get_turf(src)))] *The Requests Console beeps: 'NOTICE: No server detected!'"),,4)
+			var/msg = "NOTICE: No server detected!"
+			audible_message("<b>The Requests Console</b> beeps, [SPAN_WARNING(msg)]")
 
 	//Handle screen switching
 	if(href_list["setScreen"])
@@ -386,78 +385,71 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 			msgStamped = text("<span class='notice'><b>Stamped with the [T.name]</b></span>")
 			updateUsrDialog()
 	else if (istype(O, /obj/item/paper_bundle))
-		if(lid)	//More of that restocking business
-			var/obj/item/paper_bundle/C = O
+		var/obj/item/paper_bundle/C = O
+		if(lid)
+			if(alert(user, "Do you want to restock \the [src] with \the [O]?", "Paper Restocking", "Yes", "No") == "No")
+				to_chat(user, SPAN_NOTICE("You decide against restocking \the [src], noting that the lid is still open."))
+				return
 			paperstock += C.amount
 			user.drop_from_inventory(C,get_turf(src))
 			qdel(C)
-			for (var/mob/U in hearers(4, src.loc))
-				U.show_message(text("[icon2html(src, viewers(get_turf(src)))] *The Requests Console beeps: 'Paper added.'"))
-		else
-			to_chat(user, "<span class='notice'>I should open the lid to add more paper, or try faxing one paper at a time.</span>")
+			audible_message("<b>The Requests Console</b> beeps, \"Paper added.\"")
+		else if(screen == RCS_MAINMENU)	//Faxing them papers
+			fax_send(O, user)
 	else if (istype(O, /obj/item/paper))
-		if(lid)					//Stocking them papers
+		if(lid)
+			if(alert(user, "Do you want to restock \the [src] with \the [O]?", "Paper Restocking", "Yes", "No") == "No")
+				to_chat(user, SPAN_NOTICE("You decide against restocking \the [src], noting that the lid is still open."))
+				return
 			var/obj/item/paper/C = O
 			user.drop_from_inventory(C,get_turf(src))
 			qdel(C)
 			paperstock++
-			for (var/mob/U in hearers(4, src.loc))
-				U.show_message(text("[icon2html(src, viewers(get_turf(src)))] *The Requests Console beeps: 'Paper added.'"))
-		else if(screen == 0)	//Faxing them papers
-			var/pass = 0
-			var/sendto = input("Select department.", "Send Fax", null, null) in allConsoles
-			for (var/obj/machinery/message_server/MS in SSmachinery.processing_machines)
-				if(!MS.active) continue
-				pass = 1
-			if(pass)
-				var/sent = 0
-				for(var/cc in allConsoles)
-					var/obj/machinery/requests_console/Console = cc
-					if(Console == sendto)
-						if(Console.paperstock == 0)
-							alert("Error! Receiving console out of paper! Aborting!")
-							return
-						if(!sent)
-							sent = 1
-						var/obj/item/paper/C = O
-						var/obj/item/paper/P = new /obj/item/paper()
-						var/info = "<font color = #101010>"
-						var/copied = html_decode(C.info)
-						copied = replacetext(copied, "<font face=\"[P.deffont]\" color=", "<font face=\"[P.deffont]\" nocolor=")	//state of the art techniques in action
-						copied = replacetext(copied, "<font face=\"[P.crayonfont]\" color=", "<font face=\"[P.crayonfont]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
-						info += copied
-						info += "</font>"
-						var/pname = C.name
-						P.color = "#fff9e8"
-						P.fields = C.fields
-						P.stamps = C.stamps
-						P.stamped = C.stamped
-						P.ico = C.ico
-						P.offset_x = C.offset_x
-						P.offset_y = C.offset_y
-						var/list/temp_overlays = C.overlays
-						var/image/img
-						for (var/j = 1, j <= temp_overlays.len, j++)
-							if (findtext(C.ico[j], "cap") || findtext(C.ico[j], "cent"))
-								img = image('icons/obj/bureaucracy.dmi', "paper_stamp-circle")
-							else if (findtext(C.ico[j], "deny"))
-								img = image('icons/obj/bureaucracy.dmi', "paper_stamp-x")
-							else
-								img = image('icons/obj/bureaucracy.dmi', "paper_stamp-dots")
-							img.pixel_x = C.offset_x[j]
-							img.pixel_y = C.offset_y[j]
-							P.add_overlay(img)
-						P.set_content_unsafe(pname, info)
-						Console.print(P, 0, 'sound/machines/twobeep.ogg')
-						for (var/mob/player in hearers(4, Console.loc))
-							player.show_message(text("[icon2html(Console, viewers(get_turf(Console)))] *The Requests Console beeps: 'Fax received'"))
-						Console.paperstock--
-				if(sent == 1)
-					user.show_message(text("[icon2html(src, viewers(get_turf(src)))] *The Requests Console beeps: 'Message Sent.'"))
-			else
-				user.show_message(text("[icon2html(src, viewers(get_turf(src)))] *The Requests Console beeps: 'NOTICE: No server detected!'"))
+			audible_message("<b>The Requests Console</b> beeps, \"Paper added.\"")
+		else if(screen == RCS_MAINMENU)	//Faxing them papers
+			fax_send(O, user)
 
-	return
+/obj/machinery/requests_console/proc/can_send()
+	for(var/obj/machinery/message_server/MS in SSmachinery.processing_machines)
+		if(!MS.active)
+			continue
+		return TRUE
+	return FALSE
+
+/obj/machinery/requests_console/proc/fax_send(var/obj/item/O, var/mob/user)
+	var/sendto = input("Select department.", "Send Fax", null, null) as null|anything in allConsoles
+	if(!sendto)
+		return
+	if(!can_send())
+		var/msg = "NOTICE: No server detected!"
+		audible_message("<b>The Requests Console</b> beeps, [SPAN_WARNING(msg)]")
+		return
+	for(var/cc in allConsoles)
+		var/obj/machinery/requests_console/Console = cc
+		if(Console == sendto)
+			var/paperstock_usage = 1
+			var/is_paper_bundle = istype(O, /obj/item/paper_bundle)
+			if(is_paper_bundle)
+				var/obj/item/paper_bundle/OPB = O
+				paperstock_usage = OPB.amount
+			if(Console.paperstock < paperstock_usage)
+				audible_message("<b>The Requests Console</b> beeps, \"Error! Receiving console out of paper! Aborting!\"")
+				return
+			playsound(Console.loc, 'sound/machines/twobeep.ogg')
+			playsound(Console.loc, 'sound/items/polaroid1.ogg')
+			if(!is_paper_bundle)
+				var/obj/item/paper/P = copy(Console, O, FALSE, FALSE, 0, 15)
+				P.forceMove(Console.loc)
+			else
+				var/obj/item/paper_bundle/PB = bundlecopy(Console, O, FALSE, 15, FALSE)
+				PB.forceMove(Console.loc)
+			Console.audible_message("<b>The Requests Console</b> beeps, \"Fax received.\"")
+			for(var/obj/item/modular_computer/pda in Console.alert_pdas)
+				var/message = "A fax has arrived!"
+				pda.get_notification(message, 1, "[Console.department] Requests Console")
+			Console.paperstock -= paperstock_usage
+			audible_message("<b>The Requests Console</b> beeps, \"Fax sent.\"")
+			return
 
 /obj/machinery/requests_console/proc/reset_message(var/mainmenu = 0)
 	message = ""

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -220,11 +220,11 @@ var/list/admin_departments
 	// give the sprite some time to flick
 	spawn(20)
 		if (istype(incoming, /obj/item/paper))
-			copy(incoming, 1, 0, 0)
+			copy(src, incoming, 1, 0, 0)
 		else if (istype(incoming, /obj/item/photo))
-			photocopy(incoming)
+			photocopy(src, incoming)
 		else if (istype(incoming, /obj/item/paper_bundle))
-			bundlecopy(incoming)
+			bundlecopy(src, incoming)
 		do_pda_alerts()
 		use_power(active_power_usage)
 
@@ -254,11 +254,11 @@ var/list/admin_departments
 
 	var/obj/item/rcvdcopy
 	if (istype(copyitem, /obj/item/paper))
-		rcvdcopy = copy(copyitem, 0)
+		rcvdcopy = copy(src, copyitem, 0)
 	else if (istype(copyitem, /obj/item/photo))
-		rcvdcopy = photocopy(copyitem)
+		rcvdcopy = photocopy(src, copyitem)
 	else if (istype(copyitem, /obj/item/paper_bundle))
-		rcvdcopy = bundlecopy(copyitem, 0)
+		rcvdcopy = bundlecopy(src, copyitem, 0)
 	else
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 		return
@@ -306,9 +306,6 @@ var/list/admin_departments
 	discord_bot.send_to_cciaa(discord_msg)
 
 /obj/machinery/photocopier/faxmachine/proc/do_pda_alerts()
-	if (!alert_pdas || !alert_pdas.len)
-		return
-
-	for (var/obj/item/modular_computer/pda in alert_pdas)
+	for(var/obj/item/modular_computer/pda in alert_pdas)
 		var/message = "New message has arrived!"
 		pda.get_notification(message, 1, "[department] [name]")

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -56,7 +56,7 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 			if(toner <= 0)
 				break
 
-			var/c_type = copy_type()
+			var/c_type = copy_type(src, copyitem, toner)
 
 			if(!c_type) // if there's something that can't be copied
 				break
@@ -84,7 +84,7 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 			if (!selection)
 				return
 
-			var/obj/item/photo/p = photocopy(selection)
+			var/obj/item/photo/p = photocopy(src, selection)
 			if (p.desc == "")
 				p.desc += "Copied by [tempAI.name]"
 			else
@@ -124,21 +124,21 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 		to_chat(user, SPAN_NOTICE("You [anchored ? "wrench" : "unwrench"] \the [src]."))
 	return
 
-/obj/machinery/photocopier/proc/copy_type(var/c_item = copyitem) // helper proc to reduce ctrl+c ctrl+v
+/proc/copy_type(var/obj/machinery/target, var/c_item, var/toner, var/do_print = TRUE) // helper proc to reduce ctrl+c ctrl+v
 	if (istype(c_item, /obj/item/paper))
-		var/obj/item/paper/C = copy(c_item)
+		var/obj/item/paper/C = copy(target, c_item, do_print, do_print, 1 SECOND, toner)
 		sleep(20)
 		return C
 	else if (istype(c_item, /obj/item/photo))
-		var/obj/item/photo/P = photocopy(c_item)
+		var/obj/item/photo/P = photocopy(target, c_item, toner)
 		sleep(20)
 		return P
 	else if (istype(c_item, /obj/item/paper_bundle))
-		var/obj/item/paper_bundle/B = bundlecopy(c_item)
+		var/obj/item/paper_bundle/B = bundlecopy(target, c_item, TRUE, toner)
 		sleep(15*B.pages.len)
 		return B
 	else
-		to_chat(usr, SPAN_WARNING("\The [c_item] can't be copied by \the [src]."))
+		to_chat(usr, SPAN_WARNING("\The [c_item] can't be copied by \the [target]."))
 		return FALSE
 
 /obj/machinery/photocopier/ex_act(severity)
@@ -159,7 +159,7 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 					toner = 0
 	return
 
-/obj/machinery/photocopier/proc/copy(var/obj/item/paper/copy, var/print = 1, var/use_sound = 1, var/delay = 10) // note: var/delay is the delay from copy to print, it should be less than the sleep in copy_type()
+/proc/copy(var/obj/machinery/target, var/obj/item/paper/copy, var/print = TRUE, var/use_sound = TRUE, var/delay = 10, var/toner) // note: var/delay is the delay from copy to print, it should be less than the sleep in copy_type()
 	var/obj/item/paper/c = new /obj/item/paper()
 	var/info
 	var/pname
@@ -195,20 +195,22 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 
 	toner--
 	if(toner == 0)
-		visible_message(SPAN_NOTICE("A red light on \the [src] flashes, indicating that it is out of toner."))
-		flick("photocopier_notoner", src)
-		playsound(loc, 'sound/machines/buzz-two.ogg', 75, 1)
+		target.visible_message(SPAN_NOTICE("A red light on \the [target] flashes, indicating that it is out of toner."))
+		if(target.type == /obj/machinery/photocopier)
+			flick("photocopier_notoner", target)
+		playsound(target.loc, 'sound/machines/buzz-two.ogg', 75, 1)
 		return
 
 	c.set_content_unsafe(pname, info)
 	if (print)
-		flick("photocopier_print", src)
-		src.print(c, use_sound, 'sound/bureaucracy/print.ogg', delay)
+		if(target.type == /obj/machinery/photocopier)
+			flick("photocopier_print", target)
+		target.print(c, use_sound, 'sound/bureaucracy/print.ogg', delay)
 	return c
 
-/obj/machinery/photocopier/proc/photocopy(var/obj/item/photo/photocopy)
+/proc/photocopy(var/obj/machinery/target, var/obj/item/photo/photocopy, var/toner)
 	var/obj/item/photo/p = photocopy.copy()
-	p.forceMove(src.loc)
+	p.forceMove(target.loc)
 
 	var/icon/I = icon(photocopy.icon, photocopy.icon_state)
 	if(toner > 10)	//plenty of toner, go straight greyscale
@@ -223,28 +225,30 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 	toner -= 5	//photos use a lot of ink!
 	if(toner < 0)
 		toner = 0
-		visible_message(SPAN_NOTICE("A red light on \the [src] flashes, indicating that it is out of toner."))
-		flick("photocopier_notoner", src)
-		playsound(loc, 'sound/machines/buzz-two.ogg', 75, 1)
+		target.visible_message(SPAN_NOTICE("A red light on \the [target] flashes, indicating that it is out of toner."))
+		if(target.type == /obj/machinery/photocopier)
+			flick("photocopier_notoner", src)
+		playsound(target.loc, 'sound/machines/buzz-two.ogg', 75, 1)
 	return p
 
 //If need_toner is 0, the copies will still be lightened when low on toner, however it will not be prevented from printing. TODO: Implement print queues for fax machines and get rid of need_toner
-/obj/machinery/photocopier/proc/bundlecopy(var/obj/item/paper_bundle/bundle, var/need_toner=1)
-	var/obj/item/paper_bundle/p = new /obj/item/paper_bundle (src)
+/proc/bundlecopy(var/obj/machinery/target, var/obj/item/paper_bundle/bundle, var/need_toner = TRUE, var/toner, var/do_print = TRUE)
+	var/obj/item/paper_bundle/p = new /obj/item/paper_bundle(target)
 	for(var/obj/item/W in bundle.pages)
 		if(toner <= 0 && need_toner)
 			toner = 0
-			visible_message(SPAN_NOTICE("A red light on \the [src] flashes, indicating that it is out of toner."))
-			flick("photocopier_notoner", src)
-			playsound(loc, 'sound/machines/buzz-two.ogg', 75, 1)
+			target.visible_message(SPAN_NOTICE("A red light on \the [target] flashes, indicating that it is out of toner."))
+			if(target.type == /obj/machinery/photocopier)
+				flick("photocopier_notoner", target)
+			playsound(target.loc, 'sound/machines/buzz-two.ogg', 75, 1)
 			break
 
 
-		W = copy_type(W)
+		W = copy_type(target, W, need_toner ? toner : 15, do_print)
 		W.forceMove(p)
 		p.pages += W
 
-	p.forceMove(src.loc)
+	p.forceMove(target.loc)
 	p.update_icon()
 	p.icon_state = "paper_words"
 	p.name = bundle.name

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -227,7 +227,7 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 		toner = 0
 		target.visible_message(SPAN_NOTICE("A red light on \the [target] flashes, indicating that it is out of toner."))
 		if(target.type == /obj/machinery/photocopier)
-			flick("photocopier_notoner", src)
+			flick("photocopier_notoner", target)
 		playsound(target.loc, 'sound/machines/buzz-two.ogg', 75, 1)
 	return p
 

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -102,7 +102,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	for (var/token in spamfilter)
 		if (findtextEx(message,token))
 			message = "<font color=\"red\">[message]</font>"	//Rejected messages will be indicated by red color.
-			result = token										//Token caused rejection (if there are multiple, last will be chosen>.
+			result = token										//Token caused rejection (if there are multiple, last will be chosen)
 	pda_msgs += new/datum/data_pda_msg(recipient,sender,message)
 	return result
 
@@ -127,11 +127,17 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 						playsound(Console.loc, 'sound/machines/twobeep.ogg', 50, 1)
 						Console.audible_message(text("[icon2html(Console, viewers(get_turf(Console)))] *The Requests Console beeps: 'PRIORITY Alert in [sender]'"),,5)
 					Console.message_log += "<B><span class='warning'>High Priority message from <A href='?src=\ref[Console];write=[sender]'>[sender]</A></span></B><BR>[authmsg]"
+					for(var/obj/item/modular_computer/pda in Console.alert_pdas)
+						var/pda_message = "A high priority message has arrived!"
+						pda.get_notification(pda_message, 1, "[Console.department] Requests Console")
 				else
 					if(!Console.silent)
 						playsound(Console.loc, 'sound/machines/twobeep.ogg', 50, 1)
 						Console.audible_message(text("[icon2html(Console, viewers(get_turf(Console)))] *The Requests Console beeps: 'Message from [sender]'"),,4)
 					Console.message_log += "<B>Message from <A href='?src=\ref[Console];write=[sender]'>[sender]</A></B><BR>[authmsg]"
+					for(var/obj/item/modular_computer/pda in Console.alert_pdas)
+						var/pda_message = "A message has arrived!"
+						pda.get_notification(pda_message, 1, "[Console.department] Requests Console")
 			Console.set_light(2)
 
 

--- a/html/changelogs/geeves-multi_page_faxes.yml
+++ b/html/changelogs/geeves-multi_page_faxes.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Requests Consoles can now be used to send paper bundle faxes, it'll take a while to arrive, as it needs to print all the paper first."
+  - bugfix: "Receiving faxes or messages will now properly alert the linked PDAs of Request Consoles."
+  - tweak: "Increased the paper stock Request Consoles start with to 20, up from 10."


### PR DESCRIPTION
* Requests Consoles can now be used to send paper bundle faxes, it'll take a while to arrive, as it needs to print all the paper first.
* Receiving faxes or messages will now properly alert the linked PDAs of Request Consoles.
* Increased the paper stock Request Consoles start with to 20, up from 10.