### PR TITLE
SPAN_ macro improvement (999% speed) (not benched)

### DIFF
--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -1,20 +1,20 @@
 #define Clamp(x, low, high) 	max(low, min(high, x))
 #define CLAMP01(x) 		(Clamp(x, 0, 1))
 
-#define span(class, text) "<span class='[class]'>[text]</span>"
-#define SPAN_NOTICE(X) "<span class='notice'>[X]</span>"
-#define SPAN_WARNING(X) "<span class='warning'>[X]</span>"
-#define SPAN_DANGER(X) "<span class='danger'>[X]</span>"
-#define SPAN_CULT(X) "<span class='cult'>[X]</span>"
-#define SPAN_GOOD(X) "<span class='good'>[X]</span>"
-#define SPAN_BAD(X) "<span class='bad'>[X]</span>"
-#define SPAN_ALIEN(X) "<span class='alium'>[X]</span>"
-#define SPAN_ALERT(X) "<span class='alert'>[X]</span>"
-#define SPAN_INFO(X) "<span class='info'>[X]</span>"
-#define SPAN_ITALIC(X) "<span class='italic'>[X]</span>"
-#define SPAN_BOLD(X) "<span class='bold'>[X]</span>"
-#define SPAN_SUBTLE(X) "<span class='subtle'>[X]</span>"
-#define SPAN_SOGHUN(X) "<span class='soghun'>[X]</span>"
+#define span(class, text) ("<span class='[class]'>" + text + "</span>")
+#define SPAN_NOTICE(X) ("<span class='notice'>" + X + "</span>")
+#define SPAN_WARNING(X) ("<span class='warning'>" + X + "</span>")
+#define SPAN_DANGER(X) ("<span class='danger'>" + X + "</span>")
+#define SPAN_CULT(X) ("<span class='cult'>" + X + "</span>")
+#define SPAN_GOOD(X) ("<span class='good'>" + X + "</span>")
+#define SPAN_BAD(X) ("<span class='bad'>" + X + "</span>")
+#define SPAN_ALIEN(X) ("<span class='alium'>" + X + "</span>")
+#define SPAN_ALERT(X) ("<span class='alert'>" + X + "</span>")
+#define SPAN_INFO(X) ("<span class='info'>" + X + "</span>")
+#define SPAN_ITALIC(X) ("<span class='italic'>" + X + "</span>")
+#define SPAN_BOLD(X) ("<span class='bold'>" + X + "</span>")
+#define SPAN_SUBTLE(X) ("<span class='subtle'>" + X + "</span>")
+#define SPAN_SOGHUN(X) ("<span class='soghun'>" + X + "</span>")
 
 #define FONT_SIZE_SMALL 1
 #define FONT_SIZE_NORMAL 2
@@ -22,11 +22,11 @@
 #define FONT_SIZE_HUGE 4
 #define FONT_SIZE_GIANT 5
 
-#define FONT_SMALL(X) "<font size='1'>[X]</font>"
-#define FONT_NORMAL(X) "<font size='2'>[X]</font>"
-#define FONT_LARGE(X) "<font size='3'>[X]</font>"
-#define FONT_HUGE(X) "<font size='4'>[X]</font>"
-#define FONT_GIANT(X) "<font size='5'>[X]</font>"
+#define FONT_SMALL(X) ("<font size='1'>" + X + "</font>")
+#define FONT_NORMAL(X) ("<font size='2'>" + X + "</font>")
+#define FONT_LARGE(X) ("<font size='3'>" + X + "</font>")
+#define FONT_HUGE(X) ("<font size='4'>" + X + "</font>")
+#define FONT_GIANT(X) ("<font size='5'>" + X + "</font>")
 
 #define isAI(A) istype(A, /mob/living/silicon/ai)
 #define isDrone(A) istype(A, /mob/living/silicon/robot/drone)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -309,8 +309,7 @@
 
 		var/armor = H.get_blocked_ratio(target_zone, BRUTE, damage_flags = DAM_SHARP, damage = 5)*100
 		if (target != user && armor > 50 && prob(50))
-			for(var/mob/O in viewers(world.view, user))
-				O.show_message(text(SPAN_DANGER("[user] tries to stab [target] in \the [hit_area] with [src.name], but the attack is deflected by armor!")), 1)
+			user.visible_message(SPAN_DANGER("[user] tries to stab \the [target] in the [hit_area] with \the [src], but the attack is deflected by [target.get_pronoun("his")] armor!"), SPAN_WARNING("You try to stab \the [target] in the [hit_area] with \the [src], but the attack is deflected by [target.get_pronoun("his")] armor!"))
 			user.remove_from_mob(src)
 			qdel(src)
 


### PR DESCRIPTION
just plainly steals the improvements Timberpoes made to span macros. apparently doing this type of text replacement is faster than wrapping it in [ ] or something

Spotted at: https://github.com/tgstation/tgstation/pull/59685

![image](https://user-images.githubusercontent.com/22774890/123108990-2d1d8380-d43b-11eb-8ada-9d07472d0e4f.png)