### PR TITLE
Raises blood bag transfer rates for in-hand and roller bed transfusions

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -22,7 +22,7 @@
 	volume = 200
 
 	amount_per_transfer_from_this = 0.2
-	possible_transfer_amounts = list(0.2, 1, 2)
+	possible_transfer_amounts = list(0.2, 1, 2, 3, 4)
 	flags = OPENCONTAINER
 
 	var/datum/weakref/attached_mob

--- a/html/changelogs/ivchangelog.yml
+++ b/html/changelogs/ivchangelog.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: UncleJo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Blood bags can now transfer at up to 4u per second when started on roller beds or in-hand, bringing them in line with IV stand tranfusions."


### PR DESCRIPTION
Recent changes only allowed rates of 0.2, 1, and 2 units per second. Now you can transfer at 0.2, 1, 2, 3, or 4 units.