### PR TITLE
Drowsiness Changes

### DIFF
--- a/code/game/objects/structures/therapy.dm
+++ b/code/game/objects/structures/therapy.dm
@@ -94,12 +94,12 @@
 		var/thrall_response = alert(H, "Do you believe in hypnosis?", "Willpower", "Yes", "No")
 		if(thrall_response == "No")
 			H.sleeping = max(H.sleeping - 40, 0)
-			H.drowsyness = max(H.drowsyness - 60, 0)
+			H.drowsiness = max(H.drowsiness - 60, 0)
 			thrall = null
 			STOP_PROCESSING(SSfast_process, src)
 		else
 			H.sleeping = max(H.sleeping, 40)
-			H.drowsyness = max(H.drowsyness, 60)
+			H.drowsiness = max(H.drowsiness, 60)
 	else
 		STOP_PROCESSING(SSfast_process, src)
 
@@ -158,7 +158,7 @@
 		H.visible_message("<span class='warning'>[H] falls into a deep slumber!</span>", "<span class ='danger'>You fall into a deep slumber!</span>")
 
 		H.sleeping = max(H.sleeping, 40)
-		H.drowsyness = max(H.drowsyness, 60)
+		H.drowsiness = max(H.drowsiness, 60)
 		thrall = WEAKREF(H)
 		START_PROCESSING(SSfast_process, src)
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -155,7 +155,7 @@
 		return PSYCHOTIC
 	else if (druggy)
 		return DRUGGED
-	else if (drowsyness)
+	else if (drowsiness)
 		return DIZZY
 	else if (confused)
 		return DIZZY

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -498,4 +498,4 @@
 	. = contents - internal_organs
 
 /mob/living/carbon/proc/is_drowsy()
-	return (drowsyness >= 5)
+	return (drowsiness >= 5)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -496,3 +496,6 @@
 
 /mob/living/carbon/get_contained_external_atoms()
 	. = contents - internal_organs
+
+/mob/living/carbon/proc/is_drowsy()
+	return (drowsyness >= 5)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -303,6 +303,8 @@
 
 			if(M.max_stamina > 0)
 				disarm_cost = M.max_stamina / 6
+				if(M.is_drowsy())
+					disarm_cost *= 1.25
 				usesStamina = TRUE
 			else if(M.max_stamina <= 0)
 				if(M.isSynthetic())

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -65,7 +65,7 @@
 	if(aiming && aiming.aiming_at)
 		tally += 5 // Iron sights make you slower, it's a well-known fact.
 
-	if (drowsyness)
+	if (is_drowsy())
 		tally += 6
 
 	if (!(species.flags & IS_MECHANICAL))	// Machines don't move slower when cold.

--- a/code/modules/mob/living/carbon/human/intoxication.dm
+++ b/code/modules/mob/living/carbon/human/intoxication.dm
@@ -14,7 +14,7 @@
 		slurring = 0
 		confused = 0
 		eye_blurry = 0
-		drowsyness = 0
+		drowsiness = 0
 		paralysis = 0
 		sleeping = 0
 		//Many of these parameters normally tick down in life code, but some parts of that code don't run in godmode, so this prevents a BST being stuck with blurred vision

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -778,6 +778,7 @@
 		if(resting)
 			dizziness = max(0, dizziness - 15)
 			jitteriness = max(0, jitteriness - 15)
+			drowsyness = max(0, drowsyness - 5)
 			adjustHalLoss(-3)
 		else
 			dizziness = max(0, dizziness - 3)
@@ -792,10 +793,16 @@
 				drowsyness = 0
 			else
 				drowsyness--
-				eye_blurry = max(2, eye_blurry)
-				if (prob(5))
-					sleeping += 1
-					Paralyse(5)
+				eye_blurry = max(drowsyness, eye_blurry)
+				if(drowsyness > 5)
+					if(prob(drowsyness/5))
+						slurring += rand(1, 5)
+					if(prob(3))
+						make_dizzy(100 + drowsyness)
+						if(!sleeping)
+							emote("yawn")
+					if(prob(drowsyness/10))
+						eye_blind += 2
 
 		// If you're dirty, your gloves will become dirty, too.
 		if(gloves && germ_level > gloves.germ_level && prob(10))
@@ -1376,6 +1383,8 @@
 		//Any suffocation damage slows stamina regen.
 		//This includes oxyloss from low blood levels
 		var/regen = stamina_recovery * (1 - min(((getOxyLoss()) / exhaust_threshold) + ((get_shock()) / exhaust_threshold), 1))
