### PR TITLE
Roundstart SMES

### DIFF
--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -62,6 +62,27 @@
 	component_parts += new /obj/item/smes_coil/super_io(src)
 	component_parts += new /obj/item/smes_coil(src)
 
+/obj/machinery/power/smes/buildable/main_engine
+	cur_coils = 0
+	input_attempt = TRUE
+	output_attempt = TRUE
+	output_level = 1300000 // calibrated to the NSS Aurora map
+
+/obj/machinery/power/smes/buildable/main_engine/Initialize()
+	. = ..()
+	component_parts += new /obj/item/smes_coil/super_capacity(src)
+	component_parts += new /obj/item/smes_coil/super_capacity(src)
+	component_parts += new /obj/item/smes_coil/super_capacity(src)
+	component_parts += new /obj/item/smes_coil/super_capacity(src)
+	component_parts += new /obj/item/smes_coil/super_io(src)
+	component_parts += new /obj/item/smes_coil/super_io(src)
+
+/obj/machinery/power/smes/buildable/main_engine/LateInitialize()
+	cur_coils = 6
+	. = ..()
+	charge = capacity
+	input_level = input_level_max
+
 // END SMES SUBTYPES
 
 // SMES itself

--- a/html/changelogs/geeves-roundstart_smes.yml
+++ b/html/changelogs/geeves-roundstart_smes.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "The supermatter grid SMES now starts with four capacitance coils and two transmission coils, as well as full charge, max input, and 1.3 MW output."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -7402,15 +7402,6 @@
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Supermatter - Grid";
-	charge = 1e+007;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 500000;
-	output_attempt = 1;
-	output_level = 500000
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -7420,6 +7411,9 @@
 	icon_state = "0-8"
 	},
 /obj/effect/landmark/engine_setup/smes,
+/obj/machinery/power/smes/buildable/main_engine{
+	RCon_tag = "Supermatter - Grid"
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_smes)
 "aoE" = (


### PR DESCRIPTION
* The supermatter grid SMES now starts with four capacitance coils and two transmission coils, as well as full charge, max input, and 1.3 MW output.

![image](https://user-images.githubusercontent.com/22774890/126880744-7fd39dcd-17d9-4d86-af4c-54a73f05b488.png)

(This is on a roundstart station, with no other departments active, charging stuff, etc.)