### PR TITLE
Modifies modular computer programs & loadout

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -351,7 +351,7 @@
 	jobtype = /datum/job/librarian
 
 	uniform = /obj/item/clothing/under/suit_jacket/charcoal
-	l_pocket = /obj/item/modular_computer/handheld/custom_loadout/advanced
+	l_pocket = /obj/item/modular_computer/handheld/preset
 	r_pocket = /obj/item/card/tech_support
 	r_hand = /obj/item/storage/bag/circuits/basic
 	l_hand = /obj/item/modular_computer/laptop/preset

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -19,7 +19,7 @@
 	new /obj/item/clothing/head/softcap/cargo(src)
 	new /obj/item/clothing/head/bandana/cargo(src)
 	new /obj/item/clothing/head/beret/cargo(src)
-	new /obj/item/modular_computer/handheld/custom_loadout/advanced/cargo_delivery(src)
+	new /obj/item/modular_computer/handheld/preset/supply/cargo_delivery(src)
 	new /obj/item/export_scanner(src)
 
 /obj/structure/closet/secure_closet/quartermaster
@@ -44,7 +44,7 @@
 	new /obj/item/clothing/head/softcap/cargo(src)
 	new /obj/item/clothing/head/bandana/cargo(src)
 	new /obj/item/clothing/head/beret/cargo(src)
-	new /obj/item/modular_computer/handheld/custom_loadout/advanced/cargo_delivery(src)
+	new /obj/item/modular_computer/handheld/preset/supply/cargo_delivery(src)
 	new /obj/item/export_scanner(src)
 	new /obj/item/device/orbital_dropper/drill(src)
 	new /obj/item/device/megaphone/cargo(src)

--- a/code/modules/client/preference_setup/loadout/loadout_computer.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_computer.dm
@@ -1,47 +1,44 @@
 /datum/gear/computer
-	display_name = "tablet"
-	path = /obj/item/modular_computer/handheld/custom_loadout/cheap
+	display_name = "laptop computer"
+	path = /obj/item/modular_computer/laptop/preset
 	sort_category = "Modular Computers"
 	cost = 2
 
-/datum/gear/computer/laptop
-	display_name = "laptop computer"
-	path = /obj/item/modular_computer/laptop/preset
-	cost = 3
+/datum/gear/computer/handheld/tablet
+	display_name = "tablet"
+	path = /obj/item/modular_computer/handheld/preset
+
+/datum/gear/computer/handheld/tablet/New()
+	..()
+	var/tablets = list()
+	tablets["generic tablet"] = /obj/item/modular_computer/handheld/preset
+	tablets["janitor tablet"] = /obj/item/modular_computer/handheld/preset/civilian/janitor
+	tablets["cargo tablet"] = /obj/item/modular_computer/handheld/preset/supply
+	tablets["engineering tablet"] = /obj/item/modular_computer/handheld/preset/engineering
+	tablets["atmos tablet"] = /obj/item/modular_computer/handheld/preset/engineering/atmos
+	tablets["medical tablet"] =/obj/item/modular_computer/handheld/preset/medical
+	tablets["security tablet"] = /obj/item/modular_computer/handheld/preset/security
+	tablets["investigation tablet"] = /obj/item/modular_computer/handheld/preset/security/detective
+	tablets["research tablet"] = /obj/item/modular_computer/handheld/preset/research
+	tablets["robotics tablet"] = /obj/item/modular_computer/handheld/preset/research/robotics
+	gear_tweaks += new/datum/gear_tweak/path(tablets)
 
 /datum/gear/computer/handheld/wristbound
-	display_name = "wristbound computer"
-	path = /obj/item/modular_computer/handheld/wristbound/preset/cheap/generic
+	display_name = "wristbound computer selection"
+	path = /obj/item/modular_computer/handheld/wristbound/preset
 