+		if(is_drowsy())
+			regen *= 0.85
 		if (regen > 0)
 			stamina = min(max_stamina, stamina+regen)
 			adjustNutritionLoss(stamina_recovery*0.09)
@@ -1446,8 +1455,8 @@
 /mob/living/carbon/human/proc/do_fever_effects(var/fever)
 	if(prob(20/3)) // every 30 seconds, roughly
 		to_chat(src, SPAN_WARNING(pick("You feel cold and clammy...", "You shiver as if a breeze has passed through.", "Your muscles ache.", "You feel tired and fatigued.")))
-	if(prob(20)) // once every 10 seconds, roughly
-		drowsyness += 4
+	if(prob(25)) // once every 8 seconds, roughly
+		drowsyness += 5
 	if(prob(20))
 		adjustHalLoss(5 * min(fever, 5)) // muscle pain from fever
 	if(fever >= 7 && prob(10)) // your organs are boiling, figuratively speaking

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -778,7 +778,7 @@
 		if(resting)
 			dizziness = max(0, dizziness - 15)
 			jitteriness = max(0, jitteriness - 15)
-			drowsyness = max(0, drowsyness - 5)
+			drowsiness = max(0, drowsiness - 5)
 			adjustHalLoss(-3)
 		else
 			dizziness = max(0, dizziness - 3)
@@ -788,20 +788,20 @@
 		//Other
 		handle_statuses()
 
-		if (drowsyness)
-			if (drowsyness < 0)
-				drowsyness = 0
+		if (drowsiness)
+			if (drowsiness < 0)
+				drowsiness = 0
 			else
-				drowsyness--
-				eye_blurry = max(drowsyness, eye_blurry)
-				if(drowsyness > 5)
-					if(prob(drowsyness/5))
+				drowsiness--
+				eye_blurry = max(drowsiness, eye_blurry)
+				if(drowsiness > 5)
+					if(prob(drowsiness/5))
 						slurring += rand(1, 5)
 					if(prob(3))
-						make_dizzy(100 + drowsyness)
+						make_dizzy(100 + drowsiness)
 						if(!sleeping)
 							emote("yawn")
-					if(prob(drowsyness/10))
+					if(prob(drowsiness/10))
 						eye_blind += 2
 
 		// If you're dirty, your gloves will become dirty, too.
@@ -1456,7 +1456,7 @@
 	if(prob(20/3)) // every 30 seconds, roughly
 		to_chat(src, SPAN_WARNING(pick("You feel cold and clammy...", "You shiver as if a breeze has passed through.", "Your muscles ache.", "You feel tired and fatigued.")))
 	if(prob(25)) // once every 8 seconds, roughly
-		drowsyness += 5
+		drowsiness += 5
 	if(prob(20))
 		adjustHalLoss(5 * min(fever, 5)) // muscle pain from fever
 	if(fever >= 7 && prob(10)) // your organs are boiling, figuratively speaking

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -554,6 +554,8 @@
 		return 1 // Handled.
 
 	cost *= H.sprint_cost_factor
+	if(H.is_drowsy())
+		cost *= 1.25
 	if (H.stamina == -1)
 		log_debug("Error: Species with special sprint mechanics has not overridden cost function.")
 		return 0

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -66,7 +66,7 @@
 		if(EYE_BLUR)
 			eye_blurry = max(eye_blurry, effect * BLOCKED_MULT(blocked))
 		if(DROWSY)
-			drowsyness = max(drowsyness, effect * BLOCKED_MULT(blocked))
+			drowsiness = max(drowsiness, effect * BLOCKED_MULT(blocked))
 		if(INCINERATE)
 			IgniteMob(effect * BLOCKED_MULT(blocked))
 	updatehealth()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -117,7 +117,7 @@
 	var/bodytemperature = 310.055	//98.7 F
 	var/old_x = 0
 	var/old_y = 0
-	var/drowsyness = 0.0//Carbon
+	var/drowsiness = 0.0//Carbon
 	var/charges = 0.0
 	var/nutrition = BASE_MAX_NUTRITION * CREW_NUTRITION_SLIGHTLYHUNGRY  //carbon
 	var/nutrition_loss = HUNGER_FACTOR //How much hunger is lost per tick. This is modified by species

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -216,7 +216,7 @@
 		var/coercion_rank = user.psi.get_rank(PSI_COERCION)
 		if(coercion_rank >= PSI_RANK_GRANDMASTER)
 			target.AdjustParalysis(-1)
