### PR TITLE
Phoron Immune Tweak

### DIFF
--- a/code/ZAS/Phoron.dm
+++ b/code/ZAS/Phoron.dm
@@ -81,7 +81,10 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 	if(vsc.plc.CLOTH_CONTAMINATION) contaminate()
 
 	//Anything else requires them to not be dead.
-	if(stat >= 2)
+	if(stat >= DEAD)
+		return
+
+	if(species.flags & PHORON_IMMUNE)
 		return
 
 	//Burn skin if exposed.

--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -15,7 +15,7 @@
 // unused: 0x8000(32768) - higher than this will overflow
 
 // Base flags for IPCs.
-#define IS_IPC (NO_BREATHE|NO_SCAN|NO_BLOOD|NO_PAIN|NO_POISON|IS_MECHANICAL|NO_CHUBBY)
+#define IS_IPC (NO_BREATHE|NO_SCAN|NO_BLOOD|NO_PAIN|NO_POISON|IS_MECHANICAL|NO_CHUBBY|PHORON_IMMUNE)
 
 // Species spawn flags
 #define IS_WHITELISTED    0x1    // Must be whitelisted to play.

--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -1,16 +1,17 @@
 // Species flags.
-#define NO_BLOOD             1    // Vessel var is not filled with blood, cannot bleed out.
-#define NO_BREATHE           2    // Cannot suffocate or take oxygen loss.
-#define NO_SCAN              4    // Cannot be scanned in a DNA machine/genome-stolen.
-#define NO_PAIN              8    // Cannot suffer halloss/receives deceptive health indicator.
-#define NO_SLIP             16    // Cannot fall over.
-#define NO_POISON           32    // Cannot not suffer toxloss.
-#define IS_PLANT            64    // Is a treeperson.
-#define NO_EMBED            128    // Can not have shrapnel or any object embedded into its body
-#define IS_MECHANICAL       256    // Is a robot.
-#define ACCEPTS_COOLER      512    // Can wear suit coolers and have them work without a suit.
-#define NO_CHUBBY           1024   // Cannot be visibly fat from nutrition type.
-#define NO_ARTERIES         2048   // This species does not have arteries.
+#define NO_BLOOD            BITFLAG(1)    // Vessel var is not filled with blood, cannot bleed out.
+#define NO_BREATHE          BITFLAG(2)    // Cannot suffocate or take oxygen loss.
+#define NO_SCAN             BITFLAG(3)    // Cannot be scanned in a DNA machine/genome-stolen.
+#define NO_PAIN             BITFLAG(4)    // Cannot suffer halloss/receives deceptive health indicator.
+#define NO_SLIP             BITFLAG(5)    // Cannot fall over.
+#define NO_POISON           BITFLAG(6)    // Cannot not suffer toxloss.
+#define IS_PLANT            BITFLAG(7)    // Is a treeperson.
+#define NO_EMBED            BITFLAG(8)    // Can not have shrapnel or any object embedded into its body
+#define IS_MECHANICAL       BITFLAG(9)    // Is a robot.
+#define ACCEPTS_COOLER      BITFLAG(10)    // Can wear suit coolers and have them work without a suit.
+#define NO_CHUBBY           BITFLAG(11)   // Cannot be visibly fat from nutrition type.
+#define NO_ARTERIES         BITFLAG(12)   // This species does not have arteries.
+#define PHORON_IMMUNE       BITFLAG(13)   // species doesn't suffer the negative effects of phoron contamination
 // unused: 0x8000(32768) - higher than this will overflow
 
 // Base flags for IPCs.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -644,7 +644,7 @@
 			move_delay_mod += -1.5 * chem_effects[CE_SPEEDBOOST]
 
 		for(var/obj/item/I in src)
-			if(I.contaminated && !(isvaurca(src) && src.species.has_organ[BP_FILTRATION_BIT]))
+			if(I.contaminated && !(species.flags & PHORON_IMMUNE))
 				if(I == r_hand)
 					apply_damage(vsc.plc.CONTAMINATION_LOSS, BURN, BP_R_HAND)
 				else if(I == l_hand)

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -30,7 +30,7 @@ var/global/list/golem_types = list(SPECIES_GOLEM_COAL,
 
 	language = "Ceti Basic"
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch)
-	flags = NO_BREATHE | NO_PAIN | NO_BLOOD | NO_SCAN | NO_POISON | NO_EMBED
+	flags = NO_BREATHE | NO_PAIN | NO_BLOOD | NO_SCAN | NO_POISON | NO_EMBED | PHORON_IMMUNE
 	spawn_flags = IS_RESTRICTED
 	siemens_coefficient = 1
 	rarity_value = 5
@@ -776,7 +776,7 @@ var/global/list/golem_types = list(SPECIES_GOLEM_COAL,
 	short_name = null
 	name_plural = "homunculus"
 
-	flags = NO_PAIN | NO_SCAN
+	flags = NO_PAIN | NO_SCAN | PHORON_IMMUNE
 
 	unarmed_types = list(
 		/datum/unarmed_attack/claws,

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -70,7 +70,7 @@
 	heat_level_1 = 330 //Default 360
 	heat_level_2 = 380 //Default 400
 	heat_level_3 = 600 //Default 1000
-	flags = NO_SLIP | NO_CHUBBY | NO_ARTERIES
+	flags = NO_SLIP | NO_CHUBBY | NO_ARTERIES | PHORON_IMMUNE
 	spawn_flags = CAN_JOIN | IS_WHITELISTED | NO_AGE_MINIMUM
 	appearance_flags = HAS_SKIN_COLOR | HAS_HAIR_COLOR
 	blood_color = COLOR_VAURCA_BLOOD // dark yellow

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -76,7 +76,7 @@
 	stamina_recovery = 3
 
 	spawn_flags = IS_RESTRICTED
-	flags = NO_SCAN | NO_SLIP | NO_ARTERIES
+	flags = NO_SCAN | NO_SLIP | NO_ARTERIES | PHORON_IMMUNE
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/bugbite
@@ -137,7 +137,7 @@
 	warning_high_pressure = 3250 //Default 325
 
 	spawn_flags = IS_RESTRICTED
-	flags = NO_SCAN | NO_SLIP | NO_PAIN | NO_BREATHE | NO_ARTERIES
+	flags = NO_SCAN | NO_SLIP | NO_PAIN | NO_BREATHE | NO_ARTERIES | PHORON_IMMUNE
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/rebel_yell,

--- a/html/changelogs/geeves-phoron_immune.yml
+++ b/html/changelogs/geeves-phoron_immune.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Vaurca and golems are now immune to the skin burning effects of phoron."

--- a/html/changelogs/geeves-phoron_immune.yml
+++ b/html/changelogs/geeves-phoron_immune.yml
@@ -3,4 +3,4 @@ author: Geeves
 delete-after: True
 
 changes:
-  - bugfix: "Vaurca and golems are now immune to the skin burning effects of phoron."
+  - bugfix: "Vaurca, IPCS, and golems are now immune to the skin burning effects of phoron."


### PR DESCRIPTION
* Vaurca, IPCs, and golems are now immune to the skin burning effects of phoron.

i'm not marking it as a bugfix cuz golems being immune to phoron is new, and the contamination bit doesn't look for filtration bit anymore. if a maintainer thinks it's a bugfix they can mark it

resolves https://github.com/Aurorastation/Aurora.3/issues/11807