-/datum/gear/computer/handheld/wristbound/cargo
-	display_name = "wristbound computer (Cargo)"
-	path = /obj/item/modular_computer/handheld/wristbound/preset/advanced/cargo
-	allowed_roles = list("Cargo Technician", "Shaft Miner", "Quartermaster")
-
-/datum/gear/computer/handheld/wristbound/engineering
-	display_name = "wristbound computer (Engineering)"
-	path = /obj/item/modular_computer/handheld/wristbound/preset/advanced/engineering
-	allowed_roles = list("Station Engineer", "Engineering Apprentince", "Atmospheric Technician", "Engineering Apprentice")
-
-/datum/gear/computer/handheld/wristbound/medical
-	display_name = "wristbound computer (Medical)"
-	path = /obj/item/modular_computer/handheld/wristbound/preset/advanced/medical
-	allowed_roles = list("Physician", "Surgeon", "Medical Intern", "Pharmacist", "Psychiatrist", "First Responder")
-
-/datum/gear/computer/handheld/wristbound/security
-	display_name = "wristbound computer (Security)"
-	path = /obj/item/modular_computer/handheld/wristbound/preset/advanced/security
-	allowed_roles = list("Security Officer", "Warden", "Security Cadet")
-
-/datum/gear/computer/handheld/wristbound/security/investigations
-	display_name = "wristbound computer (Security Investigations)"
-	path = /obj/item/modular_computer/handheld/wristbound/preset/advanced/security/investigations
-	allowed_roles = list("Investigator")
-
-/datum/gear/computer/handheld/wristbound/security/research
-	display_name = "wristbound computer (Research)"
-	path = /obj/item/modular_computer/handheld/wristbound/preset/advanced/research
-	allowed_roles = list("Scientist", "Lab Assistant", "Roboticist", "Xenobiologist")
+/datum/gear/computer/handheld/wristbound/New()
+	..()
+	var/wristbounds = list()
+	wristbounds["cheap generic wristbound"] = /obj/item/modular_computer/handheld/wristbound/preset/cheap/generic
+	wristbounds["expensive generic wristbound"] = /obj/item/modular_computer/handheld/wristbound/preset/advanced/generic
+	wristbounds["cargo wristbound"] = /obj/item/modular_computer/handheld/wristbound/preset/advanced/cargo
+	wristbounds["engineering wristbound"] = /obj/item/modular_computer/handheld/wristbound/preset/advanced/engineering
+	wristbounds["medical wristbound"] = /obj/item/modular_computer/handheld/wristbound/preset/advanced/medical
+	wristbounds["security wristbound"] = /obj/item/modular_computer/handheld/wristbound/preset/advanced/security
+	wristbounds["investigation wristbound"] = /obj/item/modular_computer/handheld/wristbound/preset/advanced/security/investigations
+	wristbounds["research wristbound"] = /obj/item/modular_computer/handheld/wristbound/preset/advanced/research
+	gear_tweaks += new/datum/gear_tweak/path(wristbounds)
 
 /datum/gear/computer/handheld/wristbound/ce
 	display_name = "wristbound computer (Chief Engineer)"

--- a/code/modules/modular_computers/computers/subtypes/dev_handheld.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_handheld.dm
@@ -18,6 +18,6 @@
 	set_icon()
 
 /obj/item/modular_computer/handheld/proc/set_icon()
-	icon_state += pick("", "-blue", "-green", "-red", "-brown")
+	icon_state += ""// pick("", "-blue", "-green", "-red", "-brown")
 	icon_state_unpowered = icon_state
 	icon_state_broken = icon_state

--- a/code/modules/modular_computers/computers/subtypes/dev_handheld.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_handheld.dm
@@ -18,6 +18,5 @@
 	set_icon()
 
 /obj/item/modular_computer/handheld/proc/set_icon()
-	icon_state += ""// pick("", "-blue", "-green", "-red", "-brown")
 	icon_state_unpowered = icon_state
 	icon_state_broken = icon_state

