### PR TITLE
Station Tag

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -490,6 +490,7 @@
 	t = replacetext(t, "\[/large\]", "</font>")
 	t = replacetext(t, "\[small\]", "<font size = \"1\">")
 	t = replacetext(t, "\[/small\]", "</font>")
+	t = replacetext(t, "\[station\]", current_map.station_name)
 
 	// A break for signature customization code to use this proc as well.
 	if (limited)

--- a/html/changelogs/geeves-station_tag.yml
+++ b/html/changelogs/geeves-station_tag.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "You can now use the tag [station] in papercode to have it replaced with the map's current station name."


### PR DESCRIPTION
* You can now use the tag [station] in papercode to have it replaced with the map's current station name.

Ported from: https://github.com/ParadiseSS13/Paradise/pull/16074