### PR TITLE
Makes taking the remote controlled warden out of the security mining prison harder

### DIFF
--- a/html/changelogs/alberyk-prisonrobot.yml
+++ b/html/changelogs/alberyk-prisonrobot.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - tweak: "Bringing the remote controlled synthetics out of the brig's mining section should be way harder now."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -27668,9 +27668,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/ladder/up{
-	pixel_y = 16
-	},
 /turf/simulated/floor/airless,
 /area/security/penal_colony)
 "eBJ" = (
@@ -29178,7 +29175,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Penal Mining Facility";
-	req_access = list(3)
+	req_access = list(58)
 	},
 /turf/simulated/floor/airless,
 /area/security/penal_colony)

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -3334,7 +3334,7 @@
 "agC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
+	req_access = list(58)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -64050,7 +64050,7 @@
 "mlY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
+	req_access = list(58)
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -65257,9 +65257,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "orw" = (
-/obj/structure/ladder{
-	pixel_y = 16
-	},
 /obj/structure/cable{
 	d1 = 32;
 	d2 = 2;


### PR DESCRIPTION
This removes the ladder and adds hos access to the rooms. This should make taking the remote-controlled ipc out of the security mining area harder.