--- a/code/modules/modular_computers/computers/subtypes/preset_handheld.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_handheld.dm
@@ -1,33 +1,6 @@
-/obj/item/modular_computer/handheld/custom_loadout/cheap/install_default_hardware()
-	..()
-	processor_unit = new /obj/item/computer_hardware/processor_unit/small(src)
-	hard_drive = new /obj/item/computer_hardware/hard_drive/micro(src)
-	network_card = new /obj/item/computer_hardware/network_card(src)
-	battery_module = new /obj/item/computer_hardware/battery_module(src)
-	card_slot = new /obj/item/computer_hardware/card_slot(src)
-	tesla_link = new /obj/item/computer_hardware/tesla_link/charging_cable(src)
-	battery_module.charge_to_full()
-
-/obj/item/modular_computer/handheld/custom_loadout/advanced/install_default_hardware()
-	..()
-	processor_unit = new /obj/item/computer_hardware/processor_unit/small(src)
-	hard_drive = new /obj/item/computer_hardware/hard_drive/small(src)
-	network_card = new /obj/item/computer_hardware/network_card(src)
-	nano_printer = new /obj/item/computer_hardware/nano_printer(src)
-	card_slot = new /obj/item/computer_hardware/card_slot(src)
-	battery_module = new /obj/item/computer_hardware/battery_module(src)
-	tesla_link = new /obj/item/computer_hardware/tesla_link/charging_cable(src)
-	battery_module.charge_to_full()
-
-
-// Cargo Delivery
-/obj/item/modular_computer/handheld/custom_loadout/advanced/cargo_delivery
-	_app_preset_type = /datum/modular_computer_app_presets/cargo_delivery
-	enrolled = DEVICE_PRIVATE
-
 // Tablet PDA presets
 /obj/item/modular_computer/handheld/preset
-	enrolled = DEVICE_PRIVATE
+	enrolled = DEVICE_COMPANY
 
 /obj/item/modular_computer/handheld/preset/install_default_hardware()
 	..()
@@ -43,6 +16,7 @@
 
 /obj/item/modular_computer/handheld/preset/civilian
 	_app_preset_type = /datum/modular_computer_app_presets/civilian
+	enrolled = DEVICE_PRIVATE
 
 /obj/item/modular_computer/handheld/preset/civilian/bartender/Initialize()
 	. = ..()
@@ -69,6 +43,11 @@
 /obj/item/modular_computer/handheld/preset/engineering
 	_app_preset_type = /datum/modular_computer_app_presets/engineering
 
+/obj/item/modular_computer/handheld/preset/engineering/set_icon()
+	icon_state += "-brown"
+	icon_state_unpowered = icon_state
+	icon_state_broken = icon_state
+
 /obj/item/modular_computer/handheld/preset/engineering/Initialize()
 	. = ..()
 	card_slot.stored_item = new /obj/item/pen/silver
@@ -83,6 +62,11 @@
 /obj/item/modular_computer/handheld/preset/supply
 	_app_preset_type = /datum/modular_computer_app_presets/supply
 
+/obj/item/modular_computer/handheld/preset/supply/set_icon()
+	icon_state += "-brown"
+	icon_state_unpowered = icon_state
+	icon_state_broken = icon_state
+
 /obj/item/modular_computer/handheld/preset/supply/Initialize()
 	. = ..()
 	card_slot.stored_item = new /obj/item/pen/silver
@@ -91,10 +75,19 @@
 	. = ..()
 	card_slot.stored_item = new /obj/item/pen/fountain
 
+// Cargo Delivery
+/obj/item/modular_computer/handheld/preset/supply/cargo_delivery
+	_app_preset_type = /datum/modular_computer_app_presets/cargo_delivery
+
 // Medical
 
 /obj/item/modular_computer/handheld/preset/medical
 	_app_preset_type = /datum/modular_computer_app_presets/medical
+
+/obj/item/modular_computer/handheld/preset/medical/set_icon()
+	icon_state += "-green"
+	icon_state_unpowered = icon_state
+	icon_state_broken = icon_state
 
 /obj/item/modular_computer/handheld/preset/medical/Initialize()
 	. = ..()
@@ -126,6 +119,11 @@
 
 /obj/item/modular_computer/handheld/preset/security
 	_app_preset_type = /datum/modular_computer_app_presets/security
+
+/obj/item/modular_computer/handheld/preset/security/set_icon()
+	icon_state += "-blue"
+	icon_state_unpowered = icon_state
+	icon_state_broken = icon_state
 
 /obj/item/modular_computer/handheld/preset/security/detective
 	_app_preset_type = /datum/modular_computer_app_presets/security/investigations

