### PR TITLE
ID card photos now have correct character facings

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -640,7 +640,7 @@ proc/ColorTone(rgb, tone)
 /// appearance system (overlays/underlays, etc.) is not available.
 ///
 /// Only the first argument is required.
-/proc/getFlatIcon(image/A, defdir, deficon, defstate, defblend, start = TRUE, no_anim = FALSE)
+/proc/getFlatIcon(image/A, defdir, deficon, defstate, defblend, start = TRUE, no_anim = FALSE, ignore_parent_dir = FALSE)
 	//Define... defines.
 	var/static/icon/flat_template = icon('icons/effects/effects.dmi', "nothing")
 
@@ -701,7 +701,7 @@ proc/ColorTone(rgb, tone)
 	var/base_icon_dir	//We'll use this to get the icon state to display if not null BUT NOT pass it to overlays as the dir we have
 
 	//These should use the parent's direction (most likely)
-	if(!A.dir || A.dir == SOUTH)
+	if(!A.dir || A.dir == SOUTH || ignore_parent_dir)
 		curdir = defdir
 	else
 		curdir = A.dir

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -151,9 +151,9 @@ var/const/NO_EMAG_ACT = -50
 		chat_user.username = chat_user.generateUsernameIdCard(src)
 
 /obj/item/card/id/proc/set_id_photo(var/mob/M)
-	front = getFlatIcon(M, SOUTH)
+	front = getFlatIcon(M, SOUTH, ignore_parent_dir = TRUE)
 	front.Scale(128, 128)
-	side = getFlatIcon(M, WEST)
+	side = getFlatIcon(M, WEST, ignore_parent_dir = TRUE)
 	side.Scale(128, 128)
 
 /mob/proc/set_id_info(var/obj/item/card/id/id_card)

--- a/html/changelogs/id_card_photos_bugfix.yml
+++ b/html/changelogs/id_card_photos_bugfix.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "ID card photos will now face the correct directions instead of both being of the direction your character was facing when your ID card spawned."


### PR DESCRIPTION
Fixes #13211

ID card photographs were made based on the facing of your character when your ID card spawned, because getFlatIcon insisted you make the icons with the direction of the target appearance, if it has one set.