### PR TITLE
Buffs frag grenades.

### DIFF
--- a/code/datums/uplink/grenades.dm
+++ b/code/datums/uplink/grenades.dm
@@ -3,7 +3,7 @@
 ************/
 /datum/uplink_item/item/grenades
 	category = /datum/uplink_category/grenades
-	
+
 /datum/uplink_item/item/grenades/manhack
 	name = "Viscerator Delivery Grenade"
 	item_cost = 2
@@ -33,10 +33,10 @@
 	item_cost = 2
 	path = /obj/item/storage/box/emps
 	desc = "A box of five grenades that cause a risky EMP explosion, capable of toggling headsets off, permanently destroying IPC units and draining a stationbound completely."
-	
+
 /datum/uplink_item/item/grenades/frag
 	name = "5xFrag Grenades"
-	item_cost = 6
+	item_cost = 5
 	path = /obj/item/storage/box/frags
 
 /datum/uplink_item/item/grenades/cardox

--- a/code/game/objects/items/weapons/grenades/fragmentation.dm
+++ b/code/game/objects/items/weapons/grenades/fragmentation.dm
@@ -29,7 +29,8 @@ proc/fragem(var/source,var/fragx,var/fragy,var/light_dam,var/flash_dam,var/p_dam
 
 //Fragmentation grenade projectile
 /obj/item/projectile/bullet/pellet/fragment
-	damage = 10
+	damage = 15
+	armor_penetration = 35
 	range_step = 2
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone

--- a/html/changelogs/nerocavalier-fragbuff.yml
+++ b/html/changelogs/nerocavalier-fragbuff.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: NeroCavalier
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Damage for frag grenade pellets are 15 with 35 AP. This will let them affect people in sec pcarriers."
+  - tweak: "Reduces TC cost for frag grenade box to 5 TC from 6 TC."
+
+


### PR DESCRIPTION
* Damage for frag grenade pellets are 15 with 35 AP. This will let them affect people in sec pcarriers. Reduces TC cost to 5 from 6.
* This will make them more lethal, you can do upwards to 80 damage against sec pcarrier and 130 to unarmored caught 1 tile from explosion. This drops to half if it's 2. 
* It is genuinely a skill issue or ping issue if someone dies repeatedly to grenades because either the antag is super good at timing them or your ping is preventing you from moving 2 tiles to safety from the grenade.