### PR TITLE
adds an upper player limit to solo techno in secret

### DIFF
--- a/code/game/gamemodes/technomancer/technomancer.dm
+++ b/code/game/gamemodes/technomancer/technomancer.dm
@@ -7,6 +7,7 @@
 	their powers can be used for good or if their arrival foreshadows the destruction of the entire colony, or worse."
 	config_tag = "technomancer"
 	votable = 1
+	max_players = 15
 	required_players = 5
 	required_enemies = 1
 	end_on_antag_death = 0

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - tweak: "Technomancer can no longer be the sole antagonist in  secret if there is more than 15 players readied."


### PR DESCRIPTION
On request, the solo technomancer option in secret now has an upper limit of 15 readied players. This should not affect multi-antag modes.