### PR TITLE
fiber & fingerprint card storage

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -83,7 +83,8 @@
 		/obj/item/pipewrench,
 		/obj/item/powerdrill,
 		/obj/item/device/radio,
-		/obj/item/device/debugger
+		/obj/item/device/debugger,
+		/obj/item/device/eftpos
 		)
 
 

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -36,7 +36,9 @@
 		/obj/item/device/paicard,
 		/obj/item/device/encryptionkey,
 		/obj/item/fluff,
-		/obj/item/storage/business_card_holder
+		/obj/item/storage/business_card_holder,
+		/obj/item/clothing/head/bandana,
+		/obj/item/sample
 	)
 	slot_flags = SLOT_ID
 

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -30,12 +30,12 @@
 /obj/structure/filingcabinet/Initialize()
 	. = ..()
 	for(var/obj/item/I in loc)
-		if(istype(I, /obj/item/paper) || istype(I, /obj/item/folder) || istype(I, /obj/item/photo) || istype(I, /obj/item/paper_bundle))
+		if(istype(I, /obj/item/paper) || istype(I, /obj/item/folder) || istype(I, /obj/item/photo) || istype(I, /obj/item/paper_bundle) || istype(I, /obj/item/sample))
 			I.forceMove(src)
 
 
 /obj/structure/filingcabinet/attackby(obj/item/P as obj, mob/user as mob)
-	if(istype(P, /obj/item/paper) || istype(P, /obj/item/folder) || istype(P, /obj/item/photo) || istype(P, /obj/item/paper_bundle))
+	if(istype(P, /obj/item/paper) || istype(P, /obj/item/folder) || istype(P, /obj/item/photo) || istype(P, /obj/item/paper_bundle) || istype(P, /obj/item/sample))
 		to_chat(user, "<span class='notice'>You put [P] in [src].</span>")
 		user.drop_from_inventory(P,src)
 		flick("[initial(icon_state)]-open",src)

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -38,7 +38,7 @@
 	return
 
 /obj/item/folder/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/paper) || istype(W, /obj/item/photo) || istype(W, /obj/item/paper_bundle) || istype(W, /obj/item/sample/print))
+	if(istype(W, /obj/item/paper) || istype(W, /obj/item/photo) || istype(W, /obj/item/paper_bundle) || istype(W, /obj/item/sample))
 		user.drop_from_inventory(W,src)
 		to_chat(user, "<span class='notice'>You put the [W] into \the [src].</span>")
 		update_icon()
@@ -57,7 +57,7 @@
 		dat += "<A href='?src=\ref[src];remove=\ref[Ph]'>Remove</A> <A href='?src=\ref[src];rename=\ref[Ph]'>Rename</A> - <A href='?src=\ref[src];look=\ref[Ph]'>[Ph.name]</A><BR>"
 	for(var/obj/item/paper_bundle/Pb in src)
 		dat += "<A href='?src=\ref[src];remove=\ref[Pb]'>Remove</A> <A href='?src=\ref[src];rename=\ref[Pb]'>Rename</A> - <A href='?src=\ref[src];browse=\ref[Pb]'>[Pb.name]</A><BR>"
-	for(var/obj/item/sample/print/Pf in src)
+	for(var/obj/item/sample/Pf in src)
 		dat += "<A href='?src=\ref[src];remove=\ref[Pf]'>Remove</A> - [Pf.name]<BR>"
 	user << browse(dat, "window=folder")
 	onclose(user, "folder")

--- a/html/changelogs/FibersPrintsWallets.yml
+++ b/html/changelogs/FibersPrintsWallets.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheGreyWolf
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Folders can now hold fibers."
+  - rscadd: "Filing cabinets can now hold fibers & fingerprint cards."
+  - rscadd: "wallets can now contain fibers, fingerprint cards and bandanas."

--- a/html/changelogs/FibersPrintsWallets.yml
+++ b/html/changelogs/FibersPrintsWallets.yml
@@ -41,3 +41,4 @@ changes:
   - rscadd: "Folders can now hold fibers."
   - rscadd: "Filing cabinets can now hold fibers & fingerprint cards."
   - rscadd: "wallets can now contain fibers, fingerprint cards and bandanas."
+  - rscadd: "Toolbelts can now hold the EFTpos."


### PR DESCRIPTION
This lets folders hold fibers, as they could already hold fingerprint cards. The same applies to filing cabinets that can now hold both of these and with wallets. Additionally wallets can now hold bandanas as per a request and toolbelts allows the eftpos.