### PR TITLE
Beacon Team Medical Responder Adjustments

### DIFF
--- a/code/datums/outfits/ert/iac.dm
+++ b/code/datums/outfits/ert/iac.dm
@@ -11,6 +11,7 @@
 	belt = /obj/item/storage/belt/medical
 	back = /obj/item/storage/backpack/satchel_med
 	accessory = /obj/item/clothing/accessory/storage/white_vest
+	id = /obj/item/card/id/distress/iac
 	accessory_contents = list(/obj/item/stack/medical/advanced/bruise_pack = 1, /obj/item/stack/medical/advanced/ointment = 1, /obj/item/reagent_containers/glass/bottle/mortaphenyl = 1)
 
 	l_ear = /obj/item/device/radio/headset/distress

--- a/code/datums/outfits/ert/iac.dm
+++ b/code/datums/outfits/ert/iac.dm
@@ -11,8 +11,7 @@
 	belt = /obj/item/storage/belt/medical
 	back = /obj/item/storage/backpack/satchel_med
 	accessory = /obj/item/clothing/accessory/storage/white_vest
-	accessory_contents = list(/obj/item/reagent_containers/hypospray/cmo = 1, /obj/item/storage/pill_bottle/dexalin_plus = 1, /obj/item/storage/pill_bottle/mortaphenyl = 1)
-	id = /obj/item/card/id/distress/iac
+	accessory_contents = list(/obj/item/stack/medical/advanced/bruise_pack = 1, /obj/item/stack/medical/advanced/ointment = 1, /obj/item/reagent_containers/glass/bottle/mortaphenyl = 1)
 
 	l_ear = /obj/item/device/radio/headset/distress
 
@@ -26,12 +25,14 @@
 	)
 
 	belt_contents = list(
-		/obj/item/stack/medical/advanced/bruise_pack = 2,
-		/obj/item/stack/medical/advanced/ointment = 2,
-		/obj/item/stack/medical/splint = 1,
-		/obj/item/reagent_containers/syringe = 1,
-		/obj/item/reagent_containers/glass/bottle/inaprovaline = 1
-	)
+		/obj/item/reagent_containers/hypospray/cmo = 1,
+		/obj/item/reagent_containers/glass/bottle/inaprovaline = 1,
+		/obj/item/reagent_containers/glass/bottle/antitoxin = 1,
+		/obj/item/reagent_containers/glass/bottle/dexalin_plus = 1,
+		/obj/item/reagent_containers/glass/bottle/butazoline = 1,
+		/obj/item/reagent_containers/glass/bottle/dermaline = 1,
+		/obj/item/reagent_containers/glass/bottle/perconol
+		)
 
 /datum/outfit/admin/ert/iac/get_id_access()
 	return get_distress_access()
@@ -93,5 +94,6 @@
 		/obj/item/device/healthanalyzer = 1,
 		/obj/item/storage/firstaid/adv = 2,
 		/obj/item/storage/firstaid/o2 = 1,
-		/obj/item/storage/box/syringes = 1
+		/obj/item/storage/box/syringes = 1,
+		/obj/item/reagent_containers/hypospray/autoinjector/coagzolug = 1
 	)

--- a/code/datums/outfits/ert/iac.dm
+++ b/code/datums/outfits/ert/iac.dm
@@ -22,7 +22,8 @@
 		/obj/item/storage/firstaid/surgery = 1,
 		/obj/item/storage/box/gloves = 1,
 		/obj/item/storage/box/syringes = 1,
-		/obj/item/device/flashlight/pen = 1
+		/obj/item/device/flashlight/pen = 1,
+		/obj/item/device/healthanalyzer = 1
 	)
 
 	belt_contents = list(

--- a/code/datums/outfits/ert/iac.dm
+++ b/code/datums/outfits/ert/iac.dm
@@ -33,7 +33,7 @@
 		/obj/item/reagent_containers/glass/bottle/dexalin_plus = 1,
 		/obj/item/reagent_containers/glass/bottle/butazoline = 1,
 		/obj/item/reagent_containers/glass/bottle/dermaline = 1,
-		/obj/item/reagent_containers/glass/bottle/perconol
+		/obj/item/reagent_containers/glass/bottle/perconol = 1
 		)
 
 /datum/outfit/admin/ert/iac/get_id_access()

