### PR TITLE
Unit-test kitchen tags in fruits & recipes

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2981,6 +2981,7 @@
 #include "code\modules\xgm\xgm_gas_data.dm"
 #include "code\modules\xgm\xgm_gas_mixture.dm"
 #include "code\unit_tests\chemistry_tests.dm"
+#include "code\unit_tests\cooking_tests.dm"
 #include "code\unit_tests\equipment_tests.dm"
 #include "code\unit_tests\foundation_tests.dm"
 #include "code\unit_tests\gamemode_tests.dm"

--- a/code/modules/cooking/recipes/recipes_soup.dm
+++ b/code/modules/cooking/recipes/recipes_soup.dm
@@ -95,7 +95,7 @@
 
 /decl/recipe/pozole
 	appliance = SAUCEPAN | POT
-	fruit = list("dyn" = 1, "cabbage" = 1, "tomato" = 1)
+	fruit = list("dyn leaf" = 1, "cabbage" = 1, "tomato" = 1)
 	reagents = list(/decl/reagent/water = 10)
 	items = list(/obj/item/reagent_containers/food/snacks/meat)
 	result = /obj/item/reagent_containers/food/snacks/soup/pozole

--- a/code/modules/hydroponics/seed_datums/tomato.dm
+++ b/code/modules/hydroponics/seed_datums/tomato.dm
@@ -65,6 +65,7 @@
 	display_name = "blue tomato plant"
 	mutants = list("bluespacetomato")
 	chems = list(/decl/reagent/nutriment = list(1,20), /decl/reagent/lube = list(1,5))
+	kitchen_tag = "bluespacetomato"
 
 /datum/seed/tomato/blue/setup_traits()
 	..()

--- a/code/unit_tests/cooking_tests.dm
+++ b/code/unit_tests/cooking_tests.dm
@@ -17,6 +17,7 @@
 	var/list/not_found = list()
 
 	var/n_found = 0
+	var/n_affected = 0
 
 	var/ktag
 	for(var/datum/seed/S in SSplants.seeds)
@@ -37,6 +38,7 @@
 	for(var/tag in tags_required)
 		if(!(tag in tags_available))
 			not_found += tag
+			n_affected += length(tags_required[tag])
 		else
 			tags_in_use[tag] = TRUE
 
@@ -49,24 +51,25 @@
 		else
 			n_found += 1
 
-	var/n_unused = length(available_tags) - n_found
+	var/n_available = length(tags_available)
+	var/n_unused = n_available - n_found
 	if(length(not_found))
 		for (var/tag in not_found)
 			var/lstr = english_list(tags_required[tag])
 			log_unit_test(
-				"[ascii_red]--------------- Undefined '[tag]', required by [ltr]![ascii_reset]"
+				"[ascii_red]--------------- Undefined '[tag]', required by [lstr]![ascii_reset]"
 			)
 
-		var/msg = "[length(not_found)] of [length(recipes)] could not find [len(not_found)] tags!"
+		var/msg = "[n_affected] of [length(recipes)] could not find [length(not_found)] tags!"
 		if(n_unused)
-			msg += " With [length(available_tags) - n_found] unsued tags found."
+			msg += " With [n_unused] unsued tags found."
 		else
 			msg += " With no unused tags."
 		fail(msg)
 	else
 		var/msg = "All [length(recipes)] recipes could find all [n_found] needed tags!"
 		if(n_unused)
-			msg += " With [length(available_tags) - n_found] unsued tags found."
+			msg += " With [n_unused] unsued tags found."
 		else
 			msg += " With no unused tags."
 		pass(msg)

--- a/code/unit_tests/cooking_tests.dm
+++ b/code/unit_tests/cooking_tests.dm
@@ -2,7 +2,6 @@
  *  Unit Tests for recipes used in cooking.
  */
 
-
 /*
  * As long strings are used in the '/decl/recipe's, this test is absolutely necessary
  */
@@ -20,7 +19,8 @@
 	var/n_affected = 0
 
 	var/ktag
-	for(var/datum/seed/S in SSplants.seeds)
+	for(var/seed_name in SSplants.seeds)
+		var/datum/seed/S = SSplants.seeds[seed_name]
 		ktag = S.kitchen_tag
 		if(!(ktag in tags_available))
 			tags_available[ktag] = list()

--- a/code/unit_tests/cooking_tests.dm
+++ b/code/unit_tests/cooking_tests.dm
@@ -8,6 +8,9 @@
 /datum/unit_test/cooking_recipes_fruits
 	name = "COOKING: Check recipe fruit tags"
 
+	// In case you want to see all the unused tags. Disabled by default because holy shit so many.
+	var/print_all_unused_tags = FALSE
+
 /datum/unit_test/cooking_recipes_fruits/start_test()
 	var/list/tags_available = list()
 	var/list/tags_in_use = list()
@@ -22,10 +25,20 @@
 	for(var/seed_name in SSplants.seeds)
 		var/datum/seed/S = SSplants.seeds[seed_name]
 		ktag = S.kitchen_tag
-		if(!(ktag in tags_available))
-			tags_available[ktag] = list()
-			tags_in_use[ktag] = FALSE
-		tags_available[ktag] += S.type
+		if(!ktag || !length(ktag))
+			continue
+
+		var/list/tags = list(ktag)
+		if(S.get_trait(TRAIT_FLESH_COLOUR))
+			// Fuck you asfaghewqWAFAWE
+			tags += "[ktag] slice"
+			tags += "dried [ktag] slice"
+
+		for(var/tag in tags)
+			if(!(tag in tags_available))
+				tags_available[tag] = list()
+				tags_in_use[tag] = FALSE
+			tags_available[tag] += S.type
 
 	var/list/recipes = decls_repository.get_decls_of_subtype(/decl/recipe)
 	for(var/rtype in recipes)
