### PR TITLE
Adds a preference for floating chat color.

### DIFF
--- a/SQL/migrate/V067__floatiing_chat_color.sql
+++ b/SQL/migrate/V067__floatiing_chat_color.sql
@@ -1,0 +1,6 @@
+--
+-- Add a new floating chat color field
+-- 
+
+ALTER TABLE `ss13_characters`
+	ADD COLUMN `floating_chat_color` char(7) DEFAULT NULL AFTER `pronouns`

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -10,6 +10,7 @@
 	S["species"]    >> pref.species
 	S["spawnpoint"] >> pref.spawnpoint
 	S["OOC_Notes"]  >> pref.metadata
+	S["floating_chat_color"] >> pref.floating_chat_color
 	if(istype(all_species[pref.species], /datum/species/machine))
 		S["ipc_tag_status"] >> pref.machine_tag_status
 		S["ipc_serial_number"] >> pref.machine_serial_number
@@ -23,6 +24,7 @@
 	S["species"]    << pref.species
 	S["spawnpoint"] << pref.spawnpoint
 	S["OOC_Notes"]  << pref.metadata
+	S["floating_chat_color"] << pref.floating_chat_color
 	if(istype(all_species[pref.species], /datum/species/machine))
 		S["ipc_tag_status"] << pref.machine_tag_status
 		S["ipc_serial_number"] << pref.machine_serial_number
@@ -40,7 +42,8 @@
 				"age",
 				"metadata",
 				"spawnpoint",
-				"species"
+				"species",
+				"floating_chat_color"
 			),
 			"args" = list("id")
 		),
@@ -72,6 +75,7 @@
 			"metadata",
 			"spawnpoint",
 			"species",
+			"floating_chat_color",
 			"id" = 1,
 			"ckey" = 1
 		),
@@ -97,6 +101,7 @@
 		"ownership_status" = pref.machine_ownership_status,
 		"id" = pref.current_character,
 		"char_id" = pref.current_character,
+		"floating_chat_color" = pref.floating_chat_color,
 		"ckey" = PREF_CLIENT_CKEY
 	)
 
@@ -140,6 +145,7 @@
 		pref.real_name      = random_name(pref.gender, pref.species)
 	pref.spawnpoint         = sanitize_inlist(pref.spawnpoint, SSatlas.spawn_locations, initial(pref.spawnpoint))
 	pref.machine_tag_status = text2num(pref.machine_tag_status) // SQL queries return as text, so make this a num
+	pref.floating_chat_color = sanitize_hexcolor(pref.floating_chat_color, get_random_colour(0, 160, 230))
 
 /datum/category_item/player_setup_item/general/basic/content(var/mob/user)
 	var/list/dat = list("<b>Name:</b> ")
@@ -156,6 +162,7 @@
 		dat += "<b>Pronouns:</b> <a href='?src=\ref[src];pronouns=1'><b>[capitalize_first_letters(pref.pronouns)]</b></a><br>"
 	dat += "<b>Age:</b> <a href='?src=\ref[src];age=1'>[pref.age]</a><br>"
 	dat += "<b>Spawn Point</b>: <a href='?src=\ref[src];spawnpoint=1'>[pref.spawnpoint]</a><br>"
+	dat += "<b>Floating Chat Color:</b> <a href='?src=\ref[src];select_floating_chat_color=1'><b>[pref.floating_chat_color]</b></a><br>"
 	if(istype(S, /datum/species/machine))
 		if(pref.can_edit_ipc_tag)
 			dat += "<b>Has Tag:</b> <a href='?src=\ref[src];ipc_tag=1'>[pref.machine_tag_status ? "Yes" : "No"]</a><br>"
@@ -219,6 +226,15 @@
 
 		pref.real_name = random_name(pref.gender, pref.species)
 		return TOPIC_REFRESH
+
+	else if(href_list["select_floating_chat_color"])
+		var/new_fc_color = input(user, "Choose Floating Chat Color:", "Global Preference") as color|null
+		if(new_fc_color && CanUseTopic(user))
+			pref.floating_chat_color = new_fc_color
+			var/mob/living/carbon/human/H = preference_mob()
+			if(ishuman(H))
+				H.set_floating_chat_color(new_fc_color)
+			return TOPIC_REFRESH
 
 	else if(href_list["gender"])
 		var/datum/species/S = all_species[pref.species]

