### PR TITLE
Minor forensic additions

### DIFF
--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -2,6 +2,8 @@
 /obj/machinery/microscope
 	name = "high powered electron microscope"
 	desc = "A highly advanced microscope capable of zooming up to 3000x."
+	desc_info = "Use a microscope slide or a fingerprint card on this machine to insert it.\
+	\nAlt click to remove any object within it."
 	icon = 'icons/obj/forensics.dmi'
 	icon_state = "microscope"
 	anchored = 1
@@ -13,11 +15,11 @@
 /obj/machinery/microscope/attackby(obj/item/W as obj, mob/user as mob)
 
 	if(sample)
-		to_chat(user, "<span class='warning'>There is already a slide in the microscope.</span>")
+		to_chat(user, SPAN_WARNING("There is already a slide in the microscope."))
 		return
 
 	if(istype(W, /obj/item/forensics/slide) || istype(W, /obj/item/sample/print))
-		to_chat(user, "<span class='notice'>You insert \the [W] into the microscope.</span>")
+		to_chat(user, SPAN_NOTICE("You insert \the [W] into the microscope."))
 		user.unEquip(W)
 		W.forceMove(src)
 		sample = W
@@ -27,15 +29,15 @@
 /obj/machinery/microscope/attack_hand(mob/user)
 
 	if(!sample)
-		to_chat(user, "<span class='warning'>The microscope has no sample to examine.</span>")
+		to_chat(user, SPAN_WARNING("The microscope has no sample to examine."))
 		return
 
-	to_chat(user, "<span class='notice'>The microscope whirrs as you examine \the [sample].</span>")
+	to_chat(user, SPAN_NOTICE("The microscope whirrs as you examine \the [sample]."))
 
 	if(!do_after(user, 25) || !sample)
 		return
 
-	to_chat(user, "<span class='notice'>Printing findings now...</span>")
+	to_chat(user, SPAN_NOTICE("Printing findings now..."))
 	var/obj/item/paper/report = new()
 	var/pname
 	var/info
@@ -63,7 +65,7 @@
 			if(fibers.evidence)
 				info = "Molecular analysis on [fibers.name] has determined the presence of unique fiber strings.<br><br>"
 				for(var/fiber in fibers.evidence)
-					info += "<span class='notice'>Most likely match for fibers: [fiber]</span><br><br>"
+					info += SPAN_NOTICE("Most likely match for fibers: [fiber]<br><br>")
 			else
 				info += "No fibers found."
 		else
@@ -76,7 +78,7 @@
 		if(card.evidence && card.evidence.len)
 			info += "Surface analysis has determined unique fingerprint strings:<br><br>"
 			for(var/prints in card.evidence)
-				info += "<span class='notice'>Fingerprint string: </span>"
+				info += SPAN_NOTICE("Fingerprint string: ")
 				if(!is_complete_print(prints))
 					info += "INCOMPLETE PRINT"
 				else
@@ -97,9 +99,9 @@
 	if(!istype(remover) || remover.incapacitated() || !Adjacent(remover))
 		return
 	if(!sample)
-		to_chat(remover, "<span class='warning'>\The [src] does not have a sample in it.</span>")
+		to_chat(remover, SPAN_WARNING("\The [src] does not have a sample in it."))
 		return
-	to_chat(remover, "<span class='notice'>You remove \the [sample] from \the [src].</span>")
+	to_chat(remover, SPAN_NOTICE("You remove \the [sample] from \the [src]."))
 	sample.forceMove(get_turf(src))
 	remover.put_in_hands(sample)
 	sample = null

--- a/code/modules/detectivework/microscope/slides.dm
+++ b/code/modules/detectivework/microscope/slides.dm
@@ -1,34 +1,35 @@
 /obj/item/forensics/slide
 	name = "microscope slide"
 	desc = "A pair of thin glass panes used in the examination of samples beneath a microscope."
+	desc_info = "Used with fibers and GSR swab tests to examine the samples in the microscope. To empty them, use in hand."
 	icon_state = "slide"
 	var/obj/item/forensics/swab/has_swab
 	var/obj/item/sample/fibers/has_sample
 
 /obj/item/forensics/slide/attackby(var/obj/item/W, var/mob/user)
 	if(has_swab || has_sample)
-		to_chat(user, "<span class='warning'>There is already a sample in the slide.</span>")
+		to_chat(user, SPAN_WARNING("There is already a sample in the slide."))
 		return
 	if(istype (W, /obj/item/forensics/swab))
 		has_swab = W
 	else if(istype(W, /obj/item/sample/fibers))
 		has_sample = W
 	else
