### PR TITLE
Fix hypospray + autoinjector checks

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1514,7 +1514,7 @@
 #define BASE_INJECTION_MOD 1 // x1 multiplier with no effects
 #define SUIT_INJECTION_MOD 2 // x2 multiplier if target is wearing spacesuit
 
-/mob/living/carbon/human/can_inject(var/mob/user, var/error_msg, var/target_zone)
+/mob/living/carbon/human/can_inject(var/mob/user, var/error_msg, var/target_zone, var/handle_coverage = TRUE)
 	. = BASE_INJECTION_MOD
 
 	if(!target_zone)
@@ -1533,7 +1533,7 @@
 	else if (affecting.status & ORGAN_ROBOT)
 		. = INJECTION_FAIL
 		fail_msg = "That limb is robotic."
-	else
+	else if (handle_coverage)
 		. *= get_bp_coverage(target_zone)
 		if(isvaurca(src) && . == SUIT_INJECTION_MOD)
 			user.visible_message("<b>[user]</b> begins hunting for an injection port on \the [src]'s carapace.")

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -57,12 +57,8 @@
 	return 1
 
 /obj/item/reagent_containers/hypospray/borghypo/inject(var/mob/living/M, var/mob/user, proximity)
-
-	if(!proximity)
+	if(!proximity || !istype(M))
 		return
-
-	if(!istype(M))
-		return ..()
 
 	if(!reagent_volumes[reagent_ids[mode]])
 		to_chat(user,"<span class='warning'>The injector is empty.</span>")

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -56,7 +56,7 @@
 					reagent_volumes[T] = min(reagent_volumes[T] + 5, volume)
 	return 1
 
-/obj/item/reagent_containers/hypospray/borghypo/afterattack(var/mob/living/M, var/mob/user, proximity)
+/obj/item/reagent_containers/hypospray/borghypo/inject(var/mob/living/M, var/mob/user, proximity)
 
 	if(!proximity)
 		return
@@ -68,27 +68,23 @@
 		to_chat(user,"<span class='warning'>The injector is empty.</span>")
 		return
 
-	var/mob/living/carbon/human/H = M
-	if(istype(H))
-		var/obj/item/organ/external/affected = H.get_organ(user.zone_sel.selecting)
-		if(!affected)
-			to_chat(user,"<span class='danger'>\The [H] is missing that limb!</span>")
-			return
-		else if(affected.status & ORGAN_ROBOT)
-			to_chat(user,"<span class='danger'>You cannot inject a robotic limb.</span>")
-			return
+	user.visible_message("<span class='notice'>[user] injects [M] with their hypospray!</span>", "<span class='notice'>You inject [M] with your hypospray!</span>", "<span class='notice'>You hear a hissing noise.</span>")
+	to_chat(M,"<span class='notice'>You feel a tiny prick!</span>")
 
-	if (M.can_inject(user, 1))
-		user.visible_message("<span class='notice'>[user] injects [M] with their hypospray!</span>", "<span class='notice'>You inject [M] with your hypospray!</span>", "<span class='notice'>You hear a hissing noise.</span>")
-		to_chat(M,"<span class='notice'>You feel a tiny prick!</span>")
-
-		if(M.reagents)
-			var/t = min(amount_per_transfer_from_this, reagent_volumes[reagent_ids[mode]])
-			M.reagents.add_reagent(reagent_ids[mode], t)
-			reagent_volumes[reagent_ids[mode]] -= t
-			admin_inject_log(user, M, src, reagent_ids[mode], reagents.get_temperature(), t)
-			to_chat(user,"<span class='notice'>[t] units injected. [reagent_volumes[reagent_ids[mode]]] units remaining.</span>")
+	if(M.reagents)
+		var/t = min(amount_per_transfer_from_this, reagent_volumes[reagent_ids[mode]])
+		M.reagents.add_reagent(reagent_ids[mode], t)
+		reagent_volumes[reagent_ids[mode]] -= t
+		admin_inject_log(user, M, src, reagent_ids[mode], reagents.get_temperature(), t)
+		to_chat(user,"<span class='notice'>[t] units injected. [reagent_volumes[reagent_ids[mode]]] units remaining.</span>")
 	return
