### PR TITLE
Allow AltClick to remove ID from wallets

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -90,6 +90,20 @@
 	else
 		return ..()
 
+
+/obj/item/storage/wallet/AltClick(mob/user)
+	if (user != loc || user.incapacitated() || !ishuman(user))
+		return ..()
+
+	var/obj/item/card/id/id = GetID()
+	if (istype(id))
+		remove_from_storage(id)
+		user.put_in_hands(id)
+		return
+
+	return ..()
+
+
 /obj/item/storage/wallet/random/fill()
 	..()
 	var/item1_type = pick(                \

--- a/html/changelogs/sierrakomodo-alt-wallet-id.yml
+++ b/html/changelogs/sierrakomodo-alt-wallet-id.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "You can now remove ID cards from wallets with AltClick. This only works for human mobs, and only if you're holding or wearing the wallet."


### PR DESCRIPTION
This allows human mob subtypes to remove their ID cards from their wallets with alt+click, similar to doing so with a PDA that has an ID in it. It only works if you are a human subtype (No borgs), and if you're holding the wallet in your hand, wearing it, or have it in your pocket. In all other cases, it reverts to the default alt+click behavior of opening the container.