### PR TITLE
Camera static effect now displays properly on space turfs.

### DIFF
--- a/code/__defines/_layers.dm
+++ b/code/__defines/_layers.dm
@@ -2,6 +2,7 @@
 #define PLANE_SPACE_PARALLAX (PLANE_SPACE_BACKGROUND + 1) // -97
 #define PLANE_SPACE_DUST (PLANE_SPACE_PARALLAX + 1) // -96
 #define PLANE_ABOVE_PARALLAX (PLANE_SPACE_BACKGROUND + 3) // -95
+#define PLANE_DEFAULT 0
 
 #define LOWER_ON_TURF_LAYER (TURF_LAYER + 0.05)	// under the below
 #define ON_TURF_LAYER (TURF_LAYER + 0.1)	// sitting on the turf - should be preferred over direct use of TURF_LAYER

--- a/code/modules/mob/abstract/freelook/chunk.dm
+++ b/code/modules/mob/abstract/freelook/chunk.dm
@@ -24,6 +24,7 @@
 	if(!obfuscation)
 		obfuscation = image(icon, T, icon_state)
 		obfuscation.layer = OBFUSCATION_LAYER
+		obfuscation.plane = PLANE_DEFAULT
 		if(!obfuscation_underlay)
 			// Creating a new icon of a fairly common icon state, adding some random color to prevent address searching, and hoping being static kills memory locality
 			var/turf/floor = /turf/simulated/floor/tiled

--- a/html/changelogs/space_turf_obfuscation.yml
+++ b/html/changelogs/space_turf_obfuscation.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Space turfs will now properly display the camera static image when they are not visible from a camera, to an AI or camera view."


### PR DESCRIPTION
Fixes #13162
Fixes #7721

The camera static image was being displayed on the parallax plane instead of the default plane in the case of space turfs.