### PR TITLE
Fixes red nightshade

### DIFF
--- a/code/modules/client/client_color.dm
+++ b/code/modules/client/client_color.dm
@@ -112,7 +112,7 @@
 	priority = 100
 
 /datum/client_color/berserk
-	client_color = "#AF111C"
+	client_color = list(0.793, 0.4, 0.4, 0.793, 0.4, 0.4, 0, 0, 0)
 	priority = INFINITY //This effect sort of exists on its own you /have/ to be seeing RED
 	override = TRUE //Because multiplying this will inevitably fail
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -94,7 +94,7 @@
 	if(is_overdosing(M, location, holder))
 		overdose(M, alien, removed, LAZYACCESS(M.chem_doses, type)/get_overdose(M, location, holder), holder) //Actual overdose threshold now = overdose + od_minimum_dose. ie. Synaptizine; 5u OD threshold + 1 unit min. metab'd dose = 6u actual OD threshold.
 
-	if(LAZYACCESS(M.chem_doses, type) == 0)
+	if(LAZYACCESS(M.chem_doses, type) <= 0)
 		initial_effect(M,alien, holder)
 
 	LAZYSET(M.chem_doses, type, LAZYACCESS(M.chem_doses, type) + removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -666,8 +666,9 @@
 	M.add_chemical_effect(CE_BERSERK, 1)
 	if(M.a_intent != I_HURT)
 		M.a_intent_change(I_HURT)
-	if(prob(10))
-		M.add_chemical_effect(CE_NEUROTOXIC, 5*removed)
+	var/obj/item/organ/internal/heart = M.internal_organs_by_name[BP_HEART]
+	if(heart)
+		M.add_chemical_effect(CE_CARDIOTOXIC, removed * 0.020)
 
 /decl/reagent/toxin/spectrocybin
 	name = "Spectrocybin"

--- a/html/changelogs/ShadyNights.yml
+++ b/html/changelogs/ShadyNights.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "Red Nightshade berserk state now works again."
-  - bugfix: "Red Nightshade is no longer a 5 second kill timer. It now induces heart damage instead."
+  - bugfix: "Red Nightshade is no longer incredible lethal. It now induces heart damage instead."

--- a/html/changelogs/ShadyNights.yml
+++ b/html/changelogs/ShadyNights.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Red Nightshade berserk state now works again."
+  - bugfix: "Red Nightshade is no longer a 5 second kill timer. It now induces heart damage instead."


### PR DESCRIPTION
- Changed the berserk overlay to be a ColorMatrix due to the old color giving runtimes
- Fixed berserk to actually be started
- Instead of brain damage, which was incredible lethal, it now gives heart damage. Testing sets it at roughly 5.12 damage (out of 45) per 5u injected.