### PR TITLE
Hatches

### DIFF
--- a/code/controllers/subsystems/radio.dm
+++ b/code/controllers/subsystems/radio.dm
@@ -91,7 +91,7 @@ On the map:
 1443 for atmospherics - distribution loop/mixed air tank
 1445 for bot nav beacons
 1447 for mulebot, secbot and ed209 control
-1449 for airlock controls, electropack, magnets
+1449 for hatch controls, electropack, magnets
 1451 for toxin lab access
 1453 for engineering access
 1455 for AI access

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -79,8 +79,8 @@
 	item_cost = 1
 	path = /obj/item/device/multitool/hacktool
 	desc = "Appears and functions as a standard multitool until the mode is toggled by applying a screwdriver appropriately. \
-			When in hacking mode this device will grant full access to any standard airlock within 7 to 13 seconds. \
-			This device will also be able to immediately access the last 6 to 8 hacked airlocks."
+			When in hacking mode this device will grant full access to any standard hatch within 7 to 13 seconds. \
+			This device will also be able to immediately access the last 6 to 8 hacked hatches."
 
 /datum/uplink_item/item/tools/space_suit
 	name = "Space Suit"

--- a/code/game/machinery/autolathe/autolathe_datums.dm
+++ b/code/game/machinery/autolathe/autolathe_datums.dm
@@ -204,7 +204,7 @@
 	category = "General"
 
 /datum/autolathe/recipe/airlockmodule
-	name = "airlock electronics"
+	name = "hatch electronics"
 	path = /obj/item/airlock_electronics
 	category = "Engineering"
 

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -71,7 +71,7 @@
 		icon_state = "doorctrl0"
 
 /*
-	Airlock remote control
+	Hatch remote control
 */
 
 // Bitmasks for door switches.

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -6,7 +6,7 @@
 #define BOLTS_CUT 2
 
 /obj/machinery/door/airlock
-	name = "Airlock"
+	name = "Hatch"
 	icon = 'icons/obj/doors/Doorint.dmi'
 	icon_state = "door_closed"
 	power_channel = ENVIRON
@@ -96,7 +96,7 @@
 		if(assembly.created_name)
 			name = assembly.created_name
 		else
-			name = "[istext(assembly.glass) ? "[assembly.glass] airlock" : assembly.base_name]"
+			name = "[istext(assembly.glass) ? "[assembly.glass] hatch" : assembly.base_name]"
 
 		//get the dir from the assembly
 		set_dir(assembly.dir)
@@ -142,13 +142,13 @@
 	return SSmaterials.get_material_by_name(DEFAULT_WALL_MATERIAL)
 
 /obj/machinery/door/airlock/command
-	name = "Airlock"
+	name = "Hatch"
 	icon = 'icons/obj/doors/Doorcom.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_com
 	hatch_colour = "#446892"
 
 /obj/machinery/door/airlock/sac
-	name = "Airlock"
+	name = "Hatch"
 	icon = 'icons/obj/doors/DoorSAC.dmi'
 	assembly_type = null
 	aiControlDisabled = 1
@@ -157,19 +157,19 @@
 	open_sound_powered = 'sound/machines/airlock_open_force.ogg'
 
 /obj/machinery/door/airlock/security
-	name = "Airlock"
+	name = "Hatch"
 	icon = 'icons/obj/doors/Doorsec.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_sec
 	hatch_colour = "#677c97"
 
 /obj/machinery/door/airlock/engineering
-	name = "Airlock"
+	name = "Hatch"
 	icon = 'icons/obj/doors/Dooreng.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_eng
 	hatch_colour = "#caa638"
 
 /obj/machinery/door/airlock/medical
-	name = "Airlock"
+	name = "Hatch"
 	icon = 'icons/obj/doors/Doormed.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_med
 	hatch_colour = "#d2d2d2"
@@ -188,13 +188,13 @@
 	insecure = 0
 
 /obj/machinery/door/airlock/science
-	name = "Airlock"
+	name = "Hatch"
 	icon = 'icons/obj/doors/Doorsci.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_science
 	hatch_colour = "#d2d2d2"
 
 /obj/machinery/door/airlock/glass_science
-	name = "Glass Airlocks"
+	name = "Glass Hatches"
 	icon = 'icons/obj/doors/Doorsciglass.dmi'
 	opacity = FALSE
 	assembly_type = /obj/structure/door_assembly/door_assembly_science
@@ -202,7 +202,7 @@
 	hatch_colour = "#d2d2d2"
 
 /obj/machinery/door/airlock/glass
-	name = "Glass Airlock"
+	name = "Glass Hatch"
 	icon = 'icons/obj/doors/Doorglass.dmi'
 	hitsound = 'sound/effects/glass_hit.ogg'
 	open_sound_powered = 'sound/machines/windowdoor.ogg'
@@ -215,14 +215,14 @@
 	hatch_colour = "#eaeaea"
 
 /obj/machinery/door/airlock/vaurca
-	name = "Alien Biomass Airlock"
+	name = "Alien Biomass Hatch"
 	icon = 'icons/obj/doors/Doorvaurca.dmi'
 	opacity = TRUE
 	hatch_colour = "#606061"
 	hashatch = FALSE
 
 /obj/machinery/door/airlock/centcom
-	name = "Airlock"
+	name = "Hatch"
 	icon = 'icons/obj/doors/Doorele.dmi'
 	opacity = TRUE
 	hatch_colour = "#606061"
@@ -259,7 +259,7 @@
 	return
 
 /obj/machinery/door/airlock/glass_centcom
-	name = "Airlock"
+	name = "Hatch"
 	icon = 'icons/obj/doors/Dooreleglass.dmi'
 	opacity = FALSE
 	glass = 1
@@ -315,7 +315,7 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 	locked = TRUE
 
 /obj/machinery/door/airlock/freezer
-	name = "Freezer Airlock"
+	name = "Freezer Hatch"
 	icon = 'icons/obj/doors/Doorfreezer.dmi'
 	desc = "An extra thick, double-insulated door to preserve the cold atmosphere. Keep closed at all times."
 	maxhealth = 800
@@ -360,7 +360,7 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 	hatch_colour = "#7d7d7d"
 
 /obj/machinery/door/airlock/glass_command
-	name = "Glass Airlock"
+	name = "Glass Hatch"
 	icon = 'icons/obj/doors/Doorcomglass.dmi'
 	hitsound = 'sound/effects/glass_hit.ogg'
 	maxhealth = 300
@@ -371,7 +371,7 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 	hatch_colour = "#3e638c"
 
 /obj/machinery/door/airlock/glass_engineering
-	name = "Glass Airlock"
+	name = "Glass Hatch"
 	icon = 'icons/obj/doors/Doorengglass.dmi'
 	hitsound = 'sound/effects/glass_hit.ogg'
 	maxhealth = 300
@@ -382,7 +382,7 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 	hatch_colour = "#caa638"
 
 /obj/machinery/door/airlock/glass_security
-	name = "Glass Airlock"
+	name = "Glass Hatch"
 	icon = 'icons/obj/doors/Doorsecglass.dmi'
 	hitsound = 'sound/effects/glass_hit.ogg'
 	maxhealth = 300
@@ -393,7 +393,7 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 	hatch_colour = "#677c97"
 
 /obj/machinery/door/airlock/glass_medical
-	name = "Glass Airlock"
+	name = "Glass Hatch"
 	icon = 'icons/obj/doors/Doormedglass.dmi'
 	hitsound = 'sound/effects/glass_hit.ogg'
 	maxhealth = 300
@@ -404,25 +404,25 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 	hatch_colour = "#d2d2d2"
 
 /obj/machinery/door/airlock/mining
-	name = "Mining Airlock"
+	name = "Mining Hatch"
 	icon = 'icons/obj/doors/Doormining.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_min
 	hatch_colour = "#c29142"
 
 /obj/machinery/door/airlock/atmos
-	name = "Atmospherics Airlock"
+	name = "Atmospherics Hatch"
 	icon = 'icons/obj/doors/Dooratmo.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_atmo
 	hatch_colour = "#caa638"
 
 /obj/machinery/door/airlock/research
-	name = "Airlock"
+	name = "Hatch"
 	icon = 'icons/obj/doors/Doorresearch.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_research
 	hatch_colour = "#d2d2d2"
 
 /obj/machinery/door/airlock/glass_research
-	name = "Glass Airlock"
+	name = "Glass Hatch"
 	icon = 'icons/obj/doors/Doorresearchglass.dmi'
 	hitsound = 'sound/effects/glass_hit.ogg'
 	maxhealth = 300
