### PR TITLE
Mapped light bugfix

### DIFF
--- a/html/changelogs/doxxmedearly - tube_mapping.yml
+++ b/html/changelogs/doxxmedearly - tube_mapping.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - maptweak: "The surface conference room light fixtures should have visible light tubes in them now."

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -6715,14 +6715,15 @@
 	pixel_y = 5
 	},
 /obj/structure/table/standard,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/wood,
 /area/sconference_room)
 "gec" = (
@@ -17175,9 +17176,6 @@
 /obj/machinery/camera/network/civilian_surface{
 	c_tag = "Surface - Conference Room"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17188,6 +17186,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/sconference_room)

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -6953,9 +6953,11 @@
 /turf/simulated/floor/plating,
 /area/tcommsat/entrance)
 "gqn" = (
-/obj/machinery/light,
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-33"
+	},
+/obj/machinery/light{
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/sconference_room)
@@ -9042,7 +9044,9 @@
 /obj/machinery/chemical_dispenser/coffee/full{
 	spawn_cartridges = list(/obj/item/reagent_containers/chem_disp_cartridge/coffee,/obj/item/reagent_containers/chem_disp_cartridge/milk,/obj/item/reagent_containers/chem_disp_cartridge/cream,/obj/item/reagent_containers/chem_disp_cartridge/sugar)
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/wood,
 /area/sconference_room)
 "icV" = (
@@ -26105,7 +26109,9 @@
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-27"
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/wood,
 /area/sconference_room)
 "wXr" = (


### PR DESCRIPTION
Fixes some icon weirdness with light tubes mapped into the surface conference room, as noted in the attached issue.

Fixes #10661