### PR TITLE
Rampant Intelligence Event Specifies What's Been Initially Infected

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -8,7 +8,7 @@
 
 
 /datum/event/brand_intelligence/announce()
-	command_announcement.Announce("Rampant brand intelligence has been detected aboard [station_name()], please stand-by.", "Machine Learning Alert", new_sound = 'sound/AI/brandintelligence.ogg')
+	command_announcement.Announce("Rampant brand intelligence has been detected aboard the [station_name()]. The origin is believed to be \a \"[initial(originMachine.name)]\" type. Infection of other machines is likely.", "[station_name()] Machine Monitoring" , new_sound = 'sound/AI/brandintelligence.ogg')
 
 
 /datum/event/brand_intelligence/start()

--- a/html/changelogs/wickedcybs_rampant.yml
+++ b/html/changelogs/wickedcybs_rampant.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The rampant vending machine event now has the announcement say which type of vending machine was initially infected. Quick response will nip outbreaks in the bud before they spread everywhere."


### PR DESCRIPTION
The event will essentially give a hint and mention what type of vending machine was first infected. Pretty much a direct implementation of how Baystation does this when it comes to the announcement. 

![image](https://user-images.githubusercontent.com/52309324/136721760-680729cb-f44c-40f1-ad5d-c816042016f0.png)
