### PR TITLE
Makes loadout passports free

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -361,6 +361,7 @@
 /datum/gear/accessory/passcard
 	display_name = "human passcard selection"
 	path = /obj/item/clothing/accessory/badge/passcard
+	cost = 0
 
 /datum/gear/accessory/passcard/New()
 	..()
@@ -388,6 +389,7 @@
 /datum/gear/accessory/passport
 	display_name = "human passport selection"
 	path = /obj/item/clothing/accessory/badge/passport
+	cost = 0
 
 /datum/gear/accessory/passport/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/loadout_xeno/tajara.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/tajara.dm
@@ -288,6 +288,7 @@
 	sort_category = "Xenowear - Tajara"
 	whitelisted = list(SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI)
 	flags = GEAR_HAS_DESC_SELECTION
+	cost = 0
 
 /datum/gear/tajaran_passports/New()
 	..()

--- a/html/changelogs/PassportFree.yml
+++ b/html/changelogs/PassportFree.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - tweak: "Loadout passports no longer cost any points in the loadout."


### PR DESCRIPTION
Pretty much what it says. Passports no longer costs any loadout points.
based on the request from [this thread](https://forums.aurorastation.org/topic/16090-make-passports-cost-0-loadout-auto-passports).