### PR TITLE
Sleepy Ring Clarification & Tweak

### DIFF
--- a/code/datums/uplink/stealthy and inconspicuous weapons.dm
+++ b/code/datums/uplink/stealthy and inconspicuous weapons.dm
@@ -37,6 +37,7 @@
 
 /datum/uplink_item/item/stealthy_weapons/sleepy_ring
 	name = "Sleepy Ring"
+	desc = "A silver ring that will quickly put its wearer to sleep. WARNING: Do not wear this yourself. It'll end about as well as you expect it to."
 	item_cost = 3
 	path = /obj/item/clothing/ring/reagent/sleepy
 

--- a/code/modules/clothing/rings/rings.dm
+++ b/code/modules/clothing/rings/rings.dm
@@ -38,9 +38,10 @@
 /obj/item/clothing/ring/reagent/sleepy
 	name = "silver ring"
 	desc = "A ring made from what appears to be silver."
+	desc_antag = "This ring has a hidden injector that will activate when worn, injecting a strong sedative. It is safe to hold in your hands."
 	icon_state = "material"
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ILLEGAL = 5)
-	reagents_to_add = list(/decl/reagent/polysomnine = 15)
+	reagents_to_add = list(/decl/reagent/polysomnine = 10)
 
 //Seals and Signet Rings
 

--- a/html/changelogs/wickedcybs_sleepy.yml
+++ b/html/changelogs/wickedcybs_sleepy.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The sleepy ring uplink item now gives a proper description of what it actually does. The amount of poly it injects has also been lowered from 15 to 10."


### PR DESCRIPTION
The sleepy ring item available to antags in the stealthy section of their uplink had no description of how it actually worked. This frequently leads to the traitors wearing the rings and knocking themselves out. I've put in a short description that mentions how it works in the uplink and in the antag item description, which is that it will inject a strong sedative into its wearer. 

The amount of poly that it injects has also been reduced from fifteen to ten. Fifteen was way overkill and lengthy, keeping people knocked out for a very long time to stare at a black screen. Ten is still a very sizeable amount, really.