--- a/code/datums/outfits/ert/kataphract.dm
+++ b/code/datums/outfits/ert/kataphract.dm
@@ -101,6 +101,7 @@
 		/obj/item/storage/box/donkpockets = 1,
 		/obj/item/crowbar = 1,
 		/obj/item/storage/firstaid/adv = 1,
+		/obj/item/device/healthanalyzer = 1,
 		/obj/item/reagent_containers/glass/bottle/thetamycin = 1,
 		/obj/item/reagent_containers/hypospray/autoinjector/coagzolug = 1
 	)

--- a/code/datums/outfits/ert/kataphract.dm
+++ b/code/datums/outfits/ert/kataphract.dm
@@ -86,10 +86,13 @@
 	l_hand = /obj/item/melee/hammer/powered/hegemony
 
 	belt_contents = list(
-		/obj/item/reagent_containers/hypospray = 1,
-		/obj/item/stack/medical/advanced/bruise_pack = 1,
-		/obj/item/stack/medical/advanced/ointment = 1,
-		/obj/item/reagent_containers/glass/bottle/thetamycin = 1
+		/obj/item/reagent_containers/hypospray/cmo = 1,
+		/obj/item/reagent_containers/glass/bottle/inaprovaline = 1,
+		/obj/item/reagent_containers/glass/bottle/antitoxin = 1,
+		/obj/item/reagent_containers/glass/bottle/dexalin_plus = 1,
+		/obj/item/reagent_containers/glass/bottle/butazoline = 1,
+		/obj/item/reagent_containers/glass/bottle/dermaline = 1,
+		/obj/item/reagent_containers/glass/bottle/perconol = 1	
 	)
 
 	backpack_contents = list(
@@ -97,7 +100,9 @@
 		/obj/item/shield/energy/hegemony = 1,
 		/obj/item/storage/box/donkpockets = 1,
 		/obj/item/crowbar = 1,
-		/obj/item/storage/firstaid/adv = 1
+		/obj/item/storage/firstaid/adv = 1,
+		/obj/item/reagent_containers/glass/bottle/thetamycin = 1,
+		/obj/item/reagent_containers/hypospray/autoinjector/coagzolug = 1
 	)
 
 /datum/outfit/admin/ert/kataphract/specialist/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/datums/outfits/ert/med_eridani.dm
+++ b/code/datums/outfits/ert/med_eridani.dm
@@ -11,29 +11,33 @@
 	belt = /obj/item/storage/belt/medical
 	back = /obj/item/storage/backpack/satchel_med
 	accessory = /obj/item/clothing/accessory/storage/white_vest
-	accessory_contents = list(/obj/item/reagent_containers/hypospray/cmo = 1, /obj/item/storage/pill_bottle/dexalin_plus = 1, /obj/item/storage/pill_bottle/mortaphenyl = 1)
+	accessory_contents = list(/obj/item/stack/medical/advanced/bruise_pack = 1, /obj/item/stack/medical/advanced/ointment = 1, /obj/item/reagent_containers/glass/bottle/mortaphenyl = 1)
 	id = /obj/item/card/id/distress/iac
 
 	l_ear = /obj/item/device/radio/headset/distress
 
 	backpack_contents = list(
 		/obj/item/storage/box/survival = 1,
-		/obj/item/storage/firstaid/regular = 1,
+		/obj/item/device/healthanalyzer = 1,
+		/obj/item/storage/firstaid/adv = 1,
 		/obj/item/storage/firstaid/surgery = 1,
 		/obj/item/storage/box/gloves = 1,
 		/obj/item/storage/box/syringes = 1,
 		/obj/item/device/flashlight/pen = 1,
 		/obj/item/clothing/accessory/holster/armpit = 1,
 		/obj/item/gun/projectile/automatic/x9 = 1,
-		/obj/item/ammo_magazine/c45x = 2
+		/obj/item/ammo_magazine/c45x = 2,
+		/obj/item/reagent_containers/glass/bottle/thetamycin = 1
 	)
 
 	belt_contents = list(
-		/obj/item/stack/medical/advanced/bruise_pack = 2,
-		/obj/item/stack/medical/advanced/ointment = 2,
-		/obj/item/stack/medical/splint = 1,
-		/obj/item/reagent_containers/syringe = 1,
-		/obj/item/reagent_containers/glass/bottle/inaprovaline = 1
+		/obj/item/reagent_containers/hypospray/cmo = 1,
+		/obj/item/reagent_containers/glass/bottle/inaprovaline = 1,
+		/obj/item/reagent_containers/glass/bottle/antitoxin = 1,
+		/obj/item/reagent_containers/glass/bottle/dexalin_plus = 1,
+		/obj/item/reagent_containers/glass/bottle/butazoline = 1,
+		/obj/item/reagent_containers/glass/bottle/dermaline = 1,
+		/obj/item/reagent_containers/glass/bottle/perconol = 1	
 	)
 
 /datum/outfit/admin/ert/med_eridani/get_id_access()
