### PR TITLE
Fiber & print collection drag & drop

### DIFF
--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -126,6 +126,7 @@
 	desc = "A magnifying glass and tweezers. Used to lift suit fibers."
 	icon_state = "m_glass"
 	w_class = ITEMSIZE_SMALL
+	flags = NOBLUDGEON
 	var/evidence_type = "fiber"
 	var/evidence_path = /obj/item/sample/fibers
 
@@ -146,6 +147,11 @@
 	else
 		to_chat(user, "<span class='warning'>You are unable to locate any [evidence_type]s on \the [A].</span>")
 		return ..()
+
+/obj/item/forensics/sample_kit/MouseDrop(atom/over)
+	var/mob/M = loc
+	if(ismob(M) && (M.get_active_hand() == src || M.get_inactive_hand() == src))
+		afterattack(over, usr, TRUE)
 
 /obj/item/forensics/sample_kit/powder
 	name = "fingerprint powder"

--- a/html/changelogs/EvidenceCollector.yml
+++ b/html/changelogs/EvidenceCollector.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "The fiber & print collection kits can now take samples by drag clicking them in addition to ordinary clicks."


### PR DESCRIPTION
Basically they can be dragged & dropped on adjacent objects to take samples from this. Now we will no longer need to put them inside lockers/on tables. Also stops them from hitting stuff since that was annoying.