### PR TITLE
Borg Gripper Fixes, The Sequel (The ride never ends)

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -255,12 +255,15 @@
 	return FALSE
 
 /mob/living/silicon/robot/remove_from_mob(var/obj/O) //Necessary to clear gripper when trying to place items in things (grinders, smartfridges, vendors, etc)
-	drop_item()
+	if(istype(module_active, /obj/item/gripper))
+		var/obj/item/gripper/G = module_active
+		if(G.wrapped == O)
+			G.drop(get_turf(src), FALSE) //We don't need to see the "released X item" message if we're putting stuff in fridges and the like.
 
 /mob/living/silicon/robot/drop_item()
-	if (istype(module_active, /obj/item/gripper))
+	if(istype(module_active, /obj/item/gripper))
 		var/obj/item/gripper/G = module_active
-		if (G.wrapped)
+		if(G.wrapped)
 			G.drop_item()
 			return
 	uneq_active()

--- a/html/changelogs/Doxxmedearly - gripper_fix_part2.yml
+++ b/html/changelogs/Doxxmedearly - gripper_fix_part2.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Borg grippers should pick up stacks of items correctly again, instead of dropping them each time a stack is merged."
+  - tweak: "Removed the message telling you that you released an item from your gripper when you're putting said item into something like a fridge or grinder."


### PR DESCRIPTION
I swear I'm not an idiot. Having remove_from_mob call drop_item for borgs was fine for every case EXCEPT stacks because they need to call it in a strange way when checking how they combine. This caused the stacks to combine correctly, but end up on the ground. 

Now the remove_from_mob check properly makes sure the item being removed is actually the one in the gripper. Which I should have done anyway to check for weirdness (like this!)

Also removed the feedback message in remove_from_mob because you don't need to see "you release \the X" every time you put something in a fridge, grinder, vendor, etc. since they provide their own feedback messages.

May the spirit of Travis guide me from the path of insanity.

Fixes #12056 