### PR TITLE
Blast doors don't open on power restore if they were originally closed

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -188,7 +188,7 @@
 		return
 	if(stat & NOPOWER)
 		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_close)
-		securitylock = TRUE
+		securitylock = !density // blast doors will only re-open when power is restored if they were open originally
 	else if(securitylock)
 		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_open)
 		securitylock = FALSE

--- a/html/changelogs/blast_doors_stay_closed.yml
+++ b/html/changelogs/blast_doors_stay_closed.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - tweak: "Blast doors without power will only open when power is restored if they were originally open."


### PR DESCRIPTION
Fixes #13228

Not going to mark as bugfix though because I'm not sure this is a bug.