### PR TITLE
adds helpful descriptions to certain items

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -31,7 +31,7 @@
 	return null
 
 /obj/item/tank/jetpack
-	name = "jetpack (empty)"
+	name = "jetpack"
 	desc = "A tank of compressed gas for use as propulsion in zero-gravity areas. Use with caution."
 	icon_state = "jetpack"
 	item_state = "jetpack"

--- a/code/modules/economy/OrderTerminal.dm
+++ b/code/modules/economy/OrderTerminal.dm
@@ -1,6 +1,7 @@
 /obj/machinery/orderterminal
 	name = "Idris Ordering Terminal"
 	desc = "An ordering terminal designed by Idris for quicker expedition."
+	desc_info = "To edit the menu, select 'Toggle Lock' and swipe with an id with either kitchen or bar access. Afterwards click 'Toggle Lock' again to exit editting mode.\nAll credits from the machine will automatically go to the civilian account."
 	icon = 'icons/obj/terminals.dmi'
 	icon_state = "kitchenterminal"
 	anchored = 1

--- a/code/modules/mining/machine_rigpress.dm
+++ b/code/modules/mining/machine_rigpress.dm
@@ -1,6 +1,9 @@
 /obj/machinery/mineral/rigpress
 	name = "hardsuit module press"
 	desc = "This machine converts certain items permanently into hardsuit modules."
+	desc_info = "The following devices can be made:\nJetpack = maneuvering jets\nOre detector = ore scanner module \
+	\nDrill = Hardsuit drill mount\nPlasma cutter = hardsuit plasma cutter\nDiamond pickaxe = hardsuit diamond drill mount \
+	\nThermal drill = hardsuit thermal drill"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "coinpress0"
 	density = TRUE

--- a/code/modules/mining/machine_rigpress.dm
+++ b/code/modules/mining/machine_rigpress.dm
@@ -1,9 +1,7 @@
 /obj/machinery/mineral/rigpress
 	name = "hardsuit module press"
 	desc = "This machine converts certain items permanently into hardsuit modules."
-	desc_info = "The following devices can be made:\nJetpack = maneuvering jets\nOre detector = ore scanner module \
-	\nDrill = Hardsuit drill mount\nPlasma cutter = hardsuit plasma cutter\nDiamond pickaxe = hardsuit diamond drill mount \
-	\nThermal drill = hardsuit thermal drill"
+	desc_info = "The following devices can be made:"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "coinpress0"
 	density = TRUE
@@ -12,6 +10,22 @@
 	idle_power_usage = 15
 	active_power_usage = 50
 	var/pressing
+
+	var/list/press_types = list(
+	/obj/item/tank/jetpack = /obj/item/rig_module/maneuvering_jets,
+	/obj/item/mining_scanner = /obj/item/rig_module/device/orescanner,
+	/obj/item/pickaxe/drill = /obj/item/rig_module/device/basicdrill,
+	/obj/item/gun/energy/plasmacutter = /obj/item/rig_module/mounted/plasmacutter,
+	/obj/item/pickaxe/diamond = /obj/item/rig_module/device/drill,
+	/obj/item/gun/energy/vaurca/thermaldrill = /obj/item/rig_module/mounted/thermalldrill
+	)
+		
+/obj/machinery/mineral/rigpress/Initialize()
+	. = ..()
+	for(var/press_type in press_types)
+		var/obj/item/base = press_type
+		var/obj/item/product = press_types[press_type]
+		desc_info += "\n[initial(base.name)] = [initial(product.name)]"
 
 /obj/machinery/mineral/rigpress/update_icon()
 	if(pressing)
@@ -22,24 +36,10 @@
 /obj/machinery/mineral/rigpress/attackby(obj/item/W, mob/user)
 	if(!pressing)
 		var/outcome_path
