### PR TITLE
Corporate IDs and Manifest

### DIFF
--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -283,15 +283,15 @@
 /*
  * Helping functions for everyone
  */
-/proc/GetAssignment(var/mob/living/carbon/human/H)
+/proc/GetAssignment(var/mob/living/carbon/human/H, var/include_faction_prefix)
+	var/return_value = "Unassigned"
 	if(H.mind?.role_alt_title)
-		return H.mind.role_alt_title
+		return_value = H.mind.role_alt_title
 	else if(H.mind?.assigned_role)
-		return H.mind.assigned_role
+		return_value = H.mind.assigned_role
 	else if(H.job)
-		return H.job
-	else
-		return "Unassigned"
+		return_value = H.job
+	return "[return_value][include_faction_prefix ? " ([H.mind.selected_faction.title_suffix])" : ""]"
 
 /proc/generate_record_id()
 	return add_zero(num2hex(rand(1, 65535)), 4)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -53,7 +53,6 @@
 
 	var/has_been_rev = 0//Tracks if this mind has been a rev or not
 
-	var/datum/faction/faction 			//associated faction
 	var/list/antag_datums = list()
 
 	var/rev_cooldown = 0

--- a/code/datums/records.dm
+++ b/code/datums/records.dm
@@ -144,7 +144,7 @@
 	if(H)
 		name = H.real_name
 		real_rank = H.mind.assigned_role
-		rank = GetAssignment(H)
+		rank = GetAssignment(H, TRUE)
 		age = H.age
 		fingerprint = md5(H.dna.uni_identity)
 		sex = H.gender

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -37,8 +37,9 @@
 
 /proc/make_list_rank(rank)
 	for(var/prefix in acting_rank_prefixes)
-		if(findtext(rank, "[prefix] ", 1, 2+length(prefix)))
-			return copytext(rank, 2+length(prefix))
+		rank = replacetext(rank, "[prefix] ", "")
+	for(var/datum/faction/faction as anything in SSjobs.factions)
+		rank = replacetext(rank, " ([faction.title_suffix])", "")
 	return rank
 
 /obj/structure/showcase

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -199,6 +199,7 @@
 					id_card.assignment = t1
 					id_card.rank = t1
 
+				SSrecords.reset_manifest()
 				callHook("reassign_employee", list(id_card))
 		if("access")
 			if(href_list["allowed"] && computer && can_run(user, 1))

--- a/html/changelogs/geeves-trim_corp.yml
+++ b/html/changelogs/geeves-trim_corp.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Contractors now spawn with their faction next to their job title on the manifest and in their records."
+  - tweak: "Updating someone's ID will now instantly update the crew manifest."
+  - bugfix: "Contractors that have their ID assignment changed will no longer be shifted to the Misc category."


### PR DESCRIPTION
* Contractors now spawn with their faction next to their job title on the manifest and in their records.
* Updating someone's ID will now instantly update the crew manifest.
* Contractors that have their ID assignment changed will no longer be shifted to the Misc category.