### PR TITLE
Removes Skrell

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
@@ -31,7 +31,7 @@
 	grab_mod = 2
 	resist_mod = 0.5 // LIKE BABBY
 
-	spawn_flags = CAN_JOIN | IS_WHITELISTED
+	spawn_flags = IS_RESTRICTED
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_SOCKS
 	flags = NO_SLIP
 

--- a/html/changelogs/geeves-removes_skrell.yml
+++ b/html/changelogs/geeves-removes_skrell.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - security: "Due to recent lore events, skrell have been removed from the game."


### PR DESCRIPTION
* Due to recent lore events, skrell have been removed from the game.

The April Fools was inside as all along.