### PR TITLE
Makes dexalin always dangerous to vaurca

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -170,6 +170,9 @@
 	if(check_min_dose(M, 0.5))
 		M.add_chemical_effect(CE_OXYGENATED, strength/6) // 1 for dexalin, 2 for dexplus
 	holder.remove_reagent(/decl/reagent/lexorin, strength/3 * removed)
+	if(alien == IS_VAURCA) //Vaurca need a mixture of phoron and oxygen. Dexalin likely imbalances that.
+		M.adjustToxLoss(removed * strength / 2)
+		M.eye_blurry = max(M.eye_blurry, 5)
 
 //Hyperoxia causes brain and eye damage
 /decl/reagent/dexalin/overdose(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
@@ -179,9 +182,6 @@
 		var/obj/item/organ/internal/eyes/E = H.get_eyes(no_synthetic = TRUE)
 		if(E && istype(E))
 			E.take_damage(removed * (strength / 12))
-	if(alien == IS_VAURCA) //Vaurca need a mixture of phoron and oxygen. Too much dexalin likely imbalances that.
-		M.adjustToxLoss(removed * strength / 2)
-		M.eye_blurry = max(M.eye_blurry, 5)
 
 /decl/reagent/dexalin/plus
 	name = "Dexalin Plus"

--- a/html/changelogs/OxygenBugs.yml
+++ b/html/changelogs/OxygenBugs.yml
@@ -1,0 +1,4 @@
+author: TheGreyWolf
+delete-after: True
+changes:
+  - tweak: "Injecting dexalin and dexalin plus into vaurca is now always dangerous instead of only when overdosing them."


### PR DESCRIPTION
Before they needed to overdose for it to be dangerous. Now it is simply always dangerous instead. 