--- a/code/modules/modular_computers/computers/subtypes/preset_wristbound.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_wristbound.dm
@@ -10,6 +10,7 @@
 
 /obj/item/modular_computer/handheld/wristbound/preset/cheap/generic
 	_app_preset_type = /datum/modular_computer_app_presets/civilian
+	enrolled = DEVICE_PRIVATE
 
 /obj/item/modular_computer/handheld/wristbound/preset/advanced/install_default_hardware()
 	..()
@@ -23,9 +24,16 @@
 	flashlight = new /obj/item/computer_hardware/flashlight(src)
 	battery_module.charge_to_full()
 
+/obj/item/modular_computer/handheld/wristbound/preset/advanced
+	enrolled = DEVICE_COMPANY
+
+/obj/item/modular_computer/handheld/wristbound/preset/advanced/generic
+	_app_preset_type = /datum/modular_computer_app_presets/civilian
+	enrolled = DEVICE_PRIVATE
+
 /obj/item/modular_computer/handheld/wristbound/preset/advanced/cargo
 	icon_state = "wristbound_cargo"
-	_app_preset_type = /datum/modular_computer_app_presets/cargo_delivery
+	_app_preset_type = /datum/modular_computer_app_presets/supply
 
 /obj/item/modular_computer/handheld/wristbound/preset/advanced/engineering
 	icon_state = "wristbound_engineering"

--- a/code/modules/modular_computers/file_system/programs/app_presets.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets.dm
@@ -39,8 +39,7 @@
 		new /datum/computer_file/program/atmos_control(comp),
 		new /datum/computer_file/program/rcon_console(comp),
 		new /datum/computer_file/program/camera_monitor(comp),
-		new /datum/computer_file/program/lighting_control(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/lighting_control(comp)
 	)
 	return _prg_list
 
@@ -64,7 +63,6 @@
 		new /datum/computer_file/program/rcon_console(comp),
 		new /datum/computer_file/program/camera_monitor(comp),
 		new /datum/computer_file/program/lighting_control(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp),
 		new /datum/computer_file/program/scanner/gas(comp)
 	)
 	return _prg_list
@@ -92,7 +90,6 @@
 		new /datum/computer_file/program/camera_monitor(comp),
 		new /datum/computer_file/program/lighting_control(comp),
 		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp),
 		new /datum/computer_file/program/scanner/gas(comp)
 	)
 	return _prg_list
@@ -112,7 +109,6 @@
 		new /datum/computer_file/program/civilian/cargoorder(comp),
 		new /datum/computer_file/program/suit_sensors(comp),
 		new /datum/computer_file/program/records/medical(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp),
 		new /datum/computer_file/program/chemistry_codex(comp),
 		new /datum/computer_file/program/scanner/medical(comp)
 	)
@@ -136,7 +132,6 @@
 		new /datum/computer_file/program/suit_sensors(comp),
 		new /datum/computer_file/program/records/employment(comp),
 		new /datum/computer_file/program/records/medical(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp),
 		new /datum/computer_file/program/chemistry_codex(comp),
 		new /datum/computer_file/program/scanner/medical(comp),
 		new /datum/computer_file/program/scanner/science(comp)
@@ -159,7 +154,6 @@
 		new /datum/computer_file/program/civilian/cargoorder(comp),
 		new /datum/computer_file/program/ntnetmonitor(comp),
 		new /datum/computer_file/program/aidiag(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp),
 		new /datum/computer_file/program/chemistry_codex(comp),
 		new /datum/computer_file/program/scanner/science(comp),
 		new /datum/computer_file/program/scanner/gas(comp)
@@ -182,7 +176,6 @@
 		new /datum/computer_file/program/civilian/cargoorder(comp),
 		new /datum/computer_file/program/ntnetmonitor(comp),
 		new /datum/computer_file/program/aidiag(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp),
 		new /datum/computer_file/program/records/medical(comp),
 		new /datum/computer_file/program/scanner/science(comp),
 		new /datum/computer_file/program/scanner/gas(comp)
@@ -206,7 +199,6 @@
 		new /datum/computer_file/program/comm(comp, FALSE),
 		new /datum/computer_file/program/ntnetmonitor(comp),
 		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp),
 		new /datum/computer_file/program/chemistry_codex(comp),
 		new /datum/computer_file/program/scanner/science(comp),
 		new /datum/computer_file/program/scanner/gas(comp)
