### PR TITLE
Animal Hide Updates

### DIFF
--- a/code/__defines/materials.dm
+++ b/code/__defines/materials.dm
@@ -36,6 +36,7 @@
 // Leathers and related.
 #define MATERIAL_RESIN                   "resin"
 #define MATERIAL_LEATHER                 "leather"
+#define MATERIAL_LEATHER_FINE            "fine leather"
 #define MATERIAL_BONE                    "bone"
 #define MATERIAL_BONE_CURSED             "cursed bone"
 #define MATERIAL_HIDE                    "hide"

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -72,6 +72,9 @@
 	if(state in list(1,3,6) )
 		usr.forceMove(src.loc)
 
+/obj/machinery/washing_machine/AltClick(mob/user)
+	if(Adjacent(user))
+		start()
 
 /obj/machinery/washing_machine/update_icon()
 	icon_state = "wm_[state][panel]"

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -50,10 +50,11 @@
 		I.decontaminate()
 
 	//Tanning!
-	for(var/obj/item/stack/material/hairlesshide/HH in contents)
-		var/obj/item/stack/material/wetleather/WL = new(src)
-		WL.amount = HH.amount
-		qdel(HH)
+	for(var/obj/item/stack/material/animalhide/barehide/BH in contents)
+		var/obj/item/stack/material/animalhide/wetleather/WL = new(src)
+		WL.amount = BH.amount
+		contents -= BH
+		qdel(BH)
 
 	if( locate(/mob,contents) )
 		state = 7
@@ -94,7 +95,7 @@
 				state = 3
 		else
 			..()
