### PR TITLE
Catch Noise Fix

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -184,7 +184,8 @@
 				src.SpinAnimation(speed = 4, loops = 1)
 
 	//done throwing, either because it hit something or it finished moving
-	if(isobj(src)) src.throw_impact(get_turf(src),speed)
+	if(isturf(loc) && isobj(src))
+		throw_impact(loc, speed)
 	src.throwing = 0
 	src.thrower = null
 	src.throw_source = null

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -305,25 +305,24 @@
 				return 0
 
 /obj/item/throw_impact(atom/hit_atom)
-	..()
 	if(isliving(hit_atom)) //Living mobs handle hit sounds differently.
 		var/mob/living/L = hit_atom
 		if(L.in_throw_mode)
 			playsound(hit_atom, pickup_sound, PICKUP_SOUND_VOLUME, TRUE)
-			return
-		var/volume = get_volume_by_throwforce_and_or_w_class()
-		if(throwforce > 0)
-			if(mob_throw_hit_sound)
-				playsound(hit_atom, mob_throw_hit_sound, volume, TRUE, -1)
-			else if(hitsound)
-				playsound(hit_atom, hitsound, volume, TRUE, -1)
-			else
-				playsound(hit_atom, 'sound/weapons/genhit.ogg', volume, TRUE, -1)
 		else
-			playsound(hit_atom, 'sound/weapons/throwtap.ogg', 1, volume, -1)
+			var/volume = get_volume_by_throwforce_and_or_w_class()
+			if(throwforce > 0)
+				if(mob_throw_hit_sound)
+					playsound(hit_atom, mob_throw_hit_sound, volume, TRUE, -1)
+				else if(hitsound)
+					playsound(hit_atom, hitsound, volume, TRUE, -1)
+				else
+					playsound(hit_atom, 'sound/weapons/genhit.ogg', volume, TRUE, -1)
+			else
+				playsound(hit_atom, 'sound/weapons/throwtap.ogg', 1, volume, -1)
 	else
 		playsound(src, drop_sound, THROW_SOUND_VOLUME)
-
+	return ..()
 
 //Apparently called whenever an item is dropped on the floor, thrown, or placed into a container.
 //It is called after loc is set, so if placed in a container its loc will be that container.

--- a/html/changelogs/geeves-catch_noise.yml
+++ b/html/changelogs/geeves-catch_noise.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Catching something will now longer deafen you with the item's dropsound, instead, it'll just smoothly play the pick-up sound."


### PR DESCRIPTION
* Catching something will now longer deafen you with the item's dropsound, instead, it'll just smoothly play the pick-up sound.

https://github.com/Aurorastation/Aurora.3/pull/10066 but it actually works