### PR TITLE
Several Diona Fixes

### DIFF
--- a/code/modules/emotes/definitions/_mob.dm
+++ b/code/modules/emotes/definitions/_mob.dm
@@ -57,6 +57,7 @@
 		/decl/emote/visible/jump,
 		/decl/emote/visible/shiver,
 		/decl/emote/visible/collapse,
+		/decl/emote/visible/blink_r,
 		/decl/emote/audible/hiss,
 		/decl/emote/audible,
 		/decl/emote/audible/scretch,

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -136,7 +136,8 @@
 
 /obj/machinery/portable_atmospherics/hydroponics/AltClick()
 	if (istype(usr, /mob/living/carbon/alien/diona))//A diona alt+clicking feeds the plant
-
+		if(!Adjacent(usr))
+			return
 		if (closed_system)
 			to_chat(usr, "The lid is closed, you don't have hands to open it and reach the plants inside!")
 			return

--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -94,7 +94,7 @@
 		flower_color = get_random_colour(1)
 	. = ..(mapload)
 	//species = all_species[]
-	ingested = new/datum/reagents/metabolism(500, src, CHEM_INGEST)
+	ingested = new /datum/reagents/metabolism(500, src, CHEM_INGEST)
 	reagents = ingested
 	set_species(SPECIES_DIONA)
 	setup_dionastats()

--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -94,6 +94,8 @@
 		flower_color = get_random_colour(1)
 	. = ..(mapload)
 	//species = all_species[]
+	ingested = new/datum/reagents/metabolism(500, src, CHEM_INGEST)
+	reagents = ingested
 	set_species(SPECIES_DIONA)
 	setup_dionastats()
 	eat_types |= TYPE_ORGANIC

--- a/code/modules/mob/living/carbon/alien/diona/life.dm
+++ b/code/modules/mob/living/carbon/alien/diona/life.dm
@@ -14,6 +14,12 @@
 	if(touching) touching.metabolize()
 	if(bloodstr) bloodstr.metabolize()
 	if(breathing) breathing.metabolize()
+	if(ingested) ingested.metabolize()
+
+	for(var/_R in chem_doses)
+		if ((_R in bloodstr.reagent_volumes) || (_R in ingested.reagent_volumes) || (_R in breathing.reagent_volumes) || (_R in touching.reagent_volumes))
+			continue
+		chem_doses -= _R //We're no longer metabolizing this reagent. Remove it from chem_doses
 
 	// nutrition decrease
 	if(nutrition > 0 && stat != DEAD)

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -18,7 +18,11 @@ var/list/diona_banned_languages = list(
 	/datum/language/cultcommon,
 	/datum/language/corticalborer,
 	/datum/language/binary,
-	/datum/language/binary/drone)
+	/datum/language/binary/drone,
+	/datum/language/bug,
+	/datum/language/ling,
+	/datum/language/revenant,
+	/datum/language/machine)
 
 #define DIONA_LIGHT_COEFICIENT 0.25
 /mob/living/carbon/proc/diona_handle_light(var/datum/dionastats/DS) //Carbon is the highest common denominator between gestalts and nymphs. They will share light code
