### PR TITLE
Technomancer bugfixes.

### DIFF
--- a/code/_onclick/hud/ability_screen_objects.dm
+++ b/code/_onclick/hud/ability_screen_objects.dm
@@ -294,6 +294,11 @@
 	icon_state = "wiz_spell_base"
 	background_base_state = "wiz"
 
+/obj/screen/ability/obj_based/technomancer/activate()
+	if(ability_master.my_mob.incapacitated())
+		return
+	. = ..()
+
 /obj/screen/movable/ability_master/proc/add_technomancer_ability(var/obj/object_given, var/ability_icon_given)
 	if(!object_given)
 		message_admins("ERROR: add_technomancer_ability() was not given an object in its arguments.")

--- a/code/game/gamemodes/mixed/visitors.dm
+++ b/code/game/gamemodes/mixed/visitors.dm
@@ -1,10 +1,10 @@
 /datum/game_mode/visitors
-	name = "Visitors (Ninja+Wiz)"
-	round_description = "A space wizard and a ninja have invaded the station!"
-	extended_round_description = "A ninja and wizard spawn during this round."
+	name = "Visitors (Ninja+Techno)"
+	round_description = "A Technomancer and a Ninja have invaded the station!"
+	extended_round_description = "A Ninja and a Technomancer spawn during this round."
 	config_tag = "visitors"
 	required_players = 20
 	required_enemies = 3
 	end_on_antag_death = 0
-	antag_tags = list(MODE_WIZARD, MODE_NINJA)
+	antag_tags = list(MODE_TECHNOMANCER, MODE_NINJA)
 	require_all_templates = 1

--- a/code/game/gamemodes/technomancer/spells/aura/shock_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/shock_aura.dm
@@ -19,7 +19,7 @@
 /obj/item/spell/aura/shock/process()
 	if(!pay_energy(500))
 		qdel(src)
-	var/list/nearby_mobs = range(calculate_spell_power(4),owner)
+	var/list/nearby_mobs = range(calculate_spell_power(4), owner)
 	var/power = calculate_spell_power(7)
 	if(check_for_scepter())
 		power = calculate_spell_power(15)
@@ -27,6 +27,9 @@
 		light.flicker()
 	for(var/mob/living/L in nearby_mobs)
 		if(is_ally(L))
+			continue
+		
+		if(L.loc == owner)
 			continue
 
 		if(L.isSynthetic())

--- a/code/game/gamemodes/technomancer/spells/aura/unstable_aura.dm
+++ b/code/game/gamemodes/technomancer/spells/aura/unstable_aura.dm
@@ -11,7 +11,7 @@
 
 /obj/item/spell/aura/unstable
 	name = "degen aura"
-	desc = "Breaks down your entities from the inside."
+	desc = "Breaks down your entities from the inside. Synthetics will take brute damage while organics will take fire damage."
 	icon_state = "generic"
 	cast_methods = null
 	aspect = ASPECT_UNSTABLE
@@ -24,10 +24,13 @@
 	for(var/mob/living/L in nearby_mobs)
 		if(is_ally(L))
 			continue
+		
+		if(L.loc == owner)
+			continue
 
 		var/damage_to_inflict = max(L.health / L.getMaxHealth(), 0) // Otherwise, those in crit would actually be healed.
 
-		var/armor_factor = L.modify_damage_by_armor(BP_CHEST, 30, BURN, armor_pen = 30)
+		var/armor_factor = L.modify_damage_by_armor(BP_CHEST, 30, BURN, armor_pen = 40)
 		damage_to_inflict = damage_to_inflict * armor_factor
 
 		if(L.isSynthetic())
@@ -35,7 +38,7 @@
 			if(damage_to_inflict && prob(10))
 				to_chat(L, "<span class='danger'>Your chassis seems to slowly be decaying and breaking down.</span>")
 		else
-			L.adjustToxLoss(damage_to_inflict)
+			L.adjustFireLoss(damage_to_inflict)
 			if(damage_to_inflict && prob(10))
 				to_chat(L, "<span class='danger'>You feel almost like you're melting from the inside!</span>")
 

--- a/code/game/gamemodes/technomancer/spells/mend_organs.dm
+++ b/code/game/gamemodes/technomancer/spells/mend_organs.dm
@@ -46,6 +46,12 @@
 				var/obj/item/organ/external/affected = E
 				if((affected.damage < affected.min_broken_damage * config.organ_health_multiplier) && (affected.status & ORGAN_BROKEN))
 					affected.status &= ~ORGAN_BROKEN
+				
+				if(istype(affected.tendon) && !affected.tendon.intact)
+					affected.tendon.heal()
+
+				if(E.status & ORGAN_ARTERY_CUT)
+					E.status &= ~ORGAN_ARTERY_CUT
 
 			H.restore_blood() // Fix bloodloss
 		qdel(src)

--- a/code/game/gamemodes/technomancer/spells/modifier/mend_all.dm
+++ b/code/game/gamemodes/technomancer/spells/modifier/mend_all.dm
@@ -21,7 +21,7 @@
 
 /datum/modifier/technomancer/mend_all/tick()
 	if(!holder.getBruteLoss() && !holder.getFireLoss() && !holder.getToxLoss() && !holder.getOxyLoss() && !holder.getCloneLoss()) // No point existing if the spell can't heal.
