### PR TITLE
Adds comfy sofas to kitchen, diner & security break room

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -110,17 +110,53 @@
 	icon_state = "sofamiddle_preview"
 	base_icon = "sofamiddle"
 
+/obj/structure/bed/chair/comfy/sofa/leather/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_LEATHER)
+
+obj/structure/bed/chair/comfy/sofa/comfy/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_CARPET)
+
+obj/structure/bed/chair/comfy/sofa/cloth/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_CLOTH)
+
 /obj/structure/bed/chair/comfy/sofa/left
 	icon_state = "sofaend_left_preview"
 	base_icon = "sofaend_left"
+
+/obj/structure/bed/chair/comfy/sofa/left/leather/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_LEATHER)
+
+obj/structure/bed/chair/comfy/sofa/left/comfy/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_CARPET)
+
+obj/structure/bed/chair/comfy/sofa/left/cloth/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_CLOTH)
 
 /obj/structure/bed/chair/comfy/sofa/right
 	icon_state = "sofaend_right_preview"
 	base_icon = "sofaend_right"
 
+/obj/structure/bed/chair/comfy/sofa/right/leather/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_LEATHER)
+
+obj/structure/bed/chair/comfy/sofa/right/comfy/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_CARPET)
+
+obj/structure/bed/chair/comfy/sofa/right/cloth/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_CLOTH)
+
 /obj/structure/bed/chair/comfy/sofa/corner
 	icon_state = "sofacorner_preview"
 	base_icon = "sofacorner"
+
+/obj/structure/bed/chair/comfy/sofa/corner/leather/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_LEATHER)
+
+obj/structure/bed/chair/comfy/sofa/corner/comfy/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_CARPET)
+
+obj/structure/bed/chair/comfy/sofa/corner/cloth/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_CLOTH)
 
 /obj/structure/bed/chair/office
 	name = "office chair"

--- a/html/changelogs/SofaAdditions.yml
+++ b/html/changelogs/SofaAdditions.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - maptweak: "Made the diner & kitchen sofas into comfy variants."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -50077,7 +50077,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 30
 	},
-/obj/structure/bed/chair/comfy/sofa/left{
+/obj/structure/bed/chair/comfy/sofa/left/comfy{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -50092,7 +50092,7 @@
 	dir = 1;
 	icon_state = "tube1"
 	},
-/obj/structure/bed/chair/comfy/sofa/right{
+/obj/structure/bed/chair/comfy/sofa/right/comfy{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -54187,7 +54187,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bZu" = (
-/obj/structure/bed/chair/comfy/sofa/right{
+/obj/structure/bed/chair/comfy/sofa/right/comfy{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -61848,7 +61848,7 @@
 /area/maintenance/engineering)
 "hsj" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/bed/chair/comfy/sofa/left{
+/obj/structure/bed/chair/comfy/sofa/left/comfy{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -64004,7 +64004,7 @@
 /area/maintenance/medbay)
 "maY" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/bed/chair/comfy/sofa/right{
+/obj/structure/bed/chair/comfy/sofa/right/comfy{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -66419,7 +66419,7 @@
 	name = "Security - Investigations Office"
 	})
 "qlw" = (
-/obj/structure/bed/chair/comfy/sofa/left{
+/obj/structure/bed/chair/comfy/sofa/left/comfy{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -68605,7 +68605,7 @@
 /turf/simulated/floor/tiled,
 /area/security/forensics_laboratory)
 "tPg" = (
-/obj/structure/bed/chair/comfy/sofa/left{
+/obj/structure/bed/chair/comfy/sofa/left/comfy{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
@@ -71363,7 +71363,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
 "ymb" = (
-/obj/structure/bed/chair/comfy/sofa/right{
+/obj/structure/bed/chair/comfy/sofa/right/comfy{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -2463,7 +2463,7 @@
 /turf/simulated/floor/plating,
 /area/security/training_theoretical)
 "fF" = (
-/obj/structure/bed/chair/comfy/sofa/left{
+/obj/structure/bed/chair/comfy/sofa/left/comfy{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -2534,22 +2534,22 @@
 /turf/simulated/floor/plating,
 /area/security/training_theoretical)
 "gb" = (
-/obj/structure/bed/chair/comfy/sofa/corner{
+/obj/structure/bed/chair/comfy/sofa/corner/comfy{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/security/break_room)
 "gc" = (
-/obj/structure/bed/chair/comfy/sofa{
+/obj/structure/bed/chair/comfy/sofa/comfy{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/security/break_room)
 "gd" = (
-/obj/structure/bed/chair/comfy/sofa/left{
+/obj/machinery/light,
+/obj/structure/bed/chair/comfy/sofa/left/comfy{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/security/break_room)
 "ge" = (


### PR DESCRIPTION
After some quick experimentation, the steel sofas have been replaced with comfy variants instead in a lovely shade of red: 
![image](https://user-images.githubusercontent.com/8396443/120193110-4c4e3a00-c21c-11eb-9d18-36f0684047f6.png)

Sofa materials for cloth, leather & comfy have also been added in general to the code for future cases where mappers might want to use them.

Update: The security sofas are now also changed to be comfy.
