### PR TITLE
Nerfs Hallucination Sting Duration + It Injects Mindbreaker Now

### DIFF
--- a/code/game/gamemodes/changeling/implements/powers/stings.dm
+++ b/code/game/gamemodes/changeling/implements/powers/stings.dm
@@ -84,7 +84,7 @@
 
 /datum/changeling_sting/hallucinate/do_sting(mob/living/target)
 	..()
-	addtimer(CALLBACK(target, /mob/living.proc/add_hallucinate, 200), rand(5 SECONDS, 15 SECONDS))
+	addtimer(CALLBACK(target, /mob/living.proc/add_hallucinate, 65), rand(5 SECONDS, 10 SECONDS))
 
 /mob/proc/changeling_silence_sting()
 	set category = "Changeling"

--- a/code/game/gamemodes/changeling/implements/powers/stings.dm
+++ b/code/game/gamemodes/changeling/implements/powers/stings.dm
@@ -74,7 +74,7 @@
 /mob/proc/changeling_hallucinate_sting()
 	set category = "Changeling"
 	set name = "Hallucination Sting (15)"
-	set desc = "Causes target to begin hallucinating after five to fifteen seconds."
+	set desc = "Causes target to begin hallucinating after a few seconds."
 
 	changeling_sting(15, /mob/proc/changeling_hallucinate_sting, /datum/changeling_sting/hallucinate, TRUE)
 
@@ -84,7 +84,8 @@
 
 /datum/changeling_sting/hallucinate/do_sting(mob/living/target)
 	..()
-	addtimer(CALLBACK(target, /mob/living.proc/add_hallucinate, 65), rand(5 SECONDS, 10 SECONDS))
+	if(target.reagents)
+		addtimer(target.reagents.add_reagent(/decl/reagent/mindbreaker, 3), rand(5 SECONDS, 15 SECONDS))
 
 /mob/proc/changeling_silence_sting()
 	set category = "Changeling"

--- a/html/changelogs/wickedcybs_halluchungus.yml
+++ b/html/changelogs/wickedcybs_halluchungus.yml
@@ -3,4 +3,4 @@ author: WickedCybs
 delete-after: True
 
 changes:
-  - balance: "The changeling hallucination sting will no longer cause people stung to hallucinate for more than ten minutes. It'll be close to four minutes now, lasting some seconds longer than that still."
+  - balance: "The changeling hallucination sting will directly inject three units of mindbreaker into somebody instead of directly applying hallucinations that cannot be traced at all for upwards of twelve minutes. The new duration will be around three to five without medical attention, give or take as severity can be a bit random."

--- a/html/changelogs/wickedcybs_halluchungus.yml
+++ b/html/changelogs/wickedcybs_halluchungus.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - balance: "The changeling hallucination sting will no longer cause people stung to hallucinate for more than ten minutes. It'll be close to four minutes now, lasting some seconds longer than that still."


### PR DESCRIPTION
The changeling hallucination sting was putting people out of commission for upwards of twelve to fourteen minutes. That's quite a bit for a relatively inexpensive sting. Additionally, these hallucinations were applied directly. So the extent of the roleplay here was having crew go wild or being contained in medical with no real means of actually reducing it or tracing it via reagent scanners or the sleeper. The length was so long, even synap didn't seem very effective it would seem.

It will directly inject three units of mindbreaker now. If the afflicted ends up processing it all without any medical attention they'll still be looking at nearly four to six minutes of hallucinations. Fair enough since it's more solvable now.