### PR TITLE
Captain gear briefcases no longer show up in the warehouse loot

### DIFF
--- a/code/modules/cargo/random_stock/t2_uncommon.dm
+++ b/code/modules/cargo/random_stock/t2_uncommon.dm
@@ -268,11 +268,16 @@ STOCK_ITEM_UNCOMMON(rped, 1)
 	new /obj/item/storage/part_replacer(L)
 
 STOCK_ITEM_UNCOMMON(briefcase, 2)
-	if(prob(20))
-		new /obj/item/storage/secure/briefcase(L)
-	else
-		var/obj/item/storage/briefcase/B = pick(typesof(/obj/item/storage/briefcase))
-		new B(L)
+	var/list/briefcases = list(
+		/obj/item/storage/briefcase = 1,
+		/obj/item/storage/briefcase/real = 0.8,
+		/obj/item/storage/briefcase/black = 0.8,
+		/obj/item/storage/briefcase/aluminium = 0.5,
+		/obj/item/storage/briefcase/nt = 0.5
+	)
+
+	var/type = pickweight(briefcases)
+	new type(L)
 
 STOCK_ITEM_UNCOMMON(blade, 1.2)
 	var/list/blades = list(

--- a/html/changelogs/alberyk-captainrbriefcase.yml
+++ b/html/changelogs/alberyk-captainrbriefcase.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - rscdel: "Briefcases with captain gear no longer shows up in the warehouse loot."


### PR DESCRIPTION
Because it could cause some really unfunny situations.