### PR TITLE
Overmap Consoles Fix

### DIFF
--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -67,6 +67,9 @@
 		ui.set_auto_update(1)
 
 /obj/machinery/computer/ship/sensors/Topic(href, href_list)
+	if (..())
+		return TOPIC_HANDLED
+
 	if (!linked)
 		return TOPIC_NOACTION
 
@@ -98,13 +101,13 @@
 			new/obj/item/paper/(get_turf(src), O.get_scan_data(usr), "paper (Sensor Scan - [O])")
 		return TOPIC_HANDLED
 
-/obj/machinery/computer/ship/sensors/process()
+/obj/machinery/computer/ship/sensors/machinery_process()
 	..()
 	if(!linked)
 		return
 	if(sensors && sensors.use_power && sensors.powered())
 		var/sensor_range = round(sensors.range*1.5) + 1
-		linked.set_light(1, sensor_range, sensor_range+1)
+		linked.set_light(sensor_range, sensor_range+1, light_color)
 	else
 		linked.set_light(0)
 
@@ -180,7 +183,8 @@
 	update_use_power(!use_power)
 	queue_icon_update()
 
-/obj/machinery/shipsensors/process()
+/obj/machinery/shipsensors/machinery_process()
+	..()
 	if(use_power) //can't run in non-vacuum
 		if(!in_vacuum())
 			toggle()

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -37,11 +37,13 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 /obj/machinery/computer/ship/attack_hand(mob/user)
 	if(use_check_and_message(user))
 		return
-	
+
 	user.set_machine(src)
 	ui_interact(user)
 
 /obj/machinery/computer/ship/Topic(href, href_list)
+	if(..())
+		return TOPIC_HANDLED
 	if(href_list["sync"])
 		sync_linked()
 		return TOPIC_REFRESH
@@ -81,8 +83,10 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		look(user)
 
 /obj/machinery/computer/ship/check_eye(var/mob/user)
+	if(!viewing_overmap(user))
+		return FALSE
+
 	if (use_check_and_message(user) || user.blinded || inoperable() || !linked)
-		unlook(user)
 		return -1
 	else
 		return 0

--- a/html/changelogs/johnwildkins-overmap.yml
+++ b/html/changelogs/johnwildkins-overmap.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes overmap console processing / topic calls, so the consoles properly function now. Also stops an infinite-lifecycle loop while viewing the overmap."


### PR DESCRIPTION
fixes overmap consoles so they actually process, do topic calls, and don't infinitely loop checking vision