### PR TITLE
Removes Nicotine OD Paralysis 

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -936,7 +936,6 @@
 /decl/reagent/mental/nicotine/overdose(var/mob/living/carbon/M, var/alien, var/removed, var/scale, var/datum/reagents/holder)
 	. = ..()
 	M.adjustOxyLoss(10 * removed * scale)
-	M.Weaken(10 * removed * scale)
 	M.add_chemical_effect(CE_PULSE, 0.5)
 
 /decl/reagent/mental/corophenidate

--- a/html/changelogs/wickedcybs_nicotine.yml
+++ b/html/changelogs/wickedcybs_nicotine.yml
@@ -1,0 +1,6 @@
+author: ChangeMe
+
+delete-after: True
+
+changes:
+  - tweak: "Nicotine overdoses no longer weaken and paralyze people."


### PR DESCRIPTION
It was due to the weaken proc. I stripped that out.

Should make for less ahelps and confusion about spasming on the ground after smoking for a while.