### PR TITLE
Apologetic Booze Nerfs 1: No Boogaloo

### DIFF
--- a/code/modules/mob/living/carbon/human/intoxication.dm
+++ b/code/modules/mob/living/carbon/human/intoxication.dm
@@ -22,7 +22,6 @@
 	var/bac = get_blood_alcohol()
 
 	if(bac > INTOX_BUZZED*SR && bac < INTOX_MUSCLEIMP*SR)
-		move_delay_mod += -0.75
 		sprint_cost_factor += -0.1
 		if(prob(5))
 			to_chat(src,"<span class='notice'>You feel buzzed.</span>")

--- a/html/changelogs/doxxmedearly - buzzed_speeddown.yml
+++ b/html/changelogs/doxxmedearly - buzzed_speeddown.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - tweak: "Being buzzed no longer gives you a speed boost."


### PR DESCRIPTION
Being buzzed no longer gives the user a speed boost because 1) It makes zero sense and 2) You can maintain this boost easily by sipping on booze now and then, making it easily exploitable since it gives no other downsides. Booze w/ caffeine makes the boost even stronger.
Fixes #11893 