### PR TITLE
Jargon Lore Blurb and Dionae Consular Changes

### DIFF
--- a/code/modules/background/citizenship/skrell.dm
+++ b/code/modules/background/citizenship/skrell.dm
@@ -1,11 +1,11 @@
 /datum/citizenship/jargon
 	name = CITIZENSHIP_JARGON
 	description = "Home of the Skrell, a centralized union of solar systems run by councilors of different ranks and positions. The capital of the Federation is located at the city of \
-	Kal'lo on the core planet Jargon IV, also known as Querrbalak, within the Jargon system. While the majority of Skrell live within the Jargon Federation, a sizable portion live in \
-	independent nations within the Traverse, or abroad. The quality of life within Federation is considered to be the best in the galaxy (due in part to their technological advances \
-	and the availability of both C'thur and Dionaea as manual labourers), allowing Federation Citizens to focus on less intensive pursuits. A rogue artificial intelligence, \
-	Glorsh-Omega, has traumatized this nation for centuries to come, and the Federation is very wary of humanity, who has acquired AI technology (such as IPCs) after a Federation \
-	tech leak."
+	Kal'lo on the core planet Jargon IV, also known as Qerrbalak, within the Jargon system. While the majority of Skrell live within the Jargon Federation, a sizable portion live \
+	abroad. The quality of life within Federation is considered to be the best in the galaxy due to their technological advances, allowing Federation Citizens access to a quality of \
+	life almost unmatched anywhere else in the Spur. \
+	A rogue artificial intelligence, Glorsh-Omega, has traumatized this nation for centuries to come. The Federation is very wary of humanity, who has acquired AI technology \
+	after a Federation tech leak provided them with the research required to create their own AI, as well as allowing them to create IPCs." \
 	consular_outfit = /datum/outfit/job/representative/consular/jargon
 
 	job_species_blacklist = list(
@@ -20,7 +20,6 @@
 			SPECIES_IPC_UNBRANDED,
 			SPECIES_IPC_XION,
 			SPECIES_IPC_ZENGHU,
-			SPECIES_DIONA,
 			SPECIES_DIONA_COEUS,
 			SPECIES_TAJARA,
 			SPECIES_TAJARA_MSAI,

--- a/code/modules/background/citizenship/skrell.dm
+++ b/code/modules/background/citizenship/skrell.dm
@@ -5,7 +5,7 @@
 	abroad. The quality of life within Federation is considered to be the best in the galaxy due to their technological advances, allowing Federation Citizens access to a quality of \
 	life almost unmatched anywhere else in the Spur. \
 	A rogue artificial intelligence, Glorsh-Omega, has traumatized this nation for centuries to come. The Federation is very wary of humanity, who has acquired AI technology \
-	after a Federation tech leak provided them with the research required to create their own AI, as well as allowing them to create IPCs." \
+	after a Federation tech leak provided them with the research required to create their own AI, as well as allowing them to create IPCs."
 	consular_outfit = /datum/outfit/job/representative/consular/jargon
 
 	job_species_blacklist = list(

--- a/html/changelogs/blurb_fix.yml
+++ b/html/changelogs/blurb_fix.yml
@@ -1,0 +1,7 @@
+author: RyverStyx
+
+delete-after: True
+
+changes:
+  - tweak: "Fixing the Jargon blurb to be lore compliant."
+  - rscadd: "Allowing Dionae to be Jargon Consulars." 


### PR DESCRIPTION
Removing mentions of independent nations in the traverse and allowing Dionae to be Jargon Consulars.