### PR TITLE
More pain adjustments, siemens nerfs.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -914,7 +914,7 @@
 		)
 	name = "under"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	permeability_coefficient = 0.90
+	permeability_coefficient = 0.9
 	slot_flags = SLOT_ICLOTHING
 	armor = null
 	w_class = ITEMSIZE_NORMAL

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -19,7 +19,7 @@
 	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = HEAD
 	max_heat_protection_temperature = HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.5
+	siemens_coefficient = 0.75
 	w_class = ITEMSIZE_NORMAL
 	var/obj/machinery/camera/camera
 	var/allow_hair_covering = TRUE //in case if you want to allow someone to switch the BLOCKHEADHAIR var from the helmet or not
@@ -100,7 +100,7 @@
 		melee = ARMOR_MELEE_VERY_HIGH,
 		bullet = ARMOR_BALLISTIC_MINOR
 		)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.75
 	flags_inv = HIDEEARS
 	action_button_name = "Toggle Visor"
 
@@ -152,7 +152,7 @@
 		laser = ARMOR_LASER_SMALL,
 		bomb = ARMOR_BOMB_PADDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.75
 
 /obj/item/clothing/head/helmet/merc
 	name = "combat helmet"
@@ -169,7 +169,7 @@
 		energy = ARMOR_ENERGY_RESISTANT,
 		bomb = ARMOR_BOMB_PADDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/merc/scc
 	name = "heavy SCC helmet"
@@ -192,7 +192,7 @@
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.1
+	siemens_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/swat/peacekeeper
 	name = "\improper ERT civil protection helmet"
@@ -256,7 +256,7 @@
 		energy = ARMOR_ENERGY_RESISTANT,
 		bomb = ARMOR_BOMB_PADDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.6
 
 
 /obj/item/clothing/head/helmet/augment
@@ -274,7 +274,6 @@
 	body_parts_covered = HEAD|EYES
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.1
 
 /obj/item/clothing/head/helmet/iachelmet
 	name = "IAC helmet"
@@ -303,7 +302,7 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.75
 
 /obj/item/clothing/head/helmet/unathi/hegemony
 	name = "hegemony helmet"
@@ -334,7 +333,7 @@
 		bomb = ARMOR_BOMB_PADDED,
 		rad = ARMOR_RAD_RESISTANT
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.6
 
 /obj/item/clothing/head/helmet/tank
 	name = "padded cap"
@@ -345,7 +344,6 @@
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES
 	)
-	siemens_coefficient = 0.75
 
 /obj/item/clothing/head/helmet/tank/olive
 	color = "#727c58"
@@ -372,7 +370,7 @@
 		energy = ARMOR_ENERGY_RESISTANT,
 		bomb = ARMOR_BIO_MINOR
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.5
 
 //Commander
 /obj/item/clothing/head/helmet/ert/command
@@ -410,7 +408,7 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.5
 	sprite_sheets = list(
 		"Tajara" = 'icons/mob/species/tajaran/helmet.dmi',
 		"Unathi" = 'icons/mob/species/unathi/helmet.dmi',

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -64,7 +64,7 @@
 		laser = ARMOR_LASER_SMALL,
 		energy = ARMOR_ENERGY_MINOR
 	)
-	siemens_coefficient = 0.75
+	siemens_coefficient = 0.9
 
 /obj/item/clothing/head/det/grey
 	icon_state = "grey_fedora"

--- a/code/modules/clothing/head/pilot_helmet.dm
+++ b/code/modules/clothing/head/pilot_helmet.dm
@@ -13,7 +13,7 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.75
 	action_button_name = "Flip Pilot Visor"
 
 	var/flipped_up = FALSE

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -32,7 +32,7 @@
 		bio = ARMOR_BIO_MINOR
 	)
 	item_flags = NOSLIP
-	siemens_coefficient = 0.5
+	siemens_coefficient = 0.6
 	can_hold_knife = TRUE
 	build_from_parts = TRUE
 
@@ -55,7 +55,7 @@
 		bio = ARMOR_BIO_MINOR
 	)
 	item_flags = NOSLIP
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.6
 	can_hold_knife = TRUE
 	build_from_parts = TRUE
 

--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -13,7 +13,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 	)
-	siemens_coefficient = 0.1
 	emp_protection = -20
 	slowdown = 6
 	offline_slowdown = 10
