### PR TITLE
Fixes the ability to join a job as the wrong faction

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -287,12 +287,23 @@
 		ResetJobs()
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
+	var/datum/species/S = pref.get_species_datum()
 	var/datum/faction/faction = SSjobs.name_factions[pref.faction]
-	for(var/datum/job/job in faction.get_occupations())
+	for(var/datum/job/job in SSjobs.occupations)
 		for(var/department = 1 to NUM_JOB_DEPTS)
 			if(pref.GetJobDepartment(job, department) & job.flag)
+				if(!(job in faction.get_occupations()))
+					to_client_chat(SPAN_DANGER("Your faction selection does not permit this job, [job.title] as [pref.faction]."))
+					to_client_chat(SPAN_DANGER("Your jobs have been reset due to this!"))
+					ResetJobs()
+					return TOPIC_REFRESH_UPDATE_PREVIEW
 				if(pref.species in job.blacklisted_species)
 					to_client_chat(SPAN_DANGER("Your faction selection does not permit this species-occupation combination, [pref.species] as [job.title]."))
+					to_client_chat(SPAN_DANGER("Your jobs have been reset due to this!"))
+					ResetJobs()
+					return TOPIC_REFRESH_UPDATE_PREVIEW
+				if(!is_type_in_typecache(S, faction.allowed_species_types))
+					to_client_chat(SPAN_DANGER("Your faction selection does not permit this species, [pref.species] as [pref.faction]."))
 					to_client_chat(SPAN_DANGER("Your jobs have been reset due to this!"))
 					ResetJobs()
 					return TOPIC_REFRESH_UPDATE_PREVIEW

--- a/html/changelogs/JobFix.yml
+++ b/html/changelogs/JobFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "The job code now checks if a given job & species preference is permitted for a given faction when loading a character."


### PR DESCRIPTION
Apparently the code never checked if a given job/species & faction combo was permitted when loading it, only when selecting it or attempting to join in the case of species. This should fix that and make it clearer to players that the combination won't work.
Primarily a concern on NBT where there are changes, but also matters in case any of this is changed and an old character is loaded.