### PR TITLE
Trims the spawn-in job gear for first responders

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -246,13 +246,8 @@
 	jobtype = /datum/job/med_tech
 
 	uniform = /obj/item/clothing/under/rank/medical/first_responder
-	suit = /obj/item/clothing/suit/storage/toggle/first_responder_jacket
 	shoes = /obj/item/clothing/shoes/jackboots
 	id = /obj/item/card/id/white
-	head = /obj/item/clothing/head/hardhat/first_responder
-	l_hand = /obj/item/storage/firstaid/adv
-	r_hand = /obj/item/reagent_containers/hypospray
-	belt = /obj/item/storage/belt/medical/first_responder
 	
 	headset = /obj/item/device/radio/headset/headset_med
 	bowman = /obj/item/device/radio/headset/headset_med/alt
@@ -267,6 +262,10 @@
 	satchel = /obj/item/storage/backpack/satchel_med
 	dufflebag = /obj/item/storage/backpack/duffel/med
 	messengerbag = /obj/item/storage/backpack/messenger/med
+
+	backpack_contents = list(
+		/obj/item/storage/firstaid/adv = 1
+	)
 
 /datum/job/intern_med
 	title = "Medical Intern"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -124,6 +124,7 @@
 	new /obj/item/clothing/mask/gas/alt(src)
 	new /obj/item/clothing/mask/gas/half(src)
 	new /obj/item/auto_cpr(src)
+	new /obj/item/clothing/suit/storage/toggle/first_responder_jacket(src)
 
 /obj/structure/closet/secure_closet/CMO
 	name = "chief medical officer's locker"

--- a/html/changelogs/omicega-respondermoment.yml
+++ b/html/changelogs/omicega-respondermoment.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Moved some first responder equipment (hypospray, helmet etc) from the roundstart spawn gear list into their locker instead."


### PR DESCRIPTION
See title. I'm removing the hypospray, jacket, helmet and belt they get on spawn -- they have one of each of these in their lockers already, except for the jacket, which I moved in there as well for consistency. The advanced FAK they spawn with now goes in their backpack by default, rather than just appearing in their hands.

I can't think of any other jobs that spawned in essentially fully geared (pretty much every other job with a belt I can think of has to actually go and get the belt, except for engineers?), and I definitely can't think of any others that spawned with their hands full of basic gear ready to go. Now they gear up at their locker a bit more, just like everyone else.