### PR TITLE
The End of an Era: Eradication of Funny Breakfast Wrap Paincrit

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4304,11 +4304,11 @@
 
 /obj/item/reagent_containers/food/snacks/breakfast_wrap
 	name = "breakfast wrap"
-	desc = "Bacon, eggs, cheese, and tortilla grilled to perfection."
+	desc = "Bacon, eggs, cheese, and tortilla spiced and grilled to perfection."
 	icon_state = "breakfast_wrap"
 	bitesize = 4
 	center_of_mass = list("x"=16, "y"=16)
-	reagents_to_add = list(/decl/reagent/nutriment = 6, /decl/reagent/nutriment/protein = 9, /decl/reagent/capsaicin/condensed = 20) //what could possibly go wrong
+	reagents_to_add = list(/decl/reagent/nutriment = 6, /decl/reagent/nutriment/protein = 9, /decl/reagent/capsaicin = 10) //It's kind of spicy
 	reagent_data = list(/decl/reagent/nutriment = list("tortilla" = 6))
 	filling_color = "#FFF454"
 

--- a/html/changelogs/wickedcybs_begone.yml
+++ b/html/changelogs/wickedcybs_begone.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The breakfast wrap no longer has over twenty units of condesned capsaicin inside of it. That was over half of a pepperspray can. It now only has regular capsaicin and will still be spicy, but not to a paincrit level."


### PR DESCRIPTION
So, I took a look into the code and noticed that breakfast wraps had over twenty units of condensed capsaicin. Even if it had less, ingesting that would absolutely put anyone into paincrit for a bit, it's what goes inside tear gas and pepper spray cans. Really not fitting for a food item and has just led to funny memes of people rushing to the Odin's kitchen to eat the wrap at the end of a round.

I put in normal capsaicin to make it less "spicy" so there will still be messages of uncomfort and such but you will not go horizontal.