### PR TITLE
Mech Organs Don't Squeltch

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -361,6 +361,8 @@
 	robotic = ROBOTIC_MECHANICAL
 	status = ORGAN_ROBOT
 	status |= ORGAN_ASSISTED
+	drop_sound = 'sound/items/drop/metalweapon.ogg'
+	pickup_sound = 'sound/items/pickup/metalweapon.ogg'
 	if(robotic_name)
 		name = robotic_name
 	if(robotic_sprite)

--- a/html/changelogs/mechorgansound.yml
+++ b/html/changelogs/mechorgansound.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - tweak: "Changed the pickup and drop sounds for mechanical organs to be different from organic ones."


### PR DESCRIPTION
Changes mechanical organs to not share their pickup and drop sounds with their fleshy brethren.