### PR TITLE
Technomancer Apprentice Teleporter Fix

### DIFF
--- a/code/game/gamemodes/antagspawner.dm
+++ b/code/game/gamemodes/antagspawner.dm
@@ -66,6 +66,7 @@
 	request_player()
 
 /obj/item/antag_spawner/technomancer_apprentice/request_player(mob/user)
+	uses = 0
 	SSghostroles.add_spawn_atom(ghost_role_id, src)
 
 /obj/item/antag_spawner/technomancer_apprentice/Destroy()

--- a/html/changelogs/geeves-apprentice_fix.yml
+++ b/html/changelogs/geeves-apprentice_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "You can no longer spam the technomancer apprentice teleporter to open infinite slots."


### PR DESCRIPTION
* You can no longer spam the technomancer apprentice teleporter to open infinite slots.