### PR TITLE
Reduces the sell price of any materials cargo can buy

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -49,13 +49,13 @@
 	message = "platinum sheets"
 
 /datum/export/material/metal
-	cost = 0.4
+	cost = 1
 	material_id = "metal"
 	message = "metal sheets"
 
 
 /datum/export/material/glass
-	cost = 0.4
+	cost = 1
 	material_id = "glass"
 	message = "glass sheets"
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -53,6 +53,7 @@
 	material_id = "metal"
 	message = "metal sheets"
 
+
 /datum/export/material/glass
 	cost = 0.4
 	material_id = "glass"

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -49,13 +49,12 @@
 	message = "platinum sheets"
 
 /datum/export/material/metal
-	cost = 5
+	cost = 0.4
 	material_id = "metal"
 	message = "metal sheets"
 
-
 /datum/export/material/glass
-	cost = 5
+	cost = 0.4
 	material_id = "glass"
 	message = "glass sheets"
 

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -47,24 +47,24 @@
 // For base materials, see materials.dm
 
 /datum/export/stack/plasteel
-	cost = 155 // 2000u of plasma + 2000u of metal.
+	cost = 0.6
 	message = "of plasteel"
 	export_types = list(/obj/item/stack/material/plasteel)
 
-// 1 glass + 0.5 metal, cost is rounded up.
+// 1 glass + 0.5 metal
 /datum/export/stack/rglass
-	cost = 8
+	cost = 0.6
 	message = "of reinforced glass"
 	export_types = list(/obj/item/stack/material/glass/reinforced)
 
 
 /datum/export/stack/wood
-	cost = 30
+	cost = 0.4
 	unit_name = "wood plank"
 	export_types = list(/obj/item/stack/material/wood)
 
 /datum/export/stack/cardboard
-	cost = 2
+	cost = 0.4
 	message = "of cardboard"
 	export_types = list(/obj/item/stack/material/cardboard)
 

--- a/html/changelogs/Forester40-PR-12820.yml
+++ b/html/changelogs/Forester40-PR-12820.yml
@@ -1,0 +1,4 @@
+author: Forester40
+delete-after: True
+changes:
+  - balance: "The export prices for wood, glass, reinforced glass, steel, plasteel and cardboard have been significantly reduced to account for the price that the station can buy them at."

--- a/html/changelogs/Forester40-sheets.yml
+++ b/html/changelogs/Forester40-sheets.yml
@@ -1,8 +1,0 @@
-
-author: Forester40
-
-delete-after: True
-
-
-changes:
-  - tweak: "The export prices for wood, glass, reinforced glass, steel, plasteel and cardboard have been significantly reduced to account for the price that the station can buy them at."

--- a/html/changelogs/Forester40-sheets.yml
+++ b/html/changelogs/Forester40-sheets.yml
@@ -1,0 +1,8 @@
+
+author: Forester40
+
+delete-after: True
+
+
+changes:
+  - tweak: "The export prices for wood, glass, reinforced glass, steel, plasteel and cardboard have been significantly reduced to account for the price that the station can buy them at."


### PR DESCRIPTION
* Reduces the amount of credits that the station is given for exporting the following materials by the following amounts:

- Metal: 5 > 0.4
- Glass: 5 > 0.4
- Reinforced Glass: 8 > 0.6
- Plasteel: 155 > 0.6
- Wood: 30 > 0.4
- Cardboard: 2 > 0.4

Since you can purchase 50 sheets of any these from cargo for 50 or 75 credits, players can currently buy the materials and send them back for a profit. Especially plasteel.
The changelog does not list the exact new prices because I thought that would make it too long.