### PR TITLE
Table Sliding

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -5,14 +5,14 @@
 	recieving object instead, so that's the default action.  This allows you to drag
 	almost anything into a trash can.
 */
-/atom/MouseDrop(atom/over)
-	if(!usr || !over) return
-	if(!Adjacent(usr) || !over.Adjacent(usr)) return // should stop you from dragging through windows
+/atom/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	if(!usr || !over)
+		return
+	if(!Adjacent(usr) || !over.Adjacent(usr))
+		return // should stop you from dragging through windows
 
-	spawn(0)
-		over.MouseDrop_T(src,usr)
-	return
+	INVOKE_ASYNC(over, /atom/.proc/MouseDrop_T, src, usr, src_location, over_location, src_control, over_control, params)
 
 // receive a mousedrop
-/atom/proc/MouseDrop_T(atom/dropping, mob/user)
+/atom/proc/MouseDrop_T(atom/dropping, mob/user, src_location, over_location, src_control, over_control, params)
 	return

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -199,17 +199,17 @@ var/list/slot_equipment_priority = list( \
 //Drops the item in our active hand. TODO: rename this to drop_active_hand or something
 
 /mob/proc/drop_item(var/atom/Target)
-    var/obj/item/item_dropped = null
+	var/obj/item/item_dropped = null
 
-    if (hand)
-        item_dropped = l_hand
-        . = drop_l_hand(Target)
-    else
-        item_dropped = r_hand
-        . = drop_r_hand(Target)
+	if (hand)
+		item_dropped = l_hand
+		. = drop_l_hand(Target)
+	else
+		item_dropped = r_hand
+		. = drop_r_hand(Target)
 
-    if (istype(item_dropped) && !QDELETED(item_dropped))
-        addtimer(CALLBACK(src, .proc/make_item_drop_sound, item_dropped), 1)
+	if (istype(item_dropped) && !QDELETED(item_dropped))
+		addtimer(CALLBACK(src, .proc/make_item_drop_sound, item_dropped), 1)
 
 /mob/proc/make_item_drop_sound(obj/item/I)
 	if(QDELETED(I))

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -127,16 +127,30 @@
 			throw_things(user)
 	LAZYREMOVE(climbers, user)
 
-/obj/structure/table/MouseDrop_T(obj/O as obj, mob/user as mob)
+/obj/structure/table/MouseDrop_T(obj/O, mob/user, src_location, over_location, src_control, over_control, params)
+	if(ismob(O.loc)) //If placing an item
+		if(!isitem(O) || user.get_active_hand() != O)
+			return ..()
+		if(isrobot(user))
+			return
+		user.drop_item()
+		if(O.loc != src.loc)
+			step(O, get_dir(O, src))
 
-	if ((!( istype(O, /obj/item) ) || user.get_active_hand() != O))
-		return ..()
-	if(isrobot(user))
-		return
-	user.drop_item()
-	if (O.loc != src.loc)
-		step(O, get_dir(O, src))
-	return
+	else if(isturf(O.loc) && isitem(O)) //If pushing an item on the tabletop
+		var/obj/item/I = O
+		if(I.anchored)
+			return
+
+		if(!use_check_and_message(user))
+			if(O.w_class <= user.can_pull_size)
+				O.forceMove(loc)
+				auto_align(I, params, TRUE)
+			else
+				to_chat(user, SPAN_WARNING("\The [I] is too big for you to move!"))
+			return
+
+	return ..()
 
 /obj/structure/table/attackby(obj/item/W, mob/user, var/click_parameters)
 	if (!W)
@@ -221,7 +235,7 @@ closest to where the cursor has clicked on.
 Note: This proc can be overwritten to allow for different types of auto-alignment.
 */
 /obj/item/var/list/center_of_mass = list("x" = 16,"y" = 16)
-/obj/structure/table/proc/auto_align(obj/item/W, click_parameters)
+/obj/structure/table/proc/auto_align(obj/item/W, click_parameters, var/animate = FALSE)
 	if(!W.center_of_mass)
 		W.randpixel_xy()
 		W.layer = initial(W.layer) + ((32 - W.pixel_y) / 1000)
@@ -238,8 +252,16 @@ Note: This proc can be overwritten to allow for different types of auto-alignmen
 		var/cell_x = max(0, min(CELLS-1, round(mouse_x/CELLSIZE)))
 		var/cell_y = max(0, min(CELLS-1, round(mouse_y/CELLSIZE)))
 
-		W.pixel_x = (CELLSIZE * (0.5 + cell_x)) - W.center_of_mass["x"]
-		W.pixel_y = (CELLSIZE * (0.5 + cell_y)) - W.center_of_mass["y"]
+		var/target_x = (CELLSIZE * (cell_x + 0.5)) - W.center_of_mass["x"]
+		var/target_y = (CELLSIZE * (cell_y + 0.5)) - W.center_of_mass["y"]
+		if(animate)
+			var/dist_x = abs(W.pixel_x - target_x)
+			var/dist_y = abs(W.pixel_y - target_y)
+			var/dist = sqrt((dist_x*dist_x)+(dist_y*dist_y))
+			animate(W, pixel_x=target_x, pixel_y=target_y,time=dist*0.5)
+		else
+			W.pixel_x = target_x
+			W.pixel_y = target_y
 		W.layer = initial(W.layer) + ((32 - W.pixel_y) / 1000)
 
 #undef CELLS

--- a/html/changelogs/geeves-table_sliding.yml
+++ b/html/changelogs/geeves-table_sliding.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "You can now slide items across tables by click dragging from the item to the table."


### PR DESCRIPTION
* You can now slide items across tables by click dragging from the item to the table.

Ported from: https://github.com/VestaOfOrion/Vesta.Bay/pull/298