### PR TITLE
Accessory Attach Fix

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -55,7 +55,7 @@
 		mob_overlay.color = color
 	if(build_from_parts)
 		mob_overlay.cut_overlays()
-		mob_overlay.add_overlay(overlay_image(I, "[icon_state]_[worn_overlay]", flags=RESET_COLOR)) //add the overlay w/o coloration of the original sprite
+		mob_overlay.add_overlay(overlay_image(I, "[icon_state][WORN_UNDER]_[worn_overlay]", flags=RESET_COLOR)) //add the overlay w/o coloration of the original sprite
 	mob_overlay.appearance_flags = RESET_ALPHA
 	return mob_overlay
 

--- a/html/changelogs/geeves-unathi_mantle_fix.yml
+++ b/html/changelogs/geeves-unathi_mantle_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Tweaked items that can be attached as accessories to use the correct mob_overlay item_state. This might cause some accessories to break, so make a github issue or DM me on discord if you find any, preferably the former."


### PR DESCRIPTION
* Tweaked items that can be attached as accessories to use the correct mob_overlay item_state. This might cause some accessories to break, so make a github issue or DM me on discord if you find any, preferably the former.