### PR TITLE
Makes the grumble and mumble emotes use a full stop instead of an exclamation mark

### DIFF
--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -163,11 +163,11 @@
 
 /decl/emote/audible/mumble
 	key = "mumble"
-	emote_message_3p = "USER mumbles!"
+	emote_message_3p = "USER mumbles."
 
 /decl/emote/audible/grumble
 	key = "grumble"
-	emote_message_3p = "USER grumbles!"
+	emote_message_3p = "USER grumbles."
 
 /decl/emote/audible/groan
 	key = "groan"
@@ -265,7 +265,7 @@
 	key = "lwarble"
 	emote_message_3p = "USER lets out a low, throaty warble!"
 	emote_sound = 'sound/voice/low warble.ogg'
-	
+
 /decl/emote/audible/croak
 	key = "croak"
 	emote_message_3p = "USER croaks!"

--- a/html/changelogs/Forester40-grumbles.yml
+++ b/html/changelogs/Forester40-grumbles.yml
@@ -1,0 +1,7 @@
+
+author: Forester40
+
+delete-after: True
+
+changes:
+  - tweak: "The *grumble and *mumble emotes now use a full stop instead of an exclamation mark."


### PR DESCRIPTION
The point of an exclamation mark is usually to put emphasis on things or imply that they are loud and I don't think mumbling or grumbling would usually warrant one.