### PR TITLE
Nerfs Zeng-Hu Mobility Frames and removes them from Security, makes IPCs use more charge when running.

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -26,7 +26,7 @@
 	minimal_player_age = 14
 	outfit = /datum/outfit/job/hos
 
-	blacklisted_species = list(SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA_ZHAN, SPECIES_DIONA, SPECIES_IPC_G2, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR)
+	blacklisted_species = list(SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA_ZHAN, SPECIES_DIONA, SPECIES_IPC_G2, SPECIES_IPC_ZENGHU, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR)
 
 /datum/outfit/job/hos
 	name = "Head of Security"
@@ -87,6 +87,7 @@
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory, access_external_airlocks, access_weapons)
 	minimal_player_age = 7
 	outfit = /datum/outfit/job/warden
+	blacklisted_species = list(SPECIES_IPC_ZENGHU)
 
 /datum/outfit/job/warden
 	name = "Warden"
@@ -142,6 +143,7 @@
 	minimal_access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_weapons)
 	minimal_player_age = 3
 	outfit = /datum/outfit/job/forensics
+	blacklisted_species = list(SPECIES_IPC_ZENGHU)
 
 /datum/outfit/job/forensics
 	name = "Investigator"
@@ -195,6 +197,7 @@
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_external_airlocks, access_weapons)
 	minimal_player_age = 7
 	outfit = /datum/outfit/job/officer
+	blacklisted_species = list(SPECIES_IPC_ZENGHU)
 
 /datum/outfit/job/officer
 	name = "Security Officer"
@@ -245,6 +248,7 @@
 	minimal_access = list(access_security, access_sec_doors)
 	outfit = /datum/outfit/job/intern_sec
 	minimum_character_age = 18
+	blacklisted_species = list(SPECIES_IPC_ZENGHU)
 
 /datum/outfit/job/intern_sec
 	name = "Security Cadet"

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
@@ -111,6 +111,7 @@
 		)
 	stamina = -1	// Machines use power and generate heat, stamina is not a thing
 	sprint_speed_factor = 1  // About as capable of speed as a human
+	sprint_cost_factor = 1.5
 
 	max_hydration_factor = -1
 	max_nutrition_factor = -1
@@ -127,15 +128,21 @@
 
 	// Special snowflake machine vars.
 	var/sprint_temperature_factor = 1.15
-	var/sprint_charge_factor = 0.65
+	var/move_charge_factor = 1
 
 /datum/species/machine/handle_post_spawn(var/mob/living/carbon/human/H)
 	. = ..()
 	check_tag(H, H.client)
+	var/obj/item/organ/internal/cell/C = H.internal_organs_by_name[BP_CELL]
+	if(C)
+		C.move_charge_factor = move_charge_factor
 
 /datum/species/machine/handle_sprint_cost(var/mob/living/carbon/human/H, var/cost, var/pre_move)
 	if(!pre_move && H.stat == CONSCIOUS)
 		H.bodytemperature += cost * sprint_temperature_factor
+	var/obj/item/organ/internal/cell/C = H.internal_organs_by_name[BP_CELL]
+	if(C)
+		C.use(cost * sprint_cost_factor)
 	return TRUE
 
 /datum/species/machine/handle_emp_act(mob/living/carbon/human/H, var/severity)

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -432,7 +432,7 @@
 	brute_mod = 1.5
 
 	slowdown = -0.8
-	sprint_speed_factor = 1.5
+	sprint_speed_factor = 0.6
 	sprint_cost_factor = 2
 	move_charge_factor = 2
 

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -64,7 +64,7 @@
 	character_color_presets = list("Dark" = "#000000", "Warm" = "#250302", "Cold" = "#1e1e29")
 
 	sprint_temperature_factor = 1.3
-	sprint_charge_factor = 0.85
+	move_charge_factor = 0.85
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/self_diagnostics,
@@ -175,7 +175,7 @@
 
 	sprint_speed_factor = 1.4
 	sprint_temperature_factor = 0.9
-	sprint_charge_factor = 1.1
+	move_charge_factor = 1.1
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/self_diagnostics,
@@ -279,10 +279,11 @@
 		)
 	stamina	= -1
 	sprint_speed_factor = 1.25
+	sprint_cost_factor = 1
 	slowdown = 1
 
 	sprint_temperature_factor = 0.6
-	sprint_charge_factor = 0.3
+	move_charge_factor = 0.3
 
 /datum/species/machine/terminator/get_light_color()
 	return
@@ -428,16 +429,19 @@
 	preview_icon = 'icons/mob/human_races/ipc/ind_zenghu_preview.dmi'
 
 	eyes = "zenghu_eyes"
