### PR TITLE
Adjusts mob_size of all species and carry_weight

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -51,6 +51,7 @@
 	var/race_key = 0       	                             // Used for mob icon cache string.
 	var/icon/icon_template                               // Used for mob icon generation for non-32x32 species.
 	var/mob_size	= MOB_MEDIUM
+	var/carry_weight = 14								//How much a mob can carry, right now only used for fireman carrying.
 	var/show_ssd = "fast asleep"
 	var/short_sighted
 	var/bald = 0

--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -38,6 +38,7 @@
 	ethanol_resistance = -1	//Can't get drunk
 	taste_sensitivity = TASTE_NUMB
 	mob_size = 12	//Worker gestalts are 150kg
+	carry_weight = 17
 	remains_type = /obj/effect/decal/cleanable/ash //no bones, so, they just turn into dust
 	gluttonous = GLUT_ITEM_ANYTHING|GLUT_SMALLER
 	stomach_capacity = 10 //Big boys.

--- a/code/modules/mob/living/carbon/human/species/station/diona/diona_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona_subspecies.dm
@@ -6,6 +6,7 @@
 	age_max = 200
 	icobase = 'icons/mob/human_races/diona/r_coeus_diona.dmi'
 	mob_size = 10
+	carry_weight = 16
 	stomach_capacity = 8
 	blurb = "Coeus are younger Dionae gestalts whose bark is not as developed as that of the Geras. When exactly a gestalt is no longer considered a Coeus is generally up to conditions they were \
 	raised in, although bark-reduction treatments exist. Generally a gestalt remains a Coeus until they are about 80 years old, although some can be as old as 180. Due to having less bark than \

--- a/code/modules/mob/living/carbon/human/species/station/human/human.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human/human.dm
@@ -27,6 +27,7 @@
 	secondary_langs = list(LANGUAGE_SOL_COMMON)
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
 	mob_size = 9
+	carry_weight = 14 //Idk if this needs to be here but I'll add it anyway to be safe
 	spawn_flags = CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR | HAS_SOCKS | HAS_SKIN_PRESET
 	remains_type = /obj/effect/decal/remains/human

--- a/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
@@ -16,6 +16,8 @@
 	bleed_mod = 0.5
 	grab_mod = 1.1
 	resist_mod = 0.75
+	mob_size = 8
+	carry_weight = 13
 
 	warning_low_pressure = 30
 	hazard_low_pressure = 10

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
@@ -40,6 +40,8 @@
 
 	brute_mod = 1.0
 	burn_mod = 1.2
+	mob_size = 14
+	carry_weight = 16
 
 	grab_mod = 1.1 // Smooth, no real edges to grab onto
 	resist_mod = 2 // Robotic strength

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -9,6 +9,8 @@
 
 	burn_mod = 1.2
 	grab_mod = 1
+	mob_size = 14
+	carry_weight = 15
 
 	blurb = "IPCs with humanlike properties. Their focus is on service, civilian, and medical, but there are no \
 	job restrictions. Created in the late days of 2450, the Shell is a controversial IPC model equipped with a synthskin weave applied over its metal chassis \
@@ -126,7 +128,8 @@
 	name_plural = "Industrials"
 	bald = 1
 	bodytype = BODYTYPE_IPC_INDUSTRIAL
-	mob_size = 12
+	mob_size = 16
+	carry_weight = 17
 
 	unarmed_types = list(/datum/unarmed_attack/industrial, /datum/unarmed_attack/palm/industrial)
 
@@ -221,7 +224,8 @@
 	flash_mod = 0
 	siemens_coefficient = 0
 	break_cuffs = TRUE
-	mob_size = 20
+	mob_size = 18
+	carry_weight = 20
 
 	show_ssd = "laying inert, its activation glyph dark"
 
@@ -314,6 +318,8 @@
 	brute_mod = 0.7
 	grab_mod = 0.7 // Bulkier and bigger than the G1
 	resist_mod = 12 // Overall stronger than G1
