### PR TITLE
Grants janitors access to medical's custodial room

### DIFF
--- a/html/changelogs/doxxmedearly - custodial_access.yml
+++ b/html/changelogs/doxxmedearly - custodial_access.yml
@@ -1,0 +1,5 @@
+author: Doxxmedearly
+delete-after: True
+
+changes:
+  - rscadd: "Janitors now have access to the custodial area in medical."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -41251,7 +41251,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
 	name = "Custodial Closet";
-	req_access = list(66)
+	req_access = null;
+	req_one_access = list(26, 66)
 	},
 /obj/structure/cable/green{
 	d1 = 1;


### PR DESCRIPTION
Seems like an oversight way back from when cloning was removed. Not calling it a bugfix but it makes sense for them to have it. 

Fixes #10626