### PR TITLE
Fixes loadout renaming runtimes

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -300,6 +300,7 @@
 #include "code\datums\weakref.dm"
 #include "code\datums\components\_component.dm"
 #include "code\datums\components\armor\armor.dm"
+#include "code\datums\components\base_name\base_name.dm"
 #include "code\datums\components\multitool\_multitool.dm"
 #include "code\datums\components\multitool\multitool.dm"
 #include "code\datums\components\multitool\circuitboards\circuitboards.dm"

--- a/code/datums/components/base_name/base_name.dm
+++ b/code/datums/components/base_name/base_name.dm
@@ -1,0 +1,16 @@
+#define COMSIG_BASENAME_RENAME "base_name_rename"
+#define COMSIG_BASENAME_SETNAME "base_name_setname"
+
+/datum/component/base_name
+	var/base_name
+
+/datum/component/base_name/Initialize(var/name)
+	base_name = name
+	RegisterSignal(parent, COMSIG_BASENAME_RENAME, .proc/rename)
+	RegisterSignal(parent, COMSIG_BASENAME_SETNAME, .proc/change_base_name)
+
+/datum/component/base_name/proc/rename(var/name)
+	base_name = name
+
+/datum/component/base_name/proc/change_base_name(var/name, list/arguments)
+	arguments[1] = base_name

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -46,19 +46,24 @@
 	var/flipped = null
 	var/flippable = 1
 	var/wear_over_suit = 0
-	var/base_name = ""
 
 /obj/item/storage/wallet/Initialize()
 	. = ..()
-	base_name = name
+	AddComponent(/datum/component/base_name, name)
 
+/obj/item/storage/wallet/proc/update_name(var/base_name = initial(name))
+	SEND_SIGNAL(src, COMSIG_BASENAME_SETNAME, args)
+	if(front_id)
+		name = "[base_name] ([front_id])"
+	else
+		name = "[base_name]"
 
 /obj/item/storage/wallet/remove_from_storage(obj/item/W as obj, atom/new_location)
 	. = ..(W, new_location)
 	if(.)
 		if(W == front_id)
 			front_id = null
-			name = base_name
+			update_name()
 			update_icon()
 
 /obj/item/storage/wallet/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
@@ -66,7 +71,7 @@
 	if(.)
 		if(!front_id && istype(W, /obj/item/card/id))
 			front_id = W
-			name = "[name] ([front_id])"
+			update_name()
 			update_icon()
 
 /obj/item/storage/wallet/update_icon()

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -211,8 +211,12 @@ var/datum/gear_tweak/custom_name/gear_tweak_free_name = new()
 	if(!metadata)
 		return I.name
 	I.name = metadata
-	SEND_SIGNAL(I, COMSIG_BASENAME_RENAME, metadata)
 
+	// For reasons unknown, using SEND_SIGNAL instead of what is below makes rag renaming completely break.
+	var/datum/component/base_name/BN = I.GetComponent(/datum/component/base_name)
+	if(BN)
+		BN.rename(metadata)
+	
 /*
 Custom Description
 */

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -211,8 +211,7 @@ var/datum/gear_tweak/custom_name/gear_tweak_free_name = new()
 	if(!metadata)
 		return I.name
 	I.name = metadata
