### PR TITLE
Adds grenadine + cream cartridges to the booze dispenser in the bar

### DIFF
--- a/code/modules/reagents/dispenser/cartridge_presets.dm
+++ b/code/modules/reagents/dispenser/cartridge_presets.dm
@@ -53,6 +53,7 @@
 	clean_kois	spawn_reagent = /decl/reagent/kois/clean
 	cola		spawn_reagent = /decl/reagent/drink/space_cola
 	dr_gibb		spawn_reagent = /decl/reagent/drink/dr_gibb
+	grenadine	spawn_reagent = /decl/reagent/drink/grenadine
 	ice			spawn_reagent = /decl/reagent/drink/ice
 	icetea		spawn_reagent = /decl/reagent/drink/icetea
 	lemon_lime	spawn_reagent = /decl/reagent/drink/lemon_lime

--- a/code/modules/reagents/dispenser/dispenser_presets.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets.dm
@@ -131,7 +131,9 @@
 			/obj/item/reagent_containers/chem_disp_cartridge/vermouth,
 			/obj/item/reagent_containers/chem_disp_cartridge/cognac,
 			/obj/item/reagent_containers/chem_disp_cartridge/ale,
-			/obj/item/reagent_containers/chem_disp_cartridge/mead
+			/obj/item/reagent_containers/chem_disp_cartridge/mead,
+			/obj/item/reagent_containers/chem_disp_cartridge/grenadine,
+			/obj/item/reagent_containers/chem_disp_cartridge/cream
 		)
 
 /obj/machinery/chemical_dispenser/coffeemaster

--- a/html/changelogs/omicega-reefdsfdsfdsdfsfsdf.yml
+++ b/html/changelogs/omicega-reefdsfdsfdsdfsfsdf.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds a cream and grenadine cartridge to the booze dispenser."


### PR DESCRIPTION
See title. Grenadine is used in a million different drinks and only comes out of the booze-o-mat itself in tiny little bottles. Cream is used in a lot of alcoholic drinks, too, requiring you to juggle the glass between the alcohol dispenser and the soft drinks dispenser, which is annoying.

Done at the request of @NotSchwann, but made with love for bartender players everywhere.