### PR TITLE
makes steramycin detectable to scanners

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -730,6 +730,7 @@
 	color = "#81b38b"
 	od_minimum_dose = 1
 	overdose = 15
+	scannable = TRUE
 	taste_description = "bleach"
 	fallback_specific_heat = 0.605
 

--- a/html/changelogs/SteramycinScan.yml
+++ b/html/changelogs/SteramycinScan.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Steramycin is now detectable by health analyzers & the like."


### PR DESCRIPTION
A small bug I was just informed about. Thetamycin (which appears to be the weaker variant) is already scannable by health analyzers & such so it seems like an oversight.