### PR TITLE
Fixes wrist radio issues

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -69,6 +69,8 @@
 		var/mob/living/carbon/human/H = src.loc
 		if(H.l_ear == src || H.r_ear == src)
 			return ..(freq, level)
+	if(istype(src, /obj/item/device/radio/headset/wrist))
+		return ..(freq, level)
 	return -1
 
 /obj/item/device/radio/headset/attack_hand(mob/user)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -17,6 +17,8 @@
 	var/ks2type = null
 	var/radio_sound = null
 
+	var/EarSound = TRUE
+
 	drop_sound = 'sound/items/drop/component.ogg'
 	pickup_sound = 'sound/items/pickup/component.ogg'
 
@@ -69,7 +71,7 @@
 		var/mob/living/carbon/human/H = src.loc
 		if(H.l_ear == src || H.r_ear == src)
 			return ..(freq, level)
-	if(istype(src, /obj/item/device/radio/headset/wrist))
+	if(!EarSound)
 		return ..(freq, level)
 	return -1
 
@@ -186,6 +188,7 @@
 	item_state = "wristset"
 	slot_flags = SLOT_WRISTS
 	canhear_range = 1
+	EarSound = FALSE
 
 /*
  * Civillian

--- a/html/changelogs/WristRadioFix.yml
+++ b/html/changelogs/WristRadioFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes being unable to hear comms through the wrist radio."


### PR DESCRIPTION
In short: current code needs you to wear the radio on either ear to hear from it. Obviously the wrist radio should not be like that, so this makes an exception for it.