### PR TITLE
Neural Suppressor Fix

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -88,8 +88,8 @@
 				icon_state = H.pulse() ? "[modify_state]-active" : "[modify_state]-idle"
 				victim = H
 	if(victim && !victim.isSynthetic())
-		if(suppressing && victim.sleeping < 3)
-			victim.Sleeping(3 - victim.sleeping)
+		if(suppressing && victim.sleeping < 7)
+			victim.Sleeping(7 - victim.sleeping)
 			victim.willfully_sleeping = FALSE
 		return TRUE
 	icon_state = "[modify_state]-idle"

--- a/html/changelogs/neural_suppressor.yml
+++ b/html/changelogs/neural_suppressor.yml
@@ -3,4 +3,4 @@ author: Vrow
 delete-after: True
 
 changes:
-  - bugfix: "Fixes the opearing table's neural suppressors occasionally not working."
+  - bugfix: "Fixes the operating table's neural suppressors occasionally not working."

--- a/html/changelogs/neural_suppressor.yml
+++ b/html/changelogs/neural_suppressor.yml
@@ -1,0 +1,6 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the opearing table's neural suppressors occasionally not working."


### PR DESCRIPTION
So, what I _think_ is happening is that the Operating Table's check_victim() proc isn't able to restrengthen the sleeping value due possible server shenganiganry (as I couldn't replicate the bug in a private server after several attempts), and since the sleeping value is very low, patients tend to wake-up mid-surgery

The idea for this fix is that it increases the Operating Table's sleeping value (from 3 to 7) as a better buffer for the check_victim() proc. So if it doesn't fix it completely, it'll at least reduce the frequency in which the occasional faliure happens.

* Fixes #11465
* Fixes #13012