### PR TITLE
Adds skrellprints

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -195,3 +195,9 @@
 	drydesc = "A dried trail left by someone crawling."
 	coming_state = "trail1"
 	going_state  = "trail2"
+
+/obj/effect/decal/cleanable/blood/tracks/footprints/skrellprints
+	desc = "They look like still wet tracks left by skrellian feet."
+
+/obj/effect/decal/cleanable/blood/tracks/footprints/skrellprints/dry()
+	qdel(src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -277,6 +277,16 @@ var/const/enterloopsanity = 100
 				from.add_tracks(H.species.get_move_trail(H), footprint_DNA, 0, H.dir, footprint_color) // Going
 			footprint_DNA = null
 
+		else
+			if(isskrell(H))
+				if(!H.shoes)
+					footprint_color = rgb(H.r_skin, H.g_skin, H.b_skin)
+					add_tracks(/obj/effect/decal/cleanable/blood/tracks/footprints/skrellprints, footprint_DNA, H.dir, 0, footprint_color + "25") // Coming
+					var/turf/simulated/from = get_step(H, reverse_direction(H.dir))
+					if(istype(from) && from)
+						from.add_tracks(/obj/effect/decal/cleanable/blood/tracks/footprints/skrellprints, footprint_DNA, 0, H.dir, footprint_color + "25") // Going
+					footprint_DNA = H.blood_DNA
+
 	..()
 
 	var/objects = 0

--- a/html/changelogs/Skrellprints.yml
+++ b/html/changelogs/Skrellprints.yml
@@ -1,0 +1,6 @@
+author: listerla
+
+delete-after: True
+
+changes:
+  - rscadd: "Skrell now leave mostly-transparent footprints that dissipate over time when barefoot."


### PR DESCRIPTION
Skrell now leave mostly-transparent footprints when barefoot. These dissipate over time. 

![image](https://user-images.githubusercontent.com/57296132/151694814-31920728-862a-45c4-8bf3-497d2cf5c58b.png)
![image](https://user-images.githubusercontent.com/57296132/151694816-6dc1d094-7bf9-48a3-b213-73a575ae1e20.png)

Skrell Lore Guy's take on the matter from long ago.

![image](https://user-images.githubusercontent.com/57296132/151694802-6249ee6b-3c42-4629-b0cd-5f73c7ee75d5.png)

Graciously ported from https://github.com/HearthOfHestia/Nebula/pull/50