-		to_chat(user, "<span class='warning'>You don't think this will fit.</span>")
+		to_chat(user, SPAN_WARNING("You don't think this will fit."))
 		return
-	to_chat(user, "<span class='notice'>You insert the sample into the slide.</span>")
+	to_chat(user, SPAN_NOTICE("You insert the sample into the slide."))
 	user.unEquip(W)
 	W.forceMove(src)
 	update_icon()
 
 /obj/item/forensics/slide/attack_self(var/mob/user)
 	if(has_swab || has_sample)
-		to_chat(user, "<span class='notice'>You remove \the sample from \the [src].</span>")
+		to_chat(user, SPAN_NOTICE("You remove \the sample from \the [src]."))
 		if(has_swab)
-			has_swab.forceMove(get_turf(src))
+			user.put_in_hands(has_swab)
 			has_swab = null
 		if(has_sample)
-			has_sample.forceMove(get_turf(src))
+			user.put_in_hands(has_sample)
 			has_sample = null
 		update_icon()
 		return

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -3,7 +3,7 @@
 /obj/item/evidencebag
 	name = "evidence bag"
 	desc = "An empty evidence bag."
-	desc_info = "To use: Click drag it onto an object. Click it in-hand to remove an object from it."
+	desc_info = "Click drag this onto an object to put it inside. Click it in-hand to remove an object from it."
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "evidenceobj"
 	item_state = ""

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -3,6 +3,7 @@
 /obj/item/evidencebag
 	name = "evidence bag"
 	desc = "An empty evidence bag."
+	desc_info = "To use: Click drag it onto an object. Click it in-hand to remove an object from it."
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "evidenceobj"
 	item_state = ""

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -51,11 +51,15 @@
 /obj/item/sample/fibers
 	name = "fiber bag"
 	desc = "Used to hold fiber evidence for the detective."
+	desc_info = "Holds various fibe evidence. Place it in a slide and the slide into a microscope to check them."
 	icon_state = "fiberbag"
 
 /obj/item/sample/print
 	name = "fingerprint card"
 	desc = "Records a set of fingerprints."
+	desc_info = "A sample card for fingerprints. Risks putting your own prints on it if touched without gloves.\
+	\nPlace the card in a microscope to examine the contents. \
+	\nUse in hand to put your prints on it.\nTarget hands and click another creature to take their prints."
 	icon = 'icons/obj/card.dmi'
 	icon_state = "fingerprint0"
 	item_state = "paper"
@@ -124,6 +128,7 @@
 /obj/item/forensics/sample_kit
 	name = "fiber collection kit"
 	desc = "A magnifying glass and tweezers. Used to lift suit fibers."
+	desc_info = "Click drag it on to an object to collect evidence. Alternatively click on non-help intent."
 	icon_state = "m_glass"
 	w_class = ITEMSIZE_SMALL
 	flags = NOBLUDGEON

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -25,7 +25,7 @@
 		return 0
 	evidence |= supplied.evidence
 	name = "[initial(name)] (combined)"
-	to_chat(user, "<span class='notice'>You transfer the contents of \the [initial(supplied.name)] into \the [src].</span>")
+	to_chat(user, SPAN_NOTICE("You transfer the contents of \the [initial(supplied.name)] into \the [src]."))
 	return 1
 
 /obj/item/sample/print/merge_evidence(var/obj/item/sample/supplied, var/mob/user)
@@ -37,7 +37,7 @@
 		else
 			evidence[print] = supplied.evidence[print]
 	name = "[initial(name)] (combined)"
-	to_chat(user, "<span class='notice'>You overlay \the [src] and \the [initial(supplied.name)], combining the print records.</span>")
+	to_chat(user, SPAN_NOTICE("You overlay \the [src] and \the [initial(supplied.name)], combining the print records."))
 	return 1
 
 /obj/item/sample/attackby(var/obj/O, var/mob/user)
@@ -67,10 +67,10 @@
 		return
 	var/mob/living/carbon/human/H = user
 	if(H.gloves)
-		to_chat(user, "<span class='warning'>Take \the [H.gloves] off first.</span>")
+		to_chat(user, SPAN_WARNING("Take \the [H.gloves] off first."))
 		return
 
