### PR TITLE
Added a rainbow crayon to the vault maintenance area.

### DIFF
--- a/html/changelogs/RainbowCrayonPlacement.yml
+++ b/html/changelogs/RainbowCrayonPlacement.yml
@@ -1,0 +1,12 @@
+author: CodePanter
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Added a rainbow crayon to the vault maintenance area."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -65371,6 +65371,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
+"oEL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/item/pen/crayon/rainbow,
+/turf/simulated/floor/plating,
+/area/maintenance/vault)
 "oGq" = (
 /obj/effect/shuttle_landmark/burglar/caverns,
 /turf/unsimulated/floor/asteroid/ash/rocky,
@@ -111958,7 +111964,7 @@ aab
 aab
 aab
 nHe
-saL
+oEL
 tzU
 nRq
 nAn


### PR DESCRIPTION
![mapeditcrayon](https://user-images.githubusercontent.com/3697004/128772418-1327d9ce-586b-47dc-b382-f687a7c183df.PNG)

With more people using the canvas for art, the use case for the rainbow crayon has increased (which allows you to draw in any color). This crayon is normally extremely rare as it is an uncommon item in the cargo warehouse. This pull request puts one on a table in maintenance, specifically the area behind the vault, which looks like it is an abandoned bar or restaurant.
