### PR TITLE
Vaurca darkvision color update

### DIFF
--- a/code/modules/client/client_color.dm
+++ b/code/modules/client/client_color.dm
@@ -96,7 +96,7 @@
 	priority = 300
 
 /datum/client_color/vaurca
-	client_color = list(0, 0, 0.297, 0, 0, 0.739, 0, 0, 0.100)
+	client_color = list(0.793, 0.297, 0, 0.297, 0.539, 0, 0, 0, 0)
 	priority = 100
 
 /datum/client_color/deuteranopia

--- a/html/changelogs/VaurcaVision.yml
+++ b/html/changelogs/VaurcaVision.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - tweak: "Vaurca's darkvision color has been changed."


### PR DESCRIPTION
Made on desven#3538's request & with maint's permission to change the color. The specific color remains open for discussion.

Current color: 
![image](https://user-images.githubusercontent.com/8396443/119069089-ba595c80-b9e5-11eb-9761-b2fdb814c7e1.png)
