### PR TITLE
Renames skrell species again

### DIFF
--- a/code/__defines/species.dm
+++ b/code/__defines/species.dm
@@ -3,8 +3,8 @@
 #define SPECIES_UNATHI				"Unathi"
 #define SPECIES_DIONA				"Diona"
 
-#define SPECIES_SKRELL				"Skrell"
-#define SPECIES_SKRELL_AXIORI		"Axiori"
+#define SPECIES_SKRELL				"Xiialt Skrell"
+#define SPECIES_SKRELL_AXIORI		"Axiori Skrell"
 
 #define SPECIES_TAJARA				"Tajara"
 #define SPECIES_TAJARA_ZHAN			"Zhan-Khazan Tajara"

--- a/html/changelogs/SkrellNamingAgain.yml
+++ b/html/changelogs/SkrellNamingAgain.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - tweak: "Skrell and Axiori will now show up when examined as 'Xiialt Skrell' and 'Axiori Skrell' respectively."


### PR DESCRIPTION
They should now show up as Xiialt Skrell & Axiori Skrell when examined.

The DB needs to be properly updated immediately after merge to avoid any problems regarding whitelists.