### PR TITLE
Crime scene marker placement

### DIFF
--- a/code/modules/detectivework/tools/scene_cards.dm
+++ b/code/modules/detectivework/tools/scene_cards.dm
@@ -25,9 +25,20 @@
 	drop_sound = 'sound/items/drop/card.ogg'
 	pickup_sound = 'sound/items/pickup/card.ogg'
 	w_class = ITEMSIZE_TINY
+	flags = NOBLUDGEON
 	randpixel = 1
 	layer = ABOVE_MOB_LAYER //so you can mark bodies
 	var/number = 1
+
+/obj/item/csi_marker/afterattack(turf/H, mob/user, proximity)
+	if(!proximity)
+		return
+	if(!user.Adjacent(H))
+		return
+	if(H.density)
+		return
+
+	user.drop_from_inventory(src, get_turf(H))
 
 /obj/item/csi_marker/Initialize(mapload)
 	. = ..()

--- a/html/changelogs/CrimeCard.yml
+++ b/html/changelogs/CrimeCard.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Crime scene markers can now be placed on a turf by clicking on it."


### PR DESCRIPTION
Crime scene markers can now be placed on adjacent turfs. This also allows placing them under solid objcets such as lockers, consoles, vending machines & more by clicking the turf they are on.