### PR TITLE
Fortune Cookies can be made with blank fortunes

### DIFF
--- a/code/modules/cooking/recipes/recipes_pastries.dm
+++ b/code/modules/cooking/recipes/recipes_pastries.dm
@@ -56,8 +56,6 @@
 		var/obj/item/paper/paper = locate() in container
 		if (!paper || !istype(paper))
 			return COOK_CHECK_FAIL
-		if (!paper.info)
-			return COOK_CHECK_FAIL
 	return .
 
 /decl/recipe/brownies

--- a/html/changelogs/doxxmedearly - blank_cookies.yml
+++ b/html/changelogs/doxxmedearly - blank_cookies.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - tweak: "Fortune cookies can now be made even if the paper is blank."


### PR DESCRIPTION
While lame, there's no reason a recipe should fail because there's no writing on the paper.