### PR TITLE
Flavor Text Showing

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -16,6 +16,7 @@
 #include "code\stylesheet.dm"
 #include "code\world.dm"
 #include "code\__defines\_common.dm"
+#include "code\__defines\_compile_helpers.dm"
 #include "code\__defines\_compile_options.dm"
 #include "code\__defines\_layers.dm"
 #include "code\__defines\_macros.dm"

--- a/code/__defines/_compile_helpers.dm
+++ b/code/__defines/_compile_helpers.dm
@@ -1,0 +1,1 @@
+#define BITFLAG(X) (1<<(X))

--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -33,14 +33,15 @@
 #define HELDMAPTEXT        0x100 // Uses the special held maptext system, which sets a specific maptext if the item is in possession of a mob.
 
 //Flags for items (equipment)
-#define THICKMATERIAL          0x1   // Prevents syringes, parapens and hyposprays if equiped to slot_suit or slot_head.
-#define AIRTIGHT               0x2   // Functions with internals.
-#define NOSLIP                 0x4   // Prevents from slipping on wet floors, in space, etc.
-#define BLOCK_GAS_SMOKE_EFFECT 0x8  // Blocks the effect that chemical clouds would have on a mob -- glasses, mask and helmets ONLY! (NOTE: flag shared with ONESIZEFITSALL)
-#define FLEXIBLEMATERIAL       0x10  // At the moment, masks with this flag will not prevent eating even if they are covering your face.
-#define SOUNDPROTECTION        0x20  // whether wearing this item will protect you from loud noises such as flashbangs | this only works for ear slots or the head slot
-#define LIGHTSTEP              0x40  // When applied to footwear, this makes it so that they don't trigger things like landmines and mouse traps
-#define INJECTIONPORT          0x80 // Allows syringes and hyposprays to inject, even if the material is thick
+#define THICKMATERIAL          BITFLAG(0)  // Prevents syringes, parapens and hyposprays if equiped to slot_suit or slot_head.
+#define AIRTIGHT               BITFLAG(1)  // Functions with internals.
+#define NOSLIP                 BITFLAG(2)  // Prevents from slipping on wet floors, in space, etc.
+#define BLOCK_GAS_SMOKE_EFFECT BITFLAG(3)  // Blocks the effect that chemical clouds would have on a mob -- glasses, mask and helmets ONLY! (NOTE: flag shared with ONESIZEFITSALL)
+#define FLEXIBLEMATERIAL       BITFLAG(4)  // At the moment, masks with this flag will not prevent eating even if they are covering your face.
+#define SOUNDPROTECTION        BITFLAG(5)  // whether wearing this item will protect you from loud noises such as flashbangs | this only works for ear slots or the head slot
+#define LIGHTSTEP              BITFLAG(6)  // When applied to footwear, this makes it so that they don't trigger things like landmines and mouse traps
+#define INJECTIONPORT          BITFLAG(7)  // Allows syringes and hyposprays to inject, even if the material is thick
+#define SHOWFLAVORTEXT         BITFLAG(8)  // won't block flavourtext when worn on equipment slot
 
 // Flags for pass_flags.
 #define PASSTABLE		0x1

--- a/code/modules/clothing/head/berets.dm
+++ b/code/modules/clothing/head/berets.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/clothing/hats/berets.dmi'
 	icon_state = "beret"
 	item_state = "beret"
+	item_flags = SHOWFLAVORTEXT
 	contained_sprite = TRUE
 	siemens_coefficient = 0.9
 

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -228,8 +228,9 @@
 
 /obj/item/clothing/head/fez
 	name = "fez"
-	icon_state = "fez"
 	desc = "You should wear a fez. Fezzes are cool."
+	icon_state = "fez"
+	item_flags = SHOWFLAVORTEXT
 
 //end bs12 hats
 

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -3,6 +3,7 @@
 	desc = "It's a softcap in a tasteless color."
 	icon = 'icons/obj/clothing/hats/soft_caps.dmi'
 	icon_state = "softcap"
+	item_flags = SHOWFLAVORTEXT
 	contained_sprite = TRUE
 	var/flipped = FALSE
 	siemens_coefficient = 0.9

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1603,6 +1603,9 @@
 	var/feet_exposed = 1
 
 	for(var/obj/item/clothing/C in equipment)
+		if(C.item_flags & SHOWFLAVORTEXT)
+			continue
+
 		if(C.body_parts_covered & HEAD)
 			head_exposed = 0
 		if(C.body_parts_covered & FACE)

--- a/html/changelogs/geeves-show_flavor_text.yml
+++ b/html/changelogs/geeves-show_flavor_text.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Softcaps, berets, and fezzes no longer block the head flavor text."


### PR DESCRIPTION
* Softcaps, berets, and fezzes no longer block the head flavor text.

Also ports the BITFLAG helper from https://github.com/NebulaSS13/Nebula/pull/796.