### PR TITLE
Vaurca Hivenet Stuff

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -169,6 +169,11 @@
 
 	return output
 
+/proc/sanitize_readd_odd_symbols(var/input)
+	input = replacetext(input, "&#39;", "\'")
+	input = replacetext(input, "&#34;", "\"")
+	return input
+
 #undef NO_CHARS_DETECTED
 #undef SPACES_DETECTED
 #undef SYMBOLS_DETECTED

--- a/code/modules/acting/acting_items.dm
+++ b/code/modules/acting/acting_items.dm
@@ -28,7 +28,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.change_appearance(APPEARANCE_ALL, H, TRUE, H.generate_valid_species(), null, default_state, src)
-		var/getName = sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)
+		var/getName = sanitizeName(sanitize_readd_odd_symbols(sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)))
 		if(getName)
 			H.real_name = getName
 			H.name = getName

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -356,6 +356,10 @@ h1.alert, h2.alert		{color: #a4bad6;}
 .tajaran_signlang		{color: #cc2c2c;}
 .skrell					{color: #00CED1;}
 .vaurca					{color: #b9b943;}
+.vaurca_zora		{color: #c74444;}
+.vaurca_cthur		{color: #438eb9;}
+.vaurca_klax		{color: #43b97e;}
+.vaurca_liidra	{color: #af43b9;}
 .soghun					{color: #2cad2c;}
 .solcom					{color: #5f5fd4;}
 .soghun_alt				{color: #1d9b1d;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -353,6 +353,10 @@ h1.alert, h2.alert		{color: #000080;}
 .tajaran_signlang		{color: #941C1C;}
 .skrell					{color: #00CED1;}
 .vaurca					{color: #9e9e39;}
+.vaurca_zora		{color: #9e3939;}
+.vaurca_cthur		{color: #39719e;}
+.vaurca_klax		{color: #399e4a;}
+.vaurca_liidra	{color: #b350b3;}
 .soghun					{color: #228B22;}
 .solcom					{color: #22228B;}
 .soghun_alt				{color: #024402;}

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -223,9 +223,9 @@
 	log_say("[key_name(speaker)] : ([name]) [message]",ckey=key_name(speaker))
 
 	if(!speaker_mask)
-		speaker_mask = speaker.name
+		speaker_mask = speaker.real_name
 
-	var/msg = "<i><span class='game say'>[name], <span class='name'>[speaker_mask]</span>[format_message(message, get_spoken_verb(message))]</span></i>"
+	var/msg = "<i><span class='game say'>[name], <span class='name'>[speaker_mask]</span>[format_message(message, get_spoken_verb(message), speaker_mask)]</span></i>"
 
 	if(isvaurca(speaker))
 		speaker.custom_emote(VISIBLE_MESSAGE, "[pick("twitches their antennae", "twitches their antennae rhythmically")].")
@@ -239,6 +239,22 @@
 	for(var/mob/player in player_list)
 		if(istype(player,/mob/abstract/observer) || ((src in player.languages && !within_jamming_range(player)) || check_special_condition(player)))
 			to_chat(player, msg)
+
+/datum/language/bug/format_message(message, verb, speaker_mask)
+	var/message_color = colour
+	var/list/speaker_surname = splittext(speaker_mask, " ")
+	switch(speaker_surname[2])
+		if("Zo'ra")
+			message_color = "vaurca_zora"
+		if("C'thur")
+			message_color = "vaurca_cthur"
+		if("K'lax")
+			message_color = "vaurca_klax"
+		if("Lii'dra")
+			message_color = "vaurca_liidra"
+	if(copytext(message, 1, 2) == "!")
+		return " projects <span class='message'><span class='[message_color]'>[copytext(message, 2)]</span></span>"
+	return "[verb], <span class='message'><span class='[message_color]'>\"[capitalize(message)]\"</span></span>"
 
 /datum/language/bug/check_special_condition(var/mob/other)
 	if(istype(other, /mob/living/silicon))

--- a/html/changelogs/geeves-vaurca_hivenet_tweaks.yml
+++ b/html/changelogs/geeves-vaurca_hivenet_tweaks.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Vaurca hivenet speech is now color-coded based on hive. Additionally, prefixing your message with ! makes it display as an emote."
+  - bugfix: "Quickee's Plastic Surgeon stations now work properly with apostrophes in names."


### PR DESCRIPTION
* Vaurca hivenet speech is now color-coded based on hive. Additionally, prefixing your message with ! makes it display as an emote.
* Quickee's Plastic Surgeon stations now work properly with apostrophes in names.

![image](https://user-images.githubusercontent.com/22774890/147387369-03820404-30aa-4ca3-b408-b8878ff3cb69.png)
![image](https://user-images.githubusercontent.com/22774890/147387379-ad476583-3c70-45e1-ae62-23ca183ec339.png)