### PR TITLE
AIs can once again toggle turrets on/off (as well as lethality)

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -148,7 +148,7 @@
 	return 1
 
 /obj/machinery/turretid/AICtrlClick() //turns off/on Turrets
-	Topic(src, list("command"="enable", "value"="[!enabled]"))
+	Topic(src, list("turret_ref" = "this", "command"="enable", "value"="[!enabled]"))
 	return 1
 
 /atom/proc/AIAltClick(var/atom/A)
@@ -164,7 +164,7 @@
 	return 1
 
 /obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
-	Topic(src, list("command"="lethal", "value"="[!lethal]"))
+	Topic(src, list("turret_ref" = "this", "command"="lethal", "value"="[!lethal]"))
 	return 1
 
 /atom/proc/AIMiddleClick(var/mob/living/silicon/user)

--- a/html/changelogs/Shadow Quill - AI TurretControl Clickage.yml
+++ b/html/changelogs/Shadow Quill - AI TurretControl Clickage.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Shadow Quill
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "AIs can control turret controllers with hotkeys again. (Ctrl+Click toggles activeness, Alt+Click toggles lethality)"


### PR DESCRIPTION
Two years ago when the turret controllers were updated, it slightly changed the topic.
This allows AIs to control turret power/lethality from the control panels again.

Ctrl+Click = Power Toggle
Alt+Click = Lethal Toggle

Fixes #12238 

### IC changelog
`Due to an old firmware patch, Artificial Intelligence were rendered unable to use so-called 'Quick Commands' to interface with turret controllers. The issue has been patched in the most recent update.`