### PR TITLE
Bulwark Speedtweak

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -211,7 +211,7 @@
 	eyes_icons = 'icons/mob/human_face/eyes48x48.dmi'
 	eyes = "bulwark_eyes"
 
-	slowdown = 6
+	slowdown = 2
 
 	unarmed_types = list(/datum/unarmed_attack/claws/vaurca_bulwark)
 
@@ -240,6 +240,7 @@ Bulwarks are much larger and have significantly thicker carapaces than most Vaur
 	heat_level_3 = 800 //Default 1000
 
 	sprint_speed_factor = 1.4
+	stamina = 50
 
 /datum/species/bug/type_e/New()
 	..()

--- a/html/changelogs/geeves-bulwark_speed.yml
+++ b/html/changelogs/geeves-bulwark_speed.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Bulwarks now move faster, a bit slower than their other vaurca brethren. In exchange, their stamina has been halved."


### PR DESCRIPTION
* Bulwarks now move faster, a bit slower than their other vaurca brethren. In exchange, their stamina has been halved.