### PR TITLE
Phoron Bounty Update

### DIFF
--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -24,10 +24,10 @@
 /datum/bounty/item/phoron_sheet
 	name = "Phoron Sheets"
 	description = "Always prioritize this bounty. Failure to meet this quota may result in adverse impact upon your status in the NanoTrasen Corporation."
-	reward_low = 14000
-	reward_high = 18000
-	required_count = 150
-	random_count = 25
+	reward_low = 7000
+	reward_high = 9000
+	required_count = 75
+	random_count = 15
 	wanted_types = list(/obj/item/stack/material/phoron)
 	high_priority = TRUE
 
@@ -45,10 +45,10 @@
 /datum/bounty/item/phoron_canister
 	name = "Phoron Canisters"
 	description = "Updated requirement: Canisters must now be filled to at least 150% of standard stock amounts (approx. 6,800kPA at a temperature of 20C). Always prioritize this bounty. Failure to meet this quota may result in adverse impact upon your status in the NanoTrasen Corporation."
-	reward_low = 15000
-	reward_high = 18000
-	required_count = 5
-	random_count = 1 // 4 to 6
+	reward_low = 8000
+	reward_high = 10000
+	required_count = 3
+	random_count = 1 // 2 to 4
 	wanted_types = list(/obj/machinery/portable_atmospherics/canister)
 	high_priority = TRUE	
 	var/moles_required = 2700 //Roundstart total_moles is about 1871 per tank. 50% more full w/ leeway

--- a/code/modules/cargo/random_stock/t2_uncommon.dm
+++ b/code/modules/cargo/random_stock/t2_uncommon.dm
@@ -14,11 +14,11 @@ STOCK_ITEM_UNCOMMON(plasteel, 3)
 STOCK_ITEM_UNCOMMON(silver, 2)
 	new /obj/item/stack/material/silver(L, rand(5,30))
 
-STOCK_ITEM_UNCOMMON(phoronsheets, 1)
-	new /obj/item/stack/material/phoron(L, rand(5,30))
+STOCK_ITEM_UNCOMMON(phoronsheets, 0.5)
+	new /obj/item/stack/material/phoron(L, rand(5,20))
 
-STOCK_ITEM_UNCOMMON(phoronglass, 1)
-	new /obj/item/stack/material/glass/phoronglass(L, rand(10,30))
+STOCK_ITEM_UNCOMMON(phoronglass, 0.5)
+	new /obj/item/stack/material/glass/phoronglass(L, rand(10,20))
 
 STOCK_ITEM_UNCOMMON(sandstone, 2)
 	new /obj/item/stack/material/sandstone(L, 50)

--- a/html/changelogs/doxxmedearly - phoronbounty2.yml
+++ b/html/changelogs/doxxmedearly - phoronbounty2.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - tweak: "Reduced the required amounts for phoron sheet and phoron canister bounties. Reduced phoron spawns in warehouse."


### PR DESCRIPTION
Based on feedback, the amount required for the phoron bounty was way too much for even multiple miners, especially with the reduced amount of spawns on the asteroid. Compensated by making phoron sheets and phoron glass even rarer to find in the warehouse. 