### PR TITLE
Makes the wristbound spawn in the wrist slot

### DIFF
--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -333,7 +333,10 @@
 			if(OUTFIT_PDA_SMART)
 				I.icon = 'icons/obj/pda_smart.dmi'
 		I.update_icon()
-		H.equip_or_collect(I, slot_wear_id)
+		if (H.pda_choice == OUTFIT_WRISTBOUND)
+			H.equip_or_collect(I, slot_wrists)
+		else
+			H.equip_or_collect(I, slot_wear_id)
 
 	if(id)
 		var/obj/item/modular_computer/P = H.wear_id

--- a/html/changelogs/WristPdaSlot.yml
+++ b/html/changelogs/WristPdaSlot.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "When selecting the wristbound PDA type in character setup, it now spawns in the wrist slot."


### PR DESCRIPTION
ID cards will remain in the id slot and will as a result not be inside the wristbound with this change. It can still be inserted after if people want to.
This does mean the chat client won't be automatically connected until the user puts their id card into the wristbound and opens the program however.