### PR TITLE
Radio message fixes

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -201,7 +201,7 @@
 	set src in usr
 
 	normal_layer = !normal_layer
-	to_chat(usr, SPAN_NOTICE("\The [src] will now layer [normal_layer ? "under" : "over"] your outerwear."))
+	to_chat(usr, SPAN_NOTICE("\The [src] will now layer [normal_layer ? "over" : "under"] your outerwear."))
 	if (ismob(src.loc))
 		var/mob/M = src.loc
 		M.update_inv_wrists()	

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -453,11 +453,11 @@ var/global/list/default_medbay_channels = list(
 	  //#### Sending the signal to all subspace receivers ####//
 
 		for(var/obj/machinery/telecomms/receiver/R in telecomms_list)
-			R.receive_signal(signal)
+			INVOKE_ASYNC(R, /obj/proc/receive_signal, signal)
 
 		// Allinone can act as receivers.
 		for(var/obj/machinery/telecomms/allinone/R in telecomms_list)
-			R.receive_signal(signal)
+			INVOKE_ASYNC(R, /obj/proc/receive_signal, signal)
 
 		// Receiving code can be located in Telecommunications.dm
 		var/position_z_in_level = FALSE // this particular band-aid is required to make antag radios say "talks into" and not "tries to talk into" when using a radio, due to how their signals are made
@@ -513,7 +513,7 @@ var/global/list/default_medbay_channels = list(
 	signal.frequency = connection.frequency // Quick frequency set
 
 	for(var/obj/machinery/telecomms/receiver/R in telecomms_list)
-		R.receive_signal(signal)
+		INVOKE_ASYNC(R, /obj/proc/receive_signal, signal)
 
 
 	sleep(rand(10,25)) // wait a little...

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -175,7 +175,7 @@
 		if("headset")
 			var/obj/item/device/radio/R = get_radio()
 			if(R)
-				used_radios += l_ear
+				used_radios += R
 				if(R.talk_into(src, message, null, verb, speaking))
 					successful_radio += R
 		if("right ear")

--- a/html/changelogs/RadioFixes.yml
+++ b/html/changelogs/RadioFixes.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes:
   - bugfix: "Radios worn in other slots than the left ear will now properly show as being talked into if others are nearby."
   - bugfix: "The message for the wrist radio being layered over/under the outerwear is no longer reversed."
+  - bugfix: "When telecomms are damaged, the spoken message will no longer be delayed when speaking into the radio, only the radio message."

--- a/html/changelogs/RadioFixes.yml
+++ b/html/changelogs/RadioFixes.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Radios worn in other slots than the left ear will now properly show as being talked into if others are nearby."
+  - bugfix: "The message for the wrist radio being layered over/under the outerwear is no longer reversed."


### PR DESCRIPTION
- When speaking into a radio located on the right ear or wrist, it will now properly show that to those nearby.
- Fixed the message for changing wrist radio layer being reversed.
- When speaking into a radio with damaged telecomms, the spoken part will now display immediately instead of waiting for the radio message.


![radio message](https://user-images.githubusercontent.com/8396443/140149837-6bd0e806-b745-4e88-a230-82b7e05023fc.png)
