### PR TITLE
vampire stealth desc fix

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -11,7 +11,7 @@
 	if(vampire.stealth)
 		to_chat(src, SPAN_NOTICE("Your victims will now forget your interactions, and get paralyzed when you do them."))
 	else
-		to_chat(src, SPAN_NOTICE("Your victims will now remember your interactions, and stay completely mobile during them."))
+		to_chat(src, SPAN_NOTICE("Your victims will now remember your interactions."))
 
 // Drains the target's blood.
 /mob/living/carbon/human/proc/vampire_drain_blood()

--- a/html/changelogs/VampireFix.yml
+++ b/html/changelogs/VampireFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed vampire description telling that victims would be mobile when draining them when they were in fact stunned."


### PR DESCRIPTION
The victims are still stunned (thus unable to move) while draining them even if they remember it so the description was rather inaccurate. This removes the part about them being mobile.