### PR TITLE
Tool Quality: Surgery and RIG Assembly

### DIFF
--- a/code/__defines/obj.dm
+++ b/code/__defines/obj.dm
@@ -2,6 +2,9 @@
 #define OBJ_FLAG_ROTATABLE_ANCHORED (1<<2) // This object can be rotated even while anchored
 #define OBJ_FLAG_SIGNALER           (1<<3) // Can this take a signaler? only in use for machinery
 
+/obj/proc/issurgerycompatible() // set to false for things that are too unwieldy for surgery
+	return TRUE
+
 /obj/proc/iswrench()
 	return FALSE
 
@@ -25,3 +28,24 @@
 
 /obj/proc/ispen()
 	return FALSE
+
+#define SCREWDRIVER "screwdriver"
+#define WRENCH "wrench"
+#define CROWBAR "crowbar"
+#define WIRECUTTER "wirecutter"
+
+/proc/check_tool_quality(var/obj/tool, var/quality, var/return_value, var/requires_surgery_compatibility = FALSE)
+	switch(quality)
+		if(SCREWDRIVER)
+			if(tool.isscrewdriver() && (!requires_surgery_compatibility || tool.issurgerycompatible()))
+				return return_value
+		if(WRENCH)
+			if(tool.iswrench() && (!requires_surgery_compatibility || tool.issurgerycompatible()))
+				return return_value
+		if(CROWBAR)
+			if(tool.iscrowbar() && (!requires_surgery_compatibility || tool.issurgerycompatible()))
+				return return_value
+		if(WIRECUTTER)
+			if(tool.iswirecutter() && (!requires_surgery_compatibility || tool.issurgerycompatible()))
+				return return_value
+	return null

--- a/code/datums/helper_datums/construction_datum.dm
+++ b/code/datums/helper_datums/construction_datum.dm
@@ -37,6 +37,10 @@
 
 	proc/is_right_key(atom/used_atom) // returns current step num if used_atom is of the right type.
 		var/list/L = steps[steps.len]
+		if(isobj(used_atom))
+			var/return_value = check_tool_quality(used_atom, L["key"], steps.len)
+			if(return_value)
+				return return_value
 		if(istype(used_atom, L["key"]))
 			return steps.len
 		return 0
@@ -87,10 +91,21 @@
 
 	is_right_key(atom/used_atom) // returns index step
 		var/list/L = steps[index]
+		var/is_obj = FALSE
+		if(isobj(used_atom))
+			var/return_value = check_tool_quality(used_atom, L["key"], FORWARD)
+			if(return_value)
+				return return_value
+			is_obj = TRUE
 		if(istype(used_atom, L["key"]))
 			return FORWARD //to the first step -> forward
-		else if(L["backkey"] && istype(used_atom, L["backkey"]))
-			return BACKWARD //to the last step -> backwards
+		else if(L["backkey"])
+			if(is_obj)
+				var/return_value = check_tool_quality(used_atom, L["backkey"], BACKWARD)
+				if(return_value)
+					return return_value
+			if(istype(used_atom, L["backkey"]))
+				return BACKWARD //to the last step -> backwards
 		return 0
 
 	check_step(atom/used_atom,mob/user as mob)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -818,6 +818,9 @@
 	update_tool()
 	return TRUE
 
+/obj/item/powerdrill/issurgerycompatible()
+	return FALSE // too unwieldy for most surgeries
+
 /obj/item/steelwool
 	name = "steel wool"
 	desc = "Harvested from the finest NanoTrasen steel sheep."

