### PR TITLE
Pointy Stuff

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -90,7 +90,7 @@
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return TRUE
-	if(modifiers["ctrl"] && modifiers["middle"])
+	if(modifiers["shift"] && modifiers["middle"])
 		pointed(A)
 		return TRUE
 	if(modifiers["middle"])

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -595,7 +595,7 @@
 			if(!(H in mobs))
 				if(src.z == H.z && get_dist(src, H) <= range)
 					H.intent_listen(src, message)
-	
+
 /atom/proc/change_area(var/area/oldarea, var/area/newarea)
 	change_area_name(oldarea.name, newarea.name)
 
@@ -650,3 +650,9 @@
 	if(degrees)
 		appearance_flags |= PIXEL_SCALE
 	transform = M
+
+/atom/proc/get_pixel_x() // the pseudo pixel_x used when animating overlays, do not use for complex calcs
+	return pixel_x
+
+/atom/proc/get_pixel_y() // the pseudo pixel_x used when animating overlays, do not use for complex calcs
+	return pixel_y

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -450,3 +450,27 @@
 	wires.MendAll()
 	update_icon()
 	update_coverage()
+
+/obj/machinery/camera/get_pixel_x()
+	switch(dir)
+		if(NORTH)
+			return pixel_x + 11
+		if(EAST)
+			return pixel_x - 13
+		if(SOUTH)
+			return pixel_x - 10
+		if(WEST)
+			return pixel_x + 15
+	return pixel_x
+
+/obj/machinery/camera/get_pixel_y()
+	switch(dir)
+		if(NORTH)
+			return pixel_y - 11
+		if(EAST)
+			return pixel_y - 11
+		if(SOUTH)
+			return pixel_y + 14
+		if(WEST)
+			return pixel_y + 12
+	return pixel_y

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -10,6 +10,37 @@
 	anchored = 1
 	mouse_opacity = 0
 
+	var/qdel_timer
+
+/obj/effect/decal/point/Initialize(mapload, var/mob/M)
+	invisibility = M.invisibility
+	. = ..()
+	var/turf/T1
+	var/atom/A
+	if(isturf(loc))
+		T1 = loc
+	else
+		A = loc
+		T1 = get_turf(loc)
+		forceMove(T1)
+	var/turf/T2 = M.loc
+
+	if(T2.x && T2.y)
+		var/dist_x = (T2.x - T1.x)
+		var/dist_y = (T2.y - T1.y)
+
+		pixel_x = dist_x * 32
+		pixel_y = dist_y * 32
+
+		animate(src, pixel_x = A ? A.get_pixel_x() : 0, pixel_y = A ? A.get_pixel_y() : 0, time = 0.5 SECONDS, easing = QUAD_EASING)
+
+	qdel_timer = QDEL_IN(src, 2.5 SECONDS)
+
+/obj/effect/decal/point/Destroy()
+	deltimer(qdel_timer)
+	qdel_timer = null
+	return ..()
+
 // Used for spray that you spray at walls, tables, hydrovats etc
 /obj/effect/decal/spraystill
 	density = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -20,17 +20,11 @@ var/mob/living/next_point_time = 0
 	if(next_point_time >= world.time)
 		return FALSE
 
-	next_point_time = world.time + 25
+	next_point_time = world.time + 2.5 SECONDS
 	face_atom(A)
-	if(isturf(A))
-		if(pointing_effect)
-			QDEL_NULL(pointing_effect)
-		pointing_effect = new /obj/effect/decal/point(A)
-		pointing_effect.invisibility = invisibility
-		addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, pointing_effect), 2 SECONDS)
-	else
-		A.add_filter("pointglow", 1, list(type = "drop_shadow", x = 0, y = -1, offset = 1, size = 1, color = "#F00"))
-		addtimer(CALLBACK(A, /atom/movable.proc/remove_filter, "pointglow"), 2 SECONDS)
+	if(pointing_effect)
+		QDEL_NULL(pointing_effect)
+	pointing_effect = new /obj/effect/decal/point(A, src)
 	visible_message("<b>\The [src]</b> points to \the [A].")
 	return TRUE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -342,12 +342,10 @@
 	if (!tile)
 		return 0
 
-	pointing_effect = new /obj/effect/decal/point(tile)
-	pointing_effect.invisibility = invisibility
-	addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, pointing_effect), 2 SECONDS)
-
+	pointing_effect = new /obj/effect/decal/point(tile, src)
 	face_atom(A)
 	return 1
+
 /datum/mobl	// I have no idea what the fuck this is, but it's better for it to be a datum than an /obj/effect.
 	var/list/container = list()
 	var/master

--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -620,3 +620,19 @@
 	explosion(T, 0, 0, 2, 2)
 	sleep(1)
 	qdel(src)
+
+/obj/machinery/light/get_pixel_x()
+	switch(dir)
+		if(EAST)
+			return pixel_x + 15
+		if(WEST)
+			return pixel_x - 14
+	return pixel_x
+
+/obj/machinery/light/get_pixel_y()
+	switch(dir)
+		if(NORTH)
+			return pixel_y + 15
+		if(SOUTH)
+			return pixel_y - 14
+	return pixel_y

--- a/html/changelogs/geeves-pointing_hotkeys.yml
+++ b/html/changelogs/geeves-pointing_hotkeys.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Pointing at an object rather than a turf will no longer give it a red outline, instead, a red arrow will spawn on your mob and glide towards the object."
+  - tweak: "Tweaked the hotkey for pointing from Ctrl + MMB to Shift + MMB."


### PR DESCRIPTION
* Pointing at an object rather than a turf will no longer give it a red outline, instead, a red arrow will spawn on your mob and glide towards the object.
* Tweaked the hotkey for pointing from Ctrl + MMB to Shift + MMB.

Code ported from CM.