### PR TITLE
Hair Combs Can Now Be Recoloured + Rearranges the Cosmetics Ordering

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_cosmetics.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_cosmetics.dm
@@ -1,8 +1,12 @@
 /datum/gear/cosmetic
+	display_name = "handheld mirror"
+	path = /obj/item/mirror
+	sort_category = "Cosmetics" 
+
+/datum/gear/cosmetic/haircomb
 	display_name = "comb"
 	path = /obj/item/haircomb
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-	sort_category = "Cosmetics" 
 
 /datum/gear/cosmetic/lipstick
 	display_name = "lipstick selection"
@@ -31,6 +35,3 @@
 
 	gear_tweaks += new/datum/gear_tweak/path(lipsticks)
 
-/datum/gear/cosmetic/mirror
-	display_name = "handheld mirror"
-	path = /obj/item/mirror

--- a/code/modules/client/preference_setup/loadout/loadout_cosmetics.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_cosmetics.dm
@@ -1,7 +1,8 @@
 /datum/gear/cosmetic
-	display_name = "purple comb"
+	display_name = "comb"
 	path = /obj/item/haircomb
-	sort_category = "Cosmetics"
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
+	sort_category = "Cosmetics" 
 
 /datum/gear/cosmetic/lipstick
 	display_name = "lipstick selection"

--- a/html/changelogs/wickedcybs_comb.yml
+++ b/html/changelogs/wickedcybs_comb.yml
@@ -3,4 +3,4 @@ author: WickedCybs
 delete-after: True
 
 changes:
-  - tweak: "The purple comb in the cosmetics section wasn't purple, it was gray. It's been renamed to "comb" and can now be recoloured too."
+  - tweak: "The purple comb in the cosmetics section wasn't purple, it was gray. It's been renamed to 'comb' and can now be recoloured too."

--- a/html/changelogs/wickedcybs_comb.yml
+++ b/html/changelogs/wickedcybs_comb.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The purple comb in the cosmetics section wasn't purple, it was gray. It's been renamed to "comb" and can now be recoloured too."


### PR DESCRIPTION
Was kind of bothered the comb selection was called "purple comb" but it always gave a gray comb. So, I renamed it to just "comb" and added the option to recolour to whatever someone wants.

The default.
![image](https://user-images.githubusercontent.com/52309324/124337116-2f2fc280-db5e-11eb-9cfe-60d5df6f57bf.png)

Recoloured blue.
![image](https://user-images.githubusercontent.com/52309324/124337101-1aebc580-db5e-11eb-80af-771cd6cbb5cf.png)

I had to re-sort the way the cosmetic options were in order to make it so the lipstick and stuff wouldn't get the option to be coloured, so yeah.
