### PR TITLE
Chem Dispenser Safety Standards

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -27,6 +27,7 @@
 	var/max_pill_count = 20
 	flags = OPENCONTAINER
 	var/datum/asset/spritesheet/chem_master/chem_asset
+	var/list/forbidden_containers = list(/obj/item/reagent_containers/glass/bucket) //For containers we don't want people to shove into the chem machine. Like big-ass buckets.
 
 /obj/machinery/chem_master/Initialize()
 	. = ..()
@@ -42,12 +43,15 @@
 				qdel(src)
 				return
 
-/obj/machinery/chem_master/attackby(var/obj/item/B as obj, var/mob/user as mob)
+/obj/machinery/chem_master/attackby(var/obj/item/B, mob/user)
 
 	if(istype(B, /obj/item/reagent_containers/glass))
 
 		if(src.beaker)
-			to_chat(user, "A beaker is already loaded into the machine.")
+			to_chat(user, SPAN_WARNING("A beaker is already loaded into the machine."))
+			return
+		if(is_type_in_list(B, forbidden_containers))
+			to_chat(user, SPAN_WARNING("There's no way to fit [B] into \the [src]!"))
 			return
 		src.beaker = B
 		user.drop_from_inventory(B,src)

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -14,6 +14,7 @@
 
 	var/accept_drinking = 0
 	var/amount = 30
+	var/list/forbidden_containers = list(/obj/item/reagent_containers/glass/bucket) //For containers we don't want people to shove into the chem machine. Like big-ass buckets.
 
 	use_power = 1
 	idle_power_usage = 100
@@ -96,6 +97,10 @@
 			return
 
 		var/obj/item/reagent_containers/RC = W
+
+		if(is_type_in_list(RC, forbidden_containers))
+			to_chat(user, SPAN_WARNING("There's no way to fit [RC] into \the [src]!"))
+			return
 
 		if(!accept_drinking && istype(RC,/obj/item/reagent_containers/food))
 			to_chat(user, SPAN_WARNING("This machine only accepts beakers!"))

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -15,6 +15,7 @@
 	var/accept_drinking = 0
 	var/amount = 30
 	var/list/forbidden_containers = list(/obj/item/reagent_containers/glass/bucket) //For containers we don't want people to shove into the chem machine. Like big-ass buckets.
+	var/list/drink_accepted = list(/obj/item/reagent_containers/food/drinks, /obj/item/reagent_containers/food/condiment) //Allow these cans/glasses/condiment bottles but forbid ACTUAL food. 
 
 	use_power = 1
 	idle_power_usage = 100
@@ -91,7 +92,7 @@
 			to_chat(user, SPAN_NOTICE("You remove [C] from [src]."))
 			C.forceMove(loc)
 
-	else if(istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food))
+	else if(istype(W, /obj/item/reagent_containers/glass) || is_type_in_list(W, drink_accepted))
 		if(container)
 			to_chat(user, SPAN_WARNING("There is already \a [container] on [src]!"))
 			return
@@ -102,7 +103,7 @@
 			to_chat(user, SPAN_WARNING("There's no way to fit [RC] into \the [src]!"))
 			return
 
-		if(!accept_drinking && istype(RC,/obj/item/reagent_containers/food))
+		if(!accept_drinking && is_type_in_list(RC, drink_accepted))
 			to_chat(user, SPAN_WARNING("This machine only accepts beakers!"))
 			return
 

--- a/html/changelogs/doxxmedearly - bucket_chemistry.yml
+++ b/html/changelogs/doxxmedearly - bucket_chemistry.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   -tweak: "Buckets no longer fit into chem dispensers or ChemMasters."
+  -tweak: "You can no longer put food in chem dispensers, including drink dispensers."

--- a/html/changelogs/doxxmedearly - bucket_chemistry.yml
+++ b/html/changelogs/doxxmedearly - bucket_chemistry.yml
@@ -3,5 +3,5 @@ author: Doxxmedearly
 delete-after: True
 
 changes:
-  -tweak: "Buckets no longer fit into chem dispensers or ChemMasters."
-  -tweak: "You can no longer put food in chem dispensers, including drink dispensers."
+  - tweak: "Buckets no longer fit into chem dispensers or ChemMasters."
+  - tweak: "You can no longer put food in chem dispensers, including drink dispensers."

--- a/html/changelogs/doxxmedearly - bucket_chemistry.yml
+++ b/html/changelogs/doxxmedearly - bucket_chemistry.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  -tweak: "Buckets no longer fit into chem dispensers or ChemMasters."


### PR DESCRIPTION
Chem Dispensers and ChemMasters can no longer hold buckets.
Made it easy to expand the list of unacceptable containers as well if more are added.