-		target.drowsyness = 0
+		target.drowsiness = 0
 		if(istype(target, /mob/living/carbon))
 			var/mob/living/carbon/M = target
 			M.hallucination = max(M.hallucination, 10)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -21,7 +21,7 @@
 	M.add_chemical_effect(CE_PAINKILLER, 5 + round(power,5))
 
 	if(power > 5)
-		M.drowsyness = min(20,max(M.drowsyness,power - 5))
+		M.drowsiness = min(20,max(M.drowsiness,power - 5))
 
 	if(power > 10)
 		var/nutrition_percent = M.nutrition/M.max_nutrition
@@ -92,7 +92,7 @@
 	if(prob(80))
 		M.add_chemical_effect(CE_NEUROTOXIC, 3*removed)
 	if(prob(50))
-		M.drowsyness = max(M.drowsyness, 3)
+		M.drowsiness = max(M.drowsiness, 3)
 	if(prob(10))
 		M.emote("drool")
 
@@ -162,17 +162,17 @@
 
 /decl/reagent/raskara_dust/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_PAINKILLER, 10)
-	M.drowsyness += 1 * removed
+	M.drowsiness += 1 * removed
 
 /decl/reagent/raskara_dust/affect_breathe(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_PAINKILLER, 25)
-	M.drowsyness += 2 * removed
+	M.drowsiness += 2 * removed
 	if(prob(5))
 		M.emote("cough")
 
 /decl/reagent/raskara_dust/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_PAINKILLER, 50)
-	M.drowsyness += 3 * removed
+	M.drowsiness += 3 * removed
 	if(prob(5))
 		M.emote("twitch")
 
@@ -198,7 +198,7 @@
 	holder.reagent_data[type]["special"] += (REAGENT_VOLUME(holder, type)/10)*removed
 
 	M.make_jittery(5 + holder.reagent_data[type]["special"])
-	M.drowsyness = max(0,M.drowsyness - (1 + holder.reagent_data[type]["special"]*0.1))
+	M.drowsiness = max(0,M.drowsiness - (1 + holder.reagent_data[type]["special"]*0.1))
 	if(holder.reagent_data[type]["special"] > 5)
 		M.add_chemical_effect(CE_SPEEDBOOST, 1)
 		M.apply_effect(1 + holder.reagent_data[type]["special"]*0.25, STUTTER)
@@ -280,7 +280,7 @@
 	if(M.losebreath < 5)
 		M.losebreath++
 	if(prob(50))
-		M.drowsyness = max(M.drowsyness, 3)
+		M.drowsiness = max(M.drowsiness, 3)
 
 /decl/reagent/toxin/krok
 	name = "Krok Juice"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -716,7 +716,7 @@
 		if (caffeine)
 			M.add_up_to_chemical_effect(CE_SPEEDBOOST, caffeine)
 		M.dizziness = max(0, M.dizziness + adj_dizzy)
-		M.drowsyness = max(0, M.drowsyness + adj_drowsy)
+		M.drowsiness = max(0, M.drowsiness + adj_drowsy)
 		M.sleeping = max(0, M.sleeping + adj_sleepy)
 
 	if(add_nutrition == TRUE)
@@ -1368,7 +1368,7 @@
 
 	if(alien != IS_DIONA)
 		M.dizziness = max(0, M.dizziness - 5)
-		M.drowsyness = max(0, M.drowsyness - 3)
+		M.drowsiness = max(0, M.drowsiness - 3)
 		M.sleeping = max(0, M.sleeping - 2)
 		M.intoxication = max(0, (M.intoxication - (removed*0.25)))
 
@@ -1737,7 +1737,7 @@
 		M.make_jittery(20)
 		M.druggy = max(M.druggy, 30)
 		M.dizziness += 5
-		M.drowsyness = 0
+		M.drowsiness = 0
 
 /decl/reagent/drink/grenadine
 	name = "Grenadine Syrup"
@@ -2187,7 +2187,7 @@
 	..()
 	if(alien != IS_DIONA)
 		M.dizziness = max(0, M.dizziness - 5)
-		M.drowsyness = max(0, M.drowsyness - 3)
+		M.drowsiness = max(0, M.drowsiness - 3)
 		M.sleeping = max(0, M.sleeping - 2)
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
@@ -2311,7 +2311,7 @@
 	..()
 	if(alien == IS_DIONA)
 		return
-	M.drowsyness = max(0, M.drowsyness - 7)
+	M.drowsiness = max(0, M.drowsiness - 7)
 	M.make_jittery(5)
 
 	if (M.bodytemperature > 310)
@@ -4437,7 +4437,7 @@
 	if(alien != IS_DIONA)
 		M.make_jittery(20)
 		M.dizziness += 5
