### PR TITLE
Fix external auth menu

### DIFF
--- a/code/modules/mob/abstract/unauthed/login.dm
+++ b/code/modules/mob/abstract/unauthed/login.dm
@@ -25,7 +25,7 @@
 		uihtml += "<a href='?src=\ref[src];authaction=forums'>Login via forums</a>"
 	if(!config.guests_allowed && config.webint_url && config.external_auth)
 		src.OpenForumAuthWindow()
-	show_browser(src, uihtml, "window=externalauth;size=300x300;border=0;can_close=0;can_resize=0;can_minimize=0;titlebar=1")
+	show_browser(src, uihtml, "window=externalauth;size=300x300;border=0;can_close=1;can_resize=0;can_minimize=0;titlebar=1")
 	timeout_timer = addtimer(CALLBACK(src, .proc/timeout), 900, TIMER_STOPPABLE)
 
 /mob/abstract/unauthed/proc/timeout()
@@ -33,18 +33,6 @@
 		to_chat_immediate(client, "Your login time has expired. Please relog and try again.")
 	qdel(client)
 	qdel(src)
-
-/client/verb/meme_up()
-	set name = "meme up"
-	set category = "TEST"
-
-	show_browser(usr, "fuck u", "window=externalauth;size=300x300;border=0;can_close=0;can_resize=0;can_minimize=0;titlebar=1")
-
-/client/verb/meme_down()
-	set name = "meme down"
-	set category = "TEST"
-
-	show_browser(usr, null, "window=externalauth")
 
 /mob/abstract/unauthed/proc/ClientLogin(var/newkey)
 	if(!client)

--- a/code/modules/mob/abstract/unauthed/login.dm
+++ b/code/modules/mob/abstract/unauthed/login.dm
@@ -25,7 +25,7 @@
 		uihtml += "<a href='?src=\ref[src];authaction=forums'>Login via forums</a>"
 	if(!config.guests_allowed && config.webint_url && config.external_auth)
 		src.OpenForumAuthWindow()
-	show_browser(src, uihtml, "window=auth;size=300x300;border=0;can_close=0;can_resize=0;can_minimize=0;titlebar=1")
+	show_browser(src, uihtml, "window=externalauth;size=300x300;border=0;can_close=0;can_resize=0;can_minimize=0;titlebar=1")
 	timeout_timer = addtimer(CALLBACK(src, .proc/timeout), 900, TIMER_STOPPABLE)
 
 /mob/abstract/unauthed/proc/timeout()
@@ -34,13 +34,25 @@
 	qdel(client)
 	qdel(src)
 
+/client/verb/meme_up()
+	set name = "meme up"
+	set category = "TEST"
+
+	show_browser(usr, "fuck u", "window=externalauth;size=300x300;border=0;can_close=0;can_resize=0;can_minimize=0;titlebar=1")
+
+/client/verb/meme_down()
+	set name = "meme down"
+	set category = "TEST"
+
+	show_browser(usr, null, "window=externalauth")
+
 /mob/abstract/unauthed/proc/ClientLogin(var/newkey)
 	if(!client)
 		qdel(src)
 	deltimer(timeout_timer)
 	var/client/c = client // so we don't lose the client in the current mob.
 
-	show_browser(src, null, "window=auth;")
+	show_browser(src, null, "window=externalauth")
 	c.verbs += typesof(/client/verb) // Let's return regular client verbs
 	c.authed = TRUE // We declare client as authed now
 	c.prefs = null //Null them so we can load them from the db again for the correct ckey

--- a/html/changelogs/skull132_external_auth_window.yml
+++ b/html/changelogs/skull132_external_auth_window.yml
@@ -1,0 +1,6 @@
+author: Skull132
+
+delete-after: True
+
+changes:
+  - bugfix: "You can now close the external auth window, if it doesn't close by itself."


### PR DESCRIPTION
SORT OF.

I'm not sure why it doesn't auto close: there's no runtimes from this stack or nothing. I rejigged the names, maybe "auth" is special? Well, regardless, I gave it an "X" button so you can at least close it yourself now!