### PR TITLE
Name Changing Stuff

### DIFF
--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -7,7 +7,7 @@
 	if(!target.current)
 		remove_antagonist(target)
 		return 0
-	if(flags & ANTAG_CHOOSE_NAME)
+	if(!preserve_appearance && (flags & ANTAG_CHOOSE_NAME))
 		spawn(1)
 			set_antag_name(target.current)
 	if(move)
@@ -131,7 +131,7 @@
 		H.real_name = L.get_random_name()
 		H.name = H.real_name
 		H.dna.real_name = H.real_name
-	var/newname = sanitize(input(player, "You are a [role_text]. Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)
+	var/newname = sanitizeName(sanitize_readd_odd_symbols(sanitize(input(player, "You are a [role_text]. Would you like to change your name to something else?", "Name change") as null|text)))
 	if (newname)
 		player.real_name = newname
 		player.name = player.real_name

--- a/code/modules/acting/acting_items.dm
+++ b/code/modules/acting/acting_items.dm
@@ -24,14 +24,19 @@
 	anchored = 1
 	density = 1
 
-/obj/machinery/acting/changer/attack_hand(var/mob/user as mob)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		H.change_appearance(APPEARANCE_ALL, H, TRUE, H.generate_valid_species(), null, default_state, src)
-		var/getName = sanitizeName(sanitize_readd_odd_symbols(sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)))
-		if(getName)
-			H.real_name = getName
-			H.name = getName
-			H.dna.real_name = getName
-			if(H.mind)
-				H.mind.name = H.name
+/obj/machinery/acting/changer/attack_hand(var/mob/living/carbon/human/H)
+	if(!istype(H))
+		return
+
+	H.change_appearance(APPEARANCE_ALL, H, TRUE, H.generate_valid_species(), null, default_state, src)
+	var/getName = sanitizeName(sanitize_readd_odd_symbols(sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)))
+	if(getName)
+		H.real_name = getName
+		H.name = getName
+		H.dna.real_name = getName
+		if(H.mind)
+			H.mind.name = H.name
+		var/obj/item/card/id/ID = H.GetIdCard()
+		if(ID)
+			ID.registered_name = H.real_name
+			ID.update_name()

--- a/code/modules/acting/acting_items.dm
+++ b/code/modules/acting/acting_items.dm
@@ -29,7 +29,7 @@
 		return
 
 	H.change_appearance(APPEARANCE_ALL, H, TRUE, H.generate_valid_species(), null, default_state, src)
-	var/getName = sanitizeName(sanitize_readd_odd_symbols(sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)))
+	var/getName = sanitizeName(sanitize_readd_odd_symbols(sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text)))
 	if(getName)
 		H.real_name = getName
 		H.name = getName

--- a/code/modules/ghostroles/spawner/human/emergencypod.dm
+++ b/code/modules/ghostroles/spawner/human/emergencypod.dm
@@ -466,4 +466,4 @@
 	if(W)
 		W.handle_item_insertion(passport)
 
-	burglars.add_antagonist(H.mind, TRUE, TRUE, FALSE, TRUE)
+	burglars.add_antagonist(H.mind, TRUE, TRUE, FALSE, TRUE, TRUE)

--- a/code/modules/ghostroles/spawner/human/human.dm
+++ b/code/modules/ghostroles/spawner/human/human.dm
@@ -36,7 +36,7 @@
 			pick_message = "[pick_message] Auto Prefix: \"[mob_name_prefix]\" "
 		if(mob_name_suffix)
 			pick_message = "[pick_message] Auto Suffix: \"[mob_name_suffix]\" "
-		mname = sanitizeSafe(input(user, pick_message, "Name for a [species] (without prefix/suffix)"))
+		mname = sanitizeName(sanitize_readd_odd_symbols(sanitizeSafe(input(user, pick_message, "Name for a [species] (without prefix/suffix)"))))
 
 	if(!length(mname))
 		if(mob_name_prefix || mob_name_suffix)

--- a/html/changelogs/geeves-more_html_nonsense.yml
+++ b/html/changelogs/geeves-more_html_nonsense.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed some name sanitization issues when picking a ghostspawner or becoming an antagonist, apostrophes will now work correctly."
+  - rscadd: "Quickees Plastic Surgeon or changer machines will now update your ID as well."


### PR DESCRIPTION
* Fixed some name sanitization issues when picking a ghostspawner or becoming an antagonist, apostrophes will now work correctly.
* Quickees Plastic Surgeon or changer machines will now update your ID as well.