### PR TITLE
Skrell sprint is no longer absolutely terrible.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
@@ -70,9 +70,9 @@
 	ethanol_resistance = 0.5//gets drunk faster
 	taste_sensitivity = TASTE_SENSITIVE
 
-	stamina = 110
-	sprint_cost_factor = 0.3
-	sprint_speed_factor = 0.9
+	stamina = 80
+	sprint_cost_factor = 0.4
+	sprint_speed_factor = 0.8
 	bp_base_systolic = 100 // Default 120
 	bp_base_disatolic = 60 // Default 80
 	low_pulse = 30 // Default 40

--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
@@ -70,7 +70,7 @@
 	ethanol_resistance = 0.5//gets drunk faster
 	taste_sensitivity = TASTE_SENSITIVE
 
-	stamina = 130
+	stamina = 110
 	sprint_cost_factor = 0.3
 	sprint_speed_factor = 0.9
 	bp_base_systolic = 100 // Default 120

--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
@@ -70,8 +70,9 @@
 	ethanol_resistance = 0.5//gets drunk faster
 	taste_sensitivity = TASTE_SENSITIVE
 
-	stamina = 90
-	sprint_speed_factor = 1.25 //Evolved for rapid escapes from predators
+	stamina = 130
+	sprint_cost_factor = 0.3
+	sprint_speed_factor = 0.9
 	bp_base_systolic = 100 // Default 120
 	bp_base_disatolic = 60 // Default 80
 	low_pulse = 30 // Default 40

--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell_subspecies.dm
@@ -15,7 +15,7 @@
 	tail = "axiori_tail"
 	eyes = "skrell_axiori_eyes_s"
 
-	sprint_speed_factor = 1.15 // Species default 1.25
+	sprint_speed_factor = 0.7 // Species default 0.9
 	low_pulse = 40 // Species default 30
 	norm_pulse = 60 // Species default 50
 	fast_pulse = 80 // Species default 70

--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell_subspecies.dm
@@ -15,7 +15,7 @@
 	tail = "axiori_tail"
 	eyes = "skrell_axiori_eyes_s"
 
-	sprint_speed_factor = 0.7 // Species default 0.9
+	sprint_speed_factor = 0.7 // Species default 0.8
 	low_pulse = 40 // Species default 30
 	norm_pulse = 60 // Species default 50
 	fast_pulse = 80 // Species default 70

--- a/html/changelogs/mattatlas-skrellbuffslmao.yml
+++ b/html/changelogs/mattatlas-skrellbuffslmao.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Skrell sprint is now more in line with other sprints and is no longer the worst sprint in the game."


### PR DESCRIPTION
Skrell sprint was kneecapped by two different reasons, one of which I assume to be an oversight.

1. Skrell stamina is lower than human stamina - 90 as opposed to 130.
2. To add to that, Skrell sprint_cost_factor was never set. This leads to it being 0.9 on Skrell, whereas it is 0.5 on humans.

This led to skrell sprint being effectively worse to an unreasonable degree. After asking the loremaster, Skrell sprint is now overall slower, with the tailed skrell being even slower. The distance skrell run is about 10-15 tiles less than a human at a slower pace. They also have overall less stamina, so they can't disarm spam as effectively.