### PR TITLE
Borgs Can Collapse Rollerbeds

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -12,7 +12,7 @@
 	desc = "This is used to lie in, sleep in or strap on."
 	desc_info = "Click and drag yourself (or anyone) to this to buckle in. Click on this with an empty hand to undo the buckles.<br>\
 	Anyone with restraints, such as handcuffs, will not be able to unbuckle themselves. They must use the Resist button, or verb, to break free of \
-	the buckles, instead."
+	the buckles, instead. \ To unbuckle people as a stationbound, click the bed with an empty gripper."
 	icon = 'icons/obj/furniture.dmi'
 	icon_state = "bed"
 	anchored = TRUE
@@ -342,7 +342,7 @@
 	..()
 	if(use_check(usr) || !Adjacent(usr))
 		return
-	if(!ishuman(usr))
+	if(!ishuman(usr) && (!isrobot(usr) || isDrone(usr))) //Humans and borgs can collapse, but not drones
 		return
 	if(over_object == buckled && beaker)
 		if(iv_attached)

--- a/html/changelogs/Doxxmedearly - borg_rollerbeds.yml
+++ b/html/changelogs/Doxxmedearly - borg_rollerbeds.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Stationbounds can now collapse rollerbeds, as well as attach bed-connected IVs to patients, remove IVs from beds, and remove vitals monitors from beds."
+  - rscadd: "Added a tip to the rollerbed description to indicate that stationbounds can unbuckle people by clicking the bed with an empty gripper (any kind)."


### PR DESCRIPTION
Fixes #11920 

Collapsing and other rollerbed interaction was limited to humans. Also allows them to use connected IV bags and properly take attachments off a rollerbed. 

It's not super clear how a borg unbuckles a person so I included that in the additional description. 