### PR TITLE
Makes badges comply with the server rules

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -13,7 +13,7 @@
 /datum/gear_tweak/proc/tweak_gear_data(var/metadata, var/datum/gear_data)
 	return
 
-/datum/gear_tweak/proc/tweak_item(var/obj/item/I, var/metadata)
+/datum/gear_tweak/proc/tweak_item(var/obj/item/I, var/metadata, var/mob/living/carbon/human/H)
 	return
 
 /*
@@ -41,7 +41,7 @@ Color adjustment
 		return input(user, "Choose a color.", title, metadata) as null|anything in valid_colors
 	return input(user, "Choose a color.", title, metadata) as color|null
 
-/datum/gear_tweak/color/tweak_item(var/obj/item/I, var/metadata)
+/datum/gear_tweak/color/tweak_item(var/obj/item/I, var/metadata, var/mob/living/carbon/human/H)
 	if(valid_colors && !(metadata in valid_colors))
 		return
 	I.color = sanitize_hexcolor(metadata, I.color)
@@ -55,7 +55,7 @@ var/datum/gear_tweak/color/additional/gear_tweak_additional_color = new()
 /datum/gear_tweak/color/additional/get_contents(var/metadata)
 	return "Additional Color: <font color='[metadata]'>&#9899;</font>"
 
-/datum/gear_tweak/color/additional/tweak_item(var/obj/item/I, var/metadata)
+/datum/gear_tweak/color/additional/tweak_item(var/obj/item/I, var/metadata, var/mob/living/carbon/human/H)
 	if(valid_colors && !(metadata in valid_colors))
 		return
 	if(I.vars["additional_color"]) // set var/additional_color = COLOR_GREY on item
@@ -76,7 +76,7 @@ var/datum/gear_tweak/color_rotation/gear_tweak_color_rotation = new()
 /datum/gear_tweak/color_rotation/get_metadata(var/user, var/metadata, var/title = "Color Rotation")
 	return clamp(input(user, "Choose the amount of degrees to rotate the hue around the color wheel. (-180 - 180)", title, metadata) as num, -180, 180)
 
-/datum/gear_tweak/color_rotation/tweak_item(var/obj/item/I, var/metadata)
+/datum/gear_tweak/color_rotation/tweak_item(var/obj/item/I, var/metadata, var/mob/living/carbon/human/H)
 	I.color = color_rotation(metadata)
 
 /*
@@ -137,7 +137,7 @@ Content adjustment
 		else
 			return metadata
 
-/datum/gear_tweak/contents/tweak_item(var/obj/item/I, var/list/metadata)
+/datum/gear_tweak/contents/tweak_item(var/obj/item/I, var/list/metadata, var/mob/living/carbon/human/H)
 	if(metadata.len != valid_contents.len)
 		return
 	for(var/i = 1 to valid_contents.len)
@@ -174,7 +174,7 @@ Reagents adjustment
 	if(!.)
 		return metadata
 
-/datum/gear_tweak/reagents/tweak_item(var/obj/item/I, var/list/metadata)
+/datum/gear_tweak/reagents/tweak_item(var/obj/item/I, var/list/metadata, var/mob/living/carbon/human/H)
 	if(metadata == "None")
 		return
 	if(metadata == "Random")
@@ -207,7 +207,7 @@ var/datum/gear_tweak/custom_name/gear_tweak_free_name = new()
 		return input(user, "Choose an item name.", "Character Preference", metadata) as null|anything in valid_custom_names
 	return sanitize(input(user, "Choose the item's name. Leave it blank to use the default name.", "Item Name", metadata) as text|null, MAX_LNAME_LEN, extra = 0)
 
-/datum/gear_tweak/custom_name/tweak_item(var/obj/item/I, var/metadata)
+/datum/gear_tweak/custom_name/tweak_item(var/obj/item/I, var/metadata, var/mob/living/carbon/human/H)
 	if(!metadata)
 		return I.name
 	I.name = metadata
@@ -259,7 +259,7 @@ Paper Data
 /datum/gear_tweak/paper_data/get_metadata(var/user, var/metadata)
 	return sanitize(input(user, "Choose a pre-written message on the item.", "Pre-written Message", metadata) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
 
-/datum/gear_tweak/paper_data/tweak_item(var/obj/item/paper/P, var/metadata)
+/datum/gear_tweak/paper_data/tweak_item(var/obj/item/paper/P, var/metadata, var/mob/living/carbon/human/H)
 	if(!metadata || !istype(P))
 		return
 	P.info = P.parsepencode(metadata)

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -237,10 +237,15 @@ var/datum/gear_tweak/custom_desc/gear_tweak_free_desc = new()
 		return input(user, "Choose an item description.", "Character Preference", metadata) as null|anything in valid_custom_desc
 	return sanitize(input(user, "Choose the item's description. Leave it blank to use the default description.", "Item Description", metadata) as message|null, extra = 0)
 
-/datum/gear_tweak/custom_desc/tweak_item(var/obj/item/I, var/metadata)
-	if(!metadata)
+/datum/gear_tweak/custom_desc/tweak_item(var/obj/item/I, var/metadata, var/mob/living/carbon/human/H)
+	if (!metadata && ("stored_name" in I.vars))
+		I.vars["stored_name"] = H.real_name
+		return I.desc += "\nThe name [H.real_name] is written on it."
+	if (!metadata)
 		return I.desc
 	I.desc = metadata
+	if ("stored_name" in I.vars)
+		I.vars["stored_name"] = H.real_name
 
 /*
 Paper Data

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -315,15 +315,15 @@ var/list/gear_datums = list()
 	var/datum/gear_data/gd = new(path, location)
 	for(var/datum/gear_tweak/gt in gear_tweaks)
 		if(metadata["[gt]"])
-			gt.tweak_gear_data(metadata["[gt]"], gd)
+			gt.tweak_gear_data(metadata["[gt]"], gd, H)
 		else
-			gt.tweak_gear_data(gt.get_default(), gd)
+			gt.tweak_gear_data(gt.get_default(), gd, H)
 	var/item = new gd.path(gd.location)
 	for(var/datum/gear_tweak/gt in gear_tweaks)
 		if(metadata["[gt]"])
-			gt.tweak_item(item, metadata["[gt]"])
+			gt.tweak_item(item, metadata["[gt]"], H)
 		else
-			gt.tweak_item(item, gt.get_default())
+			gt.tweak_item(item, gt.get_default(), H)
 	return item
 
 /datum/gear/proc/spawn_random(var/location)

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -52,13 +52,15 @@
 
 /obj/item/clothing/accessory/badge/proc/set_name(var/new_name)
 	stored_name = new_name
-	name = "[name] ([stored_name])"
+	desc += "\nThe name [stored_name] is written on it."
 
 /obj/item/clothing/accessory/badge/attack_self(mob/user as mob)
 
 	if(!stored_name)
-		to_chat(user, "You inspect your [src.name]. Everything seems to be in order and you give it a quick cleaning with your hand.")
-		set_name(user.real_name)
+		var/imprintID = alert(user,"Do you wish to imprint your name on \the [src.name]?","Imprint id","Yes", "No")
+		if(imprintID == "Yes")
+			to_chat(user, "You inspect your [src.name]. Everything seems to be in order and you give it a quick cleaning with your hand.")
+			set_name(user.real_name)
 		return
 
 	if(isliving(user))

--- a/html/changelogs/BadgeName.yml
+++ b/html/changelogs/BadgeName.yml
@@ -1,0 +1,9 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscdel: "Badges no longer have char names visible in the item name."
+  - tweak: "Badges from the loadout will automatically have the char name attached to them."
+  - tweak: "Badges will automatically add the name attached to them to the item description. The exception is badges that had their names changed through the custom loadout."
+  - tweak: "Badges will now give a popup to confirm if a character wishes to imprint their name on the badge when used in hand."


### PR DESCRIPTION
After a discussion with Arrow last night, this:
- Badge item names will no longer show char names. They have to be examined to see it now.
- The char name is automatically added to badges from the loadout. 
- Char names are automatically added to the description of badges upon being attached, except if the description is changed in which case they have to add it themselves. This is to permit custom descriptions with their char names.
- Badges will now give a popup confirmation if a player wants to attach the char name, if none is attached and it is used in hand. No more accidentally imprinting someone's passport.