### PR TITLE
Weapon Tweaks - Ballistic Penetration & X-Ray Firing Speed

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1147,7 +1147,7 @@
 	sprite_set = "ballistic"
 	no_salvage = TRUE
 
-	eprojectile = /obj/item/projectile/bullet/rifle/a762
+	eprojectile = /obj/item/projectile/bullet/pistol/medium
 	eshot_sound	= 'sound/weapons/gunshot/gunshot_saw.ogg'
 
 	req_one_access = list(access_syndicate)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -8,6 +8,8 @@
 	fire_sound = 'sound/weapons/laser1.ogg'
 	slot_flags = SLOT_BELT|SLOT_BACK
 	accuracy = 1
+	fire_delay = 2
+	burst_delay = 2
 	w_class = ITEMSIZE_NORMAL
 	force = 10
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
@@ -120,7 +122,8 @@ obj/item/gun/energy/retro
 	projectile_type = /obj/item/projectile/beam/xray
 	charge_cost = 100
 	max_shots = 20
-	fire_delay = 1
+	fire_delay = 4
+	burst_delay = 4
 	can_turret = 1
 	turret_is_lethal = 1
 	turret_sprite_set = "xray"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -8,8 +8,6 @@
 	fire_sound = 'sound/weapons/laser1.ogg'
 	slot_flags = SLOT_BELT|SLOT_BACK
 	accuracy = 1
-	fire_delay = 2
-	burst_delay = 2
 	w_class = ITEMSIZE_NORMAL
 	force = 10
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)

--- a/code/modules/projectiles/guns/energy/rifle.dm
+++ b/code/modules/projectiles/guns/energy/rifle.dm
@@ -97,6 +97,8 @@
 	projectile_type = /obj/item/projectile/beam/xray
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_MAGNET = 2, TECH_ILLEGAL = 2)
 	max_shots = 40
+	fire_delay = 6
+	burst_delay = 6
 	secondary_projectile_type = null
 	secondary_fire_sound = null
 	can_switch_modes = 0

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -200,11 +200,12 @@
 /obj/item/projectile/bullet/rifle
 	damage = 40
 	armor_penetration = 15
-	penetrating = TRUE
+	penetrating = FALSE
 
 /obj/item/projectile/bullet/rifle/a762
 	damage = 40
 	armor_penetration = 20
+	penetrating = TRUE
 
 /obj/item/projectile/bullet/rifle/a556
 	damage = 40
@@ -214,6 +215,7 @@
 /obj/item/projectile/bullet/rifle/a556/ap 
 	damage = 35
 	armor_penetration = 40
+	penetrating = TRUE
 
 /obj/item/projectile/bullet/rifle/a145
 	damage = 80
@@ -230,6 +232,7 @@
 	name = "vintage bullet"
 	damage = 50
 	weaken = 1
+	penetrating = TRUE
 
 /obj/item/projectile/bullet/rifle/slugger
 	name = "slugger round"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -209,6 +209,7 @@
 /obj/item/projectile/bullet/rifle/a556
 	damage = 40
 	armor_penetration = 15
+	penetrating = FALSE
 
 /obj/item/projectile/bullet/rifle/a556/ap 
 	damage = 35

--- a/html/changelogs/wickedcybs_pent.yml
+++ b/html/changelogs/wickedcybs_pent.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The 5.56 rifle ammo can no longer penetrate people and obstacles anymore. The AP version is unchanged and still can."

--- a/html/changelogs/wickedcybs_pent.yml
+++ b/html/changelogs/wickedcybs_pent.yml
@@ -3,4 +3,6 @@ author: WickedCybs
 delete-after: True
 
 changes:
-  - tweak: "The 5.56 rifle ammo can no longer penetrate people and obstacles anymore. The AP version is unchanged and still can."
+  - tweak: "The 5.56 rifle ammo can no longer penetrate people and obstacles anymore. The AP version is unchanged and still can pass through stuff."
+  - tweak: "Submachinegun turrets don't fire rifle rounds anymore. They'll do the same damage as a .45 now."
+  - tweak: "There were a few lesser used laser guns in the game that would fire as fast as you could pull the trigger, namely the x-ray guns. They have a bit of a longer fire delay now."


### PR DESCRIPTION
This PR sets out to do a few things. Looking at rifle penetration and laser weapon firing speed mainly.

For rifles, 5.56 has been set to not penetrate through things in the interest of balance, the AP variant still can. 7.62 is unchanged for now. 

X-ray weapons had a case where a few of them could fire as fast as the user could click and this actually seemed intentional as the firedelay was specifically set to one on the carbine. I noticed this with the x-rays and nerfed them so that they have a longer delay. The lack of it meant easily frying people with high AP lasers. The carbine still fires faster than a rifle can.

Also, the submachine gun turret was firing rifle rounds, I made it shoot pistol medium instead, having it be more of a .45 submachine gun.