### PR TITLE
fixes securitron crafting

### DIFF
--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -649,7 +649,7 @@
 		..()
 		return
 
-	if(type != /obj/item/clothing/head/helmet) //Eh, but we don't want people making secbots out of space helmets.
+	if(type != /obj/item/clothing/head/helmet/security) //Eh, but we don't want people making secbots out of space helmets.
 		return
 
 	if(S.secured)

--- a/html/changelogs/SecuritronFix.yml
+++ b/html/changelogs/SecuritronFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes securitron construction to take security helmets."


### PR DESCRIPTION
They can now be made using the helmets security get in their lockers.