### PR TITLE
Gives First Responders OR Access 

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -220,7 +220,7 @@
 	minimum_character_age = 20
 
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_pharmacy, access_virology, access_eva, access_maint_tunnels, access_external_airlocks, access_psychiatrist, access_first_responder)
-	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_eva, access_maint_tunnels, access_external_airlocks, access_first_responder)
+	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_eva, access_maint_tunnels, access_external_airlocks, access_first_responder)
 	outfit = /datum/outfit/job/med_tech
 	blacklisted_species = list(SPECIES_DIONA, SPECIES_IPC_G2)
 

--- a/html/changelogs/wickedcybs_medicalor.yml
+++ b/html/changelogs/wickedcybs_medicalor.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "First responders now have surgery access. Their duties remain unchanged."


### PR DESCRIPTION
First Responders can now enter the OR's if needed. I'm sure a lot of medical players can say there's been a lot of times where they yelled for a medic for support within, but forgot they would have to leave their patient and walk over to open the door instead of having the medic able to come in.

Additionally, it added an extra time sink to lesser staffed medical where the medic could not deliver the patient straight to a waiting surgeon.

This is not an excuse to step out of their lane, but it should prove very helpful on very critical cases and on lowpop and sometimes even highpop, where a physician or intern (the only two other roles with access to the ORs) can't be expected to be present or may also be alone themselves.