### PR TITLE
Medical Belts Can Store Medical Tape

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -156,7 +156,8 @@
 		/obj/item/crowbar,
 		/obj/item/device/flashlight,
 		/obj/item/extinguisher/mini,
-		/obj/item/device/radio
+		/obj/item/device/radio,
+		/obj/item/taperoll/medical
 		)
 
 /obj/item/storage/belt/medical/first_responder

--- a/html/changelogs/wickedcybs_tape.yml
+++ b/html/changelogs/wickedcybs_tape.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Medical belts can hold medical tape now, if desired."


### PR DESCRIPTION
Medical tape was a recent thing given to the medical department, but they couldn't put it into their belts. Now they can. Woooo.