### PR TITLE
Multi-tile Airlock Fixes | Airlock QoL

### DIFF
--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -134,7 +134,7 @@
 		frequency = new_frequency
 		radio_connection = SSradio.add_object(src, frequency, RADIO_AIRLOCK)
 
-/obj/machinery/door/airlock/Initialize()
+/obj/machinery/door/airlock/Initialize(mapload, d = 0, populate_components = TRUE, var/obj/structure/door_assembly/DA)
 	. = ..()
 	if(frequency)
 		set_frequency(frequency)
@@ -147,6 +147,10 @@
 
 	if(SSradio)
 		set_frequency(frequency)
+
+	if(DA)
+		bound_height = DA.bound_height
+		bound_width = DA.bound_width
 
 /obj/machinery/door/airlock/Destroy()
 	if(frequency && SSradio)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -10,6 +10,7 @@
 	density = 1
 	w_class = ITEMSIZE_HUGE
 	build_amt = 4
+	obj_flags = OBJ_FLAG_ROTATABLE
 	var/state = STATE_UNWIRED
 	var/base_icon_state = ""
 	var/base_name = "Airlock"
@@ -18,6 +19,7 @@
 	var/glass_type = "/glass"
 	var/glass = 0 // 0 = glass can be installed. -1 = glass can't be installed. 1 = glass is already installed. Text = mineral plating is installed instead.
 	var/created_name = null
+	var/width = 1
 
 /obj/structure/door_assembly/Initialize(mapload)
 	. = ..()
@@ -140,7 +142,7 @@
 	icon = 'icons/obj/doors/door_assembly2x1.dmi'
 	icon_state = null //only have icons for the glass version
 	dir = EAST
-	var/width = 1
+	width = 2
 
 /*Temporary until we get sprites.
 	glass_type = "/multi_tile/glass"
@@ -152,14 +154,9 @@
 
 /obj/structure/door_assembly/multi_tile/Initialize()
 	. = ..()
-	SetBounds()
 	update_state()
 
-/obj/structure/door_assembly/multi_tile/Move()
-	. = ..()
-	SetBounds()
-
-/obj/structure/door_assembly/multi_tile/proc/SetBounds()
+/obj/structure/door_assembly/proc/SetBounds() // dont update with move or init, makes dragging impossible. do it just before airlock spawns
 	if(width > 1)
 		if(dir in list(EAST, WEST))
 			bound_width = width * world.icon_size
@@ -361,7 +358,8 @@
 			else
 				path = text2path("/obj/machinery/door/airlock[airlock_type]")
 
-			new path(src.loc, src)
+			SetBounds()
+			new path(loc, dir, FALSE, src)
 			qdel(src)
 
 	else if(istype(W, /obj/item/material/twohanded/chainsaw))

--- a/html/changelogs/geeves-multitile_airlock_bounds.yml
+++ b/html/changelogs/geeves-multitile_airlock_bounds.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Constructing multi-tile airlocks now properly sets the collision bounds."
+  - rscadd: "You can now rotate airlock assemblies by alt-clicking on them."


### PR DESCRIPTION
* Constructing multi-tile airlocks now properly sets the collision bounds.
* You can now rotate airlock assemblies by alt-clicking on them.