### PR TITLE
Lowers revolution player requirement

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -3,7 +3,7 @@
 	config_tag = "revolution"
 	round_description = "Some crewmembers are attempting to start a movement!"
 	extended_round_description = "A revolution is in the early stages of formation, and a group of loyalists are rallying to oppose them."
-	required_players = 22
+	required_players = 15
 	required_enemies = 6
 	auto_recall_shuttle = 0
 	end_on_antag_death = 0

--- a/html/changelogs/RevolutionCount.yml
+++ b/html/changelogs/RevolutionCount.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - tweak: "Revolution now only requires 15 players to be readied to start."


### PR DESCRIPTION
Revolution now only requires 15 players to be readied to be possible, to increase the chances of it being selected.