### PR TITLE
Infrared Sensor bugfixes

### DIFF
--- a/code/game/objects/items/devices/radio_jammer.dm
+++ b/code/game/objects/items/devices/radio_jammer.dm
@@ -131,6 +131,7 @@ var/list/active_radio_jammers = list()
 	if (W.isscrewdriver())
 		to_chat(user, "<span class='notice'>You disassemble the improvised signal jammer.</span>")
 		user.put_in_hands(assembly_holder)
+		assembly_holder.detached()
 		user.put_in_hands(cell)
 		qdel(src)
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -228,6 +228,7 @@
 
 	set_dir(turn(dir, 90))
 	update_icon()
+	return TRUE
 
 /obj/AltClick(var/mob/user)
 	if(obj_flags & OBJ_FLAG_ROTATABLE)

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -30,6 +30,7 @@
 		to_chat(user, SPAN_NOTICE("You disassemble \the [src]."))
 
 		bombassembly.forceMove(get_turf(user))
+		bombassembly.detached()
 		bombassembly.master = null
 		bombassembly = null
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -15,6 +15,10 @@
 	var/obj/special_assembly = null
 
 /obj/item/device/assembly_holder/proc/detached()
+	if(a_left)
+		a_left.holder_movement()
+	if(a_right)
+		a_right.holder_movement()
 	return
 
 /obj/item/device/assembly_holder/IsAssemblyHolder()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -7,13 +7,13 @@
 	origin_tech = list(TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 1000, MATERIAL_GLASS = 500)
 
-	wires = WIRE_PULSE
 	secured = FALSE
 	obj_flags = OBJ_FLAG_ROTATABLE
 
 	var/on = FALSE
 	var/visible = FALSE
 	var/obj/effect/beam/i_beam/first = null
+	var/turf/beam_origin //If we're not on this turf anymore, we've moved. Catches holder.master movements when we're attached to bombs and stuff.
 
 /obj/item/device/assembly/infra/activate()
 	if(!..())
@@ -53,12 +53,19 @@
 		holder.update_icon()
 
 /obj/item/device/assembly/infra/rotate(var/mob/user, var/anchored_ignore = FALSE)
+	if(..())
+		var/direction_text = dir2text(dir)
+		to_chat(user, SPAN_NOTICE("You rotate \the [src] to face [direction_text]."))
+		QDEL_NULL(first)
+
+/obj/item/device/assembly/infra/examine(mob/user)
 	. = ..()
 	var/direction_text = dir2text(dir)
-	to_chat(user, SPAN_NOTICE("You rotate \the [src] to face [direction_text]."))
-	QDEL_NULL(first)
+	to_chat(user, SPAN_NOTICE("It is facing [direction_text]."))
+
 
 /obj/item/device/assembly/infra/process()
+
 	if(!on || !secured)
 		QDEL_NULL(first)
 		return ..()
@@ -66,8 +73,16 @@
 	if(first && !isturf(first.loc))
 		QDEL_NULL(first)
 
-	if(!first && (isturf(loc) || (holder && isturf(holder.loc))))
-		var/obj/effect/beam/i_beam/I = new /obj/effect/beam/i_beam(holder ? holder.loc : loc, src)
+	//We have no infrared beam, so create one.
+	if(!first)
+		//We cannot create beams while being held or in a bag. So we have to compare locs to turfs.
+		//We need to check if whatever we're attached to, if anything, is on a turf. Since we can be attached to an assembly and that assembly can be attached, we have to check a couple locs.
+		//First check if we're part of an assembly(holder) and if that assembly is attached (holder.master). If we are, THOSE are the locs we care about.
+		var/true_location = holder ? holder.master ? holder.master.loc : holder.loc : loc 
+		if(!isturf(true_location)) //Wherever we are, we're not on a turf, nor is our assembly, nor is our bomb/whatever the assembly is attached to. We cannot make a beam.
+			return
+		beam_origin = true_location
+		var/obj/effect/beam/i_beam/I = new /obj/effect/beam/i_beam(true_location, src)
 		I.density = TRUE
 		step(I, I.dir)
 		if(I)
@@ -79,6 +94,10 @@
 		return
 
 	if(first)
+		if(beam_origin != get_turf(src)) //If the assembly we're attached to has moved, delete the beam.
+			QDEL_NULL(first)
+			beam_origin = null
+			return
 		first.process()
 
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -151,6 +151,7 @@
 		user.visible_message(SPAN_WARNING("\The [user] carefully removes \the [rig] from \the [src]."), \
 							SPAN_NOTICE("You carefully remove \the [rig] from \the [src]."))
 		rig.forceMove(get_turf(user))
+		rig.detached()
 		user.put_in_hands(rig)
 		rig = null
 		overlays = new/list()

--- a/html/changelogs/doxxmedearly - infrared_fixes.yml
+++ b/html/changelogs/doxxmedearly - infrared_fixes.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Infrared sensors now properly emit their beam when attached to a device, such as a bomb. Signalers can now activate infrared sensors."
+  - bugfix: "Fixed several instances where infrared beams would linger despite the sensor being moved or manipulated."


### PR DESCRIPTION
Fixes #11970 
Fixes #11067

Fixes a slew of bugs with the infrared sensor. The attached issues were easy fixes: Give it the flag to be activated by signalers, and get the turf of the bomb we're attached to. (Shout out to Yakunan for the detailed bug report). But then I found several more bugs that weren't discovered because the damn thing wasn't working:

**-Disassembling the bomb wouldn't delete the beam** (Sensor wasn't detecting it was moved. Solution: Made the detach() proc "move" devices and added the proc in places where assemblies would be detached, since it was just on grenades for some reason.)

 **-Moving the bomb wouldn't delete the beam** (holder_movement() doesn't detect when the item it's attached to moves. Solution: Added a check that we are on the same turf as we started, and deletes the beam if not)

**-Rotating it from any range (w/ altclick) would disable the beam and display a successful rotate message despite not rotating** (Rotate() parent doesn't return TRUE if rotated successfully. Solution: Made it return TRUE, added a check to sensor to make sure we rotated successfully. Tested all other items with rotate() function to make sure returning TRUE didn't fuck up like chairs or pipes or anything)

Also, examining the sensor now displays the direction it's facing. 