### PR TITLE
Tesla Spine Price Reduction

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_xeno/tajara.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/tajara.dm
@@ -247,7 +247,7 @@
 	display_name = "tesla spine"
 	description = "A People's Republic of Adhomai made tesla spine issued to disabled veterans and civilians."
 	path = /obj/item/organ/internal/augment/tesla
-	cost = 4
+	cost = 2
 	whitelisted = list(SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI)
 	sort_category = "Xenowear - Tajara"
 

--- a/html/changelogs/wickedcybs_tesla.yml
+++ b/html/changelogs/wickedcybs_tesla.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The tesla spine cost has been reduced from four loadout points to two."


### PR DESCRIPTION
The Tesla spine cost in the loadout has been reduced from four to two. Four was kind of expensive and made it hard to choose other things. The only mechanical advantage it has is that it will negate a shock every five or ten minutes if you touch something electrified.

