### PR TITLE
Removes Unathi cuff breaking

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
@@ -52,7 +52,6 @@
 	body_temperature = T0C + 24
 
 	rarity_value = 3
-	break_cuffs = TRUE
 	mob_size = 10
 	climb_coeff = 1.35
 

--- a/html/changelogs/desven-unathinerf.yml
+++ b/html/changelogs/desven-unathinerf.yml
@@ -1,0 +1,4 @@
+author: Desven
+delete-after: True
+changes:
+  - rscdel: "Unathi no longer auto break cuffs."


### PR DESCRIPTION
Basically, no other species that are bigger than Unathi, like Bulwarks or G2, can auto break them, so instead of making them all just break cuffs, why not just nerf the lizards?