@@ -71,7 +75,8 @@
 		/obj/item/storage/box/survival = 1,
 		/obj/item/storage/firstaid/regular = 1,
 		/obj/item/stack/medical/advanced/bruise_pack = 2,
-		/obj/item/gun/projectile/automatic/x9 = 1
+		/obj/item/gun/projectile/automatic/x9 = 1,
+		/obj/item/reagent_containers/glass/bottle/thetamycin = 1
 	)
 
 	belt_contents = list(
@@ -93,6 +98,7 @@
 	backpack_contents = list(
 		/obj/item/storage/box/survival = 1,
 		/obj/item/device/healthanalyzer = 1,
+		/obj/item/reagent_containers/hypospray/autoinjector/coagzolug = 1,
 		/obj/item/storage/firstaid/adv = 1,
 		/obj/item/storage/firstaid/o2 = 1,
 		/obj/item/storage/box/syringes = 1,

--- a/code/datums/outfits/ert/mercenary.dm
+++ b/code/datums/outfits/ert/mercenary.dm
@@ -41,6 +41,7 @@
 		/obj/item/ammo_magazine/a10mm = 2,
 		/obj/item/storage/firstaid/combat = 1,
 		/obj/item/storage/firstaid/adv = 2,
+		/obj/item/device/healthanalyzer = 1,
 		/obj/item/tank/oxygen = 1,
 		/obj/item/reagent_containers/glass/bottle/thetamycin = 1,
 		/obj/item/reagent_containers/hypospray/autoinjector/coagzolug = 1

--- a/code/datums/outfits/ert/mercenary.dm
+++ b/code/datums/outfits/ert/mercenary.dm
@@ -40,15 +40,20 @@
 		/obj/item/gun/projectile/automatic/c20r = 1,
 		/obj/item/ammo_magazine/a10mm = 2,
 		/obj/item/storage/firstaid/combat = 1,
-		/obj/item/storage/firstaid/adv = 1,
-		/obj/item/tank/oxygen = 1
+		/obj/item/storage/firstaid/adv = 2,
+		/obj/item/tank/oxygen = 1,
+		/obj/item/reagent_containers/glass/bottle/thetamycin = 1,
+		/obj/item/reagent_containers/hypospray/autoinjector/coagzolug = 1
 	)
 
 	belt_contents = list(
-		/obj/item/reagent_containers/hypospray = 1,
-		/obj/item/stack/medical/advanced/bruise_pack = 1,
-		/obj/item/stack/medical/advanced/ointment = 1,
-		/obj/item/reagent_containers/glass/bottle/thetamycin = 1
+		/obj/item/reagent_containers/hypospray/cmo = 1,
+		/obj/item/reagent_containers/glass/bottle/inaprovaline = 1,
+		/obj/item/reagent_containers/glass/bottle/antitoxin = 1,
+		/obj/item/reagent_containers/glass/bottle/dexalin_plus = 1,
+		/obj/item/reagent_containers/glass/bottle/butazoline = 1,
+		/obj/item/reagent_containers/glass/bottle/dermaline = 1,
+		/obj/item/reagent_containers/glass/bottle/perconol = 1	
 	)
 
 /datum/outfit/admin/ert/mercenary/engineer

--- a/code/datums/outfits/ert/nt_ert.dm
+++ b/code/datums/outfits/ert/nt_ert.dm
@@ -39,10 +39,13 @@
 	r_hand = /obj/item/storage/firstaid/combat
 
 	belt_contents = list(
-		/obj/item/reagent_containers/hypospray = 1,
-		/obj/item/stack/medical/advanced/bruise_pack = 1,
-		/obj/item/stack/medical/advanced/ointment = 1,
-		/obj/item/reagent_containers/glass/bottle/thetamycin = 1
+		/obj/item/reagent_containers/hypospray/combat/empty = 1,
+		/obj/item/reagent_containers/glass/bottle/inaprovaline = 1,
+		/obj/item/reagent_containers/glass/bottle/antitoxin = 1,
+		/obj/item/reagent_containers/glass/bottle/dexalin_plus = 1,
+		/obj/item/reagent_containers/glass/bottle/butazoline = 1,
+		/obj/item/reagent_containers/glass/bottle/dermaline = 1,
+		/obj/item/reagent_containers/glass/bottle/perconol = 1	
 	)
 
 /datum/outfit/admin/ert/nanotrasen/leader

--- a/code/datums/outfits/event/outfit_nanotrasen.dm
+++ b/code/datums/outfits/event/outfit_nanotrasen.dm
@@ -251,11 +251,11 @@
 	belt = /obj/item/storage/belt/medical
 	back = /obj/item/storage/backpack/satchel_med
 	accessory = /obj/item/clothing/accessory/storage/white_vest
-	accessory_contents = list(/obj/item/reagent_containers/hypospray/cmo = 1, /obj/item/storage/pill_bottle/dexalin_plus = 1, /obj/item/storage/pill_bottle/mortaphenyl = 1)
+	accessory_contents = list(/obj/item/stack/medical/advanced/bruise_pack = 1, /obj/item/stack/medical/advanced/ointment = 1, /obj/item/reagent_containers/glass/bottle/mortaphenyl = 1)
 
 	backpack_contents = list(
 		/obj/item/storage/box/survival = 1,
-		/obj/item/storage/firstaid/regular = 2,
+		/obj/item/storage/firstaid/adv = 1,
 		/obj/item/storage/firstaid/surgery = 1,
 		/obj/item/storage/box/gloves = 1,
 		/obj/item/storage/box/syringes = 1,
@@ -263,11 +263,13 @@
 	)
 
 	belt_contents = list(
-		/obj/item/stack/medical/advanced/bruise_pack = 2,
-		/obj/item/stack/medical/advanced/ointment = 2,
-		/obj/item/stack/medical/splint = 1,
-		/obj/item/reagent_containers/syringe = 1,
-		/obj/item/reagent_containers/glass/bottle/inaprovaline = 1
+		/obj/item/reagent_containers/hypospray/cmo = 1,
+		/obj/item/reagent_containers/glass/bottle/inaprovaline = 1,
+		/obj/item/reagent_containers/glass/bottle/antitoxin = 1,
+		/obj/item/reagent_containers/glass/bottle/dexalin_plus = 1,
+		/obj/item/reagent_containers/glass/bottle/butazoline = 1,
+		/obj/item/reagent_containers/glass/bottle/dermaline = 1,
+		/obj/item/reagent_containers/glass/bottle/perconol = 1	
 	)
 
 	id_access = "Medical Doctor"

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -187,6 +187,12 @@
 	icon_state = "bottle-1"
 	reagents_to_add = list(/decl/reagent/bicaridine = 60)
 
+/obj/item/reagent_containers/glass/bottle/butazoline
+	name = "butazoline bottle"
+	desc = "A small bottle. Contains butazoline - treats damaged tissues."
+	icon_state = "bottle-1"
+	reagents_to_add = list(/decl/reagent/butazoline = 60)
+
 /obj/item/reagent_containers/glass/bottle/dermaline
 	name = "dermaline bottle"
 	desc = "A small bottle. Contains dermaline - treats burnt tissues."

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -239,3 +239,8 @@
 	time = 0
 
 	reagents_to_add = list(/decl/reagent/oxycomorphine = 5, /decl/reagent/synaptizine = 5, /decl/reagent/hyperzine = 5, /decl/reagent/arithrazine = 5)
+
+/obj/item/reagent_containers/hypospray/combat/empty
+	name = "combat hypospray"
+	desc = "A sleek black hypospray. Its needle has the ability to bypass armor."
+	reagents_to_add = FALSE

--- a/html/changelogs/wickedcybs_beaconmed.yml
+++ b/html/changelogs/wickedcybs_beaconmed.yml
@@ -1,0 +1,8 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Medical responders for off station roles now have loadouts that will allow them to treat their teams effectively. Mainly, you'll find they now have a belt full of useful liquid medicine that can be injected along with some adjustments to what they carry in their bags."
+  - tweak: "Added a variant of the combat hypo that doesn't start loaded with reagents already."
+  - rcsadd: "Added a butazoline reagent bottle that can be spawned on demand by admins if needed, put into loadouts or mapped in if desired."

--- a/html/changelogs/wickedcybs_beaconmed.yml
+++ b/html/changelogs/wickedcybs_beaconmed.yml
@@ -5,4 +5,4 @@ delete-after: True
 changes:
   - tweak: "Medical responders for off station roles now have loadouts that will allow them to treat their teams effectively. Mainly, you'll find they now have a belt full of useful liquid medicine that can be injected along with some adjustments to what they carry in their bags."
   - tweak: "Added a variant of the combat hypo that doesn't start loaded with reagents already."
-  - rcsadd: "Added a butazoline reagent bottle that can be spawned on demand by admins if needed, put into loadouts or mapped in if desired."
+  - rscadd: "Added a butazoline reagent bottle that can be spawned on demand by admins if needed, put into loadouts or mapped in if desired."

--- a/html/changelogs/wickedcybs_beaconmed.yml
+++ b/html/changelogs/wickedcybs_beaconmed.yml
@@ -3,6 +3,6 @@ author: WickedCybs
 delete-after: True
 
 changes:
-  - tweak: "Medical responders for off station roles now have loadouts that will allow them to treat their teams effectively. Mainly, you'll find they now have a belt full of useful liquid medicine that can be injected along with some adjustments to what they carry in their bags."
+  - tweak: "Medical responders for off station roles now have loadouts that will allow them to treat their teams effectively. Mainly, you'll find they now have a belt full of useful liquid medicine that can be injected along with some adjustments to what they carry in their bags, like getting health analyzers!"
   - tweak: "Added a variant of the combat hypo that doesn't start loaded with reagents already."
   - rscadd: "Added a butazoline reagent bottle that can be spawned on demand by admins if needed, put into loadouts or mapped in if desired."


### PR DESCRIPTION
It's been a thing I've frequently seen complained about by people going as the medical responder in distress teams, and something I've experienced myself. Across the board, unless you're TCFL/NT-ERT (they have machines that dispense all the medicine they need). You simply do not have the gear you need to save anyone meaningfully. Not even the designated medical beacon teams (Eridani/IAC) are suited for this.

The standard equipment as of now is pretty much only pill based medicines and barely anything lifesaving. One bottle of inaprovaline only was the best thing most the teams had basically. The freelancer responder was the best equipped, as they came with a combat medkit containing pill forms of basic "essential" medicines. Can't be taken through voidsuits though.

I've given the medical responders more oomph to be useful across the board. Their belts contain one bottle each of the "essentials".

That would be: Inaprovaline, Dyolvene, Butazoline, Dermalin, Dexalin+ and Perconol, the last slot being filled with a hypospray. 

What they would get before this is a hypo, two brute kits, two burn kits and a bottle of inaprovaline. 

Webbings and bags were minorly adjusted for them as well but nothing major. For the NT-ERT specifically, I've given their medical responder an empty combat hypo as it seemed fitting. All combat hypos started filled by default, so I made an empty variant. The last thing is that this adds a Butazoline bottle to the bottles.dm which will allow it to be spawned easier or mapped in easier.



