### PR TITLE
Allows the holomenu to be read from any distance

### DIFF
--- a/code/game/objects/items/holomenu.dm
+++ b/code/game/objects/items/holomenu.dm
@@ -67,7 +67,7 @@
 	return ..()
 
 /obj/item/holomenu/examine(mob/user, distance)
-	if(anchored && length(menu_text) && Adjacent(user))
+	if(anchored && length(menu_text))
 		interact(user)
 		return
 	return ..()

--- a/html/changelogs/HoloMenuChanges.yml
+++ b/html/changelogs/HoloMenuChanges.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "The holomenu given to chefs and bartenders can now be read from any distance when examined."


### PR DESCRIPTION
The holomenu given to the chef and bartender can now be read from any distance when examined as having to get up and walk over to it just to read a menu is less than ideal for what is essentially text floating in the air.