### PR TITLE
Buff to Cyber Warfare Suit (Hacker Rig)

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/gear_loadout.dm
+++ b/code/game/objects/structures/crates_lockers/crates/gear_loadout.dm
@@ -437,6 +437,7 @@
 	new /obj/item/gun/energy/xray(src)
 	new /obj/item/clothing/accessory/holster/armpit/brown(src)
 	new /obj/item/gun/energy/crossbow/largecrossbow(src)
+	new /obj/item/melee/energy/sword/red(src)
 
 /obj/structure/closet/crate/secure/gear_loadout/ninja/techno
 	associated_hardsuit = /obj/item/rig/light/offworlder/techno/ninja

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -1,4 +1,4 @@
-// Light rigs are not space-capable, but don't suffer excessive slowdown or sight issues when depowered.
+// Light rigs are not space-capable, but don't suffer excessive slowdown or sight issues when depowered. 
 /obj/item/rig/light
 	name = "light suit control module"
 	desc = "A lighter, less armored hardsuit."
@@ -14,8 +14,9 @@
 		energy = ARMOR_MELEE_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 	)
-	emp_protection = 10
-	slowdown = 0
+	emp_protection = 100
+	slowdown = -1
+	species_restricted = list(BODYTYPE_HUMAN, BODYTYPE_UNATHI, BODYTYPE_SKRELL, BODYTYPE_VAURCA)
 	item_flags = THICKMATERIAL
 	offline_slowdown = 0
 	offline_vision_restriction = 0
@@ -94,7 +95,8 @@
 		/obj/item/rig_module/vision,
 		/obj/item/rig_module/teleporter,
 		/obj/item/rig_module/actuators/combat,
-		/obj/item/rig_module/device/door_hack
+		/obj/item/rig_module/device/door_hack,
+		/obj/item/rig_module/fabricator/energy_net
 		)
 
 

--- a/html/changelogs/readthisnameplz-Averys-hell.yml
+++ b/html/changelogs/readthisnameplz-Averys-hell.yml
@@ -1,0 +1,7 @@
+author: ReadThisNamePlz
+
+delete-after: True
+
+changes:
+  - tweak: "Buffed the Cyber Ninja suit. Net gun module added, 100 EMP defense, speed boost to the suit, and an energy sword to the crate."
+  - rscdel: "Removed Tajaran and IPC access to the cyberwarfare suit for balance reasons."


### PR DESCRIPTION
The cyber warfare (hacker) suit is rarely ever used. It does not have great armor, it is not usable for EVA and it has no melee options, and very limited escapes. (It can teleport.)

With this PR, I am intending to buff the suit, every other ninja rig has either the ability to hold their own in a decent fight, or decent escape options like cloaking, smoke grenades from a launcher or even hyperzine for a speedy getaway. 

The hacker suit had no real escape option aside from teleportation, but even with that they cannot teleport EVA or go into vented areas, so it is very limiting. 

With that said, I have outlined the changes below
-------------------------
- 100 EMP Defense
- Speed boost
- Red Esword in crate
- Net gun                     
-------------------------
- Removes Tajaran and IPC accessibility.
-------------------------

The speedboost is aimed at allowing for an easier getaway, since the suit is not rated for major combat, due to its very minimal armor. 
The energy sword is added so the user might save TC for other items that can assist with a gimmick, such as announcements, storms, tools, infiltration items. Etcetera. 
The net gun is added to give the wearer a non-lethal, antagonistic option. While the crossbow is there and executes great stun damage, it causes pain which can escalate a bit too much. Whereas the netgun is just a way to immobilize or capture. 


