### PR TITLE
Fixes the auto compressor not showing up in FR lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -123,7 +123,7 @@
 	new /obj/item/crowbar/red(src)
 	new /obj/item/clothing/mask/gas/alt(src)
 	new /obj/item/clothing/mask/gas/half(src)
-	new /obj/item/auto_cpr
+	new /obj/item/auto_cpr(src)
 
 /obj/structure/closet/secure_closet/CMO
 	name = "chief medical officer's locker"

--- a/html/changelogs/CPRMachineLocker.yml
+++ b/html/changelogs/CPRMachineLocker.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "The auto compressor should now properly show up in the FR lockers."


### PR DESCRIPTION
According to the PR adding them, they were meant to. This solves that.