### PR TITLE
Eyestab Stuff

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -537,7 +537,7 @@ var/list/global/slot_flags_enumeration = list(
 	return loc
 
 /obj/item/proc/eyestab(mob/living/carbon/M, mob/living/carbon/user)
-	if(M.eyes_protected(TRUE))
+	if(M.eyes_protected(src, TRUE))
 		return
 
 	var/mob/living/carbon/human/H = M
@@ -584,7 +584,7 @@ var/list/global/slot_flags_enumeration = list(
 		M.take_organ_damage(7)
 	M.eye_blurry += rand(3,4)
 
-/obj/item/proc/protects_eyestab(var/stabbed = FALSE) // if stabbed is set to true if we're being stabbed and not just checking
+/obj/item/proc/protects_eyestab(var/obj/stab_item, var/stabbed = FALSE) // if stabbed is set to true if we're being stabbed and not just checking
 	if((item_flags & THICKMATERIAL) && (body_parts_covered & EYES))
 		return TRUE
 	return FALSE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -536,35 +536,18 @@ var/list/global/slot_flags_enumeration = list(
 		L = L.loc
 	return loc
 
-/obj/item/proc/eyestab(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-
-	var/mob/living/carbon/human/H = M
-	if(istype(H))
-		for(var/obj/item/protection in list(H.head, H.wear_mask, H.glasses))
-			if(protection && (protection.body_parts_covered & EYES))
-				// you can't stab someone in the eyes wearing a mask!
-				to_chat(user, "<span class='warning'>You're going to need to remove the eye covering first.</span>")
-				return
-
-	if(!M.has_eyes())
-		to_chat(user, "<span class='warning'>You cannot locate any eyes on [M]!</span>")
+/obj/item/proc/eyestab(mob/living/carbon/M, mob/living/carbon/user)
+	if(M.eyes_protected(TRUE))
 		return
 
+	var/mob/living/carbon/human/H = M
 	admin_attack_log(user, M, "attacked [key_name(M)] with [src]", "was attacked by [key_name(user)] using \a [src]", "used \a [src] to eyestab")
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	playsound(loc, hitsound, 70, TRUE)
 	user.do_attack_animation(M)
 
-	src.add_fingerprint(user)
-	//if((CLUMSY in user.mutations) && prob(50))
-	//	M = user
-		/*
-		to_chat(M, "<span class='warning'>You stab yourself in the eye.</span>")
-		M.sdisabilities |= BLIND
-		M.weakened += 4
-		M.adjustBruteLoss(10)
-		*/
-
+	add_fingerprint(user)
 	if(istype(H))
 		var/obj/item/organ/internal/eyes/eyes = H.get_eyes()
 
@@ -581,26 +564,30 @@ var/list/global/slot_flags_enumeration = list(
 
 		eyes.take_damage(rand(3,4))
 		if(eyes.damage >= eyes.min_bruised_damage)
-			if(M.stat != 2)
+			if(H.stat != DEAD)
 				if(eyes.robotic <= 1) //robot eyes bleeding might be a bit silly
-					to_chat(M, "<span class='danger'>Your eyes start to bleed profusely!</span>")
+					to_chat(H, "<span class='danger'>Your eyes start to bleed profusely!</span>")
 			if(prob(50))
-				if(M.stat != 2)
-					to_chat(M, "<span class='warning'>You drop what you're holding and clutch at your eyes!</span>")
-					M.drop_item()
-				M.eye_blurry += 10
-				M.Paralyse(1)
-				M.Weaken(4)
+				if(H.stat != DEAD)
+					to_chat(H, "<span class='warning'>You drop what you're holding and clutch at your eyes!</span>")
+					H.drop_item()
+				H.eye_blurry += 10
+				H.Paralyse(1)
+				H.Weaken(4)
 			if (eyes.damage >= eyes.min_broken_damage)
-				if(M.stat != 2)
-					to_chat(M, "<span class='warning'>You go blind!</span>")
+				if(H.stat != DEAD)
+					to_chat(H, "<span class='warning'>You go blind!</span>")
 		var/obj/item/organ/external/affecting = H.get_organ(BP_HEAD)
-		if(affecting.take_damage(7))
-			M:UpdateDamageIcon()
+		if(affecting.take_damage(7, 0, damage_flags(), src))
+			H.UpdateDamageIcon()
 	else
 		M.take_organ_damage(7)
 	M.eye_blurry += rand(3,4)
-	return
+
+/obj/item/proc/protects_eyestab(var/stabbed = FALSE) // if stabbed is set to true if we're being stabbed and not just checking
+	if((item_flags & THICKMATERIAL) && (body_parts_covered & EYES))
+		return TRUE
+	return FALSE
 
 /obj/item/clean_blood()
 	. = ..()

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -544,7 +544,7 @@ BREATH ANALYZER
 
 	if ( ((user.is_clumsy()) || (DUMB in user.mutations)) && prob(20))
 		to_chat(user,"<span class='danger'>Your hand slips from clumsiness!</span>")
-		if(!H.eyes_protected(FALSE))
+		if(!H.eyes_protected(src, FALSE))
 			eyestab(H,user)
 		to_chat(user,"<span class='danger'>Alert: No breathing detected.</span>")
 		return

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -544,7 +544,8 @@ BREATH ANALYZER
 
 	if ( ((user.is_clumsy()) || (DUMB in user.mutations)) && prob(20))
 		to_chat(user,"<span class='danger'>Your hand slips from clumsiness!</span>")
-		eyestab(H,user)
+		if(!H.eyes_protected(FALSE))
+			eyestab(H,user)
 		to_chat(user,"<span class='danger'>Alert: No breathing detected.</span>")
 		return
 

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -37,7 +37,7 @@
 		return ..()
 
 	if(user.a_intent != I_HELP)
-		if((target_zone == BP_HEAD || target_zone == BP_EYES) && !M.eyes_protected(FALSE))
+		if((target_zone == BP_HEAD || target_zone == BP_EYES) && !M.eyes_protected(src, FALSE))
 			if((user.is_clumsy()) && prob(50))
 				M = user
 			return eyestab(M,user)

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -37,7 +37,7 @@
 		return ..()
 
 	if(user.a_intent != I_HELP)
-		if(target_zone == BP_HEAD || target_zone == BP_EYES)
+		if((target_zone == BP_HEAD || target_zone == BP_EYES) && !M.eyes_protected(FALSE))
 			if((user.is_clumsy()) && prob(50))
 				M = user
 			return eyestab(M,user)

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -25,7 +25,7 @@
 
 /obj/item/material/knife/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
 	if(active == 1)
-		if((target_zone != BP_EYES && target_zone != BP_HEAD) || M.eyes_protected(FALSE))
+		if((target_zone != BP_EYES && target_zone != BP_HEAD) || M.eyes_protected(src, FALSE))
 			return ..()
 		if((user.is_clumsy()) && prob(50))
 			M = user

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -25,7 +25,7 @@
 
 /obj/item/material/knife/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
 	if(active == 1)
-		if(target_zone != BP_EYES && target_zone != BP_HEAD)
+		if((target_zone != BP_EYES && target_zone != BP_HEAD) || M.eyes_protected(FALSE))
 			return ..()
 		if((user.is_clumsy()) && prob(50))
 			M = user

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -104,7 +104,7 @@
 /obj/item/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
 	if(!istype(M) || user.a_intent == "help")
 		return ..()
-	if(target_zone != BP_EYES && target_zone != BP_HEAD)
+	if((target_zone != BP_EYES && target_zone != BP_HEAD) || M.eyes_protected(FALSE))
 		return ..()
 	if((user.is_clumsy()) && prob(50))
 		M = user

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -104,7 +104,7 @@
 /obj/item/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob, var/target_zone)
 	if(!istype(M) || user.a_intent == "help")
 		return ..()
-	if((target_zone != BP_EYES && target_zone != BP_HEAD) || M.eyes_protected(FALSE))
+	if((target_zone != BP_EYES && target_zone != BP_HEAD) || M.eyes_protected(src, FALSE))
 		return ..()
 	if((user.is_clumsy()) && prob(50))
 		M = user

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -32,7 +32,7 @@ BLIND     // can't see anything
 	var/obj/item/clothing/glasses/hud/hud = null	// Hud glasses, if any
 	var/activated_color = null
 	var/normal_layer = TRUE
-	var/glass_material = TRUE
+	var/shatter_material = /obj/item/material/shard
 	sprite_sheets = list(
 		BODYTYPE_VAURCA_WARFORM = 'icons/mob/species/warriorform/eyes.dmi'
 		)
@@ -52,12 +52,12 @@ BLIND     // can't see anything
 	normal_layer = !normal_layer
 	to_chat(usr, SPAN_NOTICE("\The [src] will now layer [normal_layer ? "under" : "over"] your hair."))
 
-/obj/item/clothing/glasses/protects_eyestab(var/stabbed = FALSE)
-	if(stabbed && (body_parts_covered & EYES) && !(item_flags & THICKMATERIAL) && glass_material)
+/obj/item/clothing/glasses/protects_eyestab(var/obj/stab_item, var/stabbed = FALSE)
+	if(stabbed && (body_parts_covered & EYES) && !(item_flags & THICKMATERIAL) && shatter_material && prob(stab_item.force * 5))
 		var/mob/M = loc
 		M.visible_message(SPAN_WARNING("\The [src] [M] is wearing gets shattered!"))
 		playsound(loc, /decl/sound_category/glass_break_sound, 70, TRUE)
-		new /obj/item/material/shard(M.loc)
+		new shatter_material(M.loc)
 		qdel(src)
 		return FALSE
 	return ..()
@@ -522,7 +522,7 @@ BLIND     // can't see anything
 	icon_state = "blindfold"
 	item_state = "blindfold"
 	tint = TINT_BLIND
-	glass_material = FALSE
+	shatter_material = FALSE
 	drop_sound = 'sound/items/drop/gloves.ogg'
 	pickup_sound = 'sound/items/pickup/gloves.ogg'
 
@@ -544,7 +544,7 @@ BLIND     // can't see anything
 	icon_state = "blinders"
 	item_state = "blinders"
 	contained_sprite = TRUE
-	glass_material = FALSE
+	shatter_material = FALSE
 	drop_sound = 'sound/items/drop/gloves.ogg'
 	pickup_sound = 'sound/items/pickup/gloves.ogg'
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -56,9 +56,10 @@ BLIND     // can't see anything
 	if(stabbed && (body_parts_covered & EYES) && !(item_flags & THICKMATERIAL) && glass_material)
 		var/mob/M = loc
 		M.visible_message(SPAN_WARNING("\The [src] [M] is wearing gets shattered!"))
-		qdel(src)
 		playsound(loc, /decl/sound_category/glass_break_sound, 70, TRUE)
 		new /obj/item/material/shard(M.loc)
+		qdel(src)
+		return FALSE
 	return ..()
 
 /obj/item/clothing/glasses/update_clothing_icon()

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -32,6 +32,7 @@ BLIND     // can't see anything
 	var/obj/item/clothing/glasses/hud/hud = null	// Hud glasses, if any
 	var/activated_color = null
 	var/normal_layer = TRUE
+	var/glass_material = TRUE
 	sprite_sheets = list(
 		BODYTYPE_VAURCA_WARFORM = 'icons/mob/species/warriorform/eyes.dmi'
 		)
@@ -50,6 +51,15 @@ BLIND     // can't see anything
 
 	normal_layer = !normal_layer
 	to_chat(usr, SPAN_NOTICE("\The [src] will now layer [normal_layer ? "under" : "over"] your hair."))
+
+/obj/item/clothing/glasses/protects_eyestab(var/stabbed = FALSE)
+	if(stabbed && (body_parts_covered & EYES) && !(item_flags & THICKMATERIAL) && glass_material)
+		var/mob/M = loc
+		M.visible_message(SPAN_WARNING("\The [src] [M] is wearing gets shattered!"))
+		qdel(src)
+		playsound(loc, /decl/sound_category/glass_break_sound, 70, TRUE)
+		new /obj/item/material/shard(M.loc)
+	return ..()
 
 /obj/item/clothing/glasses/update_clothing_icon()
 	if (ismob(src.loc))
@@ -199,7 +209,7 @@ BLIND     // can't see anything
 	desc = "A simple pair of safety glasses. Thinner than their goggle counterparts, for those who can't decide between safety and style."
 	icon_state = "plaingoggles"
 	item_state = "plaingoggles"
-	item_flags = AIRTIGHT
+	item_flags = AIRTIGHT|THICKMATERIAL
 	unacidable = 1
 
 /obj/item/clothing/glasses/safety/goggles
@@ -466,6 +476,7 @@ BLIND     // can't see anything
 	item_state = "welding-g"
 	action_button_name = "Flip Welding Goggles"
 	var/up = 0
+	item_flags = THICKMATERIAL
 	flash_protection = FLASH_PROTECTION_MAJOR
 	tint = TINT_HEAVY
 
@@ -510,6 +521,7 @@ BLIND     // can't see anything
 	icon_state = "blindfold"
 	item_state = "blindfold"
 	tint = TINT_BLIND
+	glass_material = FALSE
 	drop_sound = 'sound/items/drop/gloves.ogg'
 	pickup_sound = 'sound/items/pickup/gloves.ogg'
 
@@ -531,6 +543,7 @@ BLIND     // can't see anything
 	icon_state = "blinders"
 	item_state = "blinders"
 	contained_sprite = TRUE
+	glass_material = FALSE
 	drop_sound = 'sound/items/drop/gloves.ogg'
 	pickup_sound = 'sound/items/pickup/gloves.ogg'
 
@@ -560,7 +573,7 @@ BLIND     // can't see anything
 	desc = "Flash-resistant goggles with inbuilt combat and security information."
 	icon_state = "swatgoggles"
 	item_state = "swatgoggles"
-	item_flags = AIRTIGHT
+	item_flags = AIRTIGHT|THICKMATERIAL
 
 /obj/item/clothing/glasses/sunglasses/sechud/head
 	name = "advanced aviators"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -2,7 +2,7 @@
 	name = "gas mask"
 	desc = "A face-covering mask that can be connected to an air supply. Filters harmful gases from the air."
 	icon_state = "gas_alt"
-	item_flags = BLOCK_GAS_SMOKE_EFFECT | AIRTIGHT
+	item_flags = BLOCK_GAS_SMOKE_EFFECT | AIRTIGHT | THICKMATERIAL
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE
 	body_parts_covered = FACE|EYES
 	w_class = ITEMSIZE_NORMAL

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -189,7 +189,7 @@ obj/item/clothing/shoes/sandal/clogs
 /obj/item/clothing/shoes/heels/attack(mob/living/carbon/M, mob/living/carbon/user, var/target_zone)
 	if(!istype(M) || user.a_intent == "help")
 		return ..()
-	if((target_zone != BP_EYES && target_zone != BP_HEAD) || M.eyes_protected(FALSE))
+	if((target_zone != BP_EYES && target_zone != BP_HEAD) || M.eyes_protected(src, FALSE))
 		return ..()
 	if((user.is_clumsy()) && prob(50))
 		M = user

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -189,7 +189,7 @@ obj/item/clothing/shoes/sandal/clogs
 /obj/item/clothing/shoes/heels/attack(mob/living/carbon/M, mob/living/carbon/user, var/target_zone)
 	if(!istype(M) || user.a_intent == "help")
 		return ..()
-	if(target_zone != BP_EYES && target_zone != BP_HEAD)
+	if((target_zone != BP_EYES && target_zone != BP_HEAD) || M.eyes_protected(FALSE))
 		return ..()
 	if((user.is_clumsy()) && prob(50))
 		M = user

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -299,3 +299,12 @@
 	if(aug && !aug.is_broken())
 		return TRUE
 	return FALSE
+
+/mob/living/carbon/human/eyes_protected(var/stabbed = FALSE) // if stabbed is set to true if we're being stabbed and not just checking
+	. = ..()
+	if(.)
+		return
+	for(var/obj/item/protection in list(head, wear_mask, glasses))
+		if(protection.protects_eyestab(stabbed))
+			return TRUE
+	return FALSE

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -300,11 +300,11 @@
 		return TRUE
 	return FALSE
 
-/mob/living/carbon/human/eyes_protected(var/stabbed = FALSE) // if stabbed is set to true if we're being stabbed and not just checking
+/mob/living/carbon/human/eyes_protected(var/obj/stab_item, var/stabbed = FALSE) // if stabbed is set to true if we're being stabbed and not just checking
 	. = ..()
 	if(.)
 		return
 	for(var/obj/item/protection in list(head, wear_mask, glasses))
-		if(protection.protects_eyestab(stabbed))
+		if(protection.protects_eyestab(stab_item, stabbed))
 			return TRUE
 	return FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -809,6 +809,11 @@ default behaviour is:
 /mob/living/proc/has_eyes()
 	return 1
 
+/mob/living/proc/eyes_protected(var/stabbed = FALSE) // if stabbed is set to true if we're being stabbed and not just checking
+	if(!has_eyes())
+		return TRUE
+	return FALSE
+
 /mob/living/proc/slip(var/slipped_on,stun_duration=8)
 	return 0
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -809,7 +809,7 @@ default behaviour is:
 /mob/living/proc/has_eyes()
 	return 1
 
-/mob/living/proc/eyes_protected(var/stabbed = FALSE) // if stabbed is set to true if we're being stabbed and not just checking
+/mob/living/proc/eyes_protected(var/obj/stab_item, var/stabbed = FALSE) // if stabbed is set to true if we're being stabbed and not just checking
 	if(!has_eyes())
 		return TRUE
 	return FALSE

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -38,7 +38,7 @@
 
 /obj/item/organ/internal/eyes/take_damage(amount, var/silent=0)
 	var/oldbroken = is_broken()
-	..()
+	. = ..()
 	if(is_broken() && !oldbroken && owner && !owner.stat)
 		to_chat(owner, "<span class='danger'>You go blind!</span>")
 

--- a/code/modules/organs/internal/species/tajara.dm
+++ b/code/modules/organs/internal/species/tajara.dm
@@ -50,7 +50,7 @@
 	owner.last_special = world.time + 20
 
 /obj/item/organ/internal/eyes/night/take_damage(var/amount, var/silent = 0)
-	..()
+	. = ..()
 	disable_night_vision()
 
 /obj/item/organ/internal/eyes/night/take_internal_damage(var/amount, var/silent = 0)

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -573,15 +573,15 @@
 		set_light(0)
 
 /obj/item/organ/internal/augment/sightlights/emp_act(severity)
-	..()
+	. = ..()
 	set_light(0)
 
 /obj/item/organ/internal/augment/sightlights/take_damage(var/amount, var/silent = 0)
-	..()
+	. = ..()
 	set_light(0)
 
 /obj/item/organ/internal/augment/sightlights/take_internal_damage(var/amount, var/silent = 0)
-	..()
+	. = ..()
 	set_light(0)
 
 /obj/item/organ/internal/augment/zenghu_plate

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -231,7 +231,7 @@
 	..()
 
 /obj/item/organ/external/head/take_damage(brute, burn, damage_flags, used_weapon = null, list/forbidden_limbs = list(), var/silent)
-	..(brute, burn, damage_flags, used_weapon, forbidden_limbs, damage_flags, silent)
+	. = ..(brute, burn, damage_flags, used_weapon, forbidden_limbs, damage_flags, silent)
 	if (!disfigured)
 		if (brute_dam > 40)
 			if (prob(50))

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -38,7 +38,7 @@
 
 	if ( ((user.is_clumsy()) || (DUMB in user.mutations)) && prob(10))
 		to_chat(user,"<span class='danger'>Your hand slips from clumsiness!</span>")
-		if(!H.eyes_protected(FALSE))
+		if(!H.eyes_protected(src, FALSE))
 			eyestab(H,user)
 		if(H.reagents)
 			var/contained = reagentlist()

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -38,7 +38,8 @@
 
 	if ( ((user.is_clumsy()) || (DUMB in user.mutations)) && prob(10))
 		to_chat(user,"<span class='danger'>Your hand slips from clumsiness!</span>")
-		eyestab(H,user)
+		if(!H.eyes_protected(FALSE))
+			eyestab(H,user)
 		if(H.reagents)
 			var/contained = reagentlist()
 			var/trans = reagents.trans_to_mob(H, amount_per_transfer_from_this, CHEM_TOUCH)

--- a/code/modules/reagents/reagent_containers/inhaler_advanced.dm
+++ b/code/modules/reagents/reagent_containers/inhaler_advanced.dm
@@ -121,7 +121,7 @@
 
 	if (((user.is_clumsy()) || (DUMB in user.mutations)) && prob(10))
 		to_chat(user,"<span class='danger'>Your hand slips from clumsiness!</span>")
-		if(M.eyes_protected(FALSE))
+		if(M.eyes_protected(src, FALSE))
 			eyestab(M,user)
 		user.visible_message("<span class='notice'>[user] accidentally sticks \the [src] in [M]'s eye!</span>","<span class='notice'>You accidentally stick the [src] in [M]'s eye!</span>")
 		return

--- a/code/modules/reagents/reagent_containers/inhaler_advanced.dm
+++ b/code/modules/reagents/reagent_containers/inhaler_advanced.dm
@@ -121,7 +121,8 @@
 
 	if (((user.is_clumsy()) || (DUMB in user.mutations)) && prob(10))
 		to_chat(user,"<span class='danger'>Your hand slips from clumsiness!</span>")
-		eyestab(M,user)
+		if(M.eyes_protected(FALSE))
+			eyestab(M,user)
 		user.visible_message("<span class='notice'>[user] accidentally sticks \the [src] in [M]'s eye!</span>","<span class='notice'>You accidentally stick the [src] in [M]'s eye!</span>")
 		return
 

--- a/html/changelogs/geeves-eyestab_stuff.yml
+++ b/html/changelogs/geeves-eyestab_stuff.yml
@@ -1,0 +1,10 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed eyestabbing not updating the damage overlay for the eyestabbee."
+  - tweak: "If the eyestabbee has eye protection, the stab will automatically be redirected to the head in general."
+  - tweak: "Only clothing considered made of thick materials will now protect from eye stabbing."
+  - rscadd: "Gas masks, safety goggles, and tactical HUDs have been given the thick material flag."
+  - rscadd: "Getting eyestabbed while wearing glasses will cause the glasses to shatter."


### PR DESCRIPTION
* Fixed eyestabbing not updating the damage overlay for the eyestabbee.
* If the eyestabbee has eye protection, the stab will automatically be redirected to the head in general.
* Only clothing considered made of thick materials will now protect from eye stabbing.
* Gas masks, safety goggles, and tactical HUDs have been given the thick material flag.
* Getting eyestabbed while wearing glasses will cause the glasses to shatter.