@@ -434,7 +434,7 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 	hatch_colour = "#d2d2d2"
 
 /obj/machinery/door/airlock/glass_mining
-	name = "Glass Airlock"
+	name = "Glass Hatch"
 	icon = 'icons/obj/doors/Doorminingglass.dmi'
 	hitsound = 'sound/effects/glass_hit.ogg'
 	maxhealth = 300
@@ -445,7 +445,7 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 	hatch_colour = "#c29142"
 
 /obj/machinery/door/airlock/glass_atmos
-	name = "Glass Airlock"
+	name = "Glass Hatch"
 	icon = 'icons/obj/doors/Dooratmoglass.dmi'
 	hitsound = 'sound/effects/glass_hit.ogg'
 	maxhealth = 300
@@ -456,37 +456,37 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 	hatch_colour = "#caa638"
 
 /obj/machinery/door/airlock/gold
-	name = "Gold Airlock"
+	name = "Gold Hatch"
 	icon = 'icons/obj/doors/Doorgold.dmi'
 	mineral = "gold"
 	hatch_colour = "#dbbb2b"
 
 /obj/machinery/door/airlock/silver
-	name = "Silver Airlock"
+	name = "Silver Hatch"
 	icon = 'icons/obj/doors/Doorsilver.dmi'
 	mineral = "silver"
 	hatch_colour = "#ffffff"
 
 /obj/machinery/door/airlock/diamond
-	name = "Diamond Airlock"
+	name = "Diamond Hatch"
 	icon = 'icons/obj/doors/Doordiamond.dmi'
 	mineral = "diamond"
 	hatch_colour = "#66eeee"
 	maxhealth = 2000
 
 /obj/machinery/door/airlock/sandstone
-	name = "Sandstone Airlock"
+	name = "Sandstone Hatch"
 	icon = 'icons/obj/doors/Doorsand.dmi'
 	mineral = "sandstone"
 	hatch_colour = "#efc8a8"
 
 /obj/machinery/door/airlock/palepurple
-	name = "airlock"
+	name = "hatch"
 	icon = 'icons/obj/doors/Doorpalepurple.dmi'
 	hashatch = FALSE
 
 /obj/machinery/door/airlock/highsecurity
-	name = "Secure Airlock"
+	name = "Secure Hatch"
 	icon = 'icons/obj/doors/hightechsecurity.dmi'
 	explosion_resistance = 20
 	secured_wires = TRUE
@@ -498,7 +498,7 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 	aiUnBoltingDelay = 5
 
 /obj/machinery/door/airlock/skrell
-	name = "airlock"
+	name = "hatch"
 	icon = 'icons/obj/doors/purple_skrell_door.dmi'
 	explosion_resistance = 20
 	secured_wires = TRUE
@@ -511,7 +511,7 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 
 //---Uranium doors
 /obj/machinery/door/airlock/uranium
-	name = "Uranium Airlock"
+	name = "Uranium Hatch"
 	desc = "And they said I was crazy."
 	icon = 'icons/obj/doors/Dooruranium.dmi'
 	mineral = "uranium"
@@ -532,7 +532,7 @@ obj/machinery/door/airlock/glass_centcom/attackby(obj/item/I, mob/user)
 
 //---Phoron door
 /obj/machinery/door/airlock/phoron
-	name = "Phoron Airlock"
+	name = "Phoron Hatch"
 	desc = "No way this can end badly."
 	icon = 'icons/obj/doors/Doorphoron.dmi'
 	mineral = MATERIAL_PHORON
@@ -767,10 +767,10 @@ About the new airlock wires panel:
 			new_overlays += "sparks_damaged"
 
 		if (hatch_image)
-			if (hatchstate)
-				hatch_image.icon_state = "[hatchstyle]_open"
+			if (hatchestate)
+				hatch_image.icon_state = "[hatchestyle]_open"
 			else
-				hatch_image.icon_state = hatchstyle
+				hatch_image.icon_state = hatchestyle
 			new_overlays += hatch_image
 	else
 		if(p_open && panel_visible_while_open)
@@ -864,45 +864,45 @@ About the new airlock wires panel:
 		src.aiHacking=1
 		spawn(20)
 			//TODO: Make this take a minute
-			to_chat(user, "Airlock AI control has been blocked. Beginning fault-detection.")
+			to_chat(user, "Hatch AI control has been blocked. Beginning fault-detection.")
 			sleep(50)
 			if(src.canAIControl())
-				to_chat(user, "Alert cancelled. Airlock control has been restored without our assistance.")
+				to_chat(user, "Alert cancelled. Hatch control has been restored without our assistance.")
 				src.aiHacking=0
 				return
 			else if(!src.canAIHack(user))
-				to_chat(user, "We've lost our connection! Unable to hack airlock.")
+				to_chat(user, "We've lost our connection! Unable to hack hatch.")
 				src.aiHacking=0
 				return
-			to_chat(user, "Fault confirmed: airlock control wire disabled or cut.")
+			to_chat(user, "Fault confirmed: hatch control wire disabled or cut.")
 			sleep(20)
-			to_chat(user, "Attempting to hack into airlock. This may take some time.")
+			to_chat(user, "Attempting to hack into hatch. This may take some time.")
 			sleep(200)
 			if(src.canAIControl())
-				to_chat(user, "Alert cancelled. Airlock control has been restored without our assistance.")
+				to_chat(user, "Alert cancelled. Hatch control has been restored without our assistance.")
 				src.aiHacking=0
 				return
 			else if(!src.canAIHack(user))
-				to_chat(user, "We've lost our connection! Unable to hack airlock.")
+				to_chat(user, "We've lost our connection! Unable to hack hatch.")
 				src.aiHacking=0
 				return
-			to_chat(user, "Upload access confirmed. Loading control program into airlock software.")
+			to_chat(user, "Upload access confirmed. Loading control program into hatch software.")
 			sleep(170)
 			if(src.canAIControl())
-				to_chat(user, "Alert cancelled. Airlock control has been restored without our assistance.")
+				to_chat(user, "Alert cancelled. Hatch control has been restored without our assistance.")
 				src.aiHacking=0
 				return
 			else if(!src.canAIHack(user))
-				to_chat(user, "We've lost our connection! Unable to hack airlock.")
+				to_chat(user, "We've lost our connection! Unable to hack hatch.")
 				src.aiHacking=0
 				return
-			to_chat(user, "Transfer complete. Forcing airlock to execute program.")
+			to_chat(user, "Transfer complete. Forcing hatch to execute program.")
 			sleep(50)
 			//disable blocked control
 			src.aiControlDisabled = 2
-			to_chat(user, "Receiving control information from airlock.")
+			to_chat(user, "Receiving control information from hatch.")
 			sleep(10)
-			//bring up airlock dialog
+			//bring up hatch dialog
 			src.aiHacking = FALSE
 			if (user)
 				src.attack_ai(user)
@@ -927,14 +927,14 @@ About the new airlock wires panel:
 			if(prob(40) && src.density)
 				playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
 				if(!istype(H.head, /obj/item/clothing/head/helmet))
-					user.visible_message(SPAN_WARNING("[user] headbutts the airlock."))
+					user.visible_message(SPAN_WARNING("[user] headbutts the hatch."))
 					var/obj/item/organ/external/affecting = H.get_organ(BP_HEAD)
 					H.Stun(8)
 					H.Weaken(5)
 					if(affecting.take_damage(10, 0))
 						H.UpdateDamageIcon()
 				else
-					user.visible_message(SPAN_WARNING("[user] headbutts the airlock. Good thing they're wearing a helmet."))
+					user.visible_message(SPAN_WARNING("[user] headbutts the hatch. Good thing they're wearing a helmet."))
 				return
 
 		if(H.a_intent == I_HURT)
@@ -944,7 +944,7 @@ About the new airlock wires panel:
 				if(!density)
 					return
 
-				H.visible_message("<b>[H]</b> begins to pry open \the [src]!", SPAN_NOTICE("You begin to pry open \the [src]!"), SPAN_WARNING("You hear the sound of an airlock being forced open."))
+				H.visible_message("<b>[H]</b> begins to pry open \the [src]!", SPAN_NOTICE("You begin to pry open \the [src]!"), SPAN_WARNING("You hear the sound of a hatch being forced open."))
 
 				if(!do_after(H, 120, 1, act_target = src))
 					return
@@ -1152,7 +1152,7 @@ About the new airlock wires panel:
 				electrify(-1 * activate, 1)
 		if("open")
 			if(src.welded)
