### PR TITLE
fixes taj and vaurca nightvision

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -234,6 +234,10 @@
 	if(istype(O))
 		O.refresh_action_button()
 
+/datum/action/item_action/organ/night_eyes
+	check_flags = AB_CHECK_STUNNED|AB_CHECK_ALIVE|AB_CHECK_INSIDE
+	button_icon_state = "night_eyes"
+
 #undef AB_WEST_OFFSET
 #undef AB_NORTH_OFFSET
 #undef AB_MAX_COLUMNS

--- a/code/modules/organs/internal/species/tajara.dm
+++ b/code/modules/organs/internal/species/tajara.dm
@@ -3,6 +3,7 @@
 	desc = "A pair of Tajaran eyes accustomed to the low light conditions of Adhomai."
 	icon_state = "tajaran_eyes"
 	action_button_name = "Activate Low Light Vision"
+	default_action_type = /datum/action/item_action/organ/night_eyes
 	relative_size = 8
 	var/night_vision = FALSE
 	var/datum/client_color/vision_color = /datum/client_color/monochrome
@@ -20,14 +21,6 @@
 /obj/item/organ/internal/eyes/night/replaced()
 	. = ..()
 	disable_night_vision()
-
-/obj/item/organ/internal/eyes/night/refresh_action_button()
-	. = ..()
-	if(.)
-		action.button_icon_state = "night_eyes"
-		action.check_flags = AB_CHECK_STUNNED|AB_CHECK_ALIVE|AB_CHECK_INSIDE
-		if(action.button)
-			action.button.update_icon()
 
 /obj/item/organ/internal/eyes/night/attack_self(var/mob/user)
 	. = ..()

--- a/code/modules/organs/internal/species/tajara.dm
+++ b/code/modules/organs/internal/species/tajara.dm
@@ -25,6 +25,7 @@
 	. = ..()
 	if(.)
 		action.button_icon_state = "night_eyes"
+		action.check_flags = AB_CHECK_STUNNED|AB_CHECK_ALIVE|AB_CHECK_INSIDE
 		if(action.button)
 			action.button.update_icon()
 

--- a/html/changelogs/NightvisionFix.yml
+++ b/html/changelogs/NightvisionFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Tajara & Vaurca nightvision can now be used even while restrained or laying down."


### PR DESCRIPTION
Tajara, vaurca and anyone else that might use a subtype of their eyes can now use the nightvision even while restrained or laying down.