### PR TITLE
Fixed empty anomaly power utilizers being invisible.

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/ano_device_battery.dm
+++ b/code/modules/research/xenoarchaeology/tools/ano_device_battery.dm
@@ -22,7 +22,7 @@
 /obj/item/anodevice
 	name = "anomaly power utilizer"
 	icon = 'icons/obj/xenoarchaeology.dmi'
-	icon_state = "anodev"
+	icon_state = "anodev_empty"
 	var/activated = 0
 	var/duration = 0
 	var/interval = 0

--- a/html/changelogs/AnomalyPowerUtelizers.yml
+++ b/html/changelogs/AnomalyPowerUtelizers.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: CodePanter
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed empty anomaly power utilizers being invisible."


### PR DESCRIPTION
As reported in #12259 the anomaly power utilizers were invisible. This was because the wrong sprite or icon state was being used. This pull request fixes it so it uses the correct name.