-				to_chat(usr, SPAN_WARNING("The airlock has been welded shut!"))
+				to_chat(usr, SPAN_WARNING("The hatch has been welded shut!"))
 			else if(src.locked)
 				to_chat(usr, SPAN_WARNING("The door bolts are down!"))
 			else if(!src.arePowerSystemsOn() && issilicon(usr)) // AIs get a nice notice that the door is unpowered
@@ -1279,27 +1279,27 @@ About the new airlock wires panel:
 		cable.plugin(src, user)
 	else if(!repairing && C.iscrowbar())
 		if(istype(C, /obj/item/melee/arm_blade))
-			if(!arePowerSystemsOn()) //if this check isn't done and empty, the armblade will never be used to hit the airlock
+			if(!arePowerSystemsOn()) //if this check isn't done and empty, the armblade will never be used to hit the hatch
 			else if(!(stat & BROKEN))
 				..()
 				return
 		if(p_open && !operating && welded)
 			if(locked)
-				to_chat(user, SPAN_WARNING("The airlock bolts are in the way of the electronics, you need to raise them before you can reach them."))
+				to_chat(user, SPAN_WARNING("The hatch bolts are in the way of the electronics, you need to raise them before you can reach them."))
 				return
 			playsound(src.loc, C.usesound, 100, 1)
-			user.visible_message("<b>[user]</b> starts removing the electronics from the airlock assembly.", SPAN_NOTICE("You start removing the electronics from the airlock assembly."))
+			user.visible_message("<b>[user]</b> starts removing the electronics from the hatch assembly.", SPAN_NOTICE("You start removing the electronics from the hatch assembly."))
 			if(do_after(user,40/C.toolspeed))
-				user.visible_message("<b>[user]</b> removes the electronics from the airlock assembly.", SPAN_NOTICE("You remove the electronics from the airlock assembly."))
+				user.visible_message("<b>[user]</b> removes the electronics from the hatch assembly.", SPAN_NOTICE("You remove the electronics from the hatch assembly."))
 				CreateAssembly()
 				return
 		else if(arePowerSystemsOn())
-			to_chat(user, SPAN_NOTICE("The airlock's motors resist your efforts to force it."))
+			to_chat(user, SPAN_NOTICE("The hatch's motors resist your efforts to force it."))
 		else if(locked)
 			if (istype(C, /obj/item/crowbar/robotic/jawsoflife))
 				cut_bolts(C, user)
 			else
-				to_chat(user, SPAN_NOTICE("The airlock's bolts prevent it from being forced."))
+				to_chat(user, SPAN_NOTICE("The hatch's bolts prevent it from being forced."))
 		else
 			if(density)
 				open(1)
@@ -1307,7 +1307,7 @@ About the new airlock wires panel:
 				close(1)
 	else if(istype(C, /obj/item/material/twohanded/fireaxe) && !arePowerSystemsOn())
 		if(locked && user.a_intent != I_HURT)
-			to_chat(user, SPAN_NOTICE("The airlock's bolts prevent it from being forced."))
+			to_chat(user, SPAN_NOTICE("The hatch's bolts prevent it from being forced."))
 		else if(locked && user.a_intent == I_HURT)
 			..()
 		else if(!welded && !operating)
@@ -1325,7 +1325,7 @@ About the new airlock wires panel:
 					to_chat(user, SPAN_WARNING("You need to be wielding \the [C] to do that."))
 	else if(istype(C, /obj/item/melee/hammer) && !arePowerSystemsOn())
 		if(locked && user.a_intent != I_HURT)
-			to_chat(user, SPAN_NOTICE("The airlock's bolts prevent it from being forced."))
+			to_chat(user, SPAN_NOTICE("The hatch's bolts prevent it from being forced."))
 		else if(locked && user.a_intent == I_HURT)
 			..()
 		else if(!welded && !operating)
@@ -1336,9 +1336,9 @@ About the new airlock wires panel:
 	else if(density && istype(C, /obj/item/material/twohanded/chainsaw))
 		var/obj/item/material/twohanded/chainsaw/ChainSawVar = C
 		if(!ChainSawVar.wielded)
-			to_chat(user, SPAN_NOTICE("Cutting the airlock requires the strength of two hands."))
+			to_chat(user, SPAN_NOTICE("Cutting the hatch requires the strength of two hands."))
 		else if(ChainSawVar.cutting)
-			to_chat(user, SPAN_NOTICE("You are already cutting an airlock open."))
+			to_chat(user, SPAN_NOTICE("You are already cutting a hatch open."))
 		else if(!ChainSawVar.powered)
 			to_chat(user, SPAN_NOTICE("The [C] needs to be on in order to open this door."))
 		else if(bracer) //Has a magnetic lock
@@ -1346,14 +1346,14 @@ About the new airlock wires panel:
 		else if(!arePowerSystemsOn())
 			ChainSawVar.cutting = 1
 			user.visible_message(\
-				SPAN_DANGER("[user.name] starts cutting the control pannel of the airlock with the [C]!"),\
-				SPAN_WARNING("You start cutting the airlock control panel..."),\
+				SPAN_DANGER("[user.name] starts cutting the control pannel of the hatch with the [C]!"),\
+				SPAN_WARNING("You start cutting the hatch control panel..."),\
 				SPAN_NOTICE("You hear a loud buzzing sound and metal grinding on metal...")\
 			)
 			if(do_after(user, ChainSawVar.opendelay SECONDS, act_target = user, extra_checks  = CALLBACK(src, .proc/CanChainsaw, C)))
 				user.visible_message(\
-					SPAN_WARNING("[user.name] finishes cutting the control pannel of the airlock with the [C]."),\
-					SPAN_WARNING("You finish cutting the airlock control panel."),\
+					SPAN_WARNING("[user.name] finishes cutting the control pannel of the hatch with the [C]."),\
+					SPAN_WARNING("You finish cutting the hatch control panel."),\
 					SPAN_NOTICE("You hear a metal clank and some sparks.")\
 				)
 				set_broken()
@@ -1364,14 +1364,14 @@ About the new airlock wires panel:
 		else if(locked)
 			ChainSawVar.cutting = 1
 			user.visible_message(\
-				SPAN_DANGER("[user.name] starts cutting below the airlock with the [C]!"),\
-				SPAN_WARNING("You start cutting below the airlock..."),\
+				SPAN_DANGER("[user.name] starts cutting below the hatch with the [C]!"),\
+				SPAN_WARNING("You start cutting below the hatch..."),\
 				SPAN_NOTICE("You hear a loud buzzing sound and metal grinding on metal...")\
 			)
 			if(do_after(user, ChainSawVar.opendelay SECONDS, act_target = user, extra_checks  = CALLBACK(src, .proc/CanChainsaw, C)))
 				user.visible_message(\
-					SPAN_WARNING("[user.name] finishes cutting below the airlock with the [C]."),\
-					SPAN_NOTICE("You finish cutting below the airlock."),\
+					SPAN_WARNING("[user.name] finishes cutting below the hatch with the [C]."),\
+					SPAN_NOTICE("You finish cutting below the hatch."),\
 					SPAN_NOTICE("You hear a metal clank and some sparks.")\
 				)
 				unlock(1)
@@ -1380,14 +1380,14 @@ About the new airlock wires panel:
 		else
 			ChainSawVar.cutting = 1
 			user.visible_message(\
-				SPAN_DANGER("[user.name] starts cutting between the airlock with the [C]!"),\
-				SPAN_WARNING("You start cutting between the airlock..."),\
+				SPAN_DANGER("[user.name] starts cutting between the hatch with the [C]!"),\
+				SPAN_WARNING("You start cutting between the hatch..."),\
 				SPAN_NOTICE("You hear a loud buzzing sound and metal grinding on metal...")\
 			)
 			if(do_after(user, ChainSawVar.opendelay SECONDS, act_target = user, extra_checks  = CALLBACK(src, .proc/CanChainsaw, C)))
 				user.visible_message(\
-					SPAN_WARNING("[user.name] finishes cutting between the airlock."),\
-					SPAN_WARNING("You finish cutting between the airlock."),\
+					SPAN_WARNING("[user.name] finishes cutting between the hatch."),\
+					SPAN_WARNING("You finish cutting between the hatch."),\
 					SPAN_NOTICE("You hear a metal clank and some sparks.")\
 				)
 				open(1)
@@ -1496,7 +1496,7 @@ About the new airlock wires panel:
 
 	SetStunned(5)
 	SetWeakened(5)
