### PR TITLE
TCFL Service & Veteran Cards

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -371,7 +371,6 @@
 	TCFLcard["veteran"] = /obj/item/clothing/accessory/badge/tcfl_papers/service/veteran
 	gear_tweaks += new/datum/gear_tweak/path(TCFLcard)
 
-
 /datum/gear/accessory/kneepads
 	display_name = "kneepads"
 	path = /obj/item/clothing/accessory/kneepads

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -359,6 +359,19 @@
 	passport["passport, coalition"] = /obj/item/clothing/accessory/badge/passport/coc
 	gear_tweaks += new/datum/gear_tweak/path(passport)
 
+/datum/gear/accessory/TCFLcard
+	display_name = "TCFL service cards"
+	description = "Identification cards given to active and former members of the Tau Ceti Foreign Legion."
+	path = /obj/item/clothing/accessory/badge/tcfl_papers
+
+/datum/gear/accessory/TCFLcard/New()
+	..()
+	var/TCFLcard = list()
+	TCFLcard["active service"] = /obj/item/clothing/accessory/badge/tcfl_papers/service
+	TCFLcard["veteran"] = /obj/item/clothing/accessory/badge/tcfl_papers/service/veteran
+	gear_tweaks += new/datum/gear_tweak/path(TCFLcard)
+
+
 /datum/gear/accessory/kneepads
 	display_name = "kneepads"
 	path = /obj/item/clothing/accessory/kneepads

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -195,6 +195,18 @@
 	drop_sound = 'sound/items/drop/card.ogg'
 	pickup_sound = 'sound/items/pickup/card.ogg'
 
+/obj/item/clothing/accessory/badge/tcfl_papers/service
+	name = "\improper TCFL service card"
+	desc = "A small card identifying one as a current member of the Tau Ceti Foreign Legion. Often shown to secure discounts in \
+	Republic shops. Go Biesel!"
+	badge_string = "Tau Ceti Foreign Legion Service Member"
+
+/obj/item/clothing/accessory/badge/tcfl_papers/service/veteran
+	name = "\improper TCFL veteran's service card"
+	desc = "A small card identifying one as a former member of the Tau Ceti Foreign Legion. Often shown to secure discounts in \
+	Republic shops. Go Biesel!"
+	badge_string = "Tau Ceti Foreign Legion Veteran"
+
 /obj/item/clothing/accessory/badge/sheriff
 	name = "sheriff badge"
 	desc = "A star-shaped brass badge denoting who the law is around these parts."

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -197,13 +197,13 @@
 
 /obj/item/clothing/accessory/badge/tcfl_papers/service
 	name = "\improper TCFL service card"
-	desc = "A small card identifying one as a current member of the Tau Ceti Foreign Legion. Often shown to secure discounts in \
+	desc = "A small card identifying one as a current member of the Tau Ceti Foreign Legion. Often used to secure discounts in \
 	Republic shops. Go Biesel!"
 	badge_string = "Tau Ceti Foreign Legion Service Member"
 
 /obj/item/clothing/accessory/badge/tcfl_papers/service/veteran
 	name = "\improper TCFL veteran's service card"
-	desc = "A small card identifying one as a former member of the Tau Ceti Foreign Legion. Often shown to secure discounts in \
+	desc = "A small card identifying one as a former member of the Tau Ceti Foreign Legion. Often used to secure discounts in \
 	Republic shops. Go Biesel!"
 	badge_string = "Tau Ceti Foreign Legion Veteran"
 

--- a/html/changelogs/wickedcybs_servicecard.yml
+++ b/html/changelogs/wickedcybs_servicecard.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - rscadd: "Added TCFL service cards to the loadout in the accessories section. Two variants for the active serving and the veterans. For the Republic!"


### PR DESCRIPTION
This adds service and veteran cards to further identify yourself as a current or former member of the TCFL on the station. It uses the same sprite as the TCFL enlistment papers Biesel/Vaurca consulars get. My thought is, it'd be nice to bring it back on station after receiving it IC and it adds a bit more flavour to active Legionnaires aboard the Aurora.

![image](https://user-images.githubusercontent.com/52309324/117743853-dc243980-b1c4-11eb-8d87-2c020995a645.png)

