### PR TITLE
Fixes radiation storm lights ending too late

### DIFF
--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -15,11 +15,7 @@
 
 /datum/event/radiation_storm/start()
 	make_maint_all_access()
-	for(var/area/A in all_areas)
-		if(A.flags & RAD_SHIELDED)
-			continue
-		A.radiation_active = TRUE
-		A.update_icon()
+	lights(TRUE)
 
 /datum/event/radiation_storm/tick()
 	if(activeFor == enterBelt)
@@ -35,6 +31,7 @@
 
 	else if(activeFor == leaveBelt)
 		command_announcement.Announce("The station has passed the radiation belt. Please report to medbay if you experience any unusual symptoms. Maintenance will lose all-access again shortly.", "Anomaly Alert")
+		lights()
 
 /datum/event/radiation_storm/proc/radiate()
 	for(var/mob/living/C in living_mob_list)
@@ -44,12 +41,18 @@
 /datum/event/radiation_storm/end(var/faked)
 	if(faked)
 		return
+	lights()
 	revoke_maint_all_access()
-	for(var/area/A in all_areas)
-		if(A.flags & RAD_SHIELDED)
-			continue
-		A.radiation_active = null
-		A.update_icon()
 
 /datum/event/radiation_storm/syndicate/radiate()
 	return
+
+/datum/event/radiation_storm/proc/lights(var/turnOn = FALSE)
+	for(var/area/A in all_areas)
+		if(A.flags & RAD_SHIELDED)
+			continue
+		if(turnOn)
+			A.radiation_active = TRUE
+		else
+			A.radiation_active = null
+		A.update_icon()

--- a/html/changelogs/RadiationLight.yml
+++ b/html/changelogs/RadiationLight.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Radiation storm lights will now end once the radiation is over."


### PR DESCRIPTION
As the title says. It should now disable once the storm itself ends, rather than when maintenance access is added back.
fixes https://github.com/Aurorastation/Aurora.3/issues/12239