### PR TITLE
Changes the premium item of the Dinnerware from an NT lunchbox to a SCC one

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -864,7 +864,7 @@
 		/obj/item/storage/toolbox/lunchbox/syndicate = 2
 	)
 	premium = list(
-		/obj/item/storage/toolbox/lunchbox/nt/filled = 2
+		/obj/item/storage/toolbox/lunchbox/scc/filled = 2
 	)
 	restock_items = 1
 	random_itemcount = 0

--- a/html/changelogs/desven-scclunchbox.yml
+++ b/html/changelogs/desven-scclunchbox.yml
@@ -1,0 +1,6 @@
+author: Desven
+
+delete-after: True
+
+changes:
+  - rscadd: "Changed the premium lunchbox from the Dinnerware from NT lunchbox to SCC lunchbox."


### PR DESCRIPTION
Just a little tweak. Since you can already get NT lunchboxes on the dinnerware, might as well change the design to the SCC one so people get more incentive to use the coin here. 