### PR TITLE
Revisiting the Freelancers: A Rebalance

### DIFF
--- a/code/datums/ert/outsider.dm
+++ b/code/datums/ert/outsider.dm
@@ -2,6 +2,7 @@
 	name = "Independent Mercenaries"
 	chance = 15
 	spawner = /datum/ghostspawner/human/ert/mercenary
+	equipment_map = /datum/map_template/distress_freelancers
 
 /datum/responseteam/kataphracts
 	name = "Kataphracts"

--- a/code/datums/outfits/ert/mercenary.dm
+++ b/code/datums/outfits/ert/mercenary.dm
@@ -8,23 +8,28 @@
 	back = /obj/item/storage/backpack/satchel_norm
 	l_hand = /obj/item/clothing/suit/space/void/freelancer
 	r_hand = /obj/item/clothing/head/helmet/space/void/freelancer
-	accessory = /obj/item/clothing/accessory/storage/black_vest
+	accessory = /obj/item/clothing/accessory/holster/thigh
+	accessory_contents = list(/obj/item/gun/projectile/colt)
 	id = /obj/item/card/id/syndicate
+	glasses = /obj/item/clothing/glasses/sunglasses/aviator
+	l_pocket = /obj/item/tank/emergency_oxygen/double
 
 	l_ear = /obj/item/device/radio/headset/distress
 
 	backpack_contents = list(
-		/obj/item/gun/projectile/automatic/c20r = 1,
+		/obj/item/storage/box/survival = 1,
+		/obj/item/gun/projectile/automatic/tommygun = 1,
 		/obj/item/storage/belt/utility/full = 1,
-		/obj/item/tank/oxygen = 1,
 		/obj/item/clothing/gloves/yellow = 1,
-		/obj/item/material/knife/trench = 1
 	)
 
 	belt_contents = list(
-		/obj/item/ammo_magazine/a10mm = 3,
-		/obj/item/handcuffs/ziptie = 2,
-		/obj/item/shield/energy = 1
+		/obj/item/ammo_magazine/submachinedrum = 1,
+		/obj/item/ammo_magazine/submachinemag = 1,
+		/obj/item/ammo_magazine/c45m = 2,
+		/obj/item/handcuffs/ziptie = 1,
+		/obj/item/shield/energy = 1,
+		/obj/item/material/knife/trench = 1
 	)
 
 /datum/outfit/admin/ert/mercenary/get_id_access()
@@ -33,17 +38,18 @@
 /datum/outfit/admin/ert/mercenary/specialist
 	name = "Mercenary Freelancer Medic"
 
+	glasses = /obj/item/clothing/glasses/hud/health/aviator
 	belt = /obj/item/storage/belt/medical/first_responder/combat
 	gloves = /obj/item/clothing/gloves/latex
 
 	backpack_contents = list(
-		/obj/item/gun/projectile/automatic/c20r = 1,
-		/obj/item/ammo_magazine/a10mm = 2,
+		/obj/item/storage/box/survival = 1,
+		/obj/item/gun/projectile/automatic/tommygun = 1,
+		/obj/item/ammo_magazine/submachinemag = 2,
+		/obj/item/ammo_magazine/c45m = 1,
 		/obj/item/storage/firstaid/combat = 1,
-		/obj/item/storage/firstaid/adv = 2,
+		/obj/item/storage/firstaid/adv = 1,
 		/obj/item/device/healthanalyzer = 1,
-		/obj/item/tank/oxygen = 1,
-		/obj/item/reagent_containers/glass/bottle/thetamycin = 1,
 		/obj/item/reagent_containers/hypospray/autoinjector/coagzolug = 1
 	)
 
@@ -54,14 +60,16 @@
 		/obj/item/reagent_containers/glass/bottle/dexalin_plus = 1,
 		/obj/item/reagent_containers/glass/bottle/butazoline = 1,
 		/obj/item/reagent_containers/glass/bottle/dermaline = 1,
-		/obj/item/reagent_containers/glass/bottle/perconol = 1	
+		/obj/item/reagent_containers/glass/bottle/perconol = 1,
+		/obj/item/reagent_containers/glass/bottle/thetamycin = 1,
+		/obj/item/material/knife/trench = 1	
 	)
 
 /datum/outfit/admin/ert/mercenary/engineer
 	name = "Mercenary Freelancer Combat Engineer"
 
+	belt = /obj/item/storage/belt/military
 	back = /obj/item/storage/backpack/duffel
-	belt = /obj/item/storage/belt/utility/full
 	gloves = /obj/item/clothing/gloves/yellow
 	accessory = /obj/item/clothing/accessory/storage/brown_vest
 	accessory_contents = list(
@@ -69,20 +77,23 @@
 							)
 
 	backpack_contents = list(
-		/obj/item/material/knife/trench = 1,
-		/obj/item/shield/energy = 1,
-		/obj/item/handcuffs/ziptie = 1,
-		/obj/item/tank/oxygen = 1,
-		/obj/item/device/multitool = 1,
-		/obj/item/weldingtool/hugetank = 1,
+		/obj/item/storage/box/survival = 1,
 		/obj/item/clothing/glasses/welding/superior = 1,
 		/obj/item/gun/projectile/shotgun/pump/combat/sol = 1,
 		/obj/item/storage/box/shotgunshells = 1,
 		/obj/item/landmine/frag = 1,
-		/obj/item/landmine/emp = 1
+		/obj/item/landmine/emp = 1,
+		/obj/item/storage/belt/utility/very_full = 1,
+		/obj/item/gun/projectile/colt = 1
 	)
 
