### PR TITLE
fixes the adhomian divination cards

### DIFF
--- a/code/datums/trading/goods.dm
+++ b/code/datums/trading/goods.dm
@@ -38,7 +38,6 @@
 		/obj/item/toy/bosunwhistle            = TRADER_THIS_TYPE,
 		/obj/item/board                = TRADER_THIS_TYPE,
 		/obj/item/deck                 = TRADER_SUBTYPES_ONLY,
-		/obj/item/deck/tarot/fluff     = TRADER_BLACKLIST_ALL,
 		/obj/item/pack                 = TRADER_SUBTYPES_ONLY,
 		/obj/item/dice                 = TRADER_ALL,
 		/obj/item/eightball                   = TRADER_ALL,

--- a/code/modules/games/tarot.dm
+++ b/code/modules/games/tarot.dm
@@ -43,7 +43,7 @@
 	desc = "An adhomian deck of divination cards, used to read the one's fortune or play games."
 	icon_state = "deck_adhomai"
 
-/obj/item/deck/tarot/fluff/adhomai/generate_deck()
+/obj/item/deck/tarot/adhomai/generate_deck()
 	var/datum/playingcard/P
 	for(var/name in list("D'as'ral Massacre","Mystic","Suns' Sister","Queen","King","Father of the Parivara","S'rendal'Matir","Tank","Royal Grenadier","Kraszarrumalkarii","Hand of Fate","Great Revolution","Assassin","Assassination","Dymtris Line",
 	"Rrak'narrr","Steeple","Messa","Raskara","S'rendarr","Kazarrhaldiye","Adhomai"))

--- a/html/changelogs/DivinationCards.yml
+++ b/html/changelogs/DivinationCards.yml
@@ -1,4 +1,4 @@
-author: ChangeMe
+author: TheGreyWolf
 
 delete-after: True
 

--- a/html/changelogs/DivinationCards.yml
+++ b/html/changelogs/DivinationCards.yml
@@ -1,0 +1,6 @@
+author: ChangeMe
+
+delete-after: True
+
+changes:
+  - bugfix: "The adhomian divination cards deck now contains the correct set of cards."


### PR DESCRIPTION
The tarot card fluff subtype is removed from the trader as well due to there being no fluff version of the tarot cards anymore. Otherwise just fixes a path issue that caused the adhomian card deck to not have the correct cards.