### PR TITLE
Cargo Bounty Tweaks

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1407,6 +1407,7 @@
 #include "code\modules\cargo\exports\large_objects.dm"
 #include "code\modules\cargo\exports\materials.dm"
 #include "code\modules\cargo\exports\parts.dm"
+#include "code\modules\cargo\exports\phoron.dm"
 #include "code\modules\cargo\exports\seeds.dm"
 #include "code\modules\cargo\exports\sheets.dm"
 #include "code\modules\cargo\exports\tools.dm"

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -19,7 +19,7 @@
 		for(var/i = 0; i < reward; ++i)
 			SScargo.try_add_bounty(SScargo.random_bounty())
 
-//during phoron scarcity lore arc. remove when lore permits. 
+//during phoron scarcity lore arc. remove when lore permits.
 
 /datum/bounty/item/phoron_sheet
 	name = "Phoron Sheets"
@@ -50,8 +50,8 @@
 	required_count = 3
 	random_count = 1 // 2 to 4
 	wanted_types = list(/obj/machinery/portable_atmospherics/canister)
-	high_priority = TRUE	
-	var/moles_required = 2000 //Roundstart total_moles for a FULL tank is about 1871 per tank. However during the arc this bounty is relevant, tanks are half full. 
+	high_priority = TRUE
+	var/moles_required = 2000 //Roundstart total_moles for a FULL tank is about 1871 per tank. However during the arc this bounty is relevant, tanks are half full.
 
 /datum/bounty/item/phoron_canister/applies_to(var/obj/machinery/portable_atmospherics/canister/O)
 	if(!..())
@@ -64,3 +64,13 @@
 		return FALSE
 
 	return O.air_contents.gas["phoron"] >= moles_required
+
+/datum/bounty/item/solar_array
+	name = "Assembled Solar Panels"
+	description = "Owing to the phoron shortage continuing for over a year, longer than projected, we have decided to use solar arrays to power various facilities across our region of influence."
+	reward_low = 8000
+	reward_high = 10000
+	required_count = 6
+	random_count = 2 // 4 to 8
+	wanted_types = list(/obj/machinery/power/solar)
+	high_priority = TRUE

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -16,7 +16,7 @@
 
 /datum/bounty/New()
 	if(reward_low > 0 && reward_high > reward_low)
-		reward = round(rand(reward_low, reward_high), 100)	
+		reward = round(rand(reward_low, reward_high), 100)
 	description = replacetext(description, "%DOCKNAME",current_map.dock_name)
 	description = replacetext(description, "%DOCKSHORT",current_map.dock_short)
 	description = replacetext(description, "%BOSSNAME",current_map.boss_name)
@@ -210,13 +210,13 @@
 	var/datum/bounty/r_subtype = pick(subtypesof(/datum/bounty/reagent))
 	try_add_bounty(new r_subtype)
 
-	//phoron arc bounties. remove when arc is done.
-	var/datum/bounty/item/phoron_bounty = pick(/datum/bounty/item/phoron_sheet, /datum/bounty/item/phoron_canister)
-	try_add_bounty(new phoron_bounty)
-
-	//uncomment the below two lines when phoron scarcity arc is done
-	//var/datum/bounty/B = pick(bounties_list)
-	//B.mark_high_priority()
+	if(prob(60))
+		//phoron arc bounties. remove when arc is done.
+		var/datum/bounty/item/phoron_bounty = pick(/datum/bounty/item/phoron_sheet, /datum/bounty/item/solar_array)
+		try_add_bounty(new phoron_bounty)
+	else
+		var/datum/bounty/B = pick(bounties_list)
+		B.mark_high_priority()
 
 	// Generate these last so they can't be high priority.
 	try_add_bounty(new /datum/bounty/more_bounties)

--- a/code/modules/cargo/exports/phoron.dm
+++ b/code/modules/cargo/exports/phoron.dm
@@ -1,0 +1,18 @@
+/datum/export/phoron_canister
+	cost = 2000 // on average, the bounty would be 3 canisters giving 9000 credits, meaning 3000 credits per. however, this is repeatable, so lower it by 1000
+	k_elasticity = 0
+	unit_name = "phoron canister"
+	export_types = list(/obj/machinery/portable_atmospherics/canister)
+	var/moles_required = 2000 //Roundstart total_moles for a FULL tank is about 1871 per tank. However during the arc this bounty is relevant, tanks are half full.
+
+/datum/export/phoron_canister/applies_to(obj/machinery/portable_atmospherics/canister/O, contr, emag)
+	if(!..())
+		return FALSE
+	if(!istype(O))
+		return FALSE
+
+	var/datum/gas_mixture/environment = O.return_air()
+	if(!environment || !O.air_contents.gas["phoron"])
+		return FALSE
+
+	return O.air_contents.gas["phoron"] >= moles_required

--- a/code/modules/modular_computers/file_system/programs/civilian/cargo_control.dm
+++ b/code/modules/modular_computers/file_system/programs/civilian/cargo_control.dm
@@ -241,6 +241,7 @@
 				if(B.claimed)
 					continue
 				text += "<h3>[B.name]</h3>"
+				text += "<font size = \"1\">[B.description]</font>"
 				text += "<ul><li>Reward: [B.reward_string()]</li>"
 				text += "<li>Completed: [B.completion_string()]</li></ul>"
 			if(!console.nano_printer.print_text(text,"paper - Bounties"))

--- a/html/changelogs/geeves-bounty_tweaks.yml
+++ b/html/changelogs/geeves-bounty_tweaks.yml
@@ -1,0 +1,9 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Replaced the high priority phoron canister bounty with the ability to export a phoron canister with more than 2000 moles for 2000 credits."
+  - rscadd: "Added a phoron scarcity bounty, assembled solar panels. Solar panels must be build by wrenching the assemblies, then adding glass to them."
+  - tweak: "Phoron scarcity bounties now only have a 60% chance of occuring a round. Otherwise, a random bounty will be made high priority."
+  - rscadd: "Printed bounty sheets now gets the fluff description too."


### PR DESCRIPTION
* Replaced the high priority phoron canister bounty with the ability to export a phoron canister with more than 2000 moles for 2000 credits.
* Added a phoron scarcity bounty, assembled solar panels. Solar panels must be build by wrenching the assemblies, then adding glass to them.
* Phoron scarcity bounties now only have a 60% chance of occuring a round. Otherwise, a random bounty will be made high priority.
* Printed bounty sheets now gets the fluff description too.