--- a/code/modules/client/preference_setup/general/06_flavor.dm
+++ b/code/modules/client/preference_setup/general/06_flavor.dm
@@ -4,9 +4,9 @@
 
 /datum/category_item/player_setup_item/general/flavor/load_character(var/savefile/S)
 	S["flavor_texts_general"] >> pref.flavor_texts["general"]
-	S["flavor_texts_head"]    >> pref.flavor_texts[BP_HEAD]
+	S["flavor_texts_head"]    >> pref.flavor_texts["head"]
 	S["flavor_texts_face"]    >> pref.flavor_texts["face"]
-	S["flavor_texts_eyes"]    >> pref.flavor_texts[BP_EYES]
+	S["flavor_texts_eyes"]    >> pref.flavor_texts["eyes"]
 	S["flavor_texts_torso"]   >> pref.flavor_texts["torso"]
 	S["flavor_texts_arms"]    >> pref.flavor_texts["arms"]
 	S["flavor_texts_hands"]   >> pref.flavor_texts["hands"]
@@ -23,9 +23,9 @@
 
 /datum/category_item/player_setup_item/general/flavor/save_character(var/savefile/S)
 	S["flavor_texts_general"] << pref.flavor_texts["general"]
-	S["flavor_texts_head"]    << pref.flavor_texts[BP_HEAD]
+	S["flavor_texts_head"]    << pref.flavor_texts["head"]
 	S["flavor_texts_face"]    << pref.flavor_texts["face"]
-	S["flavor_texts_eyes"]    << pref.flavor_texts[BP_EYES]
+	S["flavor_texts_eyes"]    << pref.flavor_texts["eyes"]
 	S["flavor_texts_torso"]   << pref.flavor_texts["torso"]
 	S["flavor_texts_arms"]    << pref.flavor_texts["arms"]
 	S["flavor_texts_hands"]   << pref.flavor_texts["hands"]
@@ -94,9 +94,9 @@
 	var/list/var_list = list(
 		"char_id" = pref.current_character,
 		"flavour_general" = pref.flavor_texts["general"],
-		"flavour_head" = pref.flavor_texts[BP_HEAD],
+		"flavour_head" = pref.flavor_texts["head"],
 		"flavour_face" = pref.flavor_texts["face"],
-		"flavour_eyes" = pref.flavor_texts[BP_EYES],
+		"flavour_eyes" = pref.flavor_texts["eyes"],
 		"flavour_torso" = pref.flavor_texts["torso"],
 		"flavour_arms" = pref.flavor_texts["arms"],
 		"flavour_hands" = pref.flavor_texts["hands"],
@@ -219,13 +219,13 @@
 	HTML += TextPreview(pref.flavor_texts["general"])
 	HTML += "<br>"
 	HTML += "<a href='?src=\ref[src];flavor_text=head'>Head:</a> "
-	HTML += TextPreview(pref.flavor_texts[BP_HEAD])
+	HTML += TextPreview(pref.flavor_texts["head"])
 	HTML += "<br>"
 	HTML += "<a href='?src=\ref[src];flavor_text=face'>Face:</a> "
 	HTML += TextPreview(pref.flavor_texts["face"])
 	HTML += "<br>"
 	HTML += "<a href='?src=\ref[src];flavor_text=eyes'>Eyes:</a> "
-	HTML += TextPreview(pref.flavor_texts[BP_EYES])
+	HTML += TextPreview(pref.flavor_texts["eyes"])
 	HTML += "<br>"
 	HTML += "<a href='?src=\ref[src];flavor_text=torso'>Body:</a> "
 	HTML += TextPreview(pref.flavor_texts["torso"])

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -9,7 +9,6 @@
 	S["html_UI_style"]  >> pref.html_UI_style
 	S["ooccolor"]       >> pref.ooccolor
 	S["clientfps"]			>> pref.clientfps
-	S["floating_chat_color"] >> pref.floating_chat_color
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(var/savefile/S)
 	S["UI_style"]       << pref.UI_style
@@ -18,7 +17,6 @@
 	S["html_UI_style"]  << pref.html_UI_style
 	S["ooccolor"]       << pref.ooccolor
 	S["clientfps"]			<< pref.clientfps
-	S["floating_chat_color"] << pref.floating_chat_color
 
 /datum/category_item/player_setup_item/player_global/ui/gather_load_query()
 	return list(
@@ -30,8 +28,7 @@
 				"html_UI_style",
 				"ooccolor",
 				"clientfps",
-				"tooltip_style",
-				"floating_chat_color"
+				"tooltip_style"
 			),
 			"args" = list("ckey")
 		)
