### PR TITLE
Pen Charge

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -658,3 +658,10 @@
 	if(ending && !correct_punctuation[ending])
 		string += "."
 	return string
+
+/proc/num2loadingbar(percent as num, numSquares = 20, reverse = FALSE)
+	var/loadstring = ""
+	var/limit = reverse ? numSquares - percent*numSquares : percent*numSquares
+	for (var/i in 1 to numSquares)
+		loadstring += i <= limit ? "█" : "░"
+	return "\[[loadstring]\]"

--- a/code/game/objects/items/weapons/syndie.dm
+++ b/code/game/objects/items/weapons/syndie.dm
@@ -102,6 +102,12 @@
 	maptext_y = 2
 	var/ready_to_use = TRUE
 	var/recharge_time = 1 MINUTE
+	var/when_recharge = 0
+
+/obj/item/syndie/teleporter/examine(mob/user, distance)
+	. = ..()
+	if(!ready_to_use && burglars.is_antagonist(user.mind))
+		to_chat(user, SPAN_NOTICE("Charging: [num2loadingbar(world.time / when_recharge)]"))
 
 /obj/item/syndie/teleporter/set_initial_maptext()
 	held_maptext = SMALL_FONTS(7, "Ready")
@@ -136,6 +142,7 @@
 	addtimer(CALLBACK(src, .proc/recharge), recharge_time)
 	ready_to_use = FALSE
 	check_maptext(SMALL_FONTS(6, "Charge"))
+	when_recharge = world.time + recharge_time
 
 /obj/item/syndie/teleporter/proc/recharge()
 	ready_to_use = TRUE

--- a/html/changelogs/geeves-pen_charge.yml
+++ b/html/changelogs/geeves-pen_charge.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Burglars can now inspect their pens to see how far their pen has charged via a loading bar."


### PR DESCRIPTION
* Burglars can now inspect their pens to see how far their pen has charged via a loading bar.

Ported from: https://github.com/BeeStation/BeeStation-Hornet/pull/4565 who got it from /tg/station.

![image](https://user-images.githubusercontent.com/22774890/124357694-2ce06d80-dc1d-11eb-85ff-0146d07f372d.png)