### PR TITLE
Modifies some security loadouts for QOL.

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -36,6 +36,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	id = /obj/item/card/id/navy
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud/head
+	l_pocket = /obj/item/device/flash
 
 	headset = /obj/item/device/radio/headset/heads/hos
 	bowman = /obj/item/device/radio/headset/heads/hos/alt
@@ -47,7 +48,7 @@
 	tablet = /obj/item/modular_computer/handheld/preset/security/hos
 
 	backpack_contents = list(
-		/obj/item/storage/box/ids = 1
+		/obj/item/handcuffs = 1
 	)
 
 	implants = list(
@@ -112,7 +113,7 @@
 	messengerbag = /obj/item/storage/backpack/messenger/sec
 
 	backpack_contents = list(
-		/obj/item/storage/box/ids = 1
+		/obj/item/handcuffs = 1
 	)
 
 /datum/outfit/job/warden/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -626,7 +626,8 @@
 		/obj/item/reagent_containers/spray/pepper = 5,
 		/obj/item/storage/box/evidence = 6,
 		/obj/item/device/holowarrant = 5,
-		/obj/item/device/flashlight/maglight = 5
+		/obj/item/device/flashlight/maglight = 5,
+		/obj/item/device/hailer = 5
 	)
 	premium = list(
 		/obj/item/storage/box/fancy/donut = 2

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -123,6 +123,7 @@
 	..()
 	//Supply
 	new /obj/item/storage/box/flashbangs(src)
+	new /obj/item/storage/box/ids(src)
 	//Appearance
 	if(prob(50))
 		new /obj/item/storage/backpack/security(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -225,6 +225,8 @@
 	new	/obj/item/clothing/suit/storage/security/warden(src)
 	new /obj/item/clothing/accessory/badge/warden(src)
 	new /obj/item/clothing/gloves/black_leather(src)
+	new /obj/item/clothing/mask/gas/alt(src)
+	new /obj/item/clothing/mask/gas/half(src)
 	//Tools
 	new /obj/item/device/radio/headset/headset_warden(src)
 	new /obj/item/device/radio/headset/headset_warden/alt(src)
@@ -234,6 +236,8 @@
 	new /obj/item/reagent_containers/spray/pepper(src)
 	new /obj/item/melee/baton/loaded(src)
 	new /obj/item/gun/energy/disruptorpistol(src)
+	new /obj/item/handcuffs(src)
+	new /obj/item/device/holowarrant(src)
 	//Belts
 	new /obj/item/clothing/accessory/storage/black_vest(src)
 	new /obj/item/clothing/accessory/holster/waist(src)

--- a/html/changelogs/omicega-fdsfdsfdsfdsdsdfs.yml
+++ b/html/changelogs/omicega-fdsfdsfdsfdsdsdfs.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Added hailers to the SecTech vendor."
-  - tweak: "Tweaked some security loadouts for quality of life, mostly the HoS and warden's."
+  - tweak: "Tweaked some security roundstart equipment and locker equipment for quality of life, mostly the HoS and warden's."

--- a/html/changelogs/omicega-fdsfdsfdsfdsdsdfs.yml
+++ b/html/changelogs/omicega-fdsfdsfdsfdsdsdfs.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Added hailers to the SecTech vendor."
+  - tweak: "Tweaked some security loadouts for quality of life, mostly the HoS and warden's."


### PR DESCRIPTION
See title. Details are as follows:

- HoS now spawns with a flash in their left pocket, like regular officers do. They also get a pair of cuffs in their backpack.
- HoS roundstart box of IDs in backpack moved to their locker.
- Warden's roundstart box of IDs in backpack removed, since they already had one in their locker, and they really don't need two.
- Warden's locker now gets handcuffs, a warrant projector, and both types of officer gas mask.
- SecTech now has hailers in it, if for some ungodly reason security ever runs out and/or needs more.

All of this stuff was already available to every job that got it, either from the armoury or elsewhere -- except hailers, which were technically limited, but it's not like they matter anyway.