### PR TITLE
Yet More Infection Tweaks

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -230,12 +230,12 @@
 	if (CE_ANTIBIOTIC in owner.chem_effects)
 		antibiotics = owner.chem_effects[CE_ANTIBIOTIC]
 
-	if (germ_level > 0 && germ_level < INFECTION_LEVEL_ONE/2 && prob(30))
+	if (germ_level > 0 && germ_level < INFECTION_LEVEL_ONE/2 && prob(35))
 		germ_level--
 
 	if (germ_level >= INFECTION_LEVEL_ONE/2)
-		//aiming for germ level to go from ambient to INFECTION_LEVEL_TWO in an average of 15 minutes
-		if(antibiotics < 5 && prob(round(germ_level/6)))
+		//aiming for germ level to go from ambient to INFECTION_LEVEL_TWO in an average of 17 minutes
+		if(antibiotics < 5 && prob(round(germ_level/7)))
 			germ_level++
 
 	if (germ_level >= INFECTION_LEVEL_TWO)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -658,10 +658,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if (owner.germ_level > W.germ_level && W.infection_check())
 			W.germ_level++
 
-	if (antibiotics < 5)
+	if(antibiotics < 5)
 		for(var/datum/wound/W in wounds)
 			//Infected wounds raise the organ's germ level
-			if (W.germ_level > germ_level)
+			if (W.germ_level > germ_level && W.infection_check())
 				germ_level++
 				break	//limit increase to a maximum of one per second
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -723,6 +723,28 @@
 	M.dizziness = max(150, M.dizziness)
 	M.make_dizzy(5)
 
+/decl/reagent/steramycin
+	name = "Steramycin"
+	description = "A preventative antibiotic that will stop small infections from growing, but only if administered early. Has no effect on internal organs, wounds, or if the infection has grown beyond its early stages."
+	reagent_state = LIQUID
+	color = "#81b38b"
+	od_minimum_dose = 1
+	overdose = 15
+	taste_description = "bleach"
+	fallback_specific_heat = 0.605
+
+/decl/reagent/steramycin/affect_blood(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder)
+	if(check_min_dose(M, 1))
+		for(var/obj/item/organ/external/E in M.organs)
+			if(E.germ_level >= INFECTION_LEVEL_ONE || !E.germ_level) //No effect if it's not infected or the infection has progressed.
+				continue
+			E.germ_level = max(E.germ_level - 4, 0)
+
+/decl/reagent/steramycin/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
+	M.dizziness = max(150, M.dizziness)
+	M.make_dizzy(5)
+	M.adjustToxLoss(1) //Antibodies start fighting your body
+
 /decl/reagent/asinodryl
 	name = "Asinodryl"
 	description = "Asinodryl is an anti-emetic medication which acts by preventing the two regions in the brain responsible for vomiting from controlling the act of emesis."

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -382,6 +382,13 @@
 	required_reagents = list(/decl/reagent/cryptobiolin = 1, /decl/reagent/dylovene = 1)
 	result_amount = 2
 
+/datum/chemical_reaction/steramycin
+	name = "Steramycin"
+	id = "steramycin"
+	result = /decl/reagent/steramycin
+	required_reagents = list(/decl/reagent/thetamycin = 2, /decl/reagent/sterilizine = 1, /decl/reagent/radium = 1)
+	result_amount = 2
+
 /datum/chemical_reaction/cetahydramine
 	name = "Cetahydramine"
 	id = "cetahydramine"

--- a/html/changelogs/Doxxmedearly - infection_tweaks_again.yml
+++ b/html/changelogs/Doxxmedearly - infection_tweaks_again.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - tweak: "Wounds are less likely to infect limbs if small or properly treated. Infections should also progress a little less quickly."
+  - rscadd: "Added a new medication, Steramycin. If administered before a limb reaches the first infection level, it has a great chance to prevent infection. It has no effect on infections that have progressed to or past level one; it's meant to be used as insurance against infections after being wounded. It does not sterilize wounds, so make sure those are treated (Or the limb may re-infect)! Created with a ratio of 2 Thetamycin to 1 Sterilizine to 1 Radium, and produces 2 units."


### PR DESCRIPTION
The gift that never stops giving.

Wounds were extremely deadly for infections, which kind of wrecks antags. And while infections remain very serious, a small wound treated in a reasonable time should not grow into something necrotic.

Wounds now use their infection check when seeing whether or not to infect the limb. Little wounds (under 10 damage), treated (salved, bandaged, etc) wounds under 25 damage, and disinfected wounds will stop transferring their germ level to the limb. I also slowed down early progression of infections.

The other issue was that only thetamycin can be used for infection treatment. Thetamycin is slow. So I added a preventative medication, Steramycin. If administered before a limb becomes infected (germ_level 100, also when infections first show on scans) it will knock the germ level down extremely quickly, which will slow progression, and if the wounds are treated, should prevent it entirely. Beyond that, it has no effect. It's intended to be a quick-acting preventative measure after receiving a serious wound.