### PR TITLE
Trace Chems Runtime Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -696,7 +696,7 @@
 	// TODO: stomach and bloodstream organ.
 	if(!isSynthetic())
 		handle_trace_chems()
-	if(!(species.flags & NO_BLOOD))
+	if(vessel && (/decl/reagent/blood in vessel.reagent_data))
 		// update the trace chems in our blood vessels
 		var/decl/reagent/blood/B = decls_repository.get_decl(/decl/reagent/blood)
 		B.handle_trace_chems(vessel)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -46,10 +46,11 @@
 	holder.remove_reagent(type, amount) // Don't typecheck this, fix anywhere this is called with a null holder.
 	if(ishuman(holder.my_atom))
 		var/mob/living/carbon/human/H = holder.my_atom
-		if(H.vessel.reagent_data[/decl/reagent/blood]["trace_chem"][type])
-			H.vessel.reagent_data[/decl/reagent/blood]["trace_chem"][type] += amount
-		else
-			H.vessel.reagent_data[/decl/reagent/blood]["trace_chem"][type] = amount
+		if(!(H.species.flags & NO_BLOOD))
+			if(H.vessel.reagent_data[/decl/reagent/blood]["trace_chem"][type])
+				H.vessel.reagent_data[/decl/reagent/blood]["trace_chem"][type] += amount
+			else
+				H.vessel.reagent_data[/decl/reagent/blood]["trace_chem"][type] = amount
 
 // This doesn't apply to skin contact - this is for, e.g. extinguishers and sprays. The difference is that reagent is not directly on the mob's skin - it might just be on their clothing.
 /decl/reagent/proc/touch_mob(var/mob/living/M, var/amount, var/datum/reagents/holder)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -46,7 +46,7 @@
 	holder.remove_reagent(type, amount) // Don't typecheck this, fix anywhere this is called with a null holder.
 	if(ishuman(holder.my_atom))
 		var/mob/living/carbon/human/H = holder.my_atom
-		if(!(H.species.flags & NO_BLOOD))
+		if(H.vessel && (/decl/reagent/blood in H.vessel.reagent_data))
 			if(H.vessel.reagent_data[/decl/reagent/blood]["trace_chem"][type])
 				H.vessel.reagent_data[/decl/reagent/blood]["trace_chem"][type] += amount
 			else


### PR DESCRIPTION
Fixes Trace Chems spewing out a gorillion runtimes when something without blood processes any reagent.