### PR TITLE
Multi-Purpose Throwing

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -369,11 +369,11 @@ var/list/slot_equipment_priority = list( \
 	if(!item)
 		return //Grab processing has a chance of returning null
 
-	if(a_intent != I_HURT && Adjacent(target) && isitem(item))
+	if(a_intent == I_HELP && Adjacent(target) && isitem(item))
 		var/obj/item/I = item
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target
-			if(H.in_throw_mode && H.a_intent != I_HURT && unEquip(I))
+			if(H.in_throw_mode && H.a_intent == I_HELP && unEquip(I))
 				I.on_give(src, target)
 				if(!QDELETED(I)) // if on_give deletes the item, we don't want runtimes below
 					H.put_in_hands(I) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -342,7 +342,6 @@ var/list/slot_equipment_priority = list( \
 	if(!item)
 		return
 
-	var/can_throw = TRUE
 	if(istype(item, /obj/item/grab))
 		var/obj/item/grab/G = item
 		item = G.throw_held() //throw the person instead of the grab
@@ -365,13 +364,30 @@ var/list/slot_equipment_priority = list( \
 
 			qdel(G)
 		else
-			can_throw = FALSE
+			return
 
-	if(!item || !can_throw)
+	if(!item)
 		return //Grab processing has a chance of returning null
 
-	src.remove_from_mob(item)
-	item.loc = src.loc
+	if(a_intent != I_HURT && Adjacent(target) && isitem(item))
+		var/obj/item/I = item
+		if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			if(H.in_throw_mode && H.a_intent != I_HURT && unEquip(I))
+				I.on_give(src, target)
+				if(!QDELETED(I)) // if on_give deletes the item, we don't want runtimes below
+					H.put_in_hands(I) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
+					visible_message("<b>[src]</b> hands \the [H] \a [I].", SPAN_NOTICE("You give \the [target] \a [I]."))
+			else
+				to_chat(src, SPAN_NOTICE("You offer \the [I] to \the [target]."))
+				do_give(H)
+			return
+		remove_from_mob(I)
+		make_item_drop_sound(I)
+		I.forceMove(get_turf(target))
+		return
+
+	remove_from_mob(item)
 
 	if(is_pacified())
 		to_chat(src, "<span class='notice'>You set [item] down gently on the ground.</span>")

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -1,7 +1,10 @@
-/mob/living/carbon/human/verb/give(var/mob/living/target in view(1)-usr)
+/mob/living/carbon/verb/give(var/mob/living/target in view(1)-usr)
 	set category = "IC"
 	set name = "Give"
 
+	do_give(target)
+
+/mob/living/carbon/proc/do_give(var/mob/living/carbon/human/target)
 	if(use_check(target))
 		to_chat(usr, SPAN_WARNING("[target.name] is in no condition to handle items!"))
 		return

--- a/html/changelogs/geeves-item_placing.yml
+++ b/html/changelogs/geeves-item_placing.yml
@@ -3,5 +3,5 @@ author: Geeves
 delete-after: True
 
 changes:
-  - rscadd: "Throwing something at a tile adjacent to you will instead put it down gently, provided you are on any intent but harm."
-  - rscadd: "Clicking on someone with an item in your hand while you have throw mode active and not on harm intent will offer it to them like you used the Give verb. If they're also on throw intent and not on harm intent, you put it into their hand directly."
+  - rscadd: "Throwing something at a tile adjacent to you will instead put it down gently, provided you are on help intent."
+  - rscadd: "Clicking on someone with an item in your hand while you have throw mode active and on help intent will offer it to them like you used the Give verb. If they're also on throw intent and on help intent, you put it into their hand directly."

--- a/html/changelogs/geeves-item_placing.yml
+++ b/html/changelogs/geeves-item_placing.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Throwing something at a tile adjacent to you will instead put it down gently, provided you are on any intent but harm."
+  - rscadd: "Clicking on someone with an item in your hand while you have throw mode active and not on harm intent will offer it to them like you used the Give verb. If they're also on throw intent and not on harm intent, you put it into their hand directly."


### PR DESCRIPTION
* Throwing something at a tile adjacent to you will instead put it down gently, provided you are on help intent.
* Clicking on someone with an item in your hand while you have throw mode active and on help intent will offer it to them like you used the Give verb. If they're also on throw intent and on help intent, you put it into their hand directly.