### PR TITLE
More Borg Gripper Bugfixes

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -113,7 +113,7 @@
 				conf_access = null
 
 /obj/item/airlock_electronics/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/airlock_electronics))
+	if(istype(W, /obj/item/airlock_electronics) &&(!isrobot(user)))
 		if(src.locked)
 			to_chat(user, SPAN_WARNING("\The [src] you're trying to set is locked! Swipe your ID to unlock."))
 			return

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -269,12 +269,13 @@
 	uneq_active()
 
 /mob/living/silicon/robot/drop_from_inventory(var/obj/item/W, var/atom/target = null)
+	var/do_feedback = target ? FALSE : TRUE //Do not do feedback messages if dropping to a target, to avoid duplicate "You release X" messages. 
 	if(W)
 		if(!target)
 			target = loc
 		if (istype(W.loc, /obj/item/gripper))
 			var/obj/item/gripper/G = W.loc
-			G.drop(target)
+			G.drop(target, do_feedback)
 			return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -272,7 +272,8 @@
 		/obj/item/reagent_containers/food/drinks/sillycup,
 		/obj/item/reagent_containers/food/drinks/medcup,
 		/obj/item/smallDelivery,
-		/obj/item/gift
+		/obj/item/gift,
+		/obj/item/reagent_containers/chem_disp_cartridge
 		)
 
 /obj/item/gripper/service //Used to handle food, drinks, and seeds.
@@ -292,7 +293,8 @@
 		/obj/item/smallDelivery,
 		/obj/item/gift,
 		/obj/item/stack/packageWrap,
-		/obj/item/stack/wrapping_paper
+		/obj/item/stack/wrapping_paper,
+		/obj/item/reagent_containers/chem_disp_cartridge //Drink cartridges
 		)
 
 /obj/item/gripper/no_use //Used when you want to hold and put items in other things, but not able to 'use' the item

--- a/code/modules/mob/living/silicon/robot/items/robot_parts.dm
+++ b/code/modules/mob/living/silicon/robot/items/robot_parts.dm
@@ -343,7 +343,7 @@
 	if(!right_flash)
 		to_chat(user, FONT_SMALL(SPAN_WARNING("It is lacking its right flash.")))
 
-/obj/item/robot_parts/head/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/robot_parts/head/attackby(obj/item/W, mob/user)
 	..()
 	if(W.ismultitool())
 		if(law_manager)
@@ -354,9 +354,9 @@
 			law_manager = TRUE
 
 	if(istype(W, /obj/item/device/flash))
-		if(istype(user, /mob/living/silicon/robot))
-			var/current_module = user.get_active_hand()
-			if(current_module == W)
+		if(isrobot(user))
+			var/mob/living/silicon/robot/R = user
+			if(istype(R.module_active, /obj/item/device/flash))
 				to_chat(user, SPAN_WARNING("You cannot detach your own flash and install it into \the [src]."))
 				return
 			else

--- a/html/changelogs/doxxmedearly - borg_gripper_hell.yml
+++ b/html/changelogs/doxxmedearly - borg_gripper_hell.yml
@@ -1,0 +1,9 @@
+author: Doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - bugfix: "Borgs can once again put flashes in robot heads."
+  - bugfix: "Borgs can once again change access on airlock electronics."
+  - bugfix: "Borg service and medical grippers can now grasp chemical dispenser cartridges."


### PR DESCRIPTION
Episode IV: No hope

Fixes more gripper weirdness; that's what I get for trying to untangle this code; all the old ways we coded around borg weirdness are coming back to bite us.
Robot heads during flash installation were just getting the active hand instead of module. Made it check for the flash module instead of in-hand.
Airlock electronics were locked for borgs due to the order of checks. Since they can't be locked out of airlock electronics, just made the check avoid bots.
Added chem dispenser carts to the med gripper (For chemistry) and service gripper (For drinks).

Also removed feedback messages on drop_from_inventory if we're dropping into a target (like a flash into a robot head) to avoid duplicating feedback messages. Already did this on remove_from_mob but forgot to do it for this one.

Fixes #12195
Fixes #12182 
Fixes #12180 