@@ -125,7 +124,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 	)
-	siemens_coefficient = 0.1
 	vision_restriction = 0
 	slowdown = 2
 	offline_slowdown = 3

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -14,7 +14,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 	)
-	siemens_coefficient = 0.1
 	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
 
@@ -55,7 +54,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 	)
-	siemens_coefficient = 0.1
 	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword,/obj/item/handcuffs)
@@ -182,7 +180,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 	)
-	siemens_coefficient = 0.1
 	offline_slowdown = 2
 	offline_vision_restriction = TINT_HEAVY
 
@@ -231,7 +228,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	siemens_coefficient = 0.1
 	offline_slowdown = 2
 	offline_vision_restriction = TINT_HEAVY
 
@@ -299,7 +295,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	siemens_coefficient = 0.1
 	offline_slowdown = 2
 	offline_vision_restriction = TINT_HEAVY
 

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -22,7 +22,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	siemens_coefficient = 0.1
 	allowed = list(
 	/obj/item/device/flashlight, /obj/item/tank, /obj/item/device/t_scanner, /obj/item/rfd/construction, /obj/item/crowbar, \
 	/obj/item/screwdriver, /obj/item/weldingtool, /obj/item/wirecutters, /obj/item/wrench, /obj/item/device/multitool, \

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -19,7 +19,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
-	siemens_coefficient = 0.1
 	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
 	emp_protection = 30
@@ -84,7 +83,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
-	siemens_coefficient = 0.1
 	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
 	emp_protection = 20

--- a/code/modules/clothing/spacesuits/rig/suits/skrell.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/skrell.dm
@@ -17,7 +17,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 		)
-	siemens_coefficient = 0.1
 	emp_protection = 30
 	vision_restriction = 0
 	slowdown = 0

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -228,7 +228,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	siemens_coefficient = 0.50
+	siemens_coefficient = 0.5
 	offline_vision_restriction = TINT_HEAVY
 	emp_protection = 40
 
@@ -267,7 +267,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	siemens_coefficient = 0.50
+	siemens_coefficient = 0.5
 	slowdown = 0
 	offline_slowdown = 2
 	offline_vision_restriction = TINT_HEAVY

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -22,7 +22,7 @@
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	min_pressure_protection = 0
 	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
-	siemens_coefficient = 0.5
+	siemens_coefficient = 0.9
 	species_restricted = list("exclude",BODYTYPE_DIONA,BODYTYPE_GOLEM)
 	flash_protection = FLASH_PROTECTION_MAJOR
 	allow_hair_covering = FALSE
@@ -55,7 +55,7 @@
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	min_pressure_protection = 0
 	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
-	siemens_coefficient = 0.5
+	siemens_coefficient = 0.9
 	species_restricted = list("exclude",BODYTYPE_DIONA,BODYTYPE_GOLEM)
 
 	var/list/supporting_limbs //If not-null, automatically splints breaks. Checked when removing the suit.

--- a/code/modules/clothing/spacesuits/void/alien.dm
+++ b/code/modules/clothing/spacesuits/void/alien.dm
@@ -12,7 +12,7 @@
 	)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	species_restricted = list(BODYTYPE_SKRELL,BODYTYPE_HUMAN)
-	siemens_coefficient = 0.5
+	siemens_coefficient = 0.75
 	refittable = FALSE
 
 /obj/item/clothing/head/helmet/space/void/skrell/white
@@ -37,7 +37,7 @@
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	species_restricted = list(BODYTYPE_SKRELL,BODYTYPE_HUMAN)
-	siemens_coefficient = 0.5
+	siemens_coefficient = 0.75
 	refittable = FALSE
 
 /obj/item/clothing/suit/space/void/skrell/white

--- a/code/modules/clothing/spacesuits/void/captain.dm
+++ b/code/modules/clothing/spacesuits/void/captain.dm
@@ -13,7 +13,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.6
 
 /obj/item/clothing/suit/space/void/captain
 	name = "captain voidsuit"
@@ -36,4 +36,4 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.6

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -17,7 +17,7 @@
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	min_pressure_protection = 0
-	siemens_coefficient = 0.5
+	siemens_coefficient = 0.75
 
 	//Species-specific stuff.
 	species_restricted = list(BODYTYPE_HUMAN, BODYTYPE_IPC_BISHOP, BODYTYPE_IPC_ZENGHU)
