### PR TITLE
Impact Wrench Maptext & Soundfix

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -737,6 +737,7 @@
 	icon_state = "impact_wrench-screw"
 	item_state = "impact_wrench"
 	contained_sprite = TRUE
+	flags = HELDMAPTEXT
 	force = 8
 	attack_verb = list("gored", "drilled", "screwed", "punctured")
 	w_class = ITEMSIZE_SMALL
@@ -751,6 +752,9 @@
 /obj/item/powerdrill/Initialize()
 	. = ..()
 	update_tool()
+
+/obj/item/powerdrill/set_initial_maptext()
+	held_maptext = SMALL_FONTS(7, "S")
 
 /obj/item/powerdrill/examine(var/mob/user)
 	. = ..()
@@ -778,11 +782,13 @@
 
 /obj/item/powerdrill/proc/update_tool()
 	if(isscrewdriver())
-		usesound = 'sound/items/air_wrench.ogg'
-		icon_state = "impact_wrench-screw"
-	else if(iswrench())
 		usesound = 'sound/items/drill_use.ogg'
+		icon_state = "impact_wrench-screw"
+		check_maptext(SMALL_FONTS(7, "S"))
+	else if(iswrench())
+		usesound = 'sound/items/air_wrench.ogg'
 		icon_state = "impact_wrench-wrench"
+		check_maptext(SMALL_FONTS(7, "W"))
 
 /obj/item/powerdrill/attack_self(var/mob/user)
 	if(++current_tool > tools.len)

--- a/html/changelogs/geeves-powerdrill_maptext.yml
+++ b/html/changelogs/geeves-powerdrill_maptext.yml
@@ -3,5 +3,5 @@ author: Geeves
 delete-after: True
 
 changes:
-  - rscadd: "Added maptext to the powerdrill to let you know which mode it's in."
-  - bugfix: "Fixed the powerdrill having flipped sounds."
+  - rscadd: "Added maptext to the impact wrench to let you know which mode it's in."
+  - bugfix: "Fixed the impact wrench having flipped sounds."

--- a/html/changelogs/geeves-powerdrill_maptext.yml
+++ b/html/changelogs/geeves-powerdrill_maptext.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added maptext to the powerdrill to let you know which mode it's in."
+  - bugfix: "Fixed the powerdrill having flipped sounds."


### PR DESCRIPTION
* Added maptext to the impact wrench to let you know which mode it's in.
* Fixed the impact wrench having flipped sounds.

![image](https://user-images.githubusercontent.com/22774890/117008649-3caa0700-aceb-11eb-9f45-696233c24aa6.png)
![image](https://user-images.githubusercontent.com/22774890/117008655-3e73ca80-aceb-11eb-8511-71ea9079a2b4.png)