### PR TITLE
fixes cult communication rune sender identity

### DIFF
--- a/code/game/gamemodes/cult/runes/communicate.dm
+++ b/code/game/gamemodes/cult/runes/communicate.dm
@@ -15,5 +15,5 @@
 	log_and_message_admins("used a communicate rune to say '[input]'")
 	for(var/datum/mind/H in cult.current_antagonists)
 		if(H.current)
-			to_chat(H.current, SPAN_CULT("The familiar voice of [H.current] fills your mind: [input]"))
+			to_chat(H.current, SPAN_CULT("The familiar voice of [user] fills your mind: [input]"))
 	qdel(A)

--- a/html/changelogs/CultTalk.yml
+++ b/html/changelogs/CultTalk.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Cult communication rune now properly says who the sender is."


### PR DESCRIPTION
Before it showed as the receiver to each receiver, now it shows the actual sender.