### PR TITLE
Fix double sanitization breaking chat in certain places

### DIFF
--- a/code/modules/mob/abstract/observer/say.dm
+++ b/code/modules/mob/abstract/observer/say.dm
@@ -1,6 +1,4 @@
 /mob/abstract/observer/say(var/message)
-	message = sanitize(message)
-
 	if (!message)
 		return
 

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -164,8 +164,6 @@
 /mob/living/bot/say(var/message)
 	var/verb = "beeps"
 
-	message = sanitize(message)
-
 	..(message, null, verb)
 
 /mob/living/bot/Collide(atom/A)

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -3,8 +3,6 @@
 	if (silent)
 		return
 
-	message = sanitize(message)
-
 	if(!(container && istype(container, /obj/item/device/mmi)))
 		return //No MMI, can't speak, bucko./N
 	else

--- a/code/modules/mob/living/carbon/slime/say.dm
+++ b/code/modules/mob/living/carbon/slime/say.dm
@@ -1,7 +1,5 @@
 /mob/living/carbon/slime/say(var/message)
 
-	message = sanitize(message)
-
 	var/verb = say_quote(message)
 
 	if(copytext(message,1,2) == "*")

--- a/code/modules/mob/living/parasite/meme_captive.dm
+++ b/code/modules/mob/living/parasite/meme_captive.dm
@@ -6,7 +6,6 @@
 /mob/living/parasite/captive_brain/say(var/message)
 	if(istype(src.loc,/mob/living/parasite/meme))
 
-		message = sanitize(message)
 		if (!message)
 			return
 		log_say("[key_name(src)] : [message]",ckey=key_name(src))

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -3,8 +3,6 @@
 		return ..(message)
 
 	if(local_transmit)
-		message = sanitize(message)
-
 		if(stat == DEAD)
 			return say_dead(message)
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -1,6 +1,3 @@
-/mob/living/silicon/say(message, sanitize = TRUE)
-	return ..(sanitize ? sanitize(message) : message)
-
 /mob/living/silicon/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
 	log_say("[key_name(src)] : [message]",ckey=key_name(src))
 

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -8,7 +8,6 @@
 
 /mob/living/captive_brain/say(var/message)
 	if(istype(src.loc,/mob/living/simple_animal/borer))
-		message = sanitize(message)
 		if(!message)
 			return
 		log_say("[key_name(src)] : [message]", ckey=key_name(src))

--- a/code/modules/mob/living/simple_animal/borer/say.dm
+++ b/code/modules/mob/living/simple_animal/borer/say.dm
@@ -1,5 +1,4 @@
 /mob/living/simple_animal/borer/say(var/message)
-	message = sanitize(message)
 	message = capitalize(message)
 
 	if(!message)

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -210,11 +210,8 @@
 
 /mob/living/simple_animal/shade/bluespace/say(var/message)
 	if(!possessive)
-		var/new_last_message_heard = sanitizeName(last_message_heard)
-		var/new_message = sanitizeName(message)
-
-		var/list/words_in_memory = dd_text2List(new_last_message_heard, " ")
-		var/list/words_in_message = dd_text2List(new_message, " ")
+		var/list/words_in_memory = dd_text2List(last_message_heard, " ")
+		var/list/words_in_message = dd_text2List(message, " ")
 		for(var/word1 in words_in_message)
 			var/valid = 0
 			for(var/word2 in words_in_memory)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -738,7 +738,6 @@
 	if(speak_emote.len)
 		verb = pick(speak_emote)
 
-	message = sanitize(message)
 	if(emote_sounds.len)
 		var/sound_chance = TRUE
 		if(client) // we do not want people who assume direct control to spam

--- a/html/changelogs/johnwildkins-sanitizeme.yml
+++ b/html/changelogs/johnwildkins-sanitizeme.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed overactive sanitization on certain mob/say types."


### PR DESCRIPTION
turns out some mobs sanitize messages and some say-types sanitize messages

turns out double-sanitizing breaks html codes

AAAAAAARRGH

this moves all sanitization out of the mob-level to the verb level

i'm like 99% sure that all calls of say() that aren't via verb are sanitized, but even assuming they aren't this is still a much smaller hole than we had before so I'm calling that good