### PR TITLE
Adds a Bottle of Theta to NanoMeds

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -459,6 +459,7 @@
 		/obj/item/reagent_containers/glass/bottle/perconol = 3,
 		/obj/item/reagent_containers/glass/bottle/toxin = 1,
 		/obj/item/reagent_containers/glass/bottle/coughsyrup = 4,
+		/obj/item/reagent_containers/glass/bottle/thetamycin = 1,
 		/obj/item/reagent_containers/syringe = 12,
 		/obj/item/device/healthanalyzer = 5,
 		/obj/item/device/breath_analyzer = 2,
@@ -474,7 +475,7 @@
 		/obj/item/reagent_containers/pill/perconol = 6,
 		/obj/item/reagent_containers/food/drinks/medcup = 4,
 		/obj/item/storage/pill_bottle = 4,
-		/obj/item/reagent_containers/spray/sterilizine = 2
+		/obj/item/reagent_containers/spray/sterilizine = 2 
 	)
 	contraband = list(
 		/obj/item/reagent_containers/inhaler/space_drugs = 2,

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -475,7 +475,7 @@
 		/obj/item/reagent_containers/pill/perconol = 6,
 		/obj/item/reagent_containers/food/drinks/medcup = 4,
 		/obj/item/storage/pill_bottle = 4,
-		/obj/item/reagent_containers/spray/sterilizine = 2 
+		/obj/item/reagent_containers/spray/sterilizine = 2
 	)
 	contraband = list(
 		/obj/item/reagent_containers/inhaler/space_drugs = 2,

--- a/html/changelogs/wickedcybs_theta.yml
+++ b/html/changelogs/wickedcybs_theta.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "NanoMed Plus vendors now get exactly one bottle of theta each."


### PR DESCRIPTION
Infections were tweaked to be more frequent and more deadly recently. Medical at the moment only has their theta syringes as readily available antibiotics, and to get more needs a pharmacist.

Since the medicine appears rather ubiquitous I don't think it's so valued that it has to be limited like this. A bottle each is well enough and this will also serve as a bonus to antags stuck in an infection spiral as securing a NanoMed is a lot quicker than going to the few pre-set spawn points. 