### PR TITLE
Coolant injectors broadcast status on atmos_init

### DIFF
--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -129,6 +129,7 @@
 	..()
 
 	set_frequency(frequency)
+	broadcast_status()
 
 /obj/machinery/atmospherics/unary/outlet_injector/receive_signal(datum/signal/signal)
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))

--- a/html/changelogs/injector_broadcast_status.yml
+++ b/html/changelogs/injector_broadcast_status.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Atmospherics consoles linked to injector outlets (e.g. Supermatter coolant control console) will no longer require you to click 'Search for input port' the first time you open it in a round, they will instead start with their mapped injector already linked properly."


### PR DESCRIPTION
Atmospherics consoles linked to injector outlets (e.g. Supermatter coolant control console) will no longer require you to click 'Search for input port' the first time you open it in a round, they will instead start with their mapped injector already linked properly, like so:

![cooling_control_opened](https://user-images.githubusercontent.com/47489928/154301112-4b30ec84-305b-4c54-8529-767e674c6189.PNG)
