### PR TITLE
Sofa Physics

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -77,6 +77,19 @@
 	base_icon = "comfychair"
 	build_amt = 2
 
+/obj/structure/bed/chair/comfy/MouseDrop_T(mob/target, mob/user)
+	if(target == user && user.loc != loc && (reverse_dir[dir] & angle2dir(Get_Angle(src, user))))
+		user.visible_message("<b>[user]</b> starts climbing over the back of \the [src]...", SPAN_NOTICE("You start climbing over the back of \the [src]..."))
+		if(do_after(user, 2 SECONDS))
+			user.forceMove(loc)
+		return
+	return ..()
+
+/obj/structure/bed/chair/comfy/CanPass(atom/movable/mover, turf/target, height, air_group)
+	if(mover.density && isliving(mover) && (reverse_dir[dir] & angle2dir(Get_Angle(src, mover))))
+		return FALSE
+	return ..()
+
 /obj/structure/bed/chair/comfy/brown/New(var/newloc)
 	..(newloc, MATERIAL_STEEL, MATERIAL_LEATHER)
 

--- a/html/changelogs/geeves-sofa_physics.yml
+++ b/html/changelogs/geeves-sofa_physics.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "You can no longer phase through the backsides of comfy chairs/sofa, you need to leap over them by click dragging yourself onto the comfy chair/sofa."


### PR DESCRIPTION
* You can no longer phase through the backsides of comfy chairs/sofa, you need to leap over them by click dragging yourself onto the comfy chair/sofa.

Illustration:
![image](https://user-images.githubusercontent.com/22774890/126902743-d7376fab-caa3-413f-8b12-ec0530d818c3.png)