### PR TITLE
Splits the integrated HUD sensors augment into an integrated security HUD and integrated medical HUD augment.

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_augments.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_augments.dm
@@ -9,11 +9,18 @@
 	flags = GEAR_NO_SELECTION
 
 /datum/gear/augment/eye_sensors
-	display_name = "integrated eye sensors"
+	display_name = "integrated eye sensors selection"
 	description = "An eye augment that allows the user to deploy medical or security sensors."
 	path = /obj/item/organ/internal/augment/eye_sensors
-	cost = 3
+	cost = 1
 	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI, SPECIES_UNATHI, SPECIES_SKRELL, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR)
+
+/datum/gear/augment/eye_sensors/New()
+	..()
+	var/list/sensors = list()
+	sensors["eye sensors, security"] = /obj/item/organ/internal/augment/eye_sensors
+	sensors["eye sensors, medical"] = /obj/item/organ/internal/augment/eye_sensors/medical
+	gear_tweaks += new /datum/gear_tweak/path(sensors)
 
 /datum/gear/augment/cyber_hair
 	display_name = "synthetic hair extensions"

--- a/code/modules/client/preference_setup/loadout/loadout_augments.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_augments.dm
@@ -18,7 +18,7 @@
 /datum/gear/augment/eye_sensors/New()
 	..()
 	var/list/sensors = list()
-	sensors["eye sensors, security"] = /obj/item/organ/internal/augment/eye_sensors
+	sensors["eye sensors, security"] = /obj/item/organ/internal/augment/eye_sensors/security
 	sensors["eye sensors, medical"] = /obj/item/organ/internal/augment/eye_sensors/medical
 	gear_tweaks += new /datum/gear_tweak/path(sensors)
 

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -229,7 +229,8 @@
 
 	var/static/list/hud_types = list(
 		"Disabled",
-		SEC_HUDTYPE)
+		SEC_HUDTYPE,
+		MED_HUDTYPE)
 
 	var/selected_hud = "Disabled"
 
@@ -276,10 +277,6 @@
 /obj/item/organ/internal/augment/eye_sensors/medical
 	name = "integrated medical HUD sensors"
 	action_button_name = "Toggle Medical Sensors"
-
-	hud_types = list(
-		"Disabled",
-		MED_HUDTYPE)
 
 /obj/item/organ/internal/augment/eye_sensors/medical/attack_self(var/mob/user)
 	. = ..()

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -242,9 +242,10 @@
 
 	if(selected_hud == "Disabled")
 		selected_hud = SEC_HUDTYPE
-
+		to_chat(user, "You activate \the [src].")
 	else
 		selected_hud = "Disabled"
+		to_chat(user, "You deactivate \the [src].")
 
 /obj/item/organ/internal/augment/eye_sensors/process()
 	..()
@@ -259,10 +260,8 @@
 			if(allowed(owner))
 				active_hud = "security"
 				process_sec_hud(owner, 1)
-				to_chat(user, "You activate \the [src].")
 			else
 				active_hud = "disabled"
-				to_chat(user, "You deactivate \the [src].")
 		else
 			active_hud = "disabled"
 
@@ -288,9 +287,10 @@
 
 	if(selected_hud == "Disabled")
 		selected_hud = MED_HUDTYPE
-
+		to_chat(user, "You activate \the [src].")
 	else
 		selected_hud = "Disabled"
+		to_chat(user, "You deactivate \the [src].")
 
 /obj/item/organ/internal/augment/eye_sensors/medical/process()
 	..()
@@ -305,10 +305,8 @@
 			if(allowed(owner))
 				active_hud = "medical"
 				process_med_hud(owner, 1)
-				to_chat(user, "You activate \the [src].")
 			else
 				active_hud = "disabled"
-				to_chat(user, "You deactivate \the [src].")
 		else
 			active_hud = "disabled"
 

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -234,18 +234,20 @@
 
 	var/selected_hud = "Disabled"
 
