### PR TITLE
Freespeak speech verb tweak + EAL singing bugfix

### DIFF
--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -58,7 +58,7 @@
 	name = LANGUAGE_GUTTER
 	short = "FREE"
 	desc = "A language of renegades and frontiersmen descending from various languages from Earth like Hindi combined into a multi-rooted jumble that sounds incoherent or even barbarian to non-native speakers. This language is the only common cultural identity for humans in the frontier. Speaking this language in itself boldly declares the speaker a free spirit. Often called 'Gutter' by Alliance citizens."
-	speech_verb = list("growls")
+	speech_verb = list("says")
 	sing_verb = list("croons")
 	colour = "rough"
 	written_style = "freespeak"

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -283,7 +283,7 @@
 	speech_verb = list("beeps")
 	ask_verb = list("beeps")
 	exclaim_verb = list("loudly beeps")
-	exclaim_verb = list("rhythmically beeps")
+	sing_verb = list("rhythmically beeps")
 	colour = "changeling"
 	written_style = "encodedaudiolanguage"
 	key = "6"

--- a/html/changelogs/omicega-freespeak.yml
+++ b/html/changelogs/omicega-freespeak.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Changed Freespeak's speech verb from 'growls' to 'says'."
+  - bugfix: "Set EAL's singing verb properly."


### PR DESCRIPTION
Changes Freespeak's standard speech verb from _growls_ to _says_, like most other human languages. Done with support from Schwann as (deputy) human lore maintainer.

Also fixes a presumed bug with EAL's speech verbs, as the exclaiming verb was defined twice with no sing verb.

Thanks to @NonQueueingMatt for his help with remembering how to use Git after like a year of not touching it at all. 😅 