### PR TITLE
RFD-C's Can Now Build Flooring on Open Space

### DIFF
--- a/code/game/objects/items/weapons/RFD.dm
+++ b/code/game/objects/items/weapons/RFD.dm
@@ -211,6 +211,10 @@ RFD Construction-Class
 			build_cost =  1
 			build_type =  "floor"
 			build_atom =  /turf/simulated/floor/airless
+		else if(istype(T, /turf/simulated/open))
+			build_cost =  1
+			build_type =  "floor"
+			build_atom =  /turf/simulated/floor/airless
 		else if(istype(T, /turf/simulated/floor))
 			build_delay = 20
 			build_cost =  3

--- a/html/changelogs/wickedcybs_RFDspace.yml
+++ b/html/changelogs/wickedcybs_RFDspace.yml
@@ -1,6 +1,6 @@
 author: WickedCybs
 
 delete-after: True
-.
+
 changes:
   - bugfix: "RFDs can now build flooring on open spaces."

--- a/html/changelogs/wickedcybs_RFDspace.yml
+++ b/html/changelogs/wickedcybs_RFDspace.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+.
+changes:
+  - bugfix: "RFD's can now build flooring on open spaces."

--- a/html/changelogs/wickedcybs_RFDspace.yml
+++ b/html/changelogs/wickedcybs_RFDspace.yml
@@ -3,4 +3,4 @@ author: WickedCybs
 delete-after: True
 .
 changes:
-  - bugfix: "RFD's can now build flooring on open spaces."
+  - bugfix: "RFDs can now build flooring on open spaces."


### PR DESCRIPTION
I noticed after the PR that made it so rocky ash isn't under EVERY floor tile, that you couldn't really build floor easily with an RFD anymore. RFD-C's when on the floor & wall setting could make floors on space and asteroid turfs, but not _open spaces._ This PR fixes that.

Code works though I'm not sure if it could be condensed. 

 