### PR TITLE
Fixes borg gripper issue

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -254,6 +254,8 @@
 	W.forceMove(get_turf(src))
 	return FALSE
 
+/mob/living/silicon/robot/remove_from_mob(var/obj/O) //Necessary to clear gripper when trying to place items in things (grinders, smartfridges, vendors, etc)
+	drop_item()
 
 /mob/living/silicon/robot/drop_item()
 	if (istype(module_active, /obj/item/gripper))

--- a/html/changelogs/doxxmedearly - borg_item_drop.yml
+++ b/html/changelogs/doxxmedearly - borg_item_drop.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed a bug where phantom items would remain in a borg's gripper after attempting to place them in things like vendors and grinders."


### PR DESCRIPTION
Somehow, when I set get_active_hand() for borgs to return a gripped item, it broke their interaction with remove_from_mob(). This caused phantom items to remain in the gripper after placing things in smartfridges and grinders, and anything else that uses this proc.

Fixes #12041 
Fixes #12042
(Latter issue likely caused by the above "phantom" items. Works fine on testing.)