### PR TITLE
Refluffs the Dominian Bomber Jacket and Sweater

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -296,7 +296,6 @@
 	coat["dominia great coat, red"] = /obj/item/clothing/suit/storage/toggle/dominia
 	coat["dominia great coat, gold"] = /obj/item/clothing/suit/storage/toggle/dominia/gold
 	coat["dominia great coat, black"] = /obj/item/clothing/suit/storage/toggle/dominia/black
-	coat["dominian bomber jacket"] = /obj/item/clothing/suit/storage/toggle/dominia/bomber
 	gear_tweaks += new/datum/gear_tweak/path(coat)
 
 /datum/gear/suit/dominia/consular
@@ -304,6 +303,11 @@
 	description = "A Dominian great coat belonging to the Diplomatic Service."
 	path = /obj/item/clothing/suit/storage/dominia/consular
 	allowed_roles = list("Consular Officer")
+
+/datum/gear/suit/dominia/bomber
+	display_name = "fisanduhian bomber jacket"
+	path = /obj/item/clothing/suit/storage/toggle/dominia/bomber
+	flags = GEAR_HAS_DESC_SELECTION
 
 /datum/gear/suit/tcfl
 	display_name = "Tau Ceti Foreign Legion jacket selection"

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -304,7 +304,7 @@
 	path = /obj/item/clothing/suit/storage/dominia/consular
 	allowed_roles = list("Consular Officer")
 
-/datum/gear/suit/dominia/bomber
+/datum/gear/suit/fisanduhian_bomber
 	display_name = "fisanduhian bomber jacket"
 	path = /obj/item/clothing/suit/storage/toggle/dominia/bomber
 	flags = GEAR_HAS_DESC_SELECTION

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -252,7 +252,7 @@
 	consular["dominian consular officer's uniform, feminine"] = /obj/item/clothing/under/dominia/consular/dress
 	gear_tweaks += new/datum/gear_tweak/path(consular)
 
-/datum/gear/uniform/dominia/sweater
+/datum/gear/uniform/fisanduhian_sweater
 	display_name = "fisanduhian sweater"
 	path = /obj/item/clothing/under/dominia/sweater
 	flags = GEAR_HAS_DESC_SELECTION

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -220,7 +220,6 @@
 	var/list/suit = list()
 	suit["dominia suit, red"] = /obj/item/clothing/under/dominia
 	suit["dominia suit, black"] = /obj/item/clothing/under/dominia/black
-	suit["dominia sweater"] = /obj/item/clothing/under/dominia/sweater
 	suit["lyodsuit"] = /obj/item/clothing/under/dominia/lyodsuit
 	suit["hoodied lyodsuit"] = /obj/item/clothing/under/dominia/lyodsuit/hoodie
 	suit["dominia noblewoman dress"] = /obj/item/clothing/under/dominia/dress
@@ -252,6 +251,11 @@
 	consular["dominian consular officer's uniform, masculine"] = /obj/item/clothing/under/dominia/consular
 	consular["dominian consular officer's uniform, feminine"] = /obj/item/clothing/under/dominia/consular/dress
 	gear_tweaks += new/datum/gear_tweak/path(consular)
+
+/datum/gear/uniform/dominia/sweater
+	display_name = "fisanduhian sweater"
+	path = /obj/item/clothing/under/dominia/sweater
+	flags = GEAR_HAS_DESC_SELECTION
 
 /datum/gear/uniform/elyra_holo
 	display_name = "elyran holographic suit selection"

--- a/code/modules/clothing/factions/dominia.dm
+++ b/code/modules/clothing/factions/dominia.dm
@@ -107,8 +107,12 @@
 	item_state = "dominia_noble_black"
 
 /obj/item/clothing/suit/storage/toggle/dominia/bomber
-	name = "dominia bomber jacket"
-	desc = "This is a bomber jacket of Dominian style."
+	name = "fisanduhian bomber jacket"
+	desc = "A bomber jacket based off of styles created by Fisanduhian refugees. The double-breasted design works well for insulating \
+	heat, or concealing a small pistol."
+	desc_fluff = "Fisanduhian fashion remains as rugged and steadfast as its people, as well as very distinctive from the usual Morozi fashions \
+	sourced from Moroz proper. Bomber jackets such as these were also frequently seen worn by members of the Fisanduh Freedom Front and came \
+	to be seen as an enduring symbol of their struggle for liberty."
 	icon = 'icons/clothing/suits/coats/dominia_bomber.dmi'
 	icon_state = "dominia_bomber"
 	item_state = "dominia_bomber"
@@ -130,8 +134,12 @@
 	item_state = "dominia_uniform_black"
 
 /obj/item/clothing/under/dominia/sweater
-	name = "dominia sweater"
-	desc = "This is a sweater of Dominian style."
+	name = "fisanduhian sweater"
+	desc = "This is a sweater of Fisanduhian style. Practical and utilitarian."
+	desc_fluff = "Fisanduhian fashion remains as rugged and steadfast as its people, as well as very distinctive from the usual Morozi fashions \
+	sourced from Moroz proper. Sweaters such as this were a common sight in the region of Fisanduh, being comfortable to wear and very useful \
+	in the cold mountainous environment they lived in. It tends to be seen as something rather basic and droll by Imperials when compared \
+	to their more extravagant and colorful attire, but this suits the Confederates just fine."
 	icon = 'icons/clothing/under/uniforms/dominia_sweater.dmi'
 	icon_state = "dom_sweater"
 	item_state = "dom_sweater"
@@ -427,6 +435,9 @@
 /obj/item/clothing/head/ushanka/dominia
 	name = "fisanduhian ushanka"
 	desc = "A warm fur hat with ear flaps that can be raised and tied to be out of the way. This one has a large Fisanduhian flag on the front."
+	desc_fluff = "Fisanduhian fashion remains as rugged and steadfast as its people, as well as very distinctive from the usual Morozi fashions \
+	sourced from Moroz proper. Ushankas such as these are still a common sight in the semi-autonomous region of Fisanduh, flag and all. Much to \
+	the ire of Moroz's Imperials."
 	icon_state = "fishushanka"
 	item_state = "fishushanka"
 

--- a/html/changelogs/wickedcybs_fisanduhification.yml
+++ b/html/changelogs/wickedcybs_fisanduhification.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Refluffs the Dominian sweater and Bomber coat to be representative Fisanduh as it fit the overall style more, and removes them from the Dominian clothing selections, having them be their own unique selection instead. They also have new fluff descriptions. Cool."


### PR DESCRIPTION
This PR refluffs the dominian bomber jacket and sweater, aligning them more-so into being indicative of Fisanduhian styles and fashions rather than with the Imperials. It also changes the descriptions a bit and adds in new fluff text, and puts them into their own unique loadout selections.

I discussed whether this would fit with Schwann and a few others, I got overall good reception so I'm tentatively putting this PR up. My reasoning here is that overall, Dominian styles trend towards a more colourful and extravagant fashion in-game. What with the cloaks, dresses, suits. Fisanduhians apply a bit more of a utilitarian dynamic I find, favouring less flashy and more rugged things. 

![image](https://user-images.githubusercontent.com/52309324/114956454-23184c80-9e1c-11eb-8aab-07e0f9d38a50.png)
