### PR TITLE
Chem Cartridge Spawning Search

### DIFF
--- a/code/modules/reagents/dispenser/cartridge_spawn.dm
+++ b/code/modules/reagents/dispenser/cartridge_spawn.dm
@@ -1,6 +1,26 @@
-/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"), reagent in decls_repository.get_decls_of_subtype(/decl/reagent/))
+/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"))
 	set name = "Spawn Chemical Dispenser Cartridge"
 	set category = "Admin"
+
+	var/rtype = input("Enter full or partial reagent path.", "Reagent Search") as text
+	if(!rtype)
+		return
+
+	var/list/matches
+	for(var/path in decls_repository.get_decls_of_subtype(/decl/reagent/))
+		if(findtext("[path]", rtype))
+			LAZYADD(matches, path)
+
+	var/reagent
+	if(!LAZYLEN(matches))
+		return
+
+	if(LAZYLEN(matches) == 1)
+		reagent = matches[1]
+	else
+		reagent = input("Select a reagent type", "Pick reagent", matches[1]) as null|anything in matches
+		if(!reagent)
+			return
 
 	var/obj/item/reagent_containers/chem_disp_cartridge/C
 	switch(size)

--- a/html/changelogs/doxxmedearly - chemdisp_spawn_search.yml
+++ b/html/changelogs/doxxmedearly - chemdisp_spawn_search.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - tweak: "Spawning a chemical dispenser cartridge as an admin now uses a search function similar to how the spawn verb works."


### PR DESCRIPTION
Spawn Chemical Dispenser Cartridge will now operate on a path search like spawning atoms does, instead of picking from an unwieldy fuckoff-huge list that seems to grow by the day. 