### PR TITLE
IV Drip Blood Injection Stop Quality of Life

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -168,7 +168,7 @@
 		to_chat(usr, SPAN_WARNING("You can't do that."))
 		return
 
-	if(usr.stat)
+	if(usr.incapacitated())
 		return
 
 	toggle_stop = !toggle_stop

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -164,7 +164,7 @@
 	set name = "Toggle Stop"
 	set src in view(1)
 
-	if(!istype(usr, /mob/living))
+	if(!isliving(usr))
 		to_chat(usr, SPAN_WARNING("You can't do that."))
 		return
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -165,7 +165,7 @@
 	set src in view(1)
 
 	if(!istype(usr, /mob/living))
-		to_chat(usr, "<span class='warning'>You can't do that.</span>")
+		to_chat(usr, SPAN_WARNING("You can't do that."))
 		return
 
 	if(usr.stat)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -172,7 +172,7 @@
 		return
 
 	toggle_stop = !toggle_stop
-	to_chat(usr, "[src]'s automatic stop mode is now [toggle_stop ? "active" : "deactivated"]")
+	usr.visible_message("<b>[usr]</b> toggles \the [src]'s automatic stop mode [toggle_stop ? "on" : "off"]", SPAN_NOTICE("You toggle \the [src]'s automatic stop mode [toggle_stop ? "on" : "off"]."))
 	playsound(usr, 'sound/machines/click.ogg', 50)
 
 /obj/machinery/iv_drip/examine(mob/user)

--- a/html/changelogs/iv_drip_stop.yml
+++ b/html/changelogs/iv_drip_stop.yml
@@ -1,0 +1,6 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a togglable automatic blood injection stop for the IV drips, which causes them to automatically and safely disengage from patients if their blood volume is full."


### PR DESCRIPTION
* IV drips that are injecting blood can now automatically and safely detach from patients whose blood volume is fully recovered.
* This automatic stop mode can be deactivated/activated via Toggle Stop (Right Click the IV drip).

**IV drip's automatic stop mode active.**
![](https://i.imgur.com/36jyE2K.png)