@@ -50,7 +47,6 @@
 			"ooccolor",
 			"clientfps",
 			"tooltip_style",
-			"floating_chat_color",
 			"ckey" = 1
 		)
 	)
@@ -64,8 +60,7 @@
 		"html_UI_style" = pref.html_UI_style,
 		"ooccolor" = pref.ooccolor,
 		"clientfps" = pref.clientfps,
-		"tooltip_style" = pref.tooltip_style,
-		"floating_chat_color" = pref.floating_chat_color
+		"tooltip_style" = pref.tooltip_style
 	)
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
@@ -75,7 +70,6 @@
 	pref.clientfps = sanitize_integer(text2num(pref.clientfps), 0, 1000, initial(pref.clientfps))
 	pref.html_UI_style       = sanitize_inlist(pref.html_UI_style, SStheming.available_html_themes, initial(pref.html_UI_style))
 	pref.ooccolor       = sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
-	pref.floating_chat_color = sanitize_hexcolor(pref.floating_chat_color, get_random_colour(0, 160, 230))
 
 /datum/category_item/player_setup_item/player_global/ui/content(mob/user)
 	var/list/dat = list()
@@ -93,7 +87,6 @@
 			dat += "<a href='?src=\ref[src];select_ooc_color=1'><b>Using Default</b></a><br>"
 		else
 			dat += "<a href='?src=\ref[src];select_ooc_color=1'><b>[pref.ooccolor]</b></a> [HTML_RECT(pref.ooccolor)] - <a href='?src=\ref[src];reset=ooc'>reset</a><br>"
-	dat += "<b>Floating Chat Color:</b> <a href='?src=\ref[src];select_floating_chat_color=1'><b>[pref.floating_chat_color]</b></a><br>"
 
 	. = dat.Join()
 
@@ -126,12 +119,6 @@
 		var/new_ooccolor = input(user, "Choose OOC color:", "Global Preference") as color|null
 		if(new_ooccolor && can_select_ooc_color(user) && CanUseTopic(user))
 			pref.ooccolor = new_ooccolor
-			return TOPIC_REFRESH
-
-	else if(href_list["select_floating_chat_color"])
-		var/new_fc_color = input(user, "Choose Floating Chat Color:", "Global Preference") as color|null
-		if(new_fc_color && CanUseTopic(user))
-			pref.floating_chat_color = new_fc_color
 			return TOPIC_REFRESH
 
 	else if(href_list["select_fps"])

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -9,6 +9,7 @@
 	S["html_UI_style"]  >> pref.html_UI_style
 	S["ooccolor"]       >> pref.ooccolor
 	S["clientfps"]			>> pref.clientfps
+	S["floating_chat_color"] >> pref.floating_chat_color
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(var/savefile/S)
 	S["UI_style"]       << pref.UI_style
@@ -17,6 +18,7 @@
 	S["html_UI_style"]  << pref.html_UI_style
 	S["ooccolor"]       << pref.ooccolor
 	S["clientfps"]			<< pref.clientfps
+	S["floating_chat_color"] << pref.floating_chat_color
 
 /datum/category_item/player_setup_item/player_global/ui/gather_load_query()
 	return list(
@@ -28,7 +30,8 @@
 				"html_UI_style",
 				"ooccolor",
 				"clientfps",
-				"tooltip_style"
+				"tooltip_style",
+				"floating_chat_color"
 			),
 			"args" = list("ckey")
 		)
@@ -47,6 +50,7 @@
 			"ooccolor",
 			"clientfps",
 			"tooltip_style",
+			"floating_chat_color",
 			"ckey" = 1
 		)
 	)
@@ -60,7 +64,8 @@
 		"html_UI_style" = pref.html_UI_style,
 		"ooccolor" = pref.ooccolor,
 		"clientfps" = pref.clientfps,
