### PR TITLE
AFK Indicator

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -1,4 +1,4 @@
-#define SMALL_FONTS(FONTSIZE, MSG) "<span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: [FONTSIZE];\">[MSG]</span>"
+#define SMALL_FONTS(FONTSIZE, MSG) "<span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: [FONTSIZE]px;\">[MSG]</span>"
 
 /*
  * Holds procs designed to help with filtering text

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -178,6 +178,11 @@
 				RangedAttack(A, params)
 	return 1
 
+/mob/living/carbon/human/ClickOn(atom/A, params)
+	marked_afk = null
+	handle_maptext()
+	return ..()
+
 /mob/proc/setClickCooldown(var/timeout)
 	next_move = max(world.time + timeout, next_move)
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1340,15 +1340,17 @@ proc/admin_notice(var/message, var/rights)
 	var/msg
 
 	if(check_rights(R_ADMIN|R_MOD))
-		if (H.paralysis == 0)
+		if(!H.admin_paralyzed)
 			msg = "has paralyzed [key_name_admin(H)]."
 			H.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <span class='warning'>[H] has been winded by a member of staff! Please freeze all roleplay involving their character until the matter is resolved! Adminhelp if you have further questions.</span>", "<span class='warning'><b>You have been winded by a member of staff! Please stand by until they contact you!</b></span>")
 			H.paralysis = 8000
+			H.admin_paralyzed = TRUE
 		else
 			if (alert("The player is currently winded. Do you want to unwind him?", "Unwind player?", "Yes", "No") == "No")
 				return
 
 			H.paralysis = 0
+			H.admin_paralyzed = FALSE
 			msg = "has unparalyzed [key_name_admin(H)]."
 			H.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <font color='green'>[H] has been unwinded by a member of staff!</font>", "<span class='warning'><b>You have been unwinded by a member of staff!</b></span>")
 		log_and_message_admins(msg)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -77,6 +77,8 @@
 
 	. = ..()
 
+	verbs += /mob/living/carbon/human/proc/mark_afk
+
 	hide_underwear.Cut()
 	for(var/category in global_underwear.categories_by_name)
 		hide_underwear[category] = FALSE

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -157,6 +157,9 @@
 			footsound = T.footstep_sound
 
 	if (client)
+		if(marked_afk && client.inactivity < 1 SECOND)
+			marked_afk = null
+			handle_maptext()
 		var/turf/B = GetAbove(T)
 		if(up_hint)
 			up_hint.icon_state = "uphint[(B ? !!B.is_hole : 0)]"

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1240,3 +1240,15 @@ mob/living/carbon/human/proc/change_monitor()
 		to_chat(M, SPAN_WARNING("You can't name a corpse."))
 		return FALSE
 	return TRUE
+
+/mob/living/carbon/human/proc/mark_afk()
+	set name = "Toggle AFK"
+	set desc = "Toggle your AFK mark."
+	set category = "OOC"
+
+	if(marked_afk)
+		marked_afk = null
+		to_chat(usr, SPAN_NOTICE("You are no longer marked as AFK."))
+	else
+		marked_afk = TRUE
+		to_chat(usr, SPAN_NOTICE("You are now marked as AFK."))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -313,3 +313,9 @@
 
 			message = "[prefix][jointext(words," ")]"
 	return message
+
+/mob/living/carbon/human/say(message, datum/language/speaking, verb, alt_name, ghost_hearing)
+	if(marked_afk)
+		marked_afk = null
+		handle_maptext()
+	return ..()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -163,6 +163,8 @@ There are several things that need to be remembered:
 			var/icon/aura_overlay = icon(A.icon, icon_state = A.icon_state)
 			ovr += aura_overlay
 
+		ovr += maptext_holder
+
 		add_overlay(ovr)
 
 	if (lying_prev != lying || size_multiplier != 1)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -6,6 +6,8 @@
 	var/maxHealth = 100 //Maximum health that should be possible.
 	var/health = 100 	//A mob's health
 
+	var/admin_paralyzed
+
 	var/hud_updateflag = 0
 
 	// Virtual Reality

--- a/html/changelogs/geeves-afk_indicator.yml
+++ b/html/changelogs/geeves-afk_indicator.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added AFK and Winded indicators, appearing beneath a character, showing you that the player is OOCly busy/away."
+  - rscadd: "Added a Toggle AFK button in the OOC tab that lets you show the AFK indicator without having to idle for ten minutes."


### PR DESCRIPTION
* Added AFK and Winded indicators, appearing beneath a character, showing you that the player is OOCly busy/away.
* Added a Toggle AFK button in the OOC tab that lets you show the AFK indicator without having to idle for ten minutes.

![image](https://user-images.githubusercontent.com/22774890/112751520-d389f200-8fce-11eb-8ecf-13dbb7c42bb3.png)
![image](https://user-images.githubusercontent.com/22774890/112751527-d8e73c80-8fce-11eb-9d9f-774ccfa73da4.png)