### PR TITLE
Adds Tape Rolls to Tool Vendors

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -902,7 +902,8 @@
 		/obj/item/wrench = 5,
 		/obj/item/device/analyzer = 5,
 		/obj/item/device/t_scanner = 5,
-		/obj/item/screwdriver = 5
+		/obj/item/screwdriver = 5,
+		/obj/item/tape_roll = 3
 	)
 	contraband = list(
 		/obj/item/weldingtool/hugetank = 2,
@@ -1032,7 +1033,8 @@
 		/obj/item/stock_parts/micro_laser = 5,
 		/obj/item/stock_parts/matter_bin = 5,
 		/obj/item/stock_parts/manipulator = 5,
-		/obj/item/stock_parts/console_screen = 5
+		/obj/item/stock_parts/console_screen = 5,
+		/obj/item/tape_roll = 5
 	)
 	// There was an incorrect entry (cablecoil/power).  I improvised to cablecoil/heavyduty.
 	// Another invalid entry, /obj/item/circuitry.  I don't even know what that would translate to, removed it.

--- a/html/changelogs/wickedcybs_tape.yml
+++ b/html/changelogs/wickedcybs_tape.yml
@@ -1,4 +1,4 @@
-author: ChangeMe
+author: WickedCybs
 
 delete-after: True
 

--- a/html/changelogs/wickedcybs_tape.yml
+++ b/html/changelogs/wickedcybs_tape.yml
@@ -1,0 +1,6 @@
+author: ChangeMe
+
+delete-after: True
+
+changes:
+  - tweak: "NT has finally found some credits in the budget to get duct tape to the tool vendors."


### PR DESCRIPTION
Tape rolls sometimes being extremely rare items you might miss out on if they don't spawn in tool areas outside of the few guaranteed spawns was a bit annoying to deal with. Especially for what is one of the more ubiquitous items on the station. It's useful to more than just the crew as well, antags appreciate it too. 

I've added three to the YouTool vendor. Five to the Robco (which is a very rare spawn in itself).