-		"tooltip_style" = pref.tooltip_style
+		"tooltip_style" = pref.tooltip_style,
+		"floating_chat_color" = pref.floating_chat_color
 	)
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
@@ -70,6 +75,7 @@
 	pref.clientfps = sanitize_integer(text2num(pref.clientfps), 0, 1000, initial(pref.clientfps))
 	pref.html_UI_style       = sanitize_inlist(pref.html_UI_style, SStheming.available_html_themes, initial(pref.html_UI_style))
 	pref.ooccolor       = sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
+	pref.floating_chat_color = sanitize_hexcolor(pref.floating_chat_color, get_random_colour(0, 160, 230))
 
 /datum/category_item/player_setup_item/player_global/ui/content(mob/user)
 	var/list/dat = list()
@@ -80,13 +86,14 @@
 	dat += "-Alpha(transparency): <a href='?src=\ref[src];select_alpha=1'><b>[pref.UI_style_alpha]</b></a> - <a href='?src=\ref[src];reset=alpha'>reset</a><br>"
 	dat += "<b>Tooltip Style:</b> <a href='?src=\ref[src];select_tooltip_style=1'><b>[pref.tooltip_style]</b></a><br>"
 	dat += "<b>HTML UI Style:</b> <a href='?src=\ref[src];select_html=1'><b>[pref.html_UI_style]</b></a><br>"
-	dat += "-FPS: <a href='?src=\ref[src];select_fps=1'><b>[pref.clientfps]</b></a> - <a href='?src=\ref[src];reset=fps'>reset</a><br>"
+	dat += "<b>FPS:</b> <a href='?src=\ref[src];select_fps=1'><b>[pref.clientfps]</b></a> - <a href='?src=\ref[src];reset=fps'>reset</a><br>"
 	if(can_select_ooc_color(user))
 		dat += "<b>OOC Color:</b> "
 		if(pref.ooccolor == initial(pref.ooccolor))
 			dat += "<a href='?src=\ref[src];select_ooc_color=1'><b>Using Default</b></a><br>"
 		else
 			dat += "<a href='?src=\ref[src];select_ooc_color=1'><b>[pref.ooccolor]</b></a> [HTML_RECT(pref.ooccolor)] - <a href='?src=\ref[src];reset=ooc'>reset</a><br>"
+	dat += "<b>Floating Chat Color:</b> <a href='?src=\ref[src];select_floating_chat_color=1'><b>[pref.floating_chat_color]</b></a><br>"
 
 	. = dat.Join()
 
@@ -119,6 +126,12 @@
 		var/new_ooccolor = input(user, "Choose OOC color:", "Global Preference") as color|null
 		if(new_ooccolor && can_select_ooc_color(user) && CanUseTopic(user))
 			pref.ooccolor = new_ooccolor
