### PR TITLE
Another Matriarch Fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -155,6 +155,8 @@
 
 /mob/living/silicon/robot/drone/construction/matriarch/ghostize(can_reenter_corpse, should_set_timer)
 	. = ..()
+	if(stat == DEAD)
+		return
 	if(src in mob_list) // needs to exist to reopen spawn atom
 		set_name(initial(name))
 		request_player()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1252,3 +1252,5 @@ proc/is_blind(A)
 	real_name = new_name
 	name = real_name
 	voice_name = real_name
+	if(mind)
+		mind.name = real_name

--- a/html/changelogs/geeves-another_matriarch_fix.yml
+++ b/html/changelogs/geeves-another_matriarch_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Matriarch drones that die without exploding now don't open a ghost spawner slot."

--- a/html/changelogs/geeves-another_matriarch_fix.yml
+++ b/html/changelogs/geeves-another_matriarch_fix.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "Matriarch drones that die without exploding now don't open a ghost spawner slot."
+  - bugfix: "Dying as a drone will now not say died as drone in deadchat, instead just using the proper name."


### PR DESCRIPTION
* Matriarch drones that die without exploding now don't open a ghost spawner slot.
* Dying as a drone will now not say died as drone in deadchat, instead just using the proper name.