### PR TITLE
Fixes meteors ignoring shields

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -135,6 +135,14 @@
 
 /obj/effect/meteor/Collide(atom/A)
 	..()
+	if(istype(A, /obj/effect/energy_field))
+		hitpwr *= 0.5
+		A.ex_act(hitpwr)
+		visible_message(SPAN_DANGER("\The [src] breaks into dust!"))
+		make_debris()
+		msg_admin_attack("Meteor collided with shields at (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
+		qdel(src)
+
 	if(A && !QDELETED(src))	// Prevents explosions and other effects when we were deleted by whatever we Bumped() - currently used by shields.
 		ram_turf(get_turf(A))
 		get_hit() //should only get hit once per move attempt

--- a/html/changelogs/MeteorFix.yml
+++ b/html/changelogs/MeteorFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Meteors will no longer ignore shields."


### PR DESCRIPTION
fixes https://github.com/Aurorastation/Aurora.3/issues/12878

The meteors now break when hitting the shields without harming their surroundings other than the shields themselves.