-	visible_message(SPAN_DANGER("[src] is crushed in the airlock!"), SPAN_DANGER("You are crushed in the airlock!"), SPAN_NOTICE("You hear airlock actuators momentarily struggle."))
+	visible_message(SPAN_DANGER("[src] is crushed in the hatch!"), SPAN_DANGER("You are crushed in the hatch!"), SPAN_NOTICE("You hear hatch actuators momentarily struggle."))
 
 	var/turf/T = loc
 	if(istype(T))

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -1,5 +1,5 @@
 /obj/item/airlock_electronics
-	name = "airlock electronics"
+	name = "hatch electronics"
 	icon = 'icons/obj/doors/door_assembly.dmi'
 	icon_state = "door_electronics"
 	w_class = ITEMSIZE_TINY
@@ -137,7 +137,7 @@
 		..()
 
 /obj/item/airlock_electronics/secure
-	name = "secure airlock electronics"
+	name = "secure hatch electronics"
 	desc = "Designed to be somewhat more resistant to hacking than standard electronics."
 	desc_info = "With these electronics, wires will be randomized and bolts will drop if the airlock is broken."
 	origin_tech = list(TECH_DATA = 2)

--- a/code/game/machinery/doors/alarmlock.dm
+++ b/code/game/machinery/doors/alarmlock.dm
@@ -1,6 +1,6 @@
 /obj/machinery/door/airlock/alarmlock
 
-	name = "Glass Alarm Airlock"
+	name = "Glass Alarm Hatch"
 	icon = 'icons/obj/doors/Doorglass.dmi'
 	opacity = 0
 	glass = 1

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -33,8 +33,8 @@
 	var/open_duration = 150//How long it stays open
 
 	var/hashatch = 0//If 1, this door has hatches, and certain small creatures can move through them without opening the door
-	var/hatchstate = 0//0: closed, 1: open
-	var/hatchstyle = "1x1"
+	var/hatchestate = 0//0: closed, 1: open
+	var/hatchestyle = "1x1"
 	var/hatch_offset_x = 0
 	var/hatch_offset_y = 0
 	var/hatch_colour = "#FFFFFF"
@@ -95,7 +95,7 @@
 			bound_height = width * world.icon_size
 
 /obj/machinery/door/proc/setup_hatch()
-	hatch_image = image('icons/obj/doors/hatches.dmi', src, hatchstyle, closed_layer+0.1)
+	hatch_image = image('icons/obj/doors/hatches.dmi', src, hatchestyle, closed_layer+0.1)
 	hatch_image.color = hatch_colour
 	hatch_image.pixel_x = hatch_offset_x
 	hatch_image.pixel_y = hatch_offset_y
@@ -104,8 +104,8 @@
 	update_icon()
 
 /obj/machinery/door/proc/open_hatch(var/atom/mover = null)
-	if (!hatchstate)
-		hatchstate = 1
+	if (!hatchestate)
+		hatchestate = 1
 		update_icon()
 		playsound(src.loc, hatch_open_sound, 40, 1, -1)
 
@@ -118,7 +118,7 @@
 
 
 /obj/machinery/door/proc/close_hatch()
-	hatchstate = 0//hatch stays open for 3 seconds
+	hatchestate = 0//hatch stays open for 3 seconds
 	update_icon()
 	playsound(src.loc, hatch_close_sound, 30, 1, -1)
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -472,10 +472,10 @@
 				do_set_light = TRUE
 
 		if (hashatch)
-			if (hatchstate && hatch_image)
-				hatch_image.icon_state = "[hatchstyle]_open"
+			if (hatchestate && hatch_image)
+				hatch_image.icon_state = "[hatchestyle]_open"
 			else
-				hatch_image.icon_state = hatchstyle
+				hatch_image.icon_state = hatchestyle
 			add_overlay(hatch_image)
 	else
 		icon_state = "door_open"

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -11,7 +11,7 @@
 		setup_hatch()
 
 /obj/machinery/door/airlock/multi_tile/glass
-	name = "Glass Airlock"
+	name = "Glass Hatch"
 	icon = 'icons/obj/doors/Door2x1glass.dmi'
 	opacity = 0
 	glass = 1
@@ -21,7 +21,7 @@
 /obj/machinery/door/airlock/multi_tile/setup_hatch()
 	if(overlays != null)
 		hatch_image = null
-		hatch_image = image('icons/obj/doors/hatches.dmi', src, hatchstyle, closed_layer+0.1)
+		hatch_image = image('icons/obj/doors/hatches.dmi', src, hatchestyle, closed_layer+0.1)
 		hatch_image.color = hatch_colour
 		hatch_image.transform = turn(hatch_image.transform, 90)
 		// reset any rotation and transformation applied

--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -30,7 +30,7 @@
 
 //Advanced airlock controller for when you want a more versatile airlock controller - useful for turning simple access control rooms into airlocks
 /obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller
-	name = "Advanced Airlock Controller"
+	name = "Advanced Hatch Controller"
 
 /obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]
@@ -87,7 +87,7 @@
 
 //Airlock controller for airlock control - most airlocks on the station use this
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller
-	name = "Airlock Controller"
+	name = "Hatch Controller"
 	tag_secure = 1
 
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)

--- a/code/game/objects/effects/decals/posters/tgposters.dm
+++ b/code/game/objects/effects/decals/posters/tgposters.dm
@@ -46,5 +46,5 @@
 
 /datum/poster/tg_10
 	name = "Hacking Guide"
-	desc = "This poster details the internal workings of the common Nanotrasen airlock."
+	desc = "This poster details the internal workings of the common Nanotrasen hatch."
 	icon_state="poster10"

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -115,7 +115,7 @@
 						<p>This place isn't noted on the blueprint.</p>
 					"}
 
-	text += "<br><a href='?src=\ref[src];action=airlock_wires'>View Airlock Wire Schema</a><br>"
+	text += "<br><a href='?src=\ref[src];action=hatch_wires'>View Hatch Wire Schema</a><br>"
 	text += "<br><a href='?src=\ref[src];action=vending_wires'>View Vending Machine Wire Schema</a><br>"
 
 	text += "</BODY></HTML>"

--- a/code/game/objects/items/devices/magnetic_lock.dm
+++ b/code/game/objects/items/devices/magnetic_lock.dm
@@ -7,7 +7,7 @@
 
 /obj/item/device/magnetic_lock
 	name = "magnetic door lock"
-	desc = "A large, ID locked device used for completely locking down airlocks."
+	desc = "A large, ID locked device used for completely locking down hatches."
 	icon = 'icons/obj/magnetic_locks.dmi'
 	icon_state = "inactive_CENTCOM"
 	//icon_state = "inactive"
@@ -48,7 +48,7 @@
 
 /obj/item/device/magnetic_lock/security/legion/Initialize()
 	. = ..()
-	desc = "A large, ID locked device used for completely locking down airlocks. This one carries the insignia of the Tau Ceti Foreign Legion."
+	desc = "A large, ID locked device used for completely locking down hatches. This one carries the insignia of the Tau Ceti Foreign Legion."
 
 /obj/item/device/magnetic_lock/Initialize()
 	. = ..()
@@ -318,7 +318,7 @@
 					return
 
 		if (locate(/obj/machinery/door/airlock) in oview(1, newtarget))
-			if (alert("Brace adjacent airlocks?",,"Yes", "No") == "Yes")
+			if (alert("Brace adjacent hatches?",,"Yes", "No") == "Yes")
 				if (!check_target(newtarget, user)) return
 				for (var/obj/machinery/door/airlock/A in get_step(newtarget.loc, turn(direction, -90)))
 					if (istype(A, newtarget.type))
@@ -457,7 +457,7 @@
 
 /obj/item/device/magnetic_lock/keypad
 	name = "magnetic door lock"
-	desc = "A large, passcode locked device used for completely locking down airlocks."
+	desc = "A large, passcode locked device used for completely locking down hatches."
 
 	req_access = list(access_none)
 

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -3,7 +3,7 @@
 #define STATE_ELECTRONICS_INSTALLED 2
 
 /obj/structure/door_assembly
-	name = "airlock assembly"
+	name = "hatch assembly"
 	icon = 'icons/obj/doors/door_assembly.dmi'
 	icon_state = "door_as_0"
 	anchored = 0
@@ -13,7 +13,7 @@
 	obj_flags = OBJ_FLAG_ROTATABLE
 	var/state = STATE_UNWIRED
 	var/base_icon_state = ""
