### PR TITLE
Amputation Confirmation

### DIFF
--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -296,7 +296,9 @@
 			to_chat(user, SPAN_WARNING("The blades aren't spinning, you can't cut anything!"))
 			return FALSE
 
-	return (affected.limb_flags & ORGAN_CAN_AMPUTATE)
+	if(affected.limb_flags & ORGAN_CAN_AMPUTATE)
+		var/confirmation = alert("You are about to amputate [target]'s [affected.name]! Are you sure you want to do that?", "Amputation confirmation", "Yes", "No")
+		return confirmation == "Yes"
 
 /decl/surgery_step/amputate/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/html/changelogs/nerocavalier-ptsd.yml
+++ b/html/changelogs/nerocavalier-ptsd.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: NeroCavalier
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "There's a confirmation box for amputations. You must click yes to continue with the amputation."


### PR DESCRIPTION
* Adds a confirmation box for amputations. Note: You're going to violently saw them when you say no so it's currently better to drop the saw.
* [Example](https://imgur.com/a/2t9JrqH)