### PR TITLE
Fixes Light Replacer Bug

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -137,6 +137,8 @@
 			return
 
 		if (do_after(user, load_interval, needhand = 0) && boxstartloc == box.loc && ourstartloc == src.loc)
+			if(uses >= max_uses) //catches loading from multiple boxes
+				break
 			uses++
 			to_chat(user, "<span class='notice'>Light loaded: [uses]/[max_uses]</span>")
 			playsound(src.loc, 'sound/machines/click.ogg', 20, 1)

--- a/html/changelogs/doxxmedearly - lightreplacer_catch.yml
+++ b/html/changelogs/doxxmedearly - lightreplacer_catch.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "You can no longer overfill a light replacer with bulbs by drawing from multiple boxes at the same time."


### PR DESCRIPTION
Fixes #11980

Extremely debilitating bug where light replacers can get an extra bulb by filling from two boxes at the same time. As this is a clear security risk to the server and all who inhabit it, I trust this will be treated with the UTMOST importance.