### PR TITLE
Allow windoors to be forced open with crowbars when depowered/broken

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -189,7 +189,7 @@
 			return
 
 	if(I.iscrowbar() && user.a_intent == I_HELP)
-		if(!operable())
+		if(inoperable())
 			visible_message("\The [user] forces \the [src] [density ? "open" : "closed"].")
 			if(density)
 				open(1)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -188,6 +188,17 @@
 			qdel(src)
 			return
 
+	if(I.iscrowbar() && user.a_intent == I_HELP)
+		if(!operable())
+			visible_message("\The [user] forces \the [src] [density ? "open" : "closed"].")
+			if(density)
+				open(1)
+			else
+				close(1)
+		else
+			to_chat(user, SPAN_NOTICE("The windoor's motors resist your efforts to force it."))
+		return
+
 	//If it's a weapon, smash windoor. Unless it's an id card, agent card, ect.. then ignore it (Cards really shouldnt damage a door anyway)
 	if(src.density && istype(I, /obj/item) && !istype(I, /obj/item/card))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/html/changelogs/WindoorCrowbars.yml
+++ b/html/changelogs/WindoorCrowbars.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "inoperable windoors can now be forced open with a crowbar."


### PR DESCRIPTION
A good alternative to waiting for the warden's office to run out of power too or breaking the windoors/windows by the security lobby whenever it runs out of power and the officers gets trapped.