### PR TITLE
Clarifies banshee use

### DIFF
--- a/code/datums/uplink/corporate_equipment.dm
+++ b/code/datums/uplink/corporate_equipment.dm
@@ -20,7 +20,7 @@
 	desc = "A full spaceworthy kit of a Hephaestus Industries Caiman-type terraforming suit. Very resistant against slow-moving blunt force, but heavy. Only wearable by Humans and Humanoid IPCs."
 
 /datum/uplink_item/item/corporate_equipment/suit/einstein
-	name = "Banshee Combat Suit"
+	name = "Banshee Infiltration Suit"
 	item_cost = 5
 	path = /obj/structure/closet/crate/gear_loadout/einstein
-	desc = "A full spaceworthy kit of an Einstein Engines Banshee-type infiltration suit. Resistant against lasers, but made of paper against anything else. Only wearable by Humans and Humanoid IPCs."
+	desc = "A full spaceworthy kit of an Einstein Engines Banshee-type infiltration suit. Resistant against small arms, but made of paper against anything else. Only wearable by Humans and Humanoid IPCs."

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -211,7 +211,7 @@
 
 //Einstein Engines espionage voidsuit
 /obj/item/clothing/head/helmet/space/void/einstein
-	name = "banshee combat suit helmet"
+	name = "banshee infiltration suit helmet"
 	desc = "A sleek, menacing voidsuit helmet with the branding of Taipei Engineering Industrial's private military contractors."
 	icon = 'icons/obj/clothing/voidsuit/megacorp.dmi'
 	icon_state = "bansheehelm"
@@ -236,7 +236,7 @@
 	refittable = FALSE
 
 /obj/item/clothing/suit/space/void/einstein
-	name = "banshee combat suit"
+	name = "banshee infiltration suit"
 	desc = "A tightly-fitting suit manufactured with shimmering, ablative plating. Looks almost weightless."
 	icon = 'icons/obj/clothing/voidsuit/megacorp.dmi'
 	icon_state = "banshee"

--- a/html/changelogs/BansheeName.yml
+++ b/html/changelogs/BansheeName.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - tweak: "The banshee voidsuit is renamed to be an infiltration instead of combat suit. Also clarified the description in the uplink a little."


### PR DESCRIPTION
The `banshee combat suit` has been renamed to `banshee infiltration suit` because it is pretty bad against anything beyond small arms which surprised at least one antag recently. The uplink description has been updated to mention this too.