@@ -229,8 +221,7 @@
 		new /datum/computer_file/program/civilian/cargoorder(comp),
 		new /datum/computer_file/program/card_mod(comp),
 		new /datum/computer_file/program/comm(comp, FALSE),
-		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/records/employment(comp)
 	)
 	return _prg_list
 
@@ -250,7 +241,6 @@
 		new /datum/computer_file/program/civilian/cargoorder(comp),
 		new /datum/computer_file/program/comm(comp, FALSE),
 		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp),
 		new /datum/computer_file/program/teleporter(comp)
 	)
 	return _prg_list
@@ -273,8 +263,7 @@
 		new /datum/computer_file/program/card_mod(comp),
 		new /datum/computer_file/program/comm(comp, FALSE),
 		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/records/security(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/records/security(comp)
 	)
 	return _prg_list
 
@@ -301,8 +290,7 @@
 		new /datum/computer_file/program/alarm_monitor(comp),
 		new /datum/computer_file/program/records/employment(comp),
 		new /datum/computer_file/program/records/medical(comp),
-		new /datum/computer_file/program/records/security(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/records/security(comp)
 	)
 	return _prg_list
 
@@ -354,12 +342,10 @@
 		new /datum/computer_file/program/chat_client(comp),
 		new /datum/computer_file/program/civilian/cargoorder(comp),
 		new /datum/computer_file/program/camera_monitor(comp),
-		new /datum/computer_file/program/comm(comp),
 		new /datum/computer_file/program/digitalwarrant(comp),
 		new /datum/computer_file/program/penal_mechs(comp),
 		new /datum/computer_file/program/records/security(comp),
-		new /datum/computer_file/program/guntracker(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/guntracker(comp)
 	)
 	return _prg_list
 
@@ -383,8 +369,7 @@
 		new /datum/computer_file/program/penal_mechs(comp),
 		new /datum/computer_file/program/records/security(comp),
 		new /datum/computer_file/program/guntracker(comp),
-		new /datum/computer_file/program/implant_tracker(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/implant_tracker(comp)
 	)
 	return _prg_list
 
@@ -404,11 +389,8 @@
 		new /datum/computer_file/program/chat_client(comp),
 		new /datum/computer_file/program/camera_monitor(comp),
 		new /datum/computer_file/program/digitalwarrant(comp),
-		new /datum/computer_file/program/penal_mechs(comp),
 		new /datum/computer_file/program/records/security(comp),
-		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/records/medical(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/records/medical(comp)
 	)
 	return _prg_list
 
@@ -432,8 +414,7 @@
 		new /datum/computer_file/program/digitalwarrant(comp),
 		new /datum/computer_file/program/penal_mechs(comp),
 		new /datum/computer_file/program/records/security(comp),
-		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/records/employment(comp)
 	)
 	return _prg_list
 
@@ -452,8 +433,7 @@
 		new /datum/computer_file/program/chat_client(comp),
 		new /datum/computer_file/program/civilian/cargoorder(comp),
 		new /datum/computer_file/program/game/arcade(comp),
-		new /datum/computer_file/program/game/sudoku(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/game/sudoku(comp)
 	)
 	return _prg_list
 
@@ -473,8 +453,7 @@
 		new /datum/computer_file/program/civilian/cargoorder(comp),
 		new /datum/computer_file/program/civilian/janitor(comp),
 		new /datum/computer_file/program/game/arcade(comp),
-		new /datum/computer_file/program/game/sudoku(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/game/sudoku(comp)
 	)
 	return _prg_list
 
@@ -505,8 +484,7 @@
 		new /datum/computer_file/program/chat_client(comp),
 		new /datum/computer_file/program/civilian/cargocontrol(comp),
 		new /datum/computer_file/program/civilian/cargoorder(comp),
-		new /datum/computer_file/program/civilian/cargodelivery(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/civilian/cargodelivery(comp)
 	)
 	return _prg_list
 
