### PR TITLE
Antag-Focused Medical Additions + Minor Bonus Responder Stuff 

### DIFF
--- a/code/datums/outfits/ert/fsf.dm
+++ b/code/datums/outfits/ert/fsf.dm
@@ -34,7 +34,7 @@
 /datum/outfit/admin/ert/fsf/medic
 	name = "Free Solarian Fleets Medic"
 
-	belt = /obj/item/storage/belt/medical
+	belt = /obj/item/storage/belt/medical/first_responder/combat
 	back = /obj/item/storage/backpack/satchel_med
 	suit_store = /obj/item/gun/projectile/shotgun/pump/combat/sol
 	gloves = /obj/item/clothing/gloves/latex

--- a/code/datums/outfits/ert/kataphract.dm
+++ b/code/datums/outfits/ert/kataphract.dm
@@ -82,7 +82,7 @@
 
 	head = /obj/item/clothing/head/helmet/space/void/kataphract/spec
 	suit = /obj/item/clothing/suit/space/void/kataphract/spec
-	belt = /obj/item/storage/belt/medical
+	belt = /obj/item/storage/belt/medical/first_responder/combat
 	l_hand = /obj/item/melee/hammer/powered/hegemony
 
 	belt_contents = list(

--- a/code/datums/outfits/ert/mercenary.dm
+++ b/code/datums/outfits/ert/mercenary.dm
@@ -33,7 +33,7 @@
 /datum/outfit/admin/ert/mercenary/specialist
 	name = "Mercenary Freelancer Medic"
 
-	belt = /obj/item/storage/belt/medical
+	belt = /obj/item/storage/belt/medical/first_responder/combat
 	gloves = /obj/item/clothing/gloves/latex
 
 	backpack_contents = list(

--- a/code/datums/outfits/ert/nt_ert.dm
+++ b/code/datums/outfits/ert/nt_ert.dm
@@ -34,7 +34,7 @@
 /datum/outfit/admin/ert/nanotrasen/specialist/medical
 	name = "Nanotrasen ERT Medical Specialist"
 
-	belt = /obj/item/storage/belt/medical
+	belt = /obj/item/storage/belt/medical/first_responder/combat
 	back = /obj/item/rig/ert/medical
 	r_hand = /obj/item/storage/firstaid/combat
 

--- a/code/datums/trading/weaponry.dm
+++ b/code/datums/trading/weaponry.dm
@@ -164,5 +164,6 @@
 		/obj/item/clothing/mask/gas/tactical                      = TRADER_THIS_TYPE,
 		/obj/item/shield/riot/tact                         = TRADER_THIS_TYPE,
 		/obj/item/storage/belt/security/tactical           = TRADER_THIS_TYPE,
+		/obj/item/storage/belt/medical/first_responder/combat	 = TRADER_THIS_TYPE,
 		/obj/item/clothing/accessory/storage/bandolier            = TRADER_THIS_TYPE
 	)

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -24,6 +24,12 @@
 	item_cost = 1
 	path = /obj/item/storage/firstaid/combat
 
+/datum/uplink_item/item/medical/medicalbelt
+	name = "Fully Loaded Combat Medical Belt"
+	item_cost = 3
+	path = /obj/item/storage/belt/medical/first_responder/combat/full
+	desc = "A fully loaded medical belt even Zeng-Hu's top First Responders would be dying to wear. It contains liquid medicines and a hypospray. Combat hypo sold seperately."
+
 /datum/uplink_item/item/medical/stimulants
 	name = "Box of Combat Stimulants"
 	item_cost = 1
@@ -38,3 +44,15 @@
 	name = "Standard First-Aid Kit"
 	item_cost = 1
 	path = /obj/item/storage/firstaid/regular
+
+/datum/uplink_item/item/medical/advfirstaid
+	name = "Advanced First-Aid Kit"
+	item_cost = 2
+	path = /obj/item/storage/firstaid/adv
+	desc = "Note: doesn't come with a medical scanner."
+
+/datum/uplink_item/item/medical/bloodpack
+	name = "O- blood pack"
+	item_cost = 2
+	path = /obj/item/reagent_containers/blood/OMinus
+	desc = "If transferring to self or others without a stand, hold firmly in hand, configure the transfer rate and attach the tubing carefully."

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -47,12 +47,12 @@
 
 /datum/uplink_item/item/medical/advfirstaid
 	name = "Advanced First-Aid Kit"
-	item_cost = 2
+	item_cost = 1
 	path = /obj/item/storage/firstaid/adv
 	desc = "Note: doesn't come with a medical scanner."
 
 /datum/uplink_item/item/medical/bloodpack
 	name = "O- blood pack"
-	item_cost = 2
+	item_cost = 1
 	path = /obj/item/reagent_containers/blood/OMinus
 	desc = "If transferring to self or others without a stand, hold firmly in hand, configure the transfer rate and attach the tubing carefully."

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -208,7 +208,8 @@
 		/obj/item/stack/telecrystal,
 		/obj/item/melee/baton,
 		/obj/item/shield/riot/tact,
-		/obj/item/grenade
+		/obj/item/grenade,
+		/obj/item/reagent_containers/blood/OMinus
 		)
 
 /obj/item/storage/belt/medical/first_responder/combat/full

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -166,6 +166,61 @@
 	icon_state = "emsbelt"
 	item_state = "emsbelt"
 
