### PR TITLE
Fixes copier bugs and allows business cards to retain their color when copied

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -89,7 +89,6 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 				p.desc += "Copied by [tempAI.name]"
 			else
 				p.desc += " - Copied by [tempAI.name]"
-			toner -= 5
 			sleep(15)
 		SSvueui.check_uis_for_change(src)
 
@@ -173,7 +172,10 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 	info += copied
 	info += "</font>"//</font>
 	pname = copy.name // -- Doohl
-	c.color = "#f0f0f0"
+	if(istype(copy, /obj/item/paper/business_card))
+		c.color = copy.color
+	else
+		c.color = "#f0f0f0"
 	c.fields = copy.fields
 	c.stamps = copy.stamps
 	c.stamped = copy.stamped
@@ -204,7 +206,9 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 	c.set_content_unsafe(pname, info)
 	if (print)
 		if(target.type == /obj/machinery/photocopier)
+			var/obj/machinery/photocopier/T = target
 			flick("photocopier_print", target)
+			--T.toner
 		target.print(c, use_sound, 'sound/bureaucracy/print.ogg', delay)
 	return c
 
@@ -229,6 +233,11 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 		if(target.type == /obj/machinery/photocopier)
 			flick("photocopier_notoner", target)
 		playsound(target.loc, 'sound/machines/buzz-two.ogg', 75, 1)
+	if(target.type == /obj/machinery/photocopier)
+		var/obj/machinery/photocopier/T = target
+		T.toner -= 5
+		flick("photocopier_print", target)
+		playsound(target.loc, 'sound/bureaucracy/print.ogg', 75, 1)
 	return p
 
 //If need_toner is 0, the copies will still be lightened when low on toner, however it will not be prevented from printing. TODO: Implement print queues for fax machines and get rid of need_toner
@@ -239,7 +248,9 @@ VUEUI_MONITOR_VARS(/obj/machinery/photocopier, photocopiermonitor)
 			toner = 0
 			target.visible_message(SPAN_NOTICE("A red light on \the [target] flashes, indicating that it is out of toner."))
 			if(target.type == /obj/machinery/photocopier)
+				var/obj/machinery/photocopier/T = target
 				flick("photocopier_notoner", target)
+				--T.toner
 			playsound(target.loc, 'sound/machines/buzz-two.ogg', 75, 1)
 			break
 

--- a/html/changelogs/CopyTweak.yml
+++ b/html/changelogs/CopyTweak.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - tweak: "Business cards no longer change color when copied in a photocopier."
+  - bugfix: "Photocopiers toner now gets used correctly."


### PR DESCRIPTION
As there is currently no other way to get multiple business cards when spawning in beyond the one you get in the loadout, this PR instead does so copying them in the copy machine won't change their color.

Additionally the copiers will now actually use their toner when copying things.