### PR TITLE
Removes the infiltration suit from the antag uplink.

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -87,12 +87,6 @@
 	item_cost = 2
 	path = /obj/item/storage/box/syndie_kit/space
 
-/datum/uplink_item/item/tools/infiltration_kit
-	name = "Infiltration Kit"
-	desc = "A large infiltration case containing an undersuit, a mask, gloves, and shoes. It will protect you against the vacuum of space and two atmospheres of overpressure."
-	item_cost = 2
-	path = /obj/item/storage/toolbox/infiltration
-
 /datum/uplink_item/item/tools/thermal
 	name = "Thermal Imaging Glasses"
 	item_cost = 2

--- a/html/changelogs/mattatlas-noinfil.yml
+++ b/html/changelogs/mattatlas-noinfil.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Removed the infiltration case from the antag uplink."


### PR DESCRIPTION
The main reasoning for this is that it's far too strong with the merc heavy armor, whose sole drawback is supposed to be that it doesn't have pressure protection. The infiltration case allows you to completely bypass that for the meager price of two TC. Raising the TC price isn't possible either since it'll make it useless for traitors and still a really good buy for mercenaries. 