### PR TITLE
Fix lighting overlays in SSLighting init

### DIFF
--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -80,7 +80,7 @@ var/datum/controller/subsystem/lighting/SSlighting
 			if (!A.dynamic_lighting)
 				continue
 
-			new /atom/movable/lighting_overlay(T)
+			T.lighting_build_overlay()
 			overlaycount++
 
 			CHECK_TICK

--- a/html/changelogs/johnwildkins-lighting.yml
+++ b/html/changelogs/johnwildkins-lighting.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Lighting SS init no longer adds lighting overlays to tiles that have already generated lighting."


### PR DESCRIPTION
The lighting subsystem previously added a lighting overlay to every tile on the map, whether or not it already had lighting
Anything that was dynamically created and lit prior to SSLighting initializing would then get two lighting overlays, which is not good or cool and causes lots of weird problems
This fixes that