### PR TITLE
Ghost pointing won't show an outline

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -346,7 +346,7 @@
 		pointing_effect = new /obj/effect/decal/point(A)
 		pointing_effect.invisibility = invisibility
 		addtimer(CALLBACK(src, .proc/end_pointing_effect, pointing_effect), 2 SECONDS)
-	else
+	else if(!invisibility)
 		var/atom/movable/M = A
 		M.add_filter("pointglow", 1, list(type = "drop_shadow", x = 0, y = -1, offset = 1, size = 1, color = "#F00"))
 		addtimer(CALLBACK(M, /atom/movable.proc/remove_filter, "pointglow"), 2 SECONDS)

--- a/html/changelogs/ghost-pointing-bugfix.yml
+++ b/html/changelogs/ghost-pointing-bugfix.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Ghosts pointing won't show an outline filter."


### PR DESCRIPTION
Fixes #13238

Can't make the filter invisible to living mobs like the arrow icon does. So this will have to do.