### PR TITLE
Reverts the changes made to the Revolution gamemode. Ups the cap of revs per round.

### DIFF
--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -1,5 +1,5 @@
 /mob/living/proc/convert_to_rev(mob/M as mob in oview(src))
-	set name = "Invite to the Contenders"
+	set name = "Invite to the Revolutionaries"
 	set category = "Abilities"
 	if(!M.mind)
 		return
@@ -47,13 +47,9 @@
 	to_chat(src, "<span class='danger'>\The [player.current] does not support the [faction.faction_descriptor]!</span>")
 
 /mob/living/proc/convert_to_loyalist(mob/M as mob in oview(src))
-	set name = "Invite to the Fellowship"
+	set name = "Invite to the Loyalists"
 	set category = "Abilities"
 	if(!M.mind)
 		return
-	for (var/obj/item/implant/mindshield/I in M)
-		if (I.implanted)
-			to_chat(src, "<span class='warning'>[M] is too loyal to be subverted!</span>")
-			return
 	convert_to_faction(M.mind, loyalists)
 

--- a/code/game/antagonist/station/loyalist.dm
+++ b/code/game/antagonist/station/loyalist.dm
@@ -2,16 +2,16 @@ var/datum/antagonist/loyalists/loyalists
 
 /datum/antagonist/loyalists
 	id = MODE_LOYALIST
-	role_text = "Head Fellow"
-	role_text_plural = "Fellowship"
+	role_text = "Head Loyalist"
+	role_text_plural = "Loyalists"
 	bantype = "loyalist"
 	feedback_tag = "loyalist_objective"
 	antag_indicator = "fellowshiphead"
-	welcome_text = "You are one of the Fellowship leaders! Your goal is your choosing but you are a subversion of the Aurora Crew, you must lead your branch of the Fellowship and progress a story. <b>Use the uplink disguised as a station-bounced radio in your backpack to help start your story!</b>"
-	victory_text = "The Contenders failed in their goals! You won!"
-	loss_text = "The Contenders put an end to your Fellowship in one fell swoop."
-	victory_feedback_tag = "You thwarted the Contenders in their devious ends."
-	loss_feedback_tag = "You were thwarted by the Contenders."
+	welcome_text = "You are one of the Loyalist leaders! You are seeking to protect the estabilishment at all costs. Give your hearts for the Company! <b>Use the uplink disguised as a station-bounced radio in your backpack to help start your story!</b>"
+	victory_text = "The Revolutionaries failed in their goals! You won!"
+	loss_text = "The Revolutionaries put an end to your Loyalists in one fell swoop."
+	victory_feedback_tag = "You thwarted the Revolutionaries in their devious ends."
+	loss_feedback_tag = "You were thwarted by the Revolutionaries."
 	antaghud_indicator = "fellowship"
 
 	hard_cap = 3
@@ -20,15 +20,15 @@ var/datum/antagonist/loyalists/loyalists
 	initial_spawn_target = 8
 
 	// Inround loyalists.
-	faction_role_text = "Fellow"
-	faction_descriptor = "Fellowship"
+	faction_role_text = "Loyalist"
+	faction_descriptor = "Loyalists"
 	faction_verb = /mob/living/proc/convert_to_loyalist
-	faction_welcome = "You have joined a budding fellowship under the forward-thinking lead of a Fellowship leader. Follow their instructions and try to achieve the Fellowship's goals."
+	faction_welcome = "You have decided to defend the estabilishment, no matter what it takes.. Follow your leaders' instructions and try to achieve the Loyalists' goals."
 	faction_indicator = "fellowship"
 	faction_invisible = FALSE
 
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Lab Assistant", "Medical Intern", "Engineering Apprentice", "Assistant", "Security Cadet", "Captain", "Head of Security")
+	protected_jobs = list("Lab Assistant", "Medical Intern", "Engineering Apprentice", "Assistant", "Security Cadet")
 	required_age = 31
 
 /datum/antagonist/loyalists/New()
@@ -47,14 +47,6 @@ var/datum/antagonist/loyalists/loyalists
 		loyal_obj.explanation_text = "Protect [player.real_name], the [player.mind.assigned_role]."
 		global_objectives += loyal_obj
 
