### PR TITLE
fixes autopsy scanners only working on harm intent

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -102,7 +102,8 @@ proc/spread_germs_to_organ(var/obj/item/organ/external/E, var/mob/living/carbon/
 		/obj/item/stack/nanopaste,
 		/obj/item/device/breath_analyzer,
 		/obj/item/personal_inhaler,
-		/obj/item/clothing/accessory/stethoscope
+		/obj/item/clothing/accessory/stethoscope,
+		/obj/item/autopsy_scanner
 		)
 	// Check for multi-surgery drifting.
 	var/zone = user.zone_sel.selecting

--- a/html/changelogs/AutopsyFix.yml
+++ b/html/changelogs/AutopsyFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Autopsy scanners now work regardless of intent."


### PR DESCRIPTION
As the title says. Adds the autopsy scanner to the list of tools bypassing surgery safety check so it can scan the corpses regardless of intent.