### PR TITLE
Kills spesscafe

### DIFF
--- a/code/modules/reagents/dispenser/coffeebeans.dm
+++ b/code/modules/reagents/dispenser/coffeebeans.dm
@@ -1,7 +1,7 @@
 /obj/item/reagent_containers/chem_disp_cartridge/espresso
-	name = "A jar of Coffee Beans "
+	name = "jar of coffee beans"
 	desc = "This goes into a coffee maker!"
-	label = "Spesscafe Dark Blend"
+	label = "Ganymede Dark Blend"
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = "coffeejar"
 
@@ -13,4 +13,3 @@
 	unacidable = 1
 
 	spawn_reagent = /decl/reagent/drink/coffee/espresso
-

--- a/html/changelogs/geeves-killspesscafe_redux.yml
+++ b/html/changelogs/geeves-killspesscafe_redux.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Spesscafe Dark Blend has been renamed to Ganymede Dark Blend, additionally the reagent container's name has been changed to 'jar of coffee beans.'"


### PR DESCRIPTION
* Spesscafe Dark Blend has been renamed to Ganymede Dark Blend, additionally the reagent container's name has been changed to 'jar of coffee beans.'