--- a/code/modules/clothing/spacesuits/rig/rig_construction.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_construction.dm
@@ -173,27 +173,27 @@
 	steps = list(
 				//1
 				list("key"=/obj/item/weldingtool,
-					"backkey"=/obj/item/wrench,
+					"backkey"=WRENCH,
 					"desc"="External armor is wrenched"),
 				//2
-				list("key"=/obj/item/wrench,
-						"backkey"=/obj/item/crowbar,
+				list("key"=WRENCH,
+						"backkey"=CROWBAR,
 						"desc"="External armor is installed"),
 				//3
 				list("key"=/obj/item/stack/material/steel,
-						"backkey"=/obj/item/screwdriver,
+						"backkey"=SCREWDRIVER,
 						"desc"="Central control module is secured"),
 				//4
-				list("key"=/obj/item/screwdriver,
-						"backkey"=/obj/item/crowbar,
+				list("key"=SCREWDRIVER,
+						"backkey"=CROWBAR,
 						"desc"="Central control module is installed"),
 				//5
 				list("key"=null,
-						"backkey"=/obj/item/wirecutters,
+						"backkey"=WIRECUTTER,
 						"desc"="The wiring is adjusted"),
 				//6
-				list("key"=/obj/item/wirecutters,
-						"backkey"=/obj/item/screwdriver,
+				list("key"=WIRECUTTER,
+						"backkey"=SCREWDRIVER,
 						"desc"="The wiring is added"),
 				//7
 				list("key"=/obj/item/stack/cable_coil,
@@ -266,11 +266,11 @@
 	steps = list(
 				//1
 				list("key"=/obj/item/weldingtool,
-						"backkey"=/obj/item/wrench,
+						"backkey"=WRENCH,
 						"desc"="External armor is wrenched."),
 				//2
-				list("key"=/obj/item/wrench,
-						"backkey"=/obj/item/crowbar,
+				list("key"=WRENCH,
+						"backkey"=CROWBAR,
 						"desc"="External armor is installed."),
 				//3
 				list("key"=/obj/item/stack/material/plasteel,
@@ -278,43 +278,43 @@
 						"desc"="Internal armor is welded."),
 				//4
 				list("key"=/obj/item/weldingtool,
-						"backkey"=/obj/item/wrench,
+						"backkey"=WRENCH,
 						"desc"="Internal armor is wrenched"),
 				//5
-				list("key"=/obj/item/wrench,
-						"backkey"=/obj/item/crowbar,
+				list("key"=WRENCH,
+						"backkey"=CROWBAR,
 						"desc"="Internal armor is installed"),
 				//6
 				list("key"=/obj/item/stack/material/steel,
-						"backkey"=/obj/item/screwdriver,
+						"backkey"=SCREWDRIVER,
 						"desc"="Advanced scanner module is secured"),
 				//7
-				list("key"=/obj/item/screwdriver,
-						"backkey"=/obj/item/crowbar,
+				list("key"=SCREWDRIVER,
+						"backkey"=CROWBAR,
 						"desc"="Advanced scanner module is installed"),
 				//8
 				list("key"=/obj/item/stock_parts/scanning_module/adv,
-						"backkey"=/obj/item/screwdriver,
+						"backkey"=SCREWDRIVER,
 						"desc"="Targeting module is secured"),
 				//9
-				list("key"=/obj/item/screwdriver,
-						"backkey"=/obj/item/crowbar,
+				list("key"=SCREWDRIVER,
+						"backkey"=CROWBAR,
 						"desc"="Targeting module is installed"),
 				//10
 				list("key"=null,
-						"backkey"=/obj/item/screwdriver,
+						"backkey"=SCREWDRIVER,
 						"desc"="Central control module is secured"),
 				//11
-				list("key"=/obj/item/screwdriver,
-						"backkey"=/obj/item/crowbar,
+				list("key"=SCREWDRIVER,
+						"backkey"=CROWBAR,
 						"desc"="Central control module is installed"),
 				//12
 				list("key"=null,
-						"backkey"=/obj/item/wirecutters,
+						"backkey"=WIRECUTTER,
 						"desc"="The wiring is adjusted"),
 				//13
-				list("key"=/obj/item/wirecutters,
-						"backkey"=/obj/item/screwdriver,
+				list("key"=WIRECUTTER,
+						"backkey"=SCREWDRIVER,
 						"desc"="The wiring is added"),
 				//14
 				list("key"=/obj/item/stack/cable_coil,

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -45,7 +45,7 @@
 	name = "Set bone"
 	allowed_tools = list(
 	/obj/item/surgery/bonesetter = 100,	\
-	/obj/item/wrench = 75		\
+	WRENCH = 75		\
 	)
 
 	min_duration = 60
@@ -85,7 +85,7 @@
 	name = "Repair skull"
 	allowed_tools = list(
 	/obj/item/surgery/bonesetter = 100,	\
-	/obj/item/wrench = 75		\
+	WRENCH = 75		\
 	)
 
 	min_duration = 60

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -158,7 +158,7 @@
 	name = "Remove foreign body"
 	allowed_tools = list(
 	/obj/item/surgery/hemostat = 100,	\
-	/obj/item/wirecutters = 75,	\
+	WIRECUTTER = 75,	\
 	/obj/item/material/kitchen/utensil/fork = 20
 	)
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -110,7 +110,7 @@
 	allowed_tools = list(
 	/obj/item/stack/nanopaste = 100,
 	/obj/item/surgery/bonegel = 30,
-	/obj/item/screwdriver = 70
+	SCREWDRIVER = 70
 	)
 
 	min_duration = 70
@@ -242,7 +242,7 @@
 	name = "Remove organ"
 	allowed_tools = list(
 	/obj/item/surgery/hemostat = 100,	\
-	/obj/item/wirecutters = 75,	\
+	WIRECUTTER = 75,	\
 	/obj/item/material/kitchen/utensil/fork = 20
 	)
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -25,13 +25,15 @@
 /decl/surgery_step/robotics/unscrew_hatch
 	name = "Unscrew Hatch"
 	allowed_tools = list(
-		/obj/item/screwdriver = 100,
+		SCREWDRIVER = 100,
 		/obj/item/coin = 50,
 		/obj/item/material/kitchen/utensil/knife = 50
 	)
 
 	min_duration = 90
 	max_duration = 110
+
+	requires_surgery_compatibility = FALSE
 
 /decl/surgery_step/robotics/unscrew_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -65,13 +67,15 @@
 /decl/surgery_step/robotics/screw_hatch
 	name = "Screw Hatch"
 	allowed_tools = list(
-		/obj/item/screwdriver = 100,
+		SCREWDRIVER = 100,
 		/obj/item/coin = 50,
 		/obj/item/material/kitchen/utensil/knife = 50
 	)
 
 	min_duration = 90
 	max_duration = 110
+
+	requires_surgery_compatibility = FALSE
 
 /decl/surgery_step/robotics/screw_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -106,7 +110,7 @@
 	name = "Open Hatch"
 	allowed_tools = list(
 		/obj/item/surgery/retractor = 100,
-		/obj/item/crowbar = 100,
+		CROWBAR = 100,
 		/obj/item/material/kitchen/utensil = 50
 	)
 
@@ -143,7 +147,7 @@
 	name = "Close Hatch"
 	allowed_tools = list(
 		/obj/item/surgery/retractor = 100,
-		/obj/item/crowbar = 100,
+		CROWBAR = 100,
 		/obj/item/material/kitchen/utensil = 50
 	)
 
@@ -321,11 +325,13 @@
 /decl/surgery_step/robotics/attach_organ_robotic
 	name = "Attach robotic organ"
 	allowed_tools = list(
-		/obj/item/screwdriver = 100
+		SCREWDRIVER = 100
 	)
 
 	min_duration = 100
 	max_duration = 120
+
+	requires_surgery_compatibility = FALSE
 
 /decl/surgery_step/robotics/attach_organ_robotic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -19,9 +19,14 @@
 	//How much blood this step can get on surgeon. 1 - hands, 2 - full body.
 	var/blood_level = 0
 
+	var/requires_surgery_compatibility = TRUE
+
 	//returns how well tool is suited for this step
 /decl/surgery_step/proc/tool_quality(obj/item/tool)
 	for(var/T in allowed_tools)
+		var/return_value = check_tool_quality(tool, T, allowed_tools[T], requires_surgery_compatibility)
+		if(return_value)
+			return return_value
 		if(istype(tool,T))
 			return allowed_tools[T]
 	return FALSE

--- a/html/changelogs/geeves-tool_quality_improvements.yml
+++ b/html/changelogs/geeves-tool_quality_improvements.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "You can now use any tool with a matching tool quality for surgery and RIG assembly, meaning you can open an IPC's hatch with a screwdriver augment. Most surgeries need you to use a surgery viable tool, meaning an impact drill cannot be used, the exception being the robotic surgeries."


### PR DESCRIPTION
* You can now use any tool with a matching tool quality for surgery and RIG assembly, meaning you can open an IPC's hatch with a screwdriver augment. Most surgeries need you to use a surgery viable tool, meaning an impact drill cannot be used, the exception being the robotic surgeries.

![image](https://user-images.githubusercontent.com/22774890/123149436-8ef0e400-d461-11eb-8029-1e3a9a0e5355.png)