### PR TITLE
Fixes mech immortality

### DIFF
--- a/code/modules/heavy_vehicle/mech_damage.dm
+++ b/code/modules/heavy_vehicle/mech_damage.dm
@@ -88,9 +88,9 @@
 	//Only 2 types of damage concern mechs and vehicles
 	switch(damagetype)
 		if(BRUTE)
-			adjustBruteLoss(damage * BLOCKED_MULT(blocked), target)
+			adjustBruteLoss(damage, target)
 		if(BURN)
-			adjustFireLoss(damage * BLOCKED_MULT(blocked), target)
+			adjustFireLoss(damage, target)
 
 	if((damagetype == BRUTE || damagetype == BURN) && prob(25+(damage*2)))
 		spark(src, 3)

--- a/html/changelogs/MechFix.yml
+++ b/html/changelogs/MechFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Mechs are no longer immortal."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/12110

So after some investigation, it appears mechs handle their own armor penetration and so on. Also they don't actually have a `blocked` var in that section of the code which didn't help.