### PR TITLE
Stamina Exhaustion Adjustments

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -553,6 +553,7 @@
 	if (!H.exhaust_threshold)
 		return 1 // Handled.
 
+	cost += H.getOxyLoss() * 0.1 //The less oxygen we get, the more we strain. 
 	cost *= H.sprint_cost_factor
 	if (H.stamina == -1)
 		log_debug("Error: Species with special sprint mechanics has not overridden cost function.")
@@ -588,15 +589,15 @@
 		if(O.is_bruised())
 			H.adjustOxyLoss(remainder*0.15)
 			H.adjustHalLoss(remainder*0.25)
-		H.adjustOxyLoss(remainder * 0.15) //Keeping oxyloss small when out of stamina to prevent old issue where running until exhausted sometimes gave you brain damage.
+		H.adjustOxyLoss(remainder * 0.2) //Keeping oxyloss small when out of stamina to prevent old issue where running until exhausted sometimes gave you brain damage.
 
 	if(!pre_move)
-		H.adjustHalLoss(remainder*0.45)
+		H.adjustHalLoss(remainder*0.3)
 		H.updatehealth()
 		if((H.get_shock() >= 10) && prob(H.get_shock() *2))
 			H.flash_pain(H.get_shock())
 
-	if((H.get_shock() + H.getOxyLoss()) >= (exhaust_threshold * 0.8))
+	if((H.get_shock() + H.getOxyLoss()*2) >= (exhaust_threshold * 0.8))
 		H.m_intent = M_WALK
 		H.hud_used.move_intent.update_move_icon(H)
 		to_chat(H, SPAN_DANGER("You're too exhausted to run anymore!"))

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -588,9 +588,10 @@
 		if(O.is_bruised())
 			H.adjustOxyLoss(remainder*0.15)
 			H.adjustHalLoss(remainder*0.25)
+		H.adjustOxyLoss(remainder * 0.15) //Keeping oxyloss small when out of stamina to prevent old issue where running until exhausted sometimes gave you brain damage.
 
 	if(!pre_move)
-		H.adjustHalLoss(remainder*0.25)
+		H.adjustHalLoss(remainder*0.45)
 		H.updatehealth()
 		if((H.get_shock() >= 10) && prob(H.get_shock() *2))
 			H.flash_pain(H.get_shock())

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -923,10 +923,6 @@
 	messagedelay = MEDICATION_MESSAGE_DELAY * 0.75
 	goodmessage = list("You feel good.","You feel relaxed.","You feel alert and focused.")
 
-/decl/reagent/mental/nicotine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	. = ..()
-	M.add_chemical_effect(CE_PAINKILLER, 5)
-
 /decl/reagent/mental/nicotine/overdose(var/mob/living/carbon/M, var/alien, var/removed, var/scale, var/datum/reagents/holder)
 	. = ..()
 	M.adjustOxyLoss(10 * removed * scale)

--- a/html/changelogs/Doxxmedearly - stamina_related_changes.yml
+++ b/html/changelogs/Doxxmedearly - stamina_related_changes.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - tweak: "Running with no stamina is now a little more painful, which makes you hit the exhaustion cap sooner, as it was way too high before. It also does slight oxy damage."
+  - rscdel: "Nicotine no longer acts as a painkiller."

--- a/html/changelogs/Doxxmedearly - stamina_related_changes.yml
+++ b/html/changelogs/Doxxmedearly - stamina_related_changes.yml
@@ -3,5 +3,6 @@ author: Doxxmedearly
 delete-after: True
 
 changes:
-  - tweak: "Running with no stamina is now a little more painful, which makes you hit the exhaustion cap sooner, as it was way too high before. It also does slight oxy damage."
+  - tweak: "Tweaked some things regarding running with no stamina. It now does oxy damage and takes oxy damage more into account when determining your exhaustion threshold. It's also very slightly more painful. Overall, this reduces the total time you can do this by a small amount."
   - rscdel: "Nicotine no longer acts as a painkiller."
+  - bugfix: "The above changes fix a bug where smoking could practically give you unlimited sprinting."


### PR DESCRIPTION
Fixes  #12060

So what stops you from sprinting infinitely is your pain + your oxyloss compared to your species exhaustion threshold. Before, sprinting did no oxyloss unless you had asthma or damaged lungs, and nicotine provided enough of a painkiller to ensure you never hit that threshold, or if you did, it would take a loooong time. So, did a few changes to address this.

Nicotine no longer provides a painkiller effect. Honestly it shouldn't have in the first place. Yes blah blah IRL blah blah but it's basically providing a free edge in combat and movement so out it goes.

Stamina exhaustion calculations now take oxyloss more into account. Sprinting does small oxyloss (I'm not trying to revive ye olden days of sprinting until brain damage or lung ruptures) and oxyloss counts for double when calculating exhaustion. It also makes the cost of sprinting higher by 1/10 of your oxyloss. This may need to be adjusted to 1/5 but I'm playing it safe for now. 

The oxyloss damage a healthy person should accrue while sprinting (at least in testing) with no painkillers is like maybe 6 for humans, 10 for unathi, which isn't dangerous. Painkillers may give you a smaller time running (since it helps you ignore that your body wants you to stop) but oxyloss can creep up on you. 

In testing this does not shorten default sprint times significantly; human sprinting to exhaustion was honestly way too much before, so it's in a better place now. Unathi still have a pretty good distance to their sprint. This should still feel like a good amount of time to sprint after exerting your stamina. It'll be even better if we get the current Pain changes test merge in, IMO. 