### PR TITLE
Adds an ion rifle to the uplink

### DIFF
--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -148,3 +148,8 @@
 	name = "Random Gun"
 	item_cost = 3
 	path = /obj/item/storage/box/syndie_kit/random_weapon
+
+/datum/uplink_item/item/visible_weapons/ionrifle
+	name = "Ion rifle"
+	item_cost = 5
+	path = /obj/item/gun/energy/rifle/ionrifle

--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -150,6 +150,6 @@
 	path = /obj/item/storage/box/syndie_kit/random_weapon
 
 /datum/uplink_item/item/visible_weapons/ionrifle
-	name = "Ion rifle"
+	name = "Ion Rifle"
 	item_cost = 5
 	path = /obj/item/gun/energy/rifle/ionrifle

--- a/html/changelogs/IonRifleLink.yml
+++ b/html/changelogs/IonRifleLink.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "The uplink now offers an ion rifle for 5 TC."


### PR DESCRIPTION
Adds an alternative to the EMP grenades or robbing the only ion rifle in the armory for antags. Currently the price for the ion rifle is set to 5 TC but is up for discussion.