### PR TITLE
Filing Cabinets store more item types

### DIFF
--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -16,6 +16,24 @@
 	icon_state = "filingcabinet"
 	density = 1
 	anchored = 1
+	var/list/accepted_items = list(
+		/obj/item/paper, 
+		/obj/item/folder, 
+		/obj/item/photo, 
+		/obj/item/paper_bundle,
+		/obj/item/sample,
+		/obj/item/book,
+		/obj/item/card,
+		/obj/item/forensics/slide,
+		/obj/item/forensics/swab,
+		/obj/item/storage/photo_album,
+		/obj/item/clipboard,
+		/obj/item/disk,
+		/obj/item/pen,
+		/obj/item/clothing/accessory/badge,
+		/obj/item/pack,
+		/obj/item/hand,
+		/obj/item/key)
 
 
 /obj/structure/filingcabinet/chestdrawer
@@ -30,12 +48,12 @@
 /obj/structure/filingcabinet/Initialize()
 	. = ..()
 	for(var/obj/item/I in loc)
-		if(istype(I, /obj/item/paper) || istype(I, /obj/item/folder) || istype(I, /obj/item/photo) || istype(I, /obj/item/paper_bundle) || istype(I, /obj/item/sample))
+		if(is_type_in_list(I, accepted_items))
 			I.forceMove(src)
 
 
-/obj/structure/filingcabinet/attackby(obj/item/P as obj, mob/user as mob)
-	if(istype(P, /obj/item/paper) || istype(P, /obj/item/folder) || istype(P, /obj/item/photo) || istype(P, /obj/item/paper_bundle) || istype(P, /obj/item/sample))
+/obj/structure/filingcabinet/attackby(obj/item/P, mob/user)
+	if(is_type_in_list(P, accepted_items))
 		to_chat(user, "<span class='notice'>You put [P] in [src].</span>")
 		user.drop_from_inventory(P,src)
 		flick("[initial(icon_state)]-open",src)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -33,7 +33,8 @@
 		/obj/item/clothing/accessory/badge,
 		/obj/item/pack,
 		/obj/item/hand,
-		/obj/item/key)
+		/obj/item/key
+)
 
 
 /obj/structure/filingcabinet/chestdrawer

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -16,7 +16,7 @@
 	icon_state = "filingcabinet"
 	density = 1
 	anchored = 1
-	var/list/accepted_items = list(
+	var/static/list/accepted_items = list(
 		/obj/item/paper, 
 		/obj/item/folder, 
 		/obj/item/photo, 

--- a/html/changelogs/Doxxmedearly - filing_cabinet_QOL.yml
+++ b/html/changelogs/Doxxmedearly - filing_cabinet_QOL.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - rscadd: "Filing cabinets can now hold books, cards (playing and ID), forensics slides and swabs, photo albums, clipboards, disks, pens, badges, passports, and keys."


### PR DESCRIPTION
Expanded the list of accepted to include more bureaucracy items: cards, clipboards, passports, badges... Also to include some forensic items as well as disks (like xenobot plant disks) to help them stow and organize them. 