### PR TITLE
Singing Fix

### DIFF
--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -78,6 +78,7 @@
 	desc = "A signed version of Ceti Basic, though its intent is primarily to help out people who are deaf and mute, "
 	speech_verb = list("signs")
 	signlang_verb = list("signs", "gestures")
+	sing_verb = null
 	colour = "i"
 	key = "4"
 	flags = NO_STUTTER|SIGNLANG

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -53,6 +53,8 @@
 		if(LAZYACCESS(partial_understanding, L.name))
 			understand_chance += partial_understanding[L.name]
 
+	var/static/list/music_notes = list("\u2669", "\u266A", "\u266B")
+
 	var/list/words = splittext(input, " ")
 	var/list/scrambled_text = list()
 	var/new_sentence = 0
@@ -60,7 +62,7 @@
 		var/nword = "[w] "
 		var/input_ending = copytext(w, length(w))
 		var/ends_sentence = findtext(".?!",input_ending)
-		if(!prob(understand_chance))
+		if(!prob(understand_chance) && !(w in music_notes))
 			nword = scramble_word(w)
 			if(new_sentence)
 				nword = capitalize(nword)

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -83,6 +83,7 @@
 	desc = "A sign language developed by Adhomai hunters"
 	speech_verb = list("signs")
 	signlang_verb = list("signs", "flicks their ears", "gestures")
+	sing_verb = null
 	colour = "i"
 	key = "i"
 	flags = NO_STUTTER | SIGNLANG | WHITELISTED

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -203,7 +203,8 @@ proc/get_radio_key_from_channel(var/channel)
 	var/is_singing = FALSE
 	if(length(message) >= 1 && copytext(message, 1, 2) == "%")
 		message = copytext(message, 2)
-		is_singing = TRUE
+		if(speaking?.sing_verb)
+			is_singing = TRUE
 
 	// This is broadcast to all mobs with the language,
 	// irrespective of distance or anything else.

--- a/html/changelogs/geeves-singing_fix.yml
+++ b/html/changelogs/geeves-singing_fix.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "You can no longer sing in sign language."
+  - bugfix: "Singing will no longer get the music notes scrambled if you don't understand the language."


### PR DESCRIPTION
* You can no longer sing in sign language.
* Singing will no longer get the music notes scrambled if you don't understand the language.

Fixes https://github.com/Aurorastation/Aurora.3/issues/11694