+
+/obj/item/reagent_containers/hypospray/borghypo/afterattack(atom/target, mob/user, proximity)
+	if (!proximity)
+		return
+
+	if (!isliving(target))
+		return ..()
 
 /obj/item/reagent_containers/hypospray/borghypo/attack_self(mob/user as mob) //Change the mode
 	var/t = ""

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -50,14 +50,16 @@
 	if(isliving(M))
 		var/mob/living/L = M
 		var/inj_time = time
-		inj_time *= L.can_inject(user, TRUE)
-		if(!inj_time)
+		var/mod_time = L.can_inject(user, TRUE, target_zone, armorcheck)
+		if(!mod_time)
 			return
+		else if(inj_time <= 0 && mod_time > 1)
+			inj_time = (1 SECOND) * mod_time
+		else
+			inj_time *= mod_time
 		user.visible_message(SPAN_WARNING("\The [user] is trying to inject \the [L] with \the [src]!"), SPAN_NOTICE("You are trying to inject \the [L] with \the [src]."))
-		if(armorcheck && L.get_blocked_ratio(target_zone, BRUTE, damage = 10))
-			inj_time += 6 SECONDS
-		if(!do_mob(user, L, inj_time))
-			return 1
+		if(do_mob(user, L, inj_time))
+			inject(M, user, M.Adjacent(user))
 
 /obj/item/reagent_containers/hypospray/update_icon()
 	cut_overlays()
@@ -73,7 +75,7 @@
 		filling.color = reagents.get_color()
 		add_overlay(filling)
 
-/obj/item/reagent_containers/hypospray/afterattack(var/mob/M, var/mob/user, proximity)
+/obj/item/reagent_containers/hypospray/proc/inject(var/mob/M, var/mob/user, proximity)
 
 	if (!istype(M))
 		return ..()
@@ -100,6 +102,13 @@
 
 	update_icon()
 	return TRUE
+
+/obj/item/reagent_containers/hypospray/afterattack(atom/target, mob/user, proximity)
+	if (!proximity)
+		return
+
+	if (!isliving(target))
+		return ..()
 
 /obj/item/reagent_containers/hypospray/autoinjector
 	name = "autoinjector"
@@ -132,7 +141,7 @@
 		return FALSE
 	. = ..()
 
-/obj/item/reagent_containers/hypospray/autoinjector/afterattack(mob/M, mob/user, proximity)
+/obj/item/reagent_containers/hypospray/autoinjector/inject(mob/M, mob/user, proximity)
 	. = ..()
 	if(.)
 		spent = TRUE
@@ -230,7 +239,7 @@
 	item_state = "combat_hypo"
 	icon_state = "combat_hypo"
 	volume = 20
-	armorcheck = 0
+	armorcheck = FALSE
 	time = 0
 
 	reagents_to_add = list(/decl/reagent/oxycomorphine = 5, /decl/reagent/synaptizine = 5, /decl/reagent/hyperzine = 5, /decl/reagent/arithrazine = 5)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -76,11 +76,7 @@
 		add_overlay(filling)
 
 /obj/item/reagent_containers/hypospray/proc/inject(var/mob/M, var/mob/user, proximity)
-
-	if (!istype(M))
-		return ..()
-
-	if(!proximity)
+	if(!proximity || !istype(M))
 		return
 
 	if(!reagents.total_volume)

--- a/html/changelogs/johnwildkins-hypofix.yml
+++ b/html/changelogs/johnwildkins-hypofix.yml
@@ -1,0 +1,5 @@
+author: JohnWildkins
+delete-after: True
+
+changes:
+  - bugfix: "Hyposprays and autoinjectors should now account for armor coverage properly, and prevent injection on invalid targets (incl. robotic limbs)."


### PR DESCRIPTION
Due to two code bugs making a mostly-working product, hyposprays and autoinjectors were failing to account for the new injection site changes in the latest PR, as well as even basic checks like "does this limb exist" or "is it robotic"