### PR TITLE
Fixes some cameras and adds lights to the brig control room

### DIFF
--- a/html/changelogs/CameraFixes.yml
+++ b/html/changelogs/CameraFixes.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - maptweak: "The sublevel crusher camera was moved up one to allow full view of the crusher contents."
+  - maptweak: "Put the bar booth, brig shower and the lower hallway outside the diner's cameras on the proper networks."

--- a/html/changelogs/CameraFixes.yml
+++ b/html/changelogs/CameraFixes.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes:
   - maptweak: "The sublevel crusher camera was moved up one to allow full view of the crusher contents."
   - maptweak: "Put the bar booth, brig shower and the lower hallway outside the diner's cameras on the proper networks."
+  - maptweak: "Brig control room lights near the windoor was moved one to the right, and another added opposite from it."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -23731,6 +23731,10 @@
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
+/obj/machinery/camera/network/supply{
+	c_tag = "Cargo - Disposals, Lower";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/maintenance/disposal)
 "bcb" = (
@@ -23744,10 +23748,6 @@
 "bcd" = (
 /obj/item/modular_computer/telescreen/preset/trashcompactor{
 	pixel_x = -32
-	},
-/obj/machinery/camera/network/supply{
-	c_tag = "Cargo - Disposals, Lower";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/disposal)

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -23770,7 +23770,8 @@
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Communal Bathroom";
-	dir = 4
+	dir = 4;
+	network = list("Prison")
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
@@ -53959,7 +53960,8 @@
 /obj/structure/table/wood,
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Bar - Booths";
-	dir = 1
+	dir = 1;
+	network = list("Service")
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
@@ -69434,7 +69436,7 @@
 /obj/machinery/camera/network/civilian_main{
 	c_tag = "Aft Corridor - Camera 2";
 	dir = 8;
-	network = list("Service")
+	network = list("Civilian Main")
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -20590,9 +20590,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Lobby Desk"
 	},
@@ -23736,6 +23733,7 @@
 /obj/structure/table/standard,
 /obj/item/folder/sec,
 /obj/item/paper_scanner,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/security/brig/control_room)
 "aPg" = (
@@ -68851,6 +68849,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/vault)
+"uiJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/control_room)
 "ujv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -101457,7 +101467,7 @@ omB
 aEm
 aGk
 aIq
-aJJ
+uiJ
 ntc
 aNp
 aPf


### PR DESCRIPTION
This moves the camera in the sublevel crusher up by one to allow full view of the crusher contents, as per suggestion at https://forums.aurorastation.org/topic/8983-minor-mapping-suggestions/?do=findComment&comment=149122

It also fixes the camera outside the diner to be a hallway camera, the booth camera inside to be a service camera and the communal shower brig camera to be a prison camera.

Lastly, as per suggested on the thread linked above, the changes to the light tubes in the brig control room were added.