### PR TITLE
photo cameras alt click to change photo size

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -175,6 +175,8 @@ var/global/photo_count = 0
 		return
 	..()
 
+/obj/item/device/camera/AltClick(var/mob/user)
+	change_size()
 
 /obj/item/device/camera/proc/get_mobs(turf/the_turf as turf)
 	var/mob_detail

--- a/html/changelogs/photocamera.yml
+++ b/html/changelogs/photocamera.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Cameras (for taking photos) can now be alt clicked to change photo size."


### PR DESCRIPTION
Alt click them to change the size instead of having to right click or do other things to get the photo size changed. 