### PR TITLE
Some TCFL Projectile Rebalances

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -346,6 +346,7 @@
 /obj/item/projectile/bullet/gauss/highex
 	name = "high-ex shell"
 	damage = 10
+	armor_penetration = 30
 
 /obj/item/projectile/bullet/gauss/highex/on_impact(var/atom/A)
 	explosion(A, -1, 0, 2)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -219,6 +219,7 @@
 
 /obj/item/projectile/energy/blaster/heavy
 	damage = 35
+	armor_penetration = 10
 
 /obj/item/projectile/energy/blaster/incendiary
 	icon_state = "laser"

--- a/html/changelogs/wickedcybs_blaster.yml
+++ b/html/changelogs/wickedcybs_blaster.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Tweaked TCFL projectiles, like the heavy blaster bolt and highex gauss round. They have some AP now, with the former being rifle level and the latter having enough to not get blocked by a standard corporate vest."


### PR DESCRIPTION
Noticed a few things, and it was that the blaster bolts weren't really touched by the introduction of AP to projectiles. Talked to Matt and apparently it was missed, so I went ahead and added 10 ap to the heavy blaster bolt, bringing it in line with rifle class lasers.

I also touched the high-ex shell used by the TCFL's exosuit. It would end up getting totally blocked by anyone wearing even light armour because it only does ten damage, though the knockout still applied. I gave it AP so it will end up doing a little bit of damage as well to armour that's not really fit for combat, but it's still not a lot.