### PR TITLE
Adds examine text when vampires are draining blood

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -374,6 +374,13 @@
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
 
 	msg += "*---------*</span>"
+
+	var/datum/vampire/vampire = vampire_power(0, 0)
+	if(vampire)
+		if(vampire.status & VAMP_DRAINING)
+			var/obj/item/grab/G = get_active_hand()
+			msg += SPAN_ALERT("\n[get_pronoun("He")] is biting [G.affecting]'[G.affecting.get_pronoun("end")] neck!")
+
 	if (pose)
 		if( findtext(pose,".",length(pose)) == 0 && findtext(pose,"!",length(pose)) == 0 && findtext(pose,"?",length(pose)) == 0 )
 			pose = addtext(pose,".") //Makes sure all emotes end with a period.

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Vampires draining blood will now show as biting someone when examined."


### PR DESCRIPTION
Vampries who are currently draining blood from someone will now show as doing so when examined.
![image](https://user-images.githubusercontent.com/8396443/134811083-0331768e-6ae8-46d3-a98f-fad3c2c49926.png)
