### PR TITLE
Fixes cigarette slot placement when extinguished

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -224,7 +224,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		set_light(2, 0.25, "#E38F46")
 		START_PROCESSING(SSprocessing, src)
 
-/obj/item/clothing/mask/smokable/proc/die(var/no_message = 0)
+/obj/item/clothing/mask/smokable/proc/die(var/no_message = FALSE, var/intentionally = FALSE)
 	var/turf/T = get_turf(src)
 	set_light(0)
 	playsound(src.loc, 'sound/items/cigs_lighters/cig_snuff.ogg', 50, 1)
@@ -235,15 +235,19 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			var/mob/living/M = loc
 			if(!no_message)
 				to_chat(M, SPAN_NOTICE("Your [name] goes out."))
-			if(M.wear_mask)
+			if(intentionally)
+				butt.loc = T
+			else if(M.wear_mask == src)
 				M.remove_from_mob(src) //un-equip it so the overlays can update
 				M.update_inv_wear_mask(0)
-				M.equip_to_slot_if_possible(butt, slot_wear_mask)
+				if(!(M.equip_to_slot_if_possible(butt, slot_wear_mask, ignore_blocked = TRUE)))
+					M.put_in_hands(butt) // In case the above somehow fails, ensure it is placed somewhere
 			else
 				M.remove_from_mob(src) // if it dies in your hand.
 				M.update_inv_l_hand(0)
 				M.update_inv_r_hand(1)
 				M.put_in_hands(butt)
+
 		STOP_PROCESSING(SSprocessing, src)
 		qdel(src)
 	else
@@ -359,7 +363,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(lit)
 		user.visible_message(SPAN_NOTICE("<b>[user]</b> calmly drops and treads on the lit [src], putting it out instantly."), SPAN_NOTICE("You calmly drop and tread on the lit [src], putting it out instantly."))
 		playsound(src.loc, 'sound/items/cigs_lighters/cig_snuff.ogg', 50, 1)
-		die(TRUE)
+		die(TRUE, TRUE)
 	else // Cigarette packing. For compulsive smokers.
 		user.visible_message(SPAN_NOTICE("<b>[user]</b> taps \the [src] against their palm."), SPAN_NOTICE("You tap \the [src] against your palm."))
 	return ..()

--- a/html/changelogs/CigSlotFix.yml
+++ b/html/changelogs/CigSlotFix.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Cigarettes will now properly be in the face slot when they go out, or in the hand if carried there."
+  - bugfix: "Cigarettes will now be dropped on the ground when intentionally put out."


### PR DESCRIPTION
Cigarettes are now placed in the correct slot when extinguished, or dropped on the ground if they are done so intentionally.

fixes https://github.com/Aurorastation/Aurora.3/issues/12388