### PR TITLE
Unarmed Damage Affects Simplemobs Again

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs/constructs/artificer.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs/artificer.dm
@@ -8,7 +8,6 @@
 	maxHealth = 50
 	health_prefix = "artificer"
 	response_harm = "viciously beaten"
-	harm_intent_damage = 5
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	attacktext = "rammed"

--- a/code/modules/mob/living/simple_animal/friendly/adhomai.dm
+++ b/code/modules/mob/living/simple_animal/friendly/adhomai.dm
@@ -95,7 +95,6 @@
 	maxHealth = 150
 	health = 150
 
-	harm_intent_damage = 3
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	attacktext = "bitten"

--- a/code/modules/mob/living/simple_animal/hostile/adhomai.dm
+++ b/code/modules/mob/living/simple_animal/hostile/adhomai.dm
@@ -18,7 +18,6 @@
 
 	pass_flags = PASSTABLE
 
-	harm_intent_damage = 5
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	attacktext = "bitten"

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -21,7 +21,7 @@
 	mob_size = 10
 
 	blood_overlay_icon = 'icons/mob/npc/blood_overlay_carp.dmi'
-	harm_intent_damage = 8
+	harm_intent_damage = 4
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	attacktext = "bitten"
@@ -136,7 +136,6 @@
 
 	mob_size = 15
 
-	harm_intent_damage = 5
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -18,7 +18,6 @@
 
 	tameable = FALSE
 
-	harm_intent_damage = 10
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	attacktext = "gripped"

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
@@ -7,7 +7,6 @@
 	blood_overlay_icon = 'icons/mob/npc/blood_overlay_hivebot.dmi'
 	health = 15
 	maxHealth = 15
-	harm_intent_damage = 3
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	break_stuff_probability = 25

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_harvester.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_harvester.dm
@@ -7,7 +7,6 @@
 	maxHealth = 100
 	blood_type = COLOR_OIL
 	blood_overlay_icon = 'icons/mob/npc/blood_overlay_hivebot.dmi'
-	harm_intent_damage = 3
 	melee_damage_lower = 30
 	melee_damage_upper = 30
 	destroy_surroundings = 0

--- a/code/modules/mob/living/simple_animal/hostile/phoron_worm.dm
+++ b/code/modules/mob/living/simple_animal/hostile/phoron_worm.dm
@@ -147,7 +147,6 @@
 	icon = 'icons/mob/npc/small_phoron_worm.dmi'
 	maxHealth = 80
 	health = 80
-	harm_intent_damage = 5
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	resist_mod = 1

--- a/code/modules/mob/living/simple_animal/hostile/pra.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pra.dm
@@ -30,7 +30,6 @@
 	universal_speak = TRUE
 	universal_understand = TRUE
 
-	harm_intent_damage = 5
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	mob_size = 5

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -55,7 +55,7 @@
 	var/response_help   = "tries to help"
 	var/response_disarm = "tries to disarm"
 	var/response_harm   = "hurts"
-	var/harm_intent_damage = 5
+	var/harm_intent_damage = 3 //The maximum amount of damage this mob can take from simple unarmed attacks that don't have damage values, like punches
 
 	//Temperature effect
 	var/minbodytemp = 250
@@ -502,7 +502,10 @@
 			simple_harm_attack(user)
 			return
 		attack.show_attack_simple(user, src, pick(organ_names))
-		apply_damage(attack.get_unarmed_damage(user), attack.damage_type)
+		var/actual_damage = attack.get_unarmed_damage(user) //Punch and kick no longer have get_unarmed_damage due to how humanmob combat works. If we have none, we'll apply a small random amount.
+		if(!actual_damage)
+			actual_damage = harm_intent_damage ? rand(1, harm_intent_damage) : 0
+		apply_damage(actual_damage, attack.damage_type)
 		user.do_attack_animation(src, FIST_ATTACK_ANIMATION)
 		return
 	simple_harm_attack(user)

--- a/html/changelogs/Doxxmedearly - simplemob_unarmed.yml
+++ b/html/changelogs/Doxxmedearly - simplemob_unarmed.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Punching and kicking simplemobs (including viscerators) now applies damage again."


### PR DESCRIPTION
Fixes #11879 

It was returning 0 damage unless the species has a stronger attack (unathi claws, etc) due to how punching/kicking was done with what I assume was the armor rework, since that changed how damage was applied. Since they have a base damage of 0 that's what was being applied.

Made it so that if the default damage is 0, it applies a random amount of damage as defined in the animal's harm_intent_damage var. This makes punches and kicks apply (small) damage while ensuring that strong species unarmed attacks still do their full damage. 

Made the harm_intent_damage slightly random and slightly lower to be more in line with unarmed damage vs humans. If you want to punch an animal to death it's gonna take some effort. 