-	to_chat(user, "<span class='notice'>You firmly press your fingertips onto the card.</span>")
+	to_chat(user, SPAN_NOTICE("You firmly press your fingertips onto the card."))
 	var/fullprint = H.get_full_print()
 	evidence[fullprint] = fullprint
 	name = "[initial(name)] (\the [H])"
@@ -87,11 +87,11 @@
 	var/mob/living/carbon/human/H = M
 
 	if(H.gloves)
-		to_chat(user, "<span class='warning'>\The [H] is wearing gloves.</span>")
+		to_chat(user, SPAN_WARNING("\The [H] is wearing gloves."))
 		return 1
 
 	if(user != H && H.a_intent != "help" && !H.lying)
-		user.visible_message("<span class='danger'>\The [user] tries to take prints from \the [H], but they move away.</span>")
+		user.visible_message(SPAN_DANGER("\The [user] tries to take prints from \the [H], but they move away."))
 		return 1
 
 	if(target_zone == BP_R_HAND || target_zone == BP_L_HAND)
@@ -104,7 +104,7 @@
 			if(istype(O) && !O.is_stump())
 				has_hand = 1
 		if(!has_hand)
-			to_chat(user, "<span class='warning'>They don't have any hands.</span>")
+			to_chat(user, SPAN_WARNING("They don't have any hands."))
 			return 1
 		user.visible_message("[user] takes a copy of \the [H]'s fingerprints.")
 		var/fullprint = H.get_full_print()
@@ -135,7 +135,7 @@
 
 /obj/item/forensics/sample_kit/proc/take_sample(var/mob/user, var/atom/supplied)
 	var/obj/item/sample/S = new evidence_path(get_turf(user), supplied)
-	to_chat(user, "<span class='notice'>You transfer [S.evidence.len] [evidence_type]\s to \the [S].</span>")
+	to_chat(user, SPAN_NOTICE("You transfer [S.evidence.len] [evidence_type]\s to \the [S]."))
 
 /obj/item/forensics/sample_kit/afterattack(var/atom/A, var/mob/user, var/proximity)
 	if(!proximity)
@@ -145,8 +145,13 @@
 		take_sample(user,A)
 		return 1
 	else
-		to_chat(user, "<span class='warning'>You are unable to locate any [evidence_type]s on \the [A].</span>")
+		to_chat(user, SPAN_WARNING("You are unable to locate any [evidence_type]s on \the [A]."))
 		return ..()
+
+/obj/item/forensics/sample_kit/resolve_attackby(atom/A, mob/user, var/click_parameters)
+	if(user.a_intent != I_HELP)
+		return FALSE
+	. = ..()
 
 /obj/item/forensics/sample_kit/MouseDrop(atom/over)
 	var/mob/M = loc

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -51,7 +51,7 @@
 /obj/item/sample/fibers
 	name = "fiber bag"
 	desc = "Used to hold fiber evidence for the detective."
-	desc_info = "Holds various fibe evidence. Place it in a slide and the slide into a microscope to check them."
+	desc_info = "Holds various fibre evidence. Place it in a slide and the slide into a microscope to check them."
 	icon_state = "fiberbag"
 
 /obj/item/sample/print

--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -6,6 +6,12 @@
 /obj/item/forensics/swab
 	name = "swab kit"
 	desc = "A sterilized cotton swab and vial used to take forensic samples."
+	desc_info = "Swab kits can be used to gather blood with DNA attached to it by clicking the blood. \
+	If it fails to collect a sample, it means that particular bit of blood has no associated DNA. \
+	\nThey can also collect DNA samples directly from people by targetting their mouth to take a saliva sample.\
+	\nGunshot Residue (GSR) can be collected from someones hands by targetting them, or from their gloves \
+	by taking the gloves and clicking on them. \n\nGSR samples are put in a slide and examined in a microscope.\
+	\nBlood and DNA samples are checked in the DNA analyzer"
 	icon_state = "swab"
 	var/gsr = 0
 	var/list/dna
@@ -28,23 +34,23 @@
 	var/sample_type
 
 	if(H.wear_mask)
-		to_chat(user, "<span class='warning'>\The [H] is wearing a mask.</span>")
+		to_chat(user, SPAN_WARNING("\The [H] is wearing a mask."))
 		return
 
 	if(!H.dna || !H.dna.unique_enzymes)
-		to_chat(user, "<span class='warning'>They don't seem to have DNA!</span>")
+		to_chat(user, SPAN_WARNING("They don't seem to have DNA!"))
 		return
 
 	if(user != H && H.a_intent != "help" && !H.lying)
