### PR TITLE
Input now changes color depending on focus

### DIFF
--- a/html/changelogs/shadow-input.yml
+++ b/html/changelogs/shadow-input.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Shadowtail117
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "The input bar now changes color depending on whether you have hotkey mode enabled or not."

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -222,7 +222,7 @@ macro "borghotkeymode"
 macro "macro"
 	elem 
 		name = "TAB"
-		command = ".winset \"mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
+		command = ".winset \"mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0\""
 	elem 
 		name = "CENTER+REP"
 		command = ".center"
@@ -392,7 +392,7 @@ macro "macro"
 macro "hotkeymode"
 	elem 
 		name = "TAB"
-		command = ".winset \"mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true\""
+		command = ".winset \"mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5\""
 	elem 
 		name = "CENTER+REP"
 		command = ".center"
@@ -1078,7 +1078,7 @@ window "mainwindow"
 		background-color = none
 		saved-params = ""
 		text = "Hotkey Toggle"
-		command = ".winset \"mainwindow.macro!=macro ? mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true : mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
+		command = ".winset \"mainwindow.macro!=macro ? mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5 : mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0\""
 		is-flat = true
 		button-type = pushbox
 	elem "mainvsplit"


### PR DESCRIPTION
- The input bar at the bottom of the screen will now change color depending on focus (i.e., depending on whether you have hotkey mode enabled or not).
- It will be colored white when focus is on the game (hotkey mode is ON).
- It will be colored the default pink when focus is on the input (hotkey mode is OFF).

Helps a player to discern at a glance whether or not hotkey mode is turned on, otherwise, they have to either watch for the cursor or try and determine if the hotkey button is toggled or not.