### PR TITLE
Fixes germ_level going negative

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -326,11 +326,11 @@
 		if(antibiotics >= 5)
 			germ_level = 0 //just finish up this small infection
 		else
-			germ_level -= antibiotics * 5 //Clears very quickly, finishing up remnants of infection
+			germ_level = max(germ_level - (antibiotics * 5), 0) //Clears very quickly, finishing up remnants of infection
 	else if(germ_level <= INFECTION_LEVEL_TWO)
-		germ_level -= min(antibiotics, 6) //Still quick, infection's not too bad. At max dose and germ_level 500, should take a minute or two
+		germ_level = max(germ_level - min(antibiotics, 6), 0) //Still quick, infection's not too bad. At max dose and germ_level 500, should take a minute or two
 	else
-		germ_level -= min(antibiotics * 0.5, 3) //Big infections, very slow to stop. At max dose and germ_level 1000, should take five to six minutes
+		germ_level = max(germ_level - min(antibiotics * 0.5, 3), 0) //Big infections, very slow to stop. At max dose and germ_level 1000, should take five to six minutes
 
 //Adds autopsy data for used_weapon.
 /obj/item/organ/proc/add_autopsy_data(var/used_weapon, var/damage)

--- a/html/changelogs/doxxmedearly - negative_infections.yml
+++ b/html/changelogs/doxxmedearly - negative_infections.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed an issue with the germ counter going into negative values on limbs, which caused odd behavior such as reoccurring infections."


### PR DESCRIPTION
Theta was making germ_level go below 0. Dunno why or how it started happening, but it's likely the cause of odd behavior like infections popping back up after being cured.
Fixes  #11766
(I think? I found no other cause for the above bug report during testing and it all seemed to be working fine. So either this was causing it in some instances or there was an error made by medical and the infection wasn't fully cleared. Either way, thetamycin is clearing infections from vaurca as normal from what I see.)