### PR TITLE
Toggling Headgear Hair Blocking

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -4,6 +4,10 @@
 	slot = slot_head
 	sort_category = "Hats and Headwear"
 
+/datum/gear/head/New()
+	..()
+	gear_tweaks += list(gear_tweak_hair_block)
+
 /datum/gear/head/ushanka_grey
 	display_name = "ushanka, grey"
 	path = /obj/item/clothing/head/ushanka/grey
@@ -344,3 +348,29 @@
 	display_name = "dominian consular cap"
 	path = /obj/item/clothing/head/dominia
 	allowed_roles = list("Consular Officer")
+
+
+/*
+	Block Hair Adjustment
+*/
+var/datum/gear_tweak/hair_block/gear_tweak_hair_block = new()
+
+/datum/gear_tweak/hair_block/get_contents(var/metadata)
+	return "Blocks Hair: [metadata]"
+
+/datum/gear_tweak/hair_block/get_default()
+	return "Default"
+
+/datum/gear_tweak/hair_block/get_metadata(var/user, var/metadata)
+	return input(user, "Choose whether you want your headgear to block hair, or use the headgear's default.", "Hair Blocking", metadata) as anything in list("Yes", "No", "Default")
+
+/datum/gear_tweak/hair_block/tweak_item(var/obj/item/clothing/head/H, var/metadata)
+	if(!istype(H))
+		return
+	if(!H.allow_hair_covering)
+		return
+	switch(metadata)
+		if("Yes")
+			H.flags_inv |= BLOCKHEADHAIR
+		if("No")
+			H.flags_inv &= ~BLOCKHEADHAIR

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -492,10 +492,25 @@
 	drop_sound = 'sound/items/drop/hat.ogg'
 	pickup_sound = 'sound/items/pickup/hat.ogg'
 
+	var/allow_hair_covering = TRUE //in case if you want to allow someone to switch the BLOCKHEADHAIR var from the helmet or not
+
 	var/light_overlay = "helmet_light"
 	var/light_applied
 	var/brightness_on
 	var/on = 0
+
+/obj/item/clothing/head/Initialize(mapload, material_key)
+	. = ..()
+	if(allow_hair_covering)
+		verbs += /obj/item/clothing/head/proc/toggle_block_hair
+
+/obj/item/clothing/head/proc/toggle_block_hair()
+	set name = "Toggle Hair Coverage"
+	set category = "Object"
+
+	if(allow_hair_covering)
+		flags_inv ^= BLOCKHEADHAIR
+		to_chat(usr, SPAN_NOTICE("[src] will now [flags_inv & BLOCKHEADHAIR ? "hide" : "show"] hair."))
 
 /obj/item/clothing/head/get_image_key_mod()
 	return on

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -511,6 +511,9 @@
 	if(allow_hair_covering)
 		flags_inv ^= BLOCKHEADHAIR
 		to_chat(usr, SPAN_NOTICE("[src] will now [flags_inv & BLOCKHEADHAIR ? "hide" : "show"] hair."))
+		if(ishuman(usr))
+			var/mob/living/carbon/human/H = usr
+			H.update_hair()
 
 /obj/item/clothing/head/get_image_key_mod()
 	return on

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -22,7 +22,6 @@
 	siemens_coefficient = 0.5
 	w_class = ITEMSIZE_NORMAL
 	var/obj/machinery/camera/camera
-	var/allow_hair_covering = TRUE //in case if you want to allow someone to switch the BLOCKHEADHAIR var from the helmet or not
 	drop_sound = 'sound/items/drop/helm.ogg'
 	pickup_sound = 'sound/items/pickup/helm.ogg'
 
@@ -52,14 +51,6 @@
 	if(..(user, 1) && camera)
 		to_chat(user, FONT_SMALL(SPAN_NOTICE("To toggle the helmet camera, right click the helmet and press <b>Toggle Helmet Camera</b>.")))
 		to_chat(user, "This helmet has a built-in camera. It's [!ispath(camera) && camera.status ? "" : "in"]active.")
-
-/obj/item/clothing/head/helmet/verb/toggle_block_hair()
-	set name = "Toggle Helmet Hair Coverage"
-	set category = "Object"
-
-	if(allow_hair_covering)
-		flags_inv ^= BLOCKHEADHAIR
-		to_chat(usr, "<span class='notice'>[src] will now [flags_inv & BLOCKHEADHAIR ? "hide" : "show"] hair.</span>")
 
 /obj/item/clothing/head/helmet/hos
 	name = "head of security helmet"

--- a/html/changelogs/geeves-readd_flb.yml
+++ b/html/changelogs/geeves-readd_flb.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Toggling whether headgear blocks hair has been moved from helmets to root level headgear, meaning any headwear can be made to toggle hair or not. Additionally, loadout headgear can now be set to block hair or not, so you don't have to do it each round."

--- a/html/changelogs/geeves-readd_flb.yml
+++ b/html/changelogs/geeves-readd_flb.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - rscadd: "Toggling whether headgear blocks hair has been moved from helmets to root level headgear, meaning any headwear can be made to toggle hair or not. Additionally, loadout headgear can now be set to block hair or not, so you don't have to do it each round."
+  - rscadd: "Toggling headgear's hair coverage now instantly updates your hair icon."


### PR DESCRIPTION
* Toggling whether headgear blocks hair has been moved from helmets to root level headgear, meaning any headwear can be made to toggle hair or not. Additionally, loadout headgear can now be set to block hair or not, so you don't have to do it each round.
* Toggling headgear's hair coverage now instantly updates your hair icon.