### PR TITLE
Fix shoes applying their slowdown twice

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -46,9 +46,6 @@
 			else if(E.status & ORGAN_BROKEN)
 				tally += 1.5
 	else
-		if(shoes)
-			tally += shoes.slowdown
-
 		for(var/organ_name in list(BP_L_FOOT,BP_R_FOOT,BP_L_LEG,BP_R_LEG))
 			var/obj/item/organ/external/E = get_organ(organ_name)
 			if(!E || E.is_stump())

--- a/html/changelogs/johnwildkins-shoefix.yml
+++ b/html/changelogs/johnwildkins-shoefix.yml
@@ -1,0 +1,4 @@
+author: JohnWildkins
+delete-after: True
+changes:
+  - bugfix: "Shoes that cause slowdown (such as activated magboots) no longer apply their slowdown twice."


### PR DESCRIPTION
Previous slowdown fixes introduced a new bug where shoes with slowdown (magboots) applied it twice in movement calculation

For those of you not intricately familiar with movement calculations at home, this means that on average, you'll gain a whopping 0.4 steps per second back!