### PR TITLE
Added crayons and canvases to the paperwork gripper.

### DIFF
--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -207,7 +207,7 @@
 		/obj/item/paper,
 		/obj/item/paper_bundle,
 		/obj/item/canvas,
-		/obj/item/pen/crayon,
+		/obj/item/pen,
 		/obj/item/card/id,
 		/obj/item/book,
 		/obj/item/newspaper,

--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -206,6 +206,8 @@
 		/obj/item/clipboard,
 		/obj/item/paper,
 		/obj/item/paper_bundle,
+		/obj/item/canvas,
+		/obj/item/pen/crayon,
 		/obj/item/card/id,
 		/obj/item/book,
 		/obj/item/newspaper,

--- a/html/changelogs/ArtisticCyborgs.yml
+++ b/html/changelogs/ArtisticCyborgs.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: CodePanter
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Added crayons and canvases to the paperwork gripper."


### PR DESCRIPTION
With this pull request, cyborgs are now able to use crayons for a variety of purposes, including, but not limited to, drawing on canvases.