### PR TITLE
Addresses limb meta with a few balance changes.

### DIFF
--- a/code/__defines/armor.dm
+++ b/code/__defines/armor.dm
@@ -15,6 +15,7 @@
 
 #define  ARMOR_LASER_MINOR			10
 #define  ARMOR_LASER_SMALL			25
+#define  ARMOR_LASER_KEVLAR			30
 #define  ARMOR_LASER_PISTOL			35	//Minimum required to block e-pistols.
 #define  ARMOR_LASER_MEDIUM			40
 #define  ARMOR_LASER_RIFLE			45	//Minimum required to block las-rifles.
@@ -25,6 +26,7 @@
 #define  ARMOR_MELEE_MINOR			5
 #define  ARMOR_MELEE_SMALL			10
 #define  ARMOR_MELEE_KNIVES			15	//Blocks most knives
+#define  ARMOR_MELEE_KEVLAR			25
 #define  ARMOR_MELEE_RESISTANT		30	//Blocks large weapons like swords and toolboxes
 #define  ARMOR_MELEE_MAJOR			50
 #define  ARMOR_MELEE_VERY_HIGH		70

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -8,9 +8,9 @@
 		)
 	item_flags = THICKMATERIAL
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT,
+		melee = ARMOR_MELEE_KEVLAR,
 		bullet = ARMOR_BALLISTIC_MEDIUM,
-		laser = ARMOR_LASER_PISTOL,
+		laser = ARMOR_LASER_KEVLAR,
 		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_PADDED
 	)

--- a/code/modules/clothing/suits/modular_armor.dm
+++ b/code/modules/clothing/suits/modular_armor.dm
@@ -87,9 +87,9 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	w_class = ITEMSIZE_NORMAL
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES,
-		bullet = ARMOR_BALLISTIC_PISTOL,
-		laser = ARMOR_LASER_SMALL,
+		melee = ARMOR_MELEE_KEVLAR,
+		bullet = ARMOR_BALLISTIC_MEDIUM,
+		laser = ARMOR_LASER_KEVLAR,
 		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_PADDED
 	)

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -10,9 +10,9 @@
 	slot = ACCESSORY_SLOT_LEG_GUARDS
 	w_class = ITEMSIZE_NORMAL
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES,
-		bullet = ARMOR_BALLISTIC_PISTOL,
-		laser = ARMOR_LASER_SMALL,
+		melee = ARMOR_MELEE_KEVLAR,
+		bullet = ARMOR_BALLISTIC_MEDIUM,
+		laser = ARMOR_LASER_KEVLAR,
 		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_PADDED
 	)
@@ -114,11 +114,11 @@
 	slot = ACCESSORY_SLOT_ARM_GUARDS
 	body_parts_covered = HANDS|ARMS
 	armor = list(
-		melee = ARMOR_MELEE_MAJOR,
-		bullet = ARMOR_BALLISTIC_MINOR,
-		laser = ARMOR_LASER_MAJOR,
-		energy = ARMOR_ENERGY_MINOR,
-		bomb = ARMOR_BOMB_MINOR
+		melee = ARMOR_MELEE_KEVLAR,
+		bullet = ARMOR_BALLISTIC_MEDIUM,
+		laser = ARMOR_LASER_KEVLAR,
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_PADDED
 	)
 	w_class = ITEMSIZE_NORMAL
 	contained_sprite = TRUE

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -227,14 +227,14 @@ var/list/global/base_miss_chance = list(
 	BP_HEAD = 70,
 	BP_CHEST = 10,
 	BP_GROIN = 20,
-	BP_L_LEG = 20,
-	BP_R_LEG = 20,
-	BP_L_ARM = 30,
-	BP_R_ARM = 30,
-	BP_L_HAND = 50,
-	BP_R_HAND = 50,
-	BP_L_FOOT = 50,
-	BP_R_FOOT = 50
+	BP_L_LEG = 40,
+	BP_R_LEG = 40,
+	BP_L_ARM = 40,
+	BP_R_ARM = 40,
+	BP_L_HAND = 60,
+	BP_R_HAND = 60,
+	BP_L_FOOT = 60,
+	BP_R_FOOT = 60
 )
 
 //Used to weight organs when an organ is hit randomly (i.e. not a directed, aimed attack).

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -86,7 +86,7 @@
 	var/body_hair
 	var/painted = 0
 
-	var/maim_bonus = 0.75 //For special projectile gibbing calculation, dubbed "maiming"
+	var/maim_bonus = 0 //For special projectile gibbing calculation, dubbed "maiming"
 
 	var/list/genetic_markings         // Markings (body_markings) to apply to the icon
 	var/list/temporary_markings	// Same as above, but not preserved when cloning
