### PR TITLE
Passport & passcard fix

### DIFF
--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -260,6 +260,7 @@
 	w_class = ITEMSIZE_TINY
 	flippable = FALSE
 	v_flippable = FALSE
+	badge_string = null
 
 	drop_sound = 'sound/items/drop/card.ogg'
 	pickup_sound = 'sound/items/pickup/card.ogg'
@@ -446,6 +447,7 @@
 	w_class = ITEMSIZE_TINY
 	flippable = FALSE
 	v_flippable = FALSE
+	badge_string = null
 
 	drop_sound = 'sound/items/drop/cloth.ogg'
 

--- a/html/changelogs/PassFix.yml
+++ b/html/changelogs/PassFix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheGreyWolf
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Human passports & passcards will no longer say they are corporate security."


### PR DESCRIPTION
Before when clicking on a passport (and by extension passcard after a quick check of the code) it would add "Corporate security" to what is displayed due to being a subtype of badges. This stops that.