+			return TOPIC_REFRESH
+
+	else if(href_list["select_floating_chat_color"])
+		var/new_fc_color = input(user, "Choose Floating Chat Color:", "Global Preference") as color|null
+		if(new_fc_color && CanUseTopic(user))
+			pref.floating_chat_color = new_fc_color
 			return TOPIC_REFRESH
 
 	else if(href_list["select_fps"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -152,6 +152,7 @@ datum/preferences
 	var/parallax_speed = 2
 	var/toggles_secondary = PARALLAX_SPACE | PARALLAX_DUST | PROGRESS_BARS | FLOATING_MESSAGES | HOTKEY_DEFAULT
 	var/clientfps = 0
+	var/floating_chat_color
 
 	var/list/pai = list()	// A list for holding pAI related data.
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -405,6 +405,7 @@ datum/preferences
 	character.set_species(species)
 	if(character.dna)
 		character.dna.real_name = character.real_name
+	character.set_floating_chat_color(floating_chat_color)
 
 	character.flavor_texts["general"] = flavor_texts["general"]
 	character.flavor_texts[BP_HEAD] = flavor_texts[BP_HEAD]
@@ -659,6 +660,8 @@ datum/preferences
 		disabilities = list()
 
 		nanotrasen_relation = "Neutral"
+	
+	update_preview_icon()
 
 // Deletes a character from the database
 /datum/preferences/proc/delete_character_sql(var/client/C)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -75,6 +75,8 @@
 	else
 		save_preferences()
 
+	update_preview_icon()
+
 	return 1
 
 /datum/preferences/proc/save_character()

--- a/code/modules/mob/floating_messages.dm
+++ b/code/modules/mob/floating_messages.dm
@@ -4,6 +4,14 @@ var/list/floating_chat_colors = list()
 /atom/movable
 	var/list/stored_chat_text
 
+/atom/movable/proc/get_floating_chat_color()
+	return get_random_colour(0, 160, 230)
+
+/mob/living/carbon/human/get_floating_chat_color()
+	if(client)
+		if(client.prefs)
+			return client.prefs.floating_chat_color
+
 /atom/movable/proc/animate_chat(message, datum/language/language, small, list/show_to, duration)
 	set waitfor = FALSE
 
@@ -21,7 +29,7 @@ var/list/floating_chat_colors = list()
 		message = "[copytext(message, 1, limit)]..."
 
 	if(!floating_chat_colors[name])
-		floating_chat_colors[name] = get_random_colour(0, 160, 230)
+		floating_chat_colors[name] = get_floating_chat_color()
 	style += "color: [floating_chat_colors[name]];"
 
 	// create 2 messages, one that appears if you know the language, and one that appears when you don't know the language

--- a/code/modules/mob/floating_messages.dm
+++ b/code/modules/mob/floating_messages.dm
@@ -7,12 +7,10 @@ var/list/floating_chat_colors = list()
 /atom/movable/proc/get_floating_chat_color()
 	return get_random_colour(0, 160, 230)
 
-/mob/living/carbon/human/get_floating_chat_color()
-	if(client)
-		if(client.prefs)
-			return client.prefs.floating_chat_color
+/atom/movable/proc/set_floating_chat_color(color)
+	floating_chat_colors[name] = color
 
-/atom/movable/proc/animate_chat(message, datum/language/language, small, list/show_to, duration)
+/atom/movable/proc/animate_chat(message, datum/language/language, small, list/show_to, duration, override_color)
 	set waitfor = FALSE
 
 	var/style	//additional style params for the message

--- a/html/changelogs/mattatlas-floatingchatcolor.yml
+++ b/html/changelogs/mattatlas-floatingchatcolor.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a preference for floating chat color. This is per-character and updates in game when you update it on the pref window too."
+  - bugfix: "Windows like the accent and citizenship window no longer go under the pref window when opened."
+  - bugfix: "Loading a new character now actually updates the preview window."

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1300,6 +1300,35 @@ window "rpane"
 		group = "rpanemode"
 		button-type = pushbox
 
+window "preferences_window"
+	elem "preferences_window"
+		type = MAIN
+		pos = 281,0
+		size = 1200x800
+		anchor1 = none
+		anchor2 = none
+		background-color = none
+		is-visible = false
+		saved-params = "pos;size;is-minimized;is-maximized"
+		statusbar = false
+		outer-size = 1216x839
+		inner-size = 1200x800
+	elem "preferences_browser"
+		type = BROWSER
+		pos = 0,0
+		size = 1000x800
+		anchor1 = 0,0
+		anchor2 = 80,100
+		background-color = none
+		saved-params = ""
+	elem "character_preview_map"
+		type = MAP
+		pos = 1000,0
+		size = 200x800
+		anchor1 = 80,0
+		anchor2 = 100,100
+		saved-params = "zoom;letterbox;zoom-mode"
+
 window "browserwindow"
 	elem "browserwindow"
 		type = MAIN
@@ -1412,33 +1441,4 @@ window "text_editor"
 		border = line
 		saved-params = ""
 		multi-line = true
-
-window "preferences_window"
-	elem "preferences_window"
-		type = MAIN
-		pos = 281,0
-		size = 1200x800
-		anchor1 = none
-		anchor2 = none
-		background-color = none
-		is-visible = false
-		saved-params = "pos;size;is-minimized;is-maximized"
-		statusbar = false
-		outer-size = 1216x839
-		inner-size = 1200x800
-	elem "preferences_browser"
-		type = BROWSER
-		pos = 0,0
-		size = 1000x800
-		anchor1 = 0,0
-		anchor2 = 80,100
-		background-color = none
-		saved-params = ""
-	elem "character_preview_map"
-		type = MAP
-		pos = 1000,0
-		size = 200x800
-		anchor1 = 80,0
-		anchor2 = 100,100
-		saved-params = "zoom;letterbox;zoom-mode"
 


### PR DESCRIPTION
Gaming.

  - Added a preference for floating chat color. This is per-character and updates in game when you update it on the pref window too.
  - Windows like the accent and citizenship window no longer go under the pref window when opened.
  - Loading a new character now actually updates the preview window.