### PR TITLE
Fixed a missing material definition for easels causing them to be dismantled into a steel plate.

### DIFF
--- a/code/game/objects/items/easel.dm
+++ b/code/game/objects/items/easel.dm
@@ -6,10 +6,13 @@
 	density = TRUE
 	build_amt = 5
 	var/obj/item/canvas/painting = null
+	var/easel_material = MATERIAL_WOOD
 
 /obj/structure/easel/Initialize(ml, _mat, _reinf_mat)
 	. = ..()
 	moved_event.register(src, src, /obj/structure/easel/proc/move_painting)
+	material = SSmaterials.get_material_by_name(easel_material)
+
 
 /obj/structure/easel/Destroy()
 	painting = null

--- a/html/changelogs/EaselMaterial.yml
+++ b/html/changelogs/EaselMaterial.yml
@@ -1,0 +1,7 @@
+author: CodePanter
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - bugfix: "Fixed a missing material definition for easels causing them to be dismantled into a steel plate."


### PR DESCRIPTION
The easel definition did not specifiy the material, so when dismantle() is used (which is triggered by using a wrench), the get_material() functions returns nothing, therefore going with the DEFAULT_WALL_MATERIAL, which is steel.