### PR TITLE
Goonchat Spacing Fix

### DIFF
--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -109,10 +109,8 @@ var/savefile/iconCache = new("data/tmp/iconCache.sav") //Cache of icons for the 
 	loaded = TRUE
 	showChat()
 
-
 	for(var/message in messageQueue)
-		// whitespace has already been handled by the original to_chat
-		to_chat(owner, message, handle_whitespace=FALSE)
+		to_chat(owner, message, FALSE, FALSE)
 
 	messageQueue = null
 	sendClientData()

--- a/html/changelogs/geeves-goonchat_spacing.yml
+++ b/html/changelogs/geeves-goonchat_spacing.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Goonchat no longer spaces messages out weirdly upon loading."


### PR DESCRIPTION
* Goonchat no longer spaces messages out weirdly upon loading.