-/obj/item/organ/internal/augment/eye_sensors/attack_self(var/mob/user)
+/obj/item/organ/internal/augment/eye_sensors/attack_self(var/mob/user, var/call_only_parent = FALSE)
 	. = ..()
 
-	if(!.)
-		return FALSE
+	if(!call_only_parent)
+		
+		if(!.)
+			return FALSE
 
-	if(selected_hud == "Disabled")
-		selected_hud = SEC_HUDTYPE
-		to_chat(user, "You activate \the [src].")
-	else
-		selected_hud = "Disabled"
-		to_chat(user, "You deactivate \the [src].")
+		if(selected_hud == "Disabled")
+			selected_hud = SEC_HUDTYPE
+			to_chat(user, "You activate \the [src].")
+		else
+			selected_hud = "Disabled"
+			to_chat(user, "You deactivate \the [src].")
 
 /obj/item/organ/internal/augment/eye_sensors/process()
 	..()
@@ -279,7 +281,7 @@
 	name = "integrated medical HUD sensors"
 	action_button_name = "Toggle Medical Sensors"
 
-/obj/item/organ/internal/augment/eye_sensors/medical/attack_self(var/mob/user)
+/obj/item/organ/internal/augment/eye_sensors/medical/attack_self(var/mob/user, var call_only_parent = TRUE)
 	. = ..()
 
 	if(!.)

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -277,7 +277,7 @@
 	name = "integrated medical HUD sensors"
 	action_button_name = "Toggle Medical Sensors"
 
-	var/static/list/hud_types = list(
+	hud_types = list(
 		"Disabled",
 		MED_HUDTYPE)
 

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -218,19 +218,18 @@
 	tesla_zap(owner, 7, 1500)
 
 /obj/item/organ/internal/augment/eye_sensors
-	name = "integrated eye sensors"
+	name = "integrated security HUD sensors"
 	icon_state = "augment_eyes"
 	cooldown = 25
 	activable = TRUE
 	organ_tag = BP_AUG_EYE_SENSORS
 	parent_organ = BP_HEAD
-	action_button_name = "Toggle Eye Sensors"
+	action_button_name = "Toggle Security Sensors"
 	var/active_hud = "disabled"
 
 	var/static/list/hud_types = list(
 		"Disabled",
-		SEC_HUDTYPE,
-		MED_HUDTYPE)
+		SEC_HUDTYPE)
 
 	var/selected_hud = "Disabled"
 
@@ -240,9 +239,11 @@
 	if(!.)
 		return FALSE
 
-	var/choice = input("Select the Sensor Type.", "Bionic Eyes Sensors") as null|anything in capitalize_list(hud_types)
+	if(selected_hud == "Disabled")
+		selected_hud = SEC_HUDTYPE
 
-	selected_hud = lowertext(choice)
+	else
+		selected_hud = "disabled"
 
 /obj/item/organ/internal/augment/eye_sensors/process()
 	..()
@@ -259,15 +260,6 @@
 				process_sec_hud(owner, 1)
 			else
 				active_hud = "disabled"
-
-		if(MED_HUDTYPE)
-			req_access = list(access_medical)
-			if(allowed(owner))
-				active_hud = "medical"
-				process_med_hud(owner, 1)
-			else
-				active_hud = "disabled"
-
 		else
 			active_hud = "disabled"
 
@@ -280,6 +272,44 @@
 
 /obj/item/organ/internal/augment/eye_sensors/proc/check_hud(var/hud)
 	return (hud == active_hud)
