### PR TITLE
Teleportation Fixes and Tweaks

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -1,6 +1,10 @@
 //wrapper
 /proc/do_teleport(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null)
-	new /datum/teleport/instant/science(arglist(args))
+	var/datum/teleport/T
+	T = new /datum/teleport/instant/science(arglist(args))
+	if(T.stable_creation)
+		return TRUE
+	return FALSE
 
 /datum/teleport
 	var/atom/movable/teleatom //atom to teleport
@@ -11,32 +15,34 @@
 	var/soundin //soundfile to play before teleportation
 	var/soundout //soundfile to play after teleportation
 	var/force_teleport = 1 //if false, teleport will use Move() proc (dense objects will prevent teleportation)
+	var/stable_creation = TRUE //This is mostly for portals, which need to delete if the do_teleport fails, due to inhibitors or other reasons we fail to initTeleport properly
 
 
 /datum/teleport/New(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null)
 	..()
 	if(!initTeleport(arglist(args)))
-		return 0
-	return 1
+		stable_creation = FALSE
+		return FALSE
+	return TRUE
 
 /datum/teleport/proc/initTeleport(ateleatom,adestination,aprecision,afteleport,aeffectin,aeffectout,asoundin,asoundout)
 	if(!setTeleatom(ateleatom))
-		return 0
+		return FALSE
 	if(!setDestination(adestination))
-		return 0
+		return FALSE
 	if(!setPrecision(aprecision))
-		return 0
+		return FALSE
 	setEffects(aeffectin,aeffectout)
 	setForceTeleport(afteleport)
 	setSounds(asoundin,asoundout)
-	return 1
+	return TRUE
 
 //must succeed
 /datum/teleport/proc/setPrecision(aprecision)
 	if(isnum(aprecision))
 		precision = aprecision
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /datum/teleport/proc/checkInhibitors(atom/adestination)
 	if(istype(adestination))
@@ -52,35 +58,43 @@
 			good_turfs += circlerangeturfs(get_turf(AB),9)
 		if(length(good_turfs) && length(bad_turfs))
 			good_turfs -= bad_turfs
-			return pick(good_turfs)
+			if(length(good_turfs))
+				return pick(good_turfs)
 
 	return adestination
+
+//Check if we're in range of a bluespace inhibitor. We can't be teleported if we are.
+/datum/teleport/proc/checkLocalInhibitors(atom/movable/teleportee)
+	for(var/obj/machinery/anti_bluespace/AB in range(8, teleportee))
+		if(AB.stat & (NOPOWER | BROKEN))
+			continue
+		else
+			AB.use_power(AB.active_power_usage)
+			return null
+	return teleportee
+
 
 //must succeed
 /datum/teleport/proc/setDestination(atom/adestination)
 	if(istype(adestination))
 		destination = checkInhibitors(adestination)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 //must succeed in most cases
 /datum/teleport/proc/setTeleatom(atom/movable/ateleatom)
 	if(!istype(ateleatom))
-		return 0
+		return FALSE
 
-	teleatom = checkInhibitors(ateleatom)
-	if(isturf(teleatom))
-		var/turf/T = teleatom
-		var/atom/valid_atoms = list()
-		for(var/atom/movable in T)
-			valid_atoms += T
-		ateleatom = pick(valid_atoms)
+	teleatom = checkLocalInhibitors(ateleatom)
+	if(isnull(teleatom))
+		return FALSE
 
 	if(istype(ateleatom, /obj/effect) && !istype(ateleatom, /obj/effect/dummy/chameleon))
 		qdel(ateleatom)
-		return 0
+		return FALSE
 
-	return 1
+	return TRUE
 
 
 //custom effects must be properly set up first for instant-type teleports
@@ -88,22 +102,22 @@
 /datum/teleport/proc/setEffects(datum/effect/effect/system/aeffectin=null,datum/effect/effect/system/aeffectout=null)
 	effectin = istype(aeffectin) ? aeffectin : null
 	effectout = istype(aeffectout) ? aeffectout : null
-	return 1
+	return TRUE
 
 //optional
 /datum/teleport/proc/setForceTeleport(afteleport)
 		force_teleport = afteleport
-		return 1
+		return TRUE
 
 //optional
 /datum/teleport/proc/setSounds(asoundin=null,asoundout=null)
 		soundin = isfile(asoundin) ? asoundin : null
 		soundout = isfile(asoundout) ? asoundout : null
-		return 1
+		return TRUE
 
 //placeholder
 /datum/teleport/proc/teleportChecks()
-		return 1
+		return TRUE
 
 /datum/teleport/proc/playSpecials(atom/location,datum/effect_system/effect,sound)
 	if(location)
@@ -131,7 +145,7 @@
 		destturf = get_turf(destination)
 
 	if(!destturf || !curturf)
