### PR TITLE
Makes the investigator program selectable in computer setup

### DIFF
--- a/code/modules/modular_computers/file_system/programs/app_presets.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets.dm
@@ -377,7 +377,7 @@
 	name = "security_inv"
 	display_name = "Security - Investigations"
 	description = "Contains the most common security and forensics programs."
-	available = FALSE
+	available = TRUE
 
 /datum/modular_computer_app_presets/security/investigations/return_install_programs(obj/item/modular_computer/comp)
 	var/list/_prg_list = list(

--- a/html/changelogs/InvestProgram.yml
+++ b/html/changelogs/InvestProgram.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "The investigator program set can now be selected as pre-installed when setting up a new modular computer device."


### PR DESCRIPTION
When setting up a new computer, the investigator program set was not available. Now it is just like the standard security set.