-		expire()
+		stop()
 		return
 	holder.adjustBruteLoss(-4 * spell_power) // Should heal roughly 120 damage over 1 minute, as tick() is run every 2 seconds.
 	holder.adjustFireLoss(-4 * spell_power)

--- a/code/game/gamemodes/technomancer/spells/modifier/mend_life.dm
+++ b/code/game/gamemodes/technomancer/spells/modifier/mend_life.dm
@@ -28,10 +28,10 @@
 	if(isliving(target))
 		var/mob/living/M = target
 		if(M.isSynthetic()) // Don't heal synths!
-			deactivate()
+			stop()
 			return
 		if(!M.getBruteLoss() && !M.getFireLoss()) // No point existing if the spell can't heal.
-			deactivate()
+			stop()
 			return
 		M.adjustBruteLoss(-4 * strength) // Should heal roughly 20 burn/brute over 10 seconds, as tick() is run every 2 seconds.
 		M.adjustFireLoss(-4 * strength) // Ditto.

--- a/code/game/gamemodes/technomancer/spells/modifier/mend_synthetic.dm
+++ b/code/game/gamemodes/technomancer/spells/modifier/mend_synthetic.dm
@@ -28,7 +28,7 @@
 	if(isliving(target))
 		var/mob/living/M = target
 		if(!M.getBruteLoss() && !M.getFireLoss()) // No point existing if the spell can't heal.
-			deactivate()
+			stop()
 			return
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = target

--- a/code/game/gamemodes/technomancer/spells/modifier/modifier.dm
+++ b/code/game/gamemodes/technomancer/spells/modifier/modifier.dm
@@ -43,6 +43,6 @@
 	..()
 	to_chat(target, SPAN_WARNING(on_created_text))
 
-/datum/modifier/technomancer/deactivate()
+/datum/modifier/technomancer/stop()
 	..()
 	to_chat(target, SPAN_WARNING(on_expired_text))

--- a/code/game/gamemodes/technomancer/spells/spawner/destablize.dm
+++ b/code/game/gamemodes/technomancer/spells/spawner/destablize.dm
@@ -1,5 +1,5 @@
 /datum/technomancer/spell/destabilize
-	name = "destabilize"
+	name = "Destabilize"
 	desc = "Creates an unstable disturbance at the targeted tile, which will afflict anyone nearby with instability who remains nearby.  This can affect you \
 	and your allies as well.  The disturbance lasts for twenty seconds."
 	cost = 100
@@ -8,7 +8,7 @@
 	category = OFFENSIVE_SPELLS
 
 /obj/item/spell/spawner/destabilize
-	name = "destabilize"
+	name = "Destabilize"
 	desc = "Now your enemies can feel what you go through when you have too much fun."
 	icon_state = "destabilize"
 	cast_methods = CAST_RANGED

--- a/code/game/gamemodes/technomancer/spells/spawner/fire_blast.dm
+++ b/code/game/gamemodes/technomancer/spells/spawner/fire_blast.dm
@@ -30,5 +30,12 @@
 	light_color = "#FF6A00"
 
 /obj/effect/temporary_effect/fire_blast/Destroy()
-	explosion(get_turf(src), -1, 1, 2, 5, adminlog = 1)
+	for(var/mob/living/M in oview(src, 2))
+		M.adjustFireLoss(30)
+		M.IgniteMob(2)
+	var/explosion_ogg = pick('sound/effects/Explosion1.ogg', 'sound/effects/Explosion2.ogg')
+	playsound(get_turf(src), explosion_ogg, 75)
+	var/datum/effect/system/explosion/E = new /datum/effect/system/explosion()
+	E.set_up(get_turf(src))
+	E.start()
 	return ..()

--- a/html/changelogs/mattatlas-technoligma.yml
+++ b/html/changelogs/mattatlas-technoligma.yml
@@ -1,0 +1,46 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Technomancer modifier spells no longer spam you with end messages."
+  - bugfix: "Technomancer fireballs now act like wizard fireballs did and don't break the floor."
+  - bugfix: "Technomancers can no longer toggle spells if they're incapacitated."
+  - bugfix: "Unstable and degen aura no longer affect mobs inside the user."
+  - bugfix: "Degen aura no longer applies toxloss."
+  - bugfix: "Mend organs now fixes tendon breaks and arterial bleeding."

--- a/html/changelogs/mattatlas-technoligma.yml
+++ b/html/changelogs/mattatlas-technoligma.yml
@@ -44,3 +44,4 @@ changes:
   - bugfix: "Unstable and degen aura no longer affect mobs inside the user."
   - bugfix: "Degen aura no longer applies toxloss."
   - bugfix: "Mend organs now fixes tendon breaks and arterial bleeding."
+  - bugfix: "Visitors now spawns a technomancer instead of a wizard."


### PR DESCRIPTION
  - Technomancer modifier spells no longer spam you with end messages.
  - Technomancer fireballs now act like wizard fireballs did and don't break the floor.
  - Technomancers can no longer toggle spells if they're incapacitated.
  - Unstable and degen aura no longer affect mobs inside the user.
  - Degen aura no longer applies toxloss.
  - Mend organs now fixes tendon breaks and arterial bleeding.
