### PR TITLE
Fixes loadout naming

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -48,6 +48,10 @@
 	var/wear_over_suit = 0
 	var/base_name = ""
 
+/obj/item/storage/wallet/Initialize()
+	. = ..()
+	base_name = name
+
 
 /obj/item/storage/wallet/remove_from_storage(obj/item/W as obj, atom/new_location)
 	. = ..(W, new_location)
@@ -62,7 +66,6 @@
 	if(.)
 		if(!front_id && istype(W, /obj/item/card/id))
 			front_id = W
-			base_name = name
 			name = "[name] ([front_id])"
 			update_icon()
 

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -195,6 +195,8 @@ var/datum/gear_tweak/custom_name/gear_tweak_free_name = new()
 	if(!metadata)
 		return I.name
 	I.name = metadata
+	if(I.vars["base_name"])
+		I.vars["base_name"] = metadata
 
 /*
 Custom Description

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -9,6 +9,10 @@
 	flippable = 1
 	var/base_name = ""
 
+/obj/item/clothing/accessory/holster/Initialize()
+	. = ..()
+	base_name = name
+
 /obj/item/clothing/accessory/holster/proc/holster(var/obj/item/I, var/mob/living/user)
 	if(holstered && istype(user))
 		to_chat(user, "<span class='warning'>There is already \a [holstered] holstered here!</span>")
@@ -28,7 +32,6 @@
 	holstered.add_fingerprint(user)
 	w_class = max(w_class, holstered.w_class)
 	user.visible_message("<span class='notice'>[user] holsters \the [holstered].</span>", "<span class='notice'>You holster \the [holstered].</span>")
-	base_name = name
 	name = "occupied [base_name]"
 
 /obj/item/clothing/accessory/holster/proc/clear_holster()

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -34,7 +34,6 @@
 	var/cleantime = 30
 	var/last_clean
 	var/clean_msg = FALSE
-	var/name_change = TRUE
 
 /obj/item/reagent_containers/glass/rag/Initialize()
 	. = ..()
@@ -66,14 +65,12 @@
 	update_icon()
 
 /obj/item/reagent_containers/glass/rag/proc/update_name()
-	if(on_fire && name_change)
-		name = "burning [initial(name)]"
-	else if(reagents.total_volume && name_change)
-		base_name = name
-		name = "damp [initial(name)]"
-	else if (name_change)
-		base_name = name
-		name = "dry [initial(name)]"
+	if(on_fire)
+		name = "burning [base_name]"
+	else if(reagents.total_volume)
+		name = "damp [base_name]"
+	else
+		name = "dry [base_name]"
 
 /obj/item/reagent_containers/glass/rag/update_icon()
 	if(on_fire)
@@ -110,7 +107,7 @@
 
 /obj/item/reagent_containers/glass/rag/proc/wipe_down(atom/A, mob/user)
 	if(!reagents.total_volume)
-		to_chat(user, SPAN_WARNING("\The [initial(name)] is dry!"))
+		to_chat(user, SPAN_WARNING("\The [base_name] is dry!"))
 	else
 		if (!(last_clean && world.time < last_clean + 120) )
 			user.visible_message("<b>[user]</b> starts to wipe [A] with [src].")
@@ -310,4 +307,3 @@
 	desc = "For cleaning a lady's hand, your bruised ego or a crime scene."
 	volume = 5
 	icon_state = "handkerchief"
-	name_change = FALSE

--- a/html/changelogs/LoadoutNames.yml
+++ b/html/changelogs/LoadoutNames.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Handkerchiefs naming are now properly fixed."


### PR DESCRIPTION
This fully fixes handkerchief naming and should make future loadout additions with name changing elements more proof as long as the relevant items are modified to fit.
Quick instructions for future additions to loadout: if an item at any point change name, they should get a var called `base_name` and this var should be used in those places. Under initialise this var should be given the name of the item. The loadout will then change this var if an item is renamed with it.
Credits to Geeves for discussing ideas with me.