### PR TITLE
Blobs can Damage Reinforced Walls Again

### DIFF
--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -85,8 +85,6 @@
 		return
 	if(istype(T, /turf/simulated/wall))
 		var/turf/simulated/wall/SW = T
-		if(SW.reinf_material && SW.reinf_material.hardness > 60)
-			return TRUE
 		SW.take_damage(80)
 		return
 	var/obj/structure/girder/G = locate() in T

--- a/html/changelogs/wickedcybs_blob.yml
+++ b/html/changelogs/wickedcybs_blob.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Blobs can damage reinforced walls now."


### PR DESCRIPTION
I understood the idea behind removing its ability to damage reinforced walls. Making it more manageable to deal with. But as of now I think that's been proven to be even more troublesome when it comes to gameplay and how the blob actually functions.

With damage to reinforced walls returned, it's really not so oppressive. Reinforced plasteel walls take quite a long time for a blob to actually break (I've counted upwards of three, to five or more minutes depending on how it has grown and how many blob tiles are attacking at once). The only time a blob removes them very quickly is when a core has spawned directly next to a reinforced wall. 

In narrow spaces, a blob ended up being even more troublesome for engineering to handle as there'd be less room to set an emitter properly. The breakage of walls helped to open up new fronts to approach a blob from, which is honestly pretty critical sometimes. As of now, if it's in a particularly annoying place it's even just ignorable with no real round impact if it happened somewhere like the research sublevel. 

TL:DR: Blobs break r-walls slowly, it's more than fair for them to do so considering the ample time for response and it's not really any more difficult to handle compared to how blobs currently are. In fact, this is likely even more manageable.
