### PR TITLE
Being assigned a special role now clears 'role_alt_title'

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -199,6 +199,7 @@
 	//Ensure that antags with ANTAG_OVERRIDE_JOB do not occupy job slots.
 	if(flags & ANTAG_OVERRIDE_JOB)
 		player.assigned_role = role_text
+		player.role_alt_title = role_text
 
 	//Ensure that a player cannot be drafted for multiple antag roles, taking up slots for antag roles that they will not fill.
 	player.special_role = role_text

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -6,6 +6,7 @@
 	//do this again, just in case
 	if(flags & ANTAG_OVERRIDE_JOB)
 		player.assigned_role = role_text
+		player.role_alt_title = role_text
 	player.special_role = role_text
 
 	if(istype(player.current, /mob/abstract))

--- a/html/changelogs/outfit_clears_job_rank.yml
+++ b/html/changelogs/outfit_clears_job_rank.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Being assigned a special role now clears 'role_alt_title', which could lead to you getting an ID with your previous job on it when spawning as an antagonist."


### PR DESCRIPTION
Fixes #12854

Was letting antagonists (e.g. mercenaries) spawn with an ID that had their selected character's job on it.