### PR TITLE
Removes advanced mutation toxin from warehouse spawns

### DIFF
--- a/code/modules/cargo/random_stock/t2_uncommon.dm
+++ b/code/modules/cargo/random_stock/t2_uncommon.dm
@@ -88,7 +88,8 @@ STOCK_ITEM_UNCOMMON(chempack, 5)
 	var/list/chems = decls_repository.get_decls_of_subtype(/decl/reagent/)
 	var/list/exclusion = list(/decl/reagent/drink, /decl/reagent, /decl/reagent/adminordrazine, /decl/reagent/polysomnine/beer2, /decl/reagent/azoth, /decl/reagent/elixir,\
 		/decl/reagent/liquid_fire, /decl/reagent/philosopher_stone, /decl/reagent/toxin/undead, /decl/reagent/love_potion, /decl/reagent/shapesand, /decl/reagent/usolve,\
-		/decl/reagent/sglue, /decl/reagent/black_matter, /decl/reagent/bottle_lightning, /decl/reagent/toxin/trioxin, /decl/reagent/toxin/nanites, /decl/reagent/nitroglycerin)
+		/decl/reagent/sglue, /decl/reagent/black_matter, /decl/reagent/bottle_lightning, /decl/reagent/toxin/trioxin, /decl/reagent/toxin/nanites, /decl/reagent/nitroglycerin, \
+		/decl/reagent/aslimetoxin)
 	chems -= exclusion
 	for (var/i in 1 to rand(2, 4))
 		var/obj/item/reagent_containers/chem_disp_cartridge/C = new /obj/item/reagent_containers/chem_disp_cartridge(L)

--- a/html/changelogs/WarehouseSlime.yml
+++ b/html/changelogs/WarehouseSlime.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscdel: "Removes advanced mutation toxin from warehouse spawns."


### PR DESCRIPTION
The chances this will be used for proper purposes is far lower than the chance someone is going to inject themself when they see it. It's better to leave it for the xenobiologists to create if they really want it.