-		return 0
+		return FALSE
 
 	playSpecials(curturf,effectin,soundin)
 
@@ -259,12 +273,12 @@
 
 	destarea.Entered(teleatom)
 
-	return 1
+	return TRUE
 
 /datum/teleport/proc/teleport()
 	if(teleportChecks())
 		return doTeleport()
-	return 0
+	return FALSE
 
 /datum/teleport/instant //teleports when datum is created
 
@@ -279,7 +293,7 @@
 		var/datum/effect_system/sparks/aeffect = new(null, FALSE, 5, alldirs)
 		effectin = effectin || aeffect
 		effectout = effectout || aeffect
-		return 1
+		return TRUE
 	else
 		return ..()
 
@@ -294,16 +308,16 @@
 		if(istype(teleatom, /mob/living))
 			var/mob/living/MM = teleatom
 			to_chat(MM, "<span class='danger'>The Bluespace interface on your [teleatom] interferes with the teleport!</span>")
-	return 1
+	return TRUE
 
 /datum/teleport/instant/science/teleportChecks()
 	if(istype(teleatom, /obj/item/disk/nuclear)) // Don't let nuke disks get teleported --NeoFite
 		teleatom.visible_message("<span class='danger'>\The [teleatom] bounces off of the portal!</span>")
-		return 0
+		return FALSE
 
 
 	if(isobserver(teleatom)) // do not teleport ghosts
-		return 0
+		return FALSE
 
 
 	if(!isemptylist(teleatom.search_contents_for(/obj/item/disk/nuclear)))
@@ -312,14 +326,14 @@
 			MM.visible_message("<span class='danger'>\The [MM] bounces off of the portal!</span>","<span class='warning'>Something you are carrying seems to be unable to pass through the portal. Better drop it if you want to go through.</span>")
 		else
 			teleatom.visible_message("<span class='danger'>\The [teleatom] bounces off of the portal!</span>")
-		return 0
+		return FALSE
 
 	if(isAdminLevel(destination.z)) //centcomm z-level
 		if(!isemptylist(teleatom.search_contents_for(/obj/item/storage/backpack/holding)))
 			teleatom.visible_message("<span class='danger'>\The [teleatom] bounces off of the portal!</span>")
-			return 0
+			return FALSE
 
 
 	if(destination.z > max_default_z_level()) //Away mission z-levels
-		return 0
-	return 1
+		return FALSE
+	return TRUE

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -1,7 +1,6 @@
 //wrapper
 /proc/do_teleport(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null)
-	var/datum/teleport/T
-	T = new /datum/teleport/instant/science(arglist(args))
+	var/datum/teleport/T = new /datum/teleport/instant/science(arglist(args))
 	if(T.stable_creation)
 		return TRUE
 	return FALSE

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -61,13 +61,19 @@
 	if(!target)
 		qdel(src)
 		return
+	var/has_teleported = FALSE
 	if(istype(M, /atom/movable))
 		if(has_failed) //oh dear a problem, put em in deep space
 			icon_state = "portal1" // only tell people the portal failed after a teleport has been done
 			desc = "A bluespace tear in space, reaching directly to another point within this region. Definitely unstable."
-			do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0)
+			if(do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0))
+				has_teleported = TRUE
 		else
-			do_teleport(M, target, precision)
+			if(do_teleport(M, target, precision))
+				has_teleported = TRUE
+	if(!has_teleported)
+		visible_message(SPAN_WARNING("\The [src] oscillates violently as \the [M] comes into contact with it, and collapses! Seems like the rift was unstable..."))
+		qdel(src)
 
 /obj/effect/portal/Destroy()
 	if(istype(creator, /obj/item/hand_tele))

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -3,11 +3,26 @@
  *		Locator
  *		Hand-tele
  *		Closet Teleporter
+ *		Inhibitor handling proc for above
  */
+
+/*
+ * Special inhibitor handling. Different from the one used by teleport datums.
+ */
+/proc/check_inhibitors(var/turf/T)
+	for(var/found_inhibitor in bluespace_inhibitors)
+		var/obj/machinery/anti_bluespace/AB = found_inhibitor
+		if(T.z != AB.z || get_dist(T, AB) > 8 || (AB.stat & (NOPOWER | BROKEN)))
+			continue
+		else
+			return FALSE
+	return TRUE
 
 /*
  * Locator
  */
+
+
 /obj/item/locator
 	name = "locator"
 	desc = "A device that can be used to track those with locator implants."
@@ -147,6 +162,11 @@ Frequency:
 		to_chat(user, SPAN_WARNING("\The [src] can't get a bearing on anything right now."))
 		return
 
