### PR TITLE
Fixes infinite item bug with lathes, and corrects multi-material filling messages

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -213,8 +213,6 @@
 		update_icon()
 		return 1
 	else
-		if(get_amount() < used)
-			return 0
 		for(var/i = 1 to charge_costs.len)
 			var/datum/matter_synth/S = synths[i]
 			if(!S.use_charge(charge_costs[i] * used)) // Doesn't need to be deleted

--- a/html/changelogs/lathe_loading_bugfix.yml
+++ b/html/changelogs/lathe_loading_bugfix.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+delete-after: True
+
+changes:
+  - bugfix: "Fixed issue where trying to load a lathe with <1 of a sheet of something didn't delete the sheet item."
+  - bugfix: "Fixed issue where loading a lathe with an object consisting of >1 materials could provide incorrect messages about how full it is."


### PR DESCRIPTION
Fixes #13140 which let you get infinite materials if you could get a non-integer amount of sheets of something.

Also fixes a bug that could appear when recycling an item consisting of multiple materials. The message saying that it was full, partly full or couldn't put the item in would be determined by the last material on the list.

Now it will check for all materials and create a message like:
"You fill the autolathe to capacity with cake and jelly beans with the thing.
You fill the autolathe with puppies, small children and possums with the thing."

Or

"The autolathe is full of liquorice. Please remove some material in order to insert more."