### PR TITLE
K'ois Healing Buff

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -14,18 +14,29 @@
 /decl/reagent/kois/affect_ingest(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(!ishuman(M))
 		return
-	var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]
-	if((alien == IS_VAURCA) || (istype(P) && P.stage >= 3))
-		M.heal_organ_damage(1.2 * removed, 1.2 * removed)
+	var/is_vaurcalike = (alien == IS_VAURCA)
+	if(!is_vaurcalike)
+		var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]
+		if(istype(P) && P.stage >= 3)
+			is_vaurcalike = TRUE
+	if(is_vaurcalike)
+		M.heal_organ_damage(1.4 * removed, 1.6 * removed)
 		M.adjustNutritionLoss(-nutriment_factor * removed)
-		M.add_chemical_effect(CE_BLOODRESTORE, 6 * removed)
-
 	else
 		infect(M, alien, removed)
 
 /decl/reagent/kois/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(ishuman(M))
 		infect(M, alien, removed)
+
+/decl/reagent/kois/affect_chem_effect(mob/living/carbon/M, alien, removed, datum/reagents/holder)
+	var/is_vaurcalike = (alien == IS_VAURCA)
+	if(!is_vaurcalike)
+		var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]
+		if(istype(P) && P.stage >= 3)
+			is_vaurcalike = TRUE
+	if(is_vaurcalike)
+		M.add_chemical_effect(CE_BLOODRESTORE, 6 * removed)
 
 /decl/reagent/kois/proc/infect(var/mob/living/carbon/human/H, var/alien, var/removed)
 	var/obj/item/organ/internal/parasite/P = H.internal_organs_by_name["blackkois"]

--- a/html/changelogs/geeves-kois_healing.yml
+++ b/html/changelogs/geeves-kois_healing.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Buffed K'ois healing, it now heals 1.4 brute damage per unit, up from 1.2. And 1.6 burn damage per unit, up from 1.2."
+  - bugfix: "Moved the blood restoring part of K'ois to the correct place, it should work properly now."


### PR DESCRIPTION
* Buffed K'ois healing, it now heals 1.4 brute damage per unit, up from 1.2. And 1.6 burn damage per unit, up from 1.2.
* Moved the blood restoring part of K'ois to the correct place, it should work properly now.