### PR TITLE
fixes cryobags deploying as bodybags

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -8,6 +8,7 @@
 	w_class = ITEMSIZE_SMALL
 	drop_sound = 'sound/items/drop/cloth.ogg'
 	pickup_sound = 'sound/items/pickup/cloth.ogg'
+	var/deploy_type = /obj/structure/closet/body_bag
 
 /obj/item/bodybag/attack_self(mob/user)
 	deploy_bag(user, user.loc)
@@ -21,10 +22,14 @@
 			deploy_bag(user, target)
 
 /obj/item/bodybag/proc/deploy_bag(mob/user, atom/location)
-	var/obj/structure/closet/body_bag/R = new /obj/structure/closet/body_bag(location)
+	var/obj/structure/closet/body_bag/R = new deploy_type(location)
 	R.add_fingerprint(user)
+	tweak_bag(R)
 	playsound(src, 'sound/items/drop/cloth.ogg', 30)
 	qdel(src)
+
+/obj/item/bodybag/proc/tweak_bag(var/obj/structure/closet/body_bag/BB)
+	return
 
 /obj/item/storage/box/bodybags
 	name = "body bags"
@@ -156,15 +161,12 @@
 	icon = 'icons/obj/cryobag.dmi'
 	icon_state = "bodybag_folded"
 	origin_tech = list(TECH_BIO = 4)
+	deploy_type = /obj/structure/closet/body_bag/cryobag
 	var/stasis_power
 
-/obj/item/bodybag/cryobag/attack_self(mob/user)
-	var/obj/structure/closet/body_bag/cryobag/R = new /obj/structure/closet/body_bag/cryobag(user.loc)
+/obj/item/bodybag/cryobag/tweak_bag(var/obj/structure/closet/body_bag/cryobag/C)
 	if(stasis_power)
-		R.stasis_power = stasis_power
-	R.update_icon()
-	R.add_fingerprint(user)
-	qdel(src)
+		C.stasis_power = stasis_power
 
 /obj/structure/closet/body_bag/cryobag
 	name = "stasis bag"

--- a/html/changelogs/CryoBagFix.yml
+++ b/html/changelogs/CryoBagFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Stasis bags can now be properly deployed on adjacent turfs without becoming bodybags."


### PR DESCRIPTION
As it says, fixes a bug where trying to place a cryo bag down on an adjacent turf instead of using it in hand would turn it into a bodybag instead.