-	brute_mod = 1.5
-	sprint_speed_factor = 1.5
+	brute_mod = 1.3
+	burn_mod = 1.3
+
+	slowdown = -0.8
+	sprint_speed_factor = 0.55
+	sprint_cost_factor = 2
+	move_charge_factor = 2
 
 	grab_mod = 1.1 // Smooth, fast
 	resist_mod = 4 // Not super strong, but still rather strong
 
 	allowed_accents = list(ACCENT_CETI, ACCENT_GIBSON, ACCENT_SOL, ACCENT_COC, ACCENT_ERIDANI, ACCENT_ERIDANIDREG, ACCENT_ELYRA, ACCENT_KONYAN, ACCENT_JUPITER, ACCENT_MARTIAN, ACCENT_LUNA,
 							ACCENT_HIMEO, ACCENT_VENUS, ACCENT_VENUSJIN, ACCENT_PHONG, ACCENT_SILVERSUN_EXPATRIATE, ACCENT_TTS, ACCENT_EUROPA, ACCENT_EARTH, ACCENT_ASSUNZIONE)
-
-	slowdown = -1.2
 
 	appearance_flags = HAS_EYE_COLOR | HAS_UNDERWEAR | HAS_SOCKS
 
@@ -480,7 +484,6 @@
 
 	eyes = "bishop_eyes"
 	eyes_icon_blend = ICON_MULTIPLY
-	sprint_charge_factor = 0.25
 
 	brute_mod = 1.2
 	grab_mod = 1.1

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -429,11 +429,10 @@
 	preview_icon = 'icons/mob/human_races/ipc/ind_zenghu_preview.dmi'
 
 	eyes = "zenghu_eyes"
-	brute_mod = 1.3
-	burn_mod = 1.3
+	brute_mod = 1.5
 
 	slowdown = -0.8
-	sprint_speed_factor = 0.55
+	sprint_speed_factor = 1.5
 	sprint_cost_factor = 2
 	move_charge_factor = 2
 

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -68,6 +68,7 @@
 	relative_size = 80
 	var/open = FALSE
 	var/obj/item/cell/cell = /obj/item/cell/super
+	var/move_charge_factor = 1
 	//at 0.8 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
 	var/servo_cost = 0.8
 
@@ -102,6 +103,7 @@
 	var/cost = get_power_drain()
 	if(world.time - owner.l_move_time < 15)
 		cost *= 2
+	cost *= move_charge_factor
 	use(cost)
 
 /obj/item/organ/internal/cell/proc/get_power_drain()

--- a/html/changelogs/mattatlas-zenghunerf.yml
+++ b/html/changelogs/mattatlas-zenghunerf.yml
@@ -38,8 +38,8 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Zeng-Hu Mobility Frames are now much slower. Their actual speed is now on par with an M'sai Tajara, both sprinting and moving normally."
-  - tweak: "Zeng-Hu Mobility Frames now take 1.3x as much brute instead of 1.5x, but also take 1.3x as much burn damage instead of 1x as much."
+  - tweak: "Zeng-Hu Mobility Frames are now slower when running. Their actual speed is now on par with an M'sai Tajara when moving normally."
   - balance: "All IPCs now use additional power when sprinting. This is about 10 units of charge."
   - balance: "Zeng-Hu Mobility Frames use twice as much power for sprinting."
   - balance: "Zeng-Hu Mobility Frames use twice as much power when moving normally."
+  - rscdel: "Zeng-Hu Mobility Frames may no longer be played in security roles."

--- a/html/changelogs/mattatlas-zenghunerf.yml
+++ b/html/changelogs/mattatlas-zenghunerf.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Zeng-Hu Mobility Frames are now much slower. Their actual speed is now on par with an M'sai Tajara, both sprinting and moving normally."
+  - tweak: "Zeng-Hu Mobility Frames now take 1.3x as much brute instead of 1.5x, but also take 1.3x as much burn damage instead of 1x as much."
+  - balance: "All IPCs now use additional power when sprinting. This is about 10 units of charge."
+  - balance: "Zeng-Hu Mobility Frames use twice as much power for sprinting."
+  - balance: "Zeng-Hu Mobility Frames use twice as much power when moving normally."


### PR DESCRIPTION
Zeng-Hus are completely busted right now. I'm sure everyone knows why: they walk faster than a running M'sai. This is no bueno, so they have to be knocked down a peg, especially considering that they have other robot attributes such as de-facto immortality and no pain at all.

I also re-instated some defunct variables that controlled movement charge usage ratios for IPCs to make Zeng-Hus use more charge when running. This translated into IPCs using more charge when running too, which I am fine with. It's just 10 units out of a 20000 power cell.