### PR TITLE
Sets the default bite size/transfer amount on all utensils to be the minimum.

### DIFF
--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -23,7 +23,7 @@
 	var/loaded      //Descriptive string for currently loaded food object.
 	var/is_liquid = FALSE //whether you've got liquid on your utensil
 	var/scoop_food = 1
-	var/transfer_amt = 5
+	var/transfer_amt = 1
 	var/list/bite_sizes = list(1,2,3,4,5)
 
 /obj/item/material/kitchen/utensil/Initialize(newloc, material_key)

--- a/html/changelogs/omicega-biterrewrfesfsof.yml
+++ b/html/changelogs/omicega-biterrewrfesfsof.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Changed the default transfer amount/bite size on all utensils to be 1 instead of 5. No more spooning up an entire bowl of soup in one click by default."


### PR DESCRIPTION
See title. I got sick of spooning up my entire bowl of soup in one click. Bite size can still be adjusted via a verb tied to each of these objects -- it just now starts at the minimum by default, rather than the maximum.