### PR TITLE
Battlemonsters Tweak

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1199,30 +1199,31 @@
 	vend_id = "battlemonsters"
 	products = list(
 		/obj/item/book/manual/wiki/battlemonsters = 10,
-		/obj/item/battle_monsters/wrapped/basic = 5,
-		/obj/item/battle_monsters/wrapped = 10,
-		/obj/item/battle_monsters/wrapped/pro = 10,
-		/obj/item/battle_monsters/wrapped/species = 4, //Human monsters
-		/obj/item/battle_monsters/wrapped/species/lizard = 4, //Reptile Monsters
-		/obj/item/battle_monsters/wrapped/species/cat = 4, //Feline Monsters
-		/obj/item/battle_monsters/wrapped/species/ant = 4, //Ant Monsters
-		/obj/item/battle_monsters/wrapped/rare = 4
+		/obj/item/battle_monsters/wrapped/basic = 20,
+		/obj/item/battle_monsters/wrapped = 20,
+		/obj/item/battle_monsters/wrapped/pro = 20,
+		/obj/item/battle_monsters/wrapped/species = 10, //Human monsters
+		/obj/item/battle_monsters/wrapped/species/lizard = 10, //Reptile Monsters
+		/obj/item/battle_monsters/wrapped/species/cat = 10, //Feline Monsters
+		/obj/item/battle_monsters/wrapped/species/ant = 10, //Ant Monsters
+		/obj/item/battle_monsters/wrapped/rare = 10
 	)
 	prices = list(
 		/obj/item/book/manual/wiki/battlemonsters = 12,
 		/obj/item/battle_monsters/wrapped = 100,
 		/obj/item/battle_monsters/wrapped/pro = 75,
-		/obj/item/battle_monsters/wrapped/species = 100,
-		/obj/item/battle_monsters/wrapped/species/lizard = 125,
-		/obj/item/battle_monsters/wrapped/species/cat = 125,
-		/obj/item/battle_monsters/wrapped/species/ant = 125,
-		/obj/item/battle_monsters/wrapped/rare = 200
+		/obj/item/battle_monsters/wrapped/species = 50,
+		/obj/item/battle_monsters/wrapped/species/lizard = 50,
+		/obj/item/battle_monsters/wrapped/species/cat = 50,
+		/obj/item/battle_monsters/wrapped/species/ant = 50,
+		/obj/item/battle_monsters/wrapped/rare = 100
 	)
 	contraband = list(
-		/obj/item/battle_monsters/wrapped/legendary = 4
+		/obj/item/battle_monsters/wrapped/legendary = 5
 	)
 	premium = list(
 		/obj/item/coin/battlemonsters = 10
 	)
-	restock_items = 0
+	restock_items = FALSE
+	random_itemcount = FALSE
 	light_color = COLOR_BABY_BLUE

--- a/code/modules/battlemonsters/items/custom_decks.dm
+++ b/code/modules/battlemonsters/items/custom_decks.dm
@@ -1,7 +1,7 @@
 /obj/item/battle_monsters/wrapped/species
 	name = "battle monsters human boosterpack"
-	desc = "A battle monsters 10 card boosterpack, containing exclusively human monsters."
-	contained_cards = 10
+	desc = "A battle monsters 15 card boosterpack, containing exclusively human monsters."
+	contained_cards = 15
 	var/list/species = list(
 		"human_male" = 1,
 		"human_female" = 1,
@@ -30,7 +30,7 @@
 
 /obj/item/battle_monsters/wrapped/species/lizard
 	name = "battle monsters reptilian boosterpack"
-	desc = "A battle monsters 10 card boosterpack, containing exclusively reptilian monsters."
+	desc = "A battle monsters 15 card boosterpack, containing exclusively reptilian monsters."
 	species = list(
 		"dragon" = 0.5,
 		"dragon_hybrid" = 0.25,
@@ -42,7 +42,7 @@
 
 /obj/item/battle_monsters/wrapped/species/cat
 	name = "battle monsters feline boosterpack"
-	desc = "A battle monsters 10 card boosterpack, containing exclusively feline monsters."
+	desc = "A battle monsters 15 card boosterpack, containing exclusively feline monsters."
 	species = list(
 		"catman" = 1,
 		"catwoman" = 1
@@ -50,7 +50,7 @@
 
 /obj/item/battle_monsters/wrapped/species/ant
 	name = "battle monsters insect boosterpack"
-	desc = "A battle monsters 10 card boosterpack, containing exclusively insect monsters."
+	desc = "A battle monsters 15 card boosterpack, containing exclusively insect monsters."
 	species = list(
 		"antman" = 1,
 		"antwoman" = 0.25

--- a/code/modules/battlemonsters/items/wrapped.dm
+++ b/code/modules/battlemonsters/items/wrapped.dm
@@ -50,24 +50,24 @@
 
 /obj/item/battle_monsters/wrapped/pro
 	name = "battle monsters booster pack"
-	desc = "A pack of 10 rare battle monster cards, with a chance of having legendary cards."
+	desc = "A pack of 15 rare battle monster cards, with a chance of having legendary cards."
 	icon_state = "pack2"
-	contained_cards = 10
+	contained_cards = 15
 	rarity_max = BATTLE_MONSTERS_RARITY_UNCOMMON
 	rarity_min = BATTLE_MONSTERS_RARITY_LEGENDARY
 
 /obj/item/battle_monsters/wrapped/rare
 	name = "battle monsters rare booster pack"
-	desc = "A pack of 10 ultra-rare battle monster cards."
+	desc = "A pack of 15 ultra-rare battle monster cards."
 	icon_state = "pack2"
-	contained_cards = 10
+	contained_cards = 15
 	rarity_max = BATTLE_MONSTERS_RARITY_RARE
 	rarity_min = BATTLE_MONSTERS_RARITY_LEGENDARY
 
 /obj/item/battle_monsters/wrapped/legendary
-	name = "battle monsters rare booster pack"
-	desc = "A pack of 4 legendary battle monster cards."
+	name = "battle monsters legendary booster pack"
+	desc = "A pack of 8 legendary battle monster cards."
 	icon_state = "pack2"
-	contained_cards = 4
+	contained_cards = 8
 	rarity_max = BATTLE_MONSTERS_RARITY_LEGENDARY
 	rarity_min = BATTLE_MONSTERS_RARITY_LEGENDARY

--- a/html/changelogs/battlemonsters_tweak.yml
+++ b/html/changelogs/battlemonsters_tweak.yml
@@ -1,0 +1,8 @@
+author: Granodd
+
+delete-after: True
+
+changes:
+  - tweak: "Battlemonster vendor stock increased and prices reduced."
+  - tweak: "Amount of cards in each pack increased."
+  - spellcheck: "Fixes the name of the Battlemonster legendary pack."


### PR DESCRIPTION
• Increases the number of packs and decks inside of the Battlemonsters vendor and reduces their prices to make the cards overall more accessible to the crew.
• Additionally, increases the number of cards in each pack to further reinforce accessibility.
• Corrects the name of the contraband packs.