-		M.drowsyness = 0
+		M.drowsiness = 0
 
 /decl/reagent/drink/zorasoda/venomgrass
 	name = "Zo'ra Soda Sour Venom Grass"
@@ -4520,7 +4520,7 @@
 	if(alien != IS_DIONA)
 		M.druggy = max(M.druggy, 30)
 		M.dizziness += 5
-		M.drowsyness = 0
+		M.drowsiness = 0
 
 /decl/reagent/drink/hrozamal_soda
 	name = "Hro'zamal Soda"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -133,7 +133,7 @@
 		return
 
 	if(remove_generic)
-		M.drowsyness = max(0, M.drowsyness - 6 * removed)
+		M.drowsiness = max(0, M.drowsiness - 6 * removed)
 		M.hallucination -= (2 * removed)
 		if(check_min_dose(M, 0.5))
 			M.add_up_to_chemical_effect(CE_ANTITOXIN, 1)
@@ -392,7 +392,7 @@
 	metabolism_min = REM * 0.0125
 
 /decl/reagent/synaptizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	M.drowsyness = max(M.drowsyness - 5, 0)
+	M.drowsiness = max(M.drowsiness - 5, 0)
 	if(REAGENT_VOLUME(holder, type) < 10) // Will prevent synaptizine interrupting a seizure caused by its own overdose.
 		M.AdjustParalysis(-1)
 	M.AdjustStunned(-1)
@@ -602,7 +602,7 @@
 
 	//These status effects will now take a little while for the dose to build up and remove them
 	M.dizziness = max(0, M.dizziness - DP)
-	M.drowsyness = max(0, M.drowsyness - DP)
+	M.drowsiness = max(0, M.drowsiness - DP)
 	M.stuttering = max(0, M.stuttering - DP)
 	M.confused = max(0, M.confused - DP)
 
@@ -788,7 +788,7 @@
 	if(prob(7))
 		M.add_chemical_effect(CE_NEUROTOXIC, 3 * removed)
 	if(prob(50))
-		M.drowsyness = max(M.drowsyness, 3)
+		M.drowsiness = max(M.drowsiness, 3)
 
 /decl/reagent/cetahydramine
 	name = "Cetahydramine"
@@ -806,7 +806,7 @@
 /decl/reagent/cetahydramine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_NOITCH, M.chem_doses[type] * 2) // 5 units of cetahydramine will counter 10 units of dermaline/butazoline itching.
 	if(prob(M.chem_doses[type]/2))
-		M.drowsyness += 2
+		M.drowsiness += 2
 
 /decl/reagent/sterilizine
 	name = "Sterilizine"
@@ -1025,7 +1025,7 @@
 	M.eye_blurry = max(M.eye_blurry, 30)
 	if(REAGENT_VOLUME(M.reagents, /decl/reagent/oxycomorphine))
 		M.ear_deaf = 20
-		M.drowsyness = max(M.drowsyness, 10)
+		M.drowsiness = max(M.drowsiness, 10)
 		M.make_dizzy(15)
 		if(prob(3))
 			to_chat(M, SPAN_GOOD(pick("You lose all sense of connection to the real world.", "Everything is so tranquil.", "You feel dettached from reality.", "Your feel disconnected from your body.", "You are aware of nothing but your conscious thoughts.")))
@@ -1081,7 +1081,7 @@
 /decl/reagent/mental/vaam/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	. = ..()
 	M.add_chemical_effect(CE_PAINKILLER, 5)
-	M.drowsyness = 0
+	M.drowsiness = 0
 
 /decl/reagent/mental/vaam/overdose(var/mob/living/carbon/human/M, var/alien, var/removed, var/scale, var/datum/reagents/holder)
 	. = ..()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -121,7 +121,7 @@
 	M.SetParalysis(0)
 	M.silent = 0
 	M.dizziness = 0
-	M.drowsyness = 0
+	M.drowsiness = 0
 	M.stuttering = 0
 	M.confused = 0
 	M.sleeping = 0

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -478,10 +478,10 @@
 	else if(dose < 7)
 		if(prob(50))
 			M.Weaken(2)
-		M.drowsyness = max(M.drowsyness, 20)
+		M.drowsiness = max(M.drowsiness, 20)
 	else
 		M.sleeping = max(M.sleeping, 20)
-		M.drowsyness = max(M.drowsyness, 60)
+		M.drowsiness = max(M.drowsiness, 60)
 
 /decl/reagent/polysomnine
 	name = "Polysomnine"
