### PR TITLE
Research Directors Can Pick the Alternate Tool Belt Too Now

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_belt.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_belt.dm
@@ -14,5 +14,5 @@
 	display_name = "tool-belt, alt"
 	cost = 0
 	path = /obj/item/storage/belt/utility/alt
-	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice", "Roboticist")
+	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice", "Roboticist", "Research Director")
 	flags = null

--- a/html/changelogs/wickedcybs_belt.yml
+++ b/html/changelogs/wickedcybs_belt.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Research Directors are now able to select the alternate tool belt variant in the loadout."


### PR DESCRIPTION
I expanded the tool belt, alt belt item to allow Research Director's to pick one too if they'd like. Makes sense from my perspective.