-
-		if(istype(W, /obj/item/tank/jetpack))
-			outcome_path = /obj/item/rig_module/maneuvering_jets
-
-		if(istype(W, /obj/item/mining_scanner))
-			outcome_path = /obj/item/rig_module/device/orescanner
-
-		if(istype(W, /obj/item/pickaxe/drill))
-			outcome_path = /obj/item/rig_module/device/basicdrill
-
-		if(istype(W, /obj/item/gun/energy/plasmacutter))
-			outcome_path = /obj/item/rig_module/mounted/plasmacutter
-
-		if(istype(W, /obj/item/pickaxe/diamond))
-			outcome_path = /obj/item/rig_module/device/drill
-
-		if(istype(W, /obj/item/gun/energy/vaurca/thermaldrill))
-			outcome_path = /obj/item/rig_module/mounted/thermalldrill
+		for(var/press_type in press_types)
+			if(istype(W, press_type))
+				outcome_path = press_types[press_type]
+				break
 
 		if(!outcome_path)
 			..()

--- a/code/modules/mining/machine_rigpress.dm
+++ b/code/modules/mining/machine_rigpress.dm
@@ -25,7 +25,7 @@
 	for(var/press_type in press_types)
 		var/obj/item/base = press_type
 		var/obj/item/product = press_types[press_type]
-		desc_info += "\n[initial(base.name)] = [initial(product.name)]"
+		desc_info += "\n[initial(base.name)] -> [initial(product.name)]"
 
 /obj/machinery/mineral/rigpress/update_icon()
 	if(pressing)

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -18,6 +18,7 @@
 /obj/effect/hoist_hook
 	name = "hoist clamp"
 	desc = "A clamp used to lift people or things."
+	desc_info = "To use the hook, click drag the object you want to it to attach it.\nTo remove an object from the hook, click drag the hook to a nearby turf."
 	icon = 'icons/obj/hoists.dmi'
 	icon_state = "hoist_hook"
 	var/obj/structure/hoist/source_hoist
@@ -89,6 +90,7 @@
 /obj/structure/hoist
 	icon = 'icons/obj/hoists.dmi'
 	icon_state = "hoist_base"
+	desc_info = "To use the hook, click drag the object you want to it to attach it.\nTo remove an object from the hook, click drag the hook to a nearby turf."
 	var/broken = 0
 	density = 1
 	anchored = 1

--- a/code/modules/paperwork/journal.dm
+++ b/code/modules/paperwork/journal.dm
@@ -2,7 +2,7 @@
 	name = "journal"
 	desc = "A journal, kind of like a folder, but bigger! And personal."
 	var/closed_desc
-	desc_info = "Ctrl-click this while it's on your person to open this journal."
+	desc_info = "Alt-click this while it's on your person to open this journal.\nWhile the journal is open, use it in hand or use a pen on it to access the contents."
 	icon = 'icons/obj/contained_items/misc/journal.dmi'
 	icon_state = "journal"
 	item_state = "journal"

--- a/code/modules/paperwork/journal.dm
+++ b/code/modules/paperwork/journal.dm
@@ -2,7 +2,7 @@
 	name = "journal"
 	desc = "A journal, kind of like a folder, but bigger! And personal."
 	var/closed_desc
-	desc_info = "Alt-click this while it's on your person to open this journal.\nWhile the journal is open, use it in hand or use a pen on it to access the contents."
+	desc_info = "Alt-click this while it's on your person or next to you to open this journal.\nWhile the journal is open, use it in hand or use a pen on it to access the contents."
 	icon = 'icons/obj/contained_items/misc/journal.dmi'
 	icon_state = "journal"
 	item_state = "journal"

--- a/html/changelogs/DescHelperFix.yml
+++ b/html/changelogs/DescHelperFix.yml
@@ -1,0 +1,6 @@
+author: TheGreywolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Adds an extended description to the hoist, idris ordering terminal and hardsuit module press to help explain how to use them."


### PR DESCRIPTION
Adds helpful descriptions to explain how to use the hoist, part of the idris ordering terminal and what items can be used on a rig module press.

Also adjusts the description of the journal custom item to be up to date and more helpful on ways it can be accessed.

![image](https://user-images.githubusercontent.com/8396443/140925080-31976500-d8cf-4510-9aa5-9b2a637ea237.png)