@@ -501,7 +501,7 @@
 	var/dose = M.chem_doses[type]
 	if(dose == metabolism)
 		M.confused += 2
-		M.drowsyness += 2
+		M.drowsiness += 2
 	else if(dose < 2)
 		M.Weaken(30)
 		M.eye_blurry = max(M.eye_blurry, 10)
@@ -619,7 +619,7 @@
 	update_canmove()
 
 /mob/living/carbon/human/proc/berserk_process()
-	drowsyness = max(drowsyness - 5, 0)
+	drowsiness = max(drowsiness - 5, 0)
 	AdjustParalysis(-1)
 	AdjustStunned(-1)
 	AdjustWeakened(-1)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_physical.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_physical.dm
@@ -225,7 +225,7 @@
 			if(ishuman(toucher) && prob(weakness * 100))
 				var/mob/living/carbon/human/H = toucher
 				to_chat(H, pick("<span class='notice'>You feel like taking a nap.</span>","<span class='notice'>You feel a yawn coming on.</span>","<span class='notice'>You feel a little tired.</span>"))
-				H.drowsyness = min(H.drowsyness + rand(5,25) * weakness, 50 * weakness)
+				H.drowsiness = min(H.drowsiness + rand(5,25) * weakness, 50 * weakness)
 				H.eye_blurry = min(H.eye_blurry + rand(1,3) * weakness, 50 * weakness)
 		else
 			to_chat(toucher, SPAN_WARNING("SYSTEM ALERT: CPU cycles slowing down!"))
@@ -244,7 +244,7 @@
 				if(prob(weakness * 100))
 					if(prob(10))
 						to_chat(H, pick("<span class='notice'>You feel like taking a nap.</span>","<span class='notice'>You feel a yawn coming on.</span>","<span class='notice'>You feel a little tired.</span>"))
-					H.drowsyness = min(H.drowsyness + 1 * weakness, 25 * weakness)
+					H.drowsiness = min(H.drowsiness + 1 * weakness, 25 * weakness)
 					H.eye_blurry = min(H.eye_blurry + 1 * weakness, 25 * weakness)
 		return TRUE
 
@@ -260,7 +260,7 @@
 				var/weakness = GetAnomalySusceptibility(H)
 				if(prob(weakness * 100))
 					to_chat(H, pick("<span class='notice'>You feel like taking a nap.</span>","<span class='notice'>You feel a yawn coming on.</span>","<span class='notice'>You feel a little tired.</span>"))
-					H.drowsyness = min(H.drowsyness + rand(5,15) * weakness, 50 * weakness)
+					H.drowsiness = min(H.drowsiness + rand(5,15) * weakness, 50 * weakness)
 					H.eye_blurry = min(H.eye_blurry + rand(5,15) * weakness, 50 * weakness)
 
 		return TRUE

--- a/html/changelogs/doxxmedearly - drowsy_changes.yml
+++ b/html/changelogs/doxxmedearly - drowsy_changes.yml
@@ -1,0 +1,8 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - tweak: "Changed how being drowsy works. Instead of randomly putting you to sleep with no warning, it now tries to replicate being drowsy via screen wobble, yawning, periodic slurring, and vision blurring/darkening."
+  - tweak: "Sufficient drowsiness has a small impact on your stamina recovery and stamina cost for things like disarming and sprinting."
+  - tweak: "Fevers have a slightly higher impact on drowsiness."


### PR DESCRIPTION
First commit is changes, second is renaming var (drowsyness -> drowsiness bc it was driving me insane)

Drowsy handling was annoying because it would sometimes add sleepiness, which resulted in the fun meme of walk walk walk faceplant walk walk faceplant. This is stupid and disruptive and hardly emulates being drowsy.

PR tries to make drowsiness emulate being drowsy a little better. Instead of periodically adding sleepiness, it periodically adds: -dizziness for screen wobble (hard to focus)
-light slurring (mumbling/drawn out sleepy speech)
-small amounts of eye blind (loss of focus, mental haze)
-periodic yawning

Additionally, since it's harder to do physical activity while tired, it makes the stamina cost of sprinting/disarming higher, as well as slowing the rate of stamina regeneration

Most of the above effects only occur with drowsiness levels above 5, so small doses of reagents with side effects or chem effects don't just slam you. 

Made fevers impact your drowsiness a little more. Changed it so only drowsiness above 5 affects your movement tally.

Overall not a whole lot adds drowsiness currently and, like my changes to hallucinations, this will hopefully make it so we can more freely add drowsy effects to things by making what it does wayyyy less stupid.  