-		user.visible_message("<span class='danger'>\The [user] tries to take a swab sample from \the [H], but they move away.</span>")
+		user.visible_message(SPAN_DANGER("\The [user] tries to take a swab sample from \the [H], but they move away."))
 		return
 
 	if(target_zone == BP_MOUTH)
 		if(!H.organs_by_name[BP_HEAD])
-			to_chat(user, "<span class='warning'>They don't have a head.</span>")
+			to_chat(user, SPAN_WARNING("They don't have a head."))
 			return
 		if(!H.check_has_mouth())
-			to_chat(user, "<span class='warning'>They don't have a mouth.</span>")
+			to_chat(user, SPAN_WARNING("They don't have a mouth."))
 			return
 		user.visible_message("[user] swabs \the [H]'s mouth for a saliva sample.")
 		dna = list(H.dna.unique_enzymes)
@@ -60,7 +66,7 @@
 			if(istype(O) && !O.is_stump())
 				has_hand = 1
 		if(!has_hand)
-			to_chat(user, "<span class='warning'>They don't have any hands.</span>")
+			to_chat(user, SPAN_WARNING("They don't have any hands."))
 			return
 		user.visible_message("[user] swabs [H]'s palm for a sample.")
 		sample_type = "GSR"
@@ -79,7 +85,7 @@
 		return
 
 	if(is_used())
-		to_chat(user, "<span class='warning'>This swab has already been used.</span>")
+		to_chat(user, SPAN_WARNING("This swab has already been used."))
 		return
 
 	add_fingerprint(user)
@@ -97,7 +103,7 @@
 
 	var/choice
 	if(!choices.len)
-		to_chat(user, "<span class='warning'>There is no evidence on \the [A].</span>")
+		to_chat(user, SPAN_WARNING("There is no evidence on \the [A]."))
 		return
 	else if(choices.len == 1)
 		choice = choices[1]
@@ -118,7 +124,7 @@
 		if (EVIDENCE_TYPE_GSR)
 			var/obj/item/clothing/B = A
 			if(!istype(B) || !B.gunshot_residue)
-				to_chat(user, "<span class='warning'>There is no residue on \the [A].</span>")
+				to_chat(user, SPAN_WARNING("There is no residue on \the [A]."))
 				return
 			gsr = B.gunshot_residue
 			sample_type = "residue"

--- a/html/changelogs/ForensicHelp.yml
+++ b/html/changelogs/ForensicHelp.yml
@@ -1,0 +1,8 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Forensic slides now deposit to the inactive hand if it is free."
+  - rscadd: "The forensic fiber & fingerprint kits will now only activate things if clicked on with help intent. Otherwise it will only collect fibers/prints."
+  - rscadd: "Several bits of forensic equipment now have additional text to explain how ot use them, when examined."

--- a/html/changelogs/ForensicHelp.yml
+++ b/html/changelogs/ForensicHelp.yml
@@ -5,4 +5,4 @@ delete-after: True
 changes:
   - rscadd: "Forensic slides now deposit to the inactive hand if it is free."
   - rscadd: "The forensic fiber & fingerprint kits will now only activate things if clicked on with help intent. Otherwise it will only collect fibers/prints."
-  - rscadd: "Several bits of forensic equipment now have additional text to explain how ot use them, when examined."
+  - rscadd: "Several bits of forensic equipment now have additional text to explain how to use them, when examined."

--- a/html/changelogs/ForensicHelp.yml
+++ b/html/changelogs/ForensicHelp.yml
@@ -6,3 +6,4 @@ changes:
   - rscadd: "Forensic slides now deposit to the inactive hand if it is free."
   - rscadd: "The forensic fiber & fingerprint kits will now only activate things if clicked on with help intent. Otherwise it will only collect fibers/prints."
   - rscadd: "Several bits of forensic equipment now have additional text to explain how to use them, when examined."
+  - tweak: "Swabs will now take GSR tests from the gloves if the person it is used on is wearing any, and only if the gloves have any residue left on them."


### PR DESCRIPTION
- Adds helpful descriptions to various forensic tools on how to use them.
- The slides now put items into a free hand if possible when emptying them.
- The fingerprint powder & fiber kit will now only be put into bags or the like if on help intent.
- Swabs will now take GSR from gloves if a person wears them, and won't be used if the person has no GSR on them.