### PR TITLE
Rotatable Drink Machines

### DIFF
--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -5,6 +5,8 @@
 	var/icon_state_active = "dispenser_active"
 	clicksound = /decl/sound_category/button_sound
 
+	obj_flags = OBJ_FLAG_ROTATABLE
+
 	var/list/spawn_cartridges = null // Set to a list of types to spawn one of each on New()
 
 	var/list/cartridges = list() // Associative, label -> cartridge

--- a/html/changelogs/geeves-rotate_drinks.yml
+++ b/html/changelogs/geeves-rotate_drinks.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Chemical dispensers like the soft drink dispenser and the alcohol dispenser can now be rotated with alt-click."


### PR DESCRIPTION
* Chemical dispensers like the soft drink dispenser and the alcohol dispenser can now be rotated with alt-click.