### PR TITLE
Better Teleportation Accidents

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -37,7 +37,7 @@
 		station.locked_obj = null
 		return
 	if(prob(station.calibration)) //oh dear a problem, put em in deep space
-		do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), 3), 2)
+		do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), pick(GetConnectedZlevels(z))), 2)
 	else
 		do_teleport(M, teleport_obj) //dead-on precision
 	if(ishuman(M))

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -75,7 +75,7 @@
 		if(has_failed) //oh dear a problem, put em in deep space
 			icon_state = "portal1" // only tell people the portal failed after a teleport has been done
 			desc = "A bluespace tear in space, reaching directly to another point within this region. Definitely unstable."
-			if(do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0))
+			if(do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), pick(GetConnectedZlevels(z))), 0))
 				has_teleported = TRUE
 		else
 			if(do_teleport(M, target, precision))

--- a/html/changelogs/geeves-better_teleportation_accidents.yml
+++ b/html/changelogs/geeves-better_teleportation_accidents.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Failed portals and teleportation attempts will now transmit you to a random level, instead of level 3 each time."


### PR DESCRIPTION
* Failed portals and teleportation attempts will now transmit you to a random level, instead of level 3 each time.

Inspired by: https://github.com/ParadiseSS13/Paradise/pull/16126

Jumped from Level 1 to Level 3
![image](https://user-images.githubusercontent.com/22774890/126897977-5584bef9-b3a6-4b34-8248-e165cdb2466f.png)