### PR TITLE
Gimme Some Sugar - Fixes sugar melting in recipes

### DIFF
--- a/code/modules/cooking/machinery/cooking_machines/_cooker.dm
+++ b/code/modules/cooking/machinery/cooking_machines/_cooker.dm
@@ -138,7 +138,7 @@
 		update_cooking_power() // update!
 	for(var/cooking_obj in cooking_objs)
 		var/datum/cooking_item/CI = cooking_obj
-		if(isemptylist(CI.container?.reagents.reagent_data))
+		if((CI.container.flags && NOREACT) || isemptylist(CI.container?.reagents.reagent_volumes))
 			continue
 		CI.container.reagents.set_temperature(min(temperature, CI.container.reagents.get_temperature() + 10*SIGN(temperature - CI.container.reagents.get_temperature()))) // max of 5C per second
 	return ..()

--- a/html/changelogs/MDP-gimmesomesugar.yml
+++ b/html/changelogs/MDP-gimmesomesugar.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MoondancerPony
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Containers with noreact will no longer be heated by stoves."
+  - fix: "Certain recipes with sugar will no longer burn and be ruined in the oven. Sugar WILL melt on the stove."
+  - fix: "Containers without reagent data (i.e. things not containing nutriment or certain medicines) will now properly heat up."

--- a/html/changelogs/MDP-gimmesomesugar.yml
+++ b/html/changelogs/MDP-gimmesomesugar.yml
@@ -38,6 +38,6 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Containers with noreact will no longer be heated by stoves."
-  - fix: "Certain recipes with sugar will no longer burn and be ruined in the oven. Sugar WILL melt on the stove."
+  - tweak: "Containers with noreact (oven dishes, fryer baskets, grill plates) will no longer be heated by appliances, to avoid accidents."
+  - fix: "Certain recipes with sugar will no longer be ruined in the oven or fryer due to caramelisation. Sugar WILL melt on the stove, though."
   - fix: "Containers without reagent data (i.e. things not containing nutriment or certain medicines) will now properly heat up."

--- a/html/changelogs/MDP-gimmesomesugar.yml
+++ b/html/changelogs/MDP-gimmesomesugar.yml
@@ -39,5 +39,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Containers with noreact (oven dishes, fryer baskets, grill plates) will no longer be heated by appliances, to avoid accidents."
-  - fix: "Certain recipes with sugar will no longer be ruined in the oven or fryer due to caramelisation. Sugar WILL melt on the stove, though."
-  - fix: "Containers without reagent data (i.e. things not containing nutriment or certain medicines) will now properly heat up."
+  - bugfix: "Certain recipes with sugar will no longer be ruined in the oven or fryer due to caramelisation. Sugar WILL melt on the stove, though."
+  - bugfix: "Containers without reagent data (i.e. things not containing nutriment or certain medicines) will now properly heat up."


### PR DESCRIPTION
- Containers with noreact will no longer be heated by appliances.
- Certain recipes with sugar will no longer burn and be ruined in the oven. Sugar WILL melt on the stove.
- Containers without reagent data (i.e. things not containing nutriment or certain medicines) will now properly heat up.

TODO later: allow normal reagent containers to be placed in so that they can be heated.