### PR TITLE
zmimic - update_above() now works

### DIFF
--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -63,7 +63,7 @@
 			A.turret_controls += src
 		else
 			control_area = null
-
+	updateTurrets()
 	if (!mapload)
 		power_change() //Checks power and initial settings
 		turretModes()
@@ -201,7 +201,6 @@
 			else if(href_list["command"] == "check_wildlife")
 				check_wildlife = value
 			updateTurrets()
-			update_icon()
 			SSvueui.check_uis_for_change(src)
 	else if(href_list["turret_ref"])
 		var/obj/machinery/porta_turret/aTurret = locate(href_list["turret_ref"]) in (control_area.turrets)
@@ -209,7 +208,6 @@
 			return
 		. = aTurret.Topic(href, href_list)
 		SSvueui.check_uis_for_change(src)
-		update_icon()
 
 /obj/machinery/turretid/proc/updateTurrets()
 	var/datum/turret_checks/TC = getState()
@@ -221,6 +219,8 @@
 			else
 				TC.enabled = 0
 				aTurret.setState(TC)
+
+	queue_icon_update()
 
 /obj/machinery/turretid/proc/getState()
 	var/datum/turret_checks/TC = new
@@ -256,12 +256,10 @@
 		var/obj/machinery/porta_turret/aTurret = control_area.turrets[1]
 		lethal = aTurret.lethal
 		updateTurrets()
-	update_icon()
 
 /obj/machinery/turretid/power_change()
 	..()
 	updateTurrets()
-	update_icon()
 
 /obj/machinery/turretid/update_icon()
 	..()

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -26,7 +26,8 @@
 	if (!bound_overlay)
 		return
 
-	if (TURF_IS_MIMICING(loc))
+	var/turf/T = loc
+	if (TURF_IS_MIMICING(T.above))
 		if (!bound_overlay.queued)
 			SSzcopy.queued_overlays += bound_overlay
 			bound_overlay.queued = TRUE

--- a/html/changelogs/zmimic_fix.yml
+++ b/html/changelogs/zmimic_fix.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Z-mimic will now update properly when something changes on the bottom visible turf."


### PR DESCRIPTION
Previously the bottom turf was checking if it mimics itself, rather than checking if the turf above it is mimicing it.

Fixes #13087 