### PR TITLE
Run only confusion

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -366,7 +366,7 @@
 							M.animate_movement = 2
 							return
 
-		else if(mob.confused && prob(25))
+		else if(mob.confused && prob(25) && mob.m_intent == M_RUN)
 			step(mob, pick(cardinal))
 		else
 			. = mob.SelfMove(n, direct)

--- a/html/changelogs/RunConfusion.yml
+++ b/html/changelogs/RunConfusion.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Being confused now only make movement random if the mob is running."


### PR DESCRIPTION
Ported/inspired by https://github.com/BeeStation/BeeStation-Hornet/pull/1100

Mobs now need their movement intent to be on run mode to have a chance of moving in a random direction.