-	else if(istype(W,/obj/item/stack/material/hairlesshide) || \
+	else if(istype(W,/obj/item/stack/material/animalhide/barehide) || \
 		istype(W,/obj/item/clothing/under) || \
 		istype(W,/obj/item/clothing/mask) || \
 		istype(W,/obj/item/clothing/head) || \

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -7,6 +7,8 @@
 	icon_has_variants = TRUE
 	drop_sound = 'sound/items/drop/cloth.ogg'
 	pickup_sound = 'sound/items/pickup/cloth.ogg'
+	var/bare = FALSE //is this hair devoid of fur, hair, scales, carapace? Prevents re-stripping. Can also apply it to a hide type if we don't want to tan, like, xeno hide.
+	var/hide_type = "hair" //type of skin this animal has; scales for lizard, carapace for xeno.
 
 /obj/item/stack/material/animalhide/human
 	name = "human skin"
@@ -45,6 +47,7 @@
 	icon_state = "sheet-lizard"
 	default_type = "lizard hide"
 	icon_has_variants = FALSE
+	hide_type = "scales"
 
 /obj/item/stack/material/animalhide/xeno
 	name = "alien hide"
@@ -53,6 +56,7 @@
 	icon_state = "sheet-xeno"
 	default_type = "alien hide"
 	icon_has_variants = FALSE
+	hide_type = "carapace"
 
 //don't see anywhere else to put these, maybe together they could be used to make the xenos suit?
 /obj/item/stack/material/xenochitin
@@ -75,44 +79,58 @@
 	icon = 'icons/mob/npc/alien.dmi'
 	icon_state = "weed_extract"
 
-/obj/item/stack/material/hairlesshide
-	name = "hairless hide"
-	desc = "This hide was stripped of it's hair, but still needs tanning. Maybe shove it in a washing machine?"
-	singular_name = "hairless hide piece"
+/obj/item/stack/material/animalhide/barehide
+	name = "bare hide"
+	desc = "A hide without fur or scales. Can be tanned into leather."
+	desc_info = "You can put this into a washing machine to make wet leather, which is the first step in making it into leather sheets."
+	singular_name = "bare hide piece"
 	icon_state = "sheet-hairlesshide"
-	default_type = "hairless hide"
+	default_type = "bare hide"
+	bare = TRUE
 
-/obj/item/stack/material/wetleather
+/obj/item/stack/material/animalhide/wetleather
 	name = "wet leather"
 	desc = "This leather has been cleaned but still needs to be dried."
+	desc_info = "This can be dried into proper leather by exposing it to a fire of a sufficient temperature, or manually with a welding tool."
 	singular_name = "wet leather piece"
 	icon_state = "sheet-wetleather"
 	default_type = "wet leather"
-	var/wetness = 30 //Reduced when exposed to high temperautres
-	var/drying_threshold_temperature = 500 //Kelvin to start drying
 	icon_has_variants = TRUE
+	bare = TRUE
+	var/wetness = 30 //Reduced when exposed to high temperautres or manually dried with a welding tool.
+	var/drying_threshold_temperature = 500 //Kelvin to start drying from exposed fire.
+	var/being_dried = FALSE //If we're manually drying this.
 
+
+//Animal Hide to leather steps
 //Step one - dehairing.
-/obj/item/stack/material/animalhide/attackby(obj/item/W as obj, mob/user as mob)
-	if(	istype(W, /obj/item/material/knife) || \
-		istype(W, /obj/item/material/kitchen/utensil/knife) || \
-		istype(W, /obj/item/material/twohanded/fireaxe) || \
-		istype(W, /obj/item/material/hatchet) )
-
+/obj/item/stack/material/animalhide/attackby(obj/item/W, mob/user)
+	if(is_sharp(W) && !W.noslice && !W.iswirecutter()) //Can we cut and slice with the item? And does the hide still have something to remove? Say no to wirecutters since it's more about bladed items.
+		if(bare)
+			to_chat(user, SPAN_WARNING("There's nothing left to remove from \the [src]!"))
+			return
 		//visible message on mobs is defined as visible_message(var/message, var/self_message, var/blind_message)
-		usr.visible_message("<span class='notice'>\The [usr] starts cutting hair off \the [src]</span>", "<span class='notice'>You start cutting the hair off \the [src]</span>", "You hear the sound of a knife rubbing against flesh")
-		if(do_after(user,50))
-			to_chat(usr, "<span class='notice'>You cut the hair from this [src.singular_name].</span>")
+		user.visible_message(SPAN_NOTICE("\The [user] starts slicing the [hide_type] from \the [src]."),
+				SPAN_NOTICE("You start slicing the [hide_type] from \the [src]"),
+				SPAN_NOTICE("You hear the sound of a knife scraping against flesh."))
+		if(do_after(user,50, act_target = src))
+			if(amount <= 0) //Ensures we don't get multiple products from queuing clicks.
+				return
+			use(1)
+			user.visible_message(SPAN_NOTICE("[user] removes \the [hide_type] from \the [singular_name]."),
+								SPAN_NOTICE("You remove \the [hide_type] from \the [singular_name]!"))
+			playsound(get_turf(src), drop_sound, 50, 1)
+
 			//Try locating an exisitng stack on the tile and add to there if possible
-			for(var/obj/item/stack/material/hairlesshide/HS in usr.loc)
-				if(HS.amount < 50)
-					HS.amount++
-					src.use(1)
-					break
-			//If it gets to here it means it did not find a suitable stack on the tile.
-			var/obj/item/stack/material/hairlesshide/HS = new(usr.loc)
-			HS.amount = 1
-			src.use(1)
+			if(locate(/obj/item/stack/material/animalhide/barehide) in get_turf(user))
+				for(var/obj/item/stack/material/animalhide/barehide/BH in get_turf(user))
+					if(BH.amount < BH.max_amount)
+						BH.amount++
+						to_chat(user, SPAN_NOTICE("You add the newly-stripped hide to the stack. It now contains [BH.amount] hides."))
+						break
+			//if there isn't one, just make a new hide.
+			else
+				new /obj/item/stack/material/animalhide/barehide(get_turf(user))
 	else
 		..()
 
@@ -120,20 +138,50 @@
 //Step two - washing..... it's actually in washing machine code.
 
 //Step three - drying
-/obj/item/stack/material/wetleather/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+/obj/item/stack/material/animalhide/wetleather/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
 	if(exposed_temperature >= drying_threshold_temperature)
 		wetness--
-		if(wetness == 0)
-			//Try locating an exisitng stack on the tile and add to there if possible
-			for(var/obj/item/stack/material/leather/HS in src.loc)
-				if(HS.amount < 50)
-					HS.amount++
-					src.use(1)
-					wetness = initial(wetness)
+		if(wetness <= 0)
+			make_leather()
+
+/obj/item/stack/material/animalhide/wetleather/attackby(obj/item/I, mob/user)
+	if(I.iswelder())
+		var/obj/item/weldingtool/WT = I
+		if(WT.isOn())
+			if(being_dried)
+				to_chat(user, SPAN_WARNING("\The [src] are already being dried"))
+				return
+			user.visible_message(SPAN_NOTICE("\The [user] starts drying \the [src] with \the [WT]."), SPAN_NOTICE("You start drying the wet leather with \the [WT]..."))
+			being_dried = TRUE
+			while(do_after(user, 20, act_target = src) && wetness < 0)
+				if(!WT.remove_fuel(1) || !WT.isOn())
 					break
-			//If it gets to here it means it did not find a suitable stack on the tile.
-			var/obj/item/stack/material/leather/HS = new(src.loc)
-			HS.amount = 1
-			wetness = initial(wetness)
-			src.use(1)
+				wetness = max(0, wetness - rand(1, 3))
+				if(wetness <= 0)
+					make_leather()
+				if(!amount || QDELETED(src)) //Safety
+					break
+			being_dried = FALSE
+				
+		else
+			to_chat(user, SPAN_NOTICE("\The [WT] dries better when it's lit."))
+			return
+	else
+		..()
+
+//This will use one piece of the stack, create a piece of leather, then reset the wetness level to simulate drying the next piece of the stack.
+/obj/item/stack/material/animalhide/wetleather/proc/make_leather()
+	//see if there's a stack we can add to
+	if(locate(/obj/item/stack/material/leather) in get_turf(src))
+		for(var/obj/item/stack/material/leather/L in get_turf(src))
+			if(L.amount < L.max_amount)
+				L.amount++
+				use(1)
+				wetness = initial(wetness)
+				break
+	//If it gets to here it means it did not find a suitable stack on the tile.
+	else
+		new /obj/item/stack/material/leather(get_turf(src))
+		use(1)
+		wetness = initial(wetness)

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -348,7 +348,7 @@
 
 /obj/item/stack/material/leather
 	name = "leather"
-	desc = "The by-product of mob grinding."
+	desc = "Created by only the finest of biogenerators!"
 	icon_state = "sheet-leather"
 	default_type = MATERIAL_LEATHER
 	icon_has_variants = TRUE
@@ -357,6 +357,11 @@
 	. = ..()
 	amount = max_amount
 	update_icon()
+
+/obj/item/stack/material/leather/fine
+	name = "fine leather"
+	desc = "Handcrafted by an artisan, this leather is a wonderful status symbol for the wealthy few... Despite it not being any tougher than its biogenerated counterpart."
+	default_type = MATERIAL_LEATHER_FINE
 
 /obj/item/stack/material/glass
 	name = "glass"

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -836,6 +836,13 @@
 	drop_sound = 'sound/items/drop/leather.ogg'
 	pickup_sound = 'sound/items/pickup/leather.ogg'
 
+/material/leather/fine
+	name = MATERIAL_LEATHER_FINE
+	icon_colour = "#4B3A27"
+	stack_type = /obj/item/stack/material/leather/fine
+	ignition_point = T0C+320
+	melting_point = T0C+320
+
 /material/cotton
 	name = MATERIAL_COTTON
 	display_name ="cotton"

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -975,6 +975,14 @@
 	stack_type = /obj/item/stack/material/animalhide/human
 	icon_colour = "#833C00"
 
+/material/hide/barehide
+	name = "bare hide"
+	stack_type = /obj/item/stack/material/animalhide/barehide
+
+/material/hide/wetleather
+	name = "wet leather"
+	stack_type = /obj/item/stack/material/animalhide/wetleather
+
 /material/bone
 	name = MATERIAL_BONE
 	icon_colour = "#e3dac9"

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -142,7 +142,7 @@
 	attacktext = "kicked"
 	health = 120
 	emote_sounds = list('sound/effects/creatures/pigsnort.ogg')
-	butchering_products = list(/obj/item/stack/material/hairlesshide = 6)
+	butchering_products = list(/obj/item/stack/material/animalhide/barehide = 6)
 	forbidden_foods = list(/obj/item/reagent_containers/food/snacks/egg)
 
 /mob/living/simple_animal/chick

--- a/html/changelogs/doxxmedearly - hide_leather_fixes.yml
+++ b/html/changelogs/doxxmedearly - hide_leather_fixes.yml
@@ -1,0 +1,12 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Hide, bare hide, and wet leather no longer act like steel."
+  - bugfix: "Fixed an issue where you could queue up many clicks on hide sheets to generate extra bare hide."
+  - tweak: "Wet leather can no longer be used for crafting."
+  - rscadd: "You can now dry wet leather manually with a welding tool. You do not need a mask to do this."
+  - rscadd: "Washing machines can now be started with alt+click."
+  - rscadd: "Added additional examine info to hide sheets that tells you how to tan it into fine leather."
+  - rscadd: "Adds fine leather, which is only made by tanning animal hides. Other than being a little harder to burn, it's just fluff material for those who want to feel rich."


### PR DESCRIPTION
Fixes #4828
Bugs:
-Animal hide was using the steel material since is had no default_type set. Fixed.
-You could get as much hairless hide as you could click when shaving animal hide. Fixed.
-Prepping a lizard/xeno hide would tell you you were removing hair from it. Fixed.

Additions/Changes:
-Adds alt+click starts to washing machines. Because testing was annoying me.
-Since the biogenerator could make leather, this whole process is kind of outdated. So instead I added fine leather for RP fluff, for those who want to go the extra mile and actually make it. It's mostly regular leather that's slightly harder to burn.
-Added desc_info help to show people HOW to tan hides into leather.
-Made wet leather unable to be used in crafting because it's gross and soggy. Can still be padding though, if people want to be weird.
-Since the only way to dry leather was to expose it to fire, I added a manual method via welding tool. Now that botany has a welding tank for beekeeping, this gives said tank another purpose. Also it makes it POSSIBLE to dry the leather. Not a lot of stuff calls fire_act()