@@ -403,12 +403,13 @@
 
 				if(isitem(used_weapon))
 					var/obj/item/W = used_weapon
+					var/dam_flags = W.damage_flags()
 					if(isprojectile(W))
 						var/obj/item/projectile/P = W
-						if(P.damage_flags & DAM_BULLET)
+						if(dam_flags & DAM_BULLET)
 							blunt_eligible = TRUE
 						maim_bonus += P.maim_rate
-					else if(W.w_class >= w_class && edge)
+					if(W.w_class >= w_class && (dam_flags & DAM_EDGE))
 						edge_eligible = TRUE
 
 				if(!blunt_eligible && edge_eligible && brute >= max_damage / (DROPLIMB_THRESHOLD_EDGE + maim_bonus))

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -53,7 +53,7 @@
 	limb_name = BP_L_ARM
 	name = "left arm"
 	icon_name = "l_arm"
-	max_damage = 50
+	max_damage = 75
 	min_broken_damage = 30
 	w_class = ITEMSIZE_NORMAL
 	body_part = ARM_LEFT
@@ -86,7 +86,7 @@
 	limb_name = BP_L_LEG
 	name = "left leg"
 	icon_name = "l_leg"
-	max_damage = 50
+	max_damage = 75
 	min_broken_damage = 30
 	w_class = ITEMSIZE_NORMAL
 	body_part = LEG_LEFT
@@ -119,7 +119,7 @@
 	limb_name = BP_L_FOOT
 	name = "left foot"
 	icon_name = "l_foot"
-	max_damage = 35
+	max_damage = 55
 	min_broken_damage = 15
 	w_class = ITEMSIZE_SMALL
 	body_part = FOOT_LEFT
@@ -129,7 +129,6 @@
 	amputation_point = "left ankle"
 	arterial_bleed_severity = 0.5
 	limb_flags = ORGAN_CAN_AMPUTATE | ORGAN_CAN_BREAK | ORGAN_CAN_MAIM | ORGAN_CAN_STAND
-	maim_bonus = 1
 	augment_limit = 1
 
 /obj/item/organ/external/foot/body_part_class()
@@ -157,7 +156,7 @@
 	limb_name = BP_L_HAND
 	name = "left hand"
 	icon_name = "l_hand"
-	max_damage = 35
+	max_damage = 55
 	min_broken_damage = 15
 	w_class = ITEMSIZE_SMALL
 	body_part = HAND_LEFT
@@ -167,7 +166,6 @@
 	amputation_point = "left wrist"
 	arterial_bleed_severity = 0.5
 	limb_flags = ORGAN_CAN_AMPUTATE | ORGAN_CAN_BREAK | ORGAN_CAN_MAIM | ORGAN_CAN_GRASP | ORGAN_HAS_TENDON
-	maim_bonus = 1
 	augment_limit = 1
 
 /obj/item/organ/external/hand/body_part_class()
@@ -202,7 +200,7 @@
 	limb_name = BP_HEAD
 	icon_name = "head"
 	name = BP_HEAD
-	max_damage = 75
+	max_damage = 125
 	min_broken_damage = 35
 	w_class = ITEMSIZE_NORMAL
 	body_part = HEAD | FACE

--- a/html/changelogs/mattatlas-limbmeta.yml
+++ b/html/changelogs/mattatlas-limbmeta.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Limbs now have higher delimb threshold."
+  - balance: "Increased the miss chance for arms, legs, hands and feet."
+  - balance: "Security's default armor is now slightly better overall. Revolvers do 27 damage instead of 40, while assault rifles retain most of their damage."
+  - bugfix: "Fixed some code that prevented melee delimbs under some circumstances."


### PR DESCRIPTION
- Security's default armor is buffed in all normal use cases. Revolvers will do 27 damage instead of 40. This is just enough to prevent instant delimbs and bone breaks while keeping revolvers a huge threat, especially when aiming for chest. ARs are unaffected.
- Limbs now take more damage to delimb in general.
- Increased miss chance for targeting limbs. It was admittedly too easy to hit and break bones in one or two hits, even disregarding delimbs (though they happened on the third hit).

Examples of how things will change: with default sec armor for all of these scenarios and aiming left leg, it takes at least 2 merc rifle bursts to delimb a leg. .45 pointblank delimbs are impossible with only one mag while aiming leg. Revolvers will take 5 or 6 hits to delimb at pointblank. Cult swords will delimb in six hits.