### PR TITLE
Espresso Cartridge Wumbofication

### DIFF
--- a/code/modules/reagents/dispenser/coffeebeans.dm
+++ b/code/modules/reagents/dispenser/coffeebeans.dm
@@ -7,7 +7,7 @@
 
 	w_class = ITEMSIZE_NORMAL
 
-	volume = CARTRIDGE_VOLUME_SMALL
+	volume = CARTRIDGE_VOLUME_LARGE
 	amount_per_transfer_from_this = 20
 	possible_transfer_amounts = list(20, 40)
 	unacidable = 1

--- a/html/changelogs/doxxmedearly - increase_coffee.yml
+++ b/html/changelogs/doxxmedearly - increase_coffee.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - tweak: "Espresso cartridges now contain 500u like all other dispenser cartridges."


### PR DESCRIPTION
Espresso was the only drink cartridge that started at 100u. This kinda blows because most coffee recipes depend on it. Made the volume equivalent to literally every other drink cartridge so they stop running out halfway through a moderately populated round. Baristas and bartenders, rejoice. 