### PR TITLE
Extools -> Auxtools Debugging

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,0 +1,2 @@
+[debugger]
+engine = "auxtools"

--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -24,6 +24,7 @@
 #include "code\__defines\antagonist.dm"
 #include "code\__defines\armor.dm"
 #include "code\__defines\atmos.dm"
+#include "code\__defines\auxtools.dm"
 #include "code\__defines\battle_monsters.dm"
 #include "code\__defines\callback.dm"
 #include "code\__defines\chemistry.dm"

--- a/code/__defines/auxtools.dm
+++ b/code/__defines/auxtools.dm
@@ -1,0 +1,18 @@
+/proc/auxtools_stack_trace(msg)
+	CRASH(msg)
+
+/proc/enable_debugging(mode, port)
+	CRASH("auxtools not loaded")
+
+/world/New()
+	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+	if (debug_server)
+		call(debug_server, "auxtools_init")()
+		enable_debugging()
+	. = ..()
+
+/world/Del()
+	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+	if (debug_server)
+		call(debug_server, "auxtools_shutdown")()
+	. = ..()

--- a/code/world.dm
+++ b/code/world.dm
@@ -57,11 +57,6 @@ var/global/datum/global_init/init = new ()
 	maxx = WORLD_MIN_SIZE	// So that we don't get map-window-popin at boot. DMMS will expand this.
 	maxy = WORLD_MIN_SIZE
 
-/world/proc/enable_debugger()
-    var/dll = world.GetConfig("env", "EXTOOLS_DLL")
-    if (dll)
-        call(dll, "debug_initialize")()
-
 #define RECOMMENDED_VERSION 510
 /world/New()
 	//logs
@@ -86,8 +81,6 @@ var/global/datum/global_init/init = new ()
 		config.server_name += " #[(world.port % 1000) / 100]"
 
 	callHook("startup")
-
-	enable_debugger()
 
 	. = ..()
 


### PR DESCRIPTION
removes extools references for debugging and replaces them with auxtools, as SpacemanDMM has moved to the latter for debug server handling

this stops VSC from exploding when you hit F5 to build and run now, and hopefully the debugger should actually work now