### PR TITLE
Corrects spelling of Burzsia in code

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_factions.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_factions.dm
@@ -262,7 +262,7 @@
 	faction = "Hephaestus Industries"
 
 /datum/gear/faction/heph_passcard
-	display_name = "hephaestus burszia passcard"
-	path = /obj/item/clothing/accessory/badge/passcard/burszia
+	display_name = "hephaestus burzsia passcard"
+	path = /obj/item/clothing/accessory/badge/passcard/burzsia
 	slot = slot_tie
 	faction = "Hephaestus Industries"

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -451,9 +451,9 @@
 	icon_state = "passcard_techno"
 	item_state = "passcard_techno"
 
-/obj/item/clothing/accessory/badge/passcard/burszia
-	name = "burszian passcard"
-	desc = "A passcard issued to Burszian Hephaestus employees and- owned IPCs- working abroad."
+/obj/item/clothing/accessory/badge/passcard/burzsia
+	name = "burzsian passcard"
+	desc = "A passcard issued to Burzsian Hephaestus employees and- owned IPCs- working abroad."
 	desc_fluff = "Despite protest from the Himean representatives in government, Hephaestus Industries- citing their 'Home is where the Hephaestus is' initiative- is permitted to issue up to five thousand \
 	sponsored passcards to participating employees on a yearly basis, both to remind them of their home and to save on imported labor costs."
 	icon_state = "passcard_burs"

--- a/html/changelogs/sierrakomodo-burzsia-spelling-fix.yml
+++ b/html/changelogs/sierrakomodo-burzsia-spelling-fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - spellcheck: "Fixed spelling of 'Burzsia' in the passcard loadout item."


### PR DESCRIPTION
Fixes the spelling of `Burzsia` in code, as a lot of cases, particularly in loadout, said `Burszia` instead.

This will probably break loadout entries for anyone using the burszian passcard.

Proof of proper spelling: https://wiki.aurorastation.org/index.php?title=Burzsia