-	var/base_name = "Airlock"
+	var/base_name = "Hatch"
 	var/obj/item/airlock_electronics/electronics = null
 	var/airlock_type = "" //the type path of the airlock once completed
 	var/glass_type = "/glass"
@@ -27,67 +27,67 @@
 
 /obj/structure/door_assembly/door_assembly_com
 	base_icon_state = "com"
-	base_name = "Command Airlock"
+	base_name = "Command Hatch"
 	glass_type = "/glass_command"
 	airlock_type = "/command"
 
 /obj/structure/door_assembly/door_assembly_sec
 	base_icon_state = "sec"
-	base_name = "Security Airlock"
+	base_name = "Security Hatch"
 	glass_type = "/glass_security"
 	airlock_type = "/security"
 
 /obj/structure/door_assembly/door_assembly_eng
 	base_icon_state = "eng"
-	base_name = "Engineering Airlock"
+	base_name = "Engineering Hatch"
 	glass_type = "/glass_engineering"
 	airlock_type = "/engineering"
 
 /obj/structure/door_assembly/door_assembly_min
 	base_icon_state = "min"
-	base_name = "Mining Airlock"
+	base_name = "Mining Hatch"
 	glass_type = "/glass_mining"
 	airlock_type = "/mining"
 
 /obj/structure/door_assembly/door_assembly_atmo
 	base_icon_state = "atmo"
-	base_name = "Atmospherics Airlock"
+	base_name = "Atmospherics Hatch"
 	glass_type = "/glass_atmos"
 	airlock_type = "/atmos"
 
 /obj/structure/door_assembly/door_assembly_research
 	base_icon_state = "res"
-	base_name = "Research Airlock"
+	base_name = "Research Hatch"
 	glass_type = "/glass_research"
 	airlock_type = "/research"
 
 /obj/structure/door_assembly/door_assembly_science
 	base_icon_state = "sci"
-	base_name = "Science Airlock"
+	base_name = "Science Hatch"
 	glass_type = "/glass_science"
 	airlock_type = "/science"
 
 /obj/structure/door_assembly/door_assembly_med
 	base_icon_state = "med"
-	base_name = "Medical Airlock"
+	base_name = "Medical Hatch"
 	glass_type = "/glass_medical"
 	airlock_type = "/medical"
 
 /obj/structure/door_assembly/door_assembly_mai
 	base_icon_state = "mai"
-	base_name = "Maintenance Airlock"
+	base_name = "Maintenance Hatch"
 	airlock_type = "/maintenance"
 	glass = -1
 
 /obj/structure/door_assembly/door_assembly_ext
 	base_icon_state = "ext"
-	base_name = "External Airlock"
+	base_name = "External Hatch"
 	airlock_type = "/external"
 	glass = -1
 
 /obj/structure/door_assembly/door_assembly_fre
 	base_icon_state = "fre"
-	base_name = "Freezer Airlock"
+	base_name = "Freezer Hatch"
 	airlock_type = "/freezer"
 	glass = -1
 
@@ -111,7 +111,7 @@
 
 /obj/structure/door_assembly/door_assembly_highsecurity
 	base_icon_state = "highsec"
-	base_name = "High Security Airlock"
+	base_name = "High Security Hatch"
 	airlock_type = "/highsecurity"
 	glass = -1
 
@@ -129,13 +129,13 @@
 
 /obj/structure/door_assembly/door_assembly_skrell
 	base_icon_state = "skrell_purple"
-	base_name = "Airlock"
+	base_name = "Hatch"
 	airlock_type = "/skrell"
 	glass = -1
 
 /obj/structure/door_assembly/door_assembly_skrell/grey
 	base_icon_state = "skrell_grey"
-	base_name = "Airlock"
+	base_name = "Hatch"
 	airlock_type = "/skrell/grey"
 
 /obj/structure/door_assembly/multi_tile
@@ -182,7 +182,7 @@
 		if(WT.remove_fuel(0, user))
 			playsound(src.loc, 'sound/items/welder_pry.ogg', 50, 1)
 			if(istext(glass))
-				user.visible_message("<b>[user]</b> starts welding the [glass] plating off the airlock assembly.", SPAN_NOTICE("You start welding the [glass] plating off the airlock assembly."))
+				user.visible_message("<b>[user]</b> starts welding the [glass] plating off the hatch assembly.", SPAN_NOTICE("You start welding the [glass] plating off the hatch assembly."))
 				if(do_after(user, 40 / W.toolspeed))
 					if(!src || !WT.isOn())
 						return
@@ -191,7 +191,7 @@
 					new M(src.loc, 2)
 					glass = FALSE
 			else if(glass == TRUE)
-				user.visible_message("<b>[user]</b> starts welding the glass panel out of the airlock assembly.", SPAN_NOTICE("You start welding the glass panel out of the airlock assembly."))
+				user.visible_message("<b>[user]</b> starts welding the glass panel out of the hatch assembly.", SPAN_NOTICE("You start welding the glass panel out of the hatch assembly."))
 				if(do_after(user, 40 / W.toolspeed))
 					if(!src || !WT.isOn())
 						return
@@ -199,11 +199,11 @@
 					new /obj/item/stack/material/glass/reinforced(src.loc)
 					glass = FALSE
 			else if(!anchored)
-				user.visible_message("<b>[user]</b> starts disassembling the airlock assembly.", SPAN_NOTICE("You start disassembling the airlock assembly."))
+				user.visible_message("<b>[user]</b> starts disassembling the hatch assembly.", SPAN_NOTICE("You start disassembling the hatch assembly."))
 				if(do_after(user, 40 / W.toolspeed))
 					if(!src || !WT.isOn())
 						return
-					to_chat(user, SPAN_NOTICE("You disassemble the airlock assembly."))
+					to_chat(user, SPAN_NOTICE("You disassemble the hatch assembly."))
 					dismantle()
 		else
 			to_chat(user, SPAN_WARNING("You need more welding fuel."))
@@ -217,11 +217,11 @@
 		playsound(src.loc, W.usesound, 100, 1)
 	
 		if(anchored)
-			user.visible_message("<b>[user]</b> begins unsecuring the airlock assembly from the floor.", \
-								SPAN_NOTICE("You start unsecuring the airlock assembly from the floor."))
+			user.visible_message("<b>[user]</b> begins unsecuring the hatch assembly from the floor.", \
+								SPAN_NOTICE("You start unsecuring the hatch assembly from the floor."))
 		else
-			user.visible_message("<b>[user]</b> begins securing the airlock assembly to the floor.", \
-								SPAN_NOTICE("You start securing the airlock assembly to the floor."))
+			user.visible_message("<b>[user]</b> begins securing the hatch assembly to the floor.", \
+								SPAN_NOTICE("You start securing the hatch assembly to the floor."))
 
 		if(do_after(user, 40 / W.toolspeed))
 			if(!src)
@@ -238,13 +238,13 @@
 			return
 		var/obj/item/stack/cable_coil/C = W
 		if (C.get_amount() < 3)
-			to_chat(user, SPAN_WARNING("You need three lengths of coil to wire the airlock assembly."))
+			to_chat(user, SPAN_WARNING("You need three lengths of coil to wire the hatch assembly."))
 			return
-		user.visible_message("<b>[user]</b> starts wiring the airlock assembly.", SPAN_NOTICE("You start wiring the airlock assembly."))
+		user.visible_message("<b>[user]</b> starts wiring the hatch assembly.", SPAN_NOTICE("You start wiring the hatch assembly."))
 		if(do_after(user, 40) && state == STATE_UNWIRED && anchored)
 			if(C.use(3))
 				state = STATE_WIRED
-				to_chat(user, SPAN_NOTICE("You wire the airlock."))
+				to_chat(user, SPAN_NOTICE("You wire the hatch."))
 
 	else if(W.iswirecutter())
 		if(state == STATE_UNWIRED)
@@ -255,12 +255,12 @@
 			return
 
 		playsound(src.loc, 'sound/items/wirecutter.ogg', 100, 1)
-		user.visible_message("<b>[user]</b> starts cutting the wires from the airlock assembly.", SPAN_NOTICE("You start cutting the wires from airlock assembly."))
+		user.visible_message("<b>[user]</b> starts cutting the wires from the hatch assembly.", SPAN_NOTICE("You start cutting the wires from hatch assembly."))
 
 		if(do_after(user, 40 / W.toolspeed))
 			if(!src)
 				return
-			to_chat(user, SPAN_NOTICE("You cut the airlock wires."))
+			to_chat(user, SPAN_NOTICE("You cut the hatch wires."))
 			new /obj/item/stack/cable_coil(src.loc, 1)
 			state = STATE_UNWIRED
 
