### PR TITLE
Fixes heating nitroglycerin.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -364,7 +364,7 @@
 
 /decl/reagent/nitroglycerin/on_heat_change(var/added_energy, var/datum/reagents/holder)
 	. = ..()
-	if(added_energy > (specific_heat * 5 / REAGENT_VOLUME(holder, type))) // heat shock
+	if(added_energy > (specific_heat * 5 * REAGENT_VOLUME(holder, type))) // heat shock
 		explode(holder)
 
 /decl/reagent/nitroglycerin/apply_force(var/force, var/datum/reagents/holder)

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -126,6 +126,12 @@
 	icon_state = "bottle-4"
 	reagents_to_add = list(/decl/reagent/acid/polyacid = 60)
 
+/obj/item/reagent_containers/glass/bottle/nitroglycerin
+	name = "nitroglycerin bottle"
+	desc = "A small bottle. Contains a small amount of Nitroglycerin."
+	icon_state = "bottle-4"
+	reagents_to_add = list(/decl/reagent/nitroglycerin = 60)
+
 /obj/item/reagent_containers/glass/bottle/adminordrazine
 	name = "adminordrazine bottle"
 	desc = "A small bottle. Contains the liquid essence of the gods."

--- a/html/changelogs/slowmode_chem_heater.yml
+++ b/html/changelogs/slowmode_chem_heater.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "It is now possible to safely heat nitroglycerin without explosions. Use a large volume and heat it in small increments."
+  - rscadd: "Chem heaters now have a 'slow mode' option that will heat your chemical in very small steps."


### PR DESCRIPTION
Fixes #13200

The chem heater slow mode is intentionally _very_ slow (2 degrees C per tick) -- Players can heat volatile things faster if they know what they're doing.