@@ -45,10 +58,11 @@
 
 	for(var/tag in tags_in_use)
 		if(!tags_in_use[tag]) // is unused
-			var/lstr = english_list(tags_available[tag])
-			log_unit_test(
-				"[ascii_yellow]--------------- Unused '[tag]', defined by [lstr].[ascii_reset]"
-			)
+			if(print_all_unused_tags)
+				var/lstr = english_list(tags_available[tag])
+				log_unit_test(
+					"[ascii_yellow]--------------- Unused '[tag]', defined by [lstr].[ascii_reset]"
+				)
 		else
 			n_found += 1
 

--- a/code/unit_tests/cooking_tests.dm
+++ b/code/unit_tests/cooking_tests.dm
@@ -27,8 +27,9 @@
 			tags_in_use[ktag] = FALSE
 		tags_available[ktag] += S.type
 
-	var/list/decl/recipe/recipes = decls_repository.get_decls_of_subtype(/decl/recipe)
-	for(var/decl/recipe/R in recipes)
+	var/list/recipes = decls_repository.get_decls_of_subtype(/decl/recipe)
+	for(var/rtype in recipes)
+		var/decl/recipe/R = decls_repository.get_decl(rtype)
 		if(R.fruit && length(R.fruit))
 			for(var/tag in R.fruit)
 				if(!(tag in tags_required))

--- a/code/unit_tests/cooking_tests.dm
+++ b/code/unit_tests/cooking_tests.dm
@@ -1,0 +1,74 @@
+/*
+ *  Unit Tests for recipes used in cooking.
+ */
+
+
+/*
+ * As long strings are used in the '/decl/recipe's, this test is absolutely necessary
+ */
+/datum/unit_test/cooking_recipes_fruits
+	name = "COOKING: Check recipe fruit tags"
+
+/datum/unit_test/cooking_recipes_fruits/start_test()
+	var/list/tags_available = list()
+	var/list/tags_in_use = list()
+	var/list/tags_required = list()
+
+	var/list/not_found = list()
+
+	var/n_found = 0
+
+	var/ktag
+	for(var/datum/seed/S in SSplants.seeds)
+		ktag = S.kitchen_tag
+		if(!(ktag in tags_available))
+			tags_available[ktag] = list()
+			tags_in_use[ktag] = FALSE
+		tags_available[ktag] += S.type
+
+	var/list/decl/recipe/recipes = decls_repository.get_decls_of_subtype(/decl/recipe)
+	for(var/decl/recipe/R in recipes)
+		if(R.fruit && length(R.fruit))
+			for(var/tag in R.fruit)
+				if(!(tag in tags_required))
+					tags_required[tag] = list()
+				tags_required[tag] += R
+
+	for(var/tag in tags_required)
+		if(!(tag in tags_available))
+			not_found += tag
+		else
+			tags_in_use[tag] = TRUE
+
+	for(var/tag in tags_in_use)
+		if(!tags_in_use[tag]) // is unused
+			var/lstr = english_list(tags_available[tag])
+			log_unit_test(
+				"[ascii_yellow]--------------- Unused '[tag]', defined by [lstr].[ascii_reset]"
+			)
+		else
+			n_found += 1
+
+	var/n_unused = length(available_tags) - n_found
+	if(length(not_found))
+		for (var/tag in not_found)
+			var/lstr = english_list(tags_required[tag])
+			log_unit_test(
+				"[ascii_red]--------------- Undefined '[tag]', required by [ltr]![ascii_reset]"
+			)
+
+		var/msg = "[length(not_found)] of [length(recipes)] could not find [len(not_found)] tags!"
+		if(n_unused)
+			msg += " With [length(available_tags) - n_found] unsued tags found."
+		else
+			msg += " With no unused tags."
+		fail(msg)
+	else
+		var/msg = "All [length(recipes)] recipes could find all [n_found] needed tags!"
+		if(n_unused)
+			msg += " With [length(available_tags) - n_found] unsued tags found."
+		else
+			msg += " With no unused tags."
+		pass(msg)
+
+	return 1

--- a/code/unit_tests/cooking_tests.dm
+++ b/code/unit_tests/cooking_tests.dm
@@ -29,10 +29,13 @@
 			continue
 
 		var/list/tags = list(ktag)
+
+		// Fuck you asfaghewqWAFAWE
+		// See /decl/recipe/proc/check_fruit(...) in recipe.dm for why
 		if(S.get_trait(TRAIT_FLESH_COLOUR))
-			// Fuck you asfaghewqWAFAWE
 			tags += "[ktag] slice"
 			tags += "dried [ktag] slice"
+		tags += "dried [ktag]"
 
 		for(var/tag in tags)
 			if(!(tag in tags_available))

--- a/html/changelogs/ml_cooking_ut.yml
+++ b/html/changelogs/ml_cooking_ut.yml
@@ -1,0 +1,8 @@
+author: martinlyra
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the recipe for dyn pozole"
+  - bugfix: "Fixed the recipe for bluespace tomato soup"
+  - backend: "Cooking recipes and fruits' kitchen tags are now unit-tested to prevent similar bugs with dyn pozole and bluespace tomato soup from happening again."


### PR DESCRIPTION
An idea I had when I was asked about an issue about how a recipe would not work. Turns out that the fruit it needed had a different tag than what the recipe requested for.

Because of the extent of recipes in this codebase. I think there are a need to make a unit-test for this purpose, Make sure that every recipe actually has defined kitchen tags that exist.

If this works as it should, I'll also fix recipes that are affected.