### PR TITLE
Unathi temperature tweak

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
@@ -85,14 +85,14 @@
 	reagent_tag = IS_UNATHI
 	base_color = "#066000"
 
-	heat_discomfort_level = 295
+	heat_discomfort_level = 304 // 30°C
 	heat_discomfort_strings = list(
 		"You feel soothingly warm.",
 		"You feel the heat sink into your bones.",
 		"You feel warm enough to take a nap."
 		)
 
-	cold_discomfort_level = 292
+	cold_discomfort_level = 294  // 20°C
 	cold_discomfort_strings = list(
 		"You feel chilly.",
 		"You feel sluggish and cold.",

--- a/html/changelogs/dekser-Unathi-tempchange.yml
+++ b/html/changelogs/dekser-Unathi-tempchange.yml
@@ -1,0 +1,5 @@
+author: Dekser
+
+delete-after: True
+changes:
+  - tweak: "Tweaks what temperature Unathi receive discomfort messages for."


### PR DESCRIPTION
Here we go with another Unathi tweak. Previously Unathi would get comfort messages in 21°C despite the fact that their summers are usually 35-40°C on both Ouerea and Moghes, changed that. Also Unathi now suffer like Tajara and get discomfort messages from the cold at 20°C instead of 19°C

Same as last, lore dev approved!