### PR TITLE
Pressure regulator connection icon fix

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -60,8 +60,8 @@
 		var/turf/T = get_turf(src)
 		if(!istype(T))
 			return
-		add_underlay(T, node1, turn(dir, 180), node1?.icon_connect_type)
-		add_underlay(T, node2, dir, node2?.icon_connect_type)
+		add_underlay(T, node1, turn(dir, 180), icon_connect_type)
+		add_underlay(T, node2, dir, icon_connect_type)
 
 /obj/machinery/atmospherics/binary/passive_gate/hide(var/i)
 	update_underlays()

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -135,8 +135,10 @@ Buildable meters
 		else if(istype(make_from, /obj/machinery/atmospherics/unary/vent_scrubber))
 			src.pipe_type = PIPE_SCRUBBER
 		else if(istype(make_from, /obj/machinery/atmospherics/binary/passive_gate/scrubbers))
+			connect_types = CONNECT_TYPE_SCRUBBER
 			src.pipe_type = PIPE_PASSIVE_GATE_SCRUBBER
 		else if(istype(make_from, /obj/machinery/atmospherics/binary/passive_gate/supply))
+			connect_types = CONNECT_TYPE_SUPPLY
 			src.pipe_type = PIPE_PASSIVE_GATE_SUPPLY
 		else if(istype(make_from, /obj/machinery/atmospherics/binary/passive_gate))
 			src.pipe_type = PIPE_PASSIVE_GATE

--- a/html/changelogs/passive_pump_icon.yml
+++ b/html/changelogs/passive_pump_icon.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes pressure regulators not creating the right underlays when connecting to universal adapters in some cases."


### PR DESCRIPTION
The supply and scrubber pipeline subtypes of the pressure regulator weren't creating the right underlays when connecting to a universal adapter, because they were incorrectly taking the pipe type from the universal adapter rather than themselves.

Current:
![current_passive_pump_scrubber](https://user-images.githubusercontent.com/47489928/154599285-054f7249-e37d-41bc-99c3-afe6f2bba9fb.PNG)

New:
![new_passive_pump_scrubber](https://user-images.githubusercontent.com/47489928/154598945-8a2be2df-962f-4db1-8e7b-0e4bce9a70bb.PNG)

EDIT: Also made them remember their type when unattached, currently they just turn into a normal pressure regulator.