### PR TITLE
Adds alt-clicking to open containers

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -138,6 +138,10 @@
 		to_chat(user, (feedback ? feedback : "You short out the lock of \the [src]."))
 		return 1
 
+/obj/item/storage/secure/AltClick(/mob/user)
+	if (!locked)
+		return ..()
+
 // -----------------------------
 //        Secure Briefcase
 // -----------------------------

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -93,6 +93,15 @@
 				usr.equip_to_slot_if_possible(src, slot_l_hand)
 		src.add_fingerprint(usr)
 
+/obj/item/storage/AltClick(var/mob/usr)
+	if(!canremove)
+		return ..()
+	if (!use_check_and_message(usr))
+		add_fingerprint(usr)
+		open(usr)
+		return TRUE
+	. = ..()
+
 /obj/item/storage/proc/return_inv()
 	. = contents.Copy()
 

--- a/html/changelogs/shadow-qualityoflife.yml
+++ b/html/changelogs/shadow-qualityoflife.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Shadowtail117
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "You can now alt-click a container that's within touching range to open it."


### PR DESCRIPTION
You can now alt-click a container to open it, following the same rules as click-dragging a container to open it. I.e., no being incapacitated and within one tile. Because QoL is good.