### PR TITLE
fixes vaurca surgery and permanent blindess

### DIFF
--- a/code/modules/organs/internal/species/vaurca.dm
+++ b/code/modules/organs/internal/species/vaurca.dm
@@ -7,6 +7,11 @@
 	vision_mechanical_color = /datum/client_color/monochrome
 	eye_emote = "'s eyes gently shift."
 
+/obj/item/organ/internal/eyes/night/vaurca/surgical_fix(mob/user)
+	..()
+	if(damage < min_broken_damage && owner.sdisabilities & BLIND)
+		owner.sdisabilities -= BLIND
+
 /obj/item/organ/internal/eyes/night/vaurca/flash_act()
 	if(!owner)
 		return

--- a/code/modules/organs/subtypes/vaurca.dm
+++ b/code/modules/organs/subtypes/vaurca.dm
@@ -340,6 +340,7 @@ obj/item/organ/vaurca/neuralsocket/process()
 
 /obj/item/organ/external/chest/vaurca
 	limb_flags = 0
+	encased = null
 
 /obj/item/organ/external/groin/vaurca
 	limb_flags = ORGAN_CAN_AMPUTATE | ORGAN_CAN_MAIM
@@ -370,3 +371,4 @@ obj/item/organ/vaurca/neuralsocket/process()
 
 /obj/item/organ/external/head/vaurca
 	limb_flags = ORGAN_CAN_AMPUTATE | ORGAN_CAN_MAIM
+	encased = null

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -488,6 +488,9 @@
 		if(E && istype(E))
 			if(E.damage > 0)
 				E.damage = max(E.damage - 5 * removed, 0)
+		if(isvaurca(H))
+			if(E.damage < E.min_broken_damage && H.sdisabilities & BLIND)
+				H.sdisabilities -= BLIND
 
 /decl/reagent/oculine/affect_chem_effect(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	. = ..()

--- a/html/changelogs/VaurcaSurgeryFix.yml
+++ b/html/changelogs/VaurcaSurgeryFix.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Vaurca head & chest no longer needs to be sawed through in surgery."
+  - bugfix: "Vaurca are no longer permanently blind when flashed. It can be fixed through surgery or by applying oculine."


### PR DESCRIPTION
- Vaurca will no longer need to have their head or chest 'sawed' open as is not encased in bone.
- Vaurca will no longer be permanently blind when flashed 2-3 times. It can be fixed through either surgery or oculine.