-	belt_contents = null
+	belt_contents = list(
+		/obj/item/material/knife/trench = 1,
+		/obj/item/ammo_magazine/c45m = 2,
+		/obj/item/handcuffs/ziptie = 1,
+		/obj/item/shield/energy = 1,
+		/obj/item/device/flashlight/flare = 1,
+	)
 
 /datum/outfit/admin/ert/mercenary/leader
 	name = "Mercenary Freelancer Leader"
@@ -92,11 +103,17 @@
 	suit_store = null
 	suit = null
 	head = null
+	mask = /obj/item/clothing/mask/smokable/cigarette/cigar/cohiba
+	glasses = /obj/item/clothing/glasses/sunglasses/aviator
+	accessory = /obj/item/clothing/accessory/holster/thigh
+	accessory_contents = list(/obj/item/gun/projectile/revolver = 1)
 
 	backpack_contents = list()
 
 	belt_contents = list(
-		/obj/item/ammo_magazine/c762 = 3,
-		/obj/item/handcuffs/ziptie = 2,
-		/obj/item/shield/energy = 1
+		/obj/item/ammo_magazine/c762 = 2,
+		/obj/item/handcuffs/ziptie = 1,
+		/obj/item/shield/energy = 1,
+		/obj/item/ammo_magazine/a357 = 2,
+		/obj/item/material/knife/trench = 1
 	)

--- a/html/changelogs/wickedcybs_freelancerwep.yml
+++ b/html/changelogs/wickedcybs_freelancerwep.yml
@@ -1,0 +1,7 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The Freelancers distress team has had its equipment changed up. Everyone now gets sidearms, the leader getting a revolver and the rest having .45s. The 10mm submachineguns have been swapped for a .45 submachinegun. People who lacked a knife have one now. At the baseline, they're stil one of the weaker ERT's comparatively but no longer major pushovers other than the lead, who has always been good."
+  - maptweak: "Freelancers now get some additional equipment if they're rolled. The Distress team base will give them zippos, cigars, holsters, vests and a few weapon racks that will provide random guns to vary up their firepower within reason. No two merc outfits are alike, right?"

--- a/maps/templates/distress/distress_equipment.dm
+++ b/maps/templates/distress/distress_equipment.dm
@@ -5,3 +5,7 @@
 /datum/map_template/distress_kataphract
 	name = "kataphract distress equipment"
 	mappath = 'maps/templates/distress/kataphracts.dmm'
+
+/datum/map_template/distress_freelancers
+	name = "freelancer distress equipment"
+	mappath = 'maps/templates/distress/freelancers.dmm'

--- a/maps/templates/distress/freelancers.dmm
+++ b/maps/templates/distress/freelancers.dmm
@@ -1,0 +1,113 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/turf/unsimulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/centcom/distress_prep)
+"d" = (
+/obj/structure/table/rack,
+/obj/random/weapon_and_ammo{
+	chosen_rarity = Common
+	},
+/turf/unsimulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/centcom/distress_prep)
+"r" = (
+/obj/structure/table/rack,
+/obj/random/weapon_and_ammo{
+	chosen_rarity = Rare
+	},
+/turf/unsimulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/centcom/distress_prep)
+"E" = (
+/obj/structure/table/rack,
+/obj/item/clothing/accessory/holster/thigh,
+/obj/item/clothing/accessory/holster/thigh,
+/obj/item/clothing/accessory/holster/thigh,
+/obj/item/clothing/accessory/holster/thigh,
+/obj/item/clothing/accessory/holster/thigh,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/turf/unsimulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/centcom/distress_prep)
+"Y" = (
+/obj/structure/table/wood,
+/obj/item/coin/gold{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/coin/gold{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/storage/box/fancy/cigarettes/cigar{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/item/storage/box/fancy/cigarettes/cigar{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/flame/lighter/zippo/gold{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/flame/lighter/zippo/gold{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/flame/lighter/zippo/royal{
+	pixel_x = 7
+	},
+/obj/item/flame/lighter/zippo/black{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/item/flame/lighter/zippo/black{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/item/lipstick/random{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/random/spacecash{
+	pixel_x = -2;
+	pixel_y = -9
+	},
+/turf/unsimulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/centcom/distress_prep)
+
+(1,1,1) = {"
+b
+E
+d
+"}
+(2,1,1) = {"
+b
+b
+r
+"}
+(3,1,1) = {"
+b
+b
+r
+"}
+(4,1,1) = {"
+b
+b
+Y
+"}


### PR DESCRIPTION
Recent rounds and some discussion has caused me to look at Freelancers and figure out what they're lacking in.

At the moment, the leader is the main heavy hitter with an AR. Everyone else gets a 10mm submachinegun excepting the engineer who gets a shotgun with pellets. The 10mm's are particularly bad as they use the weakest ammo type for pistols and ERT's are often called against threats with actual armour. With the armour rework, all the more reason to revisit them.

I've given everyone a sidearm now. The leader gets a revolver, everyone else gets a vintage .45. .45 is a decent ammo type, still easily defeated by heavier armour but better than 10mm. The responders and the medic get a .45 submachinegun which is an upgrade over their usual but still not oppressive against anyone in heavy armour, as it will be absorbed.

Additionally, the Freelancers now load in with their own unique equipment map, giving a total of three weapon racks that will contain random guns (two guaranteed rare, one guaranteed common) and a table with zippos, cigars and credits.

![image](https://user-images.githubusercontent.com/52309324/117527200-8878dc80-af87-11eb-9a70-c40b2a20d226.png)

I think this give some flavour and a chance for the freelancers to get a weapon that will punch above their weight class while still keeping them at the baseline, weaker than other ERTs. A mercenary outfit may not have identical equipment from the others in the end.

If the random guns seem a bit much I think giving the freelancer responders ballistic carbines would be the best bet, as most ERTs will have three combatants with weapons capable of defeating heavy amour and that will allow them do this as well.
