### PR TITLE
Energy Utility Knives for the Rest of the TCFL

### DIFF
--- a/html/changelogs/wickedcybs_knifey.yml
+++ b/html/changelogs/wickedcybs_knifey.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - maptweak: "The TCFL issue Energy Utility Knives are finally available to more than just the Prefect. They've been added to the rack with the Legion's various melee options. Your tax dollars at work, people."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -13649,6 +13649,30 @@
 	pixel_x = 2;
 	pixel_y = 9
 	},
+/obj/item/melee/energy/sword/knife{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/item/melee/energy/sword/knife{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/item/melee/energy/sword/knife{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/item/melee/energy/sword/knife{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/item/melee/energy/sword/knife{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/item/melee/energy/sword/knife{
+	pixel_x = 9;
+	pixel_y = -4
+	},
 /turf/unsimulated/floor,
 /area/centcom/legion/hangar5)
 "fcL" = (


### PR DESCRIPTION
The Prefect gets an energy utility knife. The rest of the Legion gets telebatons with three tac knives up for grabs. I found it weird the rest don't get their supposedly cheap energy utility knife so I've added a few to the weapons rack the Legion collects its gear from.

Stuff like this I think, benefits from being accessible to everyone and it's not actually that strong a weapon compared to the tacknife anyway. Sentinels would get the utility knife too so it's likely not just a Prefect thing, yeah? Our boys in blue deserve the finest of cheap energy knives. 