### PR TITLE
Returns Tha'kh garb to the people

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
@@ -183,7 +183,6 @@
 	path = /obj/item/clothing/mask/gas/unathi
 	cost = 1
 	whitelisted = list(SPECIES_UNATHI)
-	allowed_roles = list("Chaplain", "Roboticist")
 	sort_category = "Xenowear - Unathi"
 	flags = GEAR_HAS_DESC_SELECTION
 
@@ -192,7 +191,6 @@
 	path = /obj/item/clothing/suit/unathi/wrapping
 	cost = 1
 	whitelisted = list(SPECIES_UNATHI)
-	allowed_roles = list("Chaplain", "Roboticist")
 	sort_category = "Xenowear - Unathi"
 	flags = GEAR_HAS_DESC_SELECTION
 
@@ -246,7 +244,6 @@
 	path = /obj/item/clothing/accessory/poncho/maxtlatl
 	cost = 1
 	whitelisted = list(SPECIES_UNATHI)
-	allowed_roles = list("Chaplain")
 	sort_category = "Xenowear - Unathi"
 	flags = GEAR_HAS_DESC_SELECTION
 
@@ -254,7 +251,6 @@
 	display_name = "Thakhist wristguards"
 	path = /obj/item/clothing/wrists/unathi/maxtlatl
 	whitelisted = list(SPECIES_UNATHI)
-	allowed_roles = list("Chaplain")
 	sort_category = "Xenowear - Unathi"
 	flags = GEAR_HAS_DESC_SELECTION
 
@@ -262,7 +258,6 @@
 	display_name = "Thakhist headgear"
 	path = /obj/item/clothing/head/unathi/maxtlatl
 	whitelisted = list(SPECIES_UNATHI)
-	allowed_roles = list("Chaplain")
 	sort_category = "Xenowear - Unathi"
 	flags = GEAR_HAS_DESC_SELECTION
 

--- a/html/changelogs/Changelog - Thakh freedom.yml
+++ b/html/changelogs/Changelog - Thakh freedom.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Kaedwuff
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Removed the job requirements on Tha'kh religious garb."


### PR DESCRIPTION
Religious garb is not a job uniform, it is a cultural item.  I get the tenuous connection someone might have had for making chaplains able to get shaman garb, but not only was the restriction inconsistent, but there is zero reason why someone who is not employed as an official station chaplain (or roboticist, apparently?) cannot also be a shaman and thus have their ceremonial garb.