### PR TITLE
Adds a Synthflesh recipe to the Biogenerator; Refluffs Biomeat.

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -38,7 +38,7 @@
 	var/emag = FALSE
 
 /decl/biorecipe/food
-	name = "Bio Meat"
+	name = "Meat Substitute"
 	class = BIOGEN_FOOD
 	object = /obj/item/reagent_containers/food/snacks/meat/biogenerated
 	cost = 50
@@ -46,6 +46,10 @@
 /decl/biorecipe/food/fishfillet
 	name = "Fish Fillet"
 	object = /obj/item/reagent_containers/food/snacks/fish/fishfillet
+
+/decl/biorecipe/food/syntiflesh
+	name = "Synthetic Meat"
+	object = /obj/item/reagent_containers/food/snacks/meat/syntiflesh
 
 /decl/biorecipe/food/soywafers
 	name = "Soy Wafers"

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -52,8 +52,8 @@
 	reagents_to_add = list(/decl/reagent/nutriment/protein = 6, /decl/reagent/nutriment/triglyceride = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/biogenerated
-	name = "bio meat"
-	desc = "Did this come from the Biogenerator, or is it a biohazard? Perhaps it is both."
+	name = "meat substitute"
+	desc = "A slab of extruded plant bits that pretends to be meat."
 	icon_state = "plantmeat"
 	filling_color = "#A8AA00"
 	reagents_to_add = list(/decl/reagent/nutriment = 6)
@@ -99,4 +99,4 @@
 	name = "bat wings"
 	desc = "Like chicken wings, but with even less meat!"
 	icon_state = "batmeat"
-	reagents_to_add = list(/decl/reagent/nutriment/protein = 1) 
+	reagents_to_add = list(/decl/reagent/nutriment/protein = 1)

--- a/html/changelogs/aticius-legallydistinctmeatsubstitute.yml
+++ b/html/changelogs/aticius-legallydistinctmeatsubstitute.yml
@@ -7,4 +7,4 @@ delete-after: True
 
 changes:
   - rscadd: "Synthflesh can now be made at the Biogenerator."
-  - tweak: "Biomeat has been rebranded as "Meat Substitute" and is no longer implied to be biohazardous."
+  - rscadd: "Biomeat has been rebranded as "Meat Substitute" and is no longer implied to be biohazardous."

--- a/html/changelogs/aticius-legallydistinctmeatsubstitute.yml
+++ b/html/changelogs/aticius-legallydistinctmeatsubstitute.yml
@@ -7,4 +7,4 @@ delete-after: True
 
 changes:
   - rscadd: "Synthflesh can now be made at the Biogenerator."
-  - rscadd: "Biomeat has been rebranded as "Meat Substitute" and is no longer implied to be biohazardous."
+  - rscadd: "Biomeat has been rebranded as Meat Substitute and is no longer implied to be biohazardous."

--- a/html/changelogs/aticius-legallydistinctmeatsubstitute.yml
+++ b/html/changelogs/aticius-legallydistinctmeatsubstitute.yml
@@ -1,0 +1,10 @@
+
+author: Aticius
+
+
+delete-after: True
+
+
+changes:
+  - rscadd: "Synthflesh can now be made at the Biogenerator."
+  - tweak: "Biomeat has been rebranded as "Meat Substitute" and is no longer implied to be biohazardous."


### PR DESCRIPTION
Animal Protein isn't among the reagents that can be reproduced by the Biogenerator, this fixes that. There will be less riots over the lack of real burgers now (and possibly less workplace murders when all the Unathi eat the entire freezer and ask for their eighth meat pancake.)

Additionally, refluffs Biomeat to not be described as "biohazardous", and more accurately describes what it is.