### PR TITLE
Antag Teleporter Fix

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -147,7 +147,7 @@
 		var/turf/BT = get_turf(R)
 		if(!BT)
 			continue
-		if(isAdminLevel(BT.z) || !AreConnectedZLevels(z, BT.z))
+		if(!isAdminLevel(z) && (isAdminLevel(BT.z) || !AreConnectedZLevels(z, BT.z)))
 			continue
 		var/tmpname = BT.loc.name
 		if(area_index[tmpname])
@@ -173,7 +173,7 @@
 			var/turf/IT = get_turf(M)
 			if(!IT)
 				continue
-			if(isAdminLevel(IT.z) || !AreConnectedZLevels(z, IT.z))
+			if(!isAdminLevel(z) && (isAdminLevel(IT.z) || !AreConnectedZLevels(z, IT.z)))
 				continue
 			var/tmpname = M.real_name
 			if(area_index[tmpname])

--- a/html/changelogs/geeves-ninja_teleporter_fix.yml
+++ b/html/changelogs/geeves-ninja_teleporter_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Teleporters from antag bases and admin areas can now reach the station, but the station cannot reach back to those areas."


### PR DESCRIPTION
* Teleporters from antag bases and admin areas can now reach the station, but the station cannot reach back to those areas.