### PR TITLE
gives investigators access to security bags

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -147,6 +147,11 @@
 	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/security/detective
 	tablet = /obj/item/modular_computer/handheld/preset/security/detective
 
+	backpack = /obj/item/storage/backpack/security
+	satchel = /obj/item/storage/backpack/satchel_sec
+	dufflebag = /obj/item/storage/backpack/duffel/sec
+	messengerbag = /obj/item/storage/backpack/messenger/sec
+
 	backpack_contents = list(
 		/obj/item/storage/box/evidence = 1
 	)

--- a/html/changelogs/InvestigatorBags.yml
+++ b/html/changelogs/InvestigatorBags.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Investigators can now get the security bags in char setup."


### PR DESCRIPTION
It was kinda weird investigators were part of security but got grey bags by default so this fixes that.