### PR TITLE
Fixes fake death not showing properly and time of death

### DIFF
--- a/code/game/objects/items/devices/lighting/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/flashlight.dm
@@ -104,7 +104,7 @@
 			user.visible_message(SPAN_NOTICE("\The [user] directs [src] to [M]'s eyes."), SPAN_NOTICE("You direct [src] to [M]'s eyes."))
 
 			if (H != user)	//can't look into your own eyes buster
-				if(M.stat == DEAD || M.blinded)	//mob is dead or fully blind
+				if(M.stat == DEAD || M.blinded || M.status_flags & FAKEDEATH)	//mob is dead or fully blind
 					to_chat(user, SPAN_WARNING("\The [M]'s pupils do not react to the light!"))
 					return
 				if(XRAY in M.mutations)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -112,8 +112,8 @@ BREATH ANALYZER
 	var/brain_result = H.get_brain_status()
 	dat += "Brain activity: [brain_result]."
 
-	if(H.stat == DEAD || (H.status_flags & FAKEDEATH))
-		dat += "<span class='scan_warning'>[b]Time of Death:[endb] [time2text(worldtime2text(H.timeofdeath), "hh:mm")]</span>"
+	if(H.stat == DEAD || H.status_flags & FAKEDEATH)
+		dat += "<span class='scan_warning'>[b]Time of Death:[endb] [worldtime2text(H.timeofdeath)]</span>"
 
 	// Pulse rate.
 	var/pulse_result = "normal"
@@ -169,7 +169,7 @@ BREATH ANALYZER
 	dat += temperature_string
 
 	// Traumatic shock.
-	if(H.is_asystole())
+	if(H.is_asystole() || (H.status_flags & FAKEDEATH))
 		dat += "<span class='scan_danger'>Patient is suffering from cardiovascular shock. Administer CPR immediately.</span>"
 	else if(H.shock_stage > 80)
 		dat += "<span class='scan_warning'>Patient is at serious risk of going into shock. Pain relief recommended.</span>"

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -38,6 +38,7 @@
 				var/mob/living/carbon/C = M
 				if(C.status_flags & FAKEDEATH)
 					icon_state = "morgue2"
+					break
 				switch(C.stat)
 					if(DEAD)
 						icon_state = "morgue2"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -225,13 +225,13 @@
 		distance = 1
 	if (src.stat && !(src.species.flags & NO_BLOOD))	// No point checking pulse of a species that doesn't have one.
 		msg += "<span class='warning'>[get_pronoun("He")] [get_pronoun("is")]n't responding to anything around [get_pronoun("him")] and seems to be unconscious.</span>\n"
-		if((stat == DEAD || is_asystole() || src.losebreath) && distance <= 3)
+		if((stat == DEAD || is_asystole() || src.losebreath) && distance <= 3 || (status_flags & FAKEDEATH))
 			msg += "<span class='warning'>[get_pronoun("He")] [get_pronoun("does")] not appear to be breathing.</span>\n"
 		if(istype(user, /mob/living/carbon/human) && !user.stat && Adjacent(user))
 			spawn (0)
 				user.visible_message("<b>[user]</b> checks [src]'s pulse.", "You check [src]'s pulse.")
 				if (do_mob(user, src, 15))
-					if(pulse() == PULSE_NONE)
+					if(pulse() == PULSE_NONE || (status_flags & FAKEDEATH))
 						to_chat(user, "<span class='deadsay'>[get_pronoun("He")] [get_pronoun("has")] no pulse.</span>")
 					else
 						to_chat(user, "<span class='deadsay'>[get_pronoun("He")] [get_pronoun("has")] a pulse!</span>")
@@ -256,7 +256,7 @@
 		inactivity =  have_client ? bg.client.inactivity : null
 
 
-	if(species.show_ssd && (!species.has_organ[BP_BRAIN] || has_brain()) && stat != DEAD)
+	if(species.show_ssd && (!species.has_organ[BP_BRAIN] || has_brain()) && stat != DEAD && !(status_flags & FAKEDEATH))
 		if(!vr_mob && !key)
 			msg += "<span class='deadsay'>[get_pronoun("He")] [get_pronoun("is")] [species.show_ssd]. It doesn't look like [get_pronoun("he")] [get_pronoun("is")] waking up anytime soon.</span>\n"
 		else if(!vr_mob && !client && !bg)

--- a/html/changelogs/FakeDeathFix.yml
+++ b/html/changelogs/FakeDeathFix.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed most methods to easily detect if a fake death is fake. Primarily affects lings."
+  - bugfix: "Time of death now shows properly on health analyzers again."


### PR DESCRIPTION
This should account for the most obvious ways to detect it and actually make it visible without having medical nearby to say they are braindead.
Also health analyzers now shows time of death again.