+/obj/item/storage/belt/medical/first_responder/combat
+	name = "combat medical belt"
+	desc = "A sturdy black webbing belt with attached pouches. This one is designed for medical professionals who expect to see combat and has increased storage and utility."
+	storage_slots = 9
+	max_storage_space = 28
+	can_hold = list(
+		/obj/item/device/breath_analyzer,
+		/obj/item/device/healthanalyzer,
+		/obj/item/dnainjector,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/glass/beaker,
+		/obj/item/reagent_containers/glass/bottle,
+		/obj/item/reagent_containers/pill,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/inhaler,
+		/obj/item/reagent_containers/personal_inhaler_cartridge,
+		/obj/item/personal_inhaler,
+		/obj/item/flame/lighter/zippo,
+		/obj/item/storage/box/fancy/cigarettes,
+		/obj/item/storage/pill_bottle,
+		/obj/item/stack/medical,
+		/obj/item/device/flashlight/pen,
+		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/head/surgery,
+		/obj/item/clothing/gloves/latex,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/clothing/glasses/hud/health,
+		/obj/item/crowbar,
+		/obj/item/device/flashlight,
+		/obj/item/extinguisher/mini,
+		/obj/item/device/radio,
+		/obj/item/taperoll/medical,
+		/obj/item/handcuffs,
+		/obj/item/ammo_casing/shotgun,
+		/obj/item/ammo_magazine,
+		/obj/item/device/flash,
+		/obj/item/device/flashlight/maglight,
+		/obj/item/device/flashlight/flare,
+		/obj/item/material/knife,
+		/obj/item/stack/telecrystal,
+		/obj/item/melee/baton
+		)
+
+/obj/item/storage/belt/medical/first_responder/combat/full
+		starts_with = list(
+		/obj/item/reagent_containers/hypospray/cmo = 1,
+		/obj/item/reagent_containers/glass/bottle/inaprovaline = 1,
+		/obj/item/reagent_containers/glass/bottle/antitoxin = 1,
+		/obj/item/reagent_containers/glass/bottle/dexalin_plus = 1,
+		/obj/item/reagent_containers/glass/bottle/butazoline = 1,
+		/obj/item/reagent_containers/glass/bottle/dermaline = 1,
+		/obj/item/reagent_containers/glass/bottle/perconol = 1,
+		/obj/item/reagent_containers/glass/bottle/thetamycin = 1
+	)
+
 /obj/item/storage/belt/security
 	name = "security belt"
 	desc = "Can hold security gear like handcuffs and flashes."

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -167,8 +167,8 @@
 	item_state = "emsbelt"
 
 /obj/item/storage/belt/medical/first_responder/combat
-	name = "combat medical belt"
-	desc = "A sturdy black webbing belt with attached pouches. This one is designed for medical professionals who expect to see combat and has increased storage and utility."
+	name = "tactical medical belt"
+	desc = "A sturdy black webbing belt with attached pouches. This one is designed for medical professionals who expect to enter conflict zones on the daily. It has increased storage and utility."
 	storage_slots = 9
 	max_storage_space = 28
 	can_hold = list(

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -206,7 +206,9 @@
 		/obj/item/device/flashlight/flare,
 		/obj/item/material/knife,
 		/obj/item/stack/telecrystal,
-		/obj/item/melee/baton
+		/obj/item/melee/baton,
+		/obj/item/shield/riot/tact,
+		/obj/item/grenade
 		)
 
 /obj/item/storage/belt/medical/first_responder/combat/full

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -209,7 +209,7 @@
 		/obj/item/melee/baton,
 		/obj/item/shield/riot/tact,
 		/obj/item/grenade,
-		/obj/item/reagent_containers/blood/OMinus
+		/obj/item/reagent_containers/blood
 		)
 
 /obj/item/storage/belt/medical/first_responder/combat/full

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -409,6 +409,7 @@
 		/obj/item/storage/belt/utility = 1,
 		/obj/item/storage/belt/medical = 0.4,
 		/obj/item/storage/belt/medical/first_responder = 0.4,
+		/obj/item/storage/belt/medical/first_responder/combat = 0.1,
 		/obj/item/storage/belt/security/tactical = 0.1,
 		/obj/item/storage/belt/military = 0.1,
 		/obj/item/storage/belt/janitor = 0.4