+
+/obj/item/organ/internal/augment/eye_sensors/medical
+	name = "integrated medical HUD sensors"
+	action_button_name = "Toggle Medical Sensors"
+
+	var/static/list/hud_types = list(
+		"Disabled",
+		MED_HUDTYPE)
+
+/obj/item/organ/internal/augment/eye_sensors/medical/attack_self(var/mob/user)
+	. = ..()
+
+	if(!.)
+		return FALSE
+
+	if(selected_hud == "Disabled")
+		selected_hud = MED_HUDTYPE
+
+	else
+		selected_hud = "disabled"
+
+/obj/item/organ/internal/augment/eye_sensors/medical/process()
+	..()
+
+	if(!owner)
+		return
+
+	switch(selected_hud)
+
+		if(MED_HUDTYPE)
+			req_access = list(access_medical)
+			if(allowed(owner))
+				active_hud = "medical"
+				process_med_hud(owner, 1)
+			else
+				active_hud = "disabled"
+		else
+			active_hud = "disabled"
 
 /obj/item/organ/internal/augment/cyber_hair
 	name = "synthetic hair extensions"

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -281,7 +281,7 @@
 	name = "integrated medical HUD sensors"
 	action_button_name = "Toggle Medical Sensors"
 
-/obj/item/organ/internal/augment/eye_sensors/medical/attack_self(var/mob/user, var call_only_parent = TRUE)
+/obj/item/organ/internal/augment/eye_sensors/medical/attack_self(var/mob/user, var/call_only_parent = TRUE)
 	. = ..()
 
 	if(!.)

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -244,7 +244,7 @@
 		selected_hud = SEC_HUDTYPE
 
 	else
-		selected_hud = "disabled"
+		selected_hud = "Disabled"
 
 /obj/item/organ/internal/augment/eye_sensors/process()
 	..()
@@ -259,8 +259,10 @@
 			if(allowed(owner))
 				active_hud = "security"
 				process_sec_hud(owner, 1)
+				to_chat(user, "You activate \the [src].")
 			else
 				active_hud = "disabled"
+				to_chat(user, "You deactivate \the [src].")
 		else
 			active_hud = "disabled"
 
@@ -288,7 +290,7 @@
 		selected_hud = MED_HUDTYPE
 
 	else
-		selected_hud = "disabled"
+		selected_hud = "Disabled"
 
 /obj/item/organ/internal/augment/eye_sensors/medical/process()
 	..()
@@ -303,8 +305,10 @@
 			if(allowed(owner))
 				active_hud = "medical"
 				process_med_hud(owner, 1)
+				to_chat(user, "You activate \the [src].")
 			else
 				active_hud = "disabled"
+				to_chat(user, "You deactivate \the [src].")
 		else
 			active_hud = "disabled"
 

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -218,7 +218,7 @@
 	tesla_zap(owner, 7, 1500)
 
 /obj/item/organ/internal/augment/eye_sensors
-	name = "integrated security HUD sensors"
+	name = "integrated HUD sensors"
 	icon_state = "augment_eyes"
 	cooldown = 25
 	activable = TRUE
@@ -228,32 +228,50 @@
 	var/active_hud = "disabled"
 
 	var/static/list/hud_types = list(
-		"Disabled",
+		"disabled",
 		SEC_HUDTYPE,
 		MED_HUDTYPE)
 
-	var/selected_hud = "Disabled"
+	var/selected_hud = "disabled"
 
-/obj/item/organ/internal/augment/eye_sensors/attack_self(var/mob/user, var/call_only_parent = FALSE)
+/obj/item/organ/internal/augment/eye_sensors/attack_self(var/mob/user)
 	. = ..()
 
-	if(!call_only_parent)
-		
 		if(!.)
 			return FALSE
-
-		if(selected_hud == "Disabled")
-			selected_hud = SEC_HUDTYPE
-			to_chat(user, "You activate \the [src].")
-		else
-			selected_hud = "Disabled"
-			to_chat(user, "You deactivate \the [src].")
 
 /obj/item/organ/internal/augment/eye_sensors/process()
 	..()
 
 	if(!owner)
 		return
