### PR TITLE
fixes passport sprites

### DIFF
--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -472,9 +472,6 @@
 	to_chat(usr, SPAN_NOTICE("You [open ? "open" : "close"] \the [src]."))
 	update_icon()
 
-/obj/item/clothing/accessory/badge/passport/update_icon()
-	icon_state = "[initial(icon_state)][open ? "_o" : ""]"
-
 /obj/item/clothing/accessory/badge/passport/sol
 	name = "solarian passport"
 	desc = "A passport issued to a citizen of the Alliance of Sovereign Solarian Nations, or Sol Alliance. An outdated document for passage abroad."

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -472,6 +472,10 @@
 	to_chat(usr, SPAN_NOTICE("You [open ? "open" : "close"] \the [src]."))
 	update_icon()
 
+/obj/item/clothing/accessory/badge/passport/update_icon()
+	if(open != CANT_OPEN)
+		icon_state = "[initial(icon_state)][open ? "_o" : ""]"
+
 /obj/item/clothing/accessory/badge/passport/sol
 	name = "solarian passport"
 	desc = "A passport issued to a citizen of the Alliance of Sovereign Solarian Nations, or Sol Alliance. An outdated document for passage abroad."

--- a/html/changelogs/PassFix.yml
+++ b/html/changelogs/PassFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Human passports should now once again be visible."


### PR DESCRIPTION
fixes https://github.com/Aurorastation/Aurora.3/issues/11739

So... Apparently my testing showed this line as completely unneeded and all it did was breaking the passport sprites since the one passport who can open, jargon federation, has its own variant.