### PR TITLE
restricts eridani from being consulars

### DIFF
--- a/code/modules/background/citizenship/human.dm
+++ b/code/modules/background/citizenship/human.dm
@@ -115,6 +115,33 @@
 	and poor, yet free-willed and provocative Dregs. The Federation is controlled by several megacorporations, and although NanoTrasen is not one of them, it is a common former \
 	workplace of various contractors on board NSS Aurora."
 
+	job_species_blacklist = list(
+		"Consular Officer" = list(
+			SPECIES_HUMAN,
+			SPECIES_HUMAN_OFFWORLD,
+			SPECIES_IPC,
+			SPECIES_IPC_BISHOP,
+			SPECIES_IPC_G1,
+			SPECIES_IPC_G2,
+			SPECIES_IPC_SHELL,
+			SPECIES_IPC_UNBRANDED,
+			SPECIES_IPC_XION,
+			SPECIES_IPC_ZENGHU,
+			SPECIES_DIONA,
+			SPECIES_DIONA_COEUS,
+			SPECIES_SKRELL,
+			SPECIES_SKRELL_AXIORI,
+			SPECIES_TAJARA,
+			SPECIES_TAJARA_MSAI,
+			SPECIES_TAJARA_ZHAN,
+			SPECIES_UNATHI,
+			SPECIES_VAURCA_WORKER,
+			SPECIES_VAURCA_WARRIOR,
+			SPECIES_VAURCA_BULWARK,
+			SPECIES_VAURCA_BREEDER
+		)
+	)
+
 /datum/citizenship/coalition
 	name = CITIZENSHIP_COALITION
 	description = "The Coalition of Colonies is a loose confederation of united \"entities\" within the human frontier. These entities range \

--- a/html/changelogs/EriConsular.yml
+++ b/html/changelogs/EriConsular.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Eridani no longer have consulars, as they were sol consulars."


### PR DESCRIPTION
Apparently they used sol consulars, which weren't meant to be able to spawn at all.