+
+/obj/item/organ/internal/augment/eye_sensors/emp_act(severity)
+	..()
+	var/obj/item/organ/internal/eyes/E = owner.get_eyes()
+	if(!E)
+		return
+	E.take_damage(5)
+
+/obj/item/organ/internal/augment/eye_sensors/proc/check_hud(var/hud)
+	return (hud == active_hud)
+
+/obj/item/organ/internal/augment/eye_sensors/security
+	name = "integrated security HUD sensors"
+	action_button_name = "Toggle Security Sensors"
+
+/obj/item/organ/internal/augment/eye_sensors/security/attack_self(var/mob/user)
+	. = ..()
+
+		if(selected_hud == "disabled")
+			selected_hud = SEC_HUDTYPE
+			to_chat(user, "You activate \the [src].")
+		else
+			selected_hud = "disabled"
+			to_chat(user, "You deactivate \the [src].")
+
+/obj/item/organ/internal/augment/eye_sensors/security/process()
+	..()
 
 	switch(selected_hud)
 
@@ -266,39 +284,22 @@
 				active_hud = "disabled"
 		else
 			active_hud = "disabled"
-
-/obj/item/organ/internal/augment/eye_sensors/emp_act(severity)
-	..()
-	var/obj/item/organ/internal/eyes/E = owner.get_eyes()
-	if(!E)
-		return
-	E.take_damage(5)
-
-/obj/item/organ/internal/augment/eye_sensors/proc/check_hud(var/hud)
-	return (hud == active_hud)
-
 /obj/item/organ/internal/augment/eye_sensors/medical
 	name = "integrated medical HUD sensors"
 	action_button_name = "Toggle Medical Sensors"
 
-/obj/item/organ/internal/augment/eye_sensors/medical/attack_self(var/mob/user, var/call_only_parent = TRUE)
+/obj/item/organ/internal/augment/eye_sensors/medical/attack_self(var/mob/user)
 	. = ..()
 
-	if(!.)
-		return FALSE
-
-	if(selected_hud == "Disabled")
+	if(selected_hud == "disabled")
 		selected_hud = MED_HUDTYPE
 		to_chat(user, "You activate \the [src].")
 	else
-		selected_hud = "Disabled"
+		selected_hud = "disabled"
 		to_chat(user, "You deactivate \the [src].")
 
 /obj/item/organ/internal/augment/eye_sensors/medical/process()
 	..()
-
-	if(!owner)
-		return
 
 	switch(selected_hud)
 

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -237,8 +237,8 @@
 /obj/item/organ/internal/augment/eye_sensors/attack_self(var/mob/user)
 	. = ..()
 
-		if(!.)
-			return FALSE
+	if(!.)
+		return FALSE
 
 /obj/item/organ/internal/augment/eye_sensors/process()
 	..()
@@ -263,12 +263,12 @@
 /obj/item/organ/internal/augment/eye_sensors/security/attack_self(var/mob/user)
 	. = ..()
 
-		if(selected_hud == "disabled")
-			selected_hud = SEC_HUDTYPE
-			to_chat(user, "You activate \the [src].")
-		else
-			selected_hud = "disabled"
-			to_chat(user, "You deactivate \the [src].")
+	if(selected_hud == "disabled")
+		selected_hud = SEC_HUDTYPE
+		to_chat(user, "You activate \the [src].")
+	else
+		selected_hud = "disabled"
+		to_chat(user, "You deactivate \the [src].")
 
 /obj/item/organ/internal/augment/eye_sensors/security/process()
 	..()

--- a/html/changelogs/omicega-fdsfsdfdsfgdsfg432423.yml
+++ b/html/changelogs/omicega-fdsfsdfdsfgdsfg432423.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Split the integrated HUD sensors augment into an integrated security HUD and integrated medical HUD. Reduced loadout cost accordingly."


### PR DESCRIPTION
See title. Loadout cost for the augments dropped from 3 to 1 to compensate. You couldn't use both augments at once, anyway, _and_ they're restricted via ID access as well, so the old functionality of having both in one was useless except for perhaps heads of staff, who have super limited use for the security HUD in particular anyway.