### PR TITLE
Makes kois lunchbox products vaurca only

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_xeno/vaurca.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/vaurca.dm
@@ -129,3 +129,22 @@
 	language_processors["K'laxan [LANGUAGE_UNATHI] language processor"] = /obj/item/organ/internal/augment/language/klax
 	language_processors["C'thur [LANGUAGE_SKRELLIAN] language processor"] = /obj/item/organ/internal/augment/language/cthur
 	gear_tweaks += new /datum/gear_tweak/path(language_processors)
+
+/datum/gear/vaurca_lunchbox
+	display_name = "vaurca lunchbox"
+	description = "A lunchbox selection containing various kois products."
+	cost = 2
+	path = /obj/item/storage/toolbox/lunchbox
+	sort_category = "Xenowear - Vaurca"
+	whitelisted = list(SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR)
+
+/datum/gear/vaurca_lunchbox/New()
+	..()
+	var/list/lunchboxes = list()
+	for(var/lunchbox_type in typesof(/obj/item/storage/toolbox/lunchbox))
+		var/obj/item/storage/toolbox/lunchbox/lunchbox = lunchbox_type
+		if(!initial(lunchbox.filled))
+			lunchboxes[initial(lunchbox.name)] = lunchbox_type
+	sortTim(lunchboxes, /proc/cmp_text_asc)
+	gear_tweaks += new /datum/gear_tweak/path(lunchboxes)
+	gear_tweaks += new /datum/gear_tweak/contents(lunchables_vaurca(), lunchables_vaurca_snack(), lunchables_drinks(), lunchables_utensil())

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -11,8 +11,6 @@ var/list/lunchables_lunches_ = list(
 	/obj/item/reagent_containers/food/snacks/liquidfood,
 	/obj/item/reagent_containers/food/snacks/jellysandwich/cherry,
 	/obj/item/reagent_containers/food/snacks/salad/tossedsalad,
-	/obj/item/reagent_containers/food/snacks/koiswaffles,
-	/obj/item/reagent_containers/food/snacks/koisburger,
 	/obj/item/reagent_containers/food/snacks/funnelcake,
 	/obj/item/reagent_containers/food/snacks/hotdog,
 	/obj/item/reagent_containers/food/snacks/tajaran_bread,
@@ -47,8 +45,6 @@ var/list/lunchables_snacks_ = list(
 	/obj/item/reagent_containers/food/snacks/cakeslice/apple/filled,
 	/obj/item/reagent_containers/food/snacks/pumpkinpieslice/filled,
 	/obj/item/reagent_containers/food/snacks/skrellsnacks,
-	/obj/item/reagent_containers/food/snacks/friedkois,
-	/obj/item/reagent_containers/food/snacks/donut/kois,
 	/obj/item/reagent_containers/food/snacks/meatsnack,
 	/obj/item/reagent_containers/food/snacks/maps,
 	/obj/item/reagent_containers/food/snacks/nathisnack,
@@ -79,6 +75,20 @@ var/list/lunchables_drinks_ = list(
 	/obj/item/reagent_containers/food/drinks/small_milk,
 	/obj/item/reagent_containers/food/drinks/small_milk_choco,
 	/obj/item/reagent_containers/food/drinks/small_milk_strawberry
+)
+
+var/list/lunchables_vaurca_ = list(
+	/obj/item/reagent_containers/food/snacks/koiswaffles,
+	/obj/item/reagent_containers/food/snacks/koisburger,
+	/obj/item/reagent_containers/food/snacks/soup/kois,
+	/obj/item/reagent_containers/food/snacks/koissteak
+)
+
+var/list/lunchables_vaurca_snack_ = list(
+	/obj/item/reagent_containers/food/snacks/donut/kois,
+	/obj/item/reagent_containers/food/snacks/koiskebab3,
+	/obj/item/reagent_containers/food/snacks/friedkois,
+	/obj/item/reagent_containers/food/snacks/koismuffin
 )
 
 var/list/lunchables_utensil_ = list(
@@ -122,6 +132,16 @@ var/list/lunchables_alcohol_reagents_ = list(
 	if(!(lunchables_lunches_[lunchables_lunches_[1]]))
 		lunchables_lunches_ = init_lunchable_list(lunchables_lunches_)
 	return lunchables_lunches_
+
+/proc/lunchables_vaurca()
+	if(!(lunchables_vaurca_[lunchables_vaurca_[1]]))
+		lunchables_vaurca_ = init_lunchable_list(lunchables_vaurca_)
+	return lunchables_vaurca_
+
+/proc/lunchables_vaurca_snack()
+	if(!(lunchables_vaurca_snack_[lunchables_vaurca_snack_[1]]))
+		lunchables_vaurca_snack_ = init_lunchable_list(lunchables_vaurca_snack_)
+	return lunchables_vaurca_snack_
 
 /proc/lunchables_snacks()
 	if(!(lunchables_snacks_[lunchables_snacks_[1]]))

--- a/html/changelogs/VaurcaLunch.yml
+++ b/html/changelogs/VaurcaLunch.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Kois products were removed from the ordinary lunchbox and instead added to a new vaurca specific one listed under the vaurca xenowear tab in the loadout."


### PR DESCRIPTION
To prevent random crewmen from setting their lunchbox to random and then dying to kois, all kois products have been moved to a new lunchbox type under the vaurca xenowear tab in the loadout. 