+	mob_size = 18
+	carry_weight = 21
 
 	heat_level_1 = 1000
 	heat_level_2 = 2000
@@ -369,6 +375,8 @@
 	brute_mod = 0.9
 	grab_mod = 0.9
 	resist_mod = 8
+	mob_size = 17
+	carry_weight = 20
 
 	heat_level_1 = 700
 	heat_level_2 = 1400
@@ -430,6 +438,8 @@
 
 	eyes = "zenghu_eyes"
 	brute_mod = 1.5
+	mob_size = 13
+	carry_weight = 15
 
 	slowdown = -0.8
 	sprint_speed_factor = 0.6
@@ -487,6 +497,8 @@
 	brute_mod = 1.2
 	grab_mod = 1.1
 	resist_mod = 4
+	mob_size = 14
+	carry_weight = 15
 	num_alternate_languages = 3
 
 	appearance_flags = HAS_EYE_COLOR | HAS_UNDERWEAR | HAS_SOCKS
@@ -535,6 +547,8 @@
 
 	bald = 1
 	grab_mod = 1.1 //pity points - geeves
+	mob_size = 14
+	carry_weight = 15
 
 	appearance_flags = HAS_EYE_COLOR
 	spawn_flags = IS_RESTRICTED

--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
@@ -31,6 +31,8 @@
 
 	grab_mod = 2
 	resist_mod = 0.5 // LIKE BABBY
+	mob_size = 8
+	carry_weight = 13
 
 	spawn_flags = CAN_JOIN | IS_WHITELISTED
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_SOCKS

--- a/code/modules/mob/living/carbon/human/species/station/tajara/tajaran_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/tajara/tajaran_subspecies.dm
@@ -17,6 +17,7 @@
 	brute_mod = 1.1 // Less Brute Damage
 	ethanol_resistance = 1 // Default value
 	climb_coeff = 1.1
+	carry_weight = 15
 
 	resist_mod = 2 // ZHAN POWERRRRRR
 

--- a/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
@@ -53,7 +53,8 @@
 
 	rarity_value = 3
 	break_cuffs = TRUE
-	mob_size = 10
+	mob_size = 11
+	carry_weight = 16
 	climb_coeff = 1.35
 
 	blurb = "A heavily reptillian species, Unathi (or 'Sinta as they call themselves) hail from the Uuosa-Eso \

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -53,6 +53,7 @@
 	poison_type = GAS_NITROGEN //a species that breathes plasma shouldn't be poisoned by it.
 	breathing_sound = null //They don't work that way I guess? I'm a coder not a purple man.
 	mob_size = 13 //their half an inch thick exoskeleton and impressive height, plus all of their mechanical organs.
+	carry_weight = 16
 	natural_climbing = TRUE
 	climb_coeff = 0.75
 

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -17,6 +17,7 @@
 	resist_mod = 1.75
 
 	mob_size = 10 //fairly lighter than the worker type.
+	carry_weight = 14
 	taste_sensitivity = TASTE_DULL
 	blurb = "Type BA, a sub-type of the generic Type B Warriors, are the second most prominent type of Vaurca society, taking the form of hive security and military grunts. \
 	Type BA can range in size from 6ft tall to 9ft tall, and are bipedal. Unlike most other Type B's, Type BA are deprived of advanced augments, especially aboard \
@@ -60,6 +61,7 @@
 	toxins_mod = 1 //they're not used to all our weird human bacteria.
 	break_cuffs = TRUE
 	mob_size = 30