@@ -274,7 +274,7 @@
 		var/obj/item/airlock_electronics/EL = W
 		if(!EL.is_installed)
 			playsound(src.loc, 'sound/items/screwdriver.ogg', 100, 1)
-			user.visible_message("<b>[user]</b> starts installing \the [EL] into the airlock assembly.", SPAN_NOTICE("You start installing \the [EL] into the airlock assembly."))
+			user.visible_message("<b>[user]</b> starts installing \the [EL] into the hatch assembly.", SPAN_NOTICE("You start installing \the [EL] into the hatch assembly."))
 			EL.is_installed = TRUE
 			if(do_after(user, 40 / W.toolspeed) && state == STATE_WIRED)
 				EL.is_installed = FALSE
@@ -320,22 +320,22 @@
 			if(S.get_amount() >= 1)
 				if(material_name == "rglass")
 					playsound(src.loc, /decl/sound_category/crowbar_sound, 100, 1)
-					user.visible_message("<b>[user]</b> starts installing [S] into the airlock assembly.", "You start installing [S] into the airlock assembly.")
+					user.visible_message("<b>[user]</b> starts installing [S] into the hatch assembly.", "You start installing [S] into the hatch assembly.")
 					if(do_after(user, 40) && !glass)
 						if(S.use(1))
-							to_chat(user, SPAN_NOTICE("You install reinforced glass windows into the airlock assembly."))
+							to_chat(user, SPAN_NOTICE("You install reinforced glass windows into the hatch assembly."))
 							glass = 1
 				else if(material_name)
 					// Ugly hack, will suffice for now. Need to fix it upstream as well, may rewrite mineral walls. ~Z
 					if(!(material_name in list("gold", "silver", "diamond", "uranium", "phoron", "sandstone")))
-						to_chat(user, SPAN_WARNING("You cannot make an airlock out of [S]."))
+						to_chat(user, SPAN_WARNING("You cannot make a hatch out of [S]."))
 						return
 					if(S.get_amount() >= 2)
 						playsound(src.loc, /decl/sound_category/crowbar_sound, 100, 1)
-						user.visible_message("<b>[user]</b> starts installing [S] into the airlock assembly.", "You start installing [S] into the airlock assembly.")
+						user.visible_message("<b>[user]</b> starts installing [S] into the hatch assembly.", "You start installing [S] into the hatch assembly.")
 						if(do_after(user, 40) && !glass)
 							if (S.use(2))
-								to_chat(user, SPAN_NOTICE("You install [SSmaterials.material_display_name(material_name)] plating into the airlock assembly."))
+								to_chat(user, SPAN_NOTICE("You install [SSmaterials.material_display_name(material_name)] plating into the hatch assembly."))
 								glass = material_name
 
 	else if(W.isscrewdriver())
@@ -349,7 +349,7 @@
 		if(do_after(user, 40 / W.toolspeed))
 			if(!src)
 				return
-			to_chat(user, SPAN_NOTICE("You finish the airlock!"))
+			to_chat(user, SPAN_NOTICE("You finish the hatch!"))
 			var/path
 			if(istext(glass))
 				path = text2path("/obj/machinery/door/airlock/[glass]")
@@ -365,9 +365,9 @@
 	else if(istype(W, /obj/item/material/twohanded/chainsaw))
 		var/obj/item/material/twohanded/chainsaw/ChainSawVar = W
 		if(!ChainSawVar.wielded)
-			to_chat(user, SPAN_WARNING("Cutting the airlock requires the strength of two hands."))
+			to_chat(user, SPAN_WARNING("Cutting the hatch requires the strength of two hands."))
 		else if(ChainSawVar.cutting)
-			to_chat(user, SPAN_WARNING("You are already cutting an airlock open."))
+			to_chat(user, SPAN_WARNING("You are already cutting a hatch open."))
 		else if(!ChainSawVar.powered)
 			to_chat(user, SPAN_WARNING("\The [W] needs to be on in order to tear \the [src] apart."))
 		else
@@ -405,7 +405,7 @@
 			name = "Wired "
 		if(STATE_ELECTRONICS_INSTALLED)
 			name = "Near-finished "
-	name += "[glass == 1 ? "Window " : ""][istext(glass) ? "[glass] Airlock" : base_name] Assembly"
+	name += "[glass == 1 ? "Window " : ""][istext(glass) ? "[glass] Hatch" : base_name] Assembly"
 	if(created_name)
 		name += " ([created_name])"
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -153,7 +153,7 @@ obj/structure/windoor_assembly/Destroy()
 			//Removing wire from the assembly. Step 5 undone.
 			if(W.iswirecutter() && !src.electronics)
 				playsound(src.loc, 'sound/items/wirecutter.ogg', 100, 1)
-				user.visible_message("[user] cuts the wires from the airlock assembly.", "You start to cut the wires from airlock assembly.")
+				user.visible_message("[user] cuts the wires from the hatch assembly.", "You start to cut the wires from hatch assembly.")
 
 				if(do_after(user, 40/W.toolspeed))
 					if(!src) return
@@ -171,13 +171,13 @@ obj/structure/windoor_assembly/Destroy()
 				var/obj/item/airlock_electronics/EL = W
 				if(!EL.is_installed)
 					playsound(src.loc, 'sound/items/screwdriver.ogg', 100, 1)
-					user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
+					user.visible_message("[user] installs the electronics into the hatch assembly.", "You start to install electronics into the hatch assembly.")
 					EL.is_installed = 1
 					if(do_after(user, 40))
 						EL.is_installed = 0
 						if(!src) return
 						user.drop_from_inventory(EL,src)
-						to_chat(user, "<span class='notice'>You've installed the airlock electronics!</span>")
+						to_chat(user, "<span class='notice'>You've installed the hatch electronics!</span>")
 						src.name = "Near finished Windoor Assembly"
 						src.electronics = EL
 					else
@@ -186,11 +186,11 @@ obj/structure/windoor_assembly/Destroy()
 			//Screwdriver to remove airlock electronics. Step 6 undone.
 			else if(W.isscrewdriver() && src.electronics)
 				playsound(src.loc, W.usesound, 100, 1)
-				user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to uninstall electronics from the airlock assembly.")
+				user.visible_message("[user] removes the electronics from the hatch assembly.", "You start to uninstall electronics from the hatch assembly.")
 
 				if(do_after(user, 40/W.toolspeed))
 					if(!src || !src.electronics) return
-					to_chat(user, "<span class='notice'>You've removed the airlock electronics!</span>")
+					to_chat(user, "<span class='notice'>You've removed the hatch electronics!</span>")
 					if(src.secure)
 						src.name = "Secure Wired Windoor Assembly"
 					else

--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -56,5 +56,5 @@
 /turf/unsimulated/wall/fakeairlock
 	icon = 'icons/obj/doors/Doorele.dmi'
 	icon_state = "door_closed"
-	name = "Airlock"
+	name = "Hatch"
 	desc = "It opens and closes."

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -49,11 +49,11 @@
 
 	if(areas && areas.len > 0)
 		var/my_department = "[station_name()] firewall subroutines"
-		var/rc_message = "An unknown malicious program has been detected in the [english_list(areaName)] lighting and airlock control systems at [worldtime2text()]. Systems will be fully compromised within approximately three minutes. Direct intervention is required immediately.<br>"
+		var/rc_message = "An unknown malicious program has been detected in the [english_list(areaName)] lighting and hatch control systems at [worldtime2text()]. Systems will be fully compromised within approximately three minutes. Direct intervention is required immediately.<br>"
 		for(var/obj/machinery/message_server/MS in SSmachinery.processing_machines)
 			MS.send_rc_message("Engineering", my_department, rc_message, "", "", 2)
 		for(var/mob/living/silicon/ai/A in player_list)
-			to_chat(A, "<span class='danger'>Malicious program detected in the [english_list(areaName)] lighting and airlock control systems by [my_department].</span>")
+			to_chat(A, "<span class='danger'>Malicious program detected in the [english_list(areaName)] lighting and hatch control systems by [my_department].</span>")
 
 	else
 		world.log <<  "ERROR: Could not initate grey-tide. Unable to find suitable containment area."

--- a/code/modules/heavy_vehicle/equipment/utility.dm
+++ b/code/modules/heavy_vehicle/equipment/utility.dm
@@ -54,7 +54,7 @@
 			return
 		else if(istype(target, /obj/machinery/door/airlock))
 			if(istype(target, /obj/machinery/door/airlock/centcom))
