### PR TITLE
TCFL Medical Belt Tweaks

### DIFF
--- a/html/changelogs/wickedcybs_tcflmed.yml
+++ b/html/changelogs/wickedcybs_tcflmed.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - maptweak: "TCFL tactical medical belts start preloaded with medicines and a hypo now."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -41516,12 +41516,12 @@
 /area/centcom/specops)
 "wWK" = (
 /obj/structure/table/rack,
-/obj/item/storage/belt/medical/first_responder/combat{
+/obj/item/storage/belt/medical/first_responder/combat/full{
 	pixel_x = 5;
 	pixel_y = -5
 	},
-/obj/item/storage/belt/medical/first_responder/combat,
-/obj/item/storage/belt/medical/first_responder/combat{
+/obj/item/storage/belt/medical/first_responder/combat/full,
+/obj/item/storage/belt/medical/first_responder/combat/full{
 	pixel_x = -4;
 	pixel_y = 5
 	},


### PR DESCRIPTION
The empty medical belts that started in the Medical Legionnaire area are now preloaded with medicine and a hypo. I think this is pretty fair as it seems most aren't aware the chem dispenser will give advanced chems. Not only that but it removes an extra layer of tedium and clicking not given to other roles in the ERT. Engineering for example, gets their belts and a lot of equipment preloaded.

The extra medicine given due to this is nothing they wouldn't already be able to get as well.
