### PR TITLE
Journal Tweaks

### DIFF
--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -80,10 +80,14 @@
 				usr.put_in_hands(P)
 				handle_post_remove()
 		else if(href_list["write"])
-			var/obj/item/paper/P = locate(href_list["write"])
-			var/obj/item/I = usr.get_inactive_hand()
-			if(P && I && (P.loc == src) && istype(P) && I.ispen())
-				P.attackby(I, usr)
+			var/obj/item/paper/paper = locate(href_list["write"])
+			if(!istype(paper) || paper.loc != src)
+				return
+			var/obj/item/pen = usr.get_inactive_hand()
+			if(!pen || !pen.ispen())
+				pen = usr.get_active_hand()
+			if(pen?.ispen())
+				paper.attackby(pen, usr)
 		else if(href_list["read"])
 			var/obj/item/paper/P = locate(href_list["read"])
 			if(P && (P.loc == src) && istype(P))
@@ -141,7 +145,7 @@
 	can_write = TRUE
 
 /obj/item/folder/embedded/loc_check(var/atom/A)
-	if(loc.loc == A)
+	if(loc.loc.Adjacent(A))
 		return TRUE
 	return FALSE
 

--- a/code/modules/paperwork/journal.dm
+++ b/code/modules/paperwork/journal.dm
@@ -36,8 +36,8 @@
 	if(closed_desc)
 		desc = open ? initial(desc) + closed_desc : initial(desc)
 
-/obj/item/journal/CtrlClick(mob/user)
-	if(loc == user)
+/obj/item/journal/AltClick(mob/user)
+	if(Adjacent(user))
 		open = !open
 		to_chat(user, SPAN_NOTICE("You [open ? "open" : "close"] \the [src]."))
 		update_icon()
@@ -74,9 +74,16 @@
 		if(!E)
 			return
 		user.drop_from_inventory(I, E)
-		to_chat(user, SPAN_NOTICE("You put \the [I] into \the [E]."))
+		to_chat(user, SPAN_NOTICE("You put \the [I] into \the [E] index in \the [src]."))
 		update_icon()
 		return
+	if(I.ispen())
+		if(!open)
+			to_chat(user, SPAN_NOTICE("You open \the [src] with \the [I]."))
+			open = !open
+			update_icon()
+			return
+		attack_self(user)
 
 /obj/item/journal/proc/generate_index(var/mob/user)
 	var/obj/item/folder/embedded/E = new /obj/item/folder/embedded(src)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -122,13 +122,20 @@
 	set category = "Object"
 	set src in usr
 
+	if(use_check_and_message(usr, USE_ALLOW_NON_ADJACENT))
+		return
+
 	if((usr.is_clumsy()) && prob(50))
 		to_chat(usr, SPAN_WARNING("You cut yourself on the paper."))
 		return
-	var/n_name = sanitizeSafe(input(usr, "What would you like to label the paper?", "Paper Labelling", null) as text, MAX_NAME_LEN)
 
-	// We check loc one level up, so we can rename in clipboards and such. See also: /obj/item/photo/rename()
-	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0)
+	var/n_name = sanitizeSafe(input(usr, "What would you like to label the paper?", "Paper Labelling", null) as text, MAX_NAME_LEN)
+	
+	if(use_check_and_message(usr, USE_ALLOW_NON_ADJACENT))
+		return
+
+	var/atom/surface_atom = recursive_loc_turf_check(src, 3, usr)
+	if(surface_atom == usr || surface_atom.Adjacent(usr))
 		if(n_name)
 			name = "[initial(name)] ([n_name])"
 		else

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -73,15 +73,21 @@ var/global/photo_count = 0
 	set category = "Object"
 	set src in usr
 
+	if(use_check_and_message(usr, USE_ALLOW_NON_ADJACENT))
+		return
+
 	var/n_name = sanitizeSafe(input(usr, "What would you like to label the photo?", "Photo Labelling", null)  as text, MAX_NAME_LEN)
-	//loc.loc check is for making possible renaming photos in clipboards
-	if(((loc == usr || (loc.loc && loc.loc == usr)) && usr.stat == 0))
+
+	if(use_check_and_message(usr, USE_ALLOW_NON_ADJACENT))
+		return
+
+	var/atom/surface_atom = recursive_loc_turf_check(src, 3, usr)
+	if(surface_atom == usr || surface_atom.Adjacent(usr))
 		if(n_name)
 			name = "[initial(name)] ([n_name])"
 		else
-			name = initial(n_name)
-	add_fingerprint(usr)
-	return
+			name = initial(name)
+		add_fingerprint(usr)
 
 
 /**************


### PR DESCRIPTION
Some tweaks for a journal custom item:
* Fixes naming papers.
* Allows writing with the active and off-hand.
* Clicking a journal with a pen opens it and interacts with it if it's open.
* You now alt-click to open a journal, rather than ctrl-clicking.
* Paper stacks now work inside journals.
* Several journal interactions now work if you're adjacent to it.