### PR TITLE
Fixes #11817

### DIFF
--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -1,13 +1,13 @@
 #define SS_INIT_PERSISTENT_CONFIG 25
 #define SS_INIT_MISC_FIRST  24
 #define SS_INIT_SEEDS       23	// Plant controller setup.
-#define SS_INIT_ASSETS      22	// Assets subsystem setup.
 #define SS_INIT_MAPLOAD     21	// DMM parsing and load. Unless you know what you're doing, make sure this remains first.
 #define SS_INIT_JOBS        20
 #define SS_INIT_MAPFINALIZE 19	// Asteroid generation.
-#define SS_INIT_PARALLAX    17	// Parallax image cache generation. Must run before ghosts are able to join.
-#define SS_INIT_HOLOMAP     16
-#define SS_INIT_ATOMS       15	// World initialization. Will trigger lighting updates. Observers can join after this loads.
+#define SS_INIT_PARALLAX    18	// Parallax image cache generation. Must run before ghosts are able to join.
+#define SS_INIT_HOLOMAP     17
+#define SS_INIT_ATOMS       16	// World initialization. Will trigger lighting updates. Observers can join after this loads.
+#define SS_INIT_ASSETS      15	// Assets subsystem setup.
 #define SS_INIT_POWER       14	// Initial powernet build.
 #define SS_INIT_ECONOMY     13  // Cargo needs economy set up
 #define SS_INIT_CARGO       12	// Random warehouse generation. Runs after SSatoms because it assumes objects are initialized when it runs.

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -520,6 +520,7 @@ var/list/asset_datums = list()
 			I = S.update_appearance(TRUE)
 			Insert(imgid, I, forced=I)
 		else
+			O.update_icon()
 			if(O.overlay_queued)
 				O.compile_overlays()
 			if(O.overlays.len)

--- a/html/changelogs/MDP-11817.yml
+++ b/html/changelogs/MDP-11817.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MoondancerPony
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes certain things (bottles, grenades, etc.) having incorrect icons in vendor previews."


### PR DESCRIPTION
SSAssets now runs after SSAtoms, so that the things it creates get initialised. This means items will have the right vendor preview if their icon is changed in/due to init.
Also, explicitly calls `O.update_icon()` just to be safe.