### PR TITLE
Slicing up and Removing Underplating Without an RFD-C

### DIFF
--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -114,20 +114,21 @@
 			var/obj/item/weldingtool/welder = C
 			if(welder.isOn() && (is_plating()))
 				if(broken || burnt)
-					if(welder.remove_fuel(0, user))
-						to_chat(user, "<span class='notice'>You fix some dents on the broken plating.</span>")
-						playsound(src, 'sound/items/Welder.ogg', 80, 1)
-						icon_state = "plating"
-						burnt = null
-						broken = null
-					else
-						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
-					return
+					if(do_after(user, 5 SECONDS))
+						if(welder.remove_fuel(0, user))
+							to_chat(user, "<span class='notice'>You fix some dents on the broken plating.</span>")
+							playsound(src, 'sound/items/Welder.ogg', 80, 1)
+							icon_state = "plating"
+							burnt = null
+							broken = null
+						else
+							to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
+						return
 				else
 					if(welder.remove_fuel(0, user))
 						playsound(src, 'sound/items/Welder.ogg', 80, 1)
 						visible_message("<span class='notice'>[user] has started melting the plating's reinforcements!</span>")
-						if(do_after(user, 15 SECONDS) && welder.isOn() && welder_melt())
+						if(do_after(user, 10 SECONDS) && welder.isOn() && welder_melt())
 							visible_message("<span class='warning'>[user] has melted the plating's reinforcements! It should be possible to pry it off.</span>")
 							playsound(src, 'sound/items/Welder.ogg', 80, 1)
 					return

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -106,8 +106,6 @@
 					playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
 					if(T)
 						T.visible_message("<span class='danger'>The ceiling above has been pried off!</span>")
-			else
-				to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 				return
 			return
 		else if(C.iswelder())

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -87,19 +87,56 @@
 				update_icon(TRUE)
 				playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
 				return
-		// Repairs.
+		// Repairs and deconstruction
+		else if(C.iscrowbar())
+			if(broken || burnt)
+				playsound(src, 'sound/items/crowbar_tile.ogg', 80, 1)
+				visible_message("<span class='notice'>[user] has begun prying off the damaged plating.</span>")
+				var/turf/T = GetBelow(src)
+				if(T)
+					T.visible_message("<span class='warning'>The ceiling above looks as if it's being pried off.</span>")
+				if(do_after(user, 10 SECONDS))
+					if(!istype(src, /turf/simulated/floor))
+						return
+					if(broken || burnt && !(is_plating()))
+						return
+					visible_message("<span class='warning'>[user] has pried off the damaged plating.</span>")
+					new /obj/item/stack/tile/floor(src)
+					src.ReplaceWithLattice()
+					playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
+					if(T)
+						T.visible_message("<span class='danger'>The ceiling above has been pried off!</span>")
+			else
+				to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
+				return
+			return
 		else if(C.iswelder())
 			var/obj/item/weldingtool/welder = C
 			if(welder.isOn() && (is_plating()))
 				if(broken || burnt)
-					if(welder.remove_fuel(0,user))
+					if(welder.remove_fuel(0, user))
 						to_chat(user, "<span class='notice'>You fix some dents on the broken plating.</span>")
-						playsound(src, 'sound/items/welder.ogg', 80, 1)
+						playsound(src, 'sound/items/Welder.ogg', 80, 1)
 						icon_state = "plating"
 						burnt = null
 						broken = null
-					else
-						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
+					return
+				else
+					if(welder.remove_fuel(0, user))
+						playsound(src, 'sound/items/Welder.ogg', 80, 1)
+						visible_message("<span class='notice'>[user] has started melting the plating's reinforcements!</span>")
+						if(do_after(user, 15 SECONDS) && welder.isOn() && welder_melt())
+							visible_message("<span class='warning'>[user] has melted the plating's reinforcements! It should be possible to pry it off.</span>")
+							playsound(src, 'sound/items/Welder.ogg', 80, 1)
+					return
+	return ..()
+
+/turf/simulated/floor/proc/welder_melt()
+	if(!(is_plating()) || broken || burnt)
+		return 0
+	burnt = 1
+	update_icon()
+	return 1
 
 /turf/simulated/floor/can_lay_cable()
 	return !flooring

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -120,6 +120,8 @@
 						icon_state = "plating"
 						burnt = null
 						broken = null
+					else
+						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 					return
 				else
 					if(welder.remove_fuel(0, user))

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -369,7 +369,7 @@
 	desc = "A sleek canvas trenchcoat"
 	icon_state = "trenchcoat_green"
 	item_state = "trenchcoat_green"
-
+ 
 /obj/item/clothing/suit/storage/toggle/trench/colorable
 	name = "trenchcoat"
 	desc = "A sleek canvas trenchcoat"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -369,7 +369,7 @@
 	desc = "A sleek canvas trenchcoat"
 	icon_state = "trenchcoat_green"
 	item_state = "trenchcoat_green"
- 
+
 /obj/item/clothing/suit/storage/toggle/trench/colorable
 	name = "trenchcoat"
 	desc = "A sleek canvas trenchcoat"

--- a/html/changelogs/wickedcybs_floorslice.yml
+++ b/html/changelogs/wickedcybs_floorslice.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - rscadd: "RFD-C's are no longer the sole means of removing floor underplating. You can now weaken it with a welder and pry it off with a crowbar."


### PR DESCRIPTION
At the moment the only way to totally removing underplating is with a an exosuit drill (very fast) or an RFD (also fast). This PR adds another way to do this, and that is by slicing the floor plating with a welder and then lifting the damaged plating off with a crowbar. This will leave a lattice in its place and expose whatever was underneath. This is mostly a straight port from bay with a few things changed around so issues don't happen, so I'm sure some changes might be required, but it seemed to go well on my end.

I think from a balancing perspective, this might be seen badly because it's going to allow venting more easily and such on station, but this opens up a lot of avenues for renovations and general gameplay. It's also pretty cool on a ship based setting, where assumedly, things are going to actually be above and below each other whereas on Aurora "above and below" is just space due to how the station is designed.

![1ihSeptember2021Greatdane](https://user-images.githubusercontent.com/52309324/132179346-e1be555a-2d67-4ea6-a977-74ca31e4c562.gif)
