### PR TITLE
Ghost Menu Sorting

### DIFF
--- a/code/modules/nano/modules/ghost_menu.dm
+++ b/code/modules/nano/modules/ghost_menu.dm
@@ -62,5 +62,21 @@
 		else
 			menu_info[category] = list(list("name" = name, "ref" = ref(M)))
 
-	data["menuinfo"] = menu_info
+	data["menuinfo"] = sort_categories(menu_info)
 	return data
+
+/datum/vueui_module/ghost_menu/proc/sort_categories(var/list/menu_info)
+	var/static/list/ordered_categories = list("Alive", "Dead", "Observer", "NPCs", "Dead NPCs")
+	var/list/sorted_menu_info = list()
+
+	// antags first
+	for(var/category in menu_info)
+		if(!(category in ordered_categories))
+			sorted_menu_info[category] = menu_info[category]
+
+	// set categories in the order people probably want to look at them
+	for(var/ordered_category in ordered_categories)
+		if(menu_info[ordered_category])
+			sorted_menu_info[ordered_category] = menu_info[ordered_category]
+	
+	return sorted_menu_info

--- a/html/changelogs/geeves-ghost_menu_improvements.yml
+++ b/html/changelogs/geeves-ghost_menu_improvements.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "The Ghost Menu now sorts its output in this order: Antags, Alive, Dead, Observer, NPCs, Dead NPCs."


### PR DESCRIPTION
* The Ghost Menu now sorts its output in this order: Antags, Alive, Dead, Observer, NPCs, Dead NPCs.

![image](https://user-images.githubusercontent.com/22774890/125275676-9e03dd00-e30f-11eb-9db3-9d9724e74a73.png)