### PR TITLE
Cult Armor Rebalancing

### DIFF
--- a/code/game/gamemodes/cult/items/armor.dm
+++ b/code/game/gamemodes/cult/items/armor.dm
@@ -18,8 +18,8 @@
 	desc = "A bulky armored voidsuit helmet, bristling with menacing spikes. It looks space proof."
 	icon_state = "cult_helmet"
 	armor = list(
-		melee = ARMOR_MELEE_VERY_HIGH,
-		bullet = ARMOR_BALLISTIC_SMALL,
+		melee = ARMOR_MELEE_MAJOR,
+		bullet = ARMOR_BALLISTIC_REVOLVER,
 		laser = ARMOR_LASER_MAJOR,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
@@ -41,8 +41,8 @@
 	allowed = list(/obj/item/book/tome, /obj/item/melee/cultblade, /obj/item/gun/energy/rifle/cult, /obj/item/tank, /obj/item/device/suit_cooling_unit)
 	slowdown = 1
 	armor = list(
-		melee = ARMOR_MELEE_VERY_HIGH,
-		bullet = ARMOR_BALLISTIC_SMALL,
+		melee = ARMOR_MELEE_MAJOR,
+		bullet = ARMOR_BALLISTIC_REVOLVER,
 		laser = ARMOR_LASER_MAJOR,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,

--- a/html/changelogs/butterlogcult.yml
+++ b/html/changelogs/butterlogcult.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Butterrobber202
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Upgraded Cult Armor lost some melee protection in exchange for heightened ballistic defense. This should prevent the melee focused antagonists from getting obliterated from range."


### PR DESCRIPTION
I don't know what people in 2012 were thinking when they decided that a melee-based antagonist should be extremely weak to ranged ballistics, but here we are.

Nerfed Cult Armor's Melee Resistance.
Buffed Cult Armor's Ballistic Resistance.

Changes only apply to the upgraded variant of the Cultist Armor, which requires an artificer to acquire. 