### PR TITLE
fixes the faction loadout display & spawn

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_factions.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_factions.dm
@@ -20,12 +20,13 @@
 	display_name = "idris service skirt"
 	description = "Not for security usage."
 	path = /obj/item/clothing/under/rank/idris/service/alt
-	slot = slot_wear_suit
+	slot = slot_w_uniform
 	faction = "Idris Incorporated"
 
 /datum/gear/faction/idris_armband
 	display_name = "idris armband"
 	path = /obj/item/clothing/accessory/armband/idris
+	slot = slot_tie
 	faction = "Idris Incorporated"
 
 /datum/gear/faction/idris_windbreaker
@@ -37,11 +38,13 @@
 /datum/gear/faction/idris_passcard
 	display_name = "idris silversun passcard"
 	path = /obj/item/clothing/accessory/badge/passcard/sol/silversun
+	slot = slot_tie
 	faction = "Idris Incorporated"
 
 /datum/gear/faction/idris_rag
 	display_name = "idris advanced service cloth"
 	path = /obj/item/reagent_containers/glass/rag/advanced/idris
+	slot = slot_in_backpack
 	faction = "Idris Incorporated"
 
 /datum/gear/faction/idris_sunglasses
@@ -82,13 +85,13 @@
 /datum/gear/faction/zavodskoi_uniform_alt
 	display_name = "brown zavodskoi uniform"
 	path = /obj/item/clothing/under/rank/security/zavodskoi/alt
-	slot = slot_wear_suit
+	slot = slot_w_uniform
 	faction = "Zavodskoi Interstellar"
 
 /datum/gear/faction/zavodskoi_research_alt
 	display_name = "brown zavodskoi research uniform"
 	path = /obj/item/clothing/under/rank/zavodskoi/research/alt
-	slot = slot_wear_suit
+	slot = slot_w_uniform
 	faction = "Zavodskoi Interstellar"
 
 /datum/gear/faction/zavodskoi_labcoat
@@ -159,7 +162,7 @@
 /datum/gear/faction/zenghu_uniform_alt
 	display_name = "zeng-hu white uniform"
 	path = /obj/item/clothing/under/rank/zeng/alt
-	slot = slot_wear_suit
+	slot = slot_w_uniform
 	faction = "Zeng-Hu Pharmaceuticals"
 
 /datum/gear/faction/zenghu_beret
@@ -222,6 +225,7 @@
 	display_name = "idris security sleeve patch"
 	path = /obj/item/clothing/accessory/sleevepatch/idrissec
 	faction = "Idris Incorporated"
+	slot = slot_tie
 	allowed_roles = list("Security Officer","Investigator")
 
 /datum/gear/faction/heph_labcoat
@@ -239,4 +243,5 @@
 /datum/gear/faction/heph_passcard
 	display_name = "hephaestus burszia passcard"
 	path = /obj/item/clothing/accessory/badge/passcard/burszia
+	slot = slot_tie
 	faction = "Hephaestus Industries"

--- a/html/changelogs/FactionLoadoutFix.yml
+++ b/html/changelogs/FactionLoadoutFix.yml
@@ -1,4 +1,4 @@
-author: ChangeMe
+author: TheGreyWolf
 
 delete-after: True
 

--- a/html/changelogs/FactionLoadoutFix.yml
+++ b/html/changelogs/FactionLoadoutFix.yml
@@ -1,0 +1,6 @@
+author: ChangeMe
+
+delete-after: True
+
+changes:
+  - bugfix: "The faction loadout items should now properly display in character setup when selected."


### PR DESCRIPTION
The faction loadout items should now all spawn properly in the correct slots and show up in the character setup screen when selected.