### PR TITLE
Empty Magazine Recycling

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -166,6 +166,10 @@
 				new_state = ammo_states[idx]
 				break
 		icon_state = (new_state)? new_state : initial(icon_state)
+	if(!length(stored_ammo))
+		recyclable = TRUE
+	else
+		recyclable = FALSE
 
 /obj/item/ammo_magazine/examine(mob/user)
 	..()

--- a/html/changelogs/geeves-empty_magazine_recycling.yml
+++ b/html/changelogs/geeves-empty_magazine_recycling.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Empty magazines can now be recycled in an autolathe."


### PR DESCRIPTION
* Empty magazines can now be recycled in an autolathe.