### PR TITLE
Stationbound Bugfix Bundle

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -3,7 +3,10 @@
 
 //Returns the thing in our active hand (whatever is in our active module-slot, in this case)
 /mob/living/silicon/robot/get_active_hand()
-	// TODO: see if refactoring this to return the gripped object (should one exist) works - would make a lot of edge cases a lot simpler
+	if(istype(module_active, /obj/item/gripper))
+		var/obj/item/gripper/G = module_active
+		if(G.wrapped)
+			return G.wrapped
 	return module_active
 
 /mob/living/silicon/robot/proc/return_wirecutter()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -391,7 +391,7 @@
 			custom_name = newname
 
 		updatename()
-		if(module)
+		if(custom_sprite)
 			set_module_sprites(module.sprites) // custom synth icons
 		SSrecords.reset_manifest()
 
@@ -739,7 +739,7 @@
 				to_chat(user, SPAN_WARNING("\The [src] does not have a radio installed!"))
 				return
 		else if(W.GetID() || istype(W, /obj/item/card/robot))			// trying to unlock the interface with an ID card
-			if(emagged) //still allow them to open the cover
+			if(emagged && !is_traitor()) //still allow them to open the cover. is_traitor() dodges this text as being made traitor sets emagged to TRUE. 
 				to_chat(user, SPAN_NOTICE("You notice that \the [src]'s interface appears to be damaged."))
 			if(opened)
 				to_chat(user, SPAN_WARNING("You must close the cover to swipe an ID card."))

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -174,7 +174,14 @@
 
 		if(pages.len <= 1)
 			var/obj/item/paper/P = src[1]
-			usr.put_in_hands(P)
+			if(istype(loc, /obj/item/gripper)) //Hacky but without it there's a ghost icon with grippers and it all spills on the floor.
+				var/obj/item/gripper/G = loc
+				G.drop(get_turf(src), FALSE)
+				G.grip_item(P, usr, FALSE)
+			else
+				usr.put_in_hands(P)
+			usr.unset_machine(src)
+			usr << browse(null, "window=[name]")
 			qdel(src)
 			return
 

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -127,7 +127,6 @@
 			add_overlay("papershredder4")
 		if(10)
 			add_overlay("papershredder5")
-	update_icon()
 
 /obj/item/shreddedp/attackby(var/obj/item/W as obj, var/mob/user)
 	if(istype(W, /obj/item/flame/lighter))

--- a/html/changelogs/Doxxmedearly - Borg_Bugfixes_0611.yml
+++ b/html/changelogs/Doxxmedearly - Borg_Bugfixes_0611.yml
@@ -1,0 +1,9 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Medical borgs should be able to reattach internal organs as well as limbs/prosthetics."
+  - bugfix: "Changing your name as a borg no longer changes your sprite to the default module."
+  - bugfix: "Fixed some weird interactions with grippers and paper bundles. The icon should update when you remove the last paper from a bundle, and detaching a bundle should leave you with one piece of paper in-gripper."
+  - bugfix: "Traitor borgs will no longer show that they have a damaged interface as if they were emagged."


### PR DESCRIPTION
`  - bugfix: "Medical borgs should be able to reattach internal organs as well as limbs/prosthetics."`
Surgery steps for these used get_active_hand(), which did not find items in the gripper. get_active_hand() now returns the gripped item if there is one, or active module if not (default behavior).

`  - bugfix: "Changing your name as a borg no longer changes your sprite to the default chassis."`
 This has something to do with custom sprites. But instead of looking for a custom sprite it just looked for any job module. Set it to check for custom sprites only. 

`  - bugfix: "Fixed some weird interactions with grippers and paper bundles. The icon should update when you remove the last paper from a bundle, and detaching a bundle should leave you with one piece of paper in-gripper."`
If you removed the last page of paper from a bundle via the paper UI, it would still show a ghost icon of a paper bundle in your gripper. Now this no longer happens, plus it keeps one of the pages in your gripper, like a normal hand.
(Also added two runtime fixes: Removing the last page of paper in a bundle closes the UI (Prevents runtimes from clicking on "Remove Page" after the bundle was gone) and I removed the infinite update_icon() loop in paper shredders. )

`  - bugfix: "Traitor borgs will no longer show that they have a damaged interface as if they were emagged."`
Being set as traitor emags you for access reasons. Now the damaged interface message won't show up if you're a traitor, since an emag never technically damaged you.

Fixes #11179
Fixes #11397
Fixes #12022
Fixes #10247
Fixes #11183
Fixes #10321
Fixes #9834