### PR TITLE
Fixes some more cryo spawn bugs

### DIFF
--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -91,6 +91,8 @@
 
 #define isprojectile(A) istype(A, /obj/item/projectile)
 
+#define isclothing(A) istype(A, /obj/item/clothing)
+
 /// General I/O helpers
 #define to_target(target, payload)                          target << (payload)
 #define from_target(target, receiver)                       target >> (receiver)

--- a/code/game/machinery/megavend.dm
+++ b/code/game/machinery/megavend.dm
@@ -37,8 +37,14 @@
 		return
 
 	var/obj/item/storage/box/gearbox = new(null, TRUE)
+	var/list/AC
+	var/obj/BE
+	LAZYINITLIST(AC)
 	gearbox.name = "personal possessions box"
 	gearbox.desc = "All of the personal effects of [H.real_name], packaged neatly by the AutoDrobe."
+
+	if(H.belt)
+		BE = H.belt
 	for(var/obj/item/W in H.contents) //Strip 'em
 		if(istype(W,/obj/item/organ))
 			continue
@@ -46,6 +52,12 @@
 			continue
 		if(!W.canremove)
 			continue
+
+		if(isclothing(W))
+			var/obj/item/clothing/U = W
+			for(var/obj/item/clothing/accessory/A in U.accessories)
+				U.remove_accessory(H, A)
+				LAZYADD(AC, A)
 		H.drop_from_inventory(W,gearbox)
 
 	to_chat(H, SPAN_NOTICE(change_message))
@@ -60,6 +72,12 @@
 	else		
 		H.put_in_any_hand_if_possible(gearbox)
 
+	for(var/obj/item/clothing/accessory/A as anything in AC)
+		H.remove_from_mob(A)
+		H.equip_to_slot(A, slot_tie, FALSE)
+		LAZYREMOVE(AC, A)
+	if(BE)
+		H.equip_to_slot_if_possible(BE, slot_belt, disable_warning = TRUE)
 	return
 
 /obj/machinery/megavendor/vendor

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -46,7 +46,8 @@
 		if(!C.occupant)
 			C.set_occupant(victim, 1)
 			victim.Sleeping(3)
-			to_chat(victim, SPAN_NOTICE("You are slowly waking up from the cryostasis aboard [current_map.full_name]. It might take a few seconds.\nYour workplace attire is waiting for you at the nearest autodrobe vendor."))
+			to_chat(victim, SPAN_NOTICE("You are slowly waking up from the cryostasis aboard [current_map.full_name]. It might take a few seconds."))
+			to_chat(victim, FONT_LARGE("<b>Your workplace attire is waiting for you at the nearest autodrobe vendor.</b>"))
 			return
 
 /datum/spawnpoint/cyborg

--- a/html/changelogs/CryoFixesAgain.yml
+++ b/html/changelogs/CryoFixesAgain.yml
@@ -1,0 +1,8 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Belts will now properly stay on when using the autodrobe."
+  - bugfix: "Accessories will now correctly transfer to the uniform when using the autodrobe."
+  - tweak: "The text guiding one to use the autodrobe when spawning at cryo now stands out more."


### PR DESCRIPTION
This fixes belts being dropped on the ground when using the autodrobe and makes it so accessories worn on any uniform that is moved to the bag will have the accessories attached to the new uniform instead. 


![OQvEKWn](https://user-images.githubusercontent.com/8396443/136433597-9b3f342c-8a6d-400a-865c-05405d5e2307.png)