@@ -56,7 +56,7 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.5
+	siemens_coefficient = 0.75
 
 	species_restricted = list(BODYTYPE_HUMAN, BODYTYPE_SKRELL, BODYTYPE_IPC_BISHOP, BODYTYPE_IPC_ZENGHU)
 	sprite_sheets_refit = list(

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -7,7 +7,7 @@
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = UPPER_TORSO|LOWER_TORSO
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.5
+	siemens_coefficient = 0.6
 	var/obj/item/storage/internal/pockets
 	var/pocket_slots = 2
 	var/pocket_size = 2
@@ -127,7 +127,7 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.5
 	pocket_slots = 4//fullbody, more slots
 
 /obj/item/clothing/suit/armor/swat/officer
@@ -266,7 +266,7 @@
 		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_PADDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.5
 
 //Commander
 /obj/item/clothing/suit/armor/vest/ert/command
@@ -297,7 +297,7 @@
 	icon_state = "kvest"
 	item_state = "kvest"
 	allowed = list(/obj/item/gun,/obj/item/reagent_containers/spray/pepper,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/device/flashlight)
-	siemens_coefficient = 0.5
+	siemens_coefficient = 0.6
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
 		bullet = ARMOR_BALLISTIC_PISTOL,
@@ -364,7 +364,7 @@
 	icon_state = "hazard_cadet"
 	item_state = "hazard_cadet"
 	allowed = list(/obj/item/gun,/obj/item/reagent_containers/spray/pepper,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/device/flashlight)
-	siemens_coefficient = 0.5
+	siemens_coefficient = 0.75
 	armor = list(
 		melee = ARMOR_MELEE_SMALL,
 		energy = ARMOR_ENERGY_MINOR,
@@ -425,7 +425,7 @@
 		energy = ARMOR_ENERGY_RESISTANT,
 		bomb = ARMOR_BOMB_PADDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.6
 	slowdown = 0
 
 /obj/item/clothing/suit/storage/vest/heavy/ert/commander
@@ -477,7 +477,7 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.6
 
 /obj/item/clothing/suit/armor/unathi/hegemony
 	name = "hegemony body armor"
@@ -502,7 +502,7 @@
 	contained_sprite = TRUE
 	species_restricted = list(BODYTYPE_VAURCA)
 	allowed = list(/obj/item/gun/projectile, /obj/item/gun/energy, /obj/item/gun/launcher, /obj/item/melee, /obj/item/reagent_containers/spray/pepper, /obj/item/ammo_magazine, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/handcuffs, /obj/item/device/flashlight)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.6
 	armor = list(
 		melee = ARMOR_MELEE_VERY_HIGH,
 		bullet = ARMOR_BALLISTIC_PISTOL,
@@ -518,7 +518,7 @@
 	icon_state = "legion_armor"
 	item_state = "legion_armor"
 	body_parts_covered = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.6
 	allowed = list(
 		/obj/item/gun,
 		/obj/item/reagent_containers/spray/pepper,
@@ -590,7 +590,6 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	slowdown = 3
 	flags_inv = HIDEWRISTS|HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	siemens_coefficient = 0.1
 	pocket_slots = 3
 
 /obj/item/clothing/suit/armor/tdome

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -249,7 +249,7 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.6
 
 /obj/item/clothing/suit/storage/toggle/leather_jacket/military
 	name = "military jacket"

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -191,7 +191,7 @@
 		bio = ARMOR_BIO_RESISTANT,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.75
 
 
 /obj/item/clothing/suit/radiation
@@ -214,7 +214,7 @@
 		bio = ARMOR_BIO_RESISTANT, 
 		rad = ARMOR_RAD_SHIELDED
 	)
-	siemens_coefficient = 0.35
+	siemens_coefficient = 0.75
 	flags_inv = HIDEJUMPSUIT|HIDETAIL
 
 

--- a/code/modules/clothing/suits/xeno/tajara.dm
+++ b/code/modules/clothing/suits/xeno/tajara.dm
@@ -204,4 +204,4 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_MINOR
 	)
-	siemens_coefficient = 0.50
+	siemens_coefficient = 0.5

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -137,7 +137,7 @@
 	armor = list(
 		rad = ARMOR_RAD_MINOR
 	)
-	siemens_coefficient = 0.75
+	siemens_coefficient = 0.9
 
 /obj/item/clothing/under/rank/hephaestus/tech
 	name = "Hephaestus Industries technician uniform"
@@ -195,7 +195,7 @@
 	armor = list(
 		rad = ARMOR_RAD_MINOR
 	)
-	siemens_coefficient = 0.75
+	siemens_coefficient = 0.9
 
 /obj/item/clothing/under/rank/zeng
 	name = "Zeng-Hu uniform"

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -8,7 +8,7 @@
 	armor = list(
 		rad = ARMOR_RAD_MINOR
 	)
-	siemens_coefficient = 0.75
+	siemens_coefficient = 0.9
 
 /obj/item/clothing/under/rank/atmospheric_technician
 	name = "atmospheric technician's jumpsuit"
@@ -16,7 +16,6 @@
 	icon_state = "atmos"
 	item_state = "atmos_suit"
 	worn_state = "atmos"
-	siemens_coefficient = 0.75
 
 /obj/item/clothing/under/rank/engineer
 	name = "engineer's jumpsuit"
@@ -27,7 +26,6 @@
 	armor = list(
 		rad = ARMOR_RAD_MINOR
 	)
-	siemens_coefficient = 0.75
 
 /obj/item/clothing/under/rank/engineer/apprentice
 	name = "engineering apprentice's jumpsuit"
@@ -41,4 +39,3 @@
 	icon_state = "robotics"
 	item_state = "bl_suit"
 	worn_state = "robotics"
-	siemens_coefficient = 0.75

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -17,7 +17,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_SMALL
 		)
-	siemens_coefficient = 0.75
+	siemens_coefficient = 0.8
 
 /obj/item/clothing/under/rank/security/corp
 	icon_state = "officer_corporate"
@@ -35,7 +35,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_SMALL
 		)
