### PR TITLE
Corrects revenant announcement grammar

### DIFF
--- a/code/modules/ghostroles/spawner/antagonist/revenant.dm
+++ b/code/modules/ghostroles/spawner/antagonist/revenant.dm
@@ -75,7 +75,7 @@
 		if(rift_turf)
 			new /obj/effect/portal/revenant(rift_turf)
 			if(!first_rift_done)
-				command_announcement.Announce("Aurora, we're detecting energy signatures eerily similar to a bluespace rift breach inside your hull. [SScargo.shuttle ? "We're sending you a bluespace neutralizer via the cargo shuttle. If you need more, your research department should be able to print neutralizers as well if they've been increasing their Bluespace research levels." : ""]Locate the rift and shut it down.", "Bluespace Breach Alert")
+				command_announcement.Announce("Aurora, we're detecting energy signatures eerily similar to a bluespace rift breach inside your hull. [SScargo.shuttle ? "We're sending you a bluespace neutralizer via the cargo shuttle. If you need more, your research department should be able to print neutralizers as well if they've been increasing their bluespace research levels. " : ""]Locate the rift and shut it down.", "Bluespace Breach Alert")
 				first_rift_done = TRUE
 				if(SScargo.shuttle)
 					var/turf/T = pick_area_turf(pick(SScargo.shuttle.shuttle_area), list(/proc/not_turf_contains_dense_objects))

--- a/html/changelogs/bluecheck.yml
+++ b/html/changelogs/bluecheck.yml
@@ -1,0 +1,6 @@
+author: listerla
+
+delete-after: True
+
+changes:
+  - spellcheck: "Corrected the grammar of the revenant bluespace rift announcement."


### PR DESCRIPTION
'Bluespace' is not a proper noun, and without a space at the end the end of the announcement reads like this.

![image](https://user-images.githubusercontent.com/57296132/121792133-47e03480-cbbf-11eb-9b29-de4e1e7480d5.png)