+	carry_weight = 30
 	taste_sensitivity = TASTE_DULL
 	blurb = {"Type CB Vaurcae, also known as Breeders, are the leaders of the Vaurca Society. Type C, being the only fertile caste, provide life to the Hive. Most of them, however, are not producing more eggs but in charge of hive-cells of other castes, coordinating their everyday life.<br>
 	Some Type CB Vaurcae have been recently used as representatives for their respective queens, due their keen social intelligence, making them ideal candidates for negotiating with aliens on economic and political matters. They easily grasp the nuances of social context, contracts, and systems that other castes have difficulty navigating.<br>
@@ -132,6 +134,7 @@
 	total_health = 200
 	break_cuffs = TRUE
 	mob_size = 30
+	carry_weight = 40
 
 	speech_sounds = list('sound/voice/hiss1.ogg','sound/voice/hiss2.ogg','sound/voice/hiss3.ogg','sound/voice/hiss4.ogg')
 	speech_chance = 100
@@ -226,7 +229,7 @@
 	grab_mod = 0.8
 	resist_mod = 4
 
-	mob_size = 28
+	mob_size = 23
 	taste_sensitivity = TASTE_DULL
 	blurb = {"Type E Vaurca, otherwise known as the Bulwarks, are a new bodyform derived from the worker caste in a collaboration by the C’thur and Jargon scientists. Originally only the C’thur had access to these behemoths, but after a short amount of time, the bodyform started appearing in the ranks of the Zo’ra and K’lax as well, causing an even more strained relationship between the hives.<br>
 Similar to Workers, Bulwarks are generally passive, and prefer to flee a fight rather than resist. Though due to their speed, they may still choose to defend themselves should they be unable to properly escape a battle. The main exception to this is when another Vaurca is in danger. When this occurs, they tend to put themselves in between the attacker and the Vaurca, acting as a shield of sorts. They won’t go out of their way to take down the attacker, but will ensure the others get away safely.<br>

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -442,8 +442,8 @@
 		to_chat(H, SPAN_WARNING("You can only fireman carry humanoids!"))
 		return
 	var/mob/living/carbon/human/affected_human = affecting
-	if(affected_human.species.mob_size > 25)
-		to_chat(H, SPAN_WARNING("\The [affected_human] is way too big to fireman carry!"))
+	if(assailant.species.carry_weight < affected_human.species.mob_size)
+		to_chat(H, SPAN_WARNING("\The [affected_human] is too big to fireman carry!"))
 		return
 	if(state < GRAB_AGGRESSIVE)
 		to_chat(H, SPAN_WARNING("You need an aggressive grab before you can fireman carry someone!"))


### PR DESCRIPTION
OKAY so the idea behind this change was, a G2 should be able to fireman carry a G2 but a Human shouldn't, I ended up adjusting a lot of stats so I put it all into this semi-readable graph thing.

-------------------------------------------
**MOB_SIZE**
Skrell - 8 /
Off-worlder - 8 /
Human - 9 /
Tajara - 9 /
Diona baby - 10 /
Unathi - 11 
Diona - 12 /
Vaurca worker - 13 /

***Robots:***
Zenghu frame - 13 /
Baseline frame - 14 /
Shell frame - 14 /
Bishop frame - 14 /
Industrial G1 frame - 16  /
Industrial Xion frame - 17 /
Industrial G2 frame - 18 /

Unbranded frame - 14 /

***Vaurca subspecies***
Warrior - 10 /
Bulwark - 23 /
Breeder - 30 /
type_big - 30 /
-------------------------------------------
**CARRY_WEIGHT**
Skrell - 13 /
Off-worlder - 13 /
Human - 14 /
Tajara - 14 /
Tajara Zhan - 15 /
Vaurca worker - 16 /
Unathi - 16
Diona - 17 /
Diona baby - 16 /

***Robots:***
Bishop frame - 15 /
Zenghu frame - 15 /
Shell frame - 15 /
Baseline frame - 16 /
Industrial G1 frame - 17 /
Industrial Xion frame - 20 /
Industrial G2 frame - 21 /

Unbranded frame - 15 /

***Vaurca subspecies:***
Warrior - 14 /
Bulwark - 25 /
Breeder - 30 /
type_big - 40 /
-------------------------------------------

carry_weight is how much `mob_size` a species can carry
/ is if it's loredev approved yet

This has a lot of Lore Devs contradicting what another said earlier so I'm going to post this PR but expect changes.