### PR TITLE
No-Handed humans can no longer strip people

### DIFF
--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -9,9 +9,9 @@
 	if(ishuman(user))
 		// If you're a human and don't have hands, you shouldn't be able to strip someone.
 		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/r_hand = H.organs_by_name[BP_L_HAND]
-		var/obj/item/organ/external/l_hand = H.organs_by_name[BP_R_HAND]
-		if((l_hand && !l_hand.is_usable()) && (r_hand && !r_hand.is_usable()))
+		var/obj/item/organ/external/l_hand = H.get_organ(BP_L_HAND)
+		var/obj/item/organ/external/r_hand = H.get_organ(BP_R_HAND)
+		if(!(l_hand && l_hand.is_usable()) && !(r_hand && r_hand.is_usable()))
 			to_chat(user, SPAN_WARNING("You can't do that without working hands!"))
 			return FALSE
 

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -6,6 +6,15 @@
 		user << browse(null, text("window=mob[src.name]"))
 		return FALSE
 
+	if(ishuman(user))
+		// If you're a human and don't have hands, you shouldn't be able to strip someone.
+		var/mob/living/carbon/human/H = user
+		var/obj/item/organ/external/r_hand = H.organs_by_name[BP_L_HAND]
+		var/obj/item/organ/external/l_hand = H.organs_by_name[BP_R_HAND]
+		if((l_hand && !l_hand.is_usable()) && (r_hand && !r_hand.is_usable()))
+			to_chat(user, SPAN_WARNING("You can't do that without working hands!"))
+			return FALSE
+
 	var/obj/item/target_slot = get_equipped_item(text2num(slot_to_strip))
 	if(istype(target_slot, /obj/item/clothing/ears/offear))
 		target_slot = (l_ear == target_slot ? r_ear : l_ear)

--- a/html/changelogs/Shadow Quill-PR-12414.yml
+++ b/html/changelogs/Shadow Quill-PR-12414.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Shadow Quill
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Human mobs can no longer use the strip panel if they don't have working hands."


### PR DESCRIPTION
As per title.
tldr; humans can no longer interact with the strip panel if they don't have the hands to do so.
Fixes #12408 