### PR TITLE
Eridani ERT Access Fix

### DIFF
--- a/code/datums/outfits/ert/ap_eridani.dm
+++ b/code/datums/outfits/ert/ap_eridani.dm
@@ -37,6 +37,9 @@
 		/obj/item/grenade/flashbang = 1
 	)
 
+/datum/outfit/admin/ert/ap_eridani/get_id_access()
+	return get_distress_access()
+
 /datum/outfit/admin/ert/ap_eridani/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(visualsOnly)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -525,9 +525,9 @@ var/const/NO_EMAG_ACT = -50
 	overlay_state = "erisec_card"
 
 /obj/item/card/id/distress/ap_eridani/New()
-	access = list(access_distress, access_maint_tunnels, access_external_airlocks, access_security, access_medical, access_medical_equip)
+	access = get_distress_access()
 	..()
-
+ 
 /obj/item/card/id/distress/iac
 	name = "\improper Interstellar Aid Corps ID"
 	assignment = "Interstellar Aid Corps Responder"

--- a/html/changelogs/wickedcybs_strike.yml
+++ b/html/changelogs/wickedcybs_strike.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "Eridani ERT responders got ID cards with no additional access added, which wasn't intentional. They get standard distress access now and the Lead can actually use their hardsuit."


### PR DESCRIPTION
Turns out only specifying the access on the card made it so anyone spawned in the ERT actually had zero access. I had to include the whole "get_distress_access" in the ERT loadout for it to work, like the others.

This means the ERT lead should be able to use their hardsuit now. 