### PR TITLE
Expands Burglar Ghost Role Species Selection

### DIFF
--- a/code/modules/ghostroles/spawner/human/emergencypod.dm
+++ b/code/modules/ghostroles/spawner/human/emergencypod.dm
@@ -10,7 +10,7 @@
 
 	//Vars related to human mobs
 	outfit = /datum/outfit/admin/random/visitor
-	possible_species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
+	possible_species = list(SPECIES_HUMAN,SPECIES_HUMAN_OFFWORLD,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_TAJARA_MSAI,SPECIES_TAJARA_ZHAN,SPECIES_UNATHI,SPECIES_VAURCA_WARRIOR,SPECIES_VAURCA_WORKER)
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
 	assigned_role = "Pod Survivor"

--- a/html/changelogs/wickedcybs_burglar.yml
+++ b/html/changelogs/wickedcybs_burglar.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The burglar pod ghost role can select Offworlders, the Taj subspecies and Vaurca now."


### PR DESCRIPTION
Adds Offworlders, the Taj subspecies and Vaurca to the burglar pod. To do this they had to set in the possible_species list for 

human/rescuepodsurv

Because the burglar pod is a subtype of it. As far as I can tell, this should cause no issues because all the specific pod scenarios choose their possible species based on the role, which is more restrictive than the default list already.