### PR TITLE
stops ghosts from interacting with the shield generator

### DIFF
--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -260,6 +260,9 @@
 	return data
 
 /obj/machinery/shield_gen/Topic(href, href_list)
+	if(isobserver(usr) && !check_rights(R_ADMIN, FALSE, usr))
+		return 
+
 	if (!isturf(loc))
 		return 0
 

--- a/html/changelogs/ShieldFix.yml
+++ b/html/changelogs/ShieldFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Ghosts can no longer interact with the shield generator unless they're staff."


### PR DESCRIPTION
Non-admin ghosts can now only watch the ui of the shield generator but not change any of the options on it.