### PR TITLE
Missing hand equip bugfix

### DIFF
--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -119,8 +119,9 @@
 
 	return
 
-// Used to equip an item to the mob. Mainly to prevent copypasta for collect_not_del.
-/datum/outfit/proc/equip_item(mob/living/carbon/human/H, path, slot, var/set_no_remove = FALSE)
+// Used to equip an item to the mob. Mainly to prevent copypasta for collect_not_del. 
+//override_collect temporarily allows equip_or_collect without enabling it for the job. Mostly used to prevent weirdness with hand equips when the player is missing one
+/datum/outfit/proc/equip_item(mob/living/carbon/human/H, path, slot, var/set_no_remove = FALSE, var/override_collect = FALSE)
 	var/obj/item/I
 
 	if(isnum(path))	//Check if parameter is not numeric. Must be a path, list of paths or name of a gear datum
@@ -138,7 +139,7 @@
 	if(set_no_remove)
 		I.autodrobe_no_remove = TRUE
 
-	if(collect_not_del)
+	if(collect_not_del || override_collect)
 		H.equip_or_collect(I, slot)
 	else
 		H.equip_to_slot_or_del(I, slot)
@@ -240,10 +241,22 @@
 	if(suit_store)
 		equip_item(H, suit_store, slot_s_store)
 
+	//Hand equips. If person is missing an arm or hand it attempts to put it in the other hand. 
+	//Override_collect should attempt to collect any items that can't be equipped regardless of collect_not_del settings for the outfit.
 	if(l_hand)
-		equip_item(H, l_hand, slot_l_hand)
+		var/obj/item/organ/external/O
+		O = H.organs_by_name[BP_L_HAND]
+		if(!O || !O.is_usable())
+			equip_item(H, l_hand, slot_r_hand, override_collect = TRUE)
+		else
+			equip_item(H, l_hand, slot_l_hand, override_collect = TRUE)
 	if(r_hand)
-		equip_item(H, r_hand, slot_r_hand)
+		var/obj/item/organ/external/O
+		O = H.organs_by_name[BP_R_HAND]
+		if(!O || !O.is_usable())
+			equip_item(H, r_hand, slot_l_hand, override_collect = TRUE)
+		else
+			equip_item(H, r_hand, slot_r_hand, override_collect = TRUE)
 
 	if(allow_pda_choice)
 		switch(H.pda_choice)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -442,6 +442,16 @@ var/list/global/slot_flags_enumeration = list(
 				return 0
 		if(slot_wear_id)
 			return 1
+		if(slot_l_hand)
+			var/obj/item/organ/external/O
+			O = H.organs_by_name[BP_L_HAND]
+			if(!O || O.is_stump() || !O.is_usable() || O.is_malfunctioning())
+				return FALSE
+		if(slot_r_hand)
+			var/obj/item/organ/external/O
+			O = H.organs_by_name[BP_R_HAND]
+			if(!O || O.is_stump() || !O.is_usable() || O.is_malfunctioning())
+				return FALSE
 		if(slot_l_store, slot_r_store)
 			if(!H.w_uniform && (slot_w_uniform in mob_equip))
 				if(!disable_warning)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -445,12 +445,12 @@ var/list/global/slot_flags_enumeration = list(
 		if(slot_l_hand)
 			var/obj/item/organ/external/O
 			O = H.organs_by_name[BP_L_HAND]
-			if(!O || O.is_stump() || !O.is_usable() || O.is_malfunctioning())
+			if(!O || !O.is_usable() || O.is_malfunctioning())
 				return FALSE
 		if(slot_r_hand)
 			var/obj/item/organ/external/O
 			O = H.organs_by_name[BP_R_HAND]
-			if(!O || O.is_stump() || !O.is_usable() || O.is_malfunctioning())
+			if(!O || !O.is_usable() || O.is_malfunctioning())
 				return FALSE
 		if(slot_l_store, slot_r_store)
 			if(!H.w_uniform && (slot_w_uniform in mob_equip))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1169,6 +1169,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return 0
 
 /obj/item/organ/external/is_usable()
+	if(is_stump())
+		return FALSE
 	if(is_dislocated())
 		return FALSE
 	if(tendon_status() & TENDON_CUT)

--- a/html/changelogs/doxxmedearly - one_handed_equips.yml
+++ b/html/changelogs/doxxmedearly - one_handed_equips.yml
@@ -3,4 +3,5 @@ author: Doxxmedearly
 delete-after: True
 
 changes:
-  - bugfix: "Fixed some strange behavior relating to missing arms or hands. For example, handgun magazines drop to the floor instead of disappearing, and liaison briefcases should be placed in your backpack instead of being deleted. Report any other buggy behavior."
+  - bugfix: "Fixed some strange behavior relating to missing arms or hands. For example, unloading handgun magazines drops them to the floor instead of deleting them. Report any other buggy behavior."
+  - bugfix: "Fixed an issue where spawning with a missing hand would cause job items to be deleted, such as liaison briefcases. Now it tries to put it in your other hand. If it can't, it will spawn in your bag or on the floor."

--- a/html/changelogs/doxxmedearly - one_handed_equips.yml
+++ b/html/changelogs/doxxmedearly - one_handed_equips.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed some strange behavior relating to missing arms or hands. For example, handgun magazines drop to the floor instead of disappearing, and liaison briefcases should be placed in your backpack instead of being deleted. Report any other buggy behavior."


### PR DESCRIPTION
Fixes #11859

Two bugs: Unloading a pistol deleted the magazine if you had one hand, and briefcases wouldn't spawn for liaisons if you were missing a hand.

For the first, what I saw is that on `put_in_inactive_hand` was returning successful and placing the item in the missing hand's slot, which in turn made it disappear. In theory this happened any time `put_in_inactive_hand` or `put_in_active_hand` was called for a person missing a hand, and wasn't just pistol-specific. 

Seemed best to put the check for missing or disabled hands in `mob_can_equip`. So it checks for hands now. Tests fine, and shouldn't be any issues, but I guess it's possible weirdness might happen with `put_in_X_hand` procs?

For the second, the issue was that `collect_or_del` was called for slots that couldn't equip an item for whatever reason. So any outfits that had l_hand or r_hand gear (like briefcases) would delete if that hand was missing. Changed it so that it first tries to put it in your other hand. If it can't because you're missing that too or something else is equipped there, it puts it in the bag (or drops it on the ground if it can't). It updates the mannequin in the character setup, too. 

Tests fine. Tried it with the liaison, item moved to other hand fine. Tried spawning with no hands, item moved to backpack fine. Added a r_hand loadout temporarily to liaison and spawned with both one hand and no hands. Items were moved properly to the backpack. Granted, only like adminspawn outfits have both a r_hand and l_hand equip. But at least they're covered, too. God knows loadout code is balls tho so who knows what problems might happen.
