### PR TITLE
Cult Sword Buff

### DIFF
--- a/code/game/gamemodes/cult/items/sword.dm
+++ b/code/game/gamemodes/cult/items/sword.dm
@@ -1,12 +1,13 @@
 /obj/item/melee/cultblade
 	name = "eldritch blade"
-	desc = "A sword humming with unholy energy. It glows with a dim red light."
+	desc = "A sword humming with unholy energy. It glows with a dim red light and looks deadly sharp."
 	desc_antag = "This sword is a powerful weapon, capable of severing limbs easily, if they are targeted.  Non-believers are unable to use this weapon."
 	icon = 'icons/obj/sword.dmi'
 	icon_state = "cultblade"
 	item_state = "cultblade"
 	contained_sprite = TRUE
 	force = 25
+	armor_penetration = 50 // Narsie's blessing is strong. Also needed so the cult isn't obliterated by the average voidsuit with melee resistance.
 	w_class = ITEMSIZE_LARGE
 	throwforce = 10
 	slot_flags = SLOT_BELT

--- a/html/changelogs/wickedcybs_APmob.yml
+++ b/html/changelogs/wickedcybs_APmob.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Cult constructs and weapons now have armour penentration added so they stay deadly in close quarters. Before this, even an engineering voidsuit could block a cult sword."

--- a/html/changelogs/wickedcybs_APmob.yml
+++ b/html/changelogs/wickedcybs_APmob.yml
@@ -3,4 +3,4 @@ author: WickedCybs
 delete-after: True
 
 changes:
-  - tweak: "Cult constructs and weapons now have armour penentration added so they stay deadly in close quarters. Before this, even an engineering voidsuit could block a cult sword."
+  - tweak: "The Eldritch blade can now penetrate through most armour thanks to the power of the Dark God. Previously, it could get blocked by an engineering voidsuit."


### PR DESCRIPTION
Gives the cult sword a heavy helping of AP to always keep it viable for the cult, which is already easily shut down already at range. Currently, they do twenty five force and most crew voidsuits can easily resist this and easily absorb its blows. Not to mention, security decked out in riot gear and heavy armour are pretty much all that's needed to block a cult at the moment.

I will take a look at the cult constructs later, couldn't figure out simple mob AP at the moment.