### PR TITLE
Fixes for Bulwark antennae

### DIFF
--- a/code/modules/mob/abstract/new_player/sprite_accessories.dm
+++ b/code/modules/mob/abstract/new_player/sprite_accessories.dm
@@ -1734,14 +1734,14 @@ Follow by example and make good judgement based on length which list to include 
 	icon = 'icons/mob/hair_gradients.dmi'
 	species_allowed = list(/datum/species/human,/datum/species/human/offworlder,/datum/species/machine/shell,/datum/species/machine/shell/rogue,/datum/species/zombie,
 		/datum/species/tajaran,/datum/species/tajaran/zhan_khazan,/datum/species/tajaran/m_sai,/datum/species/zombie/tajara,
-		/datum/species/skrell, /datum/species/skrell/axiori, /datum/species/zombie/skrell, /datum/species/bug, /datum/species/bug/type_b, /datum/species/bug/type_e)
+		/datum/species/skrell, /datum/species/skrell/axiori, /datum/species/zombie/skrell, /datum/species/bug, /datum/species/bug/type_b)
 
 	none
 		name = "None"
 		icon_state = "none"
 		species_allowed = list(/datum/species/human,/datum/species/human/offworlder,/datum/species/machine/shell,/datum/species/machine/shell/rogue,/datum/species/zombie,/datum/species/unathi,/datum/species/zombie/unathi,
 		/datum/species/tajaran,/datum/species/tajaran/zhan_khazan,/datum/species/tajaran/m_sai,/datum/species/zombie/tajara,/datum/species/skrell,/datum/species/skrell/axiori,/datum/species/zombie/skrell, /datum/species/bug,
-		/datum/species/bug/type_b, /datum/species/bug/type_e)
+		/datum/species/bug/type_b)
 
 	fade_up
 		name = "Fade (Up)"
@@ -1785,6 +1785,12 @@ Follow by example and make good judgement based on length which list to include 
 		name = "Skrell Spots"
 		icon_state = "skrell_gradient_spots"
 		species_allowed = list(/datum/species/skrell, /datum/species/skrell/axiori)
+
+	bulwark_default
+		name = "Bulwark Horn"
+		icon = "icons/mob/base_48.dmi"
+		icon_state = "blank"
+		species_allowed = list(/datum/species/bug/type_e)
 
 /*
 ///////////////////////////////////
@@ -2920,7 +2926,7 @@ Follow by example and make good judgement based on length which list to include 
 			length = 2
 
 //Bulwark antennae
-	bulwark_classic 
+	bulwark_classic
 		icon = 'icons/mob/human_face/bulwark_hair.dmi'
 		name = "Classic Antennae"
 		icon_state = "bully_classic"
@@ -2933,14 +2939,14 @@ Follow by example and make good judgement based on length which list to include 
 			icon_state = "bully_inj_left"
 			chatname = "antenna"
 			length = 1
-		
-		bulwark_damaged_right 
+
+		bulwark_damaged_right
 			name = "Injured Antenna, Right"
 			icon_state = "bully_inj_right"
 			chatname = "antenna"
 			length = 1
 
-		bulwark_knight 
+		bulwark_knight
 			name = "Knight Antennae"
 			icon_state = "bully_knight"
 			chatname = "antennae"
@@ -2975,13 +2981,13 @@ Follow by example and make good judgement based on length which list to include 
 			icon_state = "bully_stag"
 			chatname = "antennae"
 			length = 5
-		
+
 		bulwark_rhino
 			name = "Rhinoceros Antenna"
 			icon_state = "bully_rhino"
 			chatname = "antenna"
 			length = 5
-		
+
 		bulwark_ladybug
 			name = "Ladybug Antennae"
 			icon_state = "bully_ladybug"

--- a/code/modules/mob/abstract/new_player/sprite_accessories.dm
+++ b/code/modules/mob/abstract/new_player/sprite_accessories.dm
@@ -2928,26 +2928,26 @@ Follow by example and make good judgement based on length which list to include 
 //Bulwark antennae
 	bulwark_classic
 		icon = 'icons/mob/human_face/bulwark_hair.dmi'
-		name = "Classic Antennae"
+		name = "Bulwark Classic Antennae"
 		icon_state = "bully_classic"
 		species_allowed = list(/datum/species/bug/type_e)
 		gender = NEUTER
 		chatname = "antennae"
 
 		bulwark_damaged_left
-			name = "Injured Antenna, Left"
+			name = "Bulwark Injured Antenna, Left"
 			icon_state = "bully_inj_left"
 			chatname = "antenna"
 			length = 1
-
-		bulwark_damaged_right
-			name = "Injured Antenna, Right"
+		
+		bulwark_damaged_right 
+			name = "Bulwark Injured Antenna, Right"
 			icon_state = "bully_inj_right"
 			chatname = "antenna"
 			length = 1
 
-		bulwark_knight
-			name = "Knight Antennae"
+		bulwark_knight 
+			name = "Bulwark Knight Antennae"
 			icon_state = "bully_knight"
 			chatname = "antennae"
 			length = 2

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -196,7 +196,7 @@
 	canvas_icon = 'icons/mob/base_48.dmi'
 	talk_bubble_icon = 'icons/mob/talk_bulwark.dmi'
 
-	default_h_style = "Classic Antennae"
+	default_h_style = "Bulwark Classic Antennae"
 
 	icon_x_offset = -9
 	healths_x = 22

--- a/html/changelogs/ml_des_antennae.yml
+++ b/html/changelogs/ml_des_antennae.yml
@@ -1,0 +1,7 @@
+author: Desven, martinlyra
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed gradient issue affecting Vaurca Bulwarks"
+  - bugfix: "Fixed missing antennae styles for Vaurca Bulwarks"

--- a/html/changelogs/ml_des_antennae.yml
+++ b/html/changelogs/ml_des_antennae.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "Fixed gradient issue affecting Vaurca Bulwarks"
-  - bugfix: "Fixed missing antennae styles for Vaurca Bulwarks"
+  - bugfix: "Fixed missing antennae styles for Vaurca subspecies other than Bulwarks"


### PR DESCRIPTION
A joint bugfix PR with @desvenlafaxine 

- Fixes the colouring not applied correctly due to the wrong size of hair gradients used.
- Fixes some antennae being missing for Vaucra subspecies other than Bulwarks

| The issue | The fix |
|----------|--------|
|![image](https://user-images.githubusercontent.com/13331724/140792055-2b204fd3-8c5e-44e5-a67b-87a5183d9ce9.png)|![image](https://user-images.githubusercontent.com/13331724/140792088-da877658-68ba-4df6-a61b-fb4c9692fda2.png)|