### PR TITLE
Machinery Stack Spawning Fix

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -142,11 +142,16 @@ Class Procs:
 		component_parts = list()
 		for (var/type in component_types)
 			var/count = component_types[type]
-			if (count > 1)
-				for (var/i in 1 to count)
-					component_parts += new type(src)
+			if(ispath(type, /obj/item/stack))
+				if(isnull(count))
+					count = 1
+				component_parts += new type(src, count)
 			else
-				component_parts += new type(src)
+				if(count > 1)
+					for (var/i in 1 to count)
+						component_parts += new type(src)
+				else
+					component_parts += new type(src)
 
 		if(component_parts.len)
 			RefreshParts()

--- a/html/changelogs/geeves-machinery_stack_spawning.yml
+++ b/html/changelogs/geeves-machinery_stack_spawning.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Machines that need a stack of materials to be made now spawns the right amount if mapped in."


### PR DESCRIPTION
* Machines that need a stack of materials to be made now spawns the right amount if mapped in.