### PR TITLE
Lets You Roll up the Tribunalist Cape From the Objects Menu

### DIFF
--- a/code/modules/clothing/factions/dominia.dm
+++ b/code/modules/clothing/factions/dominia.dm
@@ -293,6 +293,7 @@
 /obj/item/clothing/accessory/poncho/dominia/red/verb/roll_up_mantle()
 	set name = "Roll Up Cape Mantle"
 	set desc = "Roll up your cape's mantle. Doesn't work with some capes."
+	set category = "Object"
 	set src in usr
 
 	if(use_check_and_message(usr))

--- a/html/changelogs/wickedcybs_capefix.yml
+++ b/html/changelogs/wickedcybs_capefix.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "The tribunalist cape can be rolled up now, which was always its intentional behaviour."

--- a/html/changelogs/wickedcybs_capefix.yml
+++ b/html/changelogs/wickedcybs_capefix.yml
@@ -3,4 +3,4 @@ author: WickedCybs
 delete-after: True
 
 changes:
-  - bugfix: "The tribunalist cape can be rolled up now, if desired."
+  - bugfix: "The tribunalist cape can be rolled up from the objects menu now, also allowing this function to remain when worn as an accessory."

--- a/html/changelogs/wickedcybs_capefix.yml
+++ b/html/changelogs/wickedcybs_capefix.yml
@@ -3,4 +3,4 @@ author: WickedCybs
 delete-after: True
 
 changes:
-  - bugfix: "The tribunalist cape can be rolled up now, which was always its intentional behaviour."
+  - bugfix: "The tribunalist cape can be rolled up now, if desired."


### PR DESCRIPTION
~The ability to roll it up was always intended and was in the code + has sprites, it just wasn't possible in game due to the lack of a "set category" line.~

The Tribunalist Cape can be rolled up from the objects menu now, like how similar accessories and clothing items do it. This means it can also be rolled up while worn as an accessory if desired.