+	//Cannot make one if too close to an inhibitor
+	if(!check_inhibitors(current_location))
+		to_chat(user, SPAN_DANGER("\The [src] can't seem to find a lock. Something in the area must be preventing the portal from opening..."))
+		return
+
 	var/list/teleport_options = list()
 	for(var/obj/machinery/teleport/station/S in SSmachinery.all_machines)
 		if(S.locked_obj)
@@ -164,6 +184,9 @@ Frequency:
 			continue
 		if(T.density || turf_contains_dense_objects(T))
 			continue
+		if(!check_inhibitors(T))
+			continue
+		
 		potential_turfs += T
 
 	if(length(potential_turfs))
@@ -207,17 +230,21 @@ Frequency:
 /obj/item/closet_teleporter/proc/do_teleport(var/mob/user)
 	if(!attached_closet)
 		to_chat(user, SPAN_WARNING("\The [src] doesn't have an attached closet!"))
-		return
+		return FALSE
 	if(!linked_teleporter)
 		to_chat(user, SPAN_WARNING("\The [src] doesn't have a linked teleporter!"))
-		return
+		return FALSE
 	if(!linked_teleporter.attached_closet)
 		to_chat(user, SPAN_WARNING("The linked teleporter doesn't have an attached closet!"))
-		return
+		return FALSE
 	if(last_use + 600 > world.time)
-		return
+		return FALSE
+	if(!check_inhibitors(get_turf(attached_closet)) || !check_inhibitors(get_turf(linked_teleporter.attached_closet)))
+		to_chat(user, SPAN_WARNING("Something near you or your destination is destabilizing the bluespace network between the closets. \The [src] can't get a clear link to the other side!"))
+		return FALSE
+
 	var/obj/structure/closet/target_closet = linked_teleporter.attached_closet
-	user.forceMove(target_closet)
+	user.forceMove(target_closet.opened ? get_turf(target_closet) : target_closet)
 	if(target_closet.opened)
 		user.visible_message(SPAN_NOTICE("\The [user] steps out of the back of \the [target_closet]."), SPAN_NOTICE("You teleport into the linked closet, stepping out of it."))
 	else
@@ -225,6 +252,7 @@ Frequency:
 		to_chat(user, SPAN_NOTICE("You teleport into the target closet, bumping into the closed door."))
 		target_closet.shake_animation()
 		playsound(get_turf(src), 'sound/effects/grillehit.ogg', 100, TRUE)
+	return TRUE
 
 /obj/item/closet_teleporter/Destroy()
 	attached_closet = null

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -157,8 +157,8 @@
 			return
 		var/did_teleport = FALSE
 		for(var/mob/M in contents)
-			did_teleport = TRUE
-			linked_teleporter.do_teleport(M)
+			if(linked_teleporter.do_teleport(M))
+				did_teleport = TRUE
 		if(did_teleport)
 			linked_teleporter.last_use = world.time
 

--- a/html/changelogs/doxxmedearly - teleporter_stuff.yml
+++ b/html/changelogs/doxxmedearly - teleporter_stuff.yml
@@ -1,0 +1,11 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "If there's a nearby bluespace inhibitor, portals made by the hand teleporter or jaunter will close when you try to go through them, instead of sitting there blocking the tile."
+  - bugfix: "Teleporting into open closets with the closet teleporter no longer melds you into the closet and makes you stuck."
+  - bugfix: "Addressed several runtime issues with teleportation handling."
+  - bugfix: "Hand teleporter portals should no longer view any turf in range of a working bluespace inhibitor as a valid exit. However, interference from a failed teleport somewhere else may still spit you out by one."
+  - tweak: "Closet teleporters are now affected by bluespace inhibitors. If either closet is in range of one, the teleportation will fail."
+  - tweak: "You can no longer create a portal with the jaunter or hand teleporter if in range of a working bluespace inhibitor."


### PR DESCRIPTION
Set out to fix one bug, uncover a trove of shitcode.

Fixes  #12079

Bluespace inhibitors were a mess. The code to check if an inhibitor was in range of the user was trying to teleport turfs because it was trying poorly to duplicate the same method it used to check if an inhibitor was in range of the destination turf. So I unfucked THAT check with a new proc and solved a mess of runtimes during teleportation. 

Portals are dense objects and need to collapse if they can't teleport otherwise they just sit there and block turfs. Now an invalid portal will collapse. Also you can't make them with a hand tele or jaunter if in range of an inhibitor.

Made inhibitors block closet teleporters. Also fixed a bug with those where you'd be forcemoved into the locker when it was open... which didn't put you on the turf, it just actually put you into the locker like your atoms merged with it or some bullshit. 

Testing around, everything seems to be teleporting and interacting with inhibitors as normal, even the stuff I didn't directly change (Like ninja teleports).