### PR TITLE
Fixes coffee cup bugs

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_general.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_general.dm
@@ -100,13 +100,33 @@
 
 /datum/gear/coffeecup/New()
 	..()
-	var/list/coffeecups = list()
-	for(var/coffeecup_type in typesof(/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup))
-		var/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/coffeecup = coffeecup_type
-		coffeecups[initial(coffeecup.name)] = coffeecup_type
-	sortTim(coffeecups, /proc/cmp_text_asc)
+	var/coffeecups = list()
+	coffeecups["plain coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup
+	coffeecups["sol coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/sol
+	coffeecups["dominian coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom
+	coffeecups["NKA coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/nka
+	coffeecups["PRA coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/pra
+	coffeecups["DPRA coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal/dpra
+	coffeecups["NT coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/nt
+	coffeecups["TCFL coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/tcfl
+	coffeecups["#1 coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/one
+	coffeecups["#1 monkey coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/puni
+	coffeecups["heart coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/heart
+	coffeecups["pawn coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/pawn
+	coffeecups["diona coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/diona
+	coffeecups["british coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/britcup
+	coffeecups["black coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/black
+	coffeecups["green coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/green
+	coffeecups["dark green coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/green/dark
+	coffeecups["rainbow coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/rainbow
+	coffeecups["metal coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal
+	coffeecups["glass coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/glass
+	coffeecups["tall coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/tall
+	coffeecups["tall black coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/tall/black
+	coffeecups["tall metal coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/tall/metal
+	coffeecups["tall rainbow coffee cup"] = /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/tall/rainbow
 	gear_tweaks += new/datum/gear_tweak/path(coffeecups)
-	gear_tweaks += new/datum/gear_tweak/reagents(lunchables_drink_reagents())
+	gear_tweaks += new/datum/gear_tweak/reagents(lunchables_drink_reagents())	
 
 /datum/gear/coffeecup/spawn_item(var/location, var/metadata)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -477,6 +477,7 @@ If you add a drink with no empty icon sprite, ensure it is flagged as NO_EMPTY_I
 	unacidable = TRUE
 	amount_per_transfer_from_this = 10
 	volume = 120
+	possible_transfer_amounts = list(5,10,15,30,60,120)
 
 /obj/item/reagent_containers/food/drinks/flask
 	name = "captain's flask"

--- a/code/modules/reagents/reagent_containers/glass/coffeecup.dm
+++ b/code/modules/reagents/reagent_containers/glass/coffeecup.dm
@@ -49,7 +49,7 @@
 	icon_state = "coffeecup_dpra"
 
 // Organisations
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/NT
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/nt
 	name = "\improper NT coffee cup"
 	desc = "A blue NanoTrasen coffee cup."
 	icon_state = "coffeecup_NT"

--- a/code/modules/reagents/reagent_containers/glass/newdrinkingglas.dm
+++ b/code/modules/reagents/reagent_containers/glass/newdrinkingglas.dm
@@ -1,5 +1,5 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass
-	
+	center_of_mass = list("x"=16, "y"=14)
 
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/on_reagent_change()
 	update_icon()

--- a/html/changelogs/CoffeeFix.yml
+++ b/html/changelogs/CoffeeFix.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes loadout coffee cup being the basic one when spawning."
+  - bugfix: "Fixes coffee cup placement on tables."


### PR DESCRIPTION
Coffee cups apparently spawned as the basic white one unless the type was selected again in the given round. 
Given feedback, this also allows the coffee pitcher to have the transfer amount set.