### PR TITLE
fixes ear slot sprites

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_ears.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_ears.dm
@@ -2,7 +2,7 @@
 	display_name = "earmuffs"
 	path = /obj/item/clothing/ears/earmuffs
 	sort_category = "Earwear"
-	slot = slot_r_ear
+	slot = null
 
 /datum/gear/ears/bandanna
 	display_name = "neck bandanna selection"

--- a/code/modules/client/preference_setup/loadout/loadout_ears.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_ears.dm
@@ -1,7 +1,12 @@
 /datum/gear/ears
+	display_name = "earwear, circuitry (empty)"
+	path = /obj/item/clothing/ears/circuitry
+	sort_category = "Earwear"
+	slot = slot_r_ear
+
+/datum/gear/ears/double
 	display_name = "earmuffs"
 	path = /obj/item/clothing/ears/earmuffs
-	sort_category = "Earwear"
 	slot = null
 
 /datum/gear/ears/bandanna
@@ -21,13 +26,9 @@
 	path = /obj/item/clothing/ears/bandanna_colorable
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 
-/datum/gear/ears/headphones
+/datum/gear/ears/double/headphones
 	display_name = "headphones"
 	path = /obj/item/clothing/ears/earmuffs/headphones
-
-/datum/gear/ears/circuitry
-	display_name = "earwear, circuitry (empty)"
-	path = /obj/item/clothing/ears/circuitry
 
 /datum/gear/ears/earrings
 	display_name = "earring selection"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -720,7 +720,7 @@ There are several things that need to be remembered:
 	if(QDELING(src))
 		return
 
-	if(check_draw_ears())
+	if(check_draw_left_ear())
 		if(l_ear)
 			var/image/result_layer = null
 
@@ -763,7 +763,7 @@ There are several things that need to be remembered:
 	if(QDELING(src))
 		return
 
-	if(check_draw_ears())
+	if(check_draw_right_ear())
 		if(r_ear)
 			var/image/result_layer = null
 
@@ -1568,15 +1568,24 @@ There are several things that need to be remembered:
 	else
 		return TRUE
 
-/mob/living/carbon/human/proc/check_draw_ears()
-	if (!l_ear && !r_ear)
+/mob/living/carbon/human/proc/check_draw_right_ear()
+	if (!r_ear)
 		return FALSE
-	else if ((l_ear && (l_ear.flags_inv & ALWAYSDRAW)) || (r_ear && (r_ear.flags_inv & ALWAYSDRAW)))
+	else if (r_ear.flags_inv & ALWAYSDRAW)
 		return TRUE
-	else if( (head && (head.flags_inv & (HIDEEARS))) || (wear_mask && (wear_mask.flags_inv & (HIDEEARS))))
+	else if ((head && (head.flags_inv & (HIDEEARS))) || (wear_mask && (wear_mask.flags_inv & (HIDEEARS))))
 		return FALSE
-	else
+	return TRUE
+
+
+/mob/living/carbon/human/proc/check_draw_left_ear()
+	if (!l_ear)
+		return FALSE
+	else if (l_ear.flags_inv & ALWAYSDRAW)
 		return TRUE
+	else if ((head && (head.flags_inv & (HIDEEARS))) || (wear_mask && (wear_mask.flags_inv & (HIDEEARS))))
+		return FALSE
+	return TRUE
 
 /mob/living/carbon/human/proc/check_draw_glasses()
 	if (!glasses)

--- a/html/changelogs/EarFix.yml
+++ b/html/changelogs/EarFix.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "Ear slot mob sprites will now update properly again."
-  - bugfix: "Prevented an issue from causing earmuffs & headphones to replace headsets for latejoins. All loadout ear items now spawn in a bag."
+  - bugfix: "Prevented an issue from causing earmuffs & headphones to replace headsets for latejoins. All two ear items will now spawn in bags rather than on the ear."

--- a/html/changelogs/EarFix.yml
+++ b/html/changelogs/EarFix.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Ear slot mob sprites will now update properly again."
+  - bugfix: "Prevented an issue from causing earmuffs & headphones to replace headsets for latejoins. All loadout ear items now spawn in a bag."


### PR DESCRIPTION
fixes https://github.com/Aurorastation/Aurora.3/issues/11620
fixes https://github.com/Aurorastation/Aurora.3/issues/11208
fixes https://github.com/Aurorastation/Aurora.3/issues/11185

Apparently the old thing was broken so this checks it properly. Also double ear slot items are set to spawn in a bag like ordinary items now to prevent cases where latejoins (at least on the arrival shuttle) would spawn with earmuffs/headphones on which meant their job headset would not spawn.