### PR TITLE
Round # ?? of Borg Gripper Fixes

### DIFF
--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -105,6 +105,7 @@
 		add_fingerprint(user)
 	if(istype(I, /obj/item/pipe) || istype(I, /obj/item/pipe_meter))
 		to_chat(usr, SPAN_NOTICE("You put \the [I] back into \the [src]."))
+		user.remove_from_mob(I) //Catches robot gripper duplication
 		qdel(I)
 		return
 	else if(I.iswrench())

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -348,6 +348,7 @@
 		for(var/datum/data/vending_product/R in product_records)
 			if(W.type == R.product_path)
 				stock(R, user)
+				user.remove_from_mob(W) //Catches gripper duplication
 				qdel(W)
 				return
 		..()

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -16,7 +16,7 @@
 		return
 	..()
 
-/obj/item/frame/proc/try_build(turf/on_wall)
+/obj/item/frame/proc/try_build(turf/on_wall, mob/user)
 	if(!build_machine_type)
 		return
 
@@ -49,6 +49,7 @@
 	M.fingerprints = src.fingerprints
 	M.fingerprintshidden = src.fingerprintshidden
 	M.fingerprintslast = src.fingerprintslast
+	user.remove_from_mob(src) //Prevents gripper duplication
 	qdel(src)
 
 /obj/item/frame/fire_alarm

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -370,7 +370,7 @@
 
 	if(istype(W,/obj/item/frame))
 		var/obj/item/frame/F = W
-		F.try_build(src)
+		F.try_build(src, user)
 		return
 
 	else if(!istype(W,/obj/item/rfd/construction) && !istype(W, /obj/item/reagent_containers))

--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -108,14 +108,15 @@
 	set desc = "Release an item from your magnetic gripper."
 	set category = "Robot Commands"
 
-	drop(get_turf(src))
+	drop(get_turf(src), usr)
 
-/obj/item/gripper/proc/drop(var/atom/target, var/feedback = TRUE)
+/obj/item/gripper/proc/drop(var/atom/target, mob/user, var/feedback = TRUE)
 	if(wrapped)
 		if(wrapped.loc == src)
 			if(force_holder)
 				wrapped.force = force_holder
 			wrapped.forceMove(target)
+			wrapped.dropped(user)
 			force_holder = null
 		if(feedback)
 			to_chat(loc, SPAN_NOTICE("You release \the [wrapped].")) // loc will always be the cyborg
@@ -145,6 +146,9 @@
 
 /obj/item/gripper/attackby(obj/item/O, mob/user)
 	if(wrapped)
+		if(O == wrapped)
+			attack_self(user) //Allows gripper to be clicked to use item. 
+			return
 		var/resolved = wrapped.attackby(O,user)
 		if(!resolved && wrapped && O)
 			O.afterattack(wrapped, user ,1)//We pass along things targeting the gripper, to objects inside the gripper. So that we can draw chemicals from held beakers for instance

--- a/html/changelogs/Doxxmedearly - Gripper_Fixes_Part_Whoknowsanymore.yml
+++ b/html/changelogs/Doxxmedearly - Gripper_Fixes_Part_Whoknowsanymore.yml
@@ -1,0 +1,8 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed item duplication/icon updating issues related to borg gripper interactions with vending machines, pipe dispensers, and light fixtures."
+  - bugfix: "Borg players can once again click on the active gripper icon to activate the held item."
+  - bugfix: "Stacks dropped or placed by borg grippers will no longer display the stack amount next to the icon."


### PR DESCRIPTION
Qdel() hates items in grippers. Have to make sure the items are dropped from the mob before they're deleted (Which most things already do, since it causes weird duplicating issues across the board, not just with grippers). Just going to have to fix these as they come up. Throwing remove_from_mob before qdel() will fix them. 

Clicking on the gripper instead of using a hotkey would make you attack the held item with the held item. Fixed that by changing it to an attack_self.

Fixed an icon issue Geeves brought up when dropping stacks; the number would remain when the item is placed down, because the gripper's drop proc did not call the dropped item's `dropped` proc, which clears that stuff. 

Fixes #12236 