### PR TITLE
ED209 Recipe Fix

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -42,9 +42,12 @@
 	else
 		..(over_object)
 
-/obj/item/clothing/suit/armor/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/clothing/suit/armor/attackby(obj/item/W, mob/user)
 	..()
-	if (pockets)
+	if(istype(W, /obj/item/clothing/accessory/armor_plate))
+		if(W in accessories) //We already attached this. Don't try to put it in our pockets
+			return
+	if(pockets)
 		pockets.attackby(W, user)
 
 /obj/item/clothing/suit/armor/emp_act(severity)

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -322,7 +322,7 @@
 				return 1
 
 		if(2)
-			if(istype(W, /obj/item/clothing/suit/storage/vest))
+			if(istype(W, /obj/item/clothing/accessory/armor_plate))
 				user.drop_from_inventory(W,get_turf(src))
 				qdel(W)
 				build_step++
@@ -377,7 +377,7 @@
 				return
 
 		if(7)
-			if(istype(W, /obj/item/gun/energy/taser))
+			if(istype(W, /obj/item/gun/energy/disruptorpistol))
 				name = "taser ED-209 assembly"
 				build_step++
 				to_chat(user, "<span class='notice'>You add [W] to [src].</span>")

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -338,7 +338,7 @@
 				if(WT.remove_fuel(0, user))
 					build_step++
 					name = "shielded frame assembly"
-					to_chat(user, "<span class='notice'>You welded the vest to [src].</span>")
+					to_chat(user, "<span class='notice'>You welded the armor to [src].</span>")
 					return 1
 		if(4)
 			if(istype(W, /obj/item/clothing/head/helmet))

--- a/html/changelogs/doxxmedearly - ed209_update.yml
+++ b/html/changelogs/doxxmedearly - ed209_update.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Updated the ED-209 construction recipe to the new equipment. It now uses armor plates (NOT the plate carriers) instead of the old vests, and disruptor pistols instead of tasers."
+  - bugfix: "Fixed a bug where attaching armor plate to a plate carrier would also try to put the plate in its pockets, giving the message that the plate was too long to fit in the carrier."


### PR DESCRIPTION
We kind of left this recipe in the dust with sec's new gear.
Uses armor plates, but not the carriers, for armor. Any will work. This replaces the security vest in the recipe.
Uses a disruptor pistol for guns. Any will work. This replaces the taser in the recipe.

Also while testing this, found a bug regarding attaching armor plates to carriers. It would attach but then tell you "The armor plate is too long for the carrier." That's because it was also trying to put it in its pockets afterward. Fixed by checking that we successfully attached it, and not trying to shove it in our pockets if we did.

Fixes #12077