### PR TITLE
Fixes pda spawning as unknown

### DIFF
--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -369,7 +369,7 @@
 		var/obj/item/I = new id(H)
 		imprint_idcard(H,I)
 		if(istype(P) && P.card_slot)
-			addtimer(CALLBACK(src, .proc/register_pda, P, I), 1 SECOND)
+			addtimer(CALLBACK(src, .proc/register_pda, P, I), 2 SECOND)
 		else
 			H.equip_or_collect(I, slot_wear_id)
 

--- a/html/changelogs/PDAFix.yml
+++ b/html/changelogs/PDAFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "PDAs should no longer show up as 'unknown' on roundstart."


### PR DESCRIPTION
The id imprinting used a timer to delay it by about a second, causing it to not be registered properly to the user before the pda tried to register the user. This should fix that without too much trouble.

fixes https://github.com/Aurorastation/Aurora.3/issues/12756
