### PR TITLE
Changes Vaurca to spawn with the filter port, allows Vaurca to select mechanical organs

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -134,12 +134,12 @@
 	default_accent = ACCENT_TTS
 	allowed_accents = list(ACCENT_TTS, ACCENT_ZORA, ACCENT_KLAX, ACCENT_CTHUR)
 
-	alterable_internal_organs = list(BP_EYES)
+	alterable_internal_organs = list(BP_HEART, BP_EYES, BP_LUNGS, BP_LIVER, BP_KIDNEYS, BP_STOMACH)
 
 /datum/species/bug/before_equip(var/mob/living/carbon/human/H)
 	. = ..()
 	H.gender = NEUTER
-	var/obj/item/clothing/mask/breath/M = new /obj/item/clothing/mask/breath(H)
+	var/obj/item/clothing/mask/breath/vaurca/filter/M = new /obj/item/clothing/mask/breath/vaurca/filter(H)
 	if(H.equip_to_slot_or_del(M, slot_wear_mask))
 		M.autodrobe_no_remove = 1
 

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -134,7 +134,7 @@
 	default_accent = ACCENT_TTS
 	allowed_accents = list(ACCENT_TTS, ACCENT_ZORA, ACCENT_KLAX, ACCENT_CTHUR)
 
-	alterable_internal_organs = list(BP_HEART, BP_EYES, BP_LUNGS, BP_LIVER, BP_KIDNEYS, BP_STOMACH)
+	alterable_internal_organs = list(BP_HEART, BP_EYES, BP_LUNGS, BP_STOMACH)
 
 /datum/species/bug/before_equip(var/mob/living/carbon/human/H)
 	. = ..()

--- a/html/changelogs/desven-filter.yml
+++ b/html/changelogs/desven-filter.yml
@@ -1,0 +1,7 @@
+author: Desven
+
+delete-after: True
+
+changes:
+  - rscadd: "Vaurca can now select mechanical organs."
+  - tweak: "Vaurca now spawn with a filter port."


### PR DESCRIPTION
As it stands, there is no easy way to have the filter port override the breathing mask. The filter port is the number one filter choice for Vaurca players, and it's part of an annoying ritual when spawning to change masks, having to gasp for a few seconds. Now, Breeders already spawn with a filter port in their faces. This just allows the common bug to spawn with it too. I left the port at the loadout because you can still select it and rename it if you want to be a snowflake.

As for the organs, I reported this as a bug. It's an intended feature to allow Vaurcae to choose mechanical organs. I just decided I might as well add it to the same PR since I was already modifying the file. So fixes #12331 