### PR TITLE
Adds Citizenship and Religion to the Agent ID

### DIFF
--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -64,6 +64,8 @@
 	entries[++entries.len] = list("name" = "Name", 				"value" = registered_name)
 	entries[++entries.len] = list("name" = "Photo", 			"value" = "Update")
 	entries[++entries.len] = list("name" = "Sex", 				"value" = sex)
+	entries[++entries.len] = list("name" = "Citizenship",		"value" = citizenship)
+	entries[++entries.len] = list("name" = "Religion",			"value" = religion)
 	entries[++entries.len] = list("name" = "Factory Reset",		"value" = "Use With Care")
 	data["electronic_warfare"] = electronic_warfare
 	data["entries"] = entries
@@ -214,6 +216,18 @@
 					src.sex = new_sex
 					to_chat(user, "<span class='notice'>Sex changed to '[new_sex]'.</span>")
 					. = 1
+			if("Citizenship")
+				var/new_citizenship = sanitize(input(user,"Which citizenship would you like to put on this card?","Agent Card Citizenship", citizenship) as null|text)
+				if(!isnull(new_citizenship) && CanUseTopic(user,state))
+					src.citizenship = new_citizenship
+					to_chat(user, "<span class='notice'>Citizenship changed to '[new_citizenship]'.</span>")
+					. = 1
+			if("Religion")
+				var/new_religion = sanitize(input(user,"What religion would you like to put on this card?","Agent Card Religion", religion) as null|text)
+				if(!isnull(new_religion) && CanUseTopic(user,state))
+					src.religion = new_religion
+					to_chat(user, "<span class='notice'>Religion changed to '[new_religion]'.</span>")
+					. = 1
 			if("Factory Reset")
 				if(alert("This will factory reset the card, including access and owner. Continue?", "Factory Reset", "No", "Yes") == "Yes" && CanUseTopic(user, state))
 					age = initial(age)
@@ -228,6 +242,8 @@
 					registered_name = initial(registered_name)
 					unset_registered_user()
 					sex = initial(sex)
+					citizenship = initial(citizenship)
+					religion = initial(religion)
 					to_chat(user, "<span class='notice'>All information has been deleted from \the [src].</span>")
 					. = 1
 

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -234,6 +234,7 @@
 					access = syndicate_access.Copy()
 					assignment = initial(assignment)
 					blood_type = initial(blood_type)
+					citizenship = initial(citizenship)
 					dna_hash = initial(dna_hash)
 					electronic_warfare = initial(electronic_warfare)
 					fingerprint_hash = initial(fingerprint_hash)
@@ -241,9 +242,8 @@
 					name = initial(name)
 					registered_name = initial(registered_name)
 					unset_registered_user()
-					sex = initial(sex)
-					citizenship = initial(citizenship)
 					religion = initial(religion)
+					sex = initial(sex)
 					to_chat(user, "<span class='notice'>All information has been deleted from \the [src].</span>")
 					. = 1
 

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -220,7 +220,7 @@
 				var/new_citizenship = sanitize(input(user,"Which citizenship would you like to put on this card?","Agent Card Citizenship", citizenship) as null|text)
 				if(!isnull(new_citizenship) && CanUseTopic(user,state))
 					src.citizenship = new_citizenship
-					to_chat(user, "<span class='notice'>Citizenship changed to '[new_citizenship]'.</span>")
+					to_chat(user, SPAN_NOTICE("Citizenship changed to '[new_citizenship]'."))
 					. = 1
 			if("Religion")
 				var/new_religion = sanitize(input(user,"What religion would you like to put on this card?","Agent Card Religion", religion) as null|text)

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -226,7 +226,7 @@
 				var/new_religion = sanitize(input(user,"What religion would you like to put on this card?","Agent Card Religion", religion) as null|text)
 				if(!isnull(new_religion) && CanUseTopic(user,state))
 					src.religion = new_religion
-					to_chat(user, "<span class='notice'>Religion changed to '[new_religion]'.</span>")
+					to_chat(user, SPAN_NOTICE("Religion changed to '[new_religion]'."))
 					. = 1
 			if("Factory Reset")
 				if(alert("This will factory reset the card, including access and owner. Continue?", "Factory Reset", "No", "Yes") == "Yes" && CanUseTopic(user, state))

--- a/html/changelogs/desven-citizenshipid.yml
+++ b/html/changelogs/desven-citizenshipid.yml
@@ -1,0 +1,4 @@
+author: Desven
+delete-after: True
+changes:
+  - rscadd: "Added religion and nationality to the agent ID card."


### PR DESCRIPTION
Now you can change them on the agent ID, as per forum request.

Pictured: nationality change (before religion was added too)
![imagen](https://user-images.githubusercontent.com/45808369/130362721-cbc29e3e-3a06-4263-a1fd-4ca903ab171d.png)
![imagen](https://user-images.githubusercontent.com/45808369/130362724-b4bae831-88a0-4701-8359-faa92f712f89.png)

