### PR TITLE
fixes windoors

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -188,7 +188,7 @@
 			qdel(src)
 			return
 
-	if(!ishuman(I))
+	if(!isliving(I))
 		if(I.iscrowbar() && user.a_intent == I_HELP)
 			if(inoperable())
 				visible_message("\The [user] forces \the [src] [density ? "open" : "closed"].")

--- a/html/changelogs/WindoorFixAgain.yml
+++ b/html/changelogs/WindoorFixAgain.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Borgs can once more use windoors from a distance."


### PR DESCRIPTION
Cyborgs can now use windoors from a distance again.
fixes https://github.com/Aurorastation/Aurora.3/issues/12644