-				to_chat(user, SPAN_WARNING("You can't force these airlocks!"))
+				to_chat(user, SPAN_WARNING("You can't force these hatches!"))
 				return
 			var/obj/machinery/door/airlock/AD = target
 			if(!AD.operating)

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -79,25 +79,25 @@
 			new /datum/stack_recipe("sofa (corner)", /obj/structure/bed/stool/chair/sofa/corner, BUILD_AMT, one_per_turf = 1, on_floor = 1)
 		))
 
-	recipes += new /datum/stack_recipe_list("airlock assemblies",
+	recipes += new /datum/stack_recipe_list("hatch assemblies",
 		list(
-			new /datum/stack_recipe("standard airlock assembly", /obj/structure/door_assembly, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("command airlock assembly", /obj/structure/door_assembly/door_assembly_com, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("security airlock assembly", /obj/structure/door_assembly/door_assembly_sec, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("engineering airlock assembly", /obj/structure/door_assembly/door_assembly_eng, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("mining airlock assembly", /obj/structure/door_assembly/door_assembly_min, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("atmospherics airlock assembly", /obj/structure/door_assembly/door_assembly_atmo, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("research airlock assembly", /obj/structure/door_assembly/door_assembly_research, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("medical airlock assembly", /obj/structure/door_assembly/door_assembly_med, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("maintenance airlock assembly", /obj/structure/door_assembly/door_assembly_mai, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("external airlock assembly", /obj/structure/door_assembly/door_assembly_ext, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("freezer airlock assembly", /obj/structure/door_assembly/door_assembly_fre, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("standard hatch assembly", /obj/structure/door_assembly, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("command hatch assembly", /obj/structure/door_assembly/door_assembly_com, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("security hatch assembly", /obj/structure/door_assembly/door_assembly_sec, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("engineering hatch assembly", /obj/structure/door_assembly/door_assembly_eng, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("mining hatch assembly", /obj/structure/door_assembly/door_assembly_min, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("atmospherics hatch assembly", /obj/structure/door_assembly/door_assembly_atmo, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("research hatch assembly", /obj/structure/door_assembly/door_assembly_research, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("medical hatch assembly", /obj/structure/door_assembly/door_assembly_med, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("maintenance hatch assembly", /obj/structure/door_assembly/door_assembly_mai, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("external hatch assembly", /obj/structure/door_assembly/door_assembly_ext, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("freezer hatch assembly", /obj/structure/door_assembly/door_assembly_fre, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
 			new /datum/stack_recipe("airtight hatch assembly", /obj/structure/door_assembly/door_assembly_hatch, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
 			new /datum/stack_recipe("maintenance hatch assembly", /obj/structure/door_assembly/door_assembly_mhatch, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("high security airlock assembly", /obj/structure/door_assembly/door_assembly_highsecurity, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
+			new /datum/stack_recipe("high security hatch assembly", /obj/structure/door_assembly/door_assembly_highsecurity, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
 			new /datum/stack_recipe("vault assembly", /obj/structure/door_assembly/door_assembly_vault, BUILD_AMT, time = 100, one_per_turf = 1, on_floor = 1),
 			new /datum/stack_recipe("emergency shutter", /obj/structure/firedoor_assembly, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1),
-			new /datum/stack_recipe("multi-tile airlock assembly", /obj/structure/door_assembly/multi_tile, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1)
+			new /datum/stack_recipe("multi-tile hatch assembly", /obj/structure/door_assembly/multi_tile, BUILD_AMT, time = 50, one_per_turf = 1, on_floor = 1)
 		))
 
 	recipes += new /datum/stack_recipe_list("turret frames",

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -64,7 +64,7 @@
 	sparring_variant_type = /datum/unarmed_attack/pain_strike/heavy // unathi have heavier pain hits in this mode
 
 /datum/unarmed_attack/claws/shredding
-	desc = "Use your in-built knives to turn your foes into mincemeat. These claws are durable enough for you to shred some objects open, such as airlocks. Some call it unfair, some call it species superiority. Can't complain if they're dead*, though.<br/>*Citation Needed"
+	desc = "Use your in-built knives to turn your foes into mincemeat. These claws are durable enough for you to shred some objects open, such as hatches. Some call it unfair, some call it species superiority. Can't complain if they're dead*, though.<br/>*Citation Needed"
 	shredding = TRUE
 	attack_name = "durable claws"
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/projectile/heavysniper
 	name = "anti-materiel rifle"
-	desc = "The PTR-7 is man-portable anti-armor rifle fitted with a high-powered scope, capable of penetrating through most windows, airlocks, and non-reinforced walls with ease. Fires armor piercing 14.5mm shells."
+	desc = "The PTR-7 is man-portable anti-armor rifle fitted with a high-powered scope, capable of penetrating through most windows, hatches, and non-reinforced walls with ease. Fires armor piercing 14.5mm shells."
 	desc_info = "A single-shot, bolt-action anachronism in an age of energy weapons, the PTR-7 was originally developed to combat exosuits, either by disabling critical systems \
 	or killing the pilot. Firing a high-velocity 14.5mm cartridge designed to defeat heavy armor, the PTR-7 boasts penetrative power unmatched by most in its class, though recent advancements \
 	in composites have rendered the weapon less effective at its intended purpose. Nonetheless, it still sees use among some groups as a general-purpose anti-materiel rifle."

--- a/code/modules/research/designs/circuit/misc_electronics.dm
+++ b/code/modules/research/designs/circuit/misc_electronics.dm
@@ -2,7 +2,7 @@
 	p_category = "Electronics Designs"
 
 /datum/design/circuit/electronics/secure_airlock
-	name = "Secure Airlock Electronics"
-	desc = "Allows for the construction of a tamper-resistant airlock electronics."
+	name = "Secure Hatch Electronics"
+	desc = "Allows for the construction of a tamper-resistant hatch electronics."
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/airlock_electronics/secure

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -162,11 +162,11 @@ var/global/maint_all_access = 0
 
 /proc/make_maint_all_access()
 	maint_all_access = 1
-	security_announcement.Announce("The maintenance access requirement has been revoked on all airlocks.","Attention!")
+	security_announcement.Announce("The maintenance access requirement has been revoked on all hatches.","Attention!")
 
 /proc/revoke_maint_all_access()
 	maint_all_access = 0
-	security_announcement.Announce("The maintenance access requirement has been readded on all maintenance airlocks.","Attention!")
+	security_announcement.Announce("The maintenance access requirement has been readded on all maintenance hatches.","Attention!")
 
 /obj/machinery/door/airlock/allowed(mob/M)
 	var/obj/item/I = M.GetIdCard()

--- a/html/changelogs/hatches.yml
+++ b/html/changelogs/hatches.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - tweak: "Changed the name of airlocks to hatches, to better reflect what an airlock is."

--- a/maps/_common/areas/station/engineering.dm
+++ b/maps/_common/areas/station/engineering.dm
@@ -44,7 +44,7 @@
 	ambience = AMBIENCE_SINGULARITY
 
 /area/engineering/engine_airlock
-	name = "Engineering - Engine Room Airlock"
+	name = "Engineering - Engine Room Hatch"
 	icon_state = "engine"
 
 /area/engineering/engine_monitoring

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -9909,7 +9909,7 @@
 /turf/unsimulated/wall/fakeairlock{
 	icon = 'icons/obj/doors/Doorext.dmi';
 	icon_state = "door_locked";
-	name = "Service Airlock"
+	name = "Service Hatch"
 	},
 /area/centcom/legion)
 "cDL" = (
@@ -20867,7 +20867,7 @@
 /turf/unsimulated/wall/fakeairlock{
 	icon = 'icons/obj/doors/Doorext.dmi';
 	icon_state = "door_locked";
-	name = "Service Airlock"
+	name = "Service Hatch"
 	},
 /area/centcom/ferry)
 "jre" = (
@@ -22679,7 +22679,7 @@
 /turf/unsimulated/wall/fakeairlock{
 	icon = 'icons/obj/doors/Doorext.dmi';
 	icon_state = "door_locked";
-	name = "airlock"
+	name = "hatch"
 	},
 /area/centcom/specops)
 "kCR" = (
@@ -29983,7 +29983,7 @@
 /turf/unsimulated/wall/fakeairlock{
 	icon = 'icons/obj/doors/Doorext.dmi';
 	icon_state = "door_locked";
-	name = "Service Airlock"
+	name = "Service Hatch"
 	},
 /area/centcom/legion/hangar5)
 "pkN" = (
@@ -32314,7 +32314,7 @@
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/doors/door_assembly.dmi';
 	icon_state = "door_as_ext0";
-	name = "damaged airlock"
+	name = "damaged hatch"
 	},
 /turf/unsimulated/floor{
 	icon_state = "panelscorched"
@@ -32812,7 +32812,7 @@
 /turf/unsimulated/wall/fakeairlock{
 	icon = 'icons/obj/doors/Doorext.dmi';
 	icon_state = "door_locked";
-	name = "service airlock"
+	name = "service hatch"
 	},
 /area/template_noop)
 "rhm" = (
@@ -34178,7 +34178,7 @@
 /obj/machinery/door/airlock/external{
 	close_sound_powered = 'sound/machines/airlock_close_force.ogg';
 	glass = 1;
-	name = "airlock";
+	name = "hatch";
 	opacity = 0;
 	open_sound_powered = 'sound/machines/airlock_open_force.ogg'
 	},
@@ -41346,7 +41346,7 @@
 /turf/unsimulated/wall/fakeairlock{
 	icon = 'icons/obj/doors/Doorext.dmi';
 	icon_state = "door_locked";
-	name = "service airlock"
+	name = "service hatch"
 	},
 /area/centcom/specops)
 "wOm" = (
@@ -43680,7 +43680,7 @@
 /obj/machinery/door/airlock/external{
 	close_sound_powered = 'sound/machines/airlock_close_force.ogg';
 	glass = 1;
-	name = "airlock";
+	name = "hatch";
 	opacity = 0;
 	open_sound_powered = 'sound/machines/airlock_open_force.ogg'
 	},

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -6975,7 +6975,7 @@
 	icon_state = "door_locked";
 	id_tag = "ai_core_outer";
 	locked = 1;
-	name = "Outer Core Airlock";
+	name = "Outer Core Hatch";
 	req_access = list(13)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6992,7 +6992,7 @@
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "ai_core_airlock";
-	name = "AI Core airlock controller";
+	name = "AI Core hatch controller";
 	pixel_y = 30;
 	req_one_access = list(13);
 	tag_airpump = "ai_core_pump";
@@ -7034,7 +7034,7 @@
 	icon_state = "door_locked";
 	id_tag = "ai_core_inner";
 	locked = 1;
-	name = "Inner Core Airlock";
+	name = "Inner Core Hatch";
 	req_access = list(13)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -10602,7 +10602,7 @@
 	},
 /obj/machinery/button/remote/airlock{
 	id = "bunker2";
-	name = "Bunker Outer Airlock Bolt Control";
+	name = "Bunker Outer Hatch Bolt Control";
 	pixel_x = 26;
 	req_access = list(20);
 	specialfunctions = 4
@@ -11178,7 +11178,7 @@
 	},
 /obj/machinery/button/remote/airlock{
 	id = "bunker3";
-	name = "Bunker Inner Airlock Bolt Control";
+	name = "Bunker Inner Hatch Bolt Control";
 	pixel_x = 26;
 	req_access = list(19);
 	specialfunctions = 4
@@ -11189,7 +11189,7 @@
 "auq" = (
 /obj/machinery/button/remote/airlock{
 	id = "bunker3";
-	name = "Bunker Inner Airlock Bolt Control";
+	name = "Bunker Inner Hatch Bolt Control";
 	pixel_x = -26;
 	req_access = list(19);
 	specialfunctions = 4
@@ -11686,7 +11686,7 @@
 	},
 /obj/machinery/button/remote/airlock{
 	id = "bunker2";
-	name = "Bunker Outer Airlock Bolt Control";
+	name = "Bunker Outer Hatch Bolt Control";
 	pixel_x = -26;
 	req_access = list(20);
 	specialfunctions = 4
@@ -14375,7 +14375,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass_medical{
-	name = "Dusty Airlock";
+	name = "Dusty Hatch";
 	req_access = list(66)
 	},
 /turf/simulated/floor/tiled/white,
@@ -19123,7 +19123,7 @@
 	icon_state = "door_locked";
 	id_tag = "xeno_airlock_exterior";
 	locked = 1;
-	name = "Xenobiology External Airlock";
+	name = "Xenobiology External Hatch";
 	req_access = list(55)
 	},
 /obj/machinery/access_button{
@@ -28052,7 +28052,7 @@
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "eng_sl_eva_airlock";
-	name = "Engineering Sub-level Airlock Console";
+	name = "Engineering Sub-level Hatch Console";
 	pixel_x = 24;
 	req_access = list(13,10);
 	tag_airpump = "eng_sl_eva_pump";
@@ -28802,7 +28802,7 @@
 	icon_state = "door_locked";
 	id_tag = "tesla2_airlock_exterior";
 	locked = 1;
-	name = "Engine Airlock Exterior";
+	name = "Engine Hatch Exterior";
 	req_access = list(11)
 	},
 /obj/machinery/door/firedoor,
@@ -28880,7 +28880,7 @@
 	icon_state = "door_locked";
 	id_tag = "tesla1_airlock_interior";
 	locked = 1;
-	name = "Engine Airlock Interior";
+	name = "Engine Hatch Interior";
 	req_access = list(11)
 	},
 /obj/machinery/access_button{
@@ -31577,7 +31577,7 @@
 	icon_state = "door_locked";
 	id_tag = "xenobotany_airlock_interior";
 	locked = 1;
-	name = "Hazardous Specimens Interior Airlock";
+	name = "Hazardous Specimens Interior Hatch";
 	req_access = list(55)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -32265,7 +32265,7 @@
 	icon_state = "door_locked";
 	id_tag = "tesla1_airlock_exterior";
 	locked = 1;
-	name = "Engine Airlock Exterior";
+	name = "Engine Hatch Exterior";
 	req_access = list(11)
 	},
 /obj/machinery/access_button{
@@ -35185,7 +35185,7 @@
 	icon_state = "door_locked";
 	id_tag = "tesla2_airlock_interior";
 	locked = 1;
-	name = "Engine Airlock Interior";
+	name = "Engine Hatch Interior";
 	req_access = list(11)
 	},
 /obj/machinery/door/firedoor,
@@ -36795,7 +36795,7 @@
 	icon_state = "door_locked";
 	id_tag = "xenobotany_airlock_exterior";
 	locked = 1;
-	name = "Hazardous Specimens Exterior Airlock";
+	name = "Hazardous Specimens Exterior Hatch";
 	req_access = list(55)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -2642,7 +2642,7 @@
 /obj/machinery/button/remote/airlock/screamer{
 	channel = "Science";
 	id = "server_door_lock";
-	message = "The Server Room Airlock's ID lock toggle has been used.";
+	message = "The Server Room Hatch's ID lock toggle has been used.";
 	name = "Server Room Control";
 	pixel_x = -24;
 	pixel_y = -24;
@@ -17795,7 +17795,7 @@
 	icon_state = "door_locked";
 	id_tag = "engine_airlock_interior";
 	locked = 1;
-	name = "Engine Airlock Interior";
+	name = "Engine Hatch Interior";
 	req_access = list(11)
 	},
 /obj/machinery/access_button{
@@ -17856,7 +17856,7 @@
 	icon_state = "door_locked";
 	id_tag = "engine_airlock_exterior";
 	locked = 1;
-	name = "Engine Airlock Exterior";
+	name = "Engine Hatch Exterior";
 	req_access = list(11)
 	},
 /obj/machinery/access_button{

--- a/maps/aurora/aurora-5_interstitial.dmm
+++ b/maps/aurora/aurora-5_interstitial.dmm
@@ -7748,7 +7748,7 @@
 	icon_state = "door_locked";
 	id_tag = "eng_ladder_outer";
 	locked = 1;
-	name = "Telecoms Ladder Shaft Exterior Airlock";
+	name = "Telecoms Ladder Shaft Exterior Hatch";
 	req_access = list(13)
 	},
 /obj/effect/decal/cleanable/dirt,

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -15910,7 +15910,7 @@
 /obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
 	frequency = 1381;
 	id_tag = "server_access_airlock";
-	name = "Server Access Airlock";
+	name = "Server Access Hatch";
 	pixel_y = 25;
 	tag_airpump = "server_access_pump";
 	tag_chamber_sensor = "server_access_sensor";


### PR DESCRIPTION
Changes all the airlocks to be called hatches, on the player-facing end at least. Code side they're still called airlocks for the sake of not breaking everything and for ease of porting stuff. Suggested [here](https://forums.aurorastation.org/topic/16892-rename-airlocks-to-hatches).