### PR TITLE
Faster oxygen loss decay, liver damage nerf.

### DIFF
--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -45,7 +45,8 @@
 		filter_effect += 1
 
 	if(filter_effect < 2) //Trouble. You're not filtering well.
-		owner.adjustToxLoss(0.5 * max(2 - filter_effect, 0))
+		if(owner.intoxication > 0)
+			owner.adjustToxLoss(0.5 * max(2 - filter_effect, 0))
 
 	// Heal a bit if needed and we're not busy. This allows recovery from low amounts of toxloss.
 	if(!owner.total_radiation && damage > 0)

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -266,11 +266,6 @@
 		owner.failed_last_breath = 1
 	else
 		owner.failed_last_breath = 0
-		if(owner.disabilities & ASTHMA)
-			owner.adjustOxyLoss(rand(-5,0))
-		else
-			owner.adjustOxyLoss(-5)
-
 
 	// Hot air hurts :(
 	handle_temperature_effects(breath)
@@ -284,6 +279,10 @@
 	else
 		last_successful_breath = world.time
 		owner.oxygen_alert = 0
+		if(owner.disabilities & ASTHMA)
+			owner.adjustOxyLoss(rand(-5,0) * inhale_efficiency)
+		else
+			owner.adjustOxyLoss(-5 * inhale_efficiency)
 		if(!BP_IS_ROBOTIC(src) && species.breathing_sound && is_below_sound_pressure(get_turf(owner)))
 			if(breathing || owner.shock_stage >= 10)
 				sound_to(owner, sound(species.breathing_sound,0,0,0,5))

--- a/html/changelogs/mattatlas-brainmedstuff.yml
+++ b/html/changelogs/mattatlas-brainmedstuff.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "The liver now only deals toxin damage to the rest of your body if you're intoxicated."
+  - tweak: "Increased the speed at which oxygen loss decays."


### PR DESCRIPTION
- Oxygen loss decay is now faster and depends on inhale efficiency. This should mean that people's blood oxygenation rises faster after having the oxygen whacked out of them.
- A damaged liver now only deals toxin damage if the person is intoxicated.