### PR TITLE
Matriarch Fixes

### DIFF
--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -193,7 +193,7 @@
 /datum/controller/subsystem/ghostroles/proc/add_spawn_atom(var/ghost_role_name, var/atom/spawn_atom)
 	if(ghost_role_name && spawn_atom)
 		var/datum/ghostspawner/G = spawners[ghost_role_name]
-		if(G)
+		if(G && !(spawn_atom in G.spawn_atoms))
 			G.spawn_atoms += spawn_atom
 			if(G.atom_add_message)
 				say_dead_direct("[G.atom_add_message]<br>Spawn in as it by using the ghost spawner menu in the ghost tab, and try to be good!")

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -194,9 +194,13 @@
 	. = ..()
 	SSghostroles.remove_spawn_atom("matriarchmaintdrone", src)
 
+/mob/living/silicon/robot/drone/construction/matriarch/do_possession(mob/abstract/observer/possessor)
+	. = ..()
+	SSghostroles.remove_spawn_atom("matriarchmaintdrone", src)
+
 /mob/living/silicon/robot/drone/construction/matriarch/ghostize(can_reenter_corpse, should_set_timer)
 	. = ..()
-	if(stat == DEAD)
+	if(can_reenter_corpse || stat == DEAD)
 		return
 	if(src in mob_list) // needs to exist to reopen spawn atom
 		set_name(initial(name))

--- a/html/changelogs/geeves-matriarch_fixes.yml
+++ b/html/changelogs/geeves-matriarch_fixes.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Dragging yourself onto a matriarch drone to possess it will now remove it from the ghost spawner list."
+  - bugfix: "Aghosting from a matriarch drone no longer reopens the slot."


### PR DESCRIPTION
* Dragging yourself onto a matriarch drone to possess it will now remove it from the ghost spawner list.
* Aghosting from a matriarch drone no longer reopens the slot.