-	siemens_coefficient = 0.75
+	siemens_coefficient = 0.8
 
 /obj/item/clothing/under/rank/warden
 	name = "warden's uniform"
@@ -45,7 +45,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_SMALL
 		)
-	siemens_coefficient = 0.75
+	siemens_coefficient = 0.8
 
 /obj/item/clothing/under/rank/warden/corp
 	icon_state = "warden_corporate"
@@ -76,7 +76,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_SMALL
 		)
-	siemens_coefficient = 0.75
+	siemens_coefficient = 0.8
 
 /obj/item/clothing/under/det/black
 	name = "hard-worn suit"
@@ -104,7 +104,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_SMALL
 		)
-	siemens_coefficient = 0.75
+	siemens_coefficient = 0.8
 
 /obj/item/clothing/under/rank/head_of_security/corp
 	icon_state = "hos_corporate"

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -8,7 +8,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MINOR
 		)
-	siemens_coefficient = 0.75
+	siemens_coefficient = 0.9
 
 /obj/item/clothing/under/syndicate/combat
 	name = "combat turtleneck"

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -418,12 +418,9 @@ This function restores all organs.
 
 	//Handle other types of damage
 	if(!(damagetype in list(BRUTE, BURN, PAIN, CLONE)))
-		if(!stat && damagetype == PAIN)
-			if((damage > 25 && prob(20)) || (damage > 50 && prob(60)))
-				emote("scream")
 		return ..()
 
-	if(!organ)
+	if(!istype(organ))
 		return FALSE
 
 	handle_suit_punctures(damagetype, damage, def_zone)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -121,9 +121,11 @@ emp_act
 
 	var/list/clothing_items = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes) // What all are we checking?
 	for(var/obj/item/clothing/C in clothing_items)
+		for(var/obj/item/clothing/accessories in C.accessories)
+			if (accessories.body_parts_covered & def_zone.body_part)
+				siemens_coefficient *= accessories.siemens_coefficient
 		if(istype(C) && (C.body_parts_covered & def_zone.body_part)) // Is that body part being targeted covered?
 			siemens_coefficient *= C.siemens_coefficient
-
 	return siemens_coefficient
 
 // Returns a list of clothing that is currently covering def_zone.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -834,7 +834,7 @@
 		return
 
 	if(stat != DEAD)
-		if((stat == UNCONSCIOUS && health < maxHealth / 2) || paralysis || InStasis())
+		if((stat == UNCONSCIOUS && health < maxHealth / 2) || InStasis())
 			//Critical damage passage overlay
 			var/severity = 0
 			switch(health - maxHealth/2)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1162,7 +1162,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(owner) owner.update_body()
 
 /obj/item/organ/external/proc/get_damage()	//returns total damage
