### PR TITLE
Reopens Adds IAC berets to the loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -269,11 +269,19 @@
 	display_name = "non la hat"
 	path = /obj/item/clothing/head/nonla
 
-/datum/gear/head/iacberet
-	display_name = "IAC Beret"
+/datum/gear/head/iac
+	display_name = "IAC headgear selection"
+	description = "A selection of hats worn by Interstellar Aid Corps volunteers."
 	path = /obj/item/clothing/head/softcap/iac
 	allowed_roles = list("Chief Medical Officer", "Physician", "Surgeon", "Pharmacist", "First Responder", "Medical Intern")
 	flags = GEAR_HAS_DESC_SELECTION
+
+/datum/gear/head/iac/New()
+	..()
+	var/list/iac = list()
+	iac["IAC cap"] = /obj/item/clothing/head/softcap/iac
+	iac["IAC beret"] = /obj/item/clothing/head/beret/iac
+	gear_tweaks += new /datum/gear_tweak/path(iac)
 
 /datum/gear/head/circuitry
 	display_name = "headwear, circuitry (empty)"

--- a/html/changelogs/Forester40-iachat.yml
+++ b/html/changelogs/Forester40-iachat.yml
@@ -1,0 +1,8 @@
+
+author: Forester40
+
+delete-after: True
+
+changes:
+  - rscadd: "IAC berets have been added to the loadout selection. You can choose between them and IAC caps in the Hats and Headgear section of the loadout."
+  - spellcheck: "The IAC cap is no longer mislabelled as a beret in the loadout." 


### PR DESCRIPTION
* Adds IAC berets, an already existing item, to the loadout selection. You can choose between them and IAC caps in the "Hats and Headgear" section of the loadout.
* Fixes IAC caps being mislabelled as berets in the loadout.

#12675 was the original PR, there was an error about unrelated build histories on that PR and I figured the easiest way for me to fix it would be to just close it and make a new one.