### PR TITLE
Limbs no longer auto-fracture at the damage threshold

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -820,9 +820,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if (open && !clamped && (H && !(H.species.flags & NO_BLOOD)))
 		status |= ORGAN_BLEEDING
 
-	//Bone fractures
-	if(config.bones_can_break && brute_dam > min_broken_damage * config.organ_health_multiplier && !(status & ORGAN_ROBOT))
-		fracture()
 	update_damage_ratios()
 
 /obj/item/organ/external/proc/update_damage_ratios()

--- a/html/changelogs/johnwildkins-fracture.yml
+++ b/html/changelogs/johnwildkins-fracture.yml
@@ -1,0 +1,5 @@
+author: JohnWildkins
+delete-after: True
+
+changes:
+  - tweak: "Fractures are no longer guaranteed once a limb takes 30 brute damage. Repairing a broken bone no longer relies on the limb being healed HP-wise."


### PR DESCRIPTION
title

this means you can repair a bone without it immediately snapping again because the limb is at 31 brute damage