### PR TITLE
Lowers headbutt damage by 5

### DIFF
--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -93,7 +93,7 @@
 		return
 	attacker.visible_message("<span class='danger'>[attacker] thrusts [attacker.get_pronoun("his")] head into [target]'s skull!</span>")
 
-	var/damage = 20
+	var/damage = 15
 	if(attacker.mob_size >= 10)
 		damage += min(attacker.mob_size, 20)
 

--- a/html/changelogs/HeadbuttNerf.yml
+++ b/html/changelogs/HeadbuttNerf.yml
@@ -1,0 +1,6 @@
+author: listerla
+
+delete-after: True
+
+changes:
+  - tweak: "Slightly lowered headbutt damage."


### PR DESCRIPTION
I saw a lot of people complaining about headbutt spam, especially from Unathi. After playing a Unathi and trying out headbutt spam, it seems pretty ludicrous. I'm not confident in making big balance changes so I'm shifting it down 5 points, which means that it has a 15 damage on most species, 20 on Unathi instead of 20 and 25. This should also lower the headbutt KO chance.