### PR TITLE
Grenade Launcher Fixes

### DIFF
--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -63,14 +63,15 @@
 	if(active)
 		return
 
-	if(ismob(user))
-		var/mob/M = user
-		admin_attack_log(M, attacker_message = "primed \a [fake ? (" fake") : ("")][src]!", admin_message = "primed \a [fake ? ("fake ") : ("")][src]!")
-	else
-		message_admins("[user.name] primed \a [fake ? ("fake ") : ("")][src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+	if(user) //Prevents runtimes with grenade launchers, which create their own admin message
+		if(ismob(user))
+			var/mob/M = user
+			admin_attack_log(M, attacker_message = "primed \a [fake ? (" fake") : ("")][src]!", admin_message = "primed \a [fake ? ("fake ") : ("")][src]!")
+		else
+			message_admins("[user.name] primed \a [fake ? ("fake ") : ("")][src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 
 	icon_state = initial(icon_state) + "_active"
-	active = 1
+	active = TRUE
 	playsound(loc, activation_sound, 75, 1, -3)
 
 	addtimer(CALLBACK(src, .proc/prime), det_time)

--- a/html/changelogs/doxxmedearly - launcher_fixes.yml
+++ b/html/changelogs/doxxmedearly - launcher_fixes.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Grenades should now exit launchers properly primed, including cyborg launchers."


### PR DESCRIPTION
Fixes #11888

Grenades were never getting to `active = TRUE` because of a runtime since launchers called `activate(mob/user)` with a null user. Fixed. All launchers work properly on testing. 