-	return max(brute_dam + burn_dam - perma_injury, perma_injury)	//could use max_damage?
+	return max(brute_dam + burn_dam)	//could use max_damage?
 
 /obj/item/organ/external/proc/has_infected_wound()
 	for(var/datum/wound/W in wounds)
@@ -1459,7 +1459,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		amount -= (owner.chem_effects[CE_PAINKILLER]/3)
 		if(amount <= 0)
 			return
-	pain = max(0, min(pain + amount, species.total_health * 2))
+	pain = max(0, min(max_damage, pain+amount))
 	if(owner && ((amount > 15 && prob(20)) || (amount > 30 && prob(60))))
 		owner.emote("scream")
 	return pain-last_pain

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -50,7 +50,7 @@ mob/var/next_pain_time = 0
 /mob/living/carbon/human/proc/handle_pain()
 	if(!can_feel_pain())
 		return
-	if(stat >= DEAD)
+	if(stat)
 		return
 	if(!can_feel_pain())
 		return
@@ -60,7 +60,7 @@ mob/var/next_pain_time = 0
 	var/maxdam = 0
 	var/obj/item/organ/external/damaged_organ = null
 	for(var/obj/item/organ/external/E in organs)
-		if(E.status & (ORGAN_DEAD|ORGAN_ROBOT)) 
+		if(!E.can_feel_pain())
 			continue
 		var/dam = E.get_damage()
 		// make the choice of the organ depend on damage,

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -10,12 +10,12 @@
 	item_state = "energystun"
 	fire_sound = 'sound/weapons/Taser.ogg'
 	slot_flags = SLOT_BELT
-	accuracy = 1
+	accuracy = 2
 	max_shots = 10
-	can_turret = 1
+	can_turret = TRUE
 	secondary_projectile_type = /obj/item/projectile/beam
 	secondary_fire_sound = 'sound/weapons/laser1.ogg'
-	can_switch_modes = 1
+	can_switch_modes = TRUE
 	turret_is_lethal = 0
 
 	projectile_type = /obj/item/projectile/beam/stun

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1400,10 +1400,10 @@
 	if(alien == IS_DIONA)
 		return
 	if(M.chem_doses[type] < 0.2)	//not that effective after initial rush
-		M.add_chemical_effect(CE_PAINKILLER, min(15*REAGENT_VOLUME(holder, type), 35))
+		M.add_chemical_effect(CE_PAINKILLER, min(30*REAGENT_VOLUME(holder, type), 80))
 		M.add_chemical_effect(CE_PULSE, 1)
 	else if(M.chem_doses[type] < 1)
-		M.add_chemical_effect(CE_PAINKILLER, min(10*REAGENT_VOLUME(holder, type), 15))
+		M.add_chemical_effect(CE_PAINKILLER, min(10*REAGENT_VOLUME(holder, type), 20))
 		M.add_chemical_effect(CE_PULSE, 2)
 	if(M.chem_doses[type] > 10)
 		M.make_jittery(5)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -296,7 +296,7 @@
 
 /decl/reagent/mortaphenyl/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(check_min_dose(M))
-		M.add_chemical_effect(CE_PAINKILLER, 50)
+		M.add_chemical_effect(CE_PAINKILLER, 80)
 		if(!M.chem_effects[CE_CLEARSIGHT])
 			M.eye_blurry = max(M.eye_blurry, 5)
 		if(!M.chem_effects[CE_STRAIGHTWALK])


### PR DESCRIPTION
Important things:

- Tear gas has been nerfed and now works off of a chance to directly stun, at 50% base and 25% with partial face coverage. It used to apply pain damage, which meant that it could easily add way too much and end up making people's hearts stop.
- Mortaphenyl has been buffed back up to 80 pain reduction.
- Limbs can no longer store twice their max_damage of pain, they now only store up to max_damage. This should result in people having to work off less pain overall.
- Adrenaline's painkiller effect has been buffed back up to what it used to be.
- Combined with the nerfs to siemens, the energy carbine's accuracy has been buffed. The hope with this is that people start using its non-lethal functions more, considering that everyone should be less resistant to stuns in general.

Pending testing.