### PR TITLE
Door Roundstart Sleep Fix

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -497,6 +497,8 @@
 
 
 /obj/machinery/door/proc/open(var/forced = 0)
+	set waitfor = FALSE
+
 	if(!can_open(forced))
 		return
 	operating = TRUE
@@ -527,6 +529,8 @@
 		close()
 
 /obj/machinery/door/proc/close(var/forced = 0)
+	set waitfor = FALSE
+
 	if(!can_close(forced))
 		if (autoclose)
 			for (var/atom/movable/M in get_turf(src))

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -98,6 +98,8 @@
 		return 1
 
 /obj/machinery/door/window/open(var/forced=FALSE)
+	set waitfor = FALSE
+
 	if(!can_open() && !forced)
 		return FALSE
 	operating = TRUE
@@ -113,6 +115,8 @@
 	return TRUE
 
 /obj/machinery/door/window/close(var/forced=FALSE)
+	set waitfor = FALSE
+
 	if (!can_close() && !forced)
 		return FALSE
 	operating = TRUE

--- a/html/changelogs/geeves-roundstart_sleep_fix.yml
+++ b/html/changelogs/geeves-roundstart_sleep_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed airlocks delaying the start of the round to close first."


### PR DESCRIPTION
* Fixed airlocks delaying the start of the round to close first.

![image](https://user-images.githubusercontent.com/22774890/122102227-82430f00-ce15-11eb-8155-fb656cf25dd2.png)
![image](https://user-images.githubusercontent.com/22774890/122102234-840cd280-ce15-11eb-9853-82c996d9e9cf.png)