--- a/code/modules/item_worth/worths_list.dm
+++ b/code/modules/item_worth/worths_list.dm
@@ -160,6 +160,7 @@ var/list/worths = list(
 					/obj/item/storage/belt/security/tactical = 500,
 					/obj/item/storage/belt/soulstone = 800,
 					/obj/item/storage/belt = -50,
+					/obj/item/storage/belt/medical/first_responder/combat = 650,
 					/obj/item/storage/backpack/holding = -3000,
 					/obj/item/storage = -30,
 //WEAPONS,

--- a/html/changelogs/wickedcybs_uplink.yml
+++ b/html/changelogs/wickedcybs_uplink.yml
@@ -1,0 +1,9 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a combat medical belt. It can hold nine things compared to the usual seven and accepts a few more items as well, like handcuffs."
+  - rscadd: "The medical section of the antag uplink now has a few more options to choose from. A fully loaded combat medical belt, an advanced medical kit and O- bloodpacks."
+  - tweak: "Mercenaries now have butazoline and perconol added to their starting medical supplies as well as one combat medical belt."
+  - tweak: "Some ERT responders now start with combat medical belts as well. Would be TCFL, FSF, Kataphracts, Freelancers, NT-ERT."

--- a/html/changelogs/wickedcybs_uplink.yml
+++ b/html/changelogs/wickedcybs_uplink.yml
@@ -3,7 +3,7 @@ author: WickedCybs
 delete-after: True
 
 changes:
-  - rscadd: "Added a combat medical belt. It can hold nine things compared to the usual seven and accepts a few more items as well, like handcuffs."
+  - rscadd: "Added a combat medical belt. It can hold nine things compared to the usual seven and accepts a few more items as well, like handcuffs and even ammo magazines."
   - rscadd: "The medical section of the antag uplink now has a few more options to choose from. A fully loaded combat medical belt, an advanced medical kit and O- bloodpacks."
   - tweak: "Mercenaries now have butazoline and perconol added to their starting medical supplies as well as one combat medical belt."
   - tweak: "Some ERT responders now start with combat medical belts as well. Would be TCFL, FSF, Kataphracts, Freelancers, NT-ERT."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -32360,11 +32360,11 @@
 	pixel_y = -12
 	},
 /obj/item/reagent_containers/glass/bottle/dermaline,
-/obj/item/reagent_containers/glass/bottle/bicaridine{
+/obj/item/reagent_containers/glass/bottle/butazoline{
 	pixel_x = -3;
 	pixel_y = -8
 	},
-/obj/item/reagent_containers/glass/bottle/bicaridine{
+/obj/item/reagent_containers/glass/bottle/butazoline{
 	pixel_x = -3;
 	pixel_y = -8
 	},
@@ -32378,6 +32378,14 @@
 	},
 /obj/item/reagent_containers/glass/bottle/thetamycin{
 	pixel_x = 9
+	},
+/obj/item/reagent_containers/glass/bottle/perconol{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/glass/bottle/perconol{
+	pixel_x = -7;
+	pixel_y = -4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mercenary)
@@ -37915,6 +37923,7 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/mask/surgical,
 /obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical/first_responder/combat,
 /obj/item/storage/belt/medical,
 /obj/structure/sink{
 	dir = 4;
@@ -41636,14 +41645,14 @@
 /area/centcom/specops)
 "wWK" = (
 /obj/structure/table/rack,
-/obj/item/storage/belt/medical{
+/obj/item/storage/belt/medical/first_responder/combat{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/storage/belt/medical/first_responder/combat,
+/obj/item/storage/belt/medical/first_responder/combat{
 	pixel_x = -4;
 	pixel_y = 5
-	},
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical{
-	pixel_x = 4;
-	pixel_y = -5
 	},
 /turf/unsimulated/floor,
 /area/centcom/legion/hangar5)


### PR DESCRIPTION
I've been thinking of what could be done for antagonists on a medical front and devised this PR. It adds a "Tactical medical belt" with nine slots versus the usual seven that can also hold a few extra things, like handcuffs or maglights. I created a "loaded" version of this that I've added to the antag uplink for what I think is a pretty reasonable price (3 tc) since it's essentially a direct upgrade over the combat medical kit and has liquid medicines plus a hypospray. Intelligent use of it would be a definite lifesaver and it has everything a first responder would need to stabilize and save a life, as well as theta to handle infections. The station _could_ maybe get the unloaded variant of the belt too assuming a merchant arrives and chooses to buy these from the tactical supplier.

Additionally, I added an advanced medical kit to the medical section of the uplink for 1 TC (it has no med scanner) and an O- bloodbag for one TC as well.

Lastly, the antag mercenaries get one of these belts for free and have had their medical supplies updated, I gave them butazoline to replace their bicardine, two bottles of perconol and gave one free combat medical belt in their medical area.

The minor bonus responder stuff part of this PR is that I've mapped in the combat medical kits for a few of the beacon responders or added it to their loadouts