### PR TITLE
Tape recorder emag change

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -161,9 +161,6 @@
 
 	if(use_check_and_message(usr))
 		return
-	if(emagged)
-		to_chat(usr, SPAN_WARNING("The tape recorder makes a scratchy noise."))
-		return
 	if(recording)
 		to_chat(usr, SPAN_WARNING("You can't playback when recording!"))
 		return
@@ -197,15 +194,15 @@
 	playing = FALSE
 	if(emagged)
 		audible_message("<font color=Maroon><B>Tape Recorder</B>: This tape recorder will self-destruct in... Five.</font>", hearing_distance = 3)
-		sleep(10)
+		sleep(15)
 		audible_message("<font color=Maroon><B>Tape Recorder</B>: Four.</font>", hearing_distance = 3)
-		sleep(10)
+		sleep(15)
 		audible_message("<font color=Maroon><B>Tape Recorder</B>: Three.</font>", hearing_distance = 3)
-		sleep(10)
+		sleep(15)
 		audible_message("<font color=Maroon><B>Tape Recorder</B>: Two.</font>", hearing_distance = 3)
-		sleep(10)
+		sleep(15)
 		audible_message("<font color=Maroon><B>Tape Recorder</B>: One.</font>", hearing_distance = 3)
-		sleep(10)
+		sleep(15)
 		explode()
 
 /obj/item/device/taperecorder/verb/print_transcript()

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -299,6 +299,9 @@
 			to_chat(usr, SPAN_NOTICE("Recording stopped."))
 			icon_state = "taperecorderidle"
 			return
+		else if(emagged)
+			to_chat(usr, SPAN_WARNING("The tape recorder's buttons doesn't react!"))
+			return
 		else if(playing)
 			playing = FALSE
 			audible_message("<font color=Maroon><B>Tape Recorder</B>: Playback stopped.</font>", hearing_distance = 3)

--- a/html/changelogs/SelfDestruct.yml
+++ b/html/changelogs/SelfDestruct.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Emagged recorders will now self destruct upon delivering their message."


### PR DESCRIPTION
Emagged tape recorders will now self destruct once their message has been played (it needs to be recorded beforehand) instead of being completely useless. The playback also can't be stopped once activated so the whole message is heard before it explodes.