### PR TITLE
Drying Rack Tweak

### DIFF
--- a/code/modules/cooking/machinery/smartfridge.dm
+++ b/code/modules/cooking/machinery/smartfridge.dm
@@ -222,15 +222,17 @@
 
 /obj/machinery/smartfridge/drying_rack/machinery_process()
 	..()
-	if (length(contents))
+	if(length(contents))
 		dry()
 
 /obj/machinery/smartfridge/drying_rack/proc/dry()
 	for(var/obj/item/reagent_containers/food/snacks/S in contents)
 		if(S.dry) continue
-		if(S.on_dry(loc))
-			if(!(S in contents))
-				item_quants[S.name]--
+		var/old_name = S.name
+		if(S.on_dry(src)) //Drying rack keeps the item but changes the name. This prevents pre-dried item lingering in the UI as vendable
+			item_quants[S.name]++
+			item_quants[old_name]--
+	SSvueui.check_uis_for_change(src)
 	return
 
 /obj/machinery/smartfridge/machinery_process()

--- a/html/changelogs/Doxxmedearly - Drying_Fixes.yml
+++ b/html/changelogs/Doxxmedearly - Drying_Fixes.yml
@@ -1,0 +1,8 @@
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - tweak: "Drying racks now hold dried items in their inventory, instead of spitting it out onto its tile."
+  - bugfix: "Fixed the drying rack UI displaying pre-dried items as vendable after drying is done."


### PR DESCRIPTION
Drying racks now hold the dried products for vending instead of spitting them out on the floor like some sort of savage.
Also fixed the UI not updating properly after drying, which was causing issues with the pre-dried item still showing up as vendable despite not existing. 

Fixes #11901 