### PR TITLE
fixes paperbags becoming invisible

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -963,9 +963,10 @@
 			"SmileyFace" = image(icon = src.icon, icon_state = "paperbag_SmileyFace")
 			))
 
-		choice = show_radial_menu(user, src, papersack_designs, radius = 42, tooltips = TRUE)
-		if(!choice)
+		var/selected = show_radial_menu(user, src, papersack_designs, radius = 42, tooltips = TRUE)
+		if(!selected)
 			return
+		choice = selected
 		switch(choice)
 			if("None")
 				desc = "A sack neatly crafted out of paper."

--- a/html/changelogs/PaperbagFix.yml
+++ b/html/changelogs/PaperbagFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed paper bags sometimes becoming invisible."


### PR DESCRIPTION
So apparently if the selection wheel was cancelled, the choice became nothing and the bag would become invisible next time it had a sprite update. Usually when adding/removing food from it. This fixes that.