### PR TITLE
Farmbot Bugfix

### DIFF
--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -143,11 +143,11 @@
 			path = list()
 			target = null
 		else
-			if(path.len && frustration < 5)
+			if(length(path) && frustration < 5)
 				if(path[1] == loc)
 					path -= path[1]
 
-				if (path.len)
+				if(length(path))
 					var/t = step_towards(src, path[1])
 					if(t)
 						path -= path[1]
@@ -167,16 +167,24 @@
 					target = tray
 					frustration = 0
 					break
+			if(target) //We found a tray we can do something to. Set path to there.
+				pathfind(target)
+				return
 			if(check_tank())
 				for(var/obj/structure/sink/source in view(7, src))
-					target = source
-					frustration = 0
-					break
-		if(target)
-			var/t = get_dir(target, src) // Turf with the tray is impassable, so a* can't navigate directly to it
-			path = AStar(loc, get_step(target, t), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id = botcard)
-			if(!path)
-				path = list()
+					if(pathfind(source)) //If we can find a valid path to this sink, it's our target
+						target = source
+						frustration = 0
+						break
+				
+
+/mob/living/bot/farmbot/proc/pathfind(var/atom/A)
+	var/t = get_dir(A, src) // Turf with the tray is impassable, so a* can't navigate directly to it
+	path = AStar(loc, get_step(A, t), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id = botcard)
+	if(!path)
+		path = list()
+		return FALSE
+	return path
 
 /mob/living/bot/farmbot/UnarmedAttack(var/atom/A, var/proximity)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -49,6 +49,11 @@
 	if(!istype(target))
 		return
 
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.isSynthetic() && !isipc(L)) //Catches bots, drones, borgs, etc. IPCs are handled below at the human level
+			return FALSE
+
 	if (isanimal(target))
 		var/mob/living/simple_animal/SA = target
 		if(!(reagents && SA.reagents))

--- a/html/changelogs/doxxmedearly - farmbot_unstuck.yml
+++ b/html/changelogs/doxxmedearly - farmbot_unstuck.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed a bug where farmbots would get stuck doing nothing because it could not path to a sink."

--- a/html/changelogs/doxxmedearly - farmbot_unstuck.yml
+++ b/html/changelogs/doxxmedearly - farmbot_unstuck.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "Fixed a bug where farmbots would get stuck doing nothing because it could not path to a sink."
+  - bugfix: "You can no longer feed food to bots and borgs."


### PR DESCRIPTION
Farmbots were stalling out because they were trying to refill their tanks at the **kitchen** sink, which they couldn't reach. This caused them to keep it as a target (and always re-acquire it as the target) despite constantly failing to pathfind to it. This is also why moving it "woke it up." I changed it so it pathfinds at the time it looks for sinks. If it can't get a path, it will find another sink. If it can't acquire a valid sink, it should go back to looking for trays it can work on.

Tested it thoroughly to find the cause and this was the only point of failure during its think() cycle.

Also fixed a bug which allowed food to be fed to farmbots (and other bots). 

Fixes #9935
Fixes #9719