@@ -523,8 +501,7 @@
 		new /datum/computer_file/program/newsbrowser(comp),
 		new /datum/computer_file/program/manifest(comp),
 		new /datum/computer_file/program/chat_client(comp),
-		new /datum/computer_file/program/civilian/cargodelivery(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/civilian/cargodelivery(comp)
 	)
 	return _prg_list
 
@@ -543,8 +520,7 @@
 		new /datum/computer_file/program/chat_client(comp),
 		new /datum/computer_file/program/game/sudoku(comp),
 		new /datum/computer_file/program/civilian/cargoorder(comp),
-		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/records/employment(comp)
 	)
 	return _prg_list
 
@@ -562,8 +538,7 @@
 		new /datum/computer_file/program/chat_client(comp),
 		new /datum/computer_file/program/civilian/cargoorder(comp),
 		new /datum/computer_file/program/camera_monitor(comp),
-		new /datum/computer_file/program/alarm_monitor(comp),
-		new /datum/computer_file/program/ntsl2_interpreter(comp)
+		new /datum/computer_file/program/alarm_monitor(comp)
 	)
 	return _prg_list
 

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -11,6 +11,7 @@
 	requires_ntnet = TRUE
 	requires_ntnet_feature = NTNET_SYSTEMCONTROL
 	requires_access_to_run = PROGRAM_ACCESS_LIST_ONE
+	requires_access_to_download = PROGRAM_ACCESS_LIST_ONE
 	usage_flags = PROGRAM_ALL_REGULAR | PROGRAM_STATIONBOUND
 
 	var/records_type = RECORD_GENERAL | RECORD_MEDICAL | RECORD_SECURITY | RECORD_VIRUS | RECORD_WARRANT | RECORD_LOCKED
@@ -38,7 +39,7 @@
 	record_prefix = "Medical "
 
 	required_access_run = list(access_medical_equip, access_forensics_lockers, access_detective, access_robotics, access_hop)
-	required_access_download = access_heads
+	required_access_download = list(access_heads, access_medical_equip, access_forensics_lockers)
 	available_on_ntnet = TRUE
 
 	records_type = RECORD_MEDICAL | RECORD_VIRUS
@@ -54,7 +55,7 @@
 	record_prefix = "Security "
 
 	required_access_run = list(access_security, access_forensics_lockers, access_lawyer, access_hop)
-	required_access_download = access_heads
+	required_access_download = list(access_heads, access_security)
 	available_on_ntnet = TRUE
 
 	records_type = RECORD_SECURITY
@@ -70,6 +71,7 @@
 	record_prefix = "Employment "
 
 	required_access_run = list(access_heads, access_lawyer, access_consular)
+	requires_access_to_download = PROGRAM_ACCESS_ONE
 	required_access_download = access_heads
 	available_on_ntnet = TRUE
 

--- a/html/changelogs/computerLoadout.yml
+++ b/html/changelogs/computerLoadout.yml
@@ -1,0 +1,11 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - tweak: "The various non-command wristbounds in the loadout have been merged into one list selection."
+  - tweak: "The loadout laptop now only costs 2 points."
+  - tweak: "Ntsl2 interpreter no longer spawns by default on any modular computer & command program has been removed from the default security computer along with employment from investigator's computers."
+  - bugfix: "Tablets & wristbounds will now start with the appropriate programs for their selected department."
+  - rscadd: "The loadout now has a department tablet selection and the color is no longer randomised for them."
+  - rscadd: "Medical & security can now download their respective records program. Investigators can download both."


### PR DESCRIPTION
- Tablets & wristbound computers (with the exception of command types) are now in a list selection.
- This fixes it so that they properly start with the programs they are supposed to.
- Tablets no longer spawn with random colors and the existing ones were assigned as they appeared appropriate.
- Security can now download the sec record program, medical the med record program and investigators both as they have access to it.
- This removes the ntsl2 interpreter along with a few other programs such as employment records for investigators (who can't use them) as they were mostly bloat in the computers. The ntsl2 interpreter can still be downloaded as normal.
- Loadout computers were changed to cost only 2 points as while they can use certain programs like cameras, they also have to be put on the ground and opened to be used.
- Tablets were also reorganised slightly as there was some unneeded copy-paste.