### PR TITLE
Grab Resist Cuffing

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -181,7 +181,12 @@
 	addtimer(CALLBACK(psi, /datum/psi_complexus/.proc/check_latency_trigger, 100, source, TRUE), 4.5 SECONDS)
 
 /mob/living/carbon/human/get_resist_power()
-	return species.resist_mod
+	var/mod = 1
+	if(handcuffed)
+		mod -= 0.5
+	if(legcuffed)
+		mod -= 0.5
+	return species.resist_mod * mod
 
 // Handle cases where the mob's awareness may reside in another mob, but still cares about how its brain is doing
 /mob/living/carbon/human/proc/find_mob_consciousness()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -744,7 +744,7 @@ default behaviour is:
 	var/resisting = 0
 	var/resist_power = get_resist_power() // How easily the mob can break out of a grab
 	if(length(grabbed_by) && resist_power <= 0)
-		to_chat(src, SPAN_WARNING("You don't have enough power to resist out of any grabs!"))
+		to_chat(src, SPAN_WARNING("You aren't powerful enough to break out of this grab!"))
 		return
 	for(var/obj/item/grab/G in grabbed_by)
 		resisting++

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -742,11 +742,10 @@ default behaviour is:
 		to_chat(src, "<span class='notice'>You can't move...</span>")
 		return
 	var/resisting = 0
-	for(var/obj/O in requests)
-		requests.Remove(O)
-		qdel(O)
-		resisting++
 	var/resist_power = get_resist_power() // How easily the mob can break out of a grab
+	if(length(grabbed_by) && resist_power <= 0)
+		to_chat(src, SPAN_WARNING("You don't have enough power to resist out of any grabs!"))
+		return
 	for(var/obj/item/grab/G in grabbed_by)
 		resisting++
 		var/resist_chance

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -153,7 +153,6 @@
 	var/datum/hud/hud_used = null
 
 	var/list/grabbed_by = list(  )
-	var/list/requests = list(  )
 
 	var/list/mapobjs = list()
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -20,7 +20,7 @@
 /client/proc/Process_Grab()
 	if(isliving(mob)) //if we are being grabbed
 		var/mob/living/L = mob
-		if(!L.canmove && L.grabbed_by.len)
+		if(!L.canmove && length(L.grabbed_by))
 			L.resist() //shortcut for resisting grabs
 	for(var/obj/item/grab/G in list(mob.l_hand, mob.r_hand))
 		G.reset_kill_state() //no wandering across the station/asteroid while choking someone

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -257,6 +257,7 @@
 				if(M.pulling == mob)
 					if(!M.restrained() && M.stat == 0 && M.canmove && mob.Adjacent(M))
 						to_chat(src, SPAN_NOTICE("You're restrained! You can't move!"))
+						move_delay = world.time + 1 SECOND // prevent spam
 						return 0
 					else
 						M.stop_pulling()

--- a/html/changelogs/geeves-grab_resist.yml
+++ b/html/changelogs/geeves-grab_resist.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Being handcuffed or legcuffed makes it 50% more difficult to break out of grabs, being both handcuffed and legcuffed makes it impossible."
+  - bugfix: "Attempting to move while restrained will now longer spam your chat."


### PR DESCRIPTION
* Being handcuffed or legcuffed makes it 50% more difficult to break out of grabs, being both handcuffed and legcuffed makes it impossible.
* Attempting to move while restrained will now longer spam your chat.