-	if(I.vars["base_name"])
-		I.vars["base_name"] = metadata
+	SEND_SIGNAL(I, COMSIG_BASENAME_RENAME, metadata)
 
 /*
 Custom Description

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -8,11 +8,17 @@
 	var/sound_out = 'sound/weapons/holster/holsterout.ogg'
 	flippable = 1
 	w_class = ITEMSIZE_NORMAL
-	var/base_name = ""
 
 /obj/item/clothing/accessory/holster/Initialize()
 	. = ..()
-	base_name = name
+	AddComponent(/datum/component/base_name, name)
+
+/obj/item/clothing/accessory/holster/proc/update_name(var/base_name = initial(name))
+	SEND_SIGNAL(src, COMSIG_BASENAME_SETNAME, args)
+	if(holstered)
+		name = "occupied [base_name]"
+	else
+		name = "[base_name]"
 
 /obj/item/clothing/accessory/holster/proc/holster(var/obj/item/I, var/mob/living/user)
 	if(holstered && istype(user))
@@ -33,11 +39,11 @@
 	holstered.add_fingerprint(user)
 	w_class = max(w_class, holstered.w_class)
 	user.visible_message("<span class='notice'>[user] holsters \the [holstered].</span>", "<span class='notice'>You holster \the [holstered].</span>")
-	name = "occupied [base_name]"
+	update_name()
 
 /obj/item/clothing/accessory/holster/proc/clear_holster()
 	holstered = null
-	name = base_name
+	update_name()
 
 /obj/item/clothing/accessory/holster/proc/unholster(mob/user as mob)
 	if(!holstered)

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -9,11 +9,10 @@
 	w_class = ITEMSIZE_SMALL
 	var/obj/item/stored_item = null
 	var/label_text = ""
-	var/base_name = ""
 
 /obj/item/evidencebag/Initialize()
 	. = ..()
-	base_name = name
+	AddComponent(/datum/component/base_name, name)
 
 /obj/item/evidencebag/MouseDrop(var/obj/item/I as obj)
 	if (!ishuman(usr))
@@ -111,7 +110,8 @@
 		return
 	. = ..() 
 
-/obj/item/evidencebag/proc/update_name_label()
+/obj/item/evidencebag/proc/update_name_label(var/base_name = initial(name))
+	SEND_SIGNAL(src, COMSIG_BASENAME_SETNAME, args)
 	if(label_text == "")
 		name = base_name
 	else

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -64,7 +64,8 @@
 	update_name()
 	update_icon()
 
-/obj/item/reagent_containers/glass/rag/proc/update_name()
+/obj/item/reagent_containers/glass/rag/proc/update_name(var/base_name = initial(name))
+	SEND_SIGNAL(src, COMSIG_BASENAME_SETNAME, args)
 	if(on_fire)
 		name = "burning [base_name]"
 	else if(reagents.total_volume)
@@ -106,6 +107,7 @@
 			update_icon()
 
 /obj/item/reagent_containers/glass/rag/proc/wipe_down(atom/A, mob/user)
+	var/base_name = SEND_SIGNAL(src, COMSIG_BASENAME_SETNAME)
 	if(!reagents.total_volume)
 		to_chat(user, SPAN_WARNING("\The [base_name] is dry!"))
 	else

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -107,9 +107,8 @@
 			update_icon()
 
 /obj/item/reagent_containers/glass/rag/proc/wipe_down(atom/A, mob/user)
-	var/base_name = SEND_SIGNAL(src, COMSIG_BASENAME_SETNAME)
 	if(!reagents.total_volume)
-		to_chat(user, SPAN_WARNING("\The [base_name] is dry!"))
+		to_chat(user, SPAN_WARNING("\The [name] is dry!"))
 	else
 		if (!(last_clean && world.time < last_clean + 120) )
 			user.visible_message("<b>[user]</b> starts to wipe [A] with [src].")

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -4,7 +4,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 /obj/item/reagent_containers/glass
 	name = " "
-	var/base_name = " "
 	desc = " "
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = null
@@ -23,7 +22,7 @@
 
 /obj/item/reagent_containers/glass/Initialize()
 	. = ..()
-	base_name = name
+	AddComponent(/datum/component/base_name, name)
 
 /obj/item/reagent_containers/glass/examine(var/mob/user)
 	if(!..(user, 2))
@@ -82,7 +81,8 @@
 		return
 	. = ..() // in the case of nitroglycerin, explode BEFORE it shatters
 
-/obj/item/reagent_containers/glass/proc/update_name_label()
+/obj/item/reagent_containers/glass/proc/update_name_label(var/base_name = initial(name))
+	SEND_SIGNAL(src, COMSIG_BASENAME_SETNAME, args)
 	if(label_text == "")
 		name = base_name
 	else

--- a/html/changelogs/LoadoutRuntimeFix.yml
+++ b/html/changelogs/LoadoutRuntimeFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed runtimes related to renaming loadout items."


### PR DESCRIPTION
This fixes several runtimes that happened wen renaming an item in the loadout on an item without a base_name var.

For some reason i'm not quite certain on, the rag's `update_name` causes the `base_name` to be changed in the component unless the loadout uses `GetComponent`