### PR TITLE
Allows quartermasters, cargo techs, and shaft miners to spawn with hard hats from the loadout.

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -130,17 +130,17 @@
 	gear_tweaks += new /datum/gear_tweak/path(hoshead)
 
 /datum/gear/head/hardhat
-	display_name = "hardhat selection"
+	display_name = "hard hat selection"
 	path = /obj/item/clothing/head/hardhat
-	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice")
+	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice", "Quartermaster", "Cargo Technician", "Shaft Miner")
 
 /datum/gear/head/hardhat/New()
 	..()
 	var/list/hardhat = list()
-	hardhat["hardhat, yellow"] = /obj/item/clothing/head/hardhat
-	hardhat["hardhat, blue"] = /obj/item/clothing/head/hardhat/dblue
-	hardhat["hardhat, orange"] = /obj/item/clothing/head/hardhat/orange
-	hardhat["hardhat, red"] = /obj/item/clothing/head/hardhat/red
+	hardhat["hard hat, yellow"] = /obj/item/clothing/head/hardhat
+	hardhat["hard hat, blue"] = /obj/item/clothing/head/hardhat/dblue
+	hardhat["hard hat, orange"] = /obj/item/clothing/head/hardhat/orange
+	hardhat["hard hat, red"] = /obj/item/clothing/head/hardhat/red
 	gear_tweaks += new /datum/gear_tweak/path(hardhat)
 
 /datum/gear/head/hairflower

--- a/html/changelogs/omicega-oshamoment.yml
+++ b/html/changelogs/omicega-oshamoment.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "The supply department can now spawn with hard hats from the loadout."


### PR DESCRIPTION
See title. The warehouse is one of the only places on the station with an actual, regular drop hazard, too.