### PR TITLE
Medical Gripper and Inhaler Cartridges Fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -272,6 +272,7 @@
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/spray,
 		/obj/item/personal_inhaler,
+		/obj/item/reagent_containers/personal_inhaler_cartridge,
 		/obj/item/reagent_containers/inhaler,
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/storage/pill_bottle,

--- a/html/changelogs/medical_gripper_inh_cartridges.yml
+++ b/html/changelogs/medical_gripper_inh_cartridges.yml
@@ -1,0 +1,6 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed stationbounds's Medical Grippers being unable to hold inhaler cartridges."


### PR DESCRIPTION
* Fixes #13215 (partially)
* Fixed medical stationbounds not being able to hold inhaler cartridges with their medical gripper