### PR TITLE
Buddy Tag Options

### DIFF
--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -1,5 +1,6 @@
 #define Clamp(x, low, high) 	max(low, min(high, x))
 #define CLAMP01(x) 		(Clamp(x, 0, 1))
+#define JOINTEXT(X) jointext(X, null)
 
 #define span(class, text) "<span class='[class]'>[text]</span>"
 #define SPAN_NOTICE(X) "<span class='notice'>[X]</span>"

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -263,3 +263,32 @@ Paper Data
 	if(!metadata || !istype(P))
 		return
 	P.info = P.parsepencode(metadata)
+
+
+
+// Buddy Tag Settings
+/datum/gear_tweak/buddy_tag_config/get_contents(var/metadata)
+	return "ID: [metadata[1]] | Distance: [metadata[2]] | Interval: [metadata[3]]s"
+
+/datum/gear_tweak/buddy_tag_config/get_default()
+	return list(1, 10, 30)
+
+/datum/gear_tweak/buddy_tag_config/get_metadata(var/user, var/metadata)
+	var/newcode = input("Set new buddy ID number.", "Buddy Tag ID", metadata[1]) as num|null
+	if(isnull(newcode))
+		newcode = metadata[1]
+	var/newdist = input("Set new maximum range.", "Buddy Tag Range", metadata[2]) as num|null
+	if(isnull(newdist))
+		newdist = metadata[2]
+	var/newtime = input("Set new search interval in seconds (minimum 30s).", "Buddy Tag Time Interval", metadata[3]) as num|null
+	if(isnull(newtime))
+		newtime = metadata[3]
+	newtime = max(30, newtime)
+	return list(newcode, newdist, newtime)
+
+/datum/gear_tweak/buddy_tag_config/tweak_item(var/obj/item/clothing/accessory/buddytag/BT, var/list/metadata, var/mob/living/carbon/human/H)
+	if(!length(metadata) || !istype(BT))
+		return
+	BT.id = metadata[1]
+	BT.distance = metadata[2]
+	BT.search_interval = metadata[3] SECONDS

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -139,3 +139,7 @@
 	display_name = "buddy tag"
 	path = /obj/item/clothing/accessory/buddytag
 	cost = 2
+
+/datum/gear/utility/buddy_tag/New()
+	..()
+	gear_tweaks += new /datum/gear_tweak/buddy_tag_config()

--- a/html/changelogs/geeves-buddytag_options.yml
+++ b/html/changelogs/geeves-buddytag_options.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added additional configuration options to buddy tags. You can also set their configs in the loadout menu now, where it will persist."


### PR DESCRIPTION
* Added additional configuration options to buddy tags. You can also set their configs in the loadout menu now, where it will persist.

Options ported from: https://github.com/NebulaSS13/Nebula/pull/1789

![image](https://user-images.githubusercontent.com/22774890/124355610-5a73e980-dc12-11eb-9128-64371ed03cd9.png)