### PR TITLE
Conveyor Timer Lock

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -83,23 +83,20 @@
 
 	var/list/affecting = loc.contents.Copy() - src
 	if (affecting.len)
-		addtimer(CALLBACK(src, .proc/post_process, affecting), 1)	// slight delay to prevent infinite propagation due to map order
+		var/items_moved = 0
+		for (var/thing in affecting)
+			var/atom/movable/AM = thing
+			if (AM.anchored || !AM.simulated)
+				continue
 
-/obj/machinery/conveyor/proc/post_process(list/affecting)
-	var/items_moved = 0
-	for (var/thing in affecting)
-		var/atom/movable/AM = thing
-		if (AM.anchored || !AM.simulated)
-			continue
+			if (AM.loc != loc)	// prevents the object from being affected if it's not currently here.
+				continue
 
-		if (AM.loc != loc)	// prevents the object from being affected if it's not currently here.
-			continue
+			if (items_moved >= 10 || TICK_CHECK)
+				break
 
-		if (items_moved >= 10 || TICK_CHECK)
-			break
-
-		AM.conveyor_act(movedir)
-		items_moved++
+			AM.conveyor_act(movedir)
+			items_moved++
 
 /atom/movable/proc/conveyor_act(move_dir)
 	set waitfor = FALSE

--- a/html/changelogs/arrow768-conveyor-no-timer.yml
+++ b/html/changelogs/arrow768-conveyor-no-timer.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - experiment: "Changes conveyors so they no longer use timers and instead use machinery processing."
+  - experiment: "Adds a lock to conveyors so they only create max one timer each."

--- a/html/changelogs/arrow768-conveyor-no-timer.yml
+++ b/html/changelogs/arrow768-conveyor-no-timer.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - experiment: "Changes conveyors so they no longer use timers and instead use machinery processing."


### PR DESCRIPTION
Adds a lock to conveyor timers so one conveyor can only create one timer.
Also adds a stoplag check to conveyors so they yield in case of high tick use.

Based on tgs conveyors