### PR TITLE
Hull Shields now also protect asteroid rock walls

### DIFF
--- a/code/modules/shieldgen/shield_gen_external.dm
+++ b/code/modules/shieldgen/shield_gen_external.dm
@@ -29,7 +29,7 @@
 				if (T == U)
 					continue
 
-				if (the_station_areas[U.loc])
+				if (the_station_areas[U.loc] || istype(U, /turf/simulated/mineral/surface))
 					out += T
 					break
 

--- a/html/changelogs/ShieldUpgradeTwo.yml
+++ b/html/changelogs/ShieldUpgradeTwo.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - tweak: "The hull shield generator now also create shields around the rock walls found on the asteroid to guarantee station safety."


### PR DESCRIPTION
While shields currently protects the hull parts of the station from meteors, it can still easily be shot through the rock. So now the rock is shielded too when the hull shield generator is active.