### PR TITLE
Inductive Charger Fix

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -477,6 +477,9 @@
 		results += 2
 	return results
 
+/obj/machinery/power/apc/get_cell()
+	return cell
+
 //attack with an item - open/close cover, insert cell, or (un)lock interface
 
 /obj/machinery/power/apc/attackby(obj/item/W, mob/user)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -12,6 +12,9 @@
 	charge = 0
 	update_icon()
 
+/obj/item/cell/get_cell()
+	return src
+
 /obj/item/cell/drain_power(var/drain_check, var/surge, var/power = 0)
 
 	if(drain_check)

--- a/html/changelogs/geeves-inducer_fix.yml
+++ b/html/changelogs/geeves-inducer_fix.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes:
   - bugfix: "Inductive chargers now properly report when they don't find a cell to charge."
   - rscadd: "Using an inductive charger on a power cell or an APC will now properly charge it."
+  - bugfix: "You can no longer line up multiple inductive chargers by spamclicking the target."

--- a/html/changelogs/geeves-inducer_fix.yml
+++ b/html/changelogs/geeves-inducer_fix.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Inductive chargers now properly report when they don't find a cell to charge."
+  - rscadd: "Using an inductive charger on a power cell or an APC will now properly charge it."


### PR DESCRIPTION
* Inductive chargers now properly report when they don't find a cell to charge.
* Using an inductive charger on a power cell or an APC will now properly charge it.
* You can no longer line up multiple inductive chargers by spamclicking the target.