### PR TITLE
More informative mixing-cooking

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -677,3 +677,22 @@
 	for (var/i in 1 to numSquares)
 		loadstring += i <= limit ? "█" : "░"
 	return "\[[loadstring]\]"
+
+// Adds -s or -es to the very last word of given string
+/proc/pluralize_word(text, check_plural = FALSE)
+	var/l = length(text)
+	if (l)
+		switch(text[l])
+			if("z", "x")
+				return "[text]es"
+			if("s")
+				if (check_plural && l > 2)
+					return text
+				return "[text]es"
+			if("h") // -sh, -ch
+				if (l > 1)
+					var/second = text[l-1]
+					if(second == "s" || second == "c")
+						return "[text]es"
+		return "[text]s"
+	return ""

--- a/code/modules/cooking/machinery/cooking_machines/container.dm
+++ b/code/modules/cooking/machinery/cooking_machines/container.dm
@@ -285,6 +285,14 @@
 		var/obj/item/reagent_containers/food/snacks/R = r
 		R.forceMove(src) //Move everything from the buffer back to the container
 
+	if (length(results))
+		var/name = results[1].name
+		var/quantity = length(results)
+		if (quantity > 1)
+			to_chat(usr, SPAN_NOTICE("You made some [pluralize_word(name, TRUE)]!"))
+		else
+			to_chat(usr, SPAN_NOTICE("You made [name]!"))
+
 	QDEL_NULL(temp) //delete buffer object
 	return ..()
 

--- a/code/modules/cooking/machinery/cooking_machines/container.dm
+++ b/code/modules/cooking/machinery/cooking_machines/container.dm
@@ -290,10 +290,10 @@
 		var/obj/item/reagent_containers/food/snacks/R = r
 		R.forceMove(src) //Move everything from the buffer back to the container
 
-	if (length(results) && usr)
+	var/l = length(results)
+	if (l && usr)
 		var/name = results[1].name
-		var/quantity = length(results)
-		if (quantity > 1)
+		if (l > 1)
 			to_chat(usr, SPAN_NOTICE("You made some [pluralize_word(name, TRUE)]!"))
 		else
 			to_chat(usr, SPAN_NOTICE("You made [name]!"))

--- a/code/modules/cooking/machinery/cooking_machines/container.dm
+++ b/code/modules/cooking/machinery/cooking_machines/container.dm
@@ -29,7 +29,7 @@
 
 /obj/item/reagent_containers/cooking_container/proc/get_content_info()
 	var/string = "It contains:</br><ul><li>"
-	string += jointext(contents, "</li></br><li>") + "</li></ul>"
+	string += jointext(contents, "</li><li>") + "</li></ul>"
 	return string
 
 /obj/item/reagent_containers/cooking_container/proc/get_reagent_info()
@@ -257,6 +257,11 @@
 	flags = OPENCONTAINER // Will still react
 	volume = 15 // for things like jelly sandwiches etc
 	max_space = 25
+
+/obj/item/reagent_containers/cooking_container/plate/examine(mob/user)
+	. = ..()
+	if(length(contents) || reagents?.total_volume)
+		to_chat(user, SPAN_NOTICE("To attempt cooking; click and hold, then drag this onto your character"))
 
 /obj/item/reagent_containers/cooking_container/plate/MouseDrop(var/obj/over_obj)
 	if(over_obj != usr || use_check(usr))

--- a/code/modules/cooking/machinery/cooking_machines/container.dm
+++ b/code/modules/cooking/machinery/cooking_machines/container.dm
@@ -285,7 +285,7 @@
 		var/obj/item/reagent_containers/food/snacks/R = r
 		R.forceMove(src) //Move everything from the buffer back to the container
 
-	if (length(results))
+	if (length(results) && usr)
 		var/name = results[1].name
 		var/quantity = length(results)
 		if (quantity > 1)

--- a/code/modules/cooking/machinery/cooking_machines/container.dm
+++ b/code/modules/cooking/machinery/cooking_machines/container.dm
@@ -271,7 +271,7 @@
 	var/decl/recipe/recipe = select_recipe(src, appliance = appliancetype)
 	if(!recipe)
 		return
-	var/list/results = recipe.make_food(src)
+	var/list/obj/results = recipe.make_food(src)
 	var/obj/temp = new /obj(src) //To prevent infinite loops, all results will be moved into a temporary location so they're not considered as inputs for other recipes
 	for (var/result in results)
 		var/atom/movable/AM = result

--- a/html/changelogs/ml_food_span.yml
+++ b/html/changelogs/ml_food_span.yml
@@ -1,0 +1,4 @@
+author: martinlyra
+delete-after: True
+changes:
+  - rscadd: "Successful cooking now informs the cook what has been synthesized"

--- a/html/changelogs/ml_food_span.yml
+++ b/html/changelogs/ml_food_span.yml
@@ -2,3 +2,5 @@ author: martinlyra
 delete-after: True
 changes:
   - rscadd: "Successful cooking now informs the cook what has been synthesized"
+  - rscadd: "Examining plates / bowls now hint the player how to use them for cooking"
+  - backend: "Added `pluralize_word` for naive pluralization of nouns"


### PR DESCRIPTION
Inspired by issue #12696. But I am not sure if it does fix it. Investigating it did occur me few annoyances that I thought needed to be amended to.
* Adds a hint to the player about how to use the plate | bowl, appears only when there are ingredients put in, and only for plates or bowls.
* Removed unnecessary `<br>` in the same examination
* Successful cooking with the plate | bowl now tell the user what has been made
* Adds `pluralize_word` text helper to naively pluralize words

![image](https://user-images.githubusercontent.com/13331724/139742603-ede2a9cb-ebb4-41ea-878d-3c0b19640738.png)
![image](https://user-images.githubusercontent.com/13331724/139740393-178a24af-adb4-4a28-9cb2-2886b3d4fc25.png)
(Yellow highlighting not included)