@@ -524,6 +528,7 @@ var/list/diona_banned_languages = list(
 	languages.Cut()
 
 	add_language(species.default_language) //They always have rootsong
+	accent = host.accent //Get the accent of the main gestalt
 
 	for (var/datum/language/L in host.languages)
 		var/chance = 40
@@ -548,7 +553,7 @@ var/list/diona_banned_languages = list(
 	if(!gestalt)
 		to_chat(src, SPAN_WARNING("You have no Gestalt!"))
 	else if(gestalt.stat == DEAD)
-		to_chat(src, SPAN_DANGER("Your Gestlat is not responding! Something could have happened to it!"))
+		to_chat(src, SPAN_DANGER("Your Gestalt is not responding! Something might have happened to it!"))
 	else
 		gestalt.key = key
 		return TRUE
@@ -559,8 +564,10 @@ var/list/diona_banned_languages = list(
 	set desc = "Allows you to merge back to your parent Gestalt."
 	set category = "Abilities"
 
-	for(var/mob/living/carbon/human/H in view(src, 7))
+	for(var/mob/living/carbon/human/H in range(1))
 		if(!H.is_diona())
+			continue
+		if(!Adjacent(H))
 			continue
 		var/mob/living/carbon/human/diona/C = H
 		if(C == gestalt)

--- a/code/modules/mob/living/carbon/human/diona_gestalt.dm
+++ b/code/modules/mob/living/carbon/human/diona_gestalt.dm
@@ -278,6 +278,7 @@
 	M.detached = TRUE
 	M.update_verbs(TRUE)
 	M.languages = languages.Copy()
+	M.accent = accent
 
 	update_dionastats() //Re-find the organs in case they were lost or regained
 	nutrition -= REGROW_FOOD_REQ

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -296,7 +296,7 @@
 /decl/reagent/lithium/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(M.canmove && !M.restrained() && !(istype(M.loc, /turf/space)))
 		step(M, pick(cardinal))
-	if(prob(5))
+	if(prob(5) && ishuman(M))
 		M.emote(pick("twitch", "drool", "moan"))
 
 /decl/reagent/mercury
@@ -323,7 +323,7 @@
 		M.confused = max(M.confused, 10)
 	if(dose > 4)
 		M.add_chemical_effect(CE_CLUMSY, 1)
-		if(prob(dose/4))
+		if(prob(dose/4) && ishuman(M))
 			M.emote(pick("twitch", "shiver", "drool"))
 		if(prob(dose/4))
 			M.visible_message("<b>[M]</b> chuckles spontaneously.", "You chuckle spontaneously.")
@@ -446,7 +446,7 @@
 		M.take_organ_damage(0, removed * power * 0.2) //burn damage, since it causes chemical burns. Acid doesn't make bones shatter, like brute trauma would.
 		return
 	if(!M.unacidable && removed > 0)
-		if(istype(M, /mob/living/carbon/human) && REAGENT_VOLUME(holder, type) >= meltdose)
+		if(ishuman(M) && REAGENT_VOLUME(holder, type) >= meltdose)
 			var/mob/living/carbon/human/H = M
 			var/obj/item/organ/external/affecting = H.get_organ(BP_HEAD)
 			if(affecting)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -54,7 +54,7 @@
 
 /decl/reagent/serotrotium/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	var/mob/living/carbon/human/H = M
-	if(istype(H) && (H.species.flags & NO_BLOOD))
+	if(!istype(H) || (istype(H) && (H.species.flags & NO_BLOOD))) //If we're not human OR if we're human but don't have blood. 
 		return
 	if(prob(7))
 		M.emote(pick("twitch", "drool", "moan", "gasp"))
@@ -93,7 +93,7 @@
 		M.add_chemical_effect(CE_NEUROTOXIC, 3*removed)
 	if(prob(50))
 		M.drowsiness = max(M.drowsiness, 3)
-	if(prob(10))
+	if(prob(10) && ishuman(M))
 		M.emote("drool")
 
 /decl/reagent/mindbreaker
@@ -130,24 +130,20 @@
 	if(dose < 1)
 		M.apply_effect(3, STUTTER)
 		M.make_dizzy(5)
-		if(prob(5))
-			M.emote(pick("twitch", "giggle"))
 	else if(dose < 2)
 		M.apply_effect(3, STUTTER)
 		M.make_jittery(5)
 		M.dizziness = max(150, M.dizziness)
 		M.make_dizzy(5)
 		M.druggy = max(M.druggy, 35)
-		if(prob(10))
-			M.emote(pick("twitch", "giggle"))
 	else
 		M.apply_effect(3, STUTTER)
 		M.make_jittery(10)
 		M.dizziness = max(150, M.dizziness)
 		M.make_dizzy(10)
 		M.druggy = max(M.druggy, 40)
-		if(prob(15))
-			M.emote(pick("twitch", "giggle"))
+	if(ishuman(M) && prob(min(15, dose*5)))
+		M.emote(pick("twitch", "giggle"))
 
 /decl/reagent/raskara_dust
 	name = "Raskara Dust"
@@ -167,7 +163,7 @@
 /decl/reagent/raskara_dust/affect_breathe(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_PAINKILLER, 25)
 	M.drowsiness += 2 * removed
-	if(prob(5))
+	if(prob(5) && ishuman(M))
 		M.emote("cough")
 
 /decl/reagent/raskara_dust/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
@@ -274,8 +270,9 @@
 	M.add_chemical_effect(CE_PAINKILLER, 40) // basically like Perconol, but a bit worse
 	// doesn't make you vomit, though
 	if(prob(7))
-		M.emote(pick("twitch", "drool", "moan", "giggle"))
 		to_chat(M, SPAN_WARNING(pick("You feel great!", "You don't have a care in the world.", "You couldn't care less about anything.", "You feel so relaxed...")))
+		if(ishuman(M))
+			M.emote(pick("twitch", "drool", "moan", "giggle"))
 	M.adjustOxyLoss(0.01 * removed)
 	if(M.losebreath < 5)
 		M.losebreath++

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -121,7 +121,7 @@
 	if(injectable)
 		affect_ingest(M, alien, removed, holder)
 
-/decl/reagent/nutriment/affect_ingest(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/reagent/nutriment/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(!istype(M))
 		return
 	var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -471,7 +471,7 @@
 	M.add_chemical_effect(CE_PULSE, -2)
 	var/dose = M.chem_doses[type]
 	if(dose < 2)
-		if(dose == metabolism * 2 || prob(5))
+		if(ishuman(M) && (dose == metabolism * 2 || prob(5)))
 			M.emote("yawn")
 	else if(dose < 3.5)
 		M.eye_blurry = max(M.eye_blurry, 10)

--- a/html/changelogs/doxxmedearly - dionamedearly.yml
+++ b/html/changelogs/doxxmedearly - dionamedearly.yml
@@ -1,0 +1,11 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Nymphs split from gestalts now retain the correct accent."
+  - bugfix: "Forbid hivenet and some other special case languages from being learned by dionae."
+  - bugfix: "Nymphs can no long feed hydroponics trays from any distance."
+  - bugfix: "Detached nymphs can no longer merge back with their gestalt from long distances; you now have to be adjacent to your gestalt, as intended."
+  - bugfix: "Nymphs now properly metabolize nutriment."
+  - bugfix: "Fixed some 'unusable emote' errors for nymphs when processing reagents that forced emotes. This also allows them to use the rapid blink emote."

--- a/html/changelogs/doxxmedearly - dionamedearly.yml
+++ b/html/changelogs/doxxmedearly - dionamedearly.yml
@@ -7,5 +7,5 @@ changes:
   - bugfix: "Forbid hivenet and some other special case languages from being learned by dionae."
   - bugfix: "Nymphs can no long feed hydroponics trays from any distance."
   - bugfix: "Detached nymphs can no longer merge back with their gestalt from long distances; you now have to be adjacent to your gestalt, as intended."
-  - bugfix: "Nymphs now properly metabolize nutriment."
+  - bugfix: "Nymphs now properly metabolize nutriment. This also allows them to actually finish eating food."
   - bugfix: "Fixed some 'unusable emote' errors for nymphs when processing reagents that forced emotes. This also allows them to use the rapid blink emote."


### PR DESCRIPTION
Cleans up some Diona issues.

Fixes #10255
Fixes #12132

Accents didn't transfer with languages when splitting into a nymph. Fixed.
Detached nymphs didn't have to be adjacent to reform with the gestalt. Fixed.
Hivenet wasn't a forbidden diona-learned language. Fixed, and forbid other languages just in case.

Nymphs never actually processed nutriment because the affect_ingest was on the human level. Also, they never initialized their ingested reagents and were unable to actually eat anything, despite messages, visual cues, and taste messages indicating they were, because the reagent transfer was never able to find a target to complete. Fixed by actually initializing and setting the proper metabolism as their reagents. 

Nymphs didn't have the proper emotes for some reagents that forced emotes like yawning. Fixed this by adding ishuman checks to the messages that involved emotes they didn't have (Which would also fix this for slimes and other carbon-level mobs), and also allowed them to have the rapidblink emote. They do still have eyes, after all. 