### PR TITLE
Adjusts Plasma Pistol and Bolter 

### DIFF
--- a/code/modules/projectiles/guns/projectile/plasma.dm
+++ b/code/modules/projectiles/guns/projectile/plasma.dm
@@ -55,7 +55,7 @@
 	item_state = "plasma"
 	magazine_type = /obj/item/ammo_magazine/plasma/light/pistol
 	allowed_magazines = list(/obj/item/ammo_magazine/plasma/light/pistol)
-	slot_flags = SLOT_BELT
+	slot_flags = SLOT_BELT | SLOT_HOLSTER
 	accuracy = 1
 
 /obj/item/gun/projectile/plasma/bolter/pistol/update_icon()

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -279,7 +279,7 @@
 	name = "plasma bolt"
 	damage = 20
 	armor_penetration = 10
-	incinerate = 10
+	incinerate = 8
 
 /obj/item/missile
 	icon = 'icons/obj/grenade.dmi'

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -277,9 +277,9 @@
 
 /obj/item/projectile/plasma/light
 	name = "plasma bolt"
-	damage = 10
+	damage = 20
 	armor_penetration = 10
-	incinerate = 5
+	incinerate = 10
 
 /obj/item/missile
 	icon = 'icons/obj/grenade.dmi'

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Connorjg1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Plasma Pistol can now be holstered."
+  - balance: "Plasma Bolts now do more damage and should no longer be less useful then traditonal projectiles."

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Plasma Pistol can now be holstered."
-  - balance: "Plasma Bolts now do more damage and should no longer be less useful then traditonal projectiles."
+  - balance: "Plasma Bolts now do more damage and should no longer be less useful then traditional projectiles."


### PR DESCRIPTION
First pull request. I'm still learning Gitkraken. Send help. 

-Plasma Pistol can now be holstered like other pistols
-Plasma Bolts the ammunition used in the Plasma Rifle and the Plasma Pistol have been buffed. It now does 20 damage with 8 incinerate.

Previously they did 10 damage with 5 incinerate. After extensive testing it was not difficult to conclude this made the Plasma Pistol significantly worse then the other projectile pistols currently in the game as well an energy weapons such as the energy pistol. The only advantage it has is the armor piercing which whilst useful is not enough to make up for such lackluster damage. An incinerate of 5 only did an extremely small amount of fire damage over long periods of time and 10 damage gives it much less stopping power then the energy pistol despite the larger magazine.

Testing done with these stats puts it more on par with the other pistols.