### PR TITLE
Veilwalk tweaks

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -382,6 +382,9 @@
 	if(!vampire)
 		return
 
+	if(isAdminLevel(src.z))
+		return
+
 	if(pulledby)
 		if(pulledby.pulling == src)
 			pulledby.pulling = null
@@ -427,7 +430,7 @@
 
 /obj/effect/dummy/veil_walk/proc/eject_all()
 	for(var/atom/movable/A in src)
-		A.forceMove(loc)
+		A.forceMove(last_valid_turf)
 		if(ismob(A))
 			var/mob/M = A
 			M.reset_view(null)

--- a/html/changelogs/alberyk-vampirenerfs.yml
+++ b/html/changelogs/alberyk-vampirenerfs.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - tweak: "Vampire veilwalk no longer allows the vampire to stand inside walls or solid objects."
+  - tweak: "Vampires can no longer use veilwalk in admin levels."


### PR DESCRIPTION
-vampires can no longer teleport inside walls using veilwalk
-veilwalk can no longer be used  in admin levels