### PR TITLE
Pipegun Name Bugfix

### DIFF
--- a/code/modules/projectiles/guns/projectile/rifle.dm
+++ b/code/modules/projectiles/guns/projectile/rifle.dm
@@ -71,6 +71,12 @@
 
 	jam_chance = -10
 
+/obj/item/gun/projectile/shotgun/pump/rifle/pipegun/Initialize()
+	. = ..()
+	var/list/adjective = list("improvised", "makeshift", "jury-rigged")
+	var/list/noun = list("assblaster", "warmonger", "validator", "jam-o-matic", "tear generator")
+	name = "[pick(adjective)] [pick(noun)]"
+
 /obj/item/gun/projectile/shotgun/pump/rifle/pipegun/handle_pump_loading()
 	if(ammo_magazine && length(ammo_magazine.stored_ammo))
 		var/obj/item/ammo_casing/AC = ammo_magazine.stored_ammo[1] //load next casing.

--- a/html/changelogs/geeves-pipegun_bugfix.yml
+++ b/html/changelogs/geeves-pipegun_bugfix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "According to licensed firearms enthusiasts world-wide, a pipegun is simply a pipe with a nail on it, which is crudely used to slam a round as a makeshift firing assembly. As the pipegun in-game has received updates, it has strayed further and further from firearm scripture. With a new randomized naming system, it will remain accurate to Gun Lore as written in Heckler & Koch verse 9:12."


### PR DESCRIPTION
* According to licensed firearms enthusiasts world-wide, a pipegun is simply a pipe with a nail on it, which is crudely used to slam a round as a makeshift firing assembly. As the pipegun in-game has received updates, it has strayed further and further from firearm scripture. With a new randomized naming system, it will remain accurate to Gun Lore as written in Heckler & Koch verse 9:12.