-/datum/antagonist/loyalists/can_become_antag(var/datum/mind/player)
-	if(!..())
-		return FALSE
-	for(var/obj/item/implant/mindshield/L in player.current)
-		if(L?.imp_in == player.current)
-			return FALSE
-	return TRUE
-
 /datum/antagonist/loyalists/equip(var/mob/living/carbon/human/player)
 
 	if(!..())
@@ -66,11 +58,11 @@ var/datum/antagonist/loyalists/loyalists
 	player.equip_to_slot_or_del(new /obj/item/device/special_uplink/rev(player, player.mind), slot_in_backpack)
 
 	give_codewords(player)
-	INVOKE_ASYNC(src, .proc/alert_fellow_status, player)
+	INVOKE_ASYNC(src, .proc/alert_loyalist_status, player)
 	return TRUE
 
-/datum/antagonist/loyalists/proc/alert_fellow_status(var/mob/living/carbon/human/player) //This is still dumb but it works
-	alert(player, "As a Head Fellow you are given an uplink with a lot of telecrystals. \
+/datum/antagonist/loyalists/proc/alert_loyalist_status(var/mob/living/carbon/human/player) //This is still dumb but it works
+	alert(player, "As a Head Loyalist you are given an uplink with a lot of telecrystals. \
 				Your goal is to create and progress a story. Use the announcement device you spawn with to whip people into a frenzy, \
 				and the uplink disguised as a radio to equip them. DO NOT PLAY THIS ROLE AS A SUPER TRAITOR. \
 				Doing so may lead to administrative action being taken.",

--- a/code/game/antagonist/station/loyalist.dm
+++ b/code/game/antagonist/station/loyalist.dm
@@ -15,7 +15,7 @@ var/datum/antagonist/loyalists/loyalists
 	antaghud_indicator = "fellowship"
 
 	hard_cap = 3
-	hard_cap_round = 3
+	hard_cap_round = 4
 	initial_spawn_req = 3
 	initial_spawn_target = 8
 

--- a/code/game/antagonist/station/loyalist.dm
+++ b/code/game/antagonist/station/loyalist.dm
@@ -7,7 +7,7 @@ var/datum/antagonist/loyalists/loyalists
 	bantype = "loyalist"
 	feedback_tag = "loyalist_objective"
 	antag_indicator = "fellowshiphead"
-	welcome_text = "You are one of the Loyalist leaders! You are seeking to protect the estabilishment at all costs. Give your hearts for the Company! <b>Use the uplink disguised as a station-bounced radio in your backpack to help start your story!</b>"
+	welcome_text = "You are one of the Loyalist leaders! You are seeking to protect the establishment at all costs. Give your hearts for the Company! <b>Use the uplink disguised as a station-bounced radio in your backpack to help start your story!</b>"
 	victory_text = "The Revolutionaries failed in their goals! You won!"
 	loss_text = "The Revolutionaries put an end to your Loyalists in one fell swoop."
 	victory_feedback_tag = "You thwarted the Revolutionaries in their devious ends."
@@ -23,7 +23,7 @@ var/datum/antagonist/loyalists/loyalists
 	faction_role_text = "Loyalist"
 	faction_descriptor = "Loyalists"
 	faction_verb = /mob/living/proc/convert_to_loyalist
-	faction_welcome = "You have decided to defend the estabilishment, no matter what it takes.. Follow your leaders' instructions and try to achieve the Loyalists' goals."
+	faction_welcome = "You have decided to defend the establishment, no matter what it takes.. Follow your leaders' instructions and try to achieve the Loyalists' goals."
 	faction_indicator = "fellowship"
 	faction_invisible = FALSE
 

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -2,27 +2,27 @@ var/datum/antagonist/revolutionary/revs
 
 /datum/antagonist/revolutionary
 	id = MODE_REVOLUTIONARY
-	role_text = "Head Contender"
-	role_text_plural = "Contenders"
+	role_text = "Head Revolutionary"
+	role_text_plural = "Revolutionaries"
 	bantype = "revolutionary"
 	feedback_tag = "rev_objective"
 	antag_indicator = "contenderhead"
-	welcome_text = "You, as a subversive leader belonging to an element of the NanoTrasen Crew, have caught wind of a hostile Fellowship forming. Whatever your reasons, you fervently stand against its goals. Recruit from the Crew and lead your efforts against them."
-	victory_text = "You eliminated the Fellowship in one fell swoop."
-	loss_text = "The Fellowship threw a wrench into your plans -- permanently."
-	victory_feedback_tag = "You eliminated the Fellows in one fell swoop."
+	welcome_text = "You are a subversive seeking to demolish the current order on the station by whatever means possible. Recruit friends and strangers alike to bring Nanotrasen's tyranny to an end! Or whatever your objective is."
+	victory_text = "You eliminated the Loyalists in one fell swoop."
+	loss_text = "The Loyalists threw a wrench into your plans -- permanently."
+	victory_feedback_tag = "You eliminated the Loyalists in one fell swoop."
 	loss_feedback_tag = "No matter your efforts, you failed to thwart them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_VOTABLE
 	antaghud_indicator = "contender"
 
 	hard_cap = 3
-	hard_cap_round = 3
+	hard_cap_round = 4
 	initial_spawn_req = 3
-	initial_spawn_target = 8
+	initial_spawn_target = 4
 
 	// Inround revs.
-	faction_role_text = "Contender"
-	faction_descriptor = "Contenders"
+	faction_role_text = "Revolutionary"
+	faction_descriptor = "Revolutionaries"
 	faction_verb = /mob/living/proc/convert_to_rev
 	faction_welcome = "You joined a subversive organization in the Aurora Crew, united under a forward-thinking leader, you must achieve their goals."
 	faction_indicator = "contender"
@@ -67,11 +67,11 @@ var/datum/antagonist/revolutionary/revs
 	player.equip_to_slot_or_del(new /obj/item/device/special_uplink/rev(player, player.mind), slot_in_backpack)
 
 	give_codewords(player)
-	INVOKE_ASYNC(src, .proc/alert_contender_status, player)
+	INVOKE_ASYNC(src, .proc/alert_revolutionary_status, player)
 	return TRUE
 
-/datum/antagonist/revolutionary/proc/alert_contender_status(var/mob/living/carbon/human/player) //This is so dumb.
-	alert(player, "As a Head Contender you are given an uplink with a lot of telecrystals. \
+/datum/antagonist/revolutionary/proc/alert_revolutionary_status(var/mob/living/carbon/human/player) //This is so dumb.
+	alert(player, "As a Head Revolutionary you are given an uplink with a lot of telecrystals. \
 				Your goal is to create and progress a story. Use the announcement device you spawn with to whip people into a frenzy, \
 				and the uplink disguised as a radio to equip them. DO NOT PLAY THIS ROLE AS A SUPER TRAITOR. \
 				Doing so may lead to administrative action being taken.",

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -2,12 +2,11 @@
 	name = "Revolution"
 	config_tag = "revolution"
 	round_description = "Some crewmembers are attempting to start a movement!"
-	extended_round_description = "A fellowship is in the early stages of formation, and a group of contenders are rallying to oppose them."
+	extended_round_description = "A revolution is in the early stages of formation, and a group of loyalists are rallying to oppose them."
 	required_players = 22
 	required_enemies = 6
 	auto_recall_shuttle = 0
 	end_on_antag_death = 0
-//	shuttle_delay = 3
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST)
 	require_all_templates = 1
 	ert_disabled = TRUE

--- a/html/changelogs/mattatlas-pogpogpgogpgogogoi.yml
+++ b/html/changelogs/mattatlas-pogpogpgogpgogogoi.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Contenders and Fellows are now once again known as Loyalists and Revolutionaries. Heads of staff can now once again be loyalists."
+  - tweak: "Upped the spawn target for loyalists and revs to 4."


### PR DESCRIPTION
It can be fairly easily assessed that the changes made to Revolution have made it overall worse. There's often a lot of confusion about what contenders and fellows are in AOOC when the gamemode happens, and I've also learned that people love having a base guide to go off of. It's easy to make a gimmick with loyalists and revs, but not with contenders and fellows